### PR TITLE
fix(orchestrator): harden execution authority baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Python 3.12 and 3.13 complete the full coverage suite more slowly than
+    # 3.14. Keep the complete matrix as a required gate rather than cancelling
+    # otherwise-progressing runs at the former 15-minute job limit.
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -1,0 +1,96 @@
+# AC Runtime Execution Authority Boundary
+
+Foundation A defines a portable executor *baseline*. It is deliberately not a
+complete identity for an active execution attempt. The baseline may become one
+input to a later capsule, but it never authorizes dispatch, checkpoint reuse,
+trust reuse, or final acceptance by itself.
+
+## Inclusion matrix
+
+| Category | Foundation A treatment | Later owner |
+| --- | --- | --- |
+| Executor implementation, static `LeafDispatcher`, and token estimator | Versioned, implementation-bound portable baseline | Foundation A |
+| Runtime/backend configuration, executable generation, watchdog policy, static handle-selector implementation | Versioned, redacted/digested portable baseline | Foundation A |
+| Workspace generation, verifier implementation, and exact execution policy | Versioned portable baseline | Foundation A |
+| AC semantics, prompt, tool catalog, selected runtime handle, `ACRuntimeHandleManager`, checkpoint and resume state | Explicitly excluded from the baseline | Foundation C attempt capsule |
+| `LevelCoordinator` implementation, conflict-reconciliation policy, reasoning effort, session cache, and review session state | Explicitly excluded from the baseline | Foundation C attempt capsule |
+| `ExecutionEventEmitter`, event-store handles, `SessionSignalHub`, queues, locks, and live pools | Explicitly volatile; never upgraded by a declared identity | Foundation B event semantics / runtime process |
+
+The machine-readable form of this matrix is
+`execution_authority_boundary_contract()`, embedded in every
+`ExecutionAuthorityContract` canonical payload.
+
+## Security and portability rules
+
+- Provider-controlled identity values are never copied into canonical authority
+  JSON. Foundation A retains a deterministic digest only where a durable
+  baseline needs equality; known credential-shaped values make that input
+  unobserved and process-local.
+- An unobserved runtime or LLM backend label may bind only the initial live
+  adapter through a process-local guard. It cannot resume durably or join a
+  frugality-proof cohort, because two hidden labels cannot prove equality
+  without serializing credential material.
+- A declared identity on a live collaborator cannot make it portable. Only the
+  explicit `leaf_dispatcher` static-type allowlist is an executor subcomponent
+  of this layer.
+- A selector implementation can be baseline identity; a selected
+  `RuntimeHandle` cannot. The handle's metadata is bound by the attempt capsule
+  that actually resumes or dispatches it.
+- If a provider getter, implementation, gate-factory dependency, or directly
+  constructed gate-class member cannot be observed safely, the resulting
+  baseline is process-local rather than exposing an error message or claiming
+  cross-process portability.
+- A rate-gate class member is portable only when it is the exact original
+  import-time declaration. A dynamically installed wrapper is process-local
+  even if `functools.wraps` gives it the same module, name, signature, or source
+  shape; its live closure and module state cannot be promoted into the baseline.
+- The only portable rate-gate factory is the exact original import-time
+  `build_rate_limit_gate` declaration. Any replacement factory is process-local,
+  even when its source, metadata, closures, or dependency graph appear
+  equivalent. Mutating that original function's code, defaults, keyword
+  defaults, or closure state in place also makes it process-local.
+- The original gate classes' directly read runtime-module members are likewise
+  import-time-bound. Replacing `time.monotonic`, `asyncio.Lock`, or
+  `asyncio.sleep` makes the factory process-local rather than treating an
+  in-memory scheduling change as portable behavior.
+- For a directly read Python function or class such as `asyncio.sleep` or
+  `asyncio.Lock`, import-time binding includes its executable implementation:
+  code, defaults, closure state, raw class members, and inherited class-member
+  implementations, along with directly resolved globals, builtins, and module
+  members. An in-place stdlib monkeypatch is therefore process-local even when
+  the exported module member object and its source text are unchanged.
+- The direct gate-class member manifest must also be complete. Replacing a
+  method with a custom descriptor cannot make that member disappear from the
+  portable implementation graph, and a descriptor that reuses the original
+  `__func__` still fails closed when its own binding behavior changes.
+- Each original gate member's directly resolved globals and builtins are
+  import-time-bound too. Replacing `deque` or an internal result type therefore
+  fails closed even when a replacement copies the original display metadata.
+- The complete raw class dictionary is import-time-bound as well. Adding a
+  special descriptor such as `__getattribute__` therefore cannot reroute
+  `gate.acquire` while retaining a portable factory identity.
+- An original gate member's object identity is not sufficient by itself: its
+  code, defaults, keyword defaults, and closure state are import-time-bound.
+  In-place implementation mutation therefore fails closed instead of creating a
+  new portable algorithm digest.
+- Gate result types directly constructed by those members receive the same raw
+  class/member integrity check. Mutating `RateLimitSnapshot` or
+  `RateLimitBackoff` in place cannot alter rate-gate behavior under a portable
+  baseline.
+
+## Foundation A exit matrix
+
+Before a Foundation A PR is reviewed, tests must demonstrate all of the
+following:
+
+1. Provider credentials and property-getter exceptions never appear in
+   canonical authority JSON.
+2. Workspace, runtime implementation, verifier graph, policy, static dispatcher,
+   and the actual rate-gate factory (including direct class-member implementations)
+   change the baseline fingerprint.
+3. A live signal hub cannot become portable merely by declaring an identity.
+4. Changing an AC runtime handle, handle manager, checkpoint state, coordinator
+   session, or event emitter does not purport to change the portable baseline;
+   the encoded boundary assigns each to its later owner.
+5. `portable_across_processes` is only an identity-stability property. It is
+   insufficient for any dispatch, recovery, trust, result, or acceptance reuse.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -11,9 +11,9 @@ trust reuse, or final acceptance by itself.
 | --- | --- | --- |
 | Executor implementation, static `LeafDispatcher`, and token estimator | Versioned, implementation-bound portable baseline | Foundation A |
 | Runtime/backend configuration, executable generation, watchdog policy, static handle-selector implementation | Versioned, redacted/digested portable baseline | Foundation A |
-| Workspace generation, verifier implementation, and exact execution policy | Versioned portable baseline | Foundation A |
+| Workspace generation, verifier implementation, and exact static execution policy (including configured base reasoning effort) | Versioned portable baseline | Foundation A |
 | AC semantics, prompt, tool catalog, selected runtime handle, `ACRuntimeHandleManager`, checkpoint and resume state | Explicitly excluded from the baseline | Foundation C attempt capsule |
-| `LevelCoordinator` implementation, conflict-reconciliation policy, reasoning effort, session cache, and review session state | Explicitly excluded from the baseline | Foundation C attempt capsule |
+| `LevelCoordinator` implementation, conflict-reconciliation policy, selected per-AC reasoning effort, session cache, and review session state | Explicitly excluded from the baseline | Foundation C attempt capsule |
 | `ExecutionEventEmitter`, event-store handles, `SessionSignalHub`, queues, locks, and live pools | Explicitly volatile; never upgraded by a declared identity | Foundation B event semantics / runtime process |
 
 The machine-readable form of this matrix is
@@ -36,6 +36,10 @@ The machine-readable form of this matrix is
 - A selector implementation can be baseline identity; a selected
   `RuntimeHandle` cannot. The handle's metadata is bound by the attempt capsule
   that actually resumes or dispatches it.
+- The configured base reasoning-effort policy is baseline identity because it
+  changes the executor's static behavior. The selected effort for a concrete
+  AC (after investment assessment, decomposition role, and retry state) is
+  per-attempt data and is never represented by this baseline.
 - If a provider getter, implementation, gate-factory dependency, or directly
   constructed gate-class member cannot be observed safely, the resulting
   baseline is process-local rather than exposing an error message or claiming
@@ -90,7 +94,7 @@ following:
    change the baseline fingerprint.
 3. A live signal hub cannot become portable merely by declaring an identity.
 4. Changing an AC runtime handle, handle manager, checkpoint state, coordinator
-   session, or event emitter does not purport to change the portable baseline;
-   the encoded boundary assigns each to its later owner.
+   session, selected per-AC effort, or event emitter does not purport to change
+   the portable baseline; the encoded boundary assigns each to its later owner.
 5. `portable_across_processes` is only an identity-stability property. It is
    insufficient for any dispatch, recovery, trust, result, or acceptance reuse.

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -130,12 +130,13 @@ _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
     r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
     r")\b"
 )
-# ``token `` and ``secret_`` are useful only as direct value prefixes. Looking
-# for them after every delimiter would treat ordinary persistence keys such as
+# ``api-``, ``token ``, and ``secret_`` are useful only as direct value
+# prefixes. Looking for them after every delimiter would classify natural text
+# such as ``API-first`` and ordinary persistence keys such as
 # ``quoted_secret_preview`` as credentials. Provider-shaped prefixes remain
 # detectable after a delimiter (for example ``branch-ghp_...``).
 _DELIMITED_CREDENTIAL_PREFIXES = tuple(
-    prefix for prefix in SENSITIVE_PREFIXES if prefix not in {"bearer ", "token ", "secret_"}
+    prefix for prefix in SENSITIVE_PREFIXES if prefix not in {"api-", "token ", "secret_"}
 )
 
 

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -86,6 +86,58 @@ SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
 )
 
+# A full value that is a credential should be treated differently from an
+# otherwise useful diagnostic sentence that happens to contain one.  The
+# latter must retain enough context for replay/debugging after the embedded
+# secret is redacted, rather than becoming an opaque marker.
+_SECRET_FLAG_PATTERN = re.compile(
+    r"(?i)(--(?:"
+    r"api[-_]?key"
+    r"|(?:access|auth|bearer|github|gh|refresh)[-_]?token"
+    r"|token"
+    r"|password"
+    r"|(?:client[-_]?)?secret"
+    r"|credentials?"
+    r"|private[-_]?key"
+    r")(?:=|\s+))"
+    r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;]+)"
+)
+_SECRET_LABEL_PATTERN = re.compile(
+    r"(?i)(\b(?:"
+    r"api[-_]?key"
+    r"|(?:access|auth|bearer|github|gh|refresh)[-_]?token"
+    r"|token"
+    r"|password"
+    r"|(?:client[-_]?)?secret"
+    r"|credentials?"
+    r"|private[-_]?key"
+    r"|(?:aws[-_])?secret[-_]access[-_]key"
+    r"|authorization"
+    r")\b\s*[:=]\s*)"
+    r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^,;\n]+)"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
+    r"\b(?:"
+    r"gh[pousr]_[A-Za-z0-9_]{20,}"
+    r"|github_pat_[A-Za-z0-9_]{20,}"
+    r"|glpat-[A-Za-z0-9_-]{20,}"
+    r"|hf_[A-Za-z0-9]{20,}"
+    r"|xox[abpr]-[A-Za-z0-9-]{20,}"
+    r"|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}"
+    r"|AIza[A-Za-z0-9_-]{35}"
+    r"|(?:AKIA|ASIA)[0-9A-Z]{16}"
+    r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+    r")\b"
+)
+# ``token `` and ``secret_`` are useful only as direct value prefixes. Looking
+# for them after every delimiter would treat ordinary persistence keys such as
+# ``quoted_secret_preview`` as credentials. Provider-shaped prefixes remain
+# detectable after a delimiter (for example ``branch-ghp_...``).
+_DELIMITED_CREDENTIAL_PREFIXES = tuple(
+    prefix for prefix in SENSITIVE_PREFIXES if prefix not in {"bearer ", "token ", "secret_"}
+)
+
 
 def mask_api_key(api_key: str, visible_chars: int = 4) -> str:
     """Mask an API key for safe logging/display.
@@ -200,31 +252,54 @@ def is_sensitive_value(value: Any) -> bool:
     normalized_value = value[start:end]
     value_lower = normalized_value.lower()
 
-    # Provider labels and other configuration values sometimes include a
-    # human-readable prefix (for example ``claude:ghp_...``). A startswith-only
-    # check would allow the credential portion to survive authority contracts,
-    # events, and mismatch diagnostics. Treat a known marker at the beginning
-    # of a non-alphanumeric token as sensitive as well. We intentionally do
-    # not scan through an alphanumeric word: ``monkey`` is not a secret merely
-    # because it contains ``key``-like text.
-    def has_token_marker(marker: str) -> bool:
+    if any(value_lower.startswith(prefix.lower()) for prefix in SENSITIVE_PREFIXES):
+        return True
+    if any(pattern.match(normalized_value) for pattern in SENSITIVE_VALUE_PATTERNS):
+        return True
+
+    # Provider labels sometimes prefix a credential (for example
+    # ``claude:ghp_...``). Keep this detector fail-closed for every caller:
+    # authority construction and logging must reject a secret even when it is
+    # embedded in diagnostic prose. Persistence can retain safe prose through
+    # the dedicated ``redact_sensitive_text`` path below.
+
+    def follows_credential_delimiter(position: int) -> bool:
+        if position <= 0:
+            return False
+        preceding = normalized_value[position - 1]
+        return not preceding.isalnum() or unicodedata.category(preceding).startswith(("C", "M"))
+
+    def has_delimited_credential_prefix(prefix: str) -> bool:
         search_from = 0
-        lowered_marker = marker.lower()
+        lowered_prefix = prefix.lower()
         while True:
-            position = value_lower.find(lowered_marker, search_from)
+            position = value_lower.find(lowered_prefix, search_from)
             if position < 0:
                 return False
-            if position == 0 or not value_lower[position - 1].isalnum():
+            if follows_credential_delimiter(position):
                 return True
             search_from = position + 1
 
-    if any(has_token_marker(prefix) for prefix in SENSITIVE_PREFIXES):
+    if any(has_delimited_credential_prefix(prefix) for prefix in _DELIMITED_CREDENTIAL_PREFIXES):
         return True
     return any(
-        match.start() == 0 or not normalized_value[match.start() - 1].isalnum()
+        follows_credential_delimiter(match.start())
         for pattern in SENSITIVE_VALUE_PATTERNS
         for match in pattern.finditer(normalized_value)
     )
+
+
+def redact_sensitive_text(value: str, *, replacement: str = "[redacted]") -> str:
+    """Redact credential-shaped tokens while retaining surrounding context.
+
+    This is appropriate for durable diagnostic/event text. Callers decide
+    whether the surrounding text makes the value an identity that must be
+    replaced wholesale, or a diagnostic that can retain its non-secret context.
+    """
+    redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", value)
+    redacted = _SECRET_LABEL_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", redacted)
+    redacted = _BEARER_PATTERN.sub(f"Bearer {replacement}", redacted)
+    return _HIGH_CONFIDENCE_SECRET_PATTERN.sub(replacement, redacted)
 
 
 def mask_sensitive_value(value: Any, field_name: str | None = None) -> str:

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -52,9 +52,7 @@ SENSITIVE_FIELD_NAMES = frozenset(
 SENSITIVE_PREFIXES = (
     "sk-",
     "pk-",
-    "api-",
     "bearer ",
-    "token ",
     "secret_",
     "AIza",
     # Common provider credentials that are otherwise easy to place under a
@@ -84,6 +82,13 @@ SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
     re.compile(r"hf_[A-Za-z0-9]{20,}"),
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+)
+
+# ``api-`` and ``token `` also begin ordinary prose such as ``API-first`` and
+# ``token budget``. Keep their direct-value detection only for a sufficiently
+# long opaque payload, while provider-specific prefixes above remain strict.
+_GENERIC_CREDENTIAL_VALUE_PATTERN = re.compile(
+    r"(?i)^(?:api-[A-Za-z0-9_-]{20,}|token\s+[A-Za-z0-9_-]{20,})$"
 )
 
 # A full value that is a credential should be treated differently from an
@@ -130,13 +135,12 @@ _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
     r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
     r")\b"
 )
-# ``api-``, ``token ``, and ``secret_`` are useful only as direct value
-# prefixes. Looking for them after every delimiter would classify natural text
-# such as ``API-first`` and ordinary persistence keys such as
+# ``secret_`` is useful only as a direct value prefix. Looking for it after
+# every delimiter would classify ordinary persistence keys such as
 # ``quoted_secret_preview`` as credentials. Provider-shaped prefixes remain
 # detectable after a delimiter (for example ``branch-ghp_...``).
 _DELIMITED_CREDENTIAL_PREFIXES = tuple(
-    prefix for prefix in SENSITIVE_PREFIXES if prefix not in {"api-", "token ", "secret_"}
+    prefix for prefix in SENSITIVE_PREFIXES if prefix != "secret_"
 )
 
 
@@ -254,6 +258,8 @@ def is_sensitive_value(value: Any) -> bool:
     value_lower = normalized_value.lower()
 
     if any(value_lower.startswith(prefix.lower()) for prefix in SENSITIVE_PREFIXES):
+        return True
+    if _GENERIC_CREDENTIAL_VALUE_PATTERN.fullmatch(normalized_value):
         return True
     if any(pattern.match(normalized_value) for pattern in SENSITIVE_VALUE_PATTERNS):
         return True

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -14,6 +14,7 @@ Security Level: MEDIUM
 from pathlib import Path
 import re
 from typing import Any
+import unicodedata
 
 # Maximum sizes for external inputs (DoS prevention)
 MAX_INITIAL_CONTEXT_LENGTH = 50_000  # 50KB for initial interview context
@@ -56,6 +57,33 @@ SENSITIVE_PREFIXES = (
     "token ",
     "secret_",
     "AIza",
+    # Common provider credentials that are otherwise easy to place under a
+    # benign metadata key. Keep these prefix checks shared by logging and
+    # authority serialization rather than maintaining divergent allow-lists.
+    "ghp_",
+    "github_pat_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxr-",
+    "AKIA",
+    "ASIA",
+    "glpat-",
+    "hf_",
+)
+
+# Prefixes alone are intentionally not the whole detector: several common
+# provider credentials use distinct, structured prefixes.  These expressions
+# stay deliberately conservative so normal identifiers do not become secrets
+# merely because they happen to contain a dash or underscore.
+SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"hf_[A-Za-z0-9]{20,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
 )
 
 
@@ -153,8 +181,52 @@ def is_sensitive_value(value: Any) -> bool:
     if not isinstance(value, str):
         return False
 
-    value_lower = value.lower()
-    return any(value_lower.startswith(prefix.lower()) for prefix in SENSITIVE_PREFIXES)
+    # Callers frequently normalize configuration labels after validating them.
+    # Classify the same normalized representation here so leading/trailing
+    # whitespace (including invisible Unicode control, format, and combining
+    # mark characters such as NUL, ZWSP, BOM, WORD JOINER, CGJ, and variation
+    # selectors) cannot turn a credential into an apparently safe value that
+    # is then serialized without its prefix.
+    start = 0
+    end = len(value)
+    while start < end and (
+        value[start].isspace()
+        or unicodedata.category(value[start]).startswith(("C", "M"))
+    ):
+        start += 1
+    while end > start and (
+        value[end - 1].isspace()
+        or unicodedata.category(value[end - 1]).startswith(("C", "M"))
+    ):
+        end -= 1
+    normalized_value = value[start:end]
+    value_lower = normalized_value.lower()
+
+    # Provider labels and other configuration values sometimes include a
+    # human-readable prefix (for example ``claude:ghp_...``). A startswith-only
+    # check would allow the credential portion to survive authority contracts,
+    # events, and mismatch diagnostics. Treat a known marker at the beginning
+    # of a non-alphanumeric token as sensitive as well. We intentionally do
+    # not scan through an alphanumeric word: ``monkey`` is not a secret merely
+    # because it contains ``key``-like text.
+    def has_token_marker(marker: str) -> bool:
+        search_from = 0
+        lowered_marker = marker.lower()
+        while True:
+            position = value_lower.find(lowered_marker, search_from)
+            if position < 0:
+                return False
+            if position == 0 or not value_lower[position - 1].isalnum():
+                return True
+            search_from = position + 1
+
+    if any(has_token_marker(prefix) for prefix in SENSITIVE_PREFIXES):
+        return True
+    return any(
+        match.start() == 0 or not normalized_value[match.start() - 1].isalnum()
+        for pattern in SENSITIVE_VALUE_PATTERNS
+        for match in pattern.finditer(normalized_value)
+    )
 
 
 def mask_sensitive_value(value: Any, field_name: str | None = None) -> str:

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -48,12 +48,53 @@ SENSITIVE_FIELD_NAMES = frozenset(
     }
 )
 
+# ``is_sensitive_field`` intentionally errs on the broad side for log display
+# (for example, any field containing ``key``). Durable contracts need a more
+# precise predicate: they must reject actual credential aliases without
+# treating semantic fields such as ``token_estimator`` as secrets.
+_CREDENTIAL_FIELD_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth",
+        "auth_token",
+        "authentication",
+        "authorization",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "id_token",
+        "passwd",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "secret_access_key",
+        "token",
+    }
+)
+_CREDENTIAL_FIELD_SUFFIXES = (
+    "_api_key",
+    "_credential",
+    "_credentials",
+    "_passwd",
+    "_password",
+    "_private_key",
+    "_secret",
+    "_secret_access_key",
+    "_token",
+)
+_NON_CREDENTIAL_PROTOCOL_FIELD_NAMES = frozenset({"resume_token"})
+_API_HYPHENATED_PROSE_CONNECTORS = frozenset(
+    {"a", "an", "and", "as", "at", "by", "for", "from", "in", "of", "on", "or", "the", "to", "with"}
+)
+
 # Sensitive value prefixes that indicate secrets
 SENSITIVE_PREFIXES = (
     "sk-",
-    "pk-",
     "bearer ",
-    "secret_",
     "AIza",
     # Common provider credentials that are otherwise easy to place under a
     # benign metadata key. Keep these prefix checks shared by logging and
@@ -81,24 +122,24 @@ SENSITIVE_PREFIXES = (
 SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
     re.compile(r"hf_[A-Za-z0-9]{20,}"),
+    re.compile(r"sk_(?:live|test)_[A-Za-z0-9_-]{16,}"),
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+)
+_PEM_PRIVATE_KEY_PATTERN = re.compile(
+    r"-----BEGIN(?: [A-Z0-9]+)* PRIVATE KEY-----[\s\S]*?-----END(?: [A-Z0-9]+)* PRIVATE KEY-----"
 )
 
 # ``api-`` and ``token `` also begin ordinary prose such as ``API-first`` and
-# ``token budget``. Keep their direct-value detection only for a sufficiently
-# long opaque payload, while provider-specific prefixes above remain strict.
-_GENERIC_CREDENTIAL_VALUE_PATTERN = re.compile(
-    r"(?i)^(?:api-[A-Za-z0-9_-]{20,}|token\s+[A-Za-z0-9_-]{20,})$"
-)
-# The same generic forms can occur inside a command or diagnostic sentence.
-# Require the opaque payload so ordinary prose such as ``token budget`` and
-# ``API-first design`` remains semantic data, while a credential cannot evade
-# durable-event redaction merely by being embedded in a longer string.
+# ``token budget``. The ``api-`` form is sufficiently credential-shaped to stay
+# fail-closed at 20+ characters. A bare ``token <word>`` is not: a length-only
+# rule corrupts legitimate long words such as ``token internationalization``.
+# Those token values therefore need a digit or transport-safe punctuation in
+# addition to 20+ payload characters. Known provider prefixes remain strict.
 _GENERIC_CREDENTIAL_TEXT_PATTERN = re.compile(
-    r"(?i)(?<![A-Za-z0-9_-])"
-    r"(?P<label>api-|token\s+)"
-    r"(?P<credential>[A-Za-z0-9_-]{20,})"
-    r"(?![A-Za-z0-9_-])"
+    r"(?i)(?<![A-Za-z0-9_+/=-])"
+    r"(?P<label>api-|token[\s\u200b\ufeff\u2060\u034f\ufe0f]+)"
+    r"(?P<credential>[A-Za-z0-9_+/=-]{20,})"
+    r"(?![A-Za-z0-9_+/=-])"
 )
 
 # A full value that is a credential should be treated differently from an
@@ -140,18 +181,69 @@ _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
     r"|hf_[A-Za-z0-9]{20,}"
     r"|xox[abpr]-[A-Za-z0-9-]{20,}"
     r"|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}"
+    r"|sk_(?:live|test)_[A-Za-z0-9_-]{16,}"
     r"|AIza[A-Za-z0-9_-]{35}"
     r"|(?:AKIA|ASIA)[0-9A-Z]{16}"
     r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
     r")\b"
 )
-# ``secret_`` is useful only as a direct value prefix. Looking for it after
-# every delimiter would classify ordinary persistence keys such as
-# ``quoted_secret_preview`` as credentials. Provider-shaped prefixes remain
-# detectable after a delimiter (for example ``branch-ghp_...``).
-_DELIMITED_CREDENTIAL_PREFIXES = tuple(
-    prefix for prefix in SENSITIVE_PREFIXES if prefix != "secret_"
-)
+# Provider-shaped prefixes remain detectable after a delimiter (for example
+# ``branch-ghp_...``). Ambiguous prose prefixes such as ``pk-`` and
+# ``secret_`` are intentionally absent: they do not constitute credential
+# shape on their own and otherwise corrupt durable semantic text.
+_DELIMITED_CREDENTIAL_PREFIXES = SENSITIVE_PREFIXES
+
+
+def _is_generic_credential_match(match: re.Match[str]) -> bool:
+    """Distinguish opaque credentials from ambiguous natural-language prose."""
+    credential = match.group("credential")
+    if match.group("label").lower() == "api-":
+        # ``api-`` followed by one opaque run is credential-shaped, including
+        # an all-letter value. Preserve only an *obvious grammatical* sequence
+        # of hyphenated words (for example ``API-first-design-for-…``). Treat
+        # ambiguous opaque runs such as ``api-abcdefghij-klmnopqrst`` as a
+        # credential instead of allowing every alphabetic dash-separated tail
+        # to bypass durable-event redaction.
+        parts = credential.split("-")
+        is_hyphenated_prose = (
+            len(parts) >= 3
+            and all(part and part.isalpha() for part in parts)
+            and any(part.lower() in _API_HYPHENATED_PROSE_CONNECTORS for part in parts)
+        )
+        return not is_hyphenated_prose
+    return any(not char.isalpha() for char in credential)
+
+
+def _normalize_credential_field_name(field_name: str) -> str:
+    """Normalize common snake/kebab/camel credential-field spellings."""
+    normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", field_name.strip())
+    normalized = re.sub(r"[-\s]+", "_", normalized.lower())
+    return normalized.strip("_")
+
+
+def is_sensitive_credential_field(field_name: object) -> bool:
+    """Return whether a field names a credential rather than semantic data.
+
+    This narrowly recognizes credential-specific names and aliases such as
+    ``apiKeyValue`` and ``accessTokenValue``. It deliberately does not apply
+    the broader logging heuristic from :func:`is_sensitive_field`, so durable
+    protocol fields such as ``token_estimator`` remain valid.
+    """
+    if not isinstance(field_name, str) or not field_name.strip():
+        return False
+    normalized = _normalize_credential_field_name(field_name)
+    if normalized in _NON_CREDENTIAL_PROTOCOL_FIELD_NAMES:
+        return False
+    if normalized in _CREDENTIAL_FIELD_NAMES or normalized.endswith(_CREDENTIAL_FIELD_SUFFIXES):
+        return True
+    if normalized.endswith("_value"):
+        base_name = normalized.removesuffix("_value")
+        if base_name in _NON_CREDENTIAL_PROTOCOL_FIELD_NAMES:
+            return False
+        return base_name in _CREDENTIAL_FIELD_NAMES or base_name.endswith(
+            _CREDENTIAL_FIELD_SUFFIXES
+        )
+    return False
 
 
 def mask_api_key(api_key: str, visible_chars: int = 4) -> str:
@@ -269,9 +361,15 @@ def is_sensitive_value(value: Any) -> bool:
 
     if any(value_lower.startswith(prefix.lower()) for prefix in SENSITIVE_PREFIXES):
         return True
-    if _GENERIC_CREDENTIAL_VALUE_PATTERN.fullmatch(normalized_value):
+    if _PEM_PRIVATE_KEY_PATTERN.search(normalized_value):
         return True
-    if _GENERIC_CREDENTIAL_TEXT_PATTERN.search(normalized_value):
+    generic_direct_value = _GENERIC_CREDENTIAL_TEXT_PATTERN.fullmatch(normalized_value)
+    if generic_direct_value is not None and _is_generic_credential_match(generic_direct_value):
+        return True
+    if any(
+        _is_generic_credential_match(match)
+        for match in _GENERIC_CREDENTIAL_TEXT_PATTERN.finditer(normalized_value)
+    ):
         return True
     if any(pattern.match(normalized_value) for pattern in SENSITIVE_VALUE_PATTERNS):
         return True
@@ -315,11 +413,16 @@ def redact_sensitive_text(value: str, *, replacement: str = "[redacted]") -> str
     whether the surrounding text makes the value an identity that must be
     replaced wholesale, or a diagnostic that can retain its non-secret context.
     """
-    redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", value)
+    redacted = _PEM_PRIVATE_KEY_PATTERN.sub(replacement, value)
+    redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", redacted)
     redacted = _SECRET_LABEL_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", redacted)
     redacted = _BEARER_PATTERN.sub(f"Bearer {replacement}", redacted)
     redacted = _GENERIC_CREDENTIAL_TEXT_PATTERN.sub(
-        lambda match: f"{match.group('label')}{replacement}",
+        lambda match: (
+            f"{match.group('label')}{replacement}"
+            if _is_generic_credential_match(match)
+            else match.group(0)
+        ),
         redacted,
     )
     return _HIGH_CONFIDENCE_SECRET_PATTERN.sub(replacement, redacted)

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -90,6 +90,16 @@ SENSITIVE_VALUE_PATTERNS = (
 _GENERIC_CREDENTIAL_VALUE_PATTERN = re.compile(
     r"(?i)^(?:api-[A-Za-z0-9_-]{20,}|token\s+[A-Za-z0-9_-]{20,})$"
 )
+# The same generic forms can occur inside a command or diagnostic sentence.
+# Require the opaque payload so ordinary prose such as ``token budget`` and
+# ``API-first design`` remains semantic data, while a credential cannot evade
+# durable-event redaction merely by being embedded in a longer string.
+_GENERIC_CREDENTIAL_TEXT_PATTERN = re.compile(
+    r"(?i)(?<![A-Za-z0-9_-])"
+    r"(?P<label>api-|token\s+)"
+    r"(?P<credential>[A-Za-z0-9_-]{20,})"
+    r"(?![A-Za-z0-9_-])"
+)
 
 # A full value that is a credential should be treated differently from an
 # otherwise useful diagnostic sentence that happens to contain one.  The
@@ -261,6 +271,8 @@ def is_sensitive_value(value: Any) -> bool:
         return True
     if _GENERIC_CREDENTIAL_VALUE_PATTERN.fullmatch(normalized_value):
         return True
+    if _GENERIC_CREDENTIAL_TEXT_PATTERN.search(normalized_value):
+        return True
     if any(pattern.match(normalized_value) for pattern in SENSITIVE_VALUE_PATTERNS):
         return True
 
@@ -306,6 +318,10 @@ def redact_sensitive_text(value: str, *, replacement: str = "[redacted]") -> str
     redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", value)
     redacted = _SECRET_LABEL_PATTERN.sub(lambda match: f"{match.group(1)}{replacement}", redacted)
     redacted = _BEARER_PATTERN.sub(f"Bearer {replacement}", redacted)
+    redacted = _GENERIC_CREDENTIAL_TEXT_PATTERN.sub(
+        lambda match: f"{match.group('label')}{replacement}",
+        redacted,
+    )
     return _HIGH_CONFIDENCE_SECRET_PATTERN.sub(replacement, redacted)
 
 

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -106,11 +106,6 @@ SENSITIVE_PREFIXES = (
     "ghu_",
     "ghs_",
     "ghr_",
-    # Stripe restricted keys carry the same authority as the more familiar
-    # ``sk_live_``/``sk_test_`` family.  Keep them in the shared detector so
-    # authority serialization, durable events, and log redaction cannot drift.
-    "rk_live_",
-    "rk_test_",
     "xoxb-",
     "xoxp-",
     "xoxa-",
@@ -122,9 +117,12 @@ SENSITIVE_PREFIXES = (
 )
 
 # Prefixes alone are intentionally not the whole detector: several common
-# provider credentials use distinct, structured prefixes.  These expressions
-# stay deliberately conservative so normal identifiers do not become secrets
-# merely because they happen to contain a dash or underscore.
+# provider credentials use distinct, structured prefixes. In particular,
+# Stripe restricted-key labels must carry an opaque payload before becoming
+# sensitive, so configuration labels and explanatory prose such as
+# ``rk_live_fixture_name`` remain durable. These expressions stay deliberately
+# conservative so normal identifiers do not become secrets merely because they
+# happen to contain a dash or underscore.
 SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
     re.compile(r"hf_[A-Za-z0-9]{20,}"),

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -190,13 +190,11 @@ def is_sensitive_value(value: Any) -> bool:
     start = 0
     end = len(value)
     while start < end and (
-        value[start].isspace()
-        or unicodedata.category(value[start]).startswith(("C", "M"))
+        value[start].isspace() or unicodedata.category(value[start]).startswith(("C", "M"))
     ):
         start += 1
     while end > start and (
-        value[end - 1].isspace()
-        or unicodedata.category(value[end - 1]).startswith(("C", "M"))
+        value[end - 1].isspace() or unicodedata.category(value[end - 1]).startswith(("C", "M"))
     ):
         end -= 1
     normalized_value = value[start:end]

--- a/src/ouroboros/core/security.py
+++ b/src/ouroboros/core/security.py
@@ -61,6 +61,7 @@ _CREDENTIAL_FIELD_NAMES = frozenset(
         "auth_token",
         "authentication",
         "authorization",
+        "bearer",
         "bearer_token",
         "client_secret",
         "credential",
@@ -105,6 +106,11 @@ SENSITIVE_PREFIXES = (
     "ghu_",
     "ghs_",
     "ghr_",
+    # Stripe restricted keys carry the same authority as the more familiar
+    # ``sk_live_``/``sk_test_`` family.  Keep them in the shared detector so
+    # authority serialization, durable events, and log redaction cannot drift.
+    "rk_live_",
+    "rk_test_",
     "xoxb-",
     "xoxp-",
     "xoxa-",
@@ -123,6 +129,7 @@ SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
     re.compile(r"hf_[A-Za-z0-9]{20,}"),
     re.compile(r"sk_(?:live|test)_[A-Za-z0-9_-]{16,}"),
+    re.compile(r"rk_(?:live|test)_[A-Za-z0-9_-]{16,}"),
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
 )
 _PEM_PRIVATE_KEY_PATTERN = re.compile(
@@ -182,6 +189,7 @@ _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
     r"|xox[abpr]-[A-Za-z0-9-]{20,}"
     r"|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}"
     r"|sk_(?:live|test)_[A-Za-z0-9_-]{16,}"
+    r"|rk_(?:live|test)_[A-Za-z0-9_-]{16,}"
     r"|AIza[A-Za-z0-9_-]{35}"
     r"|(?:AKIA|ASIA)[0-9A-Z]{16}"
     r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"

--- a/src/ouroboros/events/base.py
+++ b/src/ouroboros/events/base.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
-from ouroboros.core.security import is_sensitive_value
+from ouroboros.core.security import is_sensitive_value, redact_sensitive_text
 
 _EXCLUDED_PERSISTENCE_KEYS = frozenset(
     {
@@ -104,12 +104,15 @@ def sanitize_event_data_for_persistence(value: Any) -> Any:
         sanitized: dict[Any, Any] = {}
         for key, item in value.items():
             normalized_key = str(key)
-            if _should_exclude_from_persistence(normalized_key) or is_sensitive_value(
-                normalized_key
-            ):
+            if _should_exclude_from_persistence(normalized_key):
                 continue
             if _is_sensitive_persistence_key(normalized_key):
                 sanitized[key] = "<REDACTED>"
+                continue
+            # A dynamic key may itself be a raw credential.  Check it after
+            # recognizing ordinary credential *field names*, which must be
+            # preserved as redacted fields for consumers and replay tooling.
+            if is_sensitive_value(normalized_key):
                 continue
             sanitized[key] = sanitize_event_data_for_persistence(item)
         return sanitized
@@ -117,8 +120,18 @@ def sanitize_event_data_for_persistence(value: Any) -> Any:
         return [sanitize_event_data_for_persistence(item) for item in value]
     if isinstance(value, tuple):
         return [sanitize_event_data_for_persistence(item) for item in value]
-    if isinstance(value, str) and is_sensitive_value(value):
-        return "<REDACTED>"
+    if isinstance(value, str):
+        redacted = redact_sensitive_text(value)
+        # Authority/configuration values must remain fail-closed when they are
+        # credential-shaped. Diagnostic text is different: retain its useful
+        # command or key/value context after removing the embedded secret.
+        # The separators avoid treating a compact identity such as
+        # ``branch-ghp_...`` as diagnostic prose.
+        if redacted != value and ("=" in value or any(char.isspace() for char in value)):
+            return redacted
+        if is_sensitive_value(value):
+            return "<REDACTED>"
+        return redacted
     return value
 
 

--- a/src/ouroboros/events/base.py
+++ b/src/ouroboros/events/base.py
@@ -13,7 +13,11 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
-from ouroboros.core.security import is_sensitive_value, redact_sensitive_text
+from ouroboros.core.security import (
+    is_sensitive_credential_field,
+    is_sensitive_value,
+    redact_sensitive_text,
+)
 
 _EXCLUDED_PERSISTENCE_KEYS = frozenset(
     {
@@ -32,38 +36,6 @@ _EXCLUDED_PERSISTENCE_KEYS = frozenset(
         "subscribed_payload",
         "subscribed_payloads",
     }
-)
-_SENSITIVE_PERSISTENCE_KEYS = frozenset(
-    {
-        "access_token",
-        "api_key",
-        "apikey",
-        "auth_token",
-        "authorization",
-        "bearer_token",
-        "client_secret",
-        "credential",
-        "credentials",
-        "id_token",
-        "passwd",
-        "password",
-        "private_key",
-        "refresh_token",
-        "secret",
-        "secret_access_key",
-        "token",
-    }
-)
-_SENSITIVE_PERSISTENCE_KEY_SUFFIXES = (
-    "_api_key",
-    "_credential",
-    "_credentials",
-    "_passwd",
-    "_password",
-    "_private_key",
-    "_secret",
-    "_secret_access_key",
-    "_token",
 )
 _PERSISTENCE_PROTOCOL_KEYS = frozenset({"resume_token"})
 
@@ -93,9 +65,7 @@ def _is_sensitive_persistence_key(key: str) -> bool:
     normalized = normalized.lower().replace("-", "_").replace(" ", "_")
     if normalized in _PERSISTENCE_PROTOCOL_KEYS:
         return False
-    return normalized in _SENSITIVE_PERSISTENCE_KEYS or normalized.endswith(
-        _SENSITIVE_PERSISTENCE_KEY_SUFFIXES
-    )
+    return is_sensitive_credential_field(key)
 
 
 def sanitize_event_data_for_persistence(value: Any) -> Any:

--- a/src/ouroboros/events/base.py
+++ b/src/ouroboros/events/base.py
@@ -7,10 +7,13 @@ All events in Ouroboros inherit from BaseEvent. Events are immutable
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import re
 from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
+
+from ouroboros.core.security import is_sensitive_value
 
 _EXCLUDED_PERSISTENCE_KEYS = frozenset(
     {
@@ -30,6 +33,39 @@ _EXCLUDED_PERSISTENCE_KEYS = frozenset(
         "subscribed_payloads",
     }
 )
+_SENSITIVE_PERSISTENCE_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth_token",
+        "authorization",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "id_token",
+        "passwd",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "secret_access_key",
+        "token",
+    }
+)
+_SENSITIVE_PERSISTENCE_KEY_SUFFIXES = (
+    "_api_key",
+    "_credential",
+    "_credentials",
+    "_passwd",
+    "_password",
+    "_private_key",
+    "_secret",
+    "_secret_access_key",
+    "_token",
+)
+_PERSISTENCE_PROTOCOL_KEYS = frozenset({"resume_token"})
 
 
 def _should_exclude_from_persistence(key: str) -> bool:
@@ -44,18 +80,45 @@ def _should_exclude_from_persistence(key: str) -> bool:
     )
 
 
+def _is_sensitive_persistence_key(key: str) -> bool:
+    """Return whether a key names a credential, without dropping protocol keys.
+
+    Event payloads use ordinary ``*_key`` fields for semantic AC identity,
+    idempotency, and correlation. The broad logging heuristic intentionally
+    treats every ``key`` substring as sensitive, but applying it here would
+    corrupt replay state. Restrict durable redaction to exact credential names
+    and credential-specific suffixes instead.
+    """
+    normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key.strip())
+    normalized = normalized.lower().replace("-", "_").replace(" ", "_")
+    if normalized in _PERSISTENCE_PROTOCOL_KEYS:
+        return False
+    return normalized in _SENSITIVE_PERSISTENCE_KEYS or normalized.endswith(
+        _SENSITIVE_PERSISTENCE_KEY_SUFFIXES
+    )
+
+
 def sanitize_event_data_for_persistence(value: Any) -> Any:
-    """Recursively strip raw subscribed payloads from persisted event data."""
+    """Strip raw payloads and credential-shaped values from persisted event data."""
     if isinstance(value, dict):
-        return {
-            key: sanitize_event_data_for_persistence(item)
-            for key, item in value.items()
-            if not _should_exclude_from_persistence(str(key))
-        }
+        sanitized: dict[Any, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key)
+            if _should_exclude_from_persistence(normalized_key) or is_sensitive_value(
+                normalized_key
+            ):
+                continue
+            if _is_sensitive_persistence_key(normalized_key):
+                sanitized[key] = "<REDACTED>"
+                continue
+            sanitized[key] = sanitize_event_data_for_persistence(item)
+        return sanitized
     if isinstance(value, list):
         return [sanitize_event_data_for_persistence(item) for item in value]
     if isinstance(value, tuple):
         return [sanitize_event_data_for_persistence(item) for item in value]
+    if isinstance(value, str) and is_sensitive_value(value):
+        return "<REDACTED>"
     return value
 
 

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -133,6 +133,20 @@ class ClaudeWorkerTransport:
         # command builder just appends the flags. Empty ⇒ no ``--add-dir`` at all.
         self._add_dirs = _resolve_add_dirs(context_reference_dirs, cwd=cwd)
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare static command policy; authority binds executable bytes separately."""
+        return {
+            "version": 1,
+            "configuration": {
+                "cwd": self._cwd,
+                "timeout": self._timeout,
+                "disallowed_tools": list(self._disallowed_tools),
+                "persist_sessions": self._persist_sessions,
+                "add_dirs": list(self._add_dirs),
+                "child_environment_policy_version": 1,
+            },
+        }
+
     @staticmethod
     def _permission_args(permission_mode: str | None) -> list[str]:
         normalized = (permission_mode or "").strip().lower()

--- a/src/ouroboros/orchestrator/codex_mcp_runtime.py
+++ b/src/ouroboros/orchestrator/codex_mcp_runtime.py
@@ -126,6 +126,21 @@ class CodexMcpWorkerTransport:
         # across turns so codex-reply reaches the SAME (process-bound) server.
         self._pool: dict[str, MCPSessionActor] = {}
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare static server policy while excluding the live session pool."""
+        return {
+            "version": 1,
+            "configuration": {
+                "connect_timeout": self._connect_timeout,
+                "idle_timeout": self._idle_timeout,
+                "disabled_mcp_servers": list(self._disabled_mcp_servers),
+                "index_sessions": self._index_sessions,
+                "codex_home": self._codex_home,
+                "resume_scope": "process_bound_pool_v1",
+                "child_environment_policy_version": 1,
+            },
+        }
+
     def _server_config(self) -> MCPServerConfig:
         # Strip ouroboros MCP env vars so the spawned codex server cannot recurse
         # back into the ouroboros MCP server (#185 child-env discipline).

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import stat
 from typing import Any
 import uuid
 
@@ -37,7 +38,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
-EXECUTION_AUTHORITY_VERSION = 2
+EXECUTION_AUTHORITY_VERSION = 3
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
@@ -202,10 +203,23 @@ def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
     identity = provider()
     if not isinstance(identity, Mapping):
         raise ValueError("runtime execution identity contract is not a mapping")
-    normalized = _canonical_object(
+    projected = _project_explicit_identity(
         dict(identity),
         field="runtime execution identity contract",
     )
+    try:
+        _reject_sensitive_identity_fields(projected)
+    except ValueError:
+        # Provider-owned credential-bearing identity must never reach the public
+        # authority payload. Mark it unobserved so portability fails closed.
+        return {"version": 1, "observed": False}
+    normalized = _canonical_object(
+        projected,
+        field="runtime execution identity contract",
+    )
+    encoded = _canonical_json(normalized, field="runtime execution identity contract")
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        raise ValueError("runtime execution identity contract exceeds its budget")
     return {"version": 1, "observed": True, "identity": normalized}
 
 
@@ -450,28 +464,32 @@ def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object]
         realpath = os.path.realpath(expanded)
     generation: dict[str, int] | None = None
     content_digest: str | None = None
+    executable: bool | None = None
     if realpath is not None:
         try:
             digest = hashlib.sha256()
             with Path(realpath).open("rb") as executable_file:
-                stat = os.fstat(executable_file.fileno())
+                file_stat = os.fstat(executable_file.fileno())
                 while chunk := executable_file.read(1024 * 1024):
                     digest.update(chunk)
         except OSError:
             pass
         else:
             generation = {
-                "device": stat.st_dev,
-                "inode": stat.st_ino,
-                "size": stat.st_size,
-                "mtime_ns": stat.st_mtime_ns,
+                "device": file_stat.st_dev,
+                "inode": file_stat.st_ino,
+                "size": file_stat.st_size,
+                "mtime_ns": file_stat.st_mtime_ns,
+                "mode": stat.S_IMODE(file_stat.st_mode),
             }
             content_digest = "sha256:" + digest.hexdigest()
+            executable = bool(generation["mode"] & 0o111) and os.access(realpath, os.X_OK)
     return {
         "path": value,
         "realpath": realpath,
         "generation": generation,
         "content_digest": content_digest,
+        "executable": executable,
     }
 
 
@@ -509,6 +527,7 @@ def _runtime_executable_contract(adapter: object) -> dict[str, object]:
         or item.get("realpath") is not None
         and item.get("generation") is not None
         and item.get("content_digest") is not None
+        and item.get("executable") is True
         for item in (executable, launcher)
     )
     return {
@@ -649,13 +668,13 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def _class_implementation_contract(adapter: object) -> dict[str, object]:
-    """Bind one object's class hierarchy without inspecting its instance state."""
+def _class_implementation_contract_for_type(runtime_type: type[object]) -> dict[str, object]:
+    """Bind one class hierarchy without inspecting mutable instance state."""
     classes: list[str] = []
     members: dict[str, object] = {}
     modules: dict[str, object] = {}
     durable = True
-    for runtime_class in type(adapter).__mro__:
+    for runtime_class in runtime_type.__mro__:
         if runtime_class is object:
             continue
         qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
@@ -722,6 +741,11 @@ def _class_implementation_contract(adapter: object) -> dict[str, object]:
     }
 
 
+def _class_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind one object's class hierarchy without inspecting its instance state."""
+    return _class_implementation_contract_for_type(type(adapter))
+
+
 def _safe_class_implementation_contract(value: object) -> dict[str, object]:
     try:
         return _class_implementation_contract(value)
@@ -759,25 +783,108 @@ def _instance_declared_method_overrides(value: object) -> dict[str, object]:
     return overrides
 
 
-def _executor_implementation_contract(executor: object | None) -> dict[str, object]:
+def _static_executor_component_contract(component: type[object]) -> dict[str, object]:
+    """Bind a class-selected execution component without constructing it."""
+    try:
+        implementation = _class_implementation_contract_for_type(component)
+    except Exception as exc:
+        return {
+            "mode": "static_type",
+            "stability": "process_local",
+            "type": f"{component.__module__}.{component.__qualname__}",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+    durable = implementation.get("stability") == "durable"
+    contract: dict[str, object] = {
+        "mode": "static_type",
+        "stability": "durable" if durable else "process_local",
+        "type": f"{component.__module__}.{component.__qualname__}",
+        "implementation": implementation,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _executor_component_contract(component: object) -> dict[str, object]:
+    """Describe one explicit executor-owned effect component.
+
+    A class-selected dispatcher is static executor behavior and can be durable.
+    A live helper instance, such as a session-signal hub, owns mutable
+    attempt-time state. Record its presence and implementation but never
+    serialize its queue, event store, or active targets into the baseline.
+    """
+    if component is None:
+        return {"mode": "none", "stability": "durable"}
+    if isinstance(component, type):
+        return _static_executor_component_contract(component)
+    return {
+        "mode": "live_instance",
+        "stability": "process_local",
+        "type": _qualified_type(component),
+        "implementation": _safe_class_implementation_contract(component),
+        "instance_nonce": uuid.uuid4().hex,
+    }
+
+
+def _executor_component_contracts(
+    components: Mapping[str, object] | None,
+) -> dict[str, object]:
+    if components is None:
+        return {}
+    try:
+        if len(components) > _MAX_IDENTITY_ITEMS or not all(
+            isinstance(name, str) and name for name in components
+        ):
+            raise ValueError("executor components are invalid")
+        return {
+            name: _executor_component_contract(component) for name, component in components.items()
+        }
+    except Exception as exc:
+        return {
+            "unobserved": {
+                "mode": "process_local",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            }
+        }
+
+
+def _executor_implementation_contract(
+    executor: object | None,
+    *,
+    components: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     """Bind the concrete effect-owning executor or fail closed when absent."""
+    component_contracts = _executor_component_contracts(components)
     if executor is None:
         return {
-            "version": 1,
+            "version": 2,
             "mode": "unbound",
             "stability": "process_local",
             "instance_nonce": uuid.uuid4().hex,
+            "components": component_contracts,
         }
     implementation = _safe_class_implementation_contract(executor)
     instance_overrides = _instance_declared_method_overrides(executor)
-    durable = implementation.get("stability") == "durable" and not instance_overrides
+    durable = (
+        implementation.get("stability") == "durable"
+        and not instance_overrides
+        and all(
+            isinstance(component, Mapping) and component.get("stability") == "durable"
+            for component in component_contracts.values()
+        )
+    )
     contract: dict[str, object] = {
-        "version": 1,
+        "version": 2,
         "mode": "bound",
         "type": _qualified_type(executor),
         "stability": "durable" if durable else "process_local",
         "implementation": implementation,
         "instance_overrides": instance_overrides,
+        "components": component_contracts,
     }
     if not durable:
         contract["instance_nonce"] = uuid.uuid4().hex
@@ -1408,6 +1515,7 @@ class ExecutionAuthorityContract:
         workspace: str | None,
         execution_policy: Mapping[str, object],
         executor: object | None = None,
+        executor_components: Mapping[str, object] | None = None,
         workspace_identity: Mapping[str, object] | None = None,
         workspace_generation: Mapping[str, object] | None = None,
         resolved_routing: ResolvedRuntimeAuthority | None = None,
@@ -1416,7 +1524,10 @@ class ExecutionAuthorityContract:
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
-            "executor": _executor_implementation_contract(executor),
+            "executor": _executor_implementation_contract(
+                executor,
+                components=executor_components,
+            ),
             "workspace": canonical_workspace_authority(
                 workspace,
                 identity=workspace_identity,

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -37,7 +37,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
-EXECUTION_AUTHORITY_VERSION = 1
+EXECUTION_AUTHORITY_VERSION = 2
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
@@ -391,7 +391,18 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
     elif inspect.isfunction(target) or inspect.isbuiltin(target):
         implementation = target
     else:
-        implementation = type(target).__call__
+        class_contract = _safe_class_implementation_contract(target)
+        instance_overrides = _instance_executable_overrides(target)
+        durable = class_contract.get("stability") == "durable" and not instance_overrides
+        contract: dict[str, object] = {
+            **class_contract,
+            "stability": "durable" if durable else "process_local",
+            "entrypoint": _callable_implementation_contract(type(target).__call__),
+            "instance_overrides": instance_overrides,
+        }
+        if not durable:
+            contract["instance_nonce"] = uuid.uuid4().hex
+        return contract
     return _callable_implementation_contract(implementation)
 
 
@@ -540,6 +551,24 @@ def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
 
 
 def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
+    interceptor_descriptor = inspect.getattr_static(adapter, "_interceptor", None)
+    if interceptor_descriptor is not None:
+        try:
+            interceptor = object.__getattribute__(adapter, "_interceptor")
+            component = _declared_component_contract(interceptor)
+        except Exception as exc:
+            return {
+                "mode": "delegated",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            }
+        return {
+            "mode": "delegated",
+            "stability": component.get("stability", "process_local"),
+            "component": component,
+        }
+
     dispatcher_descriptor = inspect.getattr_static(adapter, "_skill_dispatcher", None)
     dispatcher = (
         object.__getattribute__(adapter, "_skill_dispatcher")
@@ -695,6 +724,57 @@ def _safe_class_implementation_contract(value: object) -> dict[str, object]:
             "observed": False,
             "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
         }
+
+
+def _instance_declared_method_overrides(value: object) -> dict[str, object]:
+    """Bind only instance state that shadows executable class members."""
+    try:
+        instance_state = vars(value)
+    except TypeError:
+        return {}
+    missing = object()
+    overrides: dict[str, object] = {}
+    for name, item in instance_state.items():
+        if not isinstance(name, str) or not name:
+            continue
+        class_member = inspect.getattr_static(type(value), name, missing)
+        if class_member is missing or not (
+            callable(class_member) or isinstance(class_member, (classmethod, staticmethod))
+        ):
+            continue
+        if callable(item):
+            overrides[name] = {
+                "mode": "callable",
+                "implementation": _callable_entrypoint_contract(item),
+            }
+        else:
+            overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
+    return overrides
+
+
+def _executor_implementation_contract(executor: object | None) -> dict[str, object]:
+    """Bind the concrete effect-owning executor or fail closed when absent."""
+    if executor is None:
+        return {
+            "version": 1,
+            "mode": "unbound",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+        }
+    implementation = _safe_class_implementation_contract(executor)
+    instance_overrides = _instance_declared_method_overrides(executor)
+    durable = implementation.get("stability") == "durable" and not instance_overrides
+    contract: dict[str, object] = {
+        "version": 1,
+        "mode": "bound",
+        "type": _qualified_type(executor),
+        "stability": "durable" if durable else "process_local",
+        "implementation": implementation,
+        "instance_overrides": instance_overrides,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
 
 
 def _reject_sensitive_identity_fields(value: object) -> None:
@@ -1276,6 +1356,7 @@ class ExecutionAuthorityContract:
         )
         if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != {
             "version",
+            "executor",
             "workspace",
             "runtime",
             "verifier",
@@ -1319,6 +1400,7 @@ class ExecutionAuthorityContract:
         verifier: Verifier | None,
         workspace: str | None,
         execution_policy: Mapping[str, object],
+        executor: object | None = None,
         workspace_identity: Mapping[str, object] | None = None,
         workspace_generation: Mapping[str, object] | None = None,
         resolved_routing: ResolvedRuntimeAuthority | None = None,
@@ -1327,6 +1409,7 @@ class ExecutionAuthorityContract:
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
+            "executor": _executor_implementation_contract(executor),
             "workspace": canonical_workspace_authority(
                 workspace,
                 identity=workspace_identity,
@@ -1368,6 +1451,9 @@ class ExecutionAuthorityContract:
         those require a complete per-attempt capsule with the omitted inputs.
         """
         data = self.data
+        executor = data.get("executor")
+        if not isinstance(executor, Mapping) or executor.get("stability") != "durable":
+            return False
         workspace = data.get("workspace")
         if not isinstance(workspace, Mapping) or workspace.get("observed") is not True:
             return False

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,16 +1,18 @@
-"""Canonical executor-baseline authority shared by later runtime layers.
+"""Canonical portable executor baseline shared by later runtime layers.
 
-This module owns identity only. It does not authorize a dispatch, persist a
-checkpoint, or declare acceptance. Per-attempt inputs such as the AC, prompt,
-tool envelope, and a checkpoint-selected resume handle belong to the later
-attempt capsule. That capsule can compose this stable baseline instead of
-deriving narrower runtime, verifier, workspace, and policy fingerprints again.
+This module owns *baseline* identity only.  It does not authorize dispatch,
+persist checkpoints, select a resume handle, or declare acceptance.  The
+contract has an explicit boundary: a later attempt capsule owns AC semantics,
+prompt/tool data, runtime-handle selection, handle-manager state, and recovery;
+event delivery and live signal state remain volatile.  That prevents a baseline
+fingerprint from pretending to be a complete fingerprint of an active attempt.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from enum import Enum
 import hashlib
 import inspect
 import json
@@ -19,12 +21,14 @@ import math
 import os
 from pathlib import Path
 import re
+import secrets
 import shutil
 import stat
+import threading
 from typing import Any
-import uuid
+import weakref
 
-from ouroboros.core.security import is_sensitive_field
+from ouroboros.core.security import is_sensitive_field, is_sensitive_value
 from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
@@ -38,13 +42,31 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
-EXECUTION_AUTHORITY_VERSION = 3
+EXECUTION_AUTHORITY_VERSION = 5
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 1
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
+_MAX_IDENTITY_FILE_BYTES = 16 * 1024 * 1024
+_MAX_CALLABLE_DEPENDENCY_DEPTH = 16
 _RESOLVED_RUNTIME_AUTHORITY_TOKEN = object()
+_RESOLVED_RUNTIME_LABEL_BINDING_KEY = secrets.token_bytes(32)
+_RESOLVED_RUNTIME_EXECUTION_BINDING_KEY = secrets.token_bytes(32)
+_WORKSPACE_AUTHORITY_BINDING_KEY = secrets.token_bytes(32)
 _SHA256_DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+_IDENTITY_UNAVAILABLE_REASON = "identity_unavailable"
+_PROCESS_LOCAL_RUNTIME_NONCES: dict[int, tuple[weakref.ReferenceType[object], str]] = {}
+_PROCESS_LOCAL_RUNTIME_NONCES_LOCK = threading.Lock()
+_WORKSPACE_PATH_IDENTITY_FIELDS = frozenset(
+    {
+        "effective_cwd",
+        "original_cwd",
+        "repo_root",
+        "worktree_path",
+        "lock_path",
+    }
+)
 _EXECUTION_POLICY_VERSION = 1
 _EXECUTION_POLICY_KEYS = {
     "version",
@@ -62,6 +84,123 @@ _EXECUTION_POLICY_KEYS = {
     "shadow_replay_enabled",
     "dispatch_rate",
 }
+
+# This is a deliberately finite authority boundary.  Do not infer more
+# collaborators by traversing the live object graph: additions belong in the
+# named later layer, together with that layer's own replay/acceptance tests.
+_PORTABLE_BASELINE_BOUNDARY = (
+    "executor_implementation",
+    "leaf_dispatcher_implementation",
+    "dispatch_token_estimator_implementation",
+    "runtime_adapter_configuration",
+    "workspace_generation",
+    "verifier_implementation",
+    "execution_policy",
+)
+_PER_ATTEMPT_CAPSULE_BOUNDARY = (
+    "ac_semantics",
+    "prompt_and_tool_catalog",
+    "selected_runtime_handle",
+    "ac_runtime_handle_manager",
+    "checkpoint_and_resume_state",
+    "level_coordinator_behavior_and_session_state",
+)
+_VOLATILE_BOUNDARY = (
+    "session_signal_hub",
+    "event_store_handle",
+    "execution_event_emitter",
+    "locks_and_live_pools",
+)
+_PORTABLE_EXECUTOR_COMPONENTS = frozenset({"leaf_dispatcher", "dispatch_token_estimator"})
+_UNBOUND_EXECUTOR_NONCE_OWNER = object()
+# These module bindings are named explicitly in the Foundation-A boundary as
+# per-attempt or volatile collaborators. Their implementation/state belongs to
+# later capsules, so following them through an executor method would quietly
+# reintroduce excluded authority through a callable-global graph.
+_PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS = frozenset(
+    {
+        ("ouroboros.orchestrator.parallel_executor", "LevelCoordinator"),
+        ("ouroboros.orchestrator.parallel_executor", "ACRuntimeHandleManager"),
+        ("ouroboros.orchestrator.parallel_executor", "ExecutionEventEmitter"),
+    }
+)
+
+
+def execution_authority_boundary_contract() -> dict[str, object]:
+    """Return the versioned Foundation-A inclusion/exclusion matrix.
+
+    The matrix is part of canonical authority JSON so a caller cannot confuse a
+    portable baseline with the later per-attempt or event/recovery contracts.
+    """
+    return {
+        "version": EXECUTION_AUTHORITY_BOUNDARY_VERSION,
+        "portable_baseline": list(_PORTABLE_BASELINE_BOUNDARY),
+        "per_attempt_capsule": list(_PER_ATTEMPT_CAPSULE_BOUNDARY),
+        "volatile": list(_VOLATILE_BOUNDARY),
+    }
+
+
+def _valid_execution_authority_boundary(value: object) -> bool:
+    return value == execution_authority_boundary_contract()
+
+
+def _process_local_runtime_nonce(*identity_inputs: object) -> str:
+    """Return a stable-in-process opaque nonce without retaining collaborators.
+
+    A process-local baseline still needs repeatable snapshots for one live
+    object: runner routing compares its pre-dispatch snapshot with the snapshot
+    taken during construction.  A strong object-keyed cache would keep clients,
+    pools, and possibly credentials alive forever, however.  An identity-keyed
+    weak-reference side table gives each live object one random nonce and
+    removes the entry on collection; no adapter state is mutated or retained.
+    """
+    if not identity_inputs:
+        raise ValueError("a process-local identity needs at least one input")
+    primary = identity_inputs[0]
+    object_id = id(primary)
+    try:
+        with _PROCESS_LOCAL_RUNTIME_NONCES_LOCK:
+            cached = _PROCESS_LOCAL_RUNTIME_NONCES.get(object_id)
+            if cached is not None and cached[0]() is primary:
+                return cached[1]
+
+            nonce = secrets.token_hex(32)
+
+            def discard(dead_reference: weakref.ReferenceType[object], *, key: int = object_id) -> None:
+                with _PROCESS_LOCAL_RUNTIME_NONCES_LOCK:
+                    current = _PROCESS_LOCAL_RUNTIME_NONCES.get(key)
+                    if current is not None and current[0] is dead_reference:
+                        _PROCESS_LOCAL_RUNTIME_NONCES.pop(key, None)
+
+            _PROCESS_LOCAL_RUNTIME_NONCES[object_id] = (weakref.ref(primary, discard), nonce)
+            return nonce
+    except TypeError:
+        # ``__slots__``-only and foreign extension objects can be non-weakrefable.
+        # Retaining an ``id()`` table for them would reintroduce both a strong
+        # reference leak and object-id reuse risk.  Make that narrow fallback
+        # explicitly unstable instead: it can never claim cross-snapshot or
+        # cross-process portability, but it also cannot accidentally collide
+        # with a later object that reuses the same address.
+        return secrets.token_hex(32)
+
+
+def _unobserved_runtime_execution_identity(
+    adapter: object,
+    *,
+    process_local: bool,
+) -> dict[str, object]:
+    identity: dict[str, object] = {"version": 1, "observed": False}
+    if process_local:
+        identity["instance_nonce"] = _process_local_runtime_nonce(adapter)
+    return identity
+
+
+def _safe_runtime_attribute(adapter: object, name: str, default: object = None) -> object:
+    """Read provider state without allowing provider exception text to escape."""
+    try:
+        return getattr(adapter, name, default)
+    except Exception:
+        return default
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -88,6 +227,78 @@ def _sha256(value: str) -> str:
     return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _workspace_authority_contains_sensitive_data(value: object) -> bool:
+    """Return whether a workspace identity would disclose sensitive data."""
+    try:
+        _reject_sensitive_identity_fields(value)
+    except Exception:
+        return True
+    return False
+
+
+def _resolved_workspace_path(value: object) -> str | None:
+    """Resolve one workspace path without reflecting invalid provider input."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return str(Path(value).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return None
+
+
+def _canonical_workspace_identity_paths(
+    identity: Mapping[str, object],
+) -> dict[str, object] | None:
+    """Resolve path-bearing workspace fields before identity serialization.
+
+    A benign-looking symlink can resolve to a credential-shaped directory name.
+    Canonical workspace identity must inspect the same resolved path that
+    execution uses; otherwise that target enters durable authority JSON.
+    """
+    canonical = dict(identity)
+    for field_name in _WORKSPACE_PATH_IDENTITY_FIELDS:
+        if field_name not in canonical:
+            continue
+        resolved = _resolved_workspace_path(canonical[field_name])
+        if resolved is None:
+            return None
+        canonical[field_name] = resolved
+    return canonical
+
+
+def _process_local_workspace_authority(*identity_inputs: object) -> dict[str, object]:
+    """Return a non-portable workspace marker without serializing its paths.
+
+    Workspace paths, branch names, and caller-supplied identity fields can be
+    provider-controlled strings. When one contains a credential-shaped value,
+    preserve a same-process distinction with a keyed digest while omitting every
+    raw path/value from the baseline. The secret key is process-local, so this
+    marker can never claim cross-process portability or reusable authority.
+    """
+    digest = hashlib.blake2b(
+        key=_WORKSPACE_AUTHORITY_BINDING_KEY,
+        digest_size=32,
+    )
+    for index, value in enumerate(identity_inputs):
+        try:
+            encoded = _canonical_json(value, field="workspace identity")
+        except Exception:
+            encoded = f"unavailable:{id(value)}:{id(type(value))}"
+        encoded_bytes = encoded.encode("utf-8", errors="surrogatepass")
+        digest.update(index.to_bytes(2, byteorder="big", signed=False))
+        digest.update(len(encoded_bytes).to_bytes(8, byteorder="big", signed=False))
+        digest.update(encoded_bytes)
+    return {
+        "version": 1,
+        "observed": False,
+        "identity": {
+            "mode": "process_local",
+            "binding_digest": "blake2b:" + digest.hexdigest(),
+        },
+        "generation": {"observed": False},
+    }
+
+
 def canonical_workspace_authority(
     workspace: str | None,
     *,
@@ -95,21 +306,42 @@ def canonical_workspace_authority(
     generation: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Return the checkout owner plus an optional immutable generation identity."""
+    normalized_identity: dict[str, object] | None = None
+    normalized_generation: dict[str, object] | None = None
+    resolved_workspace = _resolved_workspace_path(workspace)
     if identity is not None:
-        owner = _canonical_object(dict(identity), field="workspace identity")
+        normalized_identity = _canonical_object(dict(identity), field="workspace identity")
+        resolved_identity = _canonical_workspace_identity_paths(normalized_identity)
+        if (
+            resolved_identity is None
+            or _workspace_authority_contains_sensitive_data(normalized_identity)
+            or _workspace_authority_contains_sensitive_data(resolved_identity)
+            or is_sensitive_value(workspace)
+            or is_sensitive_value(resolved_workspace)
+        ):
+            return _process_local_workspace_authority(
+                workspace,
+                normalized_identity,
+                generation,
+            )
+        owner = resolved_identity
         resolved_cwd = owner.get("effective_cwd")
         if (
-            not isinstance(workspace, str)
-            or not workspace.strip()
+            resolved_workspace is None
             or not isinstance(resolved_cwd, str)
-            or str(Path(workspace).expanduser().resolve(strict=False))
-            != str(Path(resolved_cwd).expanduser().resolve(strict=False))
+            or resolved_workspace != resolved_cwd
         ):
             raise ValueError("workspace identity disagrees with the effective workspace")
     elif isinstance(workspace, str) and workspace.strip():
+        if (
+            resolved_workspace is None
+            or is_sensitive_value(workspace)
+            or is_sensitive_value(resolved_workspace)
+        ):
+            return _process_local_workspace_authority(workspace, generation)
         owner = {
             "mode": "direct",
-            "effective_cwd": str(Path(workspace).expanduser().resolve(strict=False)),
+            "effective_cwd": resolved_workspace,
         }
     else:
         return {
@@ -119,16 +351,22 @@ def canonical_workspace_authority(
         }
     generation_contract: dict[str, object] = {"observed": False}
     if generation is not None:
-        generation_identity = _canonical_object(
+        normalized_generation = _canonical_object(
             dict(generation),
             field="workspace generation",
         )
-        if generation_identity:
-            if not _valid_workspace_generation_identity(generation_identity):
+        if _workspace_authority_contains_sensitive_data(normalized_generation):
+            return _process_local_workspace_authority(
+                workspace,
+                normalized_identity,
+                normalized_generation,
+            )
+        if normalized_generation:
+            if not _valid_workspace_generation_identity(normalized_generation):
                 raise ValueError("workspace generation identity is invalid")
             generation_contract = {
                 "observed": True,
-                "identity": generation_identity,
+                "identity": normalized_generation,
             }
     return {
         "version": 1,
@@ -162,8 +400,11 @@ def constructor_model_contract(adapter: object) -> dict[str, object]:
         return {"observed": False}
     if raw_model is None:
         return {"observed": True, "model": None}
-    if not isinstance(raw_model, str):
-        return {"observed": False}
+    if not isinstance(raw_model, str) or is_sensitive_value(raw_model):
+        return {
+            "observed": False,
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+        }
 
     normalized_model: object = raw_model.strip() or None
     normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
@@ -172,11 +413,21 @@ def constructor_model_contract(adapter: object) -> dict[str, object]:
             normalizer = object.__getattribute__(adapter, "_normalize_model")
             normalized_model = normalizer(raw_model)
         except Exception:
-            return {"observed": False}
+            return {
+                "observed": False,
+                "instance_nonce": _process_local_runtime_nonce(adapter),
+            }
     if normalized_model is None:
         return {"observed": True, "model": None}
-    if not isinstance(normalized_model, str) or not normalized_model.strip():
-        return {"observed": False}
+    if (
+        not isinstance(normalized_model, str)
+        or not normalized_model.strip()
+        or is_sensitive_value(normalized_model)
+    ):
+        return {
+            "observed": False,
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+        }
     return {"observed": True, "model": normalized_model.strip()}
 
 
@@ -185,41 +436,70 @@ def valid_constructor_model_contract(value: object) -> bool:
         return False
     model = value.get("model")
     return set(value) == {"observed", "model"} and (
-        model is None or isinstance(model, str) and bool(model.strip())
+        model is None
+        or isinstance(model, str)
+        and bool(model.strip())
+        and not is_sensitive_value(model)
     )
 
 
-def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
-    """Return backend-specific resolved identity without backend logic here."""
+def runtime_execution_identity_contract(
+    adapter: object,
+    *,
+    include_process_local_nonce: bool = True,
+) -> dict[str, object]:
+    """Return backend-specific resolved identity without backend logic here.
+
+    A runner's durable routing payload needs to preserve the legacy
+    ``observed=False`` shape so it can still validate an otherwise observable
+    runtime configuration on a later process. The Foundation-A baseline, in
+    contrast, must distinguish live instances that cannot provide an identity.
+    Callers building a baseline therefore retain the default nonce, while the
+    runner and its pre-dispatch binding use ``False`` and add the nonce only to
+    the constructed baseline.
+    """
     provider_descriptor = inspect.getattr_static(
         type(adapter),
         "execution_identity_contract",
         None,
     )
     if provider_descriptor is None:
-        return {"version": 1, "observed": False}
+        # Missing provider identity is a collision risk even when the concrete
+        # class happens to be known: private runtime state can still select
+        # materially different behavior.  Keep same-instance snapshots stable
+        # but never let two live instances share this non-portable identity.
+        return _unobserved_runtime_execution_identity(
+            adapter,
+            process_local=include_process_local_nonce,
+        )
 
-    provider = object.__getattribute__(adapter, "execution_identity_contract")
-    identity = provider()
-    if not isinstance(identity, Mapping):
-        raise ValueError("runtime execution identity contract is not a mapping")
-    projected = _project_explicit_identity(
-        dict(identity),
-        field="runtime execution identity contract",
-    )
     try:
-        _reject_sensitive_identity_fields(projected)
-    except ValueError:
+        provider = object.__getattribute__(adapter, "execution_identity_contract")
+        identity = provider()
+    except Exception:
+        # A declared provider that cannot report its identity is a construction
+        # failure, not an optional missing declaration. Do not dispatch through
+        # that ambiguity, and do not surface provider-controlled error text.
+        raise ValueError("runtime execution identity provider failed") from None
+    try:
+        if not isinstance(identity, Mapping):
+            raise ValueError("runtime execution identity contract is not a mapping")
+        normalized = _canonical_explicit_identity(
+            dict(identity),
+            field="runtime execution identity contract",
+        )
+    except Exception:
         # Provider-owned credential-bearing identity must never reach the public
         # authority payload. Mark it unobserved so portability fails closed.
-        return {"version": 1, "observed": False}
-    normalized = _canonical_object(
-        projected,
-        field="runtime execution identity contract",
-    )
-    encoded = _canonical_json(normalized, field="runtime execution identity contract")
-    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
-        raise ValueError("runtime execution identity contract exceeds its budget")
+        return _unobserved_runtime_execution_identity(
+            adapter,
+            process_local=include_process_local_nonce,
+        )
+    if not normalized:
+        return _unobserved_runtime_execution_identity(
+            adapter,
+            process_local=include_process_local_nonce,
+        )
     return {"version": 1, "observed": True, "identity": normalized}
 
 
@@ -236,7 +516,12 @@ def valid_runtime_execution_identity_contract(value: object) -> bool:
     ):
         return False
     if not observed:
-        return set(value) == {"version", "observed"}
+        nonce = value.get("instance_nonce")
+        return set(value) == {"version", "observed"} or (
+            set(value) == {"version", "observed", "instance_nonce"}
+            and isinstance(nonce, str)
+            and bool(nonce)
+        )
     identity = value.get("identity")
     if (
         set(value) != {"version", "observed", "identity"}
@@ -245,6 +530,7 @@ def valid_runtime_execution_identity_contract(value: object) -> bool:
     ):
         return False
     try:
+        _reject_sensitive_identity_fields(identity)
         _canonical_json(dict(identity), field="runtime execution identity contract")
     except ValueError:
         return False
@@ -260,37 +546,254 @@ def runtime_execution_proves_effective_model(value: object) -> bool:
     return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
 
 
-def runtime_permission_mode_contract(adapter: object) -> dict[str, object]:
-    """Return the normalized permission mode that the runtime actually executes."""
-    permission_mode: object = None
-    private_descriptor = inspect.getattr_static(adapter, "_permission_mode", None)
-    if private_descriptor is not None:
-        permission_mode = object.__getattribute__(adapter, "_permission_mode")
-    if not isinstance(permission_mode, str) or not permission_mode.strip():
-        permission_mode = getattr(adapter, "permission_mode", None)
+def _identity_digest(value: Mapping[str, object], *, field: str) -> str:
+    """Return an opaque digest without persisting provider-controlled values."""
+    return _sha256(_canonical_json(dict(value), field=field))
+
+
+def _authority_runtime_execution_identity(
+    value: object,
+    *,
+    adapter: object,
+) -> dict[str, object]:
+    """Project a runner identity into safe baseline authority data.
+
+    Runner resume contracts may need provider-specific fields to validate an
+    active run.  Foundation A never serializes those literal values: it records
+    only their deterministic digest and the one model-observation bit the
+    baseline needs.  Known credential-bearing values still fail closed before
+    this point; opaque provider values cannot egress through authority JSON.
+    """
+    if not valid_runtime_execution_identity_contract(value):
+        raise ValueError("runtime execution identity contract is invalid")
+    assert isinstance(value, Mapping)  # narrowed by the validator above
+    if value.get("observed") is not True:
+        result: dict[str, object] = {"version": 1, "observed": False}
+        nonce = value.get("instance_nonce")
+        result["instance_nonce"] = (
+            nonce
+            if isinstance(nonce, str) and nonce
+            else _process_local_runtime_nonce(adapter)
+        )
+        return result
+    identity = value.get("identity")
+    assert isinstance(identity, Mapping)  # narrowed by the validator above
+    return {
+        "version": 1,
+        "observed": True,
+        "effective_model_observed": identity.get("effective_model_observed") is True,
+        "identity_digest": _identity_digest(
+            identity,
+            field="runtime execution identity contract",
+        ),
+    }
+
+
+def _valid_authority_runtime_execution_identity(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    observed = value.get("observed")
+    if observed is False:
+        nonce = value.get("instance_nonce")
+        return set(value) == {"version", "observed"} or (
+            set(value) == {"version", "observed", "instance_nonce"}
+            and isinstance(nonce, str)
+            and bool(nonce)
+        )
     return (
-        {"observed": True, "mode": permission_mode.strip()}
-        if isinstance(permission_mode, str) and permission_mode.strip()
-        else {"observed": False}
+        observed is True
+        and set(value)
+        == {"version", "observed", "effective_model_observed", "identity_digest"}
+        and isinstance(value.get("effective_model_observed"), bool)
+        and isinstance(value.get("identity_digest"), str)
+        and _SHA256_DIGEST_PATTERN.fullmatch(value["identity_digest"]) is not None
     )
 
 
-def _active_resolved_runtime_fields(adapter: object) -> dict[str, object]:
-    runtime_backend = getattr(adapter, "runtime_backend", None)
-    llm_backend = getattr(adapter, "llm_backend", None)
+def runtime_permission_mode_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized permission mode that the runtime actually executes."""
+    permission_mode: object = None
+    missing = object()
+    private_descriptor = inspect.getattr_static(adapter, "_permission_mode", missing)
+    if private_descriptor is not missing:
+        try:
+            permission_mode = object.__getattribute__(adapter, "_permission_mode")
+        except Exception:
+            return {
+                "observed": False,
+                "instance_nonce": _process_local_runtime_nonce(adapter),
+            }
+        if permission_mode is None:
+            # A declared private ``None`` is an explicit configuration choice,
+            # not an unobservable provider value.  This matters for generic
+            # worker runtimes whose transport policy is otherwise fully
+            # authority-bound, and avoids spuriously tying a baseline to a
+            # newly-created wrapper instance.
+            return {"observed": True, "mode": None}
+    if not isinstance(permission_mode, str) or not permission_mode.strip():
+        permission_mode = _safe_runtime_attribute(adapter, "permission_mode")
+    if (
+        isinstance(permission_mode, str)
+        and permission_mode.strip()
+        and not is_sensitive_value(permission_mode)
+    ):
+        return {"observed": True, "mode": permission_mode.strip()}
     return {
-        "runtime_backend": (
-            runtime_backend.strip()
-            if isinstance(runtime_backend, str) and runtime_backend.strip()
-            else None
-        ),
-        "llm_backend": (
-            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
-        ),
+        "observed": False,
+        "instance_nonce": _process_local_runtime_nonce(adapter),
+    }
+
+
+def _runtime_label(adapter: object, attribute: str) -> tuple[str | None, bool]:
+    """Read a provider label only when it is safe to serialize verbatim."""
+    value = _safe_runtime_attribute(adapter, attribute)
+    if not isinstance(value, str):
+        return None, False
+    normalized = value.strip()
+    if normalized and not is_sensitive_value(normalized):
+        return normalized, True
+    return None, False
+
+
+def runtime_routing_labels_contract(adapter: object) -> dict[str, object]:
+    """Return runner-routing labels with explicit observation state.
+
+    The runner persists these values before binding them back to the same live
+    adapter for parallel execution. Keep the unobserved markers beside their
+    ``None`` values so a missing, fabricated, or sensitive label cannot be
+    mistaken for an observed empty selection during that bind.
+    """
+    runtime_backend, runtime_backend_observed = _runtime_label(adapter, "runtime_backend")
+    llm_backend, llm_backend_observed = _runtime_label(adapter, "llm_backend")
+    result: dict[str, object] = {
+        "runtime_backend": runtime_backend,
+        "llm_backend": llm_backend,
+    }
+    if not runtime_backend_observed:
+        result["runtime_backend_unobserved"] = True
+    if not llm_backend_observed:
+        result["llm_backend_unobserved"] = True
+    return result
+
+
+def _active_resolved_runtime_fields(adapter: object) -> dict[str, object]:
+    result = {
+        **runtime_routing_labels_contract(adapter),
         "permission_mode": runtime_permission_mode_contract(adapter),
         "constructor_model": constructor_model_contract(adapter),
-        "runtime_execution": runtime_execution_identity_contract(adapter),
+        "runtime_execution": runtime_execution_identity_contract(
+            adapter,
+            include_process_local_nonce=False,
+        ),
     }
+    return result
+
+
+def _unobserved_runtime_label_binding(
+    adapter: object,
+    labels: Mapping[str, object],
+) -> tuple[tuple[str, str], ...]:
+    """Return a process-local, non-serializable guard for hidden labels.
+
+    A credential-shaped label must never enter the durable routing payload, but
+    a same-process mutation of that label can still change dispatch behavior.
+    Capture a keyed digest solely on :class:`ResolvedRuntimeAuthority`; its
+    secret key and output never enter the canonical authority contract.  This
+    lets the original live adapter remain usable while rejecting a changed
+    hidden value before executor construction.
+    """
+    bindings: list[tuple[str, str]] = []
+    for field_name in ("runtime_backend", "llm_backend"):
+        if labels.get(f"{field_name}_unobserved") is not True:
+            continue
+        value = _safe_runtime_attribute(adapter, field_name)
+        digest = hashlib.blake2b(
+            key=_RESOLVED_RUNTIME_LABEL_BINDING_KEY,
+            digest_size=32,
+        )
+        digest.update(field_name.encode("utf-8"))
+        if isinstance(value, str):
+            encoded = value.encode("utf-8", errors="surrogatepass")
+            digest.update(b"str")
+            digest.update(len(encoded).to_bytes(8, byteorder="big", signed=False))
+            digest.update(encoded)
+        elif value is None:
+            digest.update(b"none")
+        else:
+            # Non-string backend labels are malformed and therefore
+            # non-portable. Their exact representation may itself be hostile
+            # or sensitive, so guard their process-local object identity only.
+            digest.update(b"object")
+            digest.update(str(id(type(value))).encode("ascii"))
+            digest.update(str(id(value)).encode("ascii"))
+        bindings.append((field_name, digest.hexdigest()))
+    return tuple(bindings)
+
+
+def _unobserved_runtime_execution_binding(
+    adapter: object,
+    active: Mapping[str, object],
+) -> str | None:
+    """Bind an unobservable provider identity without persisting its values.
+
+    ``runtime_execution_identity_contract`` intentionally reduces a malformed
+    or credential-bearing provider identity to ``observed=False`` before it
+    reaches a durable routing contract.  That public shape cannot distinguish
+    two secret values on the same adapter, however.  Capture a keyed,
+    process-local digest of the raw provider response for the live binding so
+    a planning-to-dispatch change is rejected without serializing any provider
+    value.  If the raw response cannot be safely normalized for this private
+    comparison, use fresh entropy: the next binding check will fail closed.
+    """
+    execution_identity = active.get("runtime_execution")
+    if (
+        not isinstance(execution_identity, Mapping)
+        or execution_identity.get("observed") is not False
+    ):
+        return None
+
+    digest = hashlib.blake2b(
+        key=_RESOLVED_RUNTIME_EXECUTION_BINDING_KEY,
+        digest_size=32,
+    )
+    digest.update(b"runtime_execution")
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "execution_identity_contract",
+        None,
+    )
+    if provider_descriptor is None:
+        # No provider exists to mutate.  The adapter-local nonce makes this
+        # private binding distinct without placing it in the routing payload.
+        digest.update(b"missing-provider")
+        digest.update(_process_local_runtime_nonce(adapter).encode("ascii"))
+        return digest.hexdigest()
+
+    try:
+        provider = object.__getattribute__(adapter, "execution_identity_contract")
+        raw_identity = provider()
+        if not isinstance(raw_identity, Mapping):
+            raise ValueError("runtime execution identity is not a mapping")
+        encoded = _canonical_json(
+            _project_explicit_identity(
+                dict(raw_identity),
+                field="unobserved runtime execution identity",
+            ),
+            field="unobserved runtime execution identity",
+        )
+    except Exception:
+        # An invalid opaque identity cannot be compared reliably.  A different
+        # value on every call deliberately prevents it from crossing the
+        # planning-to-dispatch boundary.
+        digest.update(b"unavailable")
+        digest.update(secrets.token_bytes(32))
+        return digest.hexdigest()
+
+    encoded_bytes = encoded.encode("utf-8", errors="surrogatepass")
+    digest.update(b"provider-response")
+    digest.update(len(encoded_bytes).to_bytes(8, byteorder="big", signed=False))
+    digest.update(encoded_bytes)
+    return digest.hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -300,6 +803,14 @@ class ResolvedRuntimeAuthority:
     canonical_json: str
     _binding_token: object = field(repr=False, compare=False)
     _adapter: object = field(repr=False, compare=False)
+    _unobserved_label_binding: tuple[tuple[str, str], ...] = field(
+        repr=False,
+        compare=False,
+    )
+    _unobserved_execution_binding: str | None = field(
+        repr=False,
+        compare=False,
+    )
 
     def __post_init__(self) -> None:
         if self._binding_token is not _RESOLVED_RUNTIME_AUTHORITY_TOKEN:
@@ -328,6 +839,11 @@ class ResolvedRuntimeAuthority:
             ),
             _binding_token=_RESOLVED_RUNTIME_AUTHORITY_TOKEN,
             _adapter=adapter,
+            _unobserved_label_binding=_unobserved_runtime_label_binding(adapter, active),
+            _unobserved_execution_binding=_unobserved_runtime_execution_binding(
+                adapter,
+                active,
+            ),
         )
 
     def require_adapter(self, adapter: object) -> None:
@@ -339,6 +855,13 @@ class ResolvedRuntimeAuthority:
         for field_name, active_value in active.items():
             if resolved.get(field_name) != active_value:
                 raise ValueError(f"resolved runtime authority drifted from active {field_name}")
+        if self._unobserved_label_binding != _unobserved_runtime_label_binding(adapter, active):
+            raise ValueError("resolved runtime authority drifted from an unobserved backend label")
+        if self._unobserved_execution_binding != _unobserved_runtime_execution_binding(
+            adapter,
+            active,
+        ):
+            raise ValueError("resolved runtime authority drifted from an unobserved execution identity")
 
     @property
     def data(self) -> dict[str, Any]:
@@ -368,33 +891,346 @@ def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
     }
 
 
+def _opaque_type_identity_digest(value: object) -> str:
+    """Digest a type label without exposing a dynamic module or class name."""
+    runtime_type = value if isinstance(value, type) else type(value)
+    module = getattr(runtime_type, "__module__", None)
+    qualname = getattr(runtime_type, "__qualname__", None)
+    if not isinstance(module, str) or not isinstance(qualname, str):
+        raise ValueError("type identity is unavailable")
+    return _sha256(
+        _canonical_json(
+            {"module": module, "qualname": qualname},
+            field="opaque type identity",
+        )
+    )
+
+
+def _opaque_callable_identity_digest(target: object) -> str:
+    """Digest callable display metadata rather than serializing it verbatim."""
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None)
+    if not isinstance(module, str) or not isinstance(qualname, str):
+        return _opaque_type_identity_digest(target)
+    return _sha256(
+        _canonical_json(
+            {"module": module, "qualname": qualname},
+            field="opaque callable identity",
+        )
+    )
+
+
+def _opaque_callable_data_digest(value: object, *, field: str) -> str:
+    """Digest bounded callable data without retaining argument names or values."""
+    projected = _project_explicit_identity(value, field=field)
+    return _sha256(_canonical_json(projected, field=field))
+
+
+def _callable_behavior_digest(target: object) -> str:
+    """Digest code, defaults, closures, and directly resolved behavior.
+
+    The payload is kept only while hashing.  It is deliberately a list rather
+    than a name-keyed mapping so dynamic argument/global names cannot egress
+    through authority JSON.
+    """
+    active: set[int] = set()
+    function_count = 0
+
+    def opaque_value_projection(
+        value: object,
+        *,
+        depth: int = 0,
+        seen: set[int] | None = None,
+    ) -> object:
+        """Project mutable helper data into hash-only, non-egressing state."""
+        if depth > _MAX_IDENTITY_DEPTH:
+            raise ValueError("callable data dependency graph exceeds its depth budget")
+        # ``StrEnum`` is also a ``str``, so test enums before scalar strings.
+        if isinstance(value, Enum):
+            return {
+                "kind": "enum",
+                "type": _opaque_type_identity_digest(value),
+                "name": value.name,
+                "value": opaque_value_projection(value.value, depth=depth + 1, seen=seen),
+            }
+        if value is None or isinstance(value, (bool, int, str)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                return {"kind": "non_finite_float", "type": _opaque_type_identity_digest(value)}
+            return value
+        if isinstance(value, bytes):
+            return {
+                "kind": "bytes",
+                "digest": "sha256:" + hashlib.sha256(value).hexdigest(),
+            }
+        if isinstance(value, type):
+            return {"kind": "type", "identity_digest": _opaque_type_identity_digest(value)}
+        if inspect.ismethod(value) or inspect.isfunction(value) or inspect.isbuiltin(value):
+            return {
+                "kind": "callable",
+                "identity_digest": _opaque_callable_identity_digest(value),
+            }
+        if inspect.ismodule(value):
+            module_name = getattr(value, "__name__", None)
+            source_path = getattr(value, "__file__", None)
+            if not isinstance(module_name, str) or not module_name:
+                raise ValueError("callable data module lacks an identity")
+            return {
+                "kind": "module",
+                "identity_digest": _sha256(
+                    _canonical_json(
+                        {
+                            "name": module_name,
+                            "content_digest": (
+                                _file_content_digest(source_path)
+                                if isinstance(source_path, str)
+                                else None
+                            ),
+                        },
+                        field="callable data module",
+                    )
+                ),
+            }
+
+        seen = set() if seen is None else seen
+        value_id = id(value)
+        if value_id in seen:
+            raise ValueError("callable data dependency graph contains a cycle")
+        seen.add(value_id)
+        try:
+            if isinstance(value, Mapping):
+                if len(value) > _MAX_IDENTITY_ITEMS:
+                    raise ValueError("callable data mapping is oversized")
+                items = [
+                    [
+                        opaque_value_projection(key, depth=depth + 1, seen=seen),
+                        opaque_value_projection(item, depth=depth + 1, seen=seen),
+                    ]
+                    for key, item in value.items()
+                ]
+                return {
+                    "kind": "mapping",
+                    "items": sorted(
+                        items,
+                        key=lambda item: _canonical_json(item, field="callable data mapping item"),
+                    ),
+                }
+            if isinstance(value, (list, tuple)):
+                if len(value) > _MAX_IDENTITY_ITEMS:
+                    raise ValueError("callable data sequence is oversized")
+                return {
+                    "kind": type(value).__name__,
+                    "items": [
+                        opaque_value_projection(item, depth=depth + 1, seen=seen)
+                        for item in value
+                    ],
+                }
+            if isinstance(value, (set, frozenset)):
+                if len(value) > _MAX_IDENTITY_ITEMS:
+                    raise ValueError("callable data set is oversized")
+                items = [
+                    opaque_value_projection(item, depth=depth + 1, seen=seen)
+                    for item in value
+                ]
+                return {
+                    "kind": type(value).__name__,
+                    "items": sorted(
+                        items,
+                        key=lambda item: _canonical_json(item, field="callable data set item"),
+                    ),
+                }
+        finally:
+            seen.remove(value_id)
+        # Opaque service/logging objects are intentionally represented only by
+        # type. They are not executable authority dependencies; treating them
+        # as serializable state would risk credential egress.
+        return {"kind": "opaque", "type": _opaque_type_identity_digest(value)}
+
+    def opaque_value_digest(value: object, *, field: str) -> str:
+        return _sha256(_canonical_json(opaque_value_projection(value), field=field))
+
+    def direct_global_identity(value: object, *, depth: int) -> dict[str, object]:
+        """Bind a direct global and recursively bind Ouroboros helper graphs."""
+        if inspect.ismethod(value) or inspect.isfunction(value):
+            function = value.__func__ if inspect.ismethod(value) else value
+            if not inspect.isfunction(function):  # pragma: no cover - narrowed above
+                raise ValueError("callable global is not a Python function")
+            module = getattr(function, "__module__", "")
+            if isinstance(module, str) and module.startswith("ouroboros."):
+                return {"kind": "function", "identity": collect(function, depth=depth + 1)}
+            return {
+                "kind": "function_leaf",
+                "identity_digest": _opaque_callable_identity_digest(function),
+                "code_digest": "sha256:"
+                + hashlib.sha256(marshal.dumps(function.__code__)).hexdigest(),
+                "defaults_digest": opaque_value_digest(
+                    [tuple(function.__defaults__ or ()), dict(function.__kwdefaults__ or {})],
+                    field="callable global defaults",
+                ),
+            }
+        if inspect.isbuiltin(value):
+            return {
+                "kind": "builtin",
+                "identity_digest": _opaque_callable_identity_digest(value),
+            }
+        if isinstance(value, type):
+            return {
+                "kind": "type",
+                "identity_digest": _opaque_type_identity_digest(value),
+            }
+        if inspect.ismodule(value):
+            return opaque_value_projection(value)  # type: ignore[return-value]
+        return {
+            "kind": "data",
+            "identity_digest": opaque_value_digest(value, field="callable global data"),
+        }
+
+    def collect(function_value: object, *, depth: int) -> dict[str, object]:
+        nonlocal function_count
+        if depth > _MAX_CALLABLE_DEPENDENCY_DEPTH:
+            raise ValueError("callable dependency graph exceeds its depth budget")
+        function = function_value.__func__ if inspect.ismethod(function_value) else function_value
+        if not inspect.isfunction(function):
+            raise ValueError("callable implementation is not a Python function")
+        code = function.__code__
+        code_digest = "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+        function_id = id(function)
+        if function_id in active:
+            return {"mode": "recursive", "code_digest": code_digest}
+        function_count += 1
+        if function_count > _MAX_IDENTITY_ITEMS:
+            raise ValueError("callable dependency graph has too many functions")
+        active.add(function_id)
+        try:
+            defaults_digest = opaque_value_digest(
+                [tuple(function.__defaults__ or ()), dict(function.__kwdefaults__ or {})],
+                field="callable implementation defaults",
+            )
+            closure_values: list[dict[str, object]] = []
+            for cell in function.__closure__ or ():
+                try:
+                    value = cell.cell_contents
+                except ValueError as exc:
+                    raise ValueError("callable closure cell is empty") from exc
+                if inspect.ismethod(value) or inspect.isfunction(value):
+                    closure_values.append(
+                        {"kind": "function", "identity": collect(value, depth=depth + 1)}
+                    )
+                elif isinstance(value, type):
+                    closure_values.append(
+                        {"kind": "type", "identity_digest": _opaque_type_identity_digest(value)}
+                    )
+                else:
+                    closure_values.append(
+                        {
+                            "kind": "data",
+                            "identity_digest": opaque_value_digest(
+                                value,
+                                field="callable closure data",
+                            ),
+                        }
+                    )
+
+            closure_vars = inspect.getclosurevars(function)
+            global_dependencies = [
+                direct_global_identity(dependency, depth=depth)
+                for global_name, dependency in sorted(closure_vars.globals.items())
+                if (function.__module__, global_name)
+                not in _PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS
+            ]
+            builtin_dependencies: list[dict[str, object]] = []
+            for _name, dependency in sorted(closure_vars.builtins.items()):
+                if inspect.ismethod(dependency) or inspect.isfunction(dependency):
+                    builtin_dependencies.append(
+                        {"kind": "function", "identity": collect(dependency, depth=depth + 1)}
+                    )
+                elif inspect.isbuiltin(dependency):
+                    builtin_dependencies.append(
+                        {
+                            "kind": "builtin",
+                            "identity_digest": _opaque_callable_identity_digest(dependency),
+                        }
+                    )
+                elif isinstance(dependency, type):
+                    # Normal Python methods routinely resolve constructors and
+                    # exception classes (``str``, ``dict``, ``ValueError``, …)
+                    # through ``__builtins__``.  Those are static executable
+                    # dependencies, not opaque live state.  Keep their labels
+                    # out of canonical authority JSON while still detecting a
+                    # replacement via their opaque identity digest.
+                    builtin_dependencies.append(
+                        {
+                            "kind": "type",
+                            "identity_digest": _opaque_type_identity_digest(dependency),
+                        }
+                    )
+                elif dependency is None or isinstance(dependency, (bool, int, float, str)):
+                    builtin_dependencies.append(
+                        {
+                            "kind": "data",
+                            "identity_digest": opaque_value_digest(
+                                dependency,
+                                field="callable builtin data",
+                            ),
+                        }
+                    )
+                else:
+                    # Replacing a builtin with an opaque callable/object changes
+                    # execution semantics but cannot be made portable safely.
+                    raise ValueError("callable builtin dependency is not inspectable")
+            return {
+                "code_digest": code_digest,
+                "defaults_digest": defaults_digest,
+                "closure": closure_values,
+                "global_dependencies": global_dependencies,
+                "builtin_dependencies": builtin_dependencies,
+            }
+        finally:
+            active.remove(function_id)
+
+    return _sha256(
+        _canonical_json(
+            collect(target, depth=0),
+            field="callable behavior",
+        )
+    )
+
+
 def _callable_implementation_contract(target: object) -> dict[str, object]:
-    """Identify executable behavior without persisting source or code objects."""
-    module = getattr(target, "__module__", type(target).__module__)
-    qualname = getattr(target, "__qualname__", type(target).__qualname__)
+    """Identify executable behavior without persisting source or raw metadata.
+
+    Source text alone misses in-place code/default drift.  Conversely, treating
+    every closure as opaque makes ordinary generated methods and zero-argument
+    ``super()`` process-local.  The bounded behavior digest captures safe
+    closure cells and builtins; authority-critical helper functions are bound
+    explicitly at their owning component boundary. Unsupported live state fails
+    closed to a stable per-instance process-local nonce.
+    """
     try:
         source_digest = _sha256(inspect.getsource(target))
     except (OSError, TypeError):
         source_digest = None
     code = getattr(target, "__code__", None)
-    code_digest = (
-        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
-        if source_digest is None and code is not None
-        else None
-    )
-    if source_digest is None and code_digest is None:
+    if code is None:
         return {
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
-            "module": str(module),
-            "qualname": str(qualname),
+            "instance_nonce": _process_local_runtime_nonce(target),
+        }
+    try:
+        code_digest = "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+        behavior_digest = _callable_behavior_digest(target)
+    except Exception:
+        return {
+            "stability": "process_local",
+            "instance_nonce": _process_local_runtime_nonce(target),
         }
     return {
         "stability": "durable",
-        "module": str(module),
-        "qualname": str(qualname),
+        "identity_digest": _opaque_callable_identity_digest(target),
         "source_digest": source_digest,
         "code_digest": code_digest,
+        "behavior_digest": behavior_digest,
     }
 
 
@@ -422,24 +1258,203 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
             "instance_overrides": instance_overrides,
         }
         if not durable:
-            contract["instance_nonce"] = uuid.uuid4().hex
+            contract["instance_nonce"] = _process_local_runtime_nonce(target)
         return contract
     return _callable_leaf_implementation_contract(target)
 
 
+def _callable_dependency_implementation_contract(target: object) -> dict[str, object]:
+    """Bind a transcript verifier and the Python helpers it actually invokes.
+
+    A wrapper's own source digest is not enough for an acceptance-relevant
+    verifier: its imported helpers may be replaced or evolve independently.
+    Follow direct Python-function globals only. Closures, unsupported callable
+    globals, or uninspectable dependencies make the whole verifier
+    process-local instead of claiming a durable identity. Recursive helpers are
+    represented by a bounded source-digest reference rather than unrolling an
+    infinite graph.
+    """
+
+    active: set[int] = set()
+    function_count = 0
+
+    def global_contract(value: object) -> dict[str, object]:
+        """Return a safe identity for a non-function global used by a verifier."""
+        if isinstance(value, type):
+            # A transcript verifier often uses standard-library types such as
+            # ``pathlib.Path``.  Requiring a full member-by-member class graph
+            # for those types turns an otherwise durable verifier process-local
+            # simply because a standard-library base is implemented in C or
+            # exposes a descriptor we cannot walk.  The type identity itself is
+            # sufficient for this boundary: replacing ``VerifierVerdict`` (or
+            # any other imported type) changes the opaque digest, while raw
+            # module/class labels never enter authority JSON.
+            return {"mode": "type", "identity_digest": _opaque_type_identity_digest(value)}
+        if isinstance(value, re.Pattern):
+            return {
+                "mode": "regex",
+                "identity_digest": _sha256(f"{value.pattern}\x00{value.flags}"),
+            }
+        if inspect.ismodule(value):
+            module_name = getattr(value, "__name__", None)
+            source_path = getattr(value, "__file__", None)
+            digest = _file_content_digest(source_path) if isinstance(source_path, str) else None
+            if not isinstance(module_name, str) or not module_name or digest is None:
+                raise ValueError("runtime transcript verifier module is not durable")
+            return {
+                "mode": "module",
+                "identity_digest": _sha256(
+                    _canonical_json(
+                        {"name": module_name, "content_digest": digest},
+                        field="runtime transcript verifier module",
+                    )
+                ),
+            }
+
+        if isinstance(value, (set, frozenset)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError("runtime transcript verifier global is oversized")
+            projected_items = [
+                _project_explicit_identity(
+                    item,
+                    field="runtime transcript verifier global item",
+                )
+                for item in value
+            ]
+            projected: object = {
+                "items": sorted(
+                    projected_items,
+                    key=lambda item: _canonical_json(
+                        item,
+                        field="runtime transcript verifier global item",
+                    ),
+                )
+            }
+        else:
+            projected = {"value": value}
+        return {
+            "mode": "data",
+            "identity_digest": _opaque_callable_data_digest(
+                projected,
+                field="runtime transcript verifier global",
+            ),
+        }
+
+    def collect(value: object, *, depth: int) -> dict[str, object]:
+        nonlocal function_count
+        if depth > _MAX_IDENTITY_DEPTH:
+            raise ValueError("runtime transcript verifier exceeds dependency depth")
+        if inspect.ismethod(value):
+            function = value.__func__
+        elif inspect.isfunction(value):
+            function = value
+        else:
+            raise ValueError("runtime transcript verifier has a non-Python entrypoint")
+        function_id = id(function)
+        if function_id in active:
+            implementation = _callable_implementation_contract(function)
+            if implementation.get("stability") != "durable":
+                raise ValueError("runtime transcript verifier implementation is not durable")
+            return {
+                "mode": "recursive_reference",
+                "implementation": implementation,
+            }
+        function_count += 1
+        if function_count > _MAX_IDENTITY_ITEMS:
+            raise ValueError("runtime transcript verifier has too many dependencies")
+        defaults_digest = _opaque_callable_data_digest(
+            [
+                list(function.__defaults__ or ()),
+                list((function.__kwdefaults__ or {}).values()),
+            ],
+            field="runtime transcript verifier defaults",
+        )
+
+        active.add(function_id)
+        try:
+            implementation = _callable_implementation_contract(function)
+            if implementation.get("stability") != "durable":
+                raise ValueError("runtime transcript verifier implementation is not durable")
+            dependencies: list[dict[str, object]] = []
+            missing = object()
+            for global_name in sorted(set(function.__code__.co_names)):
+                dependency = function.__globals__.get(global_name, missing)
+                if dependency is missing:
+                    continue
+                if inspect.ismethod(dependency) or inspect.isfunction(dependency):
+                    dependencies.append(collect(dependency, depth=depth + 1))
+                else:
+                    dependencies.append(global_contract(dependency))
+            return {
+                "implementation": implementation,
+                "defaults_digest": defaults_digest,
+                "dependencies": dependencies,
+            }
+        finally:
+            active.remove(function_id)
+
+    try:
+        return {
+            "stability": "durable",
+            "graph": collect(target, depth=0),
+        }
+    except Exception:
+        return {
+            "stability": "process_local",
+            "instance_nonce": _process_local_runtime_nonce(target),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
+        }
+
+
 def _qualified_type(value: object) -> str:
-    return f"{type(value).__module__}.{type(value).__qualname__}"
+    """Return an opaque type identity suitable for canonical authority JSON."""
+    return _opaque_type_identity_digest(value)
+
+
+def _bounded_regular_file_identity(
+    path: str | os.PathLike[str],
+) -> tuple[str, os.stat_result] | None:
+    """Hash a bounded regular file without opening pipes or device nodes."""
+    try:
+        initial = os.stat(path)
+        if not stat.S_ISREG(initial.st_mode) or initial.st_size > _MAX_IDENTITY_FILE_BYTES:
+            return None
+        digest = hashlib.sha256()
+        total = 0
+        with Path(path).open("rb") as source_file:
+            opened = os.fstat(source_file.fileno())
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_size > _MAX_IDENTITY_FILE_BYTES
+                or (opened.st_dev, opened.st_ino) != (initial.st_dev, initial.st_ino)
+            ):
+                return None
+            while chunk := source_file.read(min(1024 * 1024, _MAX_IDENTITY_FILE_BYTES - total + 1)):
+                total += len(chunk)
+                if total > _MAX_IDENTITY_FILE_BYTES:
+                    return None
+                digest.update(chunk)
+            final = os.fstat(source_file.fileno())
+            if (
+                final.st_dev,
+                final.st_ino,
+                final.st_size,
+                final.st_mtime_ns,
+            ) != (
+                opened.st_dev,
+                opened.st_ino,
+                opened.st_size,
+                opened.st_mtime_ns,
+            ):
+                return None
+    except OSError:
+        return None
+    return "sha256:" + digest.hexdigest(), opened
 
 
 def _file_content_digest(path: str | os.PathLike[str]) -> str | None:
-    try:
-        digest = hashlib.sha256()
-        with Path(path).open("rb") as source_file:
-            while chunk := source_file.read(1024 * 1024):
-                digest.update(chunk)
-    except OSError:
-        return None
-    return "sha256:" + digest.hexdigest()
+    identity = _bounded_regular_file_identity(path)
+    return identity[0] if identity is not None else None
 
 
 def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object] | None:
@@ -466,15 +1481,9 @@ def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object]
     content_digest: str | None = None
     executable: bool | None = None
     if realpath is not None:
-        try:
-            digest = hashlib.sha256()
-            with Path(realpath).open("rb") as executable_file:
-                file_stat = os.fstat(executable_file.fileno())
-                while chunk := executable_file.read(1024 * 1024):
-                    digest.update(chunk)
-        except OSError:
-            pass
-        else:
+        identity = _bounded_regular_file_identity(realpath)
+        if identity is not None:
+            content_digest, file_stat = identity
             generation = {
                 "device": file_stat.st_dev,
                 "inode": file_stat.st_ino,
@@ -482,11 +1491,13 @@ def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object]
                 "mtime_ns": file_stat.st_mtime_ns,
                 "mode": stat.S_IMODE(file_stat.st_mode),
             }
-            content_digest = "sha256:" + digest.hexdigest()
             executable = bool(generation["mode"] & 0o111) and os.access(realpath, os.X_OK)
     return {
-        "path": value,
-        "realpath": realpath,
+        # Paths can be provider-configured and may themselves contain a token
+        # (for example a signed download location).  They identify executable
+        # selection through stable digests without becoming authority payload.
+        "path_digest": _sha256(value),
+        "realpath_digest": _sha256(realpath) if realpath is not None else None,
         "generation": generation,
         "content_digest": content_digest,
         "executable": executable,
@@ -495,48 +1506,78 @@ def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object]
 
 def _runtime_executable_contract(adapter: object) -> dict[str, object]:
     """Bind subprocess executables, launchers, and delegated command policy."""
-    cwd_value = getattr(adapter, "working_directory", None) or getattr(adapter, "_cwd", None)
-    cwd = cwd_value if isinstance(cwd_value, str) and cwd_value else None
-    declared_descriptor = inspect.getattr_static(
-        type(adapter),
-        "executable_identity_contract",
-        None,
-    )
-    command_policy: dict[str, Any] | None = None
-    executable: dict[str, object] | None = None
-    launcher: dict[str, object] | None = None
-    if declared_descriptor is not None:
-        declared_provider = object.__getattribute__(adapter, "executable_identity_contract")
-        declared = declared_provider()
-        if not isinstance(declared, Mapping):
-            raise ValueError("runtime executable identity is not a mapping")
-        executable = _resolved_executable(declared.get("executable"), cwd=cwd)
-        launcher = _resolved_executable(declared.get("launcher"), cwd=cwd)
-        raw_policy = declared.get("command_policy")
-        if raw_policy is not None:
-            command_policy = _canonical_object(raw_policy, field="runtime command policy")
-    else:
-        executable = _resolved_executable(
-            getattr(adapter, "cli_path", None) or getattr(adapter, "_cli_path", None),
-            cwd=cwd,
+    try:
+        cwd_value = getattr(adapter, "working_directory", None) or getattr(adapter, "_cwd", None)
+        cwd = cwd_value if isinstance(cwd_value, str) and cwd_value else None
+        declared_descriptor = inspect.getattr_static(
+            type(adapter),
+            "executable_identity_contract",
+            None,
         )
-        launcher = _resolved_executable(getattr(adapter, "_electron_node_path", None), cwd=cwd)
-    required = executable is not None or launcher is not None or command_policy is not None
-    observed = not required or all(
-        item is None
-        or item.get("realpath") is not None
-        and item.get("generation") is not None
-        and item.get("content_digest") is not None
-        and item.get("executable") is True
-        for item in (executable, launcher)
-    )
-    return {
-        "required": required,
-        "observed": observed,
-        "executable": executable,
-        "launcher": launcher,
-        "command_policy": command_policy,
-    }
+        command_policy: dict[str, Any] | None = None
+        executable: dict[str, object] | None = None
+        launcher: dict[str, object] | None = None
+        if declared_descriptor is not None:
+            declared_provider = object.__getattribute__(adapter, "executable_identity_contract")
+            declared = declared_provider()
+            if not isinstance(declared, Mapping):
+                raise ValueError("runtime executable identity is not a mapping")
+            declared_identity = _canonical_explicit_identity(
+                dict(declared),
+                field="runtime executable identity",
+            )
+            if not set(declared_identity) <= {"executable", "launcher", "command_policy"}:
+                raise ValueError("runtime executable identity contains unknown fields")
+            executable = _resolved_executable(declared_identity.get("executable"), cwd=cwd)
+            launcher = _resolved_executable(declared_identity.get("launcher"), cwd=cwd)
+            raw_policy = declared_identity.get("command_policy")
+            if raw_policy is not None:
+                command_policy = _canonical_explicit_identity(
+                    raw_policy,
+                    field="runtime command policy",
+                )
+        else:
+            executable = _resolved_executable(
+                getattr(adapter, "cli_path", None) or getattr(adapter, "_cli_path", None),
+                cwd=cwd,
+            )
+            launcher = _resolved_executable(
+                getattr(adapter, "_electron_node_path", None),
+                cwd=cwd,
+            )
+        required = executable is not None or launcher is not None or command_policy is not None
+        observed = not required or all(
+            item is None
+            or item.get("realpath_digest") is not None
+            and item.get("generation") is not None
+            and item.get("content_digest") is not None
+            and item.get("executable") is True
+            for item in (executable, launcher)
+        )
+        return {
+            "required": required,
+            "observed": observed,
+            "executable": executable,
+            "launcher": launcher,
+            "command_policy_digest": (
+                _identity_digest(command_policy, field="runtime command policy")
+                if command_policy is not None
+                else None
+            ),
+        }
+    except Exception:
+        # Attribute/property failures are provider-controlled input. Make the
+        # baseline non-portable without exposing an error message *or* a custom
+        # exception type/qualname in canonical authority data.
+        return {
+            "required": True,
+            "observed": False,
+            "executable": None,
+            "launcher": None,
+            "command_policy_digest": None,
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
+        }
 
 
 def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
@@ -546,11 +1587,26 @@ def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
         None,
     )
     if provider_descriptor is not None:
-        provider = object.__getattribute__(adapter, "watchdog_identity_contract")
-        value = provider()
-        if not isinstance(value, Mapping):
-            raise ValueError("runtime watchdog identity is not a mapping")
-        return {"observed": True, "identity": _canonical_object(value, field="watchdog identity")}
+        try:
+            provider = object.__getattribute__(adapter, "watchdog_identity_contract")
+            value = provider()
+            if not isinstance(value, Mapping):
+                raise ValueError("runtime watchdog identity is not a mapping")
+            identity = _canonical_explicit_identity(value, field="watchdog identity")
+            if not identity:
+                raise ValueError("runtime watchdog identity is empty")
+        except Exception:
+            return {
+                "required": True,
+                "observed": False,
+                "instance_nonce": _process_local_runtime_nonce(adapter),
+                "reason": _IDENTITY_UNAVAILABLE_REASON,
+            }
+        return {
+            "required": True,
+            "observed": True,
+            "identity_digest": _identity_digest(identity, field="watchdog identity"),
+        }
     fields = (
         "_startup_output_timeout_seconds",
         "_stdout_idle_timeout_seconds",
@@ -561,33 +1617,66 @@ def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
         "_use_process_group",
         "_child_session_env_keys",
     )
-    missing = object()
-    values: dict[str, object] = {}
-    for field_name in fields:
-        value = inspect.getattr_static(adapter, field_name, missing)
-        if value is not missing:
-            values[field_name.removeprefix("_")] = object.__getattribute__(
-                adapter,
-                field_name,
-            )
+    try:
+        missing = object()
+        values: dict[str, object] = {}
+        for field_name in fields:
+            value = inspect.getattr_static(adapter, field_name, missing)
+            if value is not missing:
+                # This records environment variable *names*, not their values. Do
+                # not use a structural key containing ``key``: generic sensitive
+                # field screening intentionally treats that word as credential-like.
+                identity_name = (
+                    "child_session_environment_names"
+                    if field_name == "_child_session_env_keys"
+                    else field_name.removeprefix("_")
+                )
+                values[identity_name] = object.__getattribute__(
+                    adapter,
+                    field_name,
+                )
+        if not values:
+            return {"required": False, "observed": False, "identity_digest": None}
+        identity = _canonical_explicit_identity(values, field="watchdog identity")
+    except Exception:
+        return {
+            "required": True,
+            "observed": False,
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
+        }
     return {
-        "observed": bool(values),
-        "identity": _canonical_object(values, field="watchdog identity") if values else None,
+        "required": True,
+        "observed": True,
+        "identity_digest": _identity_digest(identity, field="watchdog identity"),
     }
 
 
 def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
+    """Return skill-dispatch identity without surfacing provider getter errors."""
+    try:
+        return _runtime_skill_dispatcher_contract_impl(adapter)
+    except Exception:
+        return {
+            "mode": "unobserved",
+            "stability": "process_local",
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
+        }
+
+
+def _runtime_skill_dispatcher_contract_impl(adapter: object) -> dict[str, object]:
     interceptor_descriptor = inspect.getattr_static(adapter, "_interceptor", None)
     if interceptor_descriptor is not None:
         try:
             interceptor = object.__getattribute__(adapter, "_interceptor")
             component = _declared_component_contract(interceptor)
-        except Exception as exc:
+        except Exception:
             return {
                 "mode": "delegated",
                 "stability": "process_local",
-                "instance_nonce": uuid.uuid4().hex,
-                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "instance_nonce": _process_local_runtime_nonce(interceptor),
+                "reason": _IDENTITY_UNAVAILABLE_REASON,
             }
         return {
             "mode": "delegated",
@@ -618,8 +1707,7 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
         return {
             "mode": "local_fallback",
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
-            "skills_dir": str(getattr(adapter, "_skills_dir", None)),
+            "instance_nonce": _process_local_runtime_nonce(adapter),
             "resolver_implementation": _callable_implementation_contract(local_dispatch_descriptor),
             "dispatcher_implementation": (
                 _callable_implementation_contract(local_entrypoint)
@@ -631,12 +1719,12 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     implementation = _callable_entrypoint_contract(dispatcher)
     try:
         identity_provider = getattr(dispatcher, "execution_identity_contract", None)
-    except Exception as exc:
+    except Exception:
         return {
             "mode": "custom",
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
-            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "instance_nonce": _process_local_runtime_nonce(dispatcher),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
             "implementation": implementation,
         }
     if callable(identity_provider):
@@ -644,13 +1732,17 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
             identity = identity_provider()
             if not isinstance(identity, Mapping):
                 raise ValueError("skill dispatcher identity is not a mapping")
-            encoded = _canonical_json(dict(identity), field="skill dispatcher identity")
-        except Exception as exc:
+            normalized = _canonical_explicit_identity(
+                dict(identity),
+                field="skill dispatcher identity",
+            )
+            encoded = _canonical_json(normalized, field="skill dispatcher identity")
+        except Exception:
             return {
                 "mode": "custom",
                 "stability": "process_local",
-                "instance_nonce": uuid.uuid4().hex,
-                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "instance_nonce": _process_local_runtime_nonce(dispatcher),
+                "reason": _IDENTITY_UNAVAILABLE_REASON,
                 "implementation": implementation,
             }
         if implementation.get("stability") == "durable" and local_dispatch_descriptor is None:
@@ -663,7 +1755,7 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     return {
         "mode": "custom",
         "stability": "process_local",
-        "instance_nonce": uuid.uuid4().hex,
+        "instance_nonce": _process_local_runtime_nonce(dispatcher),
         "implementation": implementation,
     }
 
@@ -677,8 +1769,8 @@ def _class_implementation_contract_for_type(runtime_type: type[object]) -> dict[
     for runtime_class in runtime_type.__mro__:
         if runtime_class is object:
             continue
-        qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
-        classes.append(qualified_name)
+        class_identity = _opaque_type_identity_digest(runtime_class)
+        classes.append(class_identity)
         if "<locals>" in runtime_class.__qualname__:
             durable = False
         class_members: dict[str, object] = {}
@@ -697,16 +1789,21 @@ def _class_implementation_contract_for_type(runtime_type: type[object]) -> dict[
             else:
                 continue
             for index, target in enumerate(targets):
-                member_key = f"{member_name}:{index}"
+                member_key = _sha256(
+                    _canonical_json(
+                        [member_name, index],
+                        field="runtime class member identity",
+                    )
+                )
                 member_contract = _callable_implementation_contract(target)
                 class_members[member_key] = member_contract
                 durable = durable and member_contract.get("stability") == "durable"
-        members[qualified_name] = {
+        members[class_identity] = {
             "observed": bool(class_members),
             "content_digest": _sha256(
                 _canonical_json(
                     class_members,
-                    field=f"runtime class members {qualified_name}",
+                    field="runtime class members",
                 )
             ),
         }
@@ -716,21 +1813,22 @@ def _class_implementation_contract_for_type(runtime_type: type[object]) -> dict[
             source_path = None
         if source_path is None:
             durable = False
-            modules[qualified_name] = {"observed": False}
+            modules[class_identity] = {"observed": False}
             continue
         try:
             realpath = str(Path(source_path).resolve(strict=False))
         except (OSError, RuntimeError):
             durable = False
-            modules[qualified_name] = {"observed": False}
+            modules[class_identity] = {"observed": False}
             continue
         digest = _file_content_digest(realpath)
         if digest is None:
             durable = False
-            modules[realpath] = {"observed": False}
+            modules[class_identity] = {"observed": False}
             continue
-        modules[realpath] = {
+        modules[class_identity] = {
             "observed": True,
+            "path_digest": _sha256(realpath),
             "content_digest": digest,
         }
     return {
@@ -749,11 +1847,11 @@ def _class_implementation_contract(adapter: object) -> dict[str, object]:
 def _safe_class_implementation_contract(value: object) -> dict[str, object]:
     try:
         return _class_implementation_contract(value)
-    except Exception as exc:
+    except Exception:
         return {
             "stability": "process_local",
             "observed": False,
-            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
         }
 
 
@@ -787,44 +1885,89 @@ def _static_executor_component_contract(component: type[object]) -> dict[str, ob
     """Bind a class-selected execution component without constructing it."""
     try:
         implementation = _class_implementation_contract_for_type(component)
-    except Exception as exc:
+    except Exception:
         return {
             "mode": "static_type",
             "stability": "process_local",
-            "type": f"{component.__module__}.{component.__qualname__}",
-            "instance_nonce": uuid.uuid4().hex,
-            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "type": _opaque_type_identity_digest(component),
+            "instance_nonce": _process_local_runtime_nonce(component),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
         }
     durable = implementation.get("stability") == "durable"
     contract: dict[str, object] = {
         "mode": "static_type",
         "stability": "durable" if durable else "process_local",
-        "type": f"{component.__module__}.{component.__qualname__}",
+        "type": _opaque_type_identity_digest(component),
         "implementation": implementation,
     }
     if not durable:
-        contract["instance_nonce"] = uuid.uuid4().hex
+        contract["instance_nonce"] = _process_local_runtime_nonce(component)
     return contract
 
 
-def _executor_component_contract(component: object) -> dict[str, object]:
-    """Describe one explicit executor-owned effect component.
+def _static_executor_callable_contract(component: object) -> dict[str, object]:
+    """Bind a captured static helper used directly by executor behavior."""
+    implementation = _callable_implementation_contract(component)
+    durable = implementation.get("stability") == "durable"
+    contract: dict[str, object] = {
+        "mode": "static_callable",
+        "stability": "durable" if durable else "process_local",
+        "implementation": implementation,
+    }
+    if not durable:
+        contract["instance_nonce"] = _process_local_runtime_nonce(component)
+    return contract
 
-    A class-selected dispatcher is static executor behavior and can be durable.
-    A live helper instance, such as a session-signal hub, owns mutable
-    attempt-time state. Record its presence and implementation but never
-    serialize its queue, event store, or active targets into the baseline.
+
+def _out_of_boundary_executor_component_contract(
+    component: object,
+    *,
+    name: str,
+) -> dict[str, object]:
+    """Fail closed for a collaborator outside Foundation A's allowlist.
+
+    ``execution_identity_contract()`` on a live object must never upgrade it
+    into a portable component.  In particular, signal hubs, session caches, and
+    recovery managers have mutable state whose authority belongs to later
+    capsule/event layers.
     """
+    category = (
+        "volatile"
+        if name in {"session_signal_hub", "execution_event_emitter", "event_store"}
+        else "per_attempt_capsule"
+    )
+    return {
+        "mode": "out_of_boundary",
+        "boundary": category,
+        "stability": "process_local",
+        "type": _qualified_type(component) if component is not None else None,
+        "instance_nonce": _process_local_runtime_nonce(component)
+        if component is not None
+        else _process_local_runtime_nonce(_UNBOUND_EXECUTOR_NONCE_OWNER),
+    }
+
+
+def _executor_component_contract(name: str, component: object) -> dict[str, object]:
+    """Describe one explicitly allowed portable executor component.
+
+    Foundation A intentionally has one executor subcomponent: the static leaf
+    dispatcher implementation.  The coordinator, runtime-handle manager,
+    signal hub, event emitter, stores, queues, and live handles are named in
+    :func:`execution_authority_boundary_contract` and are not inferred here.
+    """
+    if name not in _PORTABLE_EXECUTOR_COMPONENTS:
+        return _out_of_boundary_executor_component_contract(component, name=name)
     if component is None:
         return {"mode": "none", "stability": "durable"}
     if isinstance(component, type):
         return _static_executor_component_contract(component)
+    if inspect.ismethod(component) or inspect.isfunction(component) or inspect.isbuiltin(component):
+        return _static_executor_callable_contract(component)
     return {
-        "mode": "live_instance",
+        "mode": "invalid_portable_component",
         "stability": "process_local",
         "type": _qualified_type(component),
-        "implementation": _safe_class_implementation_contract(component),
-        "instance_nonce": uuid.uuid4().hex,
+        "instance_nonce": _process_local_runtime_nonce(component),
     }
 
 
@@ -839,15 +1982,16 @@ def _executor_component_contracts(
         ):
             raise ValueError("executor components are invalid")
         return {
-            name: _executor_component_contract(component) for name, component in components.items()
+            name: _executor_component_contract(name, component)
+            for name, component in components.items()
         }
-    except Exception as exc:
+    except Exception:
         return {
             "unobserved": {
                 "mode": "process_local",
                 "stability": "process_local",
-                "instance_nonce": uuid.uuid4().hex,
-                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "instance_nonce": _process_local_runtime_nonce(components),
+                "reason": _IDENTITY_UNAVAILABLE_REASON,
             }
         }
 
@@ -861,10 +2005,10 @@ def _executor_implementation_contract(
     component_contracts = _executor_component_contracts(components)
     if executor is None:
         return {
-            "version": 2,
+            "version": 3,
             "mode": "unbound",
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
+            "instance_nonce": _process_local_runtime_nonce(_UNBOUND_EXECUTOR_NONCE_OWNER),
             "components": component_contracts,
         }
     implementation = _safe_class_implementation_contract(executor)
@@ -878,7 +2022,7 @@ def _executor_implementation_contract(
         )
     )
     contract: dict[str, object] = {
-        "version": 2,
+        "version": 3,
         "mode": "bound",
         "type": _qualified_type(executor),
         "stability": "durable" if durable else "process_local",
@@ -887,7 +2031,7 @@ def _executor_implementation_contract(
         "components": component_contracts,
     }
     if not durable:
-        contract["instance_nonce"] = uuid.uuid4().hex
+        contract["instance_nonce"] = _process_local_runtime_nonce(executor)
     return contract
 
 
@@ -895,11 +2039,28 @@ def _reject_sensitive_identity_fields(value: object) -> None:
     if isinstance(value, Mapping):
         for key, item in value.items():
             if is_sensitive_field(key):
-                raise ValueError("component identity contains a sensitive field")
+                raise ValueError("component identity contains sensitive data")
             _reject_sensitive_identity_fields(item)
     elif isinstance(value, list):
         for item in value:
             _reject_sensitive_identity_fields(item)
+    elif is_sensitive_value(value):
+        raise ValueError("component identity contains sensitive data")
+
+
+def _canonical_explicit_identity(
+    value: object,
+    *,
+    field: str,
+) -> dict[str, Any]:
+    """Bound, sanitize, and canonicalize one provider-supplied identity mapping."""
+    projected = _project_explicit_identity(value, field=field)
+    _reject_sensitive_identity_fields(projected)
+    normalized = _canonical_object(projected, field=field)
+    encoded = _canonical_json(normalized, field=field)
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        raise ValueError(f"{field} exceeds its budget")
+    return normalized
 
 
 def _instance_executable_overrides(value: object) -> dict[str, object]:
@@ -931,11 +2092,11 @@ def _declared_component_contract(value: object) -> dict[str, object]:
     implementation = _safe_class_implementation_contract(value)
     try:
         executable = _runtime_executable_contract(value)
-    except Exception as exc:
+    except Exception:
         executable = {
             "required": True,
             "observed": False,
-            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
         }
     provider_descriptor = inspect.getattr_static(
         type(value),
@@ -948,7 +2109,7 @@ def _declared_component_contract(value: object) -> dict[str, object]:
             "mode": "process_local",
             "stability": "process_local",
             "type": _qualified_type(value),
-            "instance_nonce": uuid.uuid4().hex,
+            "instance_nonce": _process_local_runtime_nonce(value),
             "reason": "identity_not_declared",
             "implementation": implementation,
             "executable": executable,
@@ -958,11 +2119,10 @@ def _declared_component_contract(value: object) -> dict[str, object]:
         identity = provider()
         if not isinstance(identity, Mapping):
             raise ValueError("component identity is not a mapping")
-        projected = _project_explicit_identity(
+        projected = _canonical_explicit_identity(
             dict(identity),
             field="component execution identity",
         )
-        _reject_sensitive_identity_fields(projected)
         if not isinstance(projected, dict) or set(projected) != {"version", "configuration"}:
             raise ValueError("component identity has an invalid envelope")
         version = projected.get("version")
@@ -975,15 +2135,13 @@ def _declared_component_contract(value: object) -> dict[str, object]:
         ):
             raise ValueError("component identity has an invalid version or configuration")
         encoded = _canonical_json(projected, field="component execution identity")
-        if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
-            raise ValueError("component identity exceeds its budget")
-    except Exception as exc:
+    except Exception:
         return {
             "mode": "process_local",
             "stability": "process_local",
             "type": _qualified_type(value),
-            "instance_nonce": uuid.uuid4().hex,
-            "reason": f"identity_error:{type(exc).__module__}.{type(exc).__qualname__}",
+            "instance_nonce": _process_local_runtime_nonce(value),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
             "implementation": implementation,
             "executable": executable,
         }
@@ -1002,7 +2160,7 @@ def _declared_component_contract(value: object) -> dict[str, object]:
         "executable": executable,
     }
     if not durable:
-        contract["instance_nonce"] = uuid.uuid4().hex
+        contract["instance_nonce"] = _process_local_runtime_nonce(value)
     return contract
 
 
@@ -1019,18 +2177,21 @@ def _runtime_composition_contract(adapter: object) -> dict[str, object]:
         components = provider()
         if not isinstance(components, Mapping) or len(components) > _MAX_IDENTITY_ITEMS:
             raise ValueError("runtime execution components are invalid")
-        if not all(isinstance(name, str) and name for name in components):
+        if not all(
+            isinstance(name, str) and name and not is_sensitive_value(name)
+            for name in components
+        ):
             raise ValueError("runtime execution component names are invalid")
         contracts = {
             name: _declared_component_contract(component) for name, component in components.items()
         }
-    except Exception as exc:
+    except Exception:
         return {
             "version": 1,
             "mode": "declared",
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
-            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+            "reason": _IDENTITY_UNAVAILABLE_REASON,
             "components": {},
         }
     durable = all(contract.get("stability") == "durable" for contract in contracts.values())
@@ -1041,7 +2202,7 @@ def _runtime_composition_contract(adapter: object) -> dict[str, object]:
         "components": contracts,
     }
     if not durable:
-        result["instance_nonce"] = uuid.uuid4().hex
+        result["instance_nonce"] = _process_local_runtime_nonce(adapter)
     return result
 
 
@@ -1069,7 +2230,7 @@ def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
         "composition": composition,
     }
     if contract["stability"] == "process_local":
-        contract["instance_nonce"] = uuid.uuid4().hex
+        contract["instance_nonce"] = _process_local_runtime_nonce(adapter)
     return contract
 
 
@@ -1077,28 +2238,50 @@ def _runtime_handle_selector_contract(
     adapter: object,
     runtime_handle: RuntimeHandle | None,
 ) -> dict[str, object]:
-    if runtime_handle is None:
-        return {"version": 1, "mode": "none"}
+    """Bind selector *implementation*, never a selected attempt handle.
+
+    A concrete ``RuntimeHandle`` is capsule/recovery state.  Foundation A may
+    describe the adapter method that will select one, but must not fold a
+    checkpoint-selected handle or its metadata into the portable baseline.
+    """
+    del runtime_handle
     provider_descriptor = inspect.getattr_static(
         type(adapter),
         "resume_handle_execution_identity_contract",
         None,
     )
     if provider_descriptor is None:
-        return {"version": 1, "mode": "present", "observed": False}
-    provider = object.__getattribute__(
-        adapter,
-        "resume_handle_execution_identity_contract",
-    )
-    identity = provider(runtime_handle)
-    if not isinstance(identity, Mapping):
-        raise ValueError("runtime handle selector identity is not a mapping")
-    return {
+        return {
+            "version": 1,
+            "mode": "none",
+            "stability": "durable",
+        }
+    try:
+        provider = object.__getattribute__(
+            adapter,
+            "resume_handle_execution_identity_contract",
+        )
+        if not callable(provider):
+            raise ValueError("runtime handle selector identity is not callable")
+        implementation = _callable_entrypoint_contract(provider)
+    except Exception:
+        return {
+            "version": 1,
+            "mode": "declared",
+            "stability": "process_local",
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+        }
+    result: dict[str, object] = {
         "version": 1,
-        "mode": "present",
-        "observed": True,
-        "identity": _canonical_object(dict(identity), field="runtime handle selector identity"),
+        "mode": "declared",
+        "stability": (
+            "durable" if implementation.get("stability") == "durable" else "process_local"
+        ),
+        "implementation": implementation,
     }
+    if result["stability"] != "durable":
+        result["instance_nonce"] = _process_local_runtime_nonce(adapter)
+    return result
 
 
 def runtime_authority_contract(
@@ -1109,8 +2292,8 @@ def runtime_authority_contract(
 ) -> dict[str, object]:
     """Combine generic capabilities with one already-resolved runtime identity."""
     if resolved_routing is None:
-        runtime_backend = getattr(adapter, "runtime_backend", None)
-        llm_backend = getattr(adapter, "llm_backend", None)
+        runtime_backend, runtime_backend_observed = _runtime_label(adapter, "runtime_backend")
+        llm_backend, llm_backend_observed = _runtime_label(adapter, "llm_backend")
         constructor_model = constructor_model_contract(adapter)
         execution_identity = runtime_execution_identity_contract(adapter)
         permission_contract = runtime_permission_mode_contract(adapter)
@@ -1119,6 +2302,8 @@ def runtime_authority_contract(
         resolved_data = resolved_routing.data
         runtime_backend = resolved_data.get("runtime_backend")
         llm_backend = resolved_data.get("llm_backend")
+        runtime_backend_observed = resolved_data.get("runtime_backend_unobserved") is not True
+        llm_backend_observed = resolved_data.get("llm_backend_unobserved") is not True
         constructor_model = _canonical_object(
             resolved_data.get("constructor_model"),
             field="resolved constructor model",
@@ -1131,20 +2316,19 @@ def runtime_authority_contract(
             resolved_data.get("permission_mode"),
             field="resolved permission mode",
         )
-    return {
+    result: dict[str, object] = {
         "version": 1,
-        "runtime_backend": (
-            runtime_backend.strip()
-            if isinstance(runtime_backend, str) and runtime_backend.strip()
-            else None
+        "runtime_backend": runtime_backend if isinstance(runtime_backend, str) else None,
+        "self_governs_rate_limit": bool(
+            _safe_runtime_attribute(adapter, "self_governs_rate_limit", False)
         ),
-        "self_governs_rate_limit": bool(getattr(adapter, "self_governs_rate_limit", False)),
-        "llm_backend": (
-            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
-        ),
+        "llm_backend": llm_backend if isinstance(llm_backend, str) else None,
         "permission_mode": permission_contract,
         "constructor_model": constructor_model,
-        "execution_identity": execution_identity,
+        "execution_identity": _authority_runtime_execution_identity(
+            execution_identity,
+            adapter=adapter,
+        ),
         "capabilities": _runtime_capabilities_contract(adapter),
         "implementation": _runtime_implementation_contract(adapter),
         "executable": _runtime_executable_contract(adapter),
@@ -1152,6 +2336,11 @@ def runtime_authority_contract(
         "skill_dispatcher": _runtime_skill_dispatcher_contract(adapter),
         "handle_selector": _runtime_handle_selector_contract(adapter, runtime_handle),
     }
+    if not runtime_backend_observed:
+        result["runtime_backend_unobserved"] = True
+    if not llm_backend_observed:
+        result["llm_backend_unobserved"] = True
+    return result
 
 
 def _project_explicit_identity(
@@ -1223,7 +2412,7 @@ def verifier_authority_contract(
     runtime_transcript_verifier: object | None = None,
 ) -> dict[str, object]:
     """Return durable verifier identity only when it is explicitly declared."""
-    transcript_implementation = _callable_implementation_contract(
+    transcript_implementation = _callable_dependency_implementation_contract(
         runtime_transcript_verifier or _verify_atomic_evidence_against_runtime_messages
     )
     if verifier is None:
@@ -1243,7 +2432,11 @@ def verifier_authority_contract(
     if identity_descriptor is None:
         behavioral_state: dict[str, object] = {
             "stability": "process_local",
-            "instance_nonce": uuid.uuid4().hex,
+            # An undeclared custom verifier does not expose the state needed to
+            # compare two independently-built baselines.  Deliberately issue a
+            # fresh nonce for each contract rather than treating two snapshots
+            # of the same callable object as reusable authority.
+            "instance_nonce": secrets.token_hex(32),
             "reason": "verification_identity_contract is not declared",
         }
     else:
@@ -1257,7 +2450,7 @@ def verifier_authority_contract(
             identity = identity_provider()
             if not isinstance(identity, Mapping):
                 raise ValueError("verification_identity_contract is not a mapping")
-            projected = _project_explicit_identity(
+            projected = _canonical_explicit_identity(
                 dict(identity),
                 field="verification identity contract",
             )
@@ -1268,11 +2461,11 @@ def verifier_authority_contract(
                 "stability": "durable",
                 "identity_digest": _sha256(encoded),
             }
-        except Exception as exc:
+        except Exception:
             behavioral_state = {
                 "stability": "process_local",
-                "instance_nonce": uuid.uuid4().hex,
-                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "instance_nonce": _process_local_runtime_nonce(verifier),
+                "reason": _IDENTITY_UNAVAILABLE_REASON,
             }
     return {
         "version": 1,
@@ -1297,7 +2490,7 @@ def _positive_number(value: object) -> bool:
 
 
 def _valid_dispatch_rate_contract(value: object) -> bool:
-    if not isinstance(value, Mapping) or set(value) != {
+    required_keys = {
         "version",
         "backend",
         "owner",
@@ -1310,11 +2503,21 @@ def _valid_dispatch_rate_contract(value: object) -> bool:
         "heartbeat_seconds",
         "max_wait_seconds",
         "token_estimation_version",
-    }:
+        "gate_algorithm_version",
+        "gate_algorithm",
+        "token_estimator",
+    }
+    if not isinstance(value, Mapping) or (
+        set(value) != required_keys and set(value) != required_keys | {"backend_observed"}
+    ):
         return False
     version = value.get("version")
     token_version = value.get("token_estimation_version")
+    gate_algorithm_version = value.get("gate_algorithm_version")
+    gate_algorithm = value.get("gate_algorithm")
+    token_estimator = value.get("token_estimator")
     backend = value.get("backend")
+    backend_observed = value.get("backend_observed", True)
     owner = value.get("owner")
     observed = value.get("observed")
     self_governs = value.get("self_governs_rate_limit")
@@ -1326,8 +2529,11 @@ def _valid_dispatch_rate_contract(value: object) -> bool:
         or version != 1
         or isinstance(token_version, bool)
         or token_version != 1
+        or isinstance(gate_algorithm_version, bool)
+        or gate_algorithm_version != 1
         or not isinstance(backend, str)
         or not backend.strip()
+        or not isinstance(backend_observed, bool)
         or owner not in {"ouroboros", "runtime"}
         or not isinstance(observed, bool)
         or not isinstance(self_governs, bool)
@@ -1337,6 +2543,10 @@ def _valid_dispatch_rate_contract(value: object) -> bool:
         or not _positive_number(value.get("window_seconds"))
         or not _positive_number(value.get("heartbeat_seconds"))
         or not _positive_number(value.get("max_wait_seconds"))
+    ):
+        return False
+    if not _valid_rate_helper_contract(gate_algorithm) or not _valid_rate_helper_contract(
+        token_estimator
     ):
         return False
     if owner == "runtime":
@@ -1354,8 +2564,87 @@ def _valid_dispatch_rate_contract(value: object) -> bool:
     )
 
 
+def _valid_rate_helper_contract(value: object) -> bool:
+    """Validate an opaque captured gate/estimator implementation snapshot."""
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    if value.get("observed") is True:
+        return (
+            set(value) == {"version", "observed", "identity_digest", "digest"}
+            and isinstance(value.get("identity_digest"), str)
+            and _SHA256_DIGEST_PATTERN.fullmatch(value["identity_digest"]) is not None
+            and isinstance(value.get("digest"), str)
+            and _SHA256_DIGEST_PATTERN.fullmatch(value["digest"]) is not None
+        )
+    if value.get("observed") is False:
+        return (
+            set(value) == {"version", "observed", "instance_nonce"}
+            and isinstance(value.get("instance_nonce"), str)
+            and bool(value["instance_nonce"])
+        )
+    return False
+
+
+def _redacted_authority_policy_value(value: object) -> object:
+    """Return an authority-only copy with credential-shaped values opaque.
+
+    Execution policy continues to drive the live executor unchanged.  This
+    projection exists solely for the immutable authority payload, where a model
+    alias or free-form effort label must never become a credential egress path.
+    The digest preserves a deterministic distinction between two secrets while
+    keeping the surrounding schema (including model-routing strings) valid.
+    """
+    if isinstance(value, str):
+        if is_sensitive_value(value):
+            return "redacted:sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+        return value
+    if isinstance(value, Mapping):
+        return {
+            key: _redacted_authority_policy_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redacted_authority_policy_value(item) for item in value]
+    return value
+
+
+def _authority_execution_policy_contract(
+    execution_policy: Mapping[str, object],
+    *,
+    adapter: object,
+) -> dict[str, object]:
+    """Project a safe authority snapshot without changing live dispatch policy."""
+    policy = _canonical_object(dict(execution_policy), field="execution policy")
+    dispatch_rate = policy.get("dispatch_rate")
+    if isinstance(dispatch_rate, Mapping):
+        normalized_rate = dict(dispatch_rate)
+        policy_backend = normalized_rate.get("backend")
+        runtime_backend = _safe_runtime_attribute(adapter, "runtime_backend")
+        if is_sensitive_value(policy_backend) or is_sensitive_value(runtime_backend):
+            normalized_rate["backend"] = "unknown"
+            normalized_rate["backend_observed"] = False
+        policy["dispatch_rate"] = normalized_rate
+    redacted = _redacted_authority_policy_value(policy)
+    if not isinstance(redacted, dict):  # pragma: no cover - canonical object invariant
+        raise ValueError("execution policy redaction did not produce an object")
+    return redacted
+
+
+def _contains_sensitive_policy_value(value: object) -> bool:
+    """Return whether a would-be authority policy still carries a credential."""
+    if isinstance(value, str):
+        return is_sensitive_value(value)
+    if isinstance(value, Mapping):
+        return any(_contains_sensitive_policy_value(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_sensitive_policy_value(item) for item in value)
+    return False
+
+
 def valid_execution_policy_contract(value: object) -> bool:
     if not isinstance(value, Mapping) or set(value) != _EXECUTION_POLICY_KEYS:
+        return False
+    if _contains_sensitive_policy_value(value):
         return False
     version = value.get("version")
     depth = value.get("max_decomposition_depth")
@@ -1470,6 +2759,7 @@ class ExecutionAuthorityContract:
         )
         if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != {
             "version",
+            "boundary",
             "executor",
             "workspace",
             "runtime",
@@ -1477,6 +2767,8 @@ class ExecutionAuthorityContract:
             "execution_policy",
         }:
             raise ValueError("execution authority contract has an invalid shape")
+        if not _valid_execution_authority_boundary(data.get("boundary")):
+            raise ValueError("execution authority contract has an invalid boundary")
         if not valid_execution_policy_contract(data.get("execution_policy")):
             raise ValueError("execution authority contract has an invalid execution policy")
         runtime = data.get("runtime")
@@ -1496,10 +2788,21 @@ class ExecutionAuthorityContract:
         runtime_self_governs = (
             runtime.get("self_governs_rate_limit") if isinstance(runtime, Mapping) else None
         )
+        runtime_backend_unobserved = (
+            isinstance(runtime, Mapping) and runtime.get("runtime_backend_unobserved") is True
+        )
+        dispatch_backend_observed = (
+            isinstance(dispatch_rate, Mapping)
+            and dispatch_rate.get("backend_observed", True) is True
+        )
         expected_backend = (
             runtime_backend if isinstance(runtime_backend, str) and runtime_backend else "unknown"
         )
-        if dispatch_backend != expected_backend:
+        if (
+            not runtime_backend_unobserved
+            and dispatch_backend_observed
+            and dispatch_backend != expected_backend
+        ):
             raise ValueError("dispatch rate policy disagrees with the runtime backend")
         if dispatch_self_governs is not runtime_self_governs:
             raise ValueError("dispatch rate policy disagrees with runtime self-governance")
@@ -1524,6 +2827,7 @@ class ExecutionAuthorityContract:
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
+            "boundary": execution_authority_boundary_contract(),
             "executor": _executor_implementation_contract(
                 executor,
                 components=executor_components,
@@ -1542,9 +2846,9 @@ class ExecutionAuthorityContract:
                 verifier,
                 runtime_transcript_verifier=runtime_transcript_verifier,
             ),
-            "execution_policy": _canonical_object(
-                dict(execution_policy),
-                field="execution policy",
+            "execution_policy": _authority_execution_policy_contract(
+                execution_policy,
+                adapter=adapter,
             ),
         }
         return cls(_canonical_json(data, field="execution authority contract"))
@@ -1569,6 +2873,8 @@ class ExecutionAuthorityContract:
         those require a complete per-attempt capsule with the omitted inputs.
         """
         data = self.data
+        if not _valid_execution_authority_boundary(data.get("boundary")):
+            return False
         executor = data.get("executor")
         if not isinstance(executor, Mapping) or executor.get("stability") != "durable":
             return False
@@ -1589,24 +2895,39 @@ class ExecutionAuthorityContract:
         )
         if not isinstance(dispatch_rate, Mapping) or dispatch_rate.get("observed") is not True:
             return False
+        if dispatch_rate.get("backend_observed", True) is not True:
+            return False
+        gate_algorithm = dispatch_rate.get("gate_algorithm")
+        token_estimator = dispatch_rate.get("token_estimator")
+        if (
+            not isinstance(gate_algorithm, Mapping)
+            or gate_algorithm.get("observed") is not True
+            or not isinstance(token_estimator, Mapping)
+            or token_estimator.get("observed") is not True
+        ):
+            return False
 
         runtime = data.get("runtime")
         if not isinstance(runtime, Mapping):
             return False
         runtime_backend = runtime.get("runtime_backend")
-        if not isinstance(runtime_backend, str) or not runtime_backend:
+        if (
+            runtime.get("runtime_backend_unobserved") is True
+            or not isinstance(runtime_backend, str)
+            or not runtime_backend
+        ):
+            return False
+        if runtime.get("llm_backend_unobserved") is True:
             return False
         for field_name in ("permission_mode", "constructor_model", "execution_identity"):
             value = runtime.get(field_name)
             if not isinstance(value, Mapping) or value.get("observed") is not True:
                 return False
         execution_identity = runtime.get("execution_identity")
-        resolved_identity = (
-            execution_identity.get("identity") if isinstance(execution_identity, Mapping) else None
-        )
         if (
-            not isinstance(resolved_identity, Mapping)
-            or resolved_identity.get("effective_model_observed") is not True
+            not _valid_authority_runtime_execution_identity(execution_identity)
+            or not isinstance(execution_identity, Mapping)
+            or execution_identity.get("effective_model_observed") is not True
         ):
             return False
         implementation = runtime.get("implementation")
@@ -1618,8 +2939,14 @@ class ExecutionAuthorityContract:
         if executable.get("required") is True and executable.get("observed") is not True:
             return False
         watchdog = runtime.get("watchdog")
+        if (
+            not isinstance(watchdog, Mapping)
+            or watchdog.get("required") is True
+            and watchdog.get("observed") is not True
+        ):
+            return False
         if executable.get("required") is True and (
-            not isinstance(watchdog, Mapping) or watchdog.get("observed") is not True
+            watchdog.get("observed") is not True
         ):
             return False
         skill_dispatcher = runtime.get("skill_dispatcher")
@@ -1631,7 +2958,10 @@ class ExecutionAuthorityContract:
         handle_selector = runtime.get("handle_selector")
         if not isinstance(handle_selector, Mapping):
             return False
-        if handle_selector.get("mode") != "none" and handle_selector.get("observed") is not True:
+        if (
+            handle_selector.get("mode") not in {"none", "declared"}
+            or handle_selector.get("stability") != "durable"
+        ):
             return False
 
         verifier = data.get("verifier")
@@ -1656,14 +2986,17 @@ class ExecutionAuthorityContract:
 
 __all__ = [
     "EXECUTION_AUTHORITY_VERSION",
+    "EXECUTION_AUTHORITY_BOUNDARY_VERSION",
     "ExecutionAuthorityContract",
     "ResolvedRuntimeAuthority",
     "build_execution_policy_contract",
     "canonical_workspace_authority",
     "constructor_model_contract",
+    "execution_authority_boundary_contract",
     "runtime_authority_contract",
     "runtime_execution_identity_contract",
     "runtime_execution_proves_effective_model",
+    "runtime_routing_labels_contract",
     "valid_constructor_model_contract",
     "valid_execution_policy_contract",
     "valid_runtime_execution_identity_contract",

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -23,6 +23,7 @@ import shutil
 from typing import Any
 import uuid
 
+from ouroboros.core.security import is_sensitive_field
 from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
@@ -394,6 +395,10 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
     return _callable_implementation_contract(implementation)
 
 
+def _qualified_type(value: object) -> str:
+    return f"{type(value).__module__}.{type(value).__qualname__}"
+
+
 def _file_content_digest(path: str | os.PathLike[str]) -> str | None:
     try:
         digest = hashlib.sha256()
@@ -608,29 +613,12 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
-    """Bind the runtime class hierarchy without guessing execution-critical hooks."""
+def _class_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind one object's class hierarchy without inspecting its instance state."""
     classes: list[str] = []
-    instance_callables: dict[str, object] = {}
     members: dict[str, object] = {}
     modules: dict[str, object] = {}
     durable = True
-    try:
-        instance_state = vars(adapter)
-    except TypeError:
-        instance_state = {}
-        durable = False
-        instance_state_observed = False
-    else:
-        instance_state_observed = True
-    for attribute_name, value in instance_state.items():
-        if not callable(value):
-            continue
-        instance_callables[attribute_name] = _callable_entrypoint_contract(value)
-        # Instance-level executable behavior may carry closure or mutable state
-        # that a class/module digest cannot prove portable. Bind it for audit,
-        # but fail closed for cross-process composition.
-        durable = False
     for runtime_class in type(adapter).__mro__:
         if runtime_class is object:
             continue
@@ -669,13 +657,18 @@ def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
         }
         try:
             source_path = inspect.getsourcefile(runtime_class)
-        except TypeError:
+        except (OSError, TypeError):
             source_path = None
         if source_path is None:
             durable = False
             modules[qualified_name] = {"observed": False}
             continue
-        realpath = str(Path(source_path).resolve(strict=False))
+        try:
+            realpath = str(Path(source_path).resolve(strict=False))
+        except (OSError, RuntimeError):
+            durable = False
+            modules[qualified_name] = {"observed": False}
+            continue
         digest = _file_content_digest(realpath)
         if digest is None:
             durable = False
@@ -685,13 +678,201 @@ def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
             "observed": True,
             "content_digest": digest,
         }
-    contract: dict[str, object] = {
+    return {
         "stability": "durable" if durable and classes else "process_local",
         "classes": classes,
-        "instance_callables": instance_callables,
-        "instance_state_observed": instance_state_observed,
         "members": members,
         "modules": modules,
+    }
+
+
+def _safe_class_implementation_contract(value: object) -> dict[str, object]:
+    try:
+        return _class_implementation_contract(value)
+    except Exception as exc:
+        return {
+            "stability": "process_local",
+            "observed": False,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+
+
+def _reject_sensitive_identity_fields(value: object) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if is_sensitive_field(key):
+                raise ValueError("component identity contains a sensitive field")
+            _reject_sensitive_identity_fields(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_sensitive_identity_fields(item)
+
+
+def _instance_executable_overrides(value: object) -> dict[str, object]:
+    try:
+        instance_state = vars(value)
+    except TypeError:
+        return {}
+    missing = object()
+    overrides: dict[str, object] = {}
+    for name, item in instance_state.items():
+        if not isinstance(name, str) or not name:
+            continue
+        if callable(item):
+            overrides[name] = {
+                "mode": "callable",
+                "implementation": _callable_entrypoint_contract(item),
+            }
+            continue
+        class_member = inspect.getattr_static(type(value), name, missing)
+        if class_member is missing or not (
+            callable(class_member) or isinstance(class_member, (classmethod, staticmethod))
+        ):
+            continue
+        overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
+    return overrides
+
+
+def _declared_component_contract(value: object) -> dict[str, object]:
+    implementation = _safe_class_implementation_contract(value)
+    try:
+        executable = _runtime_executable_contract(value)
+    except Exception as exc:
+        executable = {
+            "required": True,
+            "observed": False,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+    provider_descriptor = inspect.getattr_static(
+        type(value),
+        "execution_identity_contract",
+        None,
+    )
+    instance_overrides = _instance_executable_overrides(value)
+    if provider_descriptor is None:
+        return {
+            "mode": "process_local",
+            "stability": "process_local",
+            "type": _qualified_type(value),
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": "identity_not_declared",
+            "implementation": implementation,
+            "executable": executable,
+        }
+    try:
+        provider = object.__getattribute__(value, "execution_identity_contract")
+        identity = provider()
+        if not isinstance(identity, Mapping):
+            raise ValueError("component identity is not a mapping")
+        projected = _project_explicit_identity(
+            dict(identity),
+            field="component execution identity",
+        )
+        _reject_sensitive_identity_fields(projected)
+        if not isinstance(projected, dict) or set(projected) != {"version", "configuration"}:
+            raise ValueError("component identity has an invalid envelope")
+        version = projected.get("version")
+        configuration = projected.get("configuration")
+        if (
+            isinstance(version, bool)
+            or version != 1
+            or not isinstance(configuration, dict)
+            or not configuration
+        ):
+            raise ValueError("component identity has an invalid version or configuration")
+        encoded = _canonical_json(projected, field="component execution identity")
+        if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+            raise ValueError("component identity exceeds its budget")
+    except Exception as exc:
+        return {
+            "mode": "process_local",
+            "stability": "process_local",
+            "type": _qualified_type(value),
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"identity_error:{type(exc).__module__}.{type(exc).__qualname__}",
+            "implementation": implementation,
+            "executable": executable,
+        }
+    durable = (
+        not instance_overrides
+        and implementation.get("stability") == "durable"
+        and (executable.get("required") is not True or executable.get("observed") is True)
+    )
+    contract: dict[str, object] = {
+        "mode": "declared",
+        "stability": "durable" if durable else "process_local",
+        "type": _qualified_type(value),
+        "identity_digest": _sha256(encoded),
+        "instance_overrides": instance_overrides,
+        "implementation": implementation,
+        "executable": executable,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _runtime_composition_contract(adapter: object) -> dict[str, object]:
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "execution_components",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "mode": "none", "stability": "durable", "components": {}}
+    try:
+        provider = object.__getattribute__(adapter, "execution_components")
+        components = provider()
+        if not isinstance(components, Mapping) or len(components) > _MAX_IDENTITY_ITEMS:
+            raise ValueError("runtime execution components are invalid")
+        if not all(isinstance(name, str) and name for name in components):
+            raise ValueError("runtime execution component names are invalid")
+        contracts = {
+            name: _declared_component_contract(component) for name, component in components.items()
+        }
+    except Exception as exc:
+        return {
+            "version": 1,
+            "mode": "declared",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "components": {},
+        }
+    durable = all(contract.get("stability") == "durable" for contract in contracts.values())
+    result: dict[str, object] = {
+        "version": 1,
+        "mode": "declared",
+        "stability": "durable" if durable else "process_local",
+        "components": contracts,
+    }
+    if not durable:
+        result["instance_nonce"] = uuid.uuid4().hex
+    return result
+
+
+def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind runtime code plus explicitly owned execution components."""
+    class_contract = _class_implementation_contract(adapter)
+    instance_overrides = _instance_executable_overrides(adapter)
+    durable = class_contract.get("stability") == "durable"
+    try:
+        vars(adapter)
+    except TypeError:
+        durable = False
+        instance_state_observed = False
+    else:
+        instance_state_observed = True
+    if instance_overrides:
+        durable = False
+    composition = _runtime_composition_contract(adapter)
+    durable = durable and composition.get("stability") == "durable"
+    contract: dict[str, object] = {
+        **class_contract,
+        "stability": "durable" if durable else "process_local",
+        "instance_overrides": instance_overrides,
+        "instance_state_observed": instance_state_observed,
+        "composition": composition,
     }
     if contract["stability"] == "process_local":
         contract["instance_nonce"] = uuid.uuid4().hex

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -384,26 +384,33 @@ def _callable_implementation_contract(target: object) -> dict[str, object]:
     }
 
 
-def _callable_entrypoint_contract(target: object) -> dict[str, object]:
-    """Fingerprint the code actually invoked for functions, methods, and callables."""
+def _callable_leaf_implementation_contract(target: object) -> dict[str, object]:
+    """Fingerprint one callable entrypoint without following nested callable state."""
     if inspect.ismethod(target):
         implementation = target.__func__
     elif inspect.isfunction(target) or inspect.isbuiltin(target):
         implementation = target
     else:
+        implementation = type(target).__call__
+    return _callable_implementation_contract(implementation)
+
+
+def _callable_entrypoint_contract(target: object) -> dict[str, object]:
+    """Fingerprint the code actually invoked for functions, methods, and callables."""
+    if not (inspect.ismethod(target) or inspect.isfunction(target) or inspect.isbuiltin(target)):
         class_contract = _safe_class_implementation_contract(target)
         instance_overrides = _instance_executable_overrides(target)
         durable = class_contract.get("stability") == "durable" and not instance_overrides
         contract: dict[str, object] = {
             **class_contract,
             "stability": "durable" if durable else "process_local",
-            "entrypoint": _callable_implementation_contract(type(target).__call__),
+            "entrypoint": _callable_leaf_implementation_contract(target),
             "instance_overrides": instance_overrides,
         }
         if not durable:
             contract["instance_nonce"] = uuid.uuid4().hex
         return contract
-    return _callable_implementation_contract(implementation)
+    return _callable_leaf_implementation_contract(target)
 
 
 def _qualified_type(value: object) -> str:
@@ -745,7 +752,7 @@ def _instance_declared_method_overrides(value: object) -> dict[str, object]:
         if callable(item):
             overrides[name] = {
                 "mode": "callable",
-                "implementation": _callable_entrypoint_contract(item),
+                "implementation": _callable_leaf_implementation_contract(item),
             }
         else:
             overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
@@ -801,7 +808,7 @@ def _instance_executable_overrides(value: object) -> dict[str, object]:
         if callable(item):
             overrides[name] = {
                 "mode": "callable",
-                "implementation": _callable_entrypoint_contract(item),
+                "implementation": _callable_leaf_implementation_contract(item),
             }
             continue
         class_member = inspect.getattr_static(type(value), name, missing)

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1299,7 +1299,20 @@ def _transcript_verdict_type_contract(value: type[object]) -> dict[str, object]:
 
     required_members = ("__init__", "__post_init__", "__setattr__")
     members: dict[str, object] = {}
+    member_shape: dict[str, str] = {}
     missing = object()
+    for member_name, raw_member in vars(value).items():
+        if not isinstance(member_name, str):
+            raise ValueError("runtime transcript verifier result member name is invalid")
+        if isinstance(raw_member, (classmethod, staticmethod, property)):
+            kind = "descriptor"
+        elif inspect.isfunction(raw_member):
+            kind = "function"
+        elif callable(raw_member):
+            kind = "callable"
+        else:
+            kind = "data"
+        member_shape[_sha256(member_name)] = kind
     for member_name in required_members:
         raw_member = inspect.getattr_static(value, member_name, missing)
         if isinstance(raw_member, (classmethod, staticmethod)):
@@ -1316,6 +1329,14 @@ def _transcript_verdict_type_contract(value: type[object]) -> dict[str, object]:
         "type": _opaque_type_identity_digest(value),
         "member_digest": _sha256(
             _canonical_json(members, field="runtime transcript verifier result members")
+        ),
+        # A newly inserted special method (for example ``__getattribute__``)
+        # can change how a verdict is consumed without changing the selected
+        # construction methods above. Bind the full member *shape* as an
+        # opaque digest while excluding comparison/repr implementation details
+        # that are unrelated to transcript acceptance.
+        "member_shape_digest": _sha256(
+            _canonical_json(member_shape, field="runtime transcript verifier result member shape")
         ),
     }
 

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,23 +1,33 @@
-"""Canonical execution authority shared by routing, recovery, and verification.
+"""Canonical executor-baseline authority shared by later runtime layers.
 
 This module owns identity only. It does not authorize a dispatch, persist a
-checkpoint, or declare acceptance. Later runtime layers can depend on one stable
-contract instead of deriving narrower fingerprints independently.
+checkpoint, or declare acceptance. Per-attempt inputs such as the AC, prompt,
+tool envelope, and a checkpoint-selected resume handle belong to the later
+attempt capsule. That capsule can compose this stable baseline instead of
+deriving narrower runtime, verifier, workspace, and policy fingerprints again.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import inspect
 import json
 import marshal
 import math
+import os
 from pathlib import Path
+import shutil
 from typing import Any
 import uuid
 
+from ouroboros.orchestrator.adapter import RuntimeHandle
+from ouroboros.orchestrator.evidence.verification import (
+    _verify_atomic_evidence_against_runtime_messages,
+)
+from ouroboros.orchestrator.model_routing import ModelRouter, serialize_model_router
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
@@ -26,6 +36,7 @@ _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
+_RESOLVED_RUNTIME_AUTHORITY_TOKEN = object()
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -52,16 +63,48 @@ def _sha256(value: str) -> str:
     return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
-    """Return the exact checkout path that owns effects for this executor."""
-    if not isinstance(workspace, str) or not workspace.strip():
-        return {"version": 1, "observed": False}
-    canonical = str(Path(workspace).expanduser().resolve(strict=False))
+def canonical_workspace_authority(
+    workspace: str | None,
+    *,
+    identity: Mapping[str, object] | None = None,
+    generation: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Return the checkout owner plus an optional immutable generation identity."""
+    if identity is not None:
+        owner = _canonical_object(dict(identity), field="workspace identity")
+        resolved_cwd = owner.get("effective_cwd")
+        if (
+            not isinstance(workspace, str)
+            or not workspace.strip()
+            or not isinstance(resolved_cwd, str)
+            or str(Path(workspace).expanduser().resolve(strict=False))
+            != str(Path(resolved_cwd).expanduser().resolve(strict=False))
+        ):
+            raise ValueError("workspace identity disagrees with the effective workspace")
+    elif isinstance(workspace, str) and workspace.strip():
+        owner = {
+            "mode": "direct",
+            "effective_cwd": str(Path(workspace).expanduser().resolve(strict=False)),
+        }
+    else:
+        return {
+            "version": 1,
+            "observed": False,
+            "generation": {"observed": False},
+        }
+    generation_contract: dict[str, object] = (
+        {
+            "observed": True,
+            "identity": _canonical_object(dict(generation), field="workspace generation"),
+        }
+        if generation is not None
+        else {"observed": False}
+    )
     return {
         "version": 1,
         "observed": True,
-        "mode": "direct",
-        "effective_cwd": canonical,
+        "identity": owner,
+        "generation": generation_contract,
     }
 
 
@@ -158,6 +201,93 @@ def runtime_execution_proves_effective_model(value: object) -> bool:
     return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
 
 
+def runtime_permission_mode_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized permission mode that the runtime actually executes."""
+    permission_mode: object = None
+    private_descriptor = inspect.getattr_static(adapter, "_permission_mode", None)
+    if private_descriptor is not None:
+        permission_mode = object.__getattribute__(adapter, "_permission_mode")
+    if not isinstance(permission_mode, str) or not permission_mode.strip():
+        permission_mode = getattr(adapter, "permission_mode", None)
+    return (
+        {"observed": True, "mode": permission_mode.strip()}
+        if isinstance(permission_mode, str) and permission_mode.strip()
+        else {"observed": False}
+    )
+
+
+def _active_resolved_runtime_fields(adapter: object) -> dict[str, object]:
+    runtime_backend = getattr(adapter, "runtime_backend", None)
+    llm_backend = getattr(adapter, "llm_backend", None)
+    return {
+        "runtime_backend": (
+            runtime_backend.strip()
+            if isinstance(runtime_backend, str) and runtime_backend.strip()
+            else None
+        ),
+        "llm_backend": (
+            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
+        ),
+        "permission_mode": runtime_permission_mode_contract(adapter),
+        "constructor_model": constructor_model_contract(adapter),
+        "runtime_execution": runtime_execution_identity_contract(adapter),
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRuntimeAuthority:
+    """Runner-resolved runtime identity validated against the active adapter."""
+
+    canonical_json: str
+    _binding_token: object = field(repr=False, compare=False)
+    _adapter: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._binding_token is not _RESOLVED_RUNTIME_AUTHORITY_TOKEN:
+            raise ValueError("resolved runtime authority was not bound to an adapter")
+        canonical = _canonical_json(
+            json.loads(self.canonical_json),
+            field="resolved runtime authority",
+        )
+        if canonical != self.canonical_json:
+            raise ValueError("resolved runtime authority is not canonical")
+
+    @classmethod
+    def bind(
+        cls,
+        adapter: object,
+        resolved_routing: Mapping[str, object],
+    ) -> ResolvedRuntimeAuthority:
+        active = _active_resolved_runtime_fields(adapter)
+        for field_name, active_value in active.items():
+            if resolved_routing.get(field_name) != active_value:
+                raise ValueError(f"resolved runtime authority disagrees with active {field_name}")
+        return cls(
+            canonical_json=_canonical_json(
+                dict(resolved_routing),
+                field="resolved runtime authority",
+            ),
+            _binding_token=_RESOLVED_RUNTIME_AUTHORITY_TOKEN,
+            _adapter=adapter,
+        )
+
+    def require_adapter(self, adapter: object) -> None:
+        """Reject reuse of a routing identity bound against another runtime instance."""
+        if self._adapter is not adapter:
+            raise ValueError("resolved runtime authority is bound to a different adapter")
+        active = _active_resolved_runtime_fields(adapter)
+        resolved = self.data
+        for field_name, active_value in active.items():
+            if resolved.get(field_name) != active_value:
+                raise ValueError(f"resolved runtime authority drifted from active {field_name}")
+
+    @property
+    def data(self) -> dict[str, Any]:
+        return _canonical_object(
+            json.loads(self.canonical_json), field="resolved runtime authority"
+        )
+
+
 def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
     capabilities = runtime_capabilities_for(adapter)
     return {
@@ -179,11 +309,409 @@ def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def runtime_authority_contract(adapter: object) -> dict[str, object]:
-    """Combine generic capabilities with backend-owned resolved identity."""
-    runtime_backend = getattr(adapter, "runtime_backend", None)
-    llm_backend = getattr(adapter, "llm_backend", None)
-    permission_mode = getattr(adapter, "permission_mode", None)
+def _callable_implementation_contract(target: object) -> dict[str, object]:
+    """Identify executable behavior without persisting source or code objects."""
+    module = getattr(target, "__module__", type(target).__module__)
+    qualname = getattr(target, "__qualname__", type(target).__qualname__)
+    try:
+        source_digest = _sha256(inspect.getsource(target))
+    except (OSError, TypeError):
+        source_digest = None
+    code = getattr(target, "__code__", None)
+    code_digest = (
+        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+        if source_digest is None and code is not None
+        else None
+    )
+    if source_digest is None and code_digest is None:
+        return {
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "module": str(module),
+            "qualname": str(qualname),
+        }
+    return {
+        "stability": "durable",
+        "module": str(module),
+        "qualname": str(qualname),
+        "source_digest": source_digest,
+        "code_digest": code_digest,
+    }
+
+
+def _callable_entrypoint_contract(target: object) -> dict[str, object]:
+    """Fingerprint the code actually invoked for functions, methods, and callables."""
+    if inspect.ismethod(target):
+        implementation = target.__func__
+    elif inspect.isfunction(target) or inspect.isbuiltin(target):
+        implementation = target
+    else:
+        implementation = type(target).__call__
+    return _callable_implementation_contract(implementation)
+
+
+def _file_content_digest(path: str | os.PathLike[str]) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as source_file:
+            while chunk := source_file.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return "sha256:" + digest.hexdigest()
+
+
+def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object] | None:
+    if isinstance(value, os.PathLike):
+        value = os.fspath(value)
+    if not isinstance(value, str) or not value:
+        return None
+    expanded = os.path.expanduser(value)
+    has_separator = os.sep in expanded or os.altsep is not None and os.altsep in expanded
+    if not has_separator:
+        search_path = os.environ.get("PATH", os.defpath)
+        if cwd is not None:
+            search_path = os.pathsep.join(
+                entry if os.path.isabs(entry) else os.path.join(cwd, entry)
+                for entry in search_path.split(os.pathsep)
+            )
+        resolved = shutil.which(expanded, path=search_path)
+        realpath = os.path.realpath(resolved) if resolved is not None else None
+    else:
+        if not os.path.isabs(expanded) and cwd is not None:
+            expanded = os.path.join(cwd, expanded)
+        realpath = os.path.realpath(expanded)
+    generation: dict[str, int] | None = None
+    content_digest: str | None = None
+    if realpath is not None:
+        try:
+            digest = hashlib.sha256()
+            with Path(realpath).open("rb") as executable_file:
+                stat = os.fstat(executable_file.fileno())
+                while chunk := executable_file.read(1024 * 1024):
+                    digest.update(chunk)
+        except OSError:
+            pass
+        else:
+            generation = {
+                "device": stat.st_dev,
+                "inode": stat.st_ino,
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+            content_digest = "sha256:" + digest.hexdigest()
+    return {
+        "path": value,
+        "realpath": realpath,
+        "generation": generation,
+        "content_digest": content_digest,
+    }
+
+
+def _runtime_executable_contract(adapter: object) -> dict[str, object]:
+    """Bind subprocess executables, launchers, and delegated command policy."""
+    cwd_value = getattr(adapter, "working_directory", None) or getattr(adapter, "_cwd", None)
+    cwd = cwd_value if isinstance(cwd_value, str) and cwd_value else None
+    declared_descriptor = inspect.getattr_static(
+        type(adapter),
+        "executable_identity_contract",
+        None,
+    )
+    command_policy: dict[str, Any] | None = None
+    executable: dict[str, object] | None = None
+    launcher: dict[str, object] | None = None
+    if declared_descriptor is not None:
+        declared_provider = object.__getattribute__(adapter, "executable_identity_contract")
+        declared = declared_provider()
+        if not isinstance(declared, Mapping):
+            raise ValueError("runtime executable identity is not a mapping")
+        executable = _resolved_executable(declared.get("executable"), cwd=cwd)
+        launcher = _resolved_executable(declared.get("launcher"), cwd=cwd)
+        raw_policy = declared.get("command_policy")
+        if raw_policy is not None:
+            command_policy = _canonical_object(raw_policy, field="runtime command policy")
+    else:
+        executable = _resolved_executable(
+            getattr(adapter, "cli_path", None) or getattr(adapter, "_cli_path", None),
+            cwd=cwd,
+        )
+        launcher = _resolved_executable(getattr(adapter, "_electron_node_path", None), cwd=cwd)
+    required = executable is not None or launcher is not None or command_policy is not None
+    observed = not required or all(
+        item is None
+        or item.get("realpath") is not None
+        and item.get("generation") is not None
+        and item.get("content_digest") is not None
+        for item in (executable, launcher)
+    )
+    return {
+        "required": required,
+        "observed": observed,
+        "executable": executable,
+        "launcher": launcher,
+        "command_policy": command_policy,
+    }
+
+
+def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "watchdog_identity_contract",
+        None,
+    )
+    if provider_descriptor is not None:
+        provider = object.__getattribute__(adapter, "watchdog_identity_contract")
+        value = provider()
+        if not isinstance(value, Mapping):
+            raise ValueError("runtime watchdog identity is not a mapping")
+        return {"observed": True, "identity": _canonical_object(value, field="watchdog identity")}
+    fields = (
+        "_startup_output_timeout_seconds",
+        "_stdout_idle_timeout_seconds",
+        "_process_shutdown_timeout_seconds",
+        "_completed_process_group_shutdown_timeout_seconds",
+        "_max_resume_retries",
+        "_max_stderr_lines",
+        "_use_process_group",
+        "_child_session_env_keys",
+    )
+    missing = object()
+    values: dict[str, object] = {}
+    for field_name in fields:
+        value = inspect.getattr_static(adapter, field_name, missing)
+        if value is not missing:
+            values[field_name.removeprefix("_")] = object.__getattribute__(
+                adapter,
+                field_name,
+            )
+    return {
+        "observed": bool(values),
+        "identity": _canonical_object(values, field="watchdog identity") if values else None,
+    }
+
+
+def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
+    dispatcher_descriptor = inspect.getattr_static(adapter, "_skill_dispatcher", None)
+    dispatcher = (
+        object.__getattribute__(adapter, "_skill_dispatcher")
+        if dispatcher_descriptor is not None
+        else None
+    )
+    local_dispatch_descriptor = inspect.getattr_static(
+        type(adapter),
+        "_maybe_dispatch_skill_intercept",
+        None,
+    )
+    if dispatcher is None and local_dispatch_descriptor is None:
+        return {"mode": "none", "stability": "durable"}
+
+    if dispatcher is None:
+        local_entrypoint = inspect.getattr_static(
+            type(adapter),
+            "_dispatch_skill_intercept_locally",
+            None,
+        )
+        return {
+            "mode": "local_fallback",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "skills_dir": str(getattr(adapter, "_skills_dir", None)),
+            "resolver_implementation": _callable_implementation_contract(local_dispatch_descriptor),
+            "dispatcher_implementation": (
+                _callable_implementation_contract(local_entrypoint)
+                if local_entrypoint is not None
+                else None
+            ),
+        }
+
+    implementation = _callable_entrypoint_contract(dispatcher)
+    try:
+        identity_provider = getattr(dispatcher, "execution_identity_contract", None)
+    except Exception as exc:
+        return {
+            "mode": "custom",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "implementation": implementation,
+        }
+    if callable(identity_provider):
+        try:
+            identity = identity_provider()
+            if not isinstance(identity, Mapping):
+                raise ValueError("skill dispatcher identity is not a mapping")
+            encoded = _canonical_json(dict(identity), field="skill dispatcher identity")
+        except Exception as exc:
+            return {
+                "mode": "custom",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "implementation": implementation,
+            }
+        if implementation.get("stability") == "durable" and local_dispatch_descriptor is None:
+            return {
+                "mode": "custom",
+                "stability": "durable",
+                "identity_digest": _sha256(encoded),
+                "implementation": implementation,
+            }
+    return {
+        "mode": "custom",
+        "stability": "process_local",
+        "instance_nonce": uuid.uuid4().hex,
+        "implementation": implementation,
+    }
+
+
+def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind the runtime class hierarchy without guessing execution-critical hooks."""
+    classes: list[str] = []
+    instance_callables: dict[str, object] = {}
+    members: dict[str, object] = {}
+    modules: dict[str, object] = {}
+    durable = True
+    try:
+        instance_state = vars(adapter)
+    except TypeError:
+        instance_state = {}
+        durable = False
+        instance_state_observed = False
+    else:
+        instance_state_observed = True
+    for attribute_name, value in instance_state.items():
+        if not callable(value):
+            continue
+        instance_callables[attribute_name] = _callable_entrypoint_contract(value)
+        # Instance-level executable behavior may carry closure or mutable state
+        # that a class/module digest cannot prove portable. Bind it for audit,
+        # but fail closed for cross-process composition.
+        durable = False
+    for runtime_class in type(adapter).__mro__:
+        if runtime_class is object:
+            continue
+        qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
+        classes.append(qualified_name)
+        if "<locals>" in runtime_class.__qualname__:
+            durable = False
+        class_members: dict[str, object] = {}
+        for member_name, raw_member in vars(runtime_class).items():
+            targets: tuple[object, ...]
+            if isinstance(raw_member, (classmethod, staticmethod)):
+                targets = (raw_member.__func__,)
+            elif isinstance(raw_member, property):
+                targets = tuple(
+                    target
+                    for target in (raw_member.fget, raw_member.fset, raw_member.fdel)
+                    if target is not None
+                )
+            elif inspect.isfunction(raw_member):
+                targets = (raw_member,)
+            else:
+                continue
+            for index, target in enumerate(targets):
+                member_key = f"{member_name}:{index}"
+                member_contract = _callable_implementation_contract(target)
+                class_members[member_key] = member_contract
+                durable = durable and member_contract.get("stability") == "durable"
+        members[qualified_name] = {
+            "observed": bool(class_members),
+            "content_digest": _sha256(
+                _canonical_json(
+                    class_members,
+                    field=f"runtime class members {qualified_name}",
+                )
+            ),
+        }
+        try:
+            source_path = inspect.getsourcefile(runtime_class)
+        except TypeError:
+            source_path = None
+        if source_path is None:
+            durable = False
+            modules[qualified_name] = {"observed": False}
+            continue
+        realpath = str(Path(source_path).resolve(strict=False))
+        digest = _file_content_digest(realpath)
+        if digest is None:
+            durable = False
+            modules[realpath] = {"observed": False}
+            continue
+        modules[realpath] = {
+            "observed": True,
+            "content_digest": digest,
+        }
+    contract: dict[str, object] = {
+        "stability": "durable" if durable and classes else "process_local",
+        "classes": classes,
+        "instance_callables": instance_callables,
+        "instance_state_observed": instance_state_observed,
+        "members": members,
+        "modules": modules,
+    }
+    if contract["stability"] == "process_local":
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _runtime_handle_selector_contract(
+    adapter: object,
+    runtime_handle: RuntimeHandle | None,
+) -> dict[str, object]:
+    if runtime_handle is None:
+        return {"version": 1, "mode": "none"}
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "resume_handle_execution_identity_contract",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "mode": "present", "observed": False}
+    provider = object.__getattribute__(
+        adapter,
+        "resume_handle_execution_identity_contract",
+    )
+    identity = provider(runtime_handle)
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime handle selector identity is not a mapping")
+    return {
+        "version": 1,
+        "mode": "present",
+        "observed": True,
+        "identity": _canonical_object(dict(identity), field="runtime handle selector identity"),
+    }
+
+
+def runtime_authority_contract(
+    adapter: object,
+    *,
+    resolved_routing: ResolvedRuntimeAuthority | None = None,
+    runtime_handle: RuntimeHandle | None = None,
+) -> dict[str, object]:
+    """Combine generic capabilities with one already-resolved runtime identity."""
+    if resolved_routing is None:
+        runtime_backend = getattr(adapter, "runtime_backend", None)
+        llm_backend = getattr(adapter, "llm_backend", None)
+        constructor_model = constructor_model_contract(adapter)
+        execution_identity = runtime_execution_identity_contract(adapter)
+        permission_contract = runtime_permission_mode_contract(adapter)
+    else:
+        resolved_routing.require_adapter(adapter)
+        resolved_data = resolved_routing.data
+        runtime_backend = resolved_data.get("runtime_backend")
+        llm_backend = resolved_data.get("llm_backend")
+        constructor_model = _canonical_object(
+            resolved_data.get("constructor_model"),
+            field="resolved constructor model",
+        )
+        execution_identity = _canonical_object(
+            resolved_data.get("runtime_execution"),
+            field="resolved runtime execution identity",
+        )
+        permission_contract = _canonical_object(
+            resolved_data.get("permission_mode"),
+            field="resolved permission mode",
+        )
     return {
         "version": 1,
         "runtime_backend": (
@@ -194,14 +722,15 @@ def runtime_authority_contract(adapter: object) -> dict[str, object]:
         "llm_backend": (
             llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
         ),
-        "permission_mode": (
-            {"observed": True, "mode": permission_mode.strip()}
-            if isinstance(permission_mode, str) and permission_mode.strip()
-            else {"observed": False}
-        ),
-        "constructor_model": constructor_model_contract(adapter),
-        "execution_identity": runtime_execution_identity_contract(adapter),
+        "permission_mode": permission_contract,
+        "constructor_model": constructor_model,
+        "execution_identity": execution_identity,
         "capabilities": _runtime_capabilities_contract(adapter),
+        "implementation": _runtime_implementation_contract(adapter),
+        "executable": _runtime_executable_contract(adapter),
+        "watchdog": _runtime_watchdog_contract(adapter),
+        "skill_dispatcher": _runtime_skill_dispatcher_contract(adapter),
+        "handle_selector": _runtime_handle_selector_contract(adapter, runtime_handle),
     }
 
 
@@ -265,35 +794,25 @@ def _project_explicit_identity(
 
 
 def _verifier_implementation_contract(verifier: Verifier) -> dict[str, object]:
-    if inspect.ismethod(verifier):
-        target = verifier.__func__
-    elif inspect.isfunction(verifier) or inspect.isbuiltin(verifier):
-        target = verifier
-    else:
-        target = type(verifier).__call__
-
-    module = getattr(target, "__module__", type(verifier).__module__)
-    qualname = getattr(target, "__qualname__", type(verifier).__qualname__)
-    try:
-        source_digest = _sha256(inspect.getsource(target))
-    except (OSError, TypeError):
-        source_digest = None
-    code = getattr(target, "__code__", None)
-    code_digest = (
-        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest() if code is not None else None
-    )
-    return {
-        "module": str(module),
-        "qualname": str(qualname),
-        "source_digest": source_digest,
-        "code_digest": code_digest,
-    }
+    return _callable_entrypoint_contract(verifier)
 
 
-def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
+def verifier_authority_contract(
+    verifier: Verifier | None,
+    *,
+    runtime_transcript_verifier: object | None = None,
+) -> dict[str, object]:
     """Return durable verifier identity only when it is explicitly declared."""
+    transcript_implementation = _callable_implementation_contract(
+        runtime_transcript_verifier or _verify_atomic_evidence_against_runtime_messages
+    )
     if verifier is None:
-        return {"version": 1, "mode": "runtime_transcript"}
+        return {
+            "version": 1,
+            "mode": "runtime_transcript",
+            "implementation": transcript_implementation,
+            "behavioral_state": {"stability": "durable", "protocol_version": 1},
+        }
 
     implementation = _verifier_implementation_contract(verifier)
     identity_descriptor = inspect.getattr_static(
@@ -329,25 +848,81 @@ def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
                 "stability": "durable",
                 "identity_digest": _sha256(encoded),
             }
-        except (AttributeError, TypeError, ValueError) as exc:
+        except Exception as exc:
             behavioral_state = {
                 "stability": "process_local",
                 "instance_nonce": uuid.uuid4().hex,
-                "reason": str(exc),
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
             }
     return {
         "version": 1,
         "mode": "custom",
         "implementation": implementation,
+        "runtime_transcript_implementation": transcript_implementation,
         "behavioral_state": behavioral_state,
+    }
+
+
+def build_execution_policy_contract(
+    *,
+    decomposition_mode: str,
+    max_decomposition_depth: int,
+    max_concurrent: int,
+    execution_profile: ExecutionProfile | None,
+    fat_harness_mode: bool,
+    run_verify_commands: bool,
+    verify_command_timeout_seconds: int,
+    ac_retry_attempts: int,
+    reasoning_effort: str | None,
+    model_router: ModelRouter | None,
+    cross_harness_redispatch: bool,
+    shadow_replay_enabled: bool,
+) -> dict[str, object]:
+    """Return the one canonical parallel-execution policy payload."""
+    return {
+        "decomposition_mode": decomposition_mode,
+        "max_decomposition_depth": max_decomposition_depth,
+        "max_concurrent": max_concurrent,
+        "execution_profile": (
+            execution_profile.model_dump(mode="json") if execution_profile is not None else None
+        ),
+        "fat_harness_mode": fat_harness_mode,
+        "run_verify_commands": run_verify_commands,
+        "verify_command_timeout_seconds": verify_command_timeout_seconds,
+        "ac_retry_attempts": ac_retry_attempts,
+        "reasoning_effort": reasoning_effort,
+        "model_routing": serialize_model_router(model_router),
+        "cross_harness_redispatch": cross_harness_redispatch,
+        "shadow_replay_enabled": shadow_replay_enabled,
     }
 
 
 @dataclass(frozen=True, slots=True)
 class ExecutionAuthorityContract:
-    """Immutable canonical JSON contract and its stable fingerprint."""
+    """Immutable executor-baseline contract and its stable fingerprint.
+
+    This excludes per-attempt AC/prompt/tool inputs and a runtime handle selected
+    later by checkpoint recovery. A later attempt capsule must compose those
+    values with this baseline before granting reusable trust or acceptance.
+    """
 
     canonical_json: str
+
+    def __post_init__(self) -> None:
+        data = _canonical_object(
+            self.canonical_json and json.loads(self.canonical_json),
+            field="execution authority contract",
+        )
+        if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != {
+            "version",
+            "workspace",
+            "runtime",
+            "verifier",
+            "execution_policy",
+        }:
+            raise ValueError("execution authority contract has an invalid shape")
+        if _canonical_json(data, field="execution authority contract") != self.canonical_json:
+            raise ValueError("execution authority contract is not canonical")
 
     @classmethod
     def build(
@@ -357,12 +932,28 @@ class ExecutionAuthorityContract:
         verifier: Verifier | None,
         workspace: str | None,
         execution_policy: Mapping[str, object],
+        workspace_identity: Mapping[str, object] | None = None,
+        workspace_generation: Mapping[str, object] | None = None,
+        resolved_routing: ResolvedRuntimeAuthority | None = None,
+        runtime_handle: RuntimeHandle | None = None,
+        runtime_transcript_verifier: object | None = None,
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
-            "workspace": canonical_workspace_authority(workspace),
-            "runtime": runtime_authority_contract(adapter),
-            "verifier": verifier_authority_contract(verifier),
+            "workspace": canonical_workspace_authority(
+                workspace,
+                identity=workspace_identity,
+                generation=workspace_generation,
+            ),
+            "runtime": runtime_authority_contract(
+                adapter,
+                resolved_routing=resolved_routing,
+                runtime_handle=runtime_handle,
+            ),
+            "verifier": verifier_authority_contract(
+                verifier,
+                runtime_transcript_verifier=runtime_transcript_verifier,
+            ),
             "execution_policy": _canonical_object(
                 dict(execution_policy),
                 field="execution policy",
@@ -382,19 +973,90 @@ class ExecutionAuthorityContract:
         return value
 
     @property
-    def reusable_across_processes(self) -> bool:
-        verifier = self.data.get("verifier")
-        if not isinstance(verifier, Mapping) or verifier.get("mode") != "custom":
-            return True
+    def portable_across_processes(self) -> bool:
+        """Return whether this baseline can be composed into a capsule elsewhere.
+
+        Portability is an identity-stability property only. It never authorizes
+        reuse of an attempt, result, checkpoint, trust verdict, or acceptance;
+        those require a complete per-attempt capsule with the omitted inputs.
+        """
+        data = self.data
+        workspace = data.get("workspace")
+        if not isinstance(workspace, Mapping) or workspace.get("observed") is not True:
+            return False
+        generation = workspace.get("generation")
+        if not isinstance(generation, Mapping) or generation.get("observed") is not True:
+            return False
+
+        runtime = data.get("runtime")
+        if not isinstance(runtime, Mapping):
+            return False
+        runtime_backend = runtime.get("runtime_backend")
+        if not isinstance(runtime_backend, str) or not runtime_backend:
+            return False
+        for field_name in ("permission_mode", "constructor_model", "execution_identity"):
+            value = runtime.get(field_name)
+            if not isinstance(value, Mapping) or value.get("observed") is not True:
+                return False
+        execution_identity = runtime.get("execution_identity")
+        resolved_identity = (
+            execution_identity.get("identity") if isinstance(execution_identity, Mapping) else None
+        )
+        if (
+            not isinstance(resolved_identity, Mapping)
+            or resolved_identity.get("effective_model_observed") is not True
+        ):
+            return False
+        implementation = runtime.get("implementation")
+        if not isinstance(implementation, Mapping) or implementation.get("stability") != "durable":
+            return False
+        executable = runtime.get("executable")
+        if not isinstance(executable, Mapping):
+            return False
+        if executable.get("required") is True and executable.get("observed") is not True:
+            return False
+        watchdog = runtime.get("watchdog")
+        if executable.get("required") is True and (
+            not isinstance(watchdog, Mapping) or watchdog.get("observed") is not True
+        ):
+            return False
+        skill_dispatcher = runtime.get("skill_dispatcher")
+        if (
+            not isinstance(skill_dispatcher, Mapping)
+            or skill_dispatcher.get("stability") != "durable"
+        ):
+            return False
+        handle_selector = runtime.get("handle_selector")
+        if not isinstance(handle_selector, Mapping):
+            return False
+        if handle_selector.get("mode") != "none" and handle_selector.get("observed") is not True:
+            return False
+
+        verifier = data.get("verifier")
+        if not isinstance(verifier, Mapping):
+            return False
+        verifier_implementation = verifier.get("implementation")
+        transcript_implementation = (
+            verifier_implementation
+            if verifier.get("mode") == "runtime_transcript"
+            else verifier.get("runtime_transcript_implementation")
+        )
         behavioral_state = verifier.get("behavioral_state")
         return (
-            isinstance(behavioral_state, Mapping) and behavioral_state.get("stability") == "durable"
+            isinstance(verifier_implementation, Mapping)
+            and verifier_implementation.get("stability") == "durable"
+            and isinstance(transcript_implementation, Mapping)
+            and transcript_implementation.get("stability") == "durable"
+            and isinstance(behavioral_state, Mapping)
+            and behavioral_state.get("stability") == "durable"
         )
 
 
 __all__ = [
     "EXECUTION_AUTHORITY_VERSION",
     "ExecutionAuthorityContract",
+    "ResolvedRuntimeAuthority",
+    "build_execution_policy_contract",
     "canonical_workspace_authority",
     "constructor_model_contract",
     "runtime_authority_contract",

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -132,7 +132,15 @@ _PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS = frozenset(
         # or reused across processes, so following their helper graph would
         # incorrectly turn an otherwise portable executor into process-local.
         ("ouroboros.orchestrator.parallel_executor", "_capture_live_callable_integrity"),
+        (
+            "ouroboros.orchestrator.parallel_executor",
+            "_capture_live_callable_integrity_checker",
+        ),
         ("ouroboros.orchestrator.parallel_executor", "_capture_runtime_dispatch_integrity"),
+        (
+            "ouroboros.orchestrator.parallel_executor",
+            "_capture_runtime_dispatch_integrity_checker",
+        ),
         ("ouroboros.orchestrator.parallel_executor", "_runtime_dispatch_integrity_is_intact"),
     }
 )

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -166,7 +166,9 @@ def _process_local_runtime_nonce(*identity_inputs: object) -> str:
 
             nonce = secrets.token_hex(32)
 
-            def discard(dead_reference: weakref.ReferenceType[object], *, key: int = object_id) -> None:
+            def discard(
+                dead_reference: weakref.ReferenceType[object], *, key: int = object_id
+            ) -> None:
                 with _PROCESS_LOCAL_RUNTIME_NONCES_LOCK:
                     current = _PROCESS_LOCAL_RUNTIME_NONCES.get(key)
                     if current is not None and current[0] is dead_reference:
@@ -571,9 +573,7 @@ def _authority_runtime_execution_identity(
         result: dict[str, object] = {"version": 1, "observed": False}
         nonce = value.get("instance_nonce")
         result["instance_nonce"] = (
-            nonce
-            if isinstance(nonce, str) and nonce
-            else _process_local_runtime_nonce(adapter)
+            nonce if isinstance(nonce, str) and nonce else _process_local_runtime_nonce(adapter)
         )
         return result
     identity = value.get("identity")
@@ -602,8 +602,7 @@ def _valid_authority_runtime_execution_identity(value: object) -> bool:
         )
     return (
         observed is True
-        and set(value)
-        == {"version", "observed", "effective_model_observed", "identity_digest"}
+        and set(value) == {"version", "observed", "effective_model_observed", "identity_digest"}
         and isinstance(value.get("effective_model_observed"), bool)
         and isinstance(value.get("identity_digest"), str)
         and _SHA256_DIGEST_PATTERN.fullmatch(value["identity_digest"]) is not None
@@ -861,7 +860,9 @@ class ResolvedRuntimeAuthority:
             adapter,
             active,
         ):
-            raise ValueError("resolved runtime authority drifted from an unobserved execution identity")
+            raise ValueError(
+                "resolved runtime authority drifted from an unobserved execution identity"
+            )
 
     @property
     def data(self) -> dict[str, Any]:
@@ -1022,16 +1023,14 @@ def _callable_behavior_digest(target: object) -> str:
                 return {
                     "kind": type(value).__name__,
                     "items": [
-                        opaque_value_projection(item, depth=depth + 1, seen=seen)
-                        for item in value
+                        opaque_value_projection(item, depth=depth + 1, seen=seen) for item in value
                     ],
                 }
             if isinstance(value, (set, frozenset)):
                 if len(value) > _MAX_IDENTITY_ITEMS:
                     raise ValueError("callable data set is oversized")
                 items = [
-                    opaque_value_projection(item, depth=depth + 1, seen=seen)
-                    for item in value
+                    opaque_value_projection(item, depth=depth + 1, seen=seen) for item in value
                 ]
                 return {
                     "kind": type(value).__name__,
@@ -1136,8 +1135,7 @@ def _callable_behavior_digest(target: object) -> str:
             global_dependencies = [
                 direct_global_identity(dependency, depth=depth)
                 for global_name, dependency in sorted(closure_vars.globals.items())
-                if (function.__module__, global_name)
-                not in _PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS
+                if (function.__module__, global_name) not in _PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS
             ]
             builtin_dependencies: list[dict[str, object]] = []
             for _name, dependency in sorted(closure_vars.builtins.items()):
@@ -2178,8 +2176,7 @@ def _runtime_composition_contract(adapter: object) -> dict[str, object]:
         if not isinstance(components, Mapping) or len(components) > _MAX_IDENTITY_ITEMS:
             raise ValueError("runtime execution components are invalid")
         if not all(
-            isinstance(name, str) and name and not is_sensitive_value(name)
-            for name in components
+            isinstance(name, str) and name and not is_sensitive_value(name) for name in components
         ):
             raise ValueError("runtime execution component names are invalid")
         contracts = {
@@ -2599,10 +2596,7 @@ def _redacted_authority_policy_value(value: object) -> object:
             return "redacted:sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
         return value
     if isinstance(value, Mapping):
-        return {
-            key: _redacted_authority_policy_value(item)
-            for key, item in value.items()
-        }
+        return {key: _redacted_authority_policy_value(item) for key, item in value.items()}
     if isinstance(value, list):
         return [_redacted_authority_policy_value(item) for item in value]
     return value
@@ -2945,9 +2939,7 @@ class ExecutionAuthorityContract:
             and watchdog.get("observed") is not True
         ):
             return False
-        if executable.get("required") is True and (
-            watchdog.get("observed") is not True
-        ):
+        if executable.get("required") is True and (watchdog.get("observed") is not True):
             return False
         skill_dispatcher = runtime.get("skill_dispatcher")
         if (

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -28,7 +28,11 @@ import threading
 from typing import Any
 import weakref
 
-from ouroboros.core.security import is_sensitive_field, is_sensitive_value
+from ouroboros.core.security import (
+    is_sensitive_credential_field,
+    is_sensitive_field,
+    is_sensitive_value,
+)
 from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
@@ -123,6 +127,13 @@ _PORTABLE_CALLABLE_GLOBAL_EXCLUSIONS = frozenset(
         ("ouroboros.orchestrator.parallel_executor", "LevelCoordinator"),
         ("ouroboros.orchestrator.parallel_executor", "ACRuntimeHandleManager"),
         ("ouroboros.orchestrator.parallel_executor", "ExecutionEventEmitter"),
+        # These process-local time-of-use guards enforce the already-bound
+        # portable baseline. Their live object references cannot be serialized
+        # or reused across processes, so following their helper graph would
+        # incorrectly turn an otherwise portable executor into process-local.
+        ("ouroboros.orchestrator.parallel_executor", "_capture_live_callable_integrity"),
+        ("ouroboros.orchestrator.parallel_executor", "_capture_runtime_dispatch_integrity"),
+        ("ouroboros.orchestrator.parallel_executor", "_runtime_dispatch_integrity_is_intact"),
     }
 )
 
@@ -224,6 +235,43 @@ def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
     if not isinstance(normalized, dict):
         raise ValueError(f"{field} is not an object")
     return normalized
+
+
+def _contains_sensitive_authority_data(value: object) -> bool:
+    """Reject credential data before any authority section is accepted.
+
+    ``ExecutionAuthorityContract`` can also be built from persisted canonical
+    JSON, not only from the local projection helpers. Screen every nested
+    section here so a forged ``runtime.provider_credential`` (or an aliased
+    credential field) cannot bypass the producer-side sanitizers. The field
+    predicate is intentionally narrower than logging's generic ``key``/
+    ``token`` heuristic: authority protocol fields such as ``token_estimator``
+    are semantic implementation labels, not credentials.
+    """
+    pending: list[object] = [value]
+    item_count = 0
+    while pending:
+        current = pending.pop()
+        item_count += 1
+        if item_count > _MAX_IDENTITY_ITEMS * 128:
+            return True
+        if isinstance(current, str):
+            if is_sensitive_value(current):
+                return True
+            continue
+        if isinstance(current, Mapping):
+            for key, item in current.items():
+                if (
+                    not isinstance(key, str)
+                    or is_sensitive_credential_field(key)
+                    or is_sensitive_value(key)
+                ):
+                    return True
+                pending.append(item)
+            continue
+        if isinstance(current, list):
+            pending.extend(current)
+    return False
 
 
 def _sha256(value: str) -> str:
@@ -2832,6 +2880,124 @@ def valid_execution_policy_contract(value: object) -> bool:
     return _valid_dispatch_rate_contract(value.get("dispatch_rate"))
 
 
+def _valid_executor_authority_envelope(value: object) -> bool:
+    """Validate the finite executor envelope before it is fingerprinted."""
+    if not isinstance(value, Mapping) or value.get("version") != 3:
+        return False
+    mode = value.get("mode")
+    stability = value.get("stability")
+    components = value.get("components")
+    if mode not in {"bound", "unbound"} or stability not in {"durable", "process_local"}:
+        return False
+    if not isinstance(components, Mapping):
+        return False
+    if mode == "unbound":
+        return set(value) == {"version", "mode", "stability", "instance_nonce", "components"} and (
+            isinstance(value.get("instance_nonce"), str) and bool(value["instance_nonce"])
+        )
+    required = {
+        "version",
+        "mode",
+        "type",
+        "stability",
+        "implementation",
+        "instance_overrides",
+        "components",
+    }
+    if not required.issubset(value) or not isinstance(value.get("type"), str):
+        return False
+    if not isinstance(value.get("implementation"), Mapping) or not isinstance(
+        value.get("instance_overrides"), Mapping
+    ):
+        return False
+    if stability == "durable":
+        return set(value) == required
+    return (
+        set(value) == required | {"instance_nonce"}
+        and isinstance(value.get("instance_nonce"), str)
+        and bool(value["instance_nonce"])
+    )
+
+
+def _valid_workspace_authority_envelope(value: object) -> bool:
+    """Validate the workspace owner and generation envelopes."""
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    observed = value.get("observed")
+    generation = value.get("generation")
+    if not isinstance(observed, bool) or not isinstance(generation, Mapping):
+        return False
+    generation_observed = generation.get("observed")
+    if not isinstance(generation_observed, bool):
+        return False
+    if generation_observed:
+        if set(generation) != {"observed", "identity"} or not _valid_workspace_generation_identity(
+            generation.get("identity")
+        ):
+            return False
+    elif set(generation) != {"observed"}:
+        return False
+    if observed:
+        return set(value) == {"version", "observed", "identity", "generation"} and isinstance(
+            value.get("identity"), Mapping
+        )
+    return set(value) in (
+        {"version", "observed", "generation"},
+        {"version", "observed", "identity", "generation"},
+    ) and ("identity" not in value or isinstance(value.get("identity"), Mapping))
+
+
+def _valid_runtime_authority_envelope(value: object) -> bool:
+    """Validate the fixed runtime authority envelope without re-executing it."""
+    required = {
+        "version",
+        "runtime_backend",
+        "self_governs_rate_limit",
+        "llm_backend",
+        "permission_mode",
+        "constructor_model",
+        "execution_identity",
+        "capabilities",
+        "implementation",
+        "executable",
+        "watchdog",
+        "skill_dispatcher",
+        "handle_selector",
+    }
+    optional = {"runtime_backend_unobserved", "llm_backend_unobserved"}
+    if (
+        not isinstance(value, Mapping)
+        or not required.issubset(value)
+        or set(value) - required - optional
+    ):
+        return False
+    if value.get("version") != 1 or not isinstance(value.get("self_governs_rate_limit"), bool):
+        return False
+    if any(
+        not isinstance(value.get(name), Mapping)
+        for name in required
+        - {"version", "runtime_backend", "self_governs_rate_limit", "llm_backend"}
+    ):
+        return False
+    return all(
+        isinstance(value.get(name), str) or value.get(name) is None
+        for name in ("runtime_backend", "llm_backend")
+    ) and all(isinstance(value.get(name, False), bool) for name in optional if name in value)
+
+
+def _valid_verifier_authority_envelope(value: object) -> bool:
+    """Validate the two allowed verifier authority shapes."""
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    mode = value.get("mode")
+    required = {"version", "mode", "implementation", "behavioral_state"}
+    if mode == "custom":
+        required |= {"runtime_transcript_implementation"}
+    if set(value) != required:
+        return False
+    return all(isinstance(value.get(name), Mapping) for name in required - {"version", "mode"})
+
+
 def build_execution_policy_contract(
     *,
     decomposition_mode: str,
@@ -2906,6 +3072,17 @@ class ExecutionAuthorityContract:
             raise ValueError("execution authority contract has an invalid shape")
         if not _valid_execution_authority_boundary(data.get("boundary")):
             raise ValueError("execution authority contract has an invalid boundary")
+        if _contains_sensitive_authority_data(data):
+            raise ValueError("execution authority contract contains sensitive data")
+        envelope_validators = {
+            "executor": _valid_executor_authority_envelope,
+            "workspace": _valid_workspace_authority_envelope,
+            "runtime": _valid_runtime_authority_envelope,
+            "verifier": _valid_verifier_authority_envelope,
+        }
+        for section_name, validator in envelope_validators.items():
+            if not validator(data.get(section_name)):
+                raise ValueError(f"execution authority contract has an invalid {section_name}")
         if not valid_execution_policy_contract(data.get("execution_policy")):
             raise ValueError("execution authority contract has an invalid execution policy")
         runtime = data.get("runtime")

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,0 +1,406 @@
+"""Canonical execution authority shared by routing, recovery, and verification.
+
+This module owns identity only. It does not authorize a dispatch, persist a
+checkpoint, or declare acceptance. Later runtime layers can depend on one stable
+contract instead of deriving narrower fingerprints independently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import inspect
+import json
+import marshal
+import math
+from pathlib import Path
+from typing import Any
+import uuid
+
+from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
+from ouroboros.orchestrator.verifier import Verifier
+
+EXECUTION_AUTHORITY_VERSION = 1
+_MAX_IDENTITY_DEPTH = 8
+_MAX_IDENTITY_ITEMS = 256
+_MAX_IDENTITY_SCALAR_CHARS = 8_192
+_MAX_IDENTITY_JSON_CHARS = 64_000
+
+
+def _canonical_json(value: object, *, field: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} is not canonical JSON") from exc
+
+
+def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
+    normalized = json.loads(_canonical_json(value, field=field))
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{field} is not an object")
+    return normalized
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
+    """Return the exact checkout path that owns effects for this executor."""
+    if not isinstance(workspace, str) or not workspace.strip():
+        return {"version": 1, "observed": False}
+    canonical = str(Path(workspace).expanduser().resolve(strict=False))
+    return {
+        "version": 1,
+        "observed": True,
+        "mode": "direct",
+        "effective_cwd": canonical,
+    }
+
+
+def constructor_model_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized constructor-level model pin, when observable."""
+    try:
+        raw_model = inspect.getattr_static(adapter, "_model")
+    except AttributeError:
+        return {"observed": False}
+    if raw_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(raw_model, str):
+        return {"observed": False}
+
+    normalized_model: object = raw_model.strip() or None
+    normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
+    if normalizer_descriptor is not None:
+        try:
+            normalizer = object.__getattribute__(adapter, "_normalize_model")
+            normalized_model = normalizer(raw_model)
+        except Exception:
+            return {"observed": False}
+    if normalized_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(normalized_model, str) or not normalized_model.strip():
+        return {"observed": False}
+    return {"observed": True, "model": normalized_model.strip()}
+
+
+def valid_constructor_model_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    model = value.get("model")
+    return set(value) == {"observed", "model"} and (
+        model is None or isinstance(model, str) and bool(model.strip())
+    )
+
+
+def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
+    """Return backend-specific resolved identity without backend logic here."""
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "execution_identity_contract",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "observed": False}
+
+    provider = object.__getattribute__(adapter, "execution_identity_contract")
+    identity = provider()
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime execution identity contract is not a mapping")
+    normalized = _canonical_object(
+        dict(identity),
+        field="runtime execution identity contract",
+    )
+    return {"version": 1, "observed": True, "identity": normalized}
+
+
+def valid_runtime_execution_identity_contract(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    version = value.get("version")
+    observed = value.get("observed")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != 1
+        or not isinstance(observed, bool)
+    ):
+        return False
+    if not observed:
+        return set(value) == {"version", "observed"}
+    identity = value.get("identity")
+    if (
+        set(value) != {"version", "observed", "identity"}
+        or not isinstance(identity, Mapping)
+        or not identity
+    ):
+        return False
+    try:
+        _canonical_json(dict(identity), field="runtime execution identity contract")
+    except ValueError:
+        return False
+    return True
+
+
+def runtime_execution_proves_effective_model(value: object) -> bool:
+    if not valid_runtime_execution_identity_contract(value):
+        return False
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    identity = value.get("identity")
+    return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+
+
+def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
+    capabilities = runtime_capabilities_for(adapter)
+    return {
+        "skill_dispatch": capabilities.skill_dispatch,
+        "targeted_resume": capabilities.targeted_resume,
+        "structured_output": capabilities.structured_output,
+        "system_prompt_support": capabilities.system_prompt_support.value,
+        "tool_restriction_support": capabilities.tool_restriction_support.value,
+        "permission_mode_support": capabilities.permission_mode_support.value,
+        "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+        "enforceable_reasoning_efforts": (
+            sorted(capabilities.enforceable_reasoning_efforts)
+            if capabilities.enforceable_reasoning_efforts is not None
+            else None
+        ),
+        "model_override_support": capabilities.model_override_support.value,
+        "subagent_orchestration": capabilities.subagent_orchestration.value,
+        "session_signals": capabilities.session_signals.to_event_data(),
+    }
+
+
+def runtime_authority_contract(adapter: object) -> dict[str, object]:
+    """Combine generic capabilities with backend-owned resolved identity."""
+    runtime_backend = getattr(adapter, "runtime_backend", None)
+    llm_backend = getattr(adapter, "llm_backend", None)
+    permission_mode = getattr(adapter, "permission_mode", None)
+    return {
+        "version": 1,
+        "runtime_backend": (
+            runtime_backend.strip()
+            if isinstance(runtime_backend, str) and runtime_backend.strip()
+            else None
+        ),
+        "llm_backend": (
+            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
+        ),
+        "permission_mode": (
+            {"observed": True, "mode": permission_mode.strip()}
+            if isinstance(permission_mode, str) and permission_mode.strip()
+            else {"observed": False}
+        ),
+        "constructor_model": constructor_model_contract(adapter),
+        "execution_identity": runtime_execution_identity_contract(adapter),
+        "capabilities": _runtime_capabilities_contract(adapter),
+    }
+
+
+def _project_explicit_identity(
+    value: object,
+    *,
+    field: str,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> object:
+    if depth > _MAX_IDENTITY_DEPTH:
+        raise ValueError(f"{field} exceeds identity depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{field} contains a non-finite float")
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_IDENTITY_SCALAR_CHARS:
+            raise ValueError(f"{field} contains oversized text")
+        return value
+
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        raise ValueError(f"{field} contains cyclic state")
+    seen.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many mapping items")
+            projected: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{field} contains a non-string or empty key")
+                if len(key) > _MAX_IDENTITY_SCALAR_CHARS:
+                    raise ValueError(f"{field} contains an oversized key")
+                projected[key] = _project_explicit_identity(
+                    item,
+                    field=f"{field}.{key}",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return projected
+        if isinstance(value, (list, tuple)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many sequence items")
+            return [
+                _project_explicit_identity(
+                    item,
+                    field=f"{field}[{index}]",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+                for index, item in enumerate(value)
+            ]
+        raise ValueError(f"{field} is not canonical JSON data")
+    finally:
+        seen.remove(value_id)
+
+
+def _verifier_implementation_contract(verifier: Verifier) -> dict[str, object]:
+    if inspect.ismethod(verifier):
+        target = verifier.__func__
+    elif inspect.isfunction(verifier) or inspect.isbuiltin(verifier):
+        target = verifier
+    else:
+        target = type(verifier).__call__
+
+    module = getattr(target, "__module__", type(verifier).__module__)
+    qualname = getattr(target, "__qualname__", type(verifier).__qualname__)
+    try:
+        source_digest = _sha256(inspect.getsource(target))
+    except (OSError, TypeError):
+        source_digest = None
+    code = getattr(target, "__code__", None)
+    code_digest = (
+        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest() if code is not None else None
+    )
+    return {
+        "module": str(module),
+        "qualname": str(qualname),
+        "source_digest": source_digest,
+        "code_digest": code_digest,
+    }
+
+
+def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
+    """Return durable verifier identity only when it is explicitly declared."""
+    if verifier is None:
+        return {"version": 1, "mode": "runtime_transcript"}
+
+    implementation = _verifier_implementation_contract(verifier)
+    identity_descriptor = inspect.getattr_static(
+        verifier,
+        "verification_identity_contract",
+        None,
+    )
+    if identity_descriptor is None:
+        behavioral_state: dict[str, object] = {
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": "verification_identity_contract is not declared",
+        }
+    else:
+        try:
+            identity_provider = object.__getattribute__(
+                verifier,
+                "verification_identity_contract",
+            )
+            if not callable(identity_provider):
+                raise ValueError("verification_identity_contract is not callable")
+            identity = identity_provider()
+            if not isinstance(identity, Mapping):
+                raise ValueError("verification_identity_contract is not a mapping")
+            projected = _project_explicit_identity(
+                dict(identity),
+                field="verification identity contract",
+            )
+            encoded = _canonical_json(projected, field="verification identity contract")
+            if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+                raise ValueError("verification identity contract exceeds its budget")
+            behavioral_state = {
+                "stability": "durable",
+                "identity_digest": _sha256(encoded),
+            }
+        except (AttributeError, TypeError, ValueError) as exc:
+            behavioral_state = {
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": str(exc),
+            }
+    return {
+        "version": 1,
+        "mode": "custom",
+        "implementation": implementation,
+        "behavioral_state": behavioral_state,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityContract:
+    """Immutable canonical JSON contract and its stable fingerprint."""
+
+    canonical_json: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+    ) -> ExecutionAuthorityContract:
+        data = {
+            "version": EXECUTION_AUTHORITY_VERSION,
+            "workspace": canonical_workspace_authority(workspace),
+            "runtime": runtime_authority_contract(adapter),
+            "verifier": verifier_authority_contract(verifier),
+            "execution_policy": _canonical_object(
+                dict(execution_policy),
+                field="execution policy",
+            ),
+        }
+        return cls(_canonical_json(data, field="execution authority contract"))
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256(self.canonical_json)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        value = json.loads(self.canonical_json)
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise ValueError("execution authority contract is not an object")
+        return value
+
+    @property
+    def reusable_across_processes(self) -> bool:
+        verifier = self.data.get("verifier")
+        if not isinstance(verifier, Mapping) or verifier.get("mode") != "custom":
+            return True
+        behavioral_state = verifier.get("behavioral_state")
+        return (
+            isinstance(behavioral_state, Mapping) and behavioral_state.get("stability") == "durable"
+        )
+
+
+__all__ = [
+    "EXECUTION_AUTHORITY_VERSION",
+    "ExecutionAuthorityContract",
+    "canonical_workspace_authority",
+    "constructor_model_contract",
+    "runtime_authority_contract",
+    "runtime_execution_identity_contract",
+    "runtime_execution_proves_effective_model",
+    "valid_constructor_model_contract",
+    "valid_runtime_execution_identity_contract",
+    "verifier_authority_contract",
+]

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -40,9 +40,9 @@ from ouroboros.orchestrator.model_routing import (
 )
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
-from ouroboros.orchestrator.verifier import Verifier
+from ouroboros.orchestrator.verifier import Verifier, VerifierVerdict
 
-EXECUTION_AUTHORITY_VERSION = 5
+EXECUTION_AUTHORITY_VERSION = 6
 EXECUTION_AUTHORITY_BOUNDARY_VERSION = 2
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
@@ -873,24 +873,41 @@ class ResolvedRuntimeAuthority:
 
 
 def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
-    capabilities = runtime_capabilities_for(adapter)
-    return {
-        "skill_dispatch": capabilities.skill_dispatch,
-        "targeted_resume": capabilities.targeted_resume,
-        "structured_output": capabilities.structured_output,
-        "system_prompt_support": capabilities.system_prompt_support.value,
-        "tool_restriction_support": capabilities.tool_restriction_support.value,
-        "permission_mode_support": capabilities.permission_mode_support.value,
-        "reasoning_effort_support": capabilities.reasoning_effort_support.value,
-        "enforceable_reasoning_efforts": (
-            sorted(capabilities.enforceable_reasoning_efforts)
-            if capabilities.enforceable_reasoning_efforts is not None
-            else None
-        ),
-        "model_override_support": capabilities.model_override_support.value,
-        "subagent_orchestration": capabilities.subagent_orchestration.value,
-        "session_signals": capabilities.session_signals.to_event_data(),
-    }
+    """Return a capability snapshot only when provider values are safe to bind.
+
+    Runtime capabilities affect dispatch behavior, but the adapter owns their
+    values. A malformed getter or credential-bearing value must therefore make
+    this baseline process-local rather than enter canonical authority JSON.
+    """
+    try:
+        capabilities = runtime_capabilities_for(adapter)
+        identity = _canonical_explicit_identity(
+            {
+                "skill_dispatch": capabilities.skill_dispatch,
+                "targeted_resume": capabilities.targeted_resume,
+                "structured_output": capabilities.structured_output,
+                "system_prompt_support": capabilities.system_prompt_support.value,
+                "tool_restriction_support": capabilities.tool_restriction_support.value,
+                "permission_mode_support": capabilities.permission_mode_support.value,
+                "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+                "enforceable_reasoning_efforts": (
+                    sorted(capabilities.enforceable_reasoning_efforts)
+                    if capabilities.enforceable_reasoning_efforts is not None
+                    else None
+                ),
+                "model_override_support": capabilities.model_override_support.value,
+                "subagent_orchestration": capabilities.subagent_orchestration.value,
+                "session_signals": capabilities.session_signals.to_event_data(),
+            },
+            field="runtime capabilities",
+        )
+    except Exception:
+        return {
+            "version": 1,
+            "observed": False,
+            "instance_nonce": _process_local_runtime_nonce(adapter),
+        }
+    return {"version": 1, "observed": True, "identity": identity}
 
 
 def _opaque_type_identity_digest(value: object) -> str:
@@ -1262,6 +1279,47 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
     return _callable_leaf_implementation_contract(target)
 
 
+def _transcript_verdict_type_contract(value: type[object]) -> dict[str, object]:
+    """Bind the result type's acceptance-relevant construction semantics.
+
+    The transcript verifier constructs :class:`VerifierVerdict` directly.
+    Its generated comparison/repr methods do not affect whether a failed
+    transcript becomes accepted, but construction, invariant enforcement, and
+    frozen-state enforcement do.  Bind that finite semantic surface explicitly
+    rather than walking every generated dataclass helper: the latter makes a
+    normally portable baseline depend on synthetic ``__eq__`` plumbing that is
+    not an execution authority.
+
+    A substituted result type is deliberately not treated as a durable
+    equivalent.  It may implement a different acceptance protocol, so the
+    surrounding transcript verifier must fail closed to process-local.
+    """
+    if value is not VerifierVerdict:
+        raise ValueError("runtime transcript verifier result type is not canonical")
+
+    required_members = ("__init__", "__post_init__", "__setattr__")
+    members: dict[str, object] = {}
+    missing = object()
+    for member_name in required_members:
+        raw_member = inspect.getattr_static(value, member_name, missing)
+        if isinstance(raw_member, (classmethod, staticmethod)):
+            raw_member = raw_member.__func__
+        if raw_member is missing or not inspect.isfunction(raw_member):
+            raise ValueError("runtime transcript verifier result member is not inspectable")
+        implementation = _callable_implementation_contract(raw_member)
+        if implementation.get("stability") != "durable":
+            raise ValueError("runtime transcript verifier result member is not durable")
+        members[_sha256(member_name)] = implementation
+
+    return {
+        "stability": "durable",
+        "type": _opaque_type_identity_digest(value),
+        "member_digest": _sha256(
+            _canonical_json(members, field="runtime transcript verifier result members")
+        ),
+    }
+
+
 def _callable_dependency_implementation_contract(target: object) -> dict[str, object]:
     """Bind a transcript verifier and the Python helpers it actually invokes.
 
@@ -1277,17 +1335,18 @@ def _callable_dependency_implementation_contract(target: object) -> dict[str, ob
     active: set[int] = set()
     function_count = 0
 
-    def global_contract(value: object) -> dict[str, object]:
+    def global_contract(value: object, *, global_name: str) -> dict[str, object]:
         """Return a safe identity for a non-function global used by a verifier."""
         if isinstance(value, type):
-            # A transcript verifier often uses standard-library types such as
-            # ``pathlib.Path``.  Requiring a full member-by-member class graph
-            # for those types turns an otherwise durable verifier process-local
-            # simply because a standard-library base is implemented in C or
-            # exposes a descriptor we cannot walk.  The type identity itself is
-            # sufficient for this boundary: replacing ``VerifierVerdict`` (or
-            # any other imported type) changes the opaque digest, while raw
-            # module/class labels never enter authority JSON.
+            if global_name == "VerifierVerdict":
+                return {
+                    "mode": "verdict_type",
+                    "implementation": _transcript_verdict_type_contract(value),
+                }
+            # Standard-library and supporting types often expose C-backed or
+            # synthetic members that cannot be walked portably. Their opaque
+            # type identity still detects a replacement without mistaking
+            # generated implementation plumbing for acceptance authority.
             return {"mode": "type", "identity_digest": _opaque_type_identity_digest(value)}
         if isinstance(value, re.Pattern):
             return {
@@ -1383,7 +1442,7 @@ def _callable_dependency_implementation_contract(target: object) -> dict[str, ob
                 if inspect.ismethod(dependency) or inspect.isfunction(dependency):
                     dependencies.append(collect(dependency, depth=depth + 1))
                 else:
-                    dependencies.append(global_contract(dependency))
+                    dependencies.append(global_contract(dependency, global_name=global_name))
             return {
                 "implementation": implementation,
                 "defaults_digest": defaults_digest,
@@ -2087,6 +2146,58 @@ def _instance_executable_overrides(value: object) -> dict[str, object]:
     return overrides
 
 
+def _builtin_mcp_handler_cache_contract(value: object) -> dict[str, object] | None:
+    """Bind a populated ``SkillInterceptor`` handler cache process-locally.
+
+    The cache changes the callable that performs local skill dispatch, but is
+    mutable runtime state rather than a portable Foundation-A component. Its
+    opaque binding detects handler replacement or implementation drift without
+    serializing tool names, handler state, or provider data.
+    """
+    missing = object()
+    try:
+        descriptor = inspect.getattr_static(value, "_builtin_mcp_handlers", missing)
+    except Exception:
+        return None
+    if descriptor is missing:
+        return None
+
+    def unobserved() -> dict[str, object]:
+        return {
+            "state": "unobserved",
+            "stability": "process_local",
+            "instance_nonce": _process_local_runtime_nonce(value),
+        }
+
+    try:
+        cache = object.__getattribute__(value, "_builtin_mcp_handlers")
+        if cache is None:
+            return {"state": "empty", "stability": "durable"}
+        if not isinstance(cache, Mapping) or len(cache) > _MAX_IDENTITY_ITEMS:
+            return unobserved()
+
+        bindings: dict[str, object] = {}
+        for tool_name, handler in cache.items():
+            if not isinstance(tool_name, str) or not tool_name or is_sensitive_value(tool_name):
+                return unobserved()
+            handle = object.__getattribute__(handler, "handle")
+            if not callable(handle):
+                return unobserved()
+            tool_digest = _sha256(tool_name)
+            bindings[tool_digest] = {
+                "implementation": _callable_entrypoint_contract(handle),
+                "instance_nonce": _process_local_runtime_nonce(handler),
+            }
+        return {
+            "state": "populated",
+            "stability": "process_local",
+            "binding_digest": _sha256(_canonical_json(bindings, field="builtin MCP handler cache")),
+            "instance_nonce": _process_local_runtime_nonce(value),
+        }
+    except Exception:
+        return unobserved()
+
+
 def _declared_component_contract(value: object) -> dict[str, object]:
     implementation = _safe_class_implementation_contract(value)
     try:
@@ -2144,10 +2255,12 @@ def _declared_component_contract(value: object) -> dict[str, object]:
             "implementation": implementation,
             "executable": executable,
         }
+    handler_cache = _builtin_mcp_handler_cache_contract(value)
     durable = (
         not instance_overrides
         and implementation.get("stability") == "durable"
         and (executable.get("required") is not True or executable.get("observed") is True)
+        and (handler_cache is None or handler_cache.get("stability") == "durable")
     )
     contract: dict[str, object] = {
         "mode": "declared",
@@ -2158,6 +2271,8 @@ def _declared_component_contract(value: object) -> dict[str, object]:
         "implementation": implementation,
         "executable": executable,
     }
+    if handler_cache is not None:
+        contract["builtin_mcp_handler_cache"] = handler_cache
     if not durable:
         contract["instance_nonce"] = _process_local_runtime_nonce(value)
     return contract
@@ -2919,6 +3034,9 @@ class ExecutionAuthorityContract:
         ):
             return False
         if runtime.get("llm_backend_unobserved") is True:
+            return False
+        capabilities = runtime.get("capabilities")
+        if not isinstance(capabilities, Mapping) or capabilities.get("observed") is not True:
             return False
         for field_name in ("permission_mode", "constructor_model", "execution_identity"):
             value = runtime.get(field_name)

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -18,6 +18,7 @@ import marshal
 import math
 import os
 from pathlib import Path
+import re
 import shutil
 from typing import Any
 import uuid
@@ -26,7 +27,11 @@ from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
 )
-from ouroboros.orchestrator.model_routing import ModelRouter, serialize_model_router
+from ouroboros.orchestrator.model_routing import (
+    ModelRouter,
+    deserialize_model_router,
+    serialize_model_router,
+)
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
@@ -37,6 +42,24 @@ _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
 _RESOLVED_RUNTIME_AUTHORITY_TOKEN = object()
+_SHA256_DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+_EXECUTION_POLICY_VERSION = 1
+_EXECUTION_POLICY_KEYS = {
+    "version",
+    "decomposition_mode",
+    "max_decomposition_depth",
+    "max_concurrent",
+    "execution_profile",
+    "fat_harness_mode",
+    "run_verify_commands",
+    "verify_command_timeout_seconds",
+    "ac_retry_attempts",
+    "reasoning_effort",
+    "model_routing",
+    "cross_harness_redispatch",
+    "shadow_replay_enabled",
+    "dispatch_rate",
+}
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -92,20 +115,41 @@ def canonical_workspace_authority(
             "observed": False,
             "generation": {"observed": False},
         }
-    generation_contract: dict[str, object] = (
-        {
-            "observed": True,
-            "identity": _canonical_object(dict(generation), field="workspace generation"),
-        }
-        if generation is not None
-        else {"observed": False}
-    )
+    generation_contract: dict[str, object] = {"observed": False}
+    if generation is not None:
+        generation_identity = _canonical_object(
+            dict(generation),
+            field="workspace generation",
+        )
+        if generation_identity:
+            if not _valid_workspace_generation_identity(generation_identity):
+                raise ValueError("workspace generation identity is invalid")
+            generation_contract = {
+                "observed": True,
+                "identity": generation_identity,
+            }
     return {
         "version": 1,
         "observed": True,
         "identity": owner,
         "generation": generation_contract,
     }
+
+
+def _valid_workspace_generation_identity(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != {"version", "kind", "digest"}:
+        return False
+    version = value.get("version")
+    kind = value.get("kind")
+    digest = value.get("digest")
+    return (
+        not isinstance(version, bool)
+        and version == 1
+        and isinstance(kind, str)
+        and bool(kind.strip())
+        and isinstance(digest, str)
+        and _SHA256_DIGEST_PATTERN.fullmatch(digest) is not None
+    )
 
 
 def constructor_model_contract(adapter: object) -> dict[str, object]:
@@ -719,6 +763,7 @@ def runtime_authority_contract(
             if isinstance(runtime_backend, str) and runtime_backend.strip()
             else None
         ),
+        "self_governs_rate_limit": bool(getattr(adapter, "self_governs_rate_limit", False)),
         "llm_backend": (
             llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
         ),
@@ -863,6 +908,135 @@ def verifier_authority_contract(
     }
 
 
+def _positive_int_or_none(value: object) -> bool:
+    return value is None or (not isinstance(value, bool) and isinstance(value, int) and value > 0)
+
+
+def _positive_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+        and value > 0
+    )
+
+
+def _valid_dispatch_rate_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != {
+        "version",
+        "backend",
+        "owner",
+        "observed",
+        "self_governs_rate_limit",
+        "requests_per_minute",
+        "tokens_per_minute",
+        "gate_enabled",
+        "window_seconds",
+        "heartbeat_seconds",
+        "max_wait_seconds",
+        "token_estimation_version",
+    }:
+        return False
+    version = value.get("version")
+    token_version = value.get("token_estimation_version")
+    backend = value.get("backend")
+    owner = value.get("owner")
+    observed = value.get("observed")
+    self_governs = value.get("self_governs_rate_limit")
+    request_limit = value.get("requests_per_minute")
+    token_limit = value.get("tokens_per_minute")
+    gate_enabled = value.get("gate_enabled")
+    if (
+        isinstance(version, bool)
+        or version != 1
+        or isinstance(token_version, bool)
+        or token_version != 1
+        or not isinstance(backend, str)
+        or not backend.strip()
+        or owner not in {"ouroboros", "runtime"}
+        or not isinstance(observed, bool)
+        or not isinstance(self_governs, bool)
+        or not isinstance(gate_enabled, bool)
+        or not _positive_int_or_none(request_limit)
+        or not _positive_int_or_none(token_limit)
+        or not _positive_number(value.get("window_seconds"))
+        or not _positive_number(value.get("heartbeat_seconds"))
+        or not _positive_number(value.get("max_wait_seconds"))
+    ):
+        return False
+    if owner == "runtime":
+        return (
+            self_governs
+            and not observed
+            and request_limit is None
+            and token_limit is None
+            and not gate_enabled
+        )
+    return (
+        not self_governs
+        and observed
+        and gate_enabled == (request_limit is not None or token_limit is not None)
+    )
+
+
+def valid_execution_policy_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != _EXECUTION_POLICY_KEYS:
+        return False
+    version = value.get("version")
+    depth = value.get("max_decomposition_depth")
+    concurrency = value.get("max_concurrent")
+    timeout = value.get("verify_command_timeout_seconds")
+    retries = value.get("ac_retry_attempts")
+    if (
+        isinstance(version, bool)
+        or version != _EXECUTION_POLICY_VERSION
+        or value.get("decomposition_mode") not in {"preflight", "bounce_only", "off"}
+        or isinstance(depth, bool)
+        or not isinstance(depth, int)
+        or depth < 0
+        or isinstance(concurrency, bool)
+        or not isinstance(concurrency, int)
+        or concurrency < 1
+        or isinstance(timeout, bool)
+        or not isinstance(timeout, int)
+        or timeout < 1
+        or isinstance(retries, bool)
+        or not isinstance(retries, int)
+        or retries < 0
+    ):
+        return False
+    for flag_name in (
+        "fat_harness_mode",
+        "run_verify_commands",
+        "cross_harness_redispatch",
+        "shadow_replay_enabled",
+    ):
+        if not isinstance(value.get(flag_name), bool):
+            return False
+    reasoning_effort = value.get("reasoning_effort")
+    if reasoning_effort is not None and (
+        not isinstance(reasoning_effort, str) or not reasoning_effort.strip()
+    ):
+        return False
+
+    raw_profile = value.get("execution_profile")
+    if raw_profile is not None:
+        if not isinstance(raw_profile, Mapping):
+            return False
+        try:
+            profile = ExecutionProfile.model_validate(dict(raw_profile))
+        except ValueError:
+            return False
+        if profile.model_dump(mode="json") != dict(raw_profile):
+            return False
+
+    raw_routing = value.get("model_routing")
+    recognized, router = deserialize_model_router(raw_routing)
+    if not recognized or serialize_model_router(router) != raw_routing:
+        return False
+    return _valid_dispatch_rate_contract(value.get("dispatch_rate"))
+
+
 def build_execution_policy_contract(
     *,
     decomposition_mode: str,
@@ -877,9 +1051,11 @@ def build_execution_policy_contract(
     model_router: ModelRouter | None,
     cross_harness_redispatch: bool,
     shadow_replay_enabled: bool,
+    dispatch_rate_policy: Mapping[str, object],
 ) -> dict[str, object]:
     """Return the one canonical parallel-execution policy payload."""
     return {
+        "version": _EXECUTION_POLICY_VERSION,
         "decomposition_mode": decomposition_mode,
         "max_decomposition_depth": max_decomposition_depth,
         "max_concurrent": max_concurrent,
@@ -894,6 +1070,10 @@ def build_execution_policy_contract(
         "model_routing": serialize_model_router(model_router),
         "cross_harness_redispatch": cross_harness_redispatch,
         "shadow_replay_enabled": shadow_replay_enabled,
+        "dispatch_rate": _canonical_object(
+            dict(dispatch_rate_policy),
+            field="dispatch rate policy",
+        ),
     }
 
 
@@ -921,6 +1101,32 @@ class ExecutionAuthorityContract:
             "execution_policy",
         }:
             raise ValueError("execution authority contract has an invalid shape")
+        if not valid_execution_policy_contract(data.get("execution_policy")):
+            raise ValueError("execution authority contract has an invalid execution policy")
+        runtime = data.get("runtime")
+        execution_policy = data.get("execution_policy")
+        runtime_backend = runtime.get("runtime_backend") if isinstance(runtime, Mapping) else None
+        dispatch_rate = (
+            execution_policy.get("dispatch_rate") if isinstance(execution_policy, Mapping) else None
+        )
+        dispatch_backend = (
+            dispatch_rate.get("backend") if isinstance(dispatch_rate, Mapping) else None
+        )
+        dispatch_self_governs = (
+            dispatch_rate.get("self_governs_rate_limit")
+            if isinstance(dispatch_rate, Mapping)
+            else None
+        )
+        runtime_self_governs = (
+            runtime.get("self_governs_rate_limit") if isinstance(runtime, Mapping) else None
+        )
+        expected_backend = (
+            runtime_backend if isinstance(runtime_backend, str) and runtime_backend else "unknown"
+        )
+        if dispatch_backend != expected_backend:
+            raise ValueError("dispatch rate policy disagrees with the runtime backend")
+        if dispatch_self_governs is not runtime_self_governs:
+            raise ValueError("dispatch rate policy disagrees with runtime self-governance")
         if _canonical_json(data, field="execution authority contract") != self.canonical_json:
             raise ValueError("execution authority contract is not canonical")
 
@@ -986,6 +1192,17 @@ class ExecutionAuthorityContract:
             return False
         generation = workspace.get("generation")
         if not isinstance(generation, Mapping) or generation.get("observed") is not True:
+            return False
+        if not _valid_workspace_generation_identity(generation.get("identity")):
+            return False
+
+        execution_policy = data.get("execution_policy")
+        if not valid_execution_policy_contract(execution_policy):
+            return False
+        dispatch_rate = (
+            execution_policy.get("dispatch_rate") if isinstance(execution_policy, Mapping) else None
+        )
+        if not isinstance(dispatch_rate, Mapping) or dispatch_rate.get("observed") is not True:
             return False
 
         runtime = data.get("runtime")
@@ -1063,6 +1280,7 @@ __all__ = [
     "runtime_execution_identity_contract",
     "runtime_execution_proves_effective_model",
     "valid_constructor_model_contract",
+    "valid_execution_policy_contract",
     "valid_runtime_execution_identity_contract",
     "verifier_authority_contract",
 ]

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -43,7 +43,7 @@ from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilitie
 from ouroboros.orchestrator.verifier import Verifier
 
 EXECUTION_AUTHORITY_VERSION = 5
-EXECUTION_AUTHORITY_BOUNDARY_VERSION = 1
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 2
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
@@ -104,6 +104,7 @@ _PER_ATTEMPT_CAPSULE_BOUNDARY = (
     "ac_runtime_handle_manager",
     "checkpoint_and_resume_state",
     "level_coordinator_behavior_and_session_state",
+    "selected_ac_reasoning_effort",
 )
 _VOLATILE_BOUNDARY = (
     "session_signal_hub",
@@ -2711,7 +2712,13 @@ def build_execution_policy_contract(
     shadow_replay_enabled: bool,
     dispatch_rate_policy: Mapping[str, object],
 ) -> dict[str, object]:
-    """Return the one canonical parallel-execution policy payload."""
+    """Return the canonical *static* parallel-execution policy payload.
+
+    ``reasoning_effort`` is the configured base policy for this executor.  The
+    actual effort selected for an AC can vary with its investment assessment,
+    decomposition role, and retry attempt; that selected value belongs to the
+    Foundation-C attempt capsule and is intentionally absent from this baseline.
+    """
     return {
         "version": _EXECUTION_POLICY_VERSION,
         "decomposition_mode": decomposition_mode,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -32,6 +32,8 @@ from collections.abc import Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+import dis
+import inspect
 import json
 import math
 import os
@@ -705,6 +707,295 @@ class _VerifyGateOutcome:
     missing_artifacts: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class _LiveCallableIntegrityBinding:
+    """Non-serializable in-process binding for one later-invoked collaborator.
+
+    The durable authority owns the collaborator's semantic fingerprint. The
+    live binding protects the narrower time-of-use boundary: execution must
+    invoke the exact collaborator object captured at construction, rather than
+    a field substituted after the authority was built. It intentionally does
+    not inspect live implementation details, which may be specialized by the
+    interpreter during ordinary execution.
+    """
+
+    value: object | None
+    member_name: str | None
+    entrypoint: object | None
+    code: object | None
+    defaults: object | None
+    keyword_defaults: object | None
+    closure_cells: tuple[tuple[object, object], ...] | None
+
+
+@dataclass(frozen=True)
+class _AuthorityBoundExecutionCollaborators:
+    """Construction-time live bindings for collaborators executed later."""
+
+    leaf_dispatcher: _LiveCallableIntegrityBinding
+    atomic_verifier: _LiveCallableIntegrityBinding
+
+
+@dataclass(frozen=True)
+class _LiveRuntimeModuleMemberBinding:
+    """One direct runtime module member captured for dispatch integrity."""
+
+    source_function: object
+    global_name: str
+    module: object
+    path: tuple[str, ...]
+    value: object
+    callable_binding: _LiveCallableIntegrityBinding | None
+
+
+@dataclass(frozen=True)
+class _RuntimeDispatchIntegrityBinding:
+    """Stable construction-time binding of direct runtime dispatch behavior."""
+
+    entrypoints: tuple[_LiveCallableIntegrityBinding, ...]
+    module_members: tuple[_LiveRuntimeModuleMemberBinding, ...]
+
+
+_RUNTIME_DISPATCH_ENTRYPOINTS = frozenset({"execute_task", "_execute_task_impl", "_run"})
+
+
+def _unwrap_live_callable_member(value: object) -> object | None:
+    """Return the direct callable a Python call will resolve to."""
+    if isinstance(value, (staticmethod, classmethod)):
+        value = value.__func__
+    if inspect.ismethod(value):
+        value = value.__func__
+    return value if callable(value) else None
+
+
+def _live_callable_entrypoint(value: object | None, *, member_name: str | None) -> object | None:
+    """Resolve the one executable entrypoint used by a bound collaborator."""
+    if value is None:
+        return None
+    if member_name is None:
+        direct = _unwrap_live_callable_member(value)
+        if inspect.isfunction(direct) or inspect.isbuiltin(direct):
+            return direct
+        owner_type = type(value)
+        try:
+            return _unwrap_live_callable_member(inspect.getattr_static(owner_type, "__call__"))
+        except (AttributeError, TypeError):
+            return None
+    try:
+        return _unwrap_live_callable_member(inspect.getattr_static(value, member_name))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _live_callable_closure_cells(
+    entrypoint: object | None,
+) -> tuple[tuple[object, object], ...] | None:
+    """Capture closure-cell object/value pairs without serializing live data."""
+    closure = getattr(entrypoint, "__closure__", None)
+    if closure is None:
+        return ()
+    try:
+        return tuple((cell, cell.cell_contents) for cell in closure)
+    except ValueError:
+        return None
+
+
+def _capture_live_callable_integrity(
+    value: object | None,
+    *,
+    member_name: str | None = None,
+) -> _LiveCallableIntegrityBinding:
+    """Capture the direct executable entrypoint selected at construction."""
+    entrypoint = _live_callable_entrypoint(value, member_name=member_name)
+    return _LiveCallableIntegrityBinding(
+        value=value,
+        member_name=member_name,
+        entrypoint=entrypoint,
+        code=getattr(entrypoint, "__code__", None),
+        defaults=getattr(entrypoint, "__defaults__", None),
+        keyword_defaults=getattr(entrypoint, "__kwdefaults__", None),
+        closure_cells=_live_callable_closure_cells(entrypoint),
+    )
+
+
+def _live_callable_integrity_is_intact(
+    binding: _LiveCallableIntegrityBinding,
+    current: object | None,
+) -> bool:
+    """Return whether execution will use its construction-time entrypoint."""
+    if current is not binding.value:
+        return False
+    current_entrypoint = _live_callable_entrypoint(current, member_name=binding.member_name)
+    if current_entrypoint is not binding.entrypoint:
+        return False
+    if binding.entrypoint is None:
+        return current is None
+    if getattr(current_entrypoint, "__code__", None) is not binding.code:
+        return False
+    if getattr(current_entrypoint, "__defaults__", None) is not binding.defaults:
+        return False
+    if getattr(current_entrypoint, "__kwdefaults__", None) is not binding.keyword_defaults:
+        return False
+    current_closure_cells = _live_callable_closure_cells(current_entrypoint)
+    if binding.closure_cells is None or current_closure_cells is None:
+        return False
+    if len(current_closure_cells) != len(binding.closure_cells):
+        return False
+    return all(
+        current_cell is expected_cell and current_value is expected_value
+        for (current_cell, current_value), (expected_cell, expected_value) in zip(
+            current_closure_cells,
+            binding.closure_cells,
+            strict=True,
+        )
+    )
+
+
+def _direct_module_member_paths(function: object, global_name: str) -> tuple[tuple[str, ...], ...]:
+    """Return direct attribute paths read from one module global by a function."""
+    if not inspect.isfunction(function):
+        return ()
+    paths: set[tuple[str, ...]] = set()
+    instructions = tuple(dis.get_instructions(function))
+    ignored_opcodes = frozenset({"CACHE", "EXTENDED_ARG", "PUSH_NULL", "COPY", "SWAP"})
+    for index, instruction in enumerate(instructions):
+        if (
+            instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"}
+            or instruction.argval != global_name
+        ):
+            continue
+        path: list[str] = []
+        for following in instructions[index + 1 :]:
+            if following.opname in ignored_opcodes:
+                continue
+            if following.opname in {"LOAD_ATTR", "LOAD_METHOD"} and isinstance(
+                following.argval, str
+            ):
+                path.append(following.argval)
+                paths.add(tuple(path))
+                continue
+            break
+    return tuple(sorted(paths))
+
+
+def _runtime_dispatch_owners(adapter: object) -> tuple[object, ...]:
+    """Return the adapter and its explicitly declared execution components."""
+    owners = [adapter]
+    try:
+        provider = object.__getattribute__(adapter, "execution_components")
+        components = provider() if callable(provider) else None
+    except Exception:
+        components = None
+    if isinstance(components, Mapping):
+        owners.extend(component for component in components.values() if component is not None)
+    unique_owners: list[object] = []
+    seen: set[int] = set()
+    for owner in owners:
+        owner_id = id(owner)
+        if owner_id not in seen:
+            seen.add(owner_id)
+            unique_owners.append(owner)
+    return tuple(unique_owners)
+
+
+def _live_value_is_intact(expected: object, current: object) -> bool:
+    """Compare direct module values without rejecting equal scalar sentinels."""
+    if expected is current:
+        return True
+    if expected is None or isinstance(expected, (bool, int, float, str, bytes)):
+        return type(current) is type(expected) and current == expected
+    return False
+
+
+def _capture_runtime_dispatch_integrity(adapter: object) -> _RuntimeDispatchIntegrityBinding:
+    """Capture direct dispatch roots and module calls without serializing live state.
+
+    This deliberately inspects only execution entrypoints and declared runtime
+    components. It covers subprocess launch surfaces (including nested
+    ``asyncio.subprocess.PIPE`` paths) while avoiding unstable retry handles,
+    pools, and interpreter-specialized code serialization.
+    """
+    entrypoints: list[_LiveCallableIntegrityBinding] = []
+    module_members: list[_LiveRuntimeModuleMemberBinding] = []
+    seen_entrypoints: set[tuple[int, str]] = set()
+    seen_module_members: set[tuple[int, str, tuple[str, ...]]] = set()
+    for owner in _runtime_dispatch_owners(adapter):
+        for name in _RUNTIME_DISPATCH_ENTRYPOINTS:
+            key = (id(owner), name)
+            if key in seen_entrypoints:
+                continue
+            binding = _capture_live_callable_integrity(owner, member_name=name)
+            if binding.entrypoint is None:
+                continue
+            seen_entrypoints.add(key)
+            entrypoints.append(binding)
+            function = binding.entrypoint
+            if not inspect.isfunction(function):
+                continue
+            try:
+                global_dependencies = inspect.getclosurevars(function).globals
+            except Exception:
+                continue
+            for global_name, dependency in global_dependencies.items():
+                if not inspect.ismodule(dependency):
+                    continue
+                for path in _direct_module_member_paths(function, global_name):
+                    member = dependency
+                    try:
+                        for attribute in path:
+                            member = inspect.getattr_static(member, attribute)
+                    except (AttributeError, TypeError):
+                        continue
+                    member_key = (id(function), global_name, path)
+                    if member_key in seen_module_members:
+                        continue
+                    seen_module_members.add(member_key)
+                    module_members.append(
+                        _LiveRuntimeModuleMemberBinding(
+                            source_function=function,
+                            global_name=global_name,
+                            module=dependency,
+                            path=path,
+                            value=member,
+                            callable_binding=(
+                                _capture_live_callable_integrity(member)
+                                if callable(member)
+                                else None
+                            ),
+                        )
+                    )
+    return _RuntimeDispatchIntegrityBinding(tuple(entrypoints), tuple(module_members))
+
+
+def _runtime_dispatch_integrity_is_intact(binding: _RuntimeDispatchIntegrityBinding) -> bool:
+    """Return whether direct runtime dispatch code and module members are unchanged."""
+    if not all(
+        _live_callable_integrity_is_intact(entrypoint, entrypoint.value)
+        for entrypoint in binding.entrypoints
+    ):
+        return False
+    for member_binding in binding.module_members:
+        global_values = getattr(member_binding.source_function, "__globals__", None)
+        if not isinstance(global_values, Mapping):
+            return False
+        if global_values.get(member_binding.global_name) is not member_binding.module:
+            return False
+        current = member_binding.module
+        try:
+            for attribute in member_binding.path:
+                current = inspect.getattr_static(current, attribute)
+        except (AttributeError, TypeError):
+            return False
+        if not _live_value_is_intact(member_binding.value, current):
+            return False
+        if member_binding.callable_binding is not None and not _live_callable_integrity_is_intact(
+            member_binding.callable_binding,
+            current,
+        ):
+            return False
+    return True
+
+
 def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
     """Return the expected artifacts absent relative to ``cwd``.
 
@@ -996,6 +1287,19 @@ class ParallelACExecutor:
         self._leaf_dispatcher_factory = LeafDispatcher
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
+        self._authority_bound_execution_collaborators = _AuthorityBoundExecutionCollaborators(
+            leaf_dispatcher=_capture_live_callable_integrity(
+                self._leaf_dispatcher_factory,
+                member_name="stream",
+            ),
+            atomic_verifier=_capture_live_callable_integrity(self._atomic_verifier),
+        )
+        self._runtime_dispatch_integrity = _capture_runtime_dispatch_integrity(adapter)
+        self._runtime_dispatch_integrity_binding = self._runtime_dispatch_integrity
+        self._runtime_dispatch_integrity_checker = _runtime_dispatch_integrity_is_intact
+        self._runtime_dispatch_integrity_checker_binding = _capture_live_callable_integrity(
+            self._runtime_dispatch_integrity_checker
+        )
         self._coordinator = LevelCoordinator(
             adapter,
             inherited_runtime_handle=self._inherited_runtime_handle,
@@ -1108,6 +1412,47 @@ class ParallelACExecutor:
     def execution_authority(self) -> ExecutionAuthorityContract:
         """Return the immutable authority snapshot used by this executor."""
         return self._execution_authority
+
+    def _execution_collaborators_are_intact(self) -> bool:
+        """Verify that later execution still uses the authority-bound collaborators."""
+        binding = self._authority_bound_execution_collaborators
+        try:
+            return _live_callable_integrity_is_intact(
+                binding.leaf_dispatcher,
+                self._leaf_dispatcher_factory,
+            ) and _live_callable_integrity_is_intact(
+                binding.atomic_verifier,
+                self._atomic_verifier,
+            )
+        except Exception:
+            return False
+
+    def _runtime_authority_is_intact(self) -> bool:
+        """Recheck the adapter implementation before it can perform an effect.
+
+        The durable contract captures the runtime implementation. This
+        process-local binding captures its direct dispatch roots and module
+        dependencies without reserializing interpreter-specialized code or
+        folding handles and retry counters into the baseline.
+        """
+        try:
+            return (
+                self._runtime_dispatch_integrity is self._runtime_dispatch_integrity_binding
+                and _live_callable_integrity_is_intact(
+                    self._runtime_dispatch_integrity_checker_binding,
+                    self._runtime_dispatch_integrity_checker,
+                )
+                and self._runtime_dispatch_integrity_checker(self._runtime_dispatch_integrity)
+            )
+        except Exception:
+            return False
+
+    def _require_execution_collaborators_intact(self) -> None:
+        """Fail closed before dispatch or acceptance behavior can drift."""
+        if not self._execution_collaborators_are_intact():
+            raise ValueError("execution collaborators drifted from execution authority")
+        if not self._runtime_authority_is_intact():
+            raise ValueError("runtime implementation drifted from execution authority")
 
     @staticmethod
     def _dispatch_rate_backend(adapter: AgentRuntime) -> str:
@@ -3563,6 +3908,7 @@ class ParallelACExecutor:
             permission_mode="bypassPermissions",
         )
 
+        self._require_execution_collaborators_intact()
         alt_executor = ParallelACExecutor(
             alt_adapter,
             self._event_store,
@@ -4613,6 +4959,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
+            self._require_execution_collaborators_intact()
             await self._leaf_dispatcher_factory(self).stream(
                 state=dispatch_state,
                 prompt=prompt,
@@ -4715,6 +5062,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
+                        self._require_execution_collaborators_intact()
                         await self._leaf_dispatcher_factory(self).stream(
                             state=dispatch_state,
                             prompt=(
@@ -6179,6 +6527,7 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return None
 
+        self._require_execution_collaborators_intact()
         verifier = self._atomic_verifier
         try:
             effective_schema = _effective_evidence_schema_for_ac(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -85,7 +85,10 @@ from ouroboros.orchestrator.atomic_prompt_builder import (
     AtomicPromptBuilder,
     _build_success_contract_block,  # noqa: F401  (re-exported for tests/back-compat)
 )
-from ouroboros.orchestrator.backend_limits import resolve_backend_limits
+from ouroboros.orchestrator.backend_limits import (
+    BackendConcurrencyLimits,
+    resolve_backend_limits,
+)
 from ouroboros.orchestrator.context_governor import SiblingStatus, compose_context
 from ouroboros.orchestrator.coordinator import CoordinatorReview, LevelCoordinator
 from ouroboros.orchestrator.decomposition_params import (
@@ -290,8 +293,7 @@ from ouroboros.orchestrator.parallel_executor_models import (
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedModelTier
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
-    RateLimitGate,
-    build_rate_limit_gate,
+    ResolvedDispatchRatePolicy,
     estimate_runtime_request_tokens,
 )
 from ouroboros.orchestrator.runtime_param_negotiation import (
@@ -907,6 +909,7 @@ class ParallelACExecutor:
         session_signal_hub: SessionSignalHub | None = None,
         resolved_routing_authority: ResolvedRuntimeAuthority | None = None,
         workspace_authority_identity: Mapping[str, object] | None = None,
+        dispatch_rate_policy: ResolvedDispatchRatePolicy | None = None,
     ):
         """Initialize executor.
 
@@ -1004,7 +1007,11 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
         self._execution_counters_lock = asyncio.Lock()
-        self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        self._dispatch_rate_policy = dispatch_rate_policy or self._resolve_dispatch_rate_policy(
+            adapter
+        )
+        self._validate_dispatch_rate_policy(adapter, self._dispatch_rate_policy)
+        self._dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1035,6 +1042,7 @@ class ParallelACExecutor:
             model_router=self._model_router,
             cross_harness_redispatch=self._cross_harness_redispatch_enabled,
             shadow_replay_enabled=self._shadow_replay_enabled,
+            dispatch_rate_policy=self._dispatch_rate_policy.to_contract_data(),
         )
         workspace = task_cwd or getattr(adapter, "working_directory", None) or os.getcwd()
         self._execution_authority = ExecutionAuthorityContract.build(
@@ -1054,8 +1062,11 @@ class ParallelACExecutor:
         return self._execution_authority
 
     @staticmethod
-    def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
-        """Build the shared dispatch rate gate for non-self-governing backends.
+    def _resolve_dispatch_rate_policy(
+        adapter: AgentRuntime,
+        limits: BackendConcurrencyLimits | None = None,
+    ) -> ResolvedDispatchRatePolicy:
+        """Resolve one immutable policy for behavior and authority identity.
 
         Ouroboros — not the runtime — paces delivery within the backend's
         declared RPM/TPM budget. Native adapters that already run their own
@@ -1067,16 +1078,25 @@ class ParallelACExecutor:
         """
         backend_attr = getattr(adapter, "runtime_backend", "")
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
-
-        if getattr(adapter, "self_governs_rate_limit", False):
-            return build_rate_limit_gate(backend, request_limit=None, token_limit=None)
-
-        limits = resolve_backend_limits(backend)
-        return build_rate_limit_gate(
-            backend,
-            request_limit=limits.requests_per_minute,
-            token_limit=limits.tokens_per_minute,
+        self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
+        resolved_limits = limits or resolve_backend_limits(backend)
+        return ResolvedDispatchRatePolicy.resolve(
+            backend=backend,
+            self_governs_rate_limit=self_governs,
+            requests_per_minute=resolved_limits.requests_per_minute,
+            tokens_per_minute=resolved_limits.tokens_per_minute,
         )
+
+    @staticmethod
+    def _validate_dispatch_rate_policy(
+        adapter: AgentRuntime,
+        policy: ResolvedDispatchRatePolicy,
+    ) -> None:
+        backend_attr = getattr(adapter, "runtime_backend", "")
+        backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
+        self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
+        if policy.backend != backend or policy.self_governs_rate_limit is not self_governs:
+            raise ValueError("dispatch rate policy disagrees with the active runtime")
 
     async def _await_dispatch_rate_budget(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -254,6 +254,7 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
+from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -273,6 +274,7 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
+    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -1015,6 +1017,35 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
+        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        self._execution_authority = ExecutionAuthorityContract.build(
+            adapter=adapter,
+            verifier=atomic_verifier,
+            workspace=workspace if isinstance(workspace, str) else None,
+            execution_policy={
+                "decomposition_mode": self._decomposition_mode,
+                "max_decomposition_depth": self._max_decomposition_depth,
+                "max_concurrent": max_concurrent,
+                "execution_profile": (
+                    self._execution_profile.model_dump(mode="json")
+                    if self._execution_profile is not None
+                    else None
+                ),
+                "fat_harness_mode": self._fat_harness_mode,
+                "run_verify_commands": self._run_verify_commands,
+                "verify_command_timeout_seconds": self._verify_command_timeout_seconds,
+                "ac_retry_attempts": self._ac_retry_attempts,
+                "reasoning_effort": self._reasoning_effort,
+                "model_routing": serialize_model_router(self._model_router),
+                "cross_harness_redispatch": self._cross_harness_redispatch_enabled,
+                "shadow_replay_enabled": self._shadow_replay_enabled,
+            },
+        )
+
+    @property
+    def execution_authority(self) -> ExecutionAuthorityContract:
+        """Return the immutable authority snapshot used by this executor."""
+        return self._execution_authority
 
     @staticmethod
     def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -254,7 +254,11 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
-from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ResolvedRuntimeAuthority,
+    build_execution_policy_contract,
+)
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -274,7 +278,6 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
-    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -902,6 +905,8 @@ class ParallelACExecutor:
         cross_harness_redispatch: bool | None = None,
         shadow_replay_enabled: bool = False,
         session_signal_hub: SessionSignalHub | None = None,
+        resolved_routing_authority: ResolvedRuntimeAuthority | None = None,
+        workspace_authority_identity: Mapping[str, object] | None = None,
     ):
         """Initialize executor.
 
@@ -1017,29 +1022,30 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
-        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        execution_policy = build_execution_policy_contract(
+            decomposition_mode=self._decomposition_mode,
+            max_decomposition_depth=self._max_decomposition_depth,
+            max_concurrent=max_concurrent,
+            execution_profile=self._execution_profile,
+            fat_harness_mode=self._fat_harness_mode,
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
+            ac_retry_attempts=self._ac_retry_attempts,
+            reasoning_effort=self._reasoning_effort,
+            model_router=self._model_router,
+            cross_harness_redispatch=self._cross_harness_redispatch_enabled,
+            shadow_replay_enabled=self._shadow_replay_enabled,
+        )
+        workspace = task_cwd or getattr(adapter, "working_directory", None) or os.getcwd()
         self._execution_authority = ExecutionAuthorityContract.build(
             adapter=adapter,
             verifier=atomic_verifier,
-            workspace=workspace if isinstance(workspace, str) else None,
-            execution_policy={
-                "decomposition_mode": self._decomposition_mode,
-                "max_decomposition_depth": self._max_decomposition_depth,
-                "max_concurrent": max_concurrent,
-                "execution_profile": (
-                    self._execution_profile.model_dump(mode="json")
-                    if self._execution_profile is not None
-                    else None
-                ),
-                "fat_harness_mode": self._fat_harness_mode,
-                "run_verify_commands": self._run_verify_commands,
-                "verify_command_timeout_seconds": self._verify_command_timeout_seconds,
-                "ac_retry_attempts": self._ac_retry_attempts,
-                "reasoning_effort": self._reasoning_effort,
-                "model_routing": serialize_model_router(self._model_router),
-                "cross_harness_redispatch": self._cross_harness_redispatch_enabled,
-                "shadow_replay_enabled": self._shadow_replay_enabled,
-            },
+            workspace=workspace if isinstance(workspace, str) else os.getcwd(),
+            workspace_identity=workspace_authority_identity,
+            execution_policy=execution_policy,
+            resolved_routing=resolved_routing_authority,
+            runtime_handle=self._inherited_runtime_handle,
+            runtime_transcript_verifier=self._verify_atomic_evidence_against_runtime_messages,
         )
 
     @property
@@ -3473,23 +3479,6 @@ class ParallelACExecutor:
             permission_mode="bypassPermissions",
         )
 
-        event = create_alt_harness_redispatch_event(
-            session_id=rerun_kwargs["session_id"],
-            ac_index=rerun_kwargs["ac_index"],
-            ac_id=runtime_identity.ac_id,
-            execution_id=rerun_kwargs["execution_id"] or None,
-            decision=decision,
-            redispatch_index=1,
-            failure_class=failure_class,
-        )
-        await self._safe_emit_event(event)
-        log.info(
-            "parallel_executor.alt_harness_redispatch",
-            from_backend=decision.from_backend,
-            to_backend=backend,
-            ac_index=rerun_kwargs["ac_index"],
-        )
-
         alt_executor = ParallelACExecutor(
             alt_adapter,
             self._event_store,
@@ -3505,12 +3494,37 @@ class ParallelACExecutor:
             # The router's backend-mismatch guard makes it inert on a different
             # backend, so passing it to the alt-harness executor is safe.
             model_router=self._model_router,
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
+            # This path intentionally performs one alternate-route attempt;
+            # ordinary same-runtime retries were already exhausted by the parent.
+            ac_retry_attempts=0,
             cross_harness_redispatch=False,
             # The router is inert on a different backend, so the baseline resolves
             # no parent-tier model and the replay self-skips — threading the flag
             # just keeps the throwaway executor's behavior consistent.
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
+        )
+
+        # Emit "redispatched" only after the alternate runtime and its authority
+        # snapshot are ready. Construction failures are preparation failures, not
+        # evidence that another harness actually received the AC.
+        event = create_alt_harness_redispatch_event(
+            session_id=rerun_kwargs["session_id"],
+            ac_index=rerun_kwargs["ac_index"],
+            ac_id=runtime_identity.ac_id,
+            execution_id=rerun_kwargs["execution_id"] or None,
+            decision=decision,
+            redispatch_index=1,
+            failure_class=failure_class,
+        )
+        await self._safe_emit_event(event)
+        log.info(
+            "parallel_executor.alt_harness_redispatch",
+            from_backend=decision.from_backend,
+            to_backend=backend,
+            ac_index=rerun_kwargs["ac_index"],
         )
         return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -28,7 +28,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -262,6 +262,7 @@ from ouroboros.orchestrator.evidence_schema import (
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
+    _callable_behavior_digest,
     build_execution_policy_contract,
     runtime_routing_labels_contract,
 )
@@ -714,9 +715,11 @@ class _LiveCallableIntegrityBinding:
     The durable authority owns the collaborator's semantic fingerprint. The
     live binding protects the narrower time-of-use boundary: execution must
     invoke the exact collaborator object captured at construction, rather than
-    a field substituted after the authority was built. It intentionally does
-    not inspect live implementation details, which may be specialized by the
-    interpreter during ordinary execution.
+    a field substituted after the authority was built. Mutable closure state
+    receives an existing hash-only behavior snapshot; other live
+    implementation details remain out of this lightweight process-local check
+    because they may be specialized by the interpreter during ordinary
+    execution.
     """
 
     value: object | None
@@ -726,6 +729,7 @@ class _LiveCallableIntegrityBinding:
     defaults: object | None
     keyword_defaults: object | None
     closure_cells: tuple[tuple[object, object], ...] | None
+    closure_behavior_digest: str | None
 
 
 @dataclass(frozen=True)
@@ -734,6 +738,8 @@ class _AuthorityBoundExecutionCollaborators:
 
     leaf_dispatcher: _LiveCallableIntegrityBinding
     atomic_verifier: _LiveCallableIntegrityBinding
+    integrity_checker: Callable[[_LiveCallableIntegrityBinding, object | None], bool]
+    integrity_checker_binding: _LiveCallableIntegrityBinding
 
 
 @dataclass(frozen=True)
@@ -807,6 +813,21 @@ def _capture_live_callable_integrity(
 ) -> _LiveCallableIntegrityBinding:
     """Capture the direct executable entrypoint selected at construction."""
     entrypoint = _live_callable_entrypoint(value, member_name=member_name)
+    closure_cells = _live_callable_closure_cells(entrypoint)
+    # Cell identity alone is not enough: a verifier may close over a mutable
+    # mapping or list whose contents change after authority construction.  Keep
+    # only the existing non-egressing behavior digest, and only when a closure
+    # exists, so ordinary hot dispatch paths retain the lightweight identity
+    # check below.
+    closure_behavior_digest: str | None = None
+    if closure_cells:
+        try:
+            closure_behavior_digest = _callable_behavior_digest(entrypoint)
+        except Exception:
+            # The structural binding still protects this process-local
+            # collaborator.  An unavailable digest must never be treated as a
+            # matching digest at time of use.
+            closure_behavior_digest = None
     return _LiveCallableIntegrityBinding(
         value=value,
         member_name=member_name,
@@ -814,18 +835,30 @@ def _capture_live_callable_integrity(
         code=getattr(entrypoint, "__code__", None),
         defaults=getattr(entrypoint, "__defaults__", None),
         keyword_defaults=getattr(entrypoint, "__kwdefaults__", None),
-        closure_cells=_live_callable_closure_cells(entrypoint),
+        closure_cells=closure_cells,
+        closure_behavior_digest=closure_behavior_digest,
     )
 
 
 def _live_callable_integrity_is_intact(
     binding: _LiveCallableIntegrityBinding,
     current: object | None,
+    *,
+    _entrypoint_resolver: Callable[..., object | None] = _live_callable_entrypoint,
+    _closure_cells_resolver: Callable[[object | None], tuple[tuple[object, object], ...] | None] = (
+        _live_callable_closure_cells
+    ),
+    _behavior_digest: Callable[[object], str] = _callable_behavior_digest,
 ) -> bool:
-    """Return whether execution will use its construction-time entrypoint."""
+    """Return whether execution will use its construction-time entrypoint.
+
+    The helper dependencies are captured in defaults deliberately.  Executors
+    retain this function object at construction, so replacing this module's
+    helper name later cannot turn a live authority guard into an allow-all.
+    """
     if current is not binding.value:
         return False
-    current_entrypoint = _live_callable_entrypoint(current, member_name=binding.member_name)
+    current_entrypoint = _entrypoint_resolver(current, member_name=binding.member_name)
     if current_entrypoint is not binding.entrypoint:
         return False
     if binding.entrypoint is None:
@@ -836,19 +869,26 @@ def _live_callable_integrity_is_intact(
         return False
     if getattr(current_entrypoint, "__kwdefaults__", None) is not binding.keyword_defaults:
         return False
-    current_closure_cells = _live_callable_closure_cells(current_entrypoint)
+    current_closure_cells = _closure_cells_resolver(current_entrypoint)
     if binding.closure_cells is None or current_closure_cells is None:
         return False
     if len(current_closure_cells) != len(binding.closure_cells):
         return False
-    return all(
+    if not all(
         current_cell is expected_cell and current_value is expected_value
         for (current_cell, current_value), (expected_cell, expected_value) in zip(
             current_closure_cells,
             binding.closure_cells,
             strict=True,
         )
-    )
+    ):
+        return False
+    if binding.closure_behavior_digest is None:
+        return True
+    try:
+        return _behavior_digest(current_entrypoint) == binding.closure_behavior_digest
+    except Exception:
+        return False
 
 
 def _direct_module_member_paths(function: object, global_name: str) -> tuple[tuple[str, ...], ...]:
@@ -967,10 +1007,16 @@ def _capture_runtime_dispatch_integrity(adapter: object) -> _RuntimeDispatchInte
     return _RuntimeDispatchIntegrityBinding(tuple(entrypoints), tuple(module_members))
 
 
-def _runtime_dispatch_integrity_is_intact(binding: _RuntimeDispatchIntegrityBinding) -> bool:
+def _runtime_dispatch_integrity_is_intact(
+    binding: _RuntimeDispatchIntegrityBinding,
+    *,
+    _callable_integrity_checker: Callable[[_LiveCallableIntegrityBinding, object | None], bool] = (
+        _live_callable_integrity_is_intact
+    ),
+) -> bool:
     """Return whether direct runtime dispatch code and module members are unchanged."""
     if not all(
-        _live_callable_integrity_is_intact(entrypoint, entrypoint.value)
+        _callable_integrity_checker(entrypoint, entrypoint.value)
         for entrypoint in binding.entrypoints
     ):
         return False
@@ -988,7 +1034,7 @@ def _runtime_dispatch_integrity_is_intact(binding: _RuntimeDispatchIntegrityBind
             return False
         if not _live_value_is_intact(member_binding.value, current):
             return False
-        if member_binding.callable_binding is not None and not _live_callable_integrity_is_intact(
+        if member_binding.callable_binding is not None and not _callable_integrity_checker(
             member_binding.callable_binding,
             current,
         ):
@@ -1287,12 +1333,17 @@ class ParallelACExecutor:
         self._leaf_dispatcher_factory = LeafDispatcher
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
+        live_callable_integrity_checker = _live_callable_integrity_is_intact
         self._authority_bound_execution_collaborators = _AuthorityBoundExecutionCollaborators(
             leaf_dispatcher=_capture_live_callable_integrity(
                 self._leaf_dispatcher_factory,
                 member_name="stream",
             ),
             atomic_verifier=_capture_live_callable_integrity(self._atomic_verifier),
+            integrity_checker=live_callable_integrity_checker,
+            integrity_checker_binding=_capture_live_callable_integrity(
+                live_callable_integrity_checker
+            ),
         )
         self._runtime_dispatch_integrity = _capture_runtime_dispatch_integrity(adapter)
         self._runtime_dispatch_integrity_binding = self._runtime_dispatch_integrity
@@ -1417,12 +1468,30 @@ class ParallelACExecutor:
         """Verify that later execution still uses the authority-bound collaborators."""
         binding = self._authority_bound_execution_collaborators
         try:
-            return _live_callable_integrity_is_intact(
-                binding.leaf_dispatcher,
-                self._leaf_dispatcher_factory,
-            ) and _live_callable_integrity_is_intact(
-                binding.atomic_verifier,
-                self._atomic_verifier,
+            checker = binding.integrity_checker
+            checker_binding = binding.integrity_checker_binding
+            # Do not resolve the predicate through the mutable module name at
+            # time of use.  Check the captured predicate's finite function
+            # shape before calling it, then let its default-captured helpers
+            # inspect the actual dispatcher and verifier.
+            checker_is_bound = (
+                checker is checker_binding.value
+                and checker is checker_binding.entrypoint
+                and getattr(checker, "__code__", None) is checker_binding.code
+                and getattr(checker, "__defaults__", None) is checker_binding.defaults
+                and getattr(checker, "__kwdefaults__", None) is checker_binding.keyword_defaults
+                and checker_binding.closure_cells == ()
+            )
+            return (
+                checker_is_bound
+                and checker(
+                    binding.leaf_dispatcher,
+                    self._leaf_dispatcher_factory,
+                )
+                and checker(
+                    binding.atomic_verifier,
+                    self._atomic_verifier,
+                )
             )
         except Exception:
             return False
@@ -1436,13 +1505,20 @@ class ParallelACExecutor:
         folding handles and retry counters into the baseline.
         """
         try:
+            checker = self._runtime_dispatch_integrity_checker
+            checker_binding = self._runtime_dispatch_integrity_checker_binding
+            checker_is_bound = (
+                checker is checker_binding.value
+                and checker is checker_binding.entrypoint
+                and getattr(checker, "__code__", None) is checker_binding.code
+                and getattr(checker, "__defaults__", None) is checker_binding.defaults
+                and getattr(checker, "__kwdefaults__", None) is checker_binding.keyword_defaults
+                and checker_binding.closure_cells == ()
+            )
             return (
                 self._runtime_dispatch_integrity is self._runtime_dispatch_integrity_binding
-                and _live_callable_integrity_is_intact(
-                    self._runtime_dispatch_integrity_checker_binding,
-                    self._runtime_dispatch_integrity_checker,
-                )
-                and self._runtime_dispatch_integrity_checker(self._runtime_dispatch_integrity)
+                and checker_is_bound
+                and checker(self._runtime_dispatch_integrity)
             )
         except Exception:
             return False

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1048,6 +1048,7 @@ class ParallelACExecutor:
         self._execution_authority = ExecutionAuthorityContract.build(
             adapter=adapter,
             verifier=atomic_verifier,
+            executor=self,
             workspace=workspace if isinstance(workspace, str) else os.getcwd(),
             workspace_identity=workspace_authority_identity,
             execution_policy=execution_policy,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -294,7 +294,11 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedMod
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
     ResolvedDispatchRatePolicy,
-    estimate_runtime_request_tokens,
+    authority_bound_rate_limit_gate_is_intact,
+    authority_bound_rate_limit_token_estimator_is_intact,
+    build_authority_bound_rate_limit_gate,
+    capture_authority_bound_rate_limit_token_estimator,
+    estimate_runtime_request_tokens,  # noqa: F401 - compatibility mutation target for integrity tests.
 )
 from ouroboros.orchestrator.runtime_param_negotiation import (
     announce_execution_param_degradations,
@@ -1014,10 +1018,36 @@ class ParallelACExecutor:
             adapter
         )
         self._validate_dispatch_rate_policy(adapter, self._dispatch_rate_policy)
-        dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
+        # Capture each rate helper exactly once.  The authority snapshots below
+        # come from the same factory/estimator objects that this executor will
+        # use; a mutable module alias cannot be checked at one moment and used
+        # as a different implementation a moment later.
+        dispatch_rate_gate_binding = build_authority_bound_rate_limit_gate(
+            self._dispatch_rate_policy.backend,
+            request_limit=(
+                self._dispatch_rate_policy.requests_per_minute
+                if self._dispatch_rate_policy.owner == "ouroboros"
+                else None
+            ),
+            token_limit=(
+                self._dispatch_rate_policy.tokens_per_minute
+                if self._dispatch_rate_policy.owner == "ouroboros"
+                else None
+            ),
+            window_seconds=self._dispatch_rate_policy.window_seconds,
+            max_wait_seconds=self._dispatch_rate_policy.max_wait_seconds,
+            heartbeat_seconds=self._dispatch_rate_policy.heartbeat_seconds,
+        )
+        dispatch_rate_gate = dispatch_rate_gate_binding.gate
+        dispatch_rate_gate_algorithm = dispatch_rate_gate_binding.algorithm
+        (
+            self._dispatch_token_estimator,
+            self._dispatch_token_estimator_contract,
+        ) = capture_authority_bound_rate_limit_token_estimator()
         if dispatch_rate_gate.enabled is not self._dispatch_rate_policy.gate_enabled:
             raise ValueError("dispatch rate gate disagrees with the resolved policy")
         self._dispatch_rate_gate = dispatch_rate_gate
+        self._dispatch_rate_gate_binding = dispatch_rate_gate_binding
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1048,7 +1078,10 @@ class ParallelACExecutor:
             model_router=self._model_router,
             cross_harness_redispatch=self._cross_harness_redispatch_enabled,
             shadow_replay_enabled=self._shadow_replay_enabled,
-            dispatch_rate_policy=self._dispatch_rate_policy.to_contract_data(),
+            dispatch_rate_policy=self._dispatch_rate_policy.to_contract_data(
+                gate_algorithm=dispatch_rate_gate_algorithm,
+                token_estimator=self._dispatch_token_estimator_contract,
+            ),
         )
         workspace = task_cwd or getattr(adapter, "working_directory", None) or os.getcwd()
         self._execution_authority = ExecutionAuthorityContract.build(
@@ -1057,13 +1090,16 @@ class ParallelACExecutor:
             executor=self,
             executor_components={
                 "leaf_dispatcher": self._leaf_dispatcher_factory,
-                "session_signal_hub": self._session_signal_hub,
             },
             workspace=workspace if isinstance(workspace, str) else os.getcwd(),
             workspace_identity=workspace_authority_identity,
             execution_policy=execution_policy,
             resolved_routing=resolved_routing_authority,
-            runtime_handle=self._inherited_runtime_handle,
+            # A selected handle, manager cache, coordinator session state, and
+            # live signal hub are intentionally per-attempt/volatile. Foundation
+            # A binds only the static selector implementation; Foundation C
+            # composes concrete handle/recovery state into its attempt capsule.
+            runtime_handle=None,
             runtime_transcript_verifier=self._verify_atomic_evidence_against_runtime_messages,
         )
 
@@ -1124,10 +1160,20 @@ class ParallelACExecutor:
         workers (they share this executor's single gate instance) and logs each
         backoff for observability.
         """
-        if not self._dispatch_rate_gate.enabled:
+        if not self._dispatch_rate_policy.gate_enabled:
             return
 
-        estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
+        if not authority_bound_rate_limit_gate_is_intact(self._dispatch_rate_gate_binding):
+            raise ValueError("dispatch rate gate drifted from execution authority")
+        if not authority_bound_rate_limit_token_estimator_is_intact(
+            self._dispatch_token_estimator,
+            self._dispatch_token_estimator_contract,
+        ):
+            raise ValueError("dispatch token estimator drifted from execution authority")
+        estimated_tokens = self._dispatch_token_estimator(
+            prompt,
+            system_prompt=system_prompt,
+        )
 
         def _log_backoff(backoff: RateLimitBackoff) -> None:
             log.info(
@@ -1142,7 +1188,7 @@ class ParallelACExecutor:
                 token_limit=backoff.snapshot.token_limit,
             )
 
-        await self._dispatch_rate_gate.acquire(estimated_tokens, on_backoff=_log_backoff)
+        await self._dispatch_rate_gate_binding.acquire(estimated_tokens, on_backoff=_log_backoff)
 
     def _announce_param_degradations(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -729,6 +729,7 @@ class _LiveCallableIntegrityBinding:
     defaults: object | None
     keyword_defaults: object | None
     closure_cells: tuple[tuple[object, object], ...] | None
+    requires_behavior_digest: bool
     closure_behavior_digest: str | None
 
 
@@ -738,7 +739,7 @@ class _AuthorityBoundExecutionCollaborators:
 
     leaf_dispatcher: _LiveCallableIntegrityBinding
     atomic_verifier: _LiveCallableIntegrityBinding
-    integrity_checker: Callable[[_LiveCallableIntegrityBinding, object | None], bool]
+    integrity_checker: _LiveCallableIntegrityChecker
     integrity_checker_binding: _LiveCallableIntegrityBinding
 
 
@@ -806,6 +807,35 @@ def _live_callable_closure_cells(
         return None
 
 
+def _callable_defaults_have_mutable_state(
+    defaults: object | None,
+    keyword_defaults: object | None,
+) -> bool:
+    """Return whether default values can drift without replacing their tuple.
+
+    A function's positional-default tuple is immutable, so scalar and nested
+    immutable values are already protected by the tuple identity check. A
+    mutable value nested in it, or any populated keyword-default mapping, can
+    change behavior in place and therefore needs the hash-only snapshot.
+    """
+
+    def is_mutable(value: object) -> bool:
+        if value is None or isinstance(value, (bool, int, float, str, bytes)):
+            return False
+        if isinstance(value, tuple):
+            return any(is_mutable(item) for item in value)
+        if isinstance(value, frozenset):
+            return any(is_mutable(item) for item in value)
+        return True
+
+    if defaults is not None:
+        if not isinstance(defaults, tuple):
+            return True
+        if any(is_mutable(value) for value in defaults):
+            return True
+    return bool(keyword_defaults)
+
+
 def _capture_live_callable_integrity(
     value: object | None,
     *,
@@ -814,81 +844,146 @@ def _capture_live_callable_integrity(
     """Capture the direct executable entrypoint selected at construction."""
     entrypoint = _live_callable_entrypoint(value, member_name=member_name)
     closure_cells = _live_callable_closure_cells(entrypoint)
+    defaults = getattr(entrypoint, "__defaults__", None)
+    keyword_defaults = getattr(entrypoint, "__kwdefaults__", None)
     # Cell identity alone is not enough: a verifier may close over a mutable
-    # mapping or list whose contents change after authority construction.  Keep
-    # only the existing non-egressing behavior digest, and only when a closure
-    # exists, so ordinary hot dispatch paths retain the lightweight identity
-    # check below.
+    # mapping/list or mutable default whose contents change after authority
+    # construction. Keep only the existing non-egressing behavior digest, and
+    # only when mutable behavior dependencies exist, so ordinary hot dispatch
+    # paths retain the lightweight identity check below.
+    requires_behavior_digest = bool(closure_cells) or _callable_defaults_have_mutable_state(
+        defaults,
+        keyword_defaults,
+    )
     closure_behavior_digest: str | None = None
-    if closure_cells:
+    if requires_behavior_digest:
         try:
             closure_behavior_digest = _callable_behavior_digest(entrypoint)
         except Exception:
-            # The structural binding still protects this process-local
-            # collaborator.  An unavailable digest must never be treated as a
-            # matching digest at time of use.
+            # An unavailable digest must never be treated as a matching digest
+            # at time of use whenever the callable has mutable behavior state.
             closure_behavior_digest = None
     return _LiveCallableIntegrityBinding(
         value=value,
         member_name=member_name,
         entrypoint=entrypoint,
         code=getattr(entrypoint, "__code__", None),
-        defaults=getattr(entrypoint, "__defaults__", None),
-        keyword_defaults=getattr(entrypoint, "__kwdefaults__", None),
+        defaults=defaults,
+        keyword_defaults=keyword_defaults,
         closure_cells=closure_cells,
+        requires_behavior_digest=requires_behavior_digest,
         closure_behavior_digest=closure_behavior_digest,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _LiveCallableIntegrityChecker:
+    """Immutable process-local checker for captured callable collaborators."""
+
+    entrypoint_resolver: Callable[..., object | None]
+    closure_cells_resolver: Callable[[object | None], tuple[tuple[object, object], ...] | None]
+    behavior_digest: Callable[[object], str]
+    entrypoint_resolver_binding: _LiveCallableIntegrityBinding
+    closure_cells_resolver_binding: _LiveCallableIntegrityBinding
+    behavior_digest_binding: _LiveCallableIntegrityBinding
+
+    def __call__(
+        self,
+        binding: _LiveCallableIntegrityBinding,
+        current: object | None,
+    ) -> bool:
+        """Return whether the exact captured callable behavior remains usable."""
+        # These three helpers are the trusted roots for this process-local
+        # check. They deliberately have no defaults or closure state; a shape
+        # change therefore fails closed instead of being injected through a
+        # mutable function ``__kwdefaults__`` mapping.
+        for helper, helper_binding in (
+            (self.entrypoint_resolver, self.entrypoint_resolver_binding),
+            (self.closure_cells_resolver, self.closure_cells_resolver_binding),
+            (self.behavior_digest, self.behavior_digest_binding),
+        ):
+            if not (
+                helper is helper_binding.value
+                and helper is helper_binding.entrypoint
+                and getattr(helper, "__code__", None) is helper_binding.code
+                and helper_binding.defaults is None
+                and getattr(helper, "__defaults__", None) is None
+                and helper_binding.keyword_defaults is None
+                and getattr(helper, "__kwdefaults__", None) is None
+                and helper_binding.closure_cells == ()
+                and getattr(helper, "__closure__", None) is None
+            ):
+                return False
+        if current is not binding.value:
+            return False
+        try:
+            current_entrypoint = self.entrypoint_resolver(
+                current,
+                member_name=binding.member_name,
+            )
+        except Exception:
+            return False
+        if current_entrypoint is not binding.entrypoint:
+            return False
+        if binding.entrypoint is None:
+            return current is None
+        if getattr(current_entrypoint, "__code__", None) is not binding.code:
+            return False
+        if getattr(current_entrypoint, "__defaults__", None) is not binding.defaults:
+            return False
+        if getattr(current_entrypoint, "__kwdefaults__", None) is not binding.keyword_defaults:
+            return False
+        try:
+            current_closure_cells = self.closure_cells_resolver(current_entrypoint)
+        except Exception:
+            return False
+        if binding.closure_cells is None or current_closure_cells is None:
+            return False
+        if len(current_closure_cells) != len(binding.closure_cells):
+            return False
+        if not all(
+            current_cell is expected_cell and current_value is expected_value
+            for (current_cell, current_value), (expected_cell, expected_value) in zip(
+                current_closure_cells,
+                binding.closure_cells,
+                strict=True,
+            )
+        ):
+            return False
+        if not binding.requires_behavior_digest:
+            return True
+        # Any mutable closure/default state requires a safe behavior digest.
+        # A cyclic, oversized, or otherwise uninspectable graph is not proof
+        # of invariant behavior and therefore cannot authorize an effect.
+        if binding.closure_behavior_digest is None:
+            return False
+        try:
+            return self.behavior_digest(current_entrypoint) == binding.closure_behavior_digest
+        except Exception:
+            return False
+
+
+def _capture_live_callable_integrity_checker() -> _LiveCallableIntegrityChecker:
+    """Capture immutable trusted roots for one executor's live guard."""
+    entrypoint_resolver = _live_callable_entrypoint
+    closure_cells_resolver = _live_callable_closure_cells
+    behavior_digest = _callable_behavior_digest
+    return _LiveCallableIntegrityChecker(
+        entrypoint_resolver=entrypoint_resolver,
+        closure_cells_resolver=closure_cells_resolver,
+        behavior_digest=behavior_digest,
+        entrypoint_resolver_binding=_capture_live_callable_integrity(entrypoint_resolver),
+        closure_cells_resolver_binding=_capture_live_callable_integrity(closure_cells_resolver),
+        behavior_digest_binding=_capture_live_callable_integrity(behavior_digest),
     )
 
 
 def _live_callable_integrity_is_intact(
     binding: _LiveCallableIntegrityBinding,
     current: object | None,
-    *,
-    _entrypoint_resolver: Callable[..., object | None] = _live_callable_entrypoint,
-    _closure_cells_resolver: Callable[[object | None], tuple[tuple[object, object], ...] | None] = (
-        _live_callable_closure_cells
-    ),
-    _behavior_digest: Callable[[object], str] = _callable_behavior_digest,
 ) -> bool:
-    """Return whether execution will use its construction-time entrypoint.
-
-    The helper dependencies are captured in defaults deliberately.  Executors
-    retain this function object at construction, so replacing this module's
-    helper name later cannot turn a live authority guard into an allow-all.
-    """
-    if current is not binding.value:
-        return False
-    current_entrypoint = _entrypoint_resolver(current, member_name=binding.member_name)
-    if current_entrypoint is not binding.entrypoint:
-        return False
-    if binding.entrypoint is None:
-        return current is None
-    if getattr(current_entrypoint, "__code__", None) is not binding.code:
-        return False
-    if getattr(current_entrypoint, "__defaults__", None) is not binding.defaults:
-        return False
-    if getattr(current_entrypoint, "__kwdefaults__", None) is not binding.keyword_defaults:
-        return False
-    current_closure_cells = _closure_cells_resolver(current_entrypoint)
-    if binding.closure_cells is None or current_closure_cells is None:
-        return False
-    if len(current_closure_cells) != len(binding.closure_cells):
-        return False
-    if not all(
-        current_cell is expected_cell and current_value is expected_value
-        for (current_cell, current_value), (expected_cell, expected_value) in zip(
-            current_closure_cells,
-            binding.closure_cells,
-            strict=True,
-        )
-    ):
-        return False
-    if binding.closure_behavior_digest is None:
-        return True
-    try:
-        return _behavior_digest(current_entrypoint) == binding.closure_behavior_digest
-    except Exception:
-        return False
+    """Compatibility wrapper for one fresh immutable live-integrity checker."""
+    return _capture_live_callable_integrity_checker()(binding, current)
 
 
 def _direct_module_member_paths(function: object, global_name: str) -> tuple[tuple[str, ...], ...]:
@@ -1007,39 +1102,80 @@ def _capture_runtime_dispatch_integrity(adapter: object) -> _RuntimeDispatchInte
     return _RuntimeDispatchIntegrityBinding(tuple(entrypoints), tuple(module_members))
 
 
-def _runtime_dispatch_integrity_is_intact(
-    binding: _RuntimeDispatchIntegrityBinding,
-    *,
-    _callable_integrity_checker: Callable[[_LiveCallableIntegrityBinding, object | None], bool] = (
-        _live_callable_integrity_is_intact
-    ),
-) -> bool:
-    """Return whether direct runtime dispatch code and module members are unchanged."""
-    if not all(
-        _callable_integrity_checker(entrypoint, entrypoint.value)
-        for entrypoint in binding.entrypoints
-    ):
-        return False
-    for member_binding in binding.module_members:
-        global_values = getattr(member_binding.source_function, "__globals__", None)
-        if not isinstance(global_values, Mapping):
-            return False
-        if global_values.get(member_binding.global_name) is not member_binding.module:
-            return False
-        current = member_binding.module
-        try:
-            for attribute in member_binding.path:
-                current = inspect.getattr_static(current, attribute)
-        except (AttributeError, TypeError):
-            return False
-        if not _live_value_is_intact(member_binding.value, current):
-            return False
-        if member_binding.callable_binding is not None and not _callable_integrity_checker(
-            member_binding.callable_binding,
-            current,
+@dataclass(frozen=True, slots=True)
+class _RuntimeDispatchIntegrityChecker:
+    """Immutable process-local runtime-dispatch checker for one executor."""
+
+    callable_integrity_checker: _LiveCallableIntegrityChecker
+    callable_integrity_checker_binding: _LiveCallableIntegrityBinding
+
+    def __call__(self, binding: _RuntimeDispatchIntegrityBinding) -> bool:
+        """Return whether direct runtime dispatch code and members are unchanged."""
+        checker = self.callable_integrity_checker
+        checker_binding = self.callable_integrity_checker_binding
+        # Do not trust a mutable field merely because this outer checker is
+        # frozen: hostile in-process code can use ``object.__setattr__``. The
+        # captured callable object's own ``__call__`` shape and identity must
+        # still match before it can assess a runtime entrypoint.
+        checker_entrypoint = type(checker).__call__
+        if not (
+            checker is checker_binding.value
+            and checker_binding.member_name is None
+            and checker_entrypoint is checker_binding.entrypoint
+            and getattr(checker_entrypoint, "__code__", None) is checker_binding.code
+            and getattr(checker_entrypoint, "__defaults__", None) is checker_binding.defaults
+            and getattr(checker_entrypoint, "__kwdefaults__", None)
+            is checker_binding.keyword_defaults
+            and checker_binding.closure_cells == ()
+            and getattr(checker_entrypoint, "__closure__", None) is None
         ):
             return False
-    return True
+        if not all(checker(entrypoint, entrypoint.value) for entrypoint in binding.entrypoints):
+            return False
+        for member_binding in binding.module_members:
+            global_values = getattr(member_binding.source_function, "__globals__", None)
+            if not isinstance(global_values, Mapping):
+                return False
+            if global_values.get(member_binding.global_name) is not member_binding.module:
+                return False
+            current = member_binding.module
+            try:
+                for attribute in member_binding.path:
+                    current = inspect.getattr_static(current, attribute)
+            except (AttributeError, TypeError):
+                return False
+            expected = member_binding.value
+            if expected is not current and not (
+                (expected is None or isinstance(expected, (bool, int, float, str, bytes)))
+                and type(current) is type(expected)
+                and current == expected
+            ):
+                return False
+            if member_binding.callable_binding is not None and not checker(
+                member_binding.callable_binding,
+                current,
+            ):
+                return False
+        return True
+
+
+def _capture_runtime_dispatch_integrity_checker(
+    callable_integrity_checker: _LiveCallableIntegrityChecker,
+) -> _RuntimeDispatchIntegrityChecker:
+    """Capture the live callable checker used by one runtime guard."""
+    return _RuntimeDispatchIntegrityChecker(
+        callable_integrity_checker=callable_integrity_checker,
+        callable_integrity_checker_binding=_capture_live_callable_integrity(
+            callable_integrity_checker
+        ),
+    )
+
+
+def _runtime_dispatch_integrity_is_intact(binding: _RuntimeDispatchIntegrityBinding) -> bool:
+    """Compatibility wrapper for one fresh immutable runtime checker."""
+    return _capture_runtime_dispatch_integrity_checker(_capture_live_callable_integrity_checker())(
+        binding
+    )
 
 
 def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
@@ -1333,7 +1469,7 @@ class ParallelACExecutor:
         self._leaf_dispatcher_factory = LeafDispatcher
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
-        live_callable_integrity_checker = _live_callable_integrity_is_intact
+        live_callable_integrity_checker = _capture_live_callable_integrity_checker()
         self._authority_bound_execution_collaborators = _AuthorityBoundExecutionCollaborators(
             leaf_dispatcher=_capture_live_callable_integrity(
                 self._leaf_dispatcher_factory,
@@ -1347,7 +1483,9 @@ class ParallelACExecutor:
         )
         self._runtime_dispatch_integrity = _capture_runtime_dispatch_integrity(adapter)
         self._runtime_dispatch_integrity_binding = self._runtime_dispatch_integrity
-        self._runtime_dispatch_integrity_checker = _runtime_dispatch_integrity_is_intact
+        self._runtime_dispatch_integrity_checker = _capture_runtime_dispatch_integrity_checker(
+            live_callable_integrity_checker
+        )
         self._runtime_dispatch_integrity_checker_binding = _capture_live_callable_integrity(
             self._runtime_dispatch_integrity_checker
         )
@@ -1471,16 +1609,21 @@ class ParallelACExecutor:
             checker = binding.integrity_checker
             checker_binding = binding.integrity_checker_binding
             # Do not resolve the predicate through the mutable module name at
-            # time of use.  Check the captured predicate's finite function
-            # shape before calling it, then let its default-captured helpers
-            # inspect the actual dispatcher and verifier.
+            # time of use. Check the captured callable object's ``__call__``
+            # implementation before it can inspect the dispatcher/verifier.
+            # This intentionally does not rely on a mutable function-default
+            # dependency map.
+            checker_entrypoint = type(checker).__call__
             checker_is_bound = (
                 checker is checker_binding.value
-                and checker is checker_binding.entrypoint
-                and getattr(checker, "__code__", None) is checker_binding.code
-                and getattr(checker, "__defaults__", None) is checker_binding.defaults
-                and getattr(checker, "__kwdefaults__", None) is checker_binding.keyword_defaults
+                and checker_binding.member_name is None
+                and checker_entrypoint is checker_binding.entrypoint
+                and getattr(checker_entrypoint, "__code__", None) is checker_binding.code
+                and getattr(checker_entrypoint, "__defaults__", None) is checker_binding.defaults
+                and getattr(checker_entrypoint, "__kwdefaults__", None)
+                is checker_binding.keyword_defaults
                 and checker_binding.closure_cells == ()
+                and getattr(checker_entrypoint, "__closure__", None) is None
             )
             return (
                 checker_is_bound
@@ -1507,13 +1650,17 @@ class ParallelACExecutor:
         try:
             checker = self._runtime_dispatch_integrity_checker
             checker_binding = self._runtime_dispatch_integrity_checker_binding
+            checker_entrypoint = type(checker).__call__
             checker_is_bound = (
                 checker is checker_binding.value
-                and checker is checker_binding.entrypoint
-                and getattr(checker, "__code__", None) is checker_binding.code
-                and getattr(checker, "__defaults__", None) is checker_binding.defaults
-                and getattr(checker, "__kwdefaults__", None) is checker_binding.keyword_defaults
+                and checker_binding.member_name is None
+                and checker_entrypoint is checker_binding.entrypoint
+                and getattr(checker_entrypoint, "__code__", None) is checker_binding.code
+                and getattr(checker_entrypoint, "__defaults__", None) is checker_binding.defaults
+                and getattr(checker_entrypoint, "__kwdefaults__", None)
+                is checker_binding.keyword_defaults
                 and checker_binding.closure_cells == ()
+                and getattr(checker_entrypoint, "__closure__", None) is None
             )
             return (
                 self._runtime_dispatch_integrity is self._runtime_dispatch_integrity_binding

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -986,6 +986,9 @@ class ParallelACExecutor:
         # successful decomposed child is re-executed in an isolated workspace to
         # measure its parent-tier baseline spend. See ``shadow_replay`` module.
         self._shadow_replay_enabled = shadow_replay_enabled
+        # Capture the selected dispatch implementation once. The authority
+        # baseline binds this factory, and execution uses the same factory.
+        self._leaf_dispatcher_factory = LeafDispatcher
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
         self._coordinator = LevelCoordinator(
@@ -1011,7 +1014,10 @@ class ParallelACExecutor:
             adapter
         )
         self._validate_dispatch_rate_policy(adapter, self._dispatch_rate_policy)
-        self._dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
+        dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
+        if dispatch_rate_gate.enabled is not self._dispatch_rate_policy.gate_enabled:
+            raise ValueError("dispatch rate gate disagrees with the resolved policy")
+        self._dispatch_rate_gate = dispatch_rate_gate
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1049,6 +1055,10 @@ class ParallelACExecutor:
             adapter=adapter,
             verifier=atomic_verifier,
             executor=self,
+            executor_components={
+                "leaf_dispatcher": self._leaf_dispatcher_factory,
+                "session_signal_hub": self._session_signal_hub,
+            },
             workspace=workspace if isinstance(workspace, str) else os.getcwd(),
             workspace_identity=workspace_authority_identity,
             execution_policy=execution_policy,
@@ -1093,6 +1103,8 @@ class ParallelACExecutor:
         adapter: AgentRuntime,
         policy: ResolvedDispatchRatePolicy,
     ) -> None:
+        if type(policy) is not ResolvedDispatchRatePolicy:
+            raise ValueError("dispatch rate policy must use the canonical policy type")
         backend_attr = getattr(adapter, "runtime_backend", "")
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
         self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
@@ -4550,7 +4562,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
-            await LeafDispatcher(self).stream(
+            await self._leaf_dispatcher_factory(self).stream(
                 state=dispatch_state,
                 prompt=prompt,
                 tools=tools,
@@ -4652,7 +4664,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
-                        await LeafDispatcher(self).stream(
+                        await self._leaf_dispatcher_factory(self).stream(
                             state=dispatch_state,
                             prompt=(
                                 render_inform_signal_prompt(queued_signal.signal)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -261,6 +261,7 @@ from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
     build_execution_policy_contract,
+    runtime_routing_labels_contract,
 )
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
@@ -1109,6 +1110,12 @@ class ParallelACExecutor:
         return self._execution_authority
 
     @staticmethod
+    def _dispatch_rate_backend(adapter: AgentRuntime) -> str:
+        """Use the same normalized/unobserved backend label as the runner."""
+        backend = runtime_routing_labels_contract(adapter).get("runtime_backend")
+        return backend if isinstance(backend, str) and backend else "unknown"
+
+    @staticmethod
     def _resolve_dispatch_rate_policy(
         adapter: AgentRuntime,
         limits: BackendConcurrencyLimits | None = None,
@@ -1123,8 +1130,7 @@ class ParallelACExecutor:
         ``~/.ouroboros/backend_limits.yaml``, or ``OUROBOROS_<BACKEND>_RPM/TPM``),
         so the default behavior is unchanged.
         """
-        backend_attr = getattr(adapter, "runtime_backend", "")
-        backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
+        backend = ParallelACExecutor._dispatch_rate_backend(adapter)
         self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
         resolved_limits = limits or resolve_backend_limits(backend)
         return ResolvedDispatchRatePolicy.resolve(
@@ -1141,8 +1147,7 @@ class ParallelACExecutor:
     ) -> None:
         if type(policy) is not ResolvedDispatchRatePolicy:
             raise ValueError("dispatch rate policy must use the canonical policy type")
-        backend_attr = getattr(adapter, "runtime_backend", "")
-        backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
+        backend = ParallelACExecutor._dispatch_rate_backend(adapter)
         self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
         if policy.backend != backend or policy.self_governs_rate_limit is not self_governs:
             raise ValueError("dispatch rate policy disagrees with the active runtime")

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -151,7 +151,10 @@ def _declared_function_direct_module_attributes(
     instructions = list(dis.get_instructions(function))
     attributes: set[str] = set()
     for index, instruction in enumerate(instructions):
-        if instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"} or instruction.argval != global_name:
+        if (
+            instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"}
+            or instruction.argval != global_name
+        ):
             continue
         for following in instructions[index + 1 : index + 4]:
             if following.opname in {"CACHE", "EXTENDED_ARG", "PUSH_NULL"}:
@@ -291,18 +294,14 @@ class _DeclaredClassImplementation:
     runtime_class: type[object]
     class_chain: tuple[type[object], ...]
     raw_items: dict[type[object], dict[str, object]]
-    member_implementations: dict[
-        tuple[type[object], str, int], _DeclaredFunctionImplementation
-    ]
+    member_implementations: dict[tuple[type[object], str, int], _DeclaredFunctionImplementation]
 
 
 def _declared_class_implementation(
     runtime_class: type[object],
 ) -> _DeclaredClassImplementation:
     """Capture executable state without recursively following class globals."""
-    class_chain = tuple(
-        current for current in runtime_class.__mro__ if current is not object
-    )
+    class_chain = tuple(current for current in runtime_class.__mro__ if current is not object)
     raw_items: dict[type[object], dict[str, object]] = {}
     member_implementations: dict[
         tuple[type[object], str, int], _DeclaredFunctionImplementation
@@ -336,12 +335,8 @@ def _declared_class_implementation_is_intact(
     for current_class in declared.class_chain:
         expected_raw_items = declared.raw_items[current_class]
         current_raw_items = dict(vars(current_class))
-        if (
-            set(current_raw_items) != set(expected_raw_items)
-            or any(
-                expected_raw_items[name] is not current
-                for name, current in current_raw_items.items()
-            )
+        if set(current_raw_items) != set(expected_raw_items) or any(
+            expected_raw_items[name] is not current for name, current in current_raw_items.items()
         ):
             return False
         for member_name, raw_member in current_raw_items.items():
@@ -349,9 +344,8 @@ def _declared_class_implementation_is_intact(
                 declared_member = declared.member_implementations.get(
                     (current_class, member_name, index)
                 )
-                if (
-                    declared_member is None
-                    or not _declared_function_implementation_is_intact(target, declared_member)
+                if declared_member is None or not _declared_function_implementation_is_intact(
+                    target, declared_member
                 ):
                     return False
     return True
@@ -676,8 +670,7 @@ _DECLARED_GATE_LEAF_CLASS_IMPLEMENTATIONS = {
     dependency: _declared_class_implementation(dependency)
     for dependencies in _DECLARED_GATE_MEMBER_GLOBALS.values()
     for dependency in dependencies.values()
-    if isinstance(dependency, type)
-    and dependency not in (SharedRateLimitBucket, RateLimitGate)
+    if isinstance(dependency, type) and dependency not in (SharedRateLimitBucket, RateLimitGate)
 }
 
 # Direct standard-module dependencies reached by the original gate classes.
@@ -832,17 +825,11 @@ def _canonical_gate_factory_data(value: object, *, depth: int = 0) -> object:
     if isinstance(value, (tuple, list)):
         if len(value) > _GATE_FACTORY_MAX_ITEMS:
             raise ValueError("rate gate factory data is oversized")
-        return [
-            _canonical_gate_factory_data(item, depth=depth + 1)
-            for item in value
-        ]
+        return [_canonical_gate_factory_data(item, depth=depth + 1) for item in value]
     if isinstance(value, (set, frozenset)):
         if len(value) > _GATE_FACTORY_MAX_ITEMS:
             raise ValueError("rate gate factory data is oversized")
-        items = [
-            _canonical_gate_factory_data(item, depth=depth + 1)
-            for item in value
-        ]
+        items = [_canonical_gate_factory_data(item, depth=depth + 1) for item in value]
         return sorted(
             items,
             key=lambda item: json.dumps(
@@ -887,7 +874,10 @@ def _gate_factory_direct_module_attributes(
     instructions = list(dis.get_instructions(function))
     attributes: set[str] = set()
     for index, instruction in enumerate(instructions):
-        if instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"} or instruction.argval != global_name:
+        if (
+            instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"}
+            or instruction.argval != global_name
+        ):
             continue
         for following in instructions[index + 1 : index + 4]:
             if following.opname in {"CACHE", "EXTENDED_ARG", "PUSH_NULL"}:
@@ -922,9 +912,7 @@ def _gate_factory_module_member_identity(value: object) -> dict[str, object]:
             "kind": "function",
             "module": function.__module__,
             "qualname": function.__qualname__,
-            "code_digest": "sha256:" + hashlib.sha256(
-                marshal.dumps(function.__code__)
-            ).hexdigest(),
+            "code_digest": "sha256:" + hashlib.sha256(marshal.dumps(function.__code__)).hexdigest(),
             "defaults_digest": _gate_factory_data_digest(
                 {
                     "positional": tuple(function.__defaults__ or ()),
@@ -935,7 +923,12 @@ def _gate_factory_module_member_identity(value: object) -> dict[str, object]:
     if inspect.isbuiltin(value):
         module = getattr(value, "__module__", None)
         qualname = getattr(value, "__qualname__", None)
-        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+        if (
+            not isinstance(module, str)
+            or not module
+            or not isinstance(qualname, str)
+            or not qualname
+        ):
             raise ValueError("rate gate factory module builtin is not identifiable")
         return {"kind": "builtin", "module": module, "qualname": qualname}
     if isinstance(value, type):
@@ -1032,9 +1025,8 @@ def _gate_factory_class_member_global_identity(
         )
     if isinstance(value, type):
         declared_implementation = _DECLARED_GATE_LEAF_CLASS_IMPLEMENTATIONS.get(value)
-        if (
-            declared_implementation is not None
-            and not _declared_class_implementation_is_intact(value, declared_implementation)
+        if declared_implementation is not None and not _declared_class_implementation_is_intact(
+            value, declared_implementation
         ):
             raise ValueError("rate gate factory result type implementation drifted")
         return _gate_factory_module_member_identity(value)
@@ -1066,9 +1058,15 @@ def _gate_factory_class_member_identity(
         raise ValueError("rate gate factory class member has unbound dependencies")
     if (
         set(closure_vars.globals) != set(expected_globals)
-        or any(expected_globals[name] is not dependency for name, dependency in closure_vars.globals.items())
+        or any(
+            expected_globals[name] is not dependency
+            for name, dependency in closure_vars.globals.items()
+        )
         or set(closure_vars.builtins) != set(expected_builtins)
-        or any(expected_builtins[name] is not dependency for name, dependency in closure_vars.builtins.items())
+        or any(
+            expected_builtins[name] is not dependency
+            for name, dependency in closure_vars.builtins.items()
+        )
     ):
         raise ValueError("rate gate factory class member dependencies drifted")
     return {
@@ -1121,20 +1119,14 @@ def _gate_factory_class_identity(value: type[object]) -> dict[str, object]:
         if runtime_class is object:
             continue
         expected_member_keys = {
-            key
-            for key in _DECLARED_GATE_CLASS_MEMBERS
-            if key[0] is runtime_class
+            key for key in _DECLARED_GATE_CLASS_MEMBERS if key[0] is runtime_class
         }
         if not expected_member_keys:
             raise ValueError("rate gate factory class is not declaration-bound")
         expected_raw_items = _DECLARED_GATE_CLASS_RAW_ITEMS[runtime_class]
         current_raw_items = dict(vars(runtime_class))
-        if (
-            set(current_raw_items) != set(expected_raw_items)
-            or any(
-                expected_raw_items[name] is not current
-                for name, current in current_raw_items.items()
-            )
+        if set(current_raw_items) != set(expected_raw_items) or any(
+            expected_raw_items[name] is not current for name, current in current_raw_items.items()
         ):
             # Special descriptors such as ``__getattribute__`` can alter a
             # gate's visible methods while never appearing as a conventional
@@ -1144,9 +1136,7 @@ def _gate_factory_class_identity(value: type[object]) -> dict[str, object]:
         observed_member_keys: set[tuple[type[object], str, int]] = set()
         qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
         for member_name, raw_member in vars(runtime_class).items():
-            expected_raw_member = _DECLARED_GATE_CLASS_RAW_MEMBERS.get(
-                (runtime_class, member_name)
-            )
+            expected_raw_member = _DECLARED_GATE_CLASS_RAW_MEMBERS.get((runtime_class, member_name))
             if expected_raw_member is not None and expected_raw_member is not raw_member:
                 # A descriptor can expose the original ``__func__`` while
                 # changing binding behavior in ``__get__``. The descriptor
@@ -1300,7 +1290,12 @@ def _gate_factory_dependency_identity(
     if inspect.isbuiltin(value):
         module = getattr(value, "__module__", None)
         qualname = getattr(value, "__qualname__", None)
-        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+        if (
+            not isinstance(module, str)
+            or not module
+            or not isinstance(qualname, str)
+            or not qualname
+        ):
             raise ValueError("rate gate factory builtin is not identifiable")
         return {"kind": "builtin", "module": module, "qualname": qualname}
     if isinstance(value, type):
@@ -1335,7 +1330,12 @@ def rate_limit_gate_algorithm_contract(
         identity = _gate_factory_function_identity(target, active=set(), depth=0)
         module = identity.get("module")
         qualname = identity.get("qualname")
-        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+        if (
+            not isinstance(module, str)
+            or not module
+            or not isinstance(qualname, str)
+            or not qualname
+        ):
             raise ValueError("rate gate factory lacks a qualified identity")
         payload = json.dumps(
             identity,
@@ -1559,7 +1559,10 @@ def authority_bound_rate_limit_gate_is_intact(binding: AuthorityBoundRateLimitGa
         return False
     try:
         bucket = object.__getattribute__(gate, "_bucket")
-        if bucket is not binding.bucket or type(bucket) is not _DECLARED_SHARED_RATE_LIMIT_BUCKET_TYPE:
+        if (
+            bucket is not binding.bucket
+            or type(bucket) is not _DECLARED_SHARED_RATE_LIMIT_BUCKET_TYPE
+        ):
             return False
         if not _same_bound_callable(object.__getattribute__(gate, "acquire"), binding.acquire):
             return False
@@ -1626,8 +1629,9 @@ def rate_limit_token_estimator_contract(
     }
 
 
-def capture_authority_bound_rate_limit_token_estimator(
-) -> tuple[Callable[[str], int], dict[str, object]]:
+def capture_authority_bound_rate_limit_token_estimator() -> tuple[
+    Callable[[str], int], dict[str, object]
+]:
     """Capture the estimator that dispatch will actually call.
 
     The returned callable is stored by :class:`ParallelACExecutor`; later

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -4,19 +4,380 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+import dis
+import hashlib
+import inspect
+import json
+import marshal
+import math
 import time
 from typing import Any, Literal
+import uuid
+
+from ouroboros.core.security import is_sensitive_field, is_sensitive_value
 
 RATE_LIMIT_WINDOW_SECONDS = 60.0
 RATE_LIMIT_HEARTBEAT_SECONDS = 30.0
 RATE_LIMIT_MAX_WAIT_SECONDS = 120.0
 RATE_LIMIT_TOKEN_ESTIMATION_VERSION = 1
+RATE_LIMIT_GATE_ALGORITHM_VERSION = 1
 DEFAULT_ANTHROPIC_RPM_CEILING = 40
 DEFAULT_ANTHROPIC_TPM_CEILING = 32_000
 _TOKEN_ESTIMATE_DIVISOR = 4
 _TOKEN_COMPLETION_CUSHION = 1024
+_GATE_FACTORY_MAX_DEPTH = 8
+_GATE_FACTORY_MAX_ITEMS = 256
+_DECLARED_RATE_GATE_FACTORY: object | None = None
+_DECLARED_RATE_GATE_FACTORY_IMPLEMENTATION: _DeclaredFunctionImplementation | None = None
+_DECLARED_RATE_TOKEN_ESTIMATOR: object | None = None
+_DECLARED_RATE_TOKEN_ESTIMATOR_IMPLEMENTATION: _DeclaredFunctionImplementation | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _DeclaredFunctionImplementation:
+    """Import-time implementation state for a portable Python function."""
+
+    code: object
+    defaults: object
+    default_values: tuple[object, ...]
+    kwdefaults: object
+    kwdefault_items: tuple[tuple[str, object], ...]
+    closure: object
+    closure_values: tuple[object, ...]
+    resolved_globals: dict[str, object]
+    resolved_builtins: dict[str, object]
+    module_member_values: dict[tuple[str, str], object]
+    global_function_bodies: dict[str, _DeclaredFunctionBody]
+    module_function_bodies: dict[tuple[str, str], _DeclaredFunctionBody]
+
+
+@dataclass(frozen=True, slots=True)
+class _DeclaredFunctionBody:
+    """The mutable implementation fields of a directly resolved function."""
+
+    code: object
+    defaults: object
+    default_values: tuple[object, ...]
+    kwdefaults: object
+    kwdefault_items: tuple[tuple[str, object], ...]
+    closure: object
+    closure_values: tuple[object, ...]
+
+
+def _function_closure_values(closure: object) -> tuple[object, ...]:
+    """Read closure cells without accepting an opaque replacement container."""
+    if closure is None:
+        return ()
+    if not isinstance(closure, tuple):
+        raise ValueError("rate gate factory closure is not a tuple")
+    return tuple(cell.cell_contents for cell in closure)
+
+
+def _declared_function_body(function: object) -> _DeclaredFunctionBody:
+    """Capture code/default/closure state without recursively traversing globals."""
+    if not inspect.isfunction(function):
+        raise RuntimeError("declared rate-gate dependency is not a Python function")
+    kwdefaults = function.__kwdefaults__
+    if kwdefaults is not None and not isinstance(kwdefaults, dict):
+        raise RuntimeError("declared rate-gate keyword defaults are invalid")
+    return _DeclaredFunctionBody(
+        code=function.__code__,
+        defaults=function.__defaults__,
+        default_values=tuple(function.__defaults__ or ()),
+        kwdefaults=kwdefaults,
+        kwdefault_items=tuple(sorted((kwdefaults or {}).items())),
+        closure=function.__closure__,
+        closure_values=_function_closure_values(function.__closure__),
+    )
+
+
+def _declared_function_body_is_intact(
+    function: object,
+    declared: _DeclaredFunctionBody,
+) -> bool:
+    """Check code/default/closure state against an import-time snapshot."""
+    if not inspect.isfunction(function):
+        return False
+    try:
+        current_kwdefaults = function.__kwdefaults__
+        current_kwdefault_items = tuple(sorted((current_kwdefaults or {}).items()))
+        current_closure_values = _function_closure_values(function.__closure__)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return (
+        function.__code__ is declared.code
+        and function.__defaults__ is declared.defaults
+        and len(function.__defaults__ or ()) == len(declared.default_values)
+        and all(
+            current is expected
+            for current, expected in zip(
+                function.__defaults__ or (),
+                declared.default_values,
+                strict=True,
+            )
+        )
+        and current_kwdefaults is declared.kwdefaults
+        and len(current_kwdefault_items) == len(declared.kwdefault_items)
+        and all(
+            current_name == expected_name and current_value is expected_value
+            for (current_name, current_value), (expected_name, expected_value) in zip(
+                current_kwdefault_items,
+                declared.kwdefault_items,
+                strict=True,
+            )
+        )
+        and function.__closure__ is declared.closure
+        and len(current_closure_values) == len(declared.closure_values)
+        and all(
+            current is expected
+            for current, expected in zip(
+                current_closure_values,
+                declared.closure_values,
+                strict=True,
+            )
+        )
+    )
+
+
+def _declared_function_direct_module_attributes(
+    function: object,
+    global_name: str,
+) -> list[str]:
+    """Find direct ``module.attribute`` reads made by a Python function."""
+    if not inspect.isfunction(function):
+        raise RuntimeError("declared rate-gate dependency is not a Python function")
+    instructions = list(dis.get_instructions(function))
+    attributes: set[str] = set()
+    for index, instruction in enumerate(instructions):
+        if instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"} or instruction.argval != global_name:
+            continue
+        for following in instructions[index + 1 : index + 4]:
+            if following.opname in {"CACHE", "EXTENDED_ARG", "PUSH_NULL"}:
+                continue
+            if following.opname in {"LOAD_ATTR", "LOAD_METHOD"} and isinstance(
+                following.argval, str
+            ):
+                attributes.add(following.argval)
+            break
+    return sorted(attributes)
+
+
+def _declared_function_implementation(
+    function: object,
+) -> _DeclaredFunctionImplementation:
+    """Capture the implementation state that must remain import-time exact."""
+    if not inspect.isfunction(function):
+        raise RuntimeError("declared rate-gate member is not a Python function")
+    body = _declared_function_body(function)
+    closure_vars = inspect.getclosurevars(function)
+    module_member_values: dict[tuple[str, str], object] = {}
+    module_function_bodies: dict[tuple[str, str], _DeclaredFunctionBody] = {}
+    for global_name, dependency in closure_vars.globals.items():
+        if not inspect.ismodule(dependency):
+            continue
+        for attribute in _declared_function_direct_module_attributes(function, global_name):
+            try:
+                member = getattr(dependency, attribute)
+            except Exception:
+                raise RuntimeError("declared rate-gate module member is unobservable") from None
+            key = (global_name, attribute)
+            module_member_values[key] = member
+            if inspect.isfunction(member):
+                module_function_bodies[key] = _declared_function_body(member)
+    return _DeclaredFunctionImplementation(
+        code=body.code,
+        defaults=body.defaults,
+        default_values=body.default_values,
+        kwdefaults=body.kwdefaults,
+        kwdefault_items=body.kwdefault_items,
+        closure=body.closure,
+        closure_values=body.closure_values,
+        resolved_globals=dict(closure_vars.globals),
+        resolved_builtins=dict(closure_vars.builtins),
+        module_member_values=module_member_values,
+        global_function_bodies={
+            name: _declared_function_body(dependency)
+            for name, dependency in closure_vars.globals.items()
+            if inspect.isfunction(dependency)
+        },
+        module_function_bodies=module_function_bodies,
+    )
+
+
+def _declared_function_implementation_is_intact(
+    function: object,
+    declared: _DeclaredFunctionImplementation,
+) -> bool:
+    """Return whether a function retains its exact import-time behavior state."""
+    if not inspect.isfunction(function):
+        return False
+    try:
+        closure_vars = inspect.getclosurevars(function)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    body_is_intact = _declared_function_body_is_intact(
+        function,
+        _DeclaredFunctionBody(
+            code=declared.code,
+            defaults=declared.defaults,
+            default_values=declared.default_values,
+            kwdefaults=declared.kwdefaults,
+            kwdefault_items=declared.kwdefault_items,
+            closure=declared.closure,
+            closure_values=declared.closure_values,
+        ),
+    )
+    if (
+        not body_is_intact
+        or set(closure_vars.globals) != set(declared.resolved_globals)
+        or any(
+            closure_vars.globals[name] is not dependency
+            for name, dependency in declared.resolved_globals.items()
+        )
+        or set(closure_vars.builtins) != set(declared.resolved_builtins)
+        or any(
+            closure_vars.builtins[name] is not dependency
+            for name, dependency in declared.resolved_builtins.items()
+        )
+    ):
+        return False
+    for (global_name, attribute), expected_member in declared.module_member_values.items():
+        dependency = closure_vars.globals.get(global_name)
+        if not inspect.ismodule(dependency):
+            return False
+        try:
+            current_member = getattr(dependency, attribute)
+        except Exception:
+            return False
+        if current_member is not expected_member:
+            return False
+    for name, declared_body in declared.global_function_bodies.items():
+        if not _declared_function_body_is_intact(closure_vars.globals[name], declared_body):
+            return False
+    for (global_name, attribute), declared_body in declared.module_function_bodies.items():
+        dependency = closure_vars.globals.get(global_name)
+        if not inspect.ismodule(dependency):
+            return False
+        try:
+            current_member = getattr(dependency, attribute)
+        except Exception:
+            return False
+        if not _declared_function_body_is_intact(current_member, declared_body):
+            return False
+    return True
+
+
+def _declared_member_function_targets(raw_member: object) -> tuple[object, ...]:
+    """Return Python-function targets exposed by a raw class member."""
+    if isinstance(raw_member, (classmethod, staticmethod)):
+        return (raw_member.__func__,)
+    if isinstance(raw_member, property):
+        return tuple(
+            target
+            for target in (raw_member.fget, raw_member.fset, raw_member.fdel)
+            if target is not None
+        )
+    if inspect.isfunction(raw_member):
+        return (raw_member,)
+    return ()
+
+
+@dataclass(frozen=True, slots=True)
+class _DeclaredClassImplementation:
+    """Import-time raw-member and executable state for a class dependency."""
+
+    runtime_class: type[object]
+    class_chain: tuple[type[object], ...]
+    raw_items: dict[type[object], dict[str, object]]
+    member_implementations: dict[
+        tuple[type[object], str, int], _DeclaredFunctionImplementation
+    ]
+
+
+def _declared_class_implementation(
+    runtime_class: type[object],
+) -> _DeclaredClassImplementation:
+    """Capture executable state without recursively following class globals."""
+    class_chain = tuple(
+        current for current in runtime_class.__mro__ if current is not object
+    )
+    raw_items: dict[type[object], dict[str, object]] = {}
+    member_implementations: dict[
+        tuple[type[object], str, int], _DeclaredFunctionImplementation
+    ] = {}
+    for current_class in class_chain:
+        current_raw_items = dict(vars(current_class))
+        raw_items[current_class] = current_raw_items
+        for member_name, raw_member in current_raw_items.items():
+            for index, target in enumerate(_declared_member_function_targets(raw_member)):
+                member_implementations[(current_class, member_name, index)] = (
+                    _declared_function_implementation(target)
+                )
+    return _DeclaredClassImplementation(
+        runtime_class=runtime_class,
+        class_chain=class_chain,
+        raw_items=raw_items,
+        member_implementations=member_implementations,
+    )
+
+
+def _declared_class_implementation_is_intact(
+    value: object,
+    declared: _DeclaredClassImplementation,
+) -> bool:
+    """Return whether a class dependency retains its imported implementation."""
+    if not isinstance(value, type) or value is not declared.runtime_class:
+        return False
+    current_mro = tuple(current for current in value.__mro__ if current is not object)
+    if current_mro != declared.class_chain:
+        return False
+    for current_class in declared.class_chain:
+        expected_raw_items = declared.raw_items[current_class]
+        current_raw_items = dict(vars(current_class))
+        if (
+            set(current_raw_items) != set(expected_raw_items)
+            or any(
+                expected_raw_items[name] is not current
+                for name, current in current_raw_items.items()
+            )
+        ):
+            return False
+        for member_name, raw_member in current_raw_items.items():
+            for index, target in enumerate(_declared_member_function_targets(raw_member)):
+                declared_member = declared.member_implementations.get(
+                    (current_class, member_name, index)
+                )
+                if (
+                    declared_member is None
+                    or not _declared_function_implementation_is_intact(target, declared_member)
+                ):
+                    return False
+    return True
+
+
+def _declared_module_member_implementation(
+    value: object,
+) -> _DeclaredFunctionImplementation | _DeclaredClassImplementation | None:
+    """Capture mutable executable state of one direct module member."""
+    if inspect.isfunction(value):
+        return _declared_function_implementation(value)
+    if isinstance(value, type):
+        return _declared_class_implementation(value)
+    return None
+
+
+def _declared_module_member_implementation_is_intact(
+    value: object,
+    declared: _DeclaredFunctionImplementation | _DeclaredClassImplementation | None,
+) -> bool:
+    """Check a direct module dependency against its import-time declaration."""
+    if declared is None:
+        return True
+    if isinstance(declared, _DeclaredFunctionImplementation):
+        return _declared_function_implementation_is_intact(value, declared)
+    return _declared_class_implementation_is_intact(value, declared)
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,6 +586,115 @@ class RateLimitGate:
 
 
 @dataclass(frozen=True, slots=True)
+class AuthorityBoundRateLimitGate:
+    """One installed gate plus the private state that its authority covers.
+
+    The public algorithm contract is intentionally digest-only. Dispatch also
+    needs a live in-process guard: an instance-field replacement can alter the
+    active bucket without changing that static digest. This binding retains only
+    references already owned by the executor so it can reject such drift before
+    the captured ``acquire`` callable is invoked.
+    """
+
+    gate: RateLimitGate
+    algorithm: dict[str, object]
+    factory: object
+    acquire: Callable[..., Any]
+    bucket: SharedRateLimitBucket
+    runtime_backend: str
+    request_limit: int | None
+    token_limit: int | None
+    window_seconds: float
+    max_wait_seconds: float
+    heartbeat_seconds: float
+    sleep: object
+    clock: object
+    lock: object
+    reservations: object
+
+
+def _declared_gate_class_members() -> dict[tuple[type[object], str, int], object]:
+    """Capture the original direct gate-class members at module load time."""
+    members: dict[tuple[type[object], str, int], object] = {}
+    for runtime_class in (SharedRateLimitBucket, RateLimitGate):
+        for member_name, raw_member in vars(runtime_class).items():
+            targets: tuple[object, ...]
+            if isinstance(raw_member, (classmethod, staticmethod)):
+                targets = (raw_member.__func__,)
+            elif isinstance(raw_member, property):
+                targets = tuple(
+                    target
+                    for target in (raw_member.fget, raw_member.fset, raw_member.fdel)
+                    if target is not None
+                )
+            elif inspect.isfunction(raw_member):
+                targets = (raw_member,)
+            else:
+                continue
+            for index, target in enumerate(targets):
+                members[(runtime_class, member_name, index)] = target
+    return members
+
+
+# This is intentionally an object-identity manifest, not module/qualname text:
+# ``functools.wraps`` can forge those display fields while leaving a live,
+# stateful replacement installed.  A replacement is valid for a process, but
+# its semantics are not portable authority data.
+_DECLARED_GATE_CLASS_MEMBERS = _declared_gate_class_members()
+_DECLARED_GATE_CLASS_RAW_MEMBERS: dict[tuple[type[object], str], object] = {
+    (runtime_class, member_name): vars(runtime_class)[member_name]
+    for runtime_class, member_name, _index in _DECLARED_GATE_CLASS_MEMBERS
+}
+_DECLARED_GATE_CLASS_RAW_ITEMS: dict[type[object], dict[str, object]] = {
+    runtime_class: dict(vars(runtime_class))
+    for runtime_class in (SharedRateLimitBucket, RateLimitGate)
+}
+_DECLARED_GATE_MEMBER_IMPLEMENTATIONS = {
+    key: _declared_function_implementation(target)
+    for key, target in _DECLARED_GATE_CLASS_MEMBERS.items()
+}
+
+
+def _declared_gate_member_dependencies(
+    attribute: str,
+) -> dict[tuple[type[object], str, int], dict[str, object]]:
+    """Capture the direct globals or builtins resolved by original members."""
+    dependencies: dict[tuple[type[object], str, int], dict[str, object]] = {}
+    for key, target in _DECLARED_GATE_CLASS_MEMBERS.items():
+        function = target.__func__ if inspect.ismethod(target) else target
+        if not inspect.isfunction(function):
+            raise RuntimeError("declared rate-gate member is not a Python function")
+        closure_vars = inspect.getclosurevars(function)
+        resolved = getattr(closure_vars, attribute)
+        dependencies[key] = dict(resolved)
+    return dependencies
+
+
+_DECLARED_GATE_MEMBER_GLOBALS = _declared_gate_member_dependencies("globals")
+_DECLARED_GATE_MEMBER_BUILTINS = _declared_gate_member_dependencies("builtins")
+_DECLARED_GATE_LEAF_CLASS_IMPLEMENTATIONS = {
+    dependency: _declared_class_implementation(dependency)
+    for dependencies in _DECLARED_GATE_MEMBER_GLOBALS.values()
+    for dependency in dependencies.values()
+    if isinstance(dependency, type)
+    and dependency not in (SharedRateLimitBucket, RateLimitGate)
+}
+
+# Direct standard-module dependencies reached by the original gate classes.
+# A new member added to those classes without updating this manifest fails
+# closed, as does an in-memory replacement of any listed member.
+_DECLARED_GATE_MODULE_MEMBERS: dict[tuple[str, str], object] = {
+    ("asyncio", "Lock"): asyncio.Lock,
+    ("asyncio", "sleep"): asyncio.sleep,
+    ("time", "monotonic"): time.monotonic,
+}
+_DECLARED_GATE_MODULE_MEMBER_IMPLEMENTATIONS = {
+    key: _declared_module_member_implementation(member)
+    for key, member in _DECLARED_GATE_MODULE_MEMBERS.items()
+}
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedDispatchRatePolicy:
     """Immutable settings used by both dispatch behavior and authority identity."""
 
@@ -238,6 +708,7 @@ class ResolvedDispatchRatePolicy:
     heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS
     max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS
     token_estimation_version: int = RATE_LIMIT_TOKEN_ESTIMATION_VERSION
+    gate_algorithm_version: int = RATE_LIMIT_GATE_ALGORITHM_VERSION
 
     @classmethod
     def resolve(
@@ -293,7 +764,20 @@ class ResolvedDispatchRatePolicy:
             heartbeat_seconds=self.heartbeat_seconds,
         )
 
-    def to_contract_data(self) -> dict[str, object]:
+    def to_contract_data(
+        self,
+        *,
+        gate_algorithm: Mapping[str, object] | None = None,
+        token_estimator: Mapping[str, object] | None = None,
+    ) -> dict[str, object]:
+        """Serialize one immutable policy with its captured rate helpers.
+
+        Executor construction supplies the algorithm returned by
+        :func:`build_authority_bound_rate_limit_gate` and the estimator returned
+        by :func:`capture_authority_bound_rate_limit_token_estimator`.  The
+        serialized identity therefore describes the exact callables installed
+        into that executor rather than a later mutable module global.
+        """
         return {
             "version": 1,
             "backend": self.backend,
@@ -307,7 +791,577 @@ class ResolvedDispatchRatePolicy:
             "heartbeat_seconds": self.heartbeat_seconds,
             "max_wait_seconds": self.max_wait_seconds,
             "token_estimation_version": self.token_estimation_version,
+            "gate_algorithm_version": self.gate_algorithm_version,
+            "gate_algorithm": dict(gate_algorithm)
+            if gate_algorithm is not None
+            else rate_limit_gate_algorithm_contract(),
+            "token_estimator": dict(token_estimator)
+            if token_estimator is not None
+            else rate_limit_token_estimator_contract(),
         }
+
+
+def _process_local_gate_algorithm_contract() -> dict[str, object]:
+    """Return a deliberately non-portable identity for an opaque factory."""
+    return {
+        "version": 1,
+        "observed": False,
+        "instance_nonce": uuid.uuid4().hex,
+    }
+
+
+def _canonical_gate_factory_data(value: object, *, depth: int = 0) -> object:
+    """Normalize safe data before it is digested into a factory identity.
+
+    Values are never retained in the authority payload; this intermediate form
+    exists only long enough to calculate a digest.  Unknown objects and
+    credential-shaped values fail closed rather than being stringified.
+    """
+    if depth > _GATE_FACTORY_MAX_DEPTH:
+        raise ValueError("rate gate factory data exceeds dependency depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("rate gate factory data is not finite")
+        return value
+    if isinstance(value, str):
+        if is_sensitive_value(value):
+            raise ValueError("rate gate factory data is sensitive")
+        return value
+    if isinstance(value, (tuple, list)):
+        if len(value) > _GATE_FACTORY_MAX_ITEMS:
+            raise ValueError("rate gate factory data is oversized")
+        return [
+            _canonical_gate_factory_data(item, depth=depth + 1)
+            for item in value
+        ]
+    if isinstance(value, (set, frozenset)):
+        if len(value) > _GATE_FACTORY_MAX_ITEMS:
+            raise ValueError("rate gate factory data is oversized")
+        items = [
+            _canonical_gate_factory_data(item, depth=depth + 1)
+            for item in value
+        ]
+        return sorted(
+            items,
+            key=lambda item: json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            ),
+        )
+    if isinstance(value, dict):
+        if len(value) > _GATE_FACTORY_MAX_ITEMS:
+            raise ValueError("rate gate factory data is oversized")
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or is_sensitive_field(key):
+                raise ValueError("rate gate factory data has an unsafe key")
+            normalized[key] = _canonical_gate_factory_data(item, depth=depth + 1)
+        return normalized
+    raise ValueError("rate gate factory data has an unsupported value")
+
+
+def _gate_factory_data_digest(value: object) -> str:
+    normalized = _canonical_gate_factory_data(value)
+    payload = json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _gate_factory_direct_module_attributes(
+    function: object,
+    global_name: str,
+) -> list[str]:
+    """Find direct ``module.attribute`` reads made by one Python function."""
+    if not inspect.isfunction(function):
+        raise ValueError("rate gate factory module owner is not inspectable")
+    instructions = list(dis.get_instructions(function))
+    attributes: set[str] = set()
+    for index, instruction in enumerate(instructions):
+        if instruction.opname not in {"LOAD_GLOBAL", "LOAD_NAME"} or instruction.argval != global_name:
+            continue
+        for following in instructions[index + 1 : index + 4]:
+            if following.opname in {"CACHE", "EXTENDED_ARG", "PUSH_NULL"}:
+                continue
+            if following.opname in {"LOAD_ATTR", "LOAD_METHOD"} and isinstance(
+                following.argval, str
+            ):
+                attributes.add(following.argval)
+            break
+    return sorted(attributes)
+
+
+def _gate_factory_has_unbound_global(function: object, names: frozenset[str]) -> bool:
+    """Distinguish a real unbound global from ordinary instance attributes."""
+    if not inspect.isfunction(function):
+        raise ValueError("rate gate factory owner is not inspectable")
+    loaded_globals = {
+        instruction.argval
+        for instruction in dis.get_instructions(function)
+        if instruction.opname in {"LOAD_GLOBAL", "LOAD_NAME"}
+        and isinstance(instruction.argval, str)
+    }
+    return bool(loaded_globals.intersection(names))
+
+
+def _gate_factory_module_member_identity(value: object) -> dict[str, object]:
+    """Identify one direct module member without traversing its object graph."""
+    if inspect.ismethod(value) or inspect.isfunction(value):
+        function = value.__func__ if inspect.ismethod(value) else value
+        assert inspect.isfunction(function)
+        return {
+            "kind": "function",
+            "module": function.__module__,
+            "qualname": function.__qualname__,
+            "code_digest": "sha256:" + hashlib.sha256(
+                marshal.dumps(function.__code__)
+            ).hexdigest(),
+            "defaults_digest": _gate_factory_data_digest(
+                {
+                    "positional": tuple(function.__defaults__ or ()),
+                    "named": dict(function.__kwdefaults__ or {}),
+                }
+            ),
+        }
+    if inspect.isbuiltin(value):
+        module = getattr(value, "__module__", None)
+        qualname = getattr(value, "__qualname__", None)
+        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+            raise ValueError("rate gate factory module builtin is not identifiable")
+        return {"kind": "builtin", "module": module, "qualname": qualname}
+    if isinstance(value, type):
+        try:
+            source = inspect.getsource(value)
+        except (OSError, TypeError):
+            source = None
+        return {
+            "kind": "class",
+            "module": value.__module__,
+            "qualname": value.__qualname__,
+            "source_digest": (
+                "sha256:" + hashlib.sha256(source.encode("utf-8")).hexdigest()
+                if source is not None
+                else None
+            ),
+        }
+    return {"kind": "data", "digest": _gate_factory_data_digest(value)}
+
+
+def _gate_factory_module_identity(
+    value: object,
+    *,
+    function: object,
+    global_name: str,
+    require_declared_members: bool = False,
+) -> dict[str, object]:
+    """Bind the precise module members read by a factory or gate-class method."""
+    if not inspect.ismodule(value):
+        raise ValueError("rate gate factory module dependency is invalid")
+    module_name = getattr(value, "__name__", None)
+    if not isinstance(module_name, str) or not module_name:
+        raise ValueError("rate gate factory module has no name")
+    attributes = _gate_factory_direct_module_attributes(function, global_name)
+    if not attributes:
+        raise ValueError("rate gate factory module is used without a bound member")
+    members: dict[str, object] = {}
+    for attribute in attributes:
+        try:
+            member = getattr(value, attribute)
+            if require_declared_members:
+                expected_member = _DECLARED_GATE_MODULE_MEMBERS.get((module_name, attribute))
+                if expected_member is not member:
+                    raise ValueError("rate gate factory module member is not declaration-bound")
+                declared_implementation = _DECLARED_GATE_MODULE_MEMBER_IMPLEMENTATIONS.get(
+                    (module_name, attribute)
+                )
+                if not _declared_module_member_implementation_is_intact(
+                    member,
+                    declared_implementation,
+                ):
+                    raise ValueError("rate gate factory module implementation drifted")
+            members[attribute] = _gate_factory_module_member_identity(member)
+        except Exception:
+            raise ValueError("rate gate factory module member is not observable") from None
+    return {"kind": "module", "name": module_name, "members": members}
+
+
+def _gate_factory_function_global_identity(
+    function: object,
+    name: str,
+    value: object,
+    *,
+    active: set[int],
+    depth: int,
+) -> dict[str, object]:
+    """Bind a function global, including an accessed module's live member."""
+    if inspect.ismodule(value):
+        return _gate_factory_module_identity(value, function=function, global_name=name)
+    return _gate_factory_dependency_identity(value, active=active, depth=depth)
+
+
+def _gate_factory_class_member_global_identity(
+    function: object,
+    name: str,
+    value: object,
+    *,
+    active: set[int],
+    depth: int,
+) -> dict[str, object]:
+    """Bind a member global without recursively expanding incidental classes.
+
+    The factory's direct classes receive a full current-member graph.  Classes
+    referenced *inside* those member methods (for example immutable result
+    dataclasses) are leaf dependencies: their implementation/source identity
+    still detects replacement without traversing generated dataclass helpers.
+    """
+    if inspect.ismodule(value):
+        return _gate_factory_module_identity(
+            value,
+            function=function,
+            global_name=name,
+            require_declared_members=True,
+        )
+    if isinstance(value, type):
+        declared_implementation = _DECLARED_GATE_LEAF_CLASS_IMPLEMENTATIONS.get(value)
+        if (
+            declared_implementation is not None
+            and not _declared_class_implementation_is_intact(value, declared_implementation)
+        ):
+            raise ValueError("rate gate factory result type implementation drifted")
+        return _gate_factory_module_member_identity(value)
+    return _gate_factory_dependency_identity(value, active=active, depth=depth)
+
+
+def _gate_factory_class_member_identity(
+    value: object,
+    *,
+    active: set[int],
+    depth: int,
+    expected_globals: dict[str, object],
+    expected_builtins: dict[str, object],
+) -> dict[str, object]:
+    """Bind a class member's currently installed executable state.
+
+    ``inspect.getsource(class)`` continues to describe the original declaration
+    after a test or plugin replaces ``Class.__init__`` in memory.  Record each
+    current function's bytecode and its safe bound state as well, so direct
+    runtime member replacement cannot retain the original factory identity.
+    """
+    function = value.__func__ if inspect.ismethod(value) else value
+    if not inspect.isfunction(function):
+        raise ValueError("rate gate factory class member is not inspectable")
+    if depth > _GATE_FACTORY_MAX_DEPTH:
+        raise ValueError("rate gate factory class member exceeds dependency depth")
+    closure_vars = inspect.getclosurevars(function)
+    if _gate_factory_has_unbound_global(function, closure_vars.unbound):
+        raise ValueError("rate gate factory class member has unbound dependencies")
+    if (
+        set(closure_vars.globals) != set(expected_globals)
+        or any(expected_globals[name] is not dependency for name, dependency in closure_vars.globals.items())
+        or set(closure_vars.builtins) != set(expected_builtins)
+        or any(expected_builtins[name] is not dependency for name, dependency in closure_vars.builtins.items())
+    ):
+        raise ValueError("rate gate factory class member dependencies drifted")
+    return {
+        "module": function.__module__,
+        "qualname": function.__qualname__,
+        "code_digest": "sha256:" + hashlib.sha256(marshal.dumps(function.__code__)).hexdigest(),
+        "defaults_digest": _gate_factory_data_digest(
+            {
+                "positional": tuple(function.__defaults__ or ()),
+                "named": dict(function.__kwdefaults__ or {}),
+            }
+        ),
+        "closures": {
+            name: _gate_factory_dependency_identity(
+                dependency,
+                active=active,
+                depth=depth + 1,
+            )
+            for name, dependency in sorted(closure_vars.nonlocals.items())
+        },
+        "globals": {
+            name: _gate_factory_class_member_global_identity(
+                function,
+                name,
+                dependency,
+                active=active,
+                depth=depth + 1,
+            )
+            for name, dependency in sorted(closure_vars.globals.items())
+        },
+        "builtins": {
+            name: _gate_factory_dependency_identity(
+                dependency,
+                active=active,
+                depth=depth + 1,
+            )
+            for name, dependency in sorted(closure_vars.builtins.items())
+        },
+    }
+
+
+def _gate_factory_class_identity(value: type[object]) -> dict[str, object]:
+    """Bind a direct class dependency and its current executable members."""
+    try:
+        source = inspect.getsource(value)
+    except (OSError, TypeError):
+        raise ValueError("rate gate factory class is not inspectable") from None
+    members: dict[str, object] = {}
+    for runtime_class in value.__mro__:
+        if runtime_class is object:
+            continue
+        expected_member_keys = {
+            key
+            for key in _DECLARED_GATE_CLASS_MEMBERS
+            if key[0] is runtime_class
+        }
+        if not expected_member_keys:
+            raise ValueError("rate gate factory class is not declaration-bound")
+        expected_raw_items = _DECLARED_GATE_CLASS_RAW_ITEMS[runtime_class]
+        current_raw_items = dict(vars(runtime_class))
+        if (
+            set(current_raw_items) != set(expected_raw_items)
+            or any(
+                expected_raw_items[name] is not current
+                for name, current in current_raw_items.items()
+            )
+        ):
+            # Special descriptors such as ``__getattribute__`` can alter a
+            # gate's visible methods while never appearing as a conventional
+            # function/classmethod/property member. Any class-dict drift is
+            # live process behavior, not portable factory identity.
+            raise ValueError("rate gate factory class dictionary drifted")
+        observed_member_keys: set[tuple[type[object], str, int]] = set()
+        qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
+        for member_name, raw_member in vars(runtime_class).items():
+            expected_raw_member = _DECLARED_GATE_CLASS_RAW_MEMBERS.get(
+                (runtime_class, member_name)
+            )
+            if expected_raw_member is not None and expected_raw_member is not raw_member:
+                # A descriptor can expose the original ``__func__`` while
+                # changing binding behavior in ``__get__``. The descriptor
+                # object itself is therefore part of static gate identity.
+                raise ValueError("rate gate factory class descriptor drifted")
+            targets: tuple[object, ...]
+            if isinstance(raw_member, (classmethod, staticmethod)):
+                targets = (raw_member.__func__,)
+            elif isinstance(raw_member, property):
+                targets = tuple(
+                    target
+                    for target in (raw_member.fget, raw_member.fset, raw_member.fdel)
+                    if target is not None
+                )
+            elif inspect.isfunction(raw_member):
+                targets = (raw_member,)
+            else:
+                continue
+            for index, target in enumerate(targets):
+                member_key = (runtime_class, member_name, index)
+                observed_member_keys.add(member_key)
+                expected_target = _DECLARED_GATE_CLASS_MEMBERS.get(member_key)
+                if expected_target is not target:
+                    # A dynamically injected member can close over or read
+                    # arbitrary process state. Display metadata is insufficient
+                    # because ``functools.wraps`` can copy the original module
+                    # and qualname; only the import-time declaration is portable.
+                    raise ValueError("rate gate factory class member is not declaration-bound")
+                declared_implementation = _DECLARED_GATE_MEMBER_IMPLEMENTATIONS.get(member_key)
+                if (
+                    declared_implementation is None
+                    or not _declared_function_implementation_is_intact(
+                        target,
+                        declared_implementation,
+                    )
+                ):
+                    # A function object can retain object identity after its
+                    # ``__code__`` or defaults have been changed in place.
+                    # That is live process behavior, not the imported gate
+                    # declaration Foundation A is allowed to make portable.
+                    raise ValueError("rate gate factory class implementation drifted")
+                members[f"{qualified_name}.{member_name}:{index}"] = (
+                    _gate_factory_class_member_identity(
+                        target,
+                        active=set(),
+                        depth=0,
+                        expected_globals=_DECLARED_GATE_MEMBER_GLOBALS[member_key],
+                        expected_builtins=_DECLARED_GATE_MEMBER_BUILTINS[member_key],
+                    )
+                )
+        if observed_member_keys != expected_member_keys:
+            raise ValueError("rate gate factory class members are incomplete")
+    return {
+        "kind": "class",
+        "module": value.__module__,
+        "qualname": value.__qualname__,
+        "source_digest": "sha256:" + hashlib.sha256(source.encode("utf-8")).hexdigest(),
+        "members": members,
+    }
+
+
+def _gate_factory_function_identity(
+    value: object,
+    *,
+    active: set[int],
+    depth: int,
+) -> dict[str, object]:
+    """Bind code plus every directly-resolved Python dependency.
+
+    ``__code__`` alone is not behavior: two closures can have identical bytecode
+    yet install gates with different limits.  Defaults, closures, globals, and
+    builtins are therefore represented by safe nested identities.  Anything we
+    cannot inspect becomes process-local through the public caller.
+    """
+    function = value.__func__ if inspect.ismethod(value) else value
+    if not inspect.isfunction(function):
+        raise ValueError("rate gate factory function is not inspectable")
+    if depth > _GATE_FACTORY_MAX_DEPTH:
+        raise ValueError("rate gate factory exceeds dependency depth")
+    code = function.__code__
+    code_digest = "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+    function_id = id(function)
+    if function_id in active:
+        return {
+            "kind": "recursive_function",
+            "module": function.__module__,
+            "qualname": function.__qualname__,
+            "code_digest": code_digest,
+        }
+
+    active.add(function_id)
+    try:
+        closure_vars = inspect.getclosurevars(function)
+        if _gate_factory_has_unbound_global(function, closure_vars.unbound):
+            raise ValueError("rate gate factory has unbound dependencies")
+        return {
+            "kind": "function",
+            "module": function.__module__,
+            "qualname": function.__qualname__,
+            "code_digest": code_digest,
+            "defaults": _gate_factory_dependency_identity(
+                tuple(function.__defaults__ or ()),
+                active=active,
+                depth=depth + 1,
+            ),
+            "kwdefaults": _gate_factory_dependency_identity(
+                dict(function.__kwdefaults__ or {}),
+                active=active,
+                depth=depth + 1,
+            ),
+            "closures": {
+                name: _gate_factory_dependency_identity(
+                    dependency,
+                    active=active,
+                    depth=depth + 1,
+                )
+                for name, dependency in sorted(closure_vars.nonlocals.items())
+            },
+            "globals": {
+                name: _gate_factory_function_global_identity(
+                    function,
+                    name,
+                    dependency,
+                    active=active,
+                    depth=depth + 1,
+                )
+                for name, dependency in sorted(closure_vars.globals.items())
+            },
+            "builtins": {
+                name: _gate_factory_dependency_identity(
+                    dependency,
+                    active=active,
+                    depth=depth + 1,
+                )
+                for name, dependency in sorted(closure_vars.builtins.items())
+            },
+        }
+    finally:
+        active.remove(function_id)
+
+
+def _gate_factory_dependency_identity(
+    value: object,
+    *,
+    active: set[int],
+    depth: int,
+) -> dict[str, object]:
+    """Return a safe, digest-only identity for one factory dependency."""
+    if inspect.ismethod(value) or inspect.isfunction(value):
+        return _gate_factory_function_identity(value, active=active, depth=depth)
+    if inspect.isbuiltin(value):
+        module = getattr(value, "__module__", None)
+        qualname = getattr(value, "__qualname__", None)
+        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+            raise ValueError("rate gate factory builtin is not identifiable")
+        return {"kind": "builtin", "module": module, "qualname": qualname}
+    if isinstance(value, type):
+        return _gate_factory_class_identity(value)
+    return {"kind": "data", "digest": _gate_factory_data_digest(value)}
+
+
+def rate_limit_gate_algorithm_contract(
+    factory: object | None = None,
+) -> dict[str, object]:
+    """Fingerprint one captured gate factory and its bound behavior.
+
+    ``factory`` deliberately defaults to the module symbol for standalone
+    inspection, but executor construction passes the callable captured *before*
+    invoking it.  A factory can otherwise restore that module symbol while
+    returning a behaviorally different gate, leaving a time-of-check/time-of-use
+    hole between construction and authority serialization.
+    """
+    target = build_rate_limit_gate if factory is None else factory
+    declared_implementation = _DECLARED_RATE_GATE_FACTORY_IMPLEMENTATION
+    if (
+        target is not _DECLARED_RATE_GATE_FACTORY
+        or declared_implementation is None
+        or not _declared_function_implementation_is_intact(target, declared_implementation)
+    ):
+        # A test/plugin may deliberately replace the factory.  It can still
+        # execute, but arbitrary callable graphs can hide mutable module,
+        # descriptor, or foreign-runtime state that Foundation A must not
+        # promote into a portable identity.
+        return _process_local_gate_algorithm_contract()
+    try:
+        identity = _gate_factory_function_identity(target, active=set(), depth=0)
+        module = identity.get("module")
+        qualname = identity.get("qualname")
+        if not isinstance(module, str) or not module or not isinstance(qualname, str) or not qualname:
+            raise ValueError("rate gate factory lacks a qualified identity")
+        payload = json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except Exception:
+        return _process_local_gate_algorithm_contract()
+    return {
+        "version": 1,
+        "observed": True,
+        # Do not expose callable display metadata in authority JSON.  Dynamic
+        # plugin labels are provider-controlled input and can contain a token.
+        "identity_digest": "sha256:"
+        + hashlib.sha256(
+            json.dumps(
+                {"module": module, "qualname": qualname},
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest(),
+        "digest": "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest(),
+    }
 
 
 def build_rate_limit_gate(
@@ -339,6 +1393,18 @@ def build_rate_limit_gate(
     )
 
 
+# Capture this only after the function declaration exists.  The comparison in
+# ``rate_limit_gate_algorithm_contract`` is object identity on purpose: copied
+# code, ``functools.wraps`` metadata, or an equivalent closure is still a live
+# replacement rather than the declared portable implementation.
+_DECLARED_RATE_GATE_FACTORY = build_rate_limit_gate
+_DECLARED_RATE_GATE_FACTORY_IMPLEMENTATION = _declared_function_implementation(
+    build_rate_limit_gate
+)
+_DECLARED_RATE_LIMIT_GATE_TYPE = RateLimitGate
+_DECLARED_SHARED_RATE_LIMIT_BUCKET_TYPE = SharedRateLimitBucket
+
+
 def estimate_runtime_request_tokens(
     prompt: str,
     *,
@@ -351,10 +1417,244 @@ def estimate_runtime_request_tokens(
     return max(1, prompt_tokens + _TOKEN_COMPLETION_CUSHION)
 
 
+_DECLARED_RATE_TOKEN_ESTIMATOR = estimate_runtime_request_tokens
+_DECLARED_RATE_TOKEN_ESTIMATOR_IMPLEMENTATION = _declared_function_implementation(
+    estimate_runtime_request_tokens
+)
+
+
+def _rate_limit_gate_matches_policy(
+    gate: object,
+    *,
+    runtime_backend: str,
+    request_limit: int | None,
+    token_limit: int | None,
+    window_seconds: float,
+    max_wait_seconds: float,
+    heartbeat_seconds: float,
+) -> bool:
+    """Check that an installed gate is exactly the policy that was authorized.
+
+    The factory is intentionally replaceable for in-process experimentation, but
+    Foundation A must not call a replacement and then serialize the original
+    policy as though it still governed dispatch.  Direct attribute reads avoid
+    an overridden descriptor manufacturing a friendly-looking view of a gate.
+    """
+    if type(gate) is not _DECLARED_RATE_LIMIT_GATE_TYPE:
+        return False
+    try:
+        bucket = object.__getattribute__(gate, "_bucket")
+        if type(bucket) is not _DECLARED_SHARED_RATE_LIMIT_BUCKET_TYPE:
+            return False
+        return (
+            object.__getattribute__(bucket, "_runtime_backend") == runtime_backend
+            and object.__getattribute__(bucket, "_request_limit") == request_limit
+            and object.__getattribute__(bucket, "_token_limit") == token_limit
+            and object.__getattribute__(bucket, "_window_seconds") == window_seconds
+            and object.__getattribute__(gate, "_max_wait_seconds") == max_wait_seconds
+            and object.__getattribute__(gate, "_heartbeat_seconds") == heartbeat_seconds
+        )
+    except Exception:
+        return False
+
+
+def build_authority_bound_rate_limit_gate(
+    runtime_backend: str,
+    *,
+    request_limit: int | None,
+    token_limit: int | None,
+    window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
+    max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS,
+    heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS,
+) -> AuthorityBoundRateLimitGate:
+    """Build a gate and capture the exact live state that dispatch will use.
+
+    The callable is captured before it is invoked and the same capture is used
+    for the algorithm contract afterwards.  This closes the mutable-global
+    alias/TOCTOU path where a factory can swap ``build_rate_limit_gate`` back to
+    the declared implementation before authority serialization.
+    """
+    factory = build_rate_limit_gate
+    if not callable(factory):
+        raise ValueError("dispatch rate gate factory is not callable")
+    gate = factory(
+        runtime_backend,
+        request_limit=request_limit,
+        token_limit=token_limit,
+        window_seconds=window_seconds,
+        max_wait_seconds=max_wait_seconds,
+        heartbeat_seconds=heartbeat_seconds,
+    )
+    if type(gate) is not _DECLARED_RATE_LIMIT_GATE_TYPE:
+        raise ValueError("dispatch rate gate factory returned an unsupported gate type")
+    algorithm = rate_limit_gate_algorithm_contract(factory)
+    if not _rate_limit_gate_matches_policy(
+        gate,
+        runtime_backend=runtime_backend,
+        request_limit=request_limit,
+        token_limit=token_limit,
+        window_seconds=window_seconds,
+        max_wait_seconds=max_wait_seconds,
+        heartbeat_seconds=heartbeat_seconds,
+    ):
+        # The gate remains usable for this live process, but it cannot be
+        # promoted to portable authority because policy and behavior disagree.
+        algorithm = _process_local_gate_algorithm_contract()
+    try:
+        bucket = object.__getattribute__(gate, "_bucket")
+        acquire = object.__getattribute__(gate, "acquire")
+        sleep = object.__getattribute__(gate, "_sleep")
+        clock = object.__getattribute__(bucket, "_time")
+        lock = object.__getattribute__(bucket, "_lock")
+        reservations = object.__getattribute__(bucket, "_reservations")
+    except Exception:
+        raise ValueError("dispatch rate gate state is not observable") from None
+    if not callable(acquire):
+        raise ValueError("dispatch rate gate acquire is not callable")
+    return AuthorityBoundRateLimitGate(
+        gate=gate,
+        algorithm=algorithm,
+        factory=factory,
+        acquire=acquire,
+        bucket=bucket,
+        runtime_backend=runtime_backend,
+        request_limit=request_limit,
+        token_limit=token_limit,
+        window_seconds=window_seconds,
+        max_wait_seconds=max_wait_seconds,
+        heartbeat_seconds=heartbeat_seconds,
+        sleep=sleep,
+        clock=clock,
+        lock=lock,
+        reservations=reservations,
+    )
+
+
+def _same_bound_callable(current: object, captured: object) -> bool:
+    """Compare a regenerated bound method without trusting display metadata."""
+    current_self = getattr(current, "__self__", None)
+    captured_self = getattr(captured, "__self__", None)
+    current_function = getattr(current, "__func__", None)
+    captured_function = getattr(captured, "__func__", None)
+    if current_self is not None or captured_self is not None:
+        return current_self is captured_self and current_function is captured_function
+    return current is captured
+
+
+def authority_bound_rate_limit_gate_is_intact(binding: AuthorityBoundRateLimitGate) -> bool:
+    """Reject post-construction gate, class, or instance-state drift.
+
+    A portable algorithm must still match the import-time implementation just
+    before dispatch. Independently, every installed gate verifies its captured
+    policy fields and live collaborators. This catches a later replacement of
+    ``RateLimitGate.acquire``/``enabled`` as well as an in-place bucket-limit,
+    clock, sleeper, lock, or queue swap.
+    """
+    if binding.algorithm.get("observed") is True and (
+        rate_limit_gate_algorithm_contract(binding.factory) != binding.algorithm
+    ):
+        return False
+    gate = binding.gate
+    if type(gate) is not _DECLARED_RATE_LIMIT_GATE_TYPE:
+        return False
+    try:
+        bucket = object.__getattribute__(gate, "_bucket")
+        if bucket is not binding.bucket or type(bucket) is not _DECLARED_SHARED_RATE_LIMIT_BUCKET_TYPE:
+            return False
+        if not _same_bound_callable(object.__getattribute__(gate, "acquire"), binding.acquire):
+            return False
+        if object.__getattribute__(gate, "_sleep") is not binding.sleep:
+            return False
+        if object.__getattribute__(bucket, "_time") is not binding.clock:
+            return False
+        if object.__getattribute__(bucket, "_lock") is not binding.lock:
+            return False
+        if object.__getattribute__(bucket, "_reservations") is not binding.reservations:
+            return False
+    except Exception:
+        return False
+    return _rate_limit_gate_matches_policy(
+        gate,
+        runtime_backend=binding.runtime_backend,
+        request_limit=binding.request_limit,
+        token_limit=binding.token_limit,
+        window_seconds=binding.window_seconds,
+        max_wait_seconds=binding.max_wait_seconds,
+        heartbeat_seconds=binding.heartbeat_seconds,
+    )
+
+
+def rate_limit_token_estimator_contract(
+    estimator: object | None = None,
+) -> dict[str, object]:
+    """Fingerprint a captured token estimator without exposing its labels."""
+    target = estimate_runtime_request_tokens if estimator is None else estimator
+    declared = _DECLARED_RATE_TOKEN_ESTIMATOR_IMPLEMENTATION
+    if (
+        target is not _DECLARED_RATE_TOKEN_ESTIMATOR
+        or declared is None
+        or not _declared_function_implementation_is_intact(target, declared)
+    ):
+        return _process_local_gate_algorithm_contract()
+    try:
+        identity = _gate_factory_function_identity(target, active=set(), depth=0)
+        payload = json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except Exception:
+        return _process_local_gate_algorithm_contract()
+    return {
+        "version": 1,
+        "observed": True,
+        "identity_digest": "sha256:"
+        + hashlib.sha256(
+            json.dumps(
+                {
+                    "module": getattr(target, "__module__", None),
+                    "qualname": getattr(target, "__qualname__", None),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest(),
+        "digest": "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest(),
+    }
+
+
+def capture_authority_bound_rate_limit_token_estimator(
+) -> tuple[Callable[[str], int], dict[str, object]]:
+    """Capture the estimator that dispatch will actually call.
+
+    The returned callable is stored by :class:`ParallelACExecutor`; later
+    module-global rebinding cannot silently change its TPM accounting.
+    """
+    estimator = estimate_runtime_request_tokens
+    if not callable(estimator):
+        raise ValueError("dispatch token estimator is not callable")
+    return estimator, rate_limit_token_estimator_contract(estimator)
+
+
+def authority_bound_rate_limit_token_estimator_is_intact(
+    estimator: object,
+    contract: Mapping[str, object],
+) -> bool:
+    """Revalidate a portable estimator immediately before dispatch."""
+    if contract.get("observed") is not True:
+        return True
+    return rate_limit_token_estimator_contract(estimator) == dict(contract)
+
+
 __all__ = [
     "DEFAULT_ANTHROPIC_RPM_CEILING",
     "DEFAULT_ANTHROPIC_TPM_CEILING",
+    "AuthorityBoundRateLimitGate",
     "RATE_LIMIT_HEARTBEAT_SECONDS",
+    "RATE_LIMIT_GATE_ALGORITHM_VERSION",
     "RATE_LIMIT_MAX_WAIT_SECONDS",
     "RATE_LIMIT_TOKEN_ESTIMATION_VERSION",
     "RATE_LIMIT_WINDOW_SECONDS",
@@ -363,6 +1663,12 @@ __all__ = [
     "RateLimitSnapshot",
     "ResolvedDispatchRatePolicy",
     "SharedRateLimitBucket",
+    "authority_bound_rate_limit_gate_is_intact",
+    "authority_bound_rate_limit_token_estimator_is_intact",
+    "build_authority_bound_rate_limit_gate",
     "build_rate_limit_gate",
+    "capture_authority_bound_rate_limit_token_estimator",
     "estimate_runtime_request_tokens",
+    "rate_limit_gate_algorithm_contract",
+    "rate_limit_token_estimator_contract",
 ]

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -7,11 +7,12 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 import time
-from typing import Any
+from typing import Any, Literal
 
 RATE_LIMIT_WINDOW_SECONDS = 60.0
 RATE_LIMIT_HEARTBEAT_SECONDS = 30.0
 RATE_LIMIT_MAX_WAIT_SECONDS = 120.0
+RATE_LIMIT_TOKEN_ESTIMATION_VERSION = 1
 DEFAULT_ANTHROPIC_RPM_CEILING = 40
 DEFAULT_ANTHROPIC_TPM_CEILING = 32_000
 _TOKEN_ESTIMATE_DIVISOR = 4
@@ -223,11 +224,98 @@ class RateLimitGate:
             total_waited += sleep_seconds
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedDispatchRatePolicy:
+    """Immutable settings used by both dispatch behavior and authority identity."""
+
+    backend: str
+    owner: Literal["ouroboros", "runtime"]
+    observed: bool
+    self_governs_rate_limit: bool
+    requests_per_minute: int | None
+    tokens_per_minute: int | None
+    window_seconds: float = RATE_LIMIT_WINDOW_SECONDS
+    heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS
+    max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS
+    token_estimation_version: int = RATE_LIMIT_TOKEN_ESTIMATION_VERSION
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        backend: str,
+        self_governs_rate_limit: bool,
+        requests_per_minute: int | None,
+        tokens_per_minute: int | None,
+    ) -> ResolvedDispatchRatePolicy:
+        normalized_backend = backend.strip() or "unknown"
+        if self_governs_rate_limit:
+            # Ouroboros deliberately installs a dormant gate, but the runtime's
+            # internal limiter is not yet exposed as a durable identity contract.
+            return cls(
+                backend=normalized_backend,
+                owner="runtime",
+                observed=False,
+                self_governs_rate_limit=True,
+                requests_per_minute=None,
+                tokens_per_minute=None,
+            )
+        return cls(
+            backend=normalized_backend,
+            owner="ouroboros",
+            observed=True,
+            self_governs_rate_limit=False,
+            requests_per_minute=(
+                requests_per_minute
+                if requests_per_minute is not None and requests_per_minute > 0
+                else None
+            ),
+            tokens_per_minute=(
+                tokens_per_minute
+                if tokens_per_minute is not None and tokens_per_minute > 0
+                else None
+            ),
+        )
+
+    @property
+    def gate_enabled(self) -> bool:
+        return self.owner == "ouroboros" and (
+            self.requests_per_minute is not None or self.tokens_per_minute is not None
+        )
+
+    def build_gate(self) -> RateLimitGate:
+        return build_rate_limit_gate(
+            self.backend,
+            request_limit=self.requests_per_minute if self.owner == "ouroboros" else None,
+            token_limit=self.tokens_per_minute if self.owner == "ouroboros" else None,
+            window_seconds=self.window_seconds,
+            max_wait_seconds=self.max_wait_seconds,
+            heartbeat_seconds=self.heartbeat_seconds,
+        )
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "version": 1,
+            "backend": self.backend,
+            "owner": self.owner,
+            "observed": self.observed,
+            "self_governs_rate_limit": self.self_governs_rate_limit,
+            "requests_per_minute": self.requests_per_minute,
+            "tokens_per_minute": self.tokens_per_minute,
+            "gate_enabled": self.gate_enabled,
+            "window_seconds": self.window_seconds,
+            "heartbeat_seconds": self.heartbeat_seconds,
+            "max_wait_seconds": self.max_wait_seconds,
+            "token_estimation_version": self.token_estimation_version,
+        }
+
+
 def build_rate_limit_gate(
     runtime_backend: str,
     *,
     request_limit: int | None,
     token_limit: int | None,
+    window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
     max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS,
     heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS,
     sleep: Callable[[float], Any] | None = None,
@@ -241,6 +329,7 @@ def build_rate_limit_gate(
         runtime_backend=runtime_backend,
         request_limit=request_limit,
         token_limit=token_limit,
+        window_seconds=window_seconds,
     )
     return RateLimitGate(
         bucket,
@@ -267,10 +356,12 @@ __all__ = [
     "DEFAULT_ANTHROPIC_TPM_CEILING",
     "RATE_LIMIT_HEARTBEAT_SECONDS",
     "RATE_LIMIT_MAX_WAIT_SECONDS",
+    "RATE_LIMIT_TOKEN_ESTIMATION_VERSION",
     "RATE_LIMIT_WINDOW_SECONDS",
     "RateLimitBackoff",
     "RateLimitGate",
     "RateLimitSnapshot",
+    "ResolvedDispatchRatePolicy",
     "SharedRateLimitBucket",
     "build_rate_limit_gate",
     "estimate_runtime_request_tokens",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -46,7 +46,7 @@ from ouroboros.core.execution_preferences import (
     execution_preferences_from_contract,
     resolve_execution_preferences,
 )
-from ouroboros.core.security import is_sensitive_value
+from ouroboros.core.security import is_sensitive_credential_field, is_sensitive_value
 from ouroboros.core.seed import AcceptanceCriterionSpec, ac_text, ac_texts
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import (
@@ -1879,7 +1879,9 @@ class OrchestratorRunner:
                     continue
                 seen_containers.add(current_id)
                 for key, item in current.items():
-                    if isinstance(key, str) and is_sensitive_value(key):
+                    if isinstance(key, str) and (
+                        is_sensitive_value(key) or is_sensitive_credential_field(key)
+                    ):
                         return True
                     pending.append(item)
                 continue

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -64,6 +64,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeHandle,
 )
 from ouroboros.orchestrator.backend_limits import (
+    BackendConcurrencyLimits,
     plan_fan_out_concurrency,
     resolve_backend_limits,
 )
@@ -122,6 +123,7 @@ from ouroboros.orchestrator.policy import (
 )
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, ProfileError, load_profile
 from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
+from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.runtime_message_projection import (
     message_tool_input,
     message_tool_name,
@@ -1223,7 +1225,10 @@ class OrchestratorRunner:
                 break
         return current_seed_id, tuple(cohort)
 
-    def _plan_parallel_workers(self) -> int:
+    def _plan_parallel_workers(
+        self,
+        limits: BackendConcurrencyLimits | None = None,
+    ) -> int:
         """Return the effective fan-out worker count for the connected backend.
 
         Ouroboros caps delivery fan-out to the connected backend's known
@@ -1232,8 +1237,8 @@ class OrchestratorRunner:
         runtimes — serialize by default and are raised only via
         ``OUROBOROS_MAX_CONCURRENCY``.
         """
-        limits = resolve_backend_limits(self._adapter.runtime_backend)
-        return plan_fan_out_concurrency(self._max_parallel_workers, limits)
+        resolved_limits = limits or resolve_backend_limits(self._adapter.runtime_backend)
+        return plan_fan_out_concurrency(self._max_parallel_workers, resolved_limits)
 
     @property
     def mcp_manager(self) -> MCPClientManager | None:
@@ -4706,7 +4711,14 @@ class OrchestratorRunner:
 
         # Cap fan-out to the connected backend's concurrency constraints so a
         # parallel dispatch never stampedes the LLM's rate/quota window (R3).
-        effective_workers = self._plan_parallel_workers()
+        delivery_limits = resolve_backend_limits(self._adapter.runtime_backend)
+        effective_workers = self._plan_parallel_workers(delivery_limits)
+        dispatch_rate_policy = ResolvedDispatchRatePolicy.resolve(
+            backend=self._adapter.runtime_backend,
+            self_governs_rate_limit=bool(getattr(self._adapter, "self_governs_rate_limit", False)),
+            requests_per_minute=delivery_limits.requests_per_minute,
+            tokens_per_minute=delivery_limits.tokens_per_minute,
+        )
         if effective_workers < self._max_parallel_workers:
             self._console.print(
                 f"[yellow]Fan-out capped to {effective_workers} worker(s) for backend "
@@ -4766,6 +4778,7 @@ class OrchestratorRunner:
             workspace_authority_identity=(
                 workspace_identity if isinstance(workspace_identity, Mapping) else None
             ),
+            dispatch_rate_policy=dispatch_rate_policy,
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,13 @@ from ouroboros.orchestrator.events import (
     create_tool_called_event,
     create_workflow_progress_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    constructor_model_contract,
+    runtime_execution_identity_contract,
+    runtime_execution_proves_effective_model,
+    valid_constructor_model_contract,
+    valid_runtime_execution_identity_contract,
+)
 from ouroboros.orchestrator.execution_guidance import (
     ExecutionGuidanceBundle,
     resolve_execution_guidance,
@@ -1584,45 +1591,12 @@ class OrchestratorRunner:
         runtimes that expose no constructor model at all; current-format resume
         then fails closed because the effective pin cannot be verified.
         """
-        try:
-            raw_model = inspect.getattr_static(self._adapter, "_model")
-        except AttributeError:
-            return {"observed": False}
-        if raw_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(raw_model, str):
-            return {"observed": False}
-
-        normalized_model: object = raw_model.strip() or None
-        normalizer_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "_normalize_model",
-            None,
-        )
-        if normalizer_descriptor is not None:
-            try:
-                normalizer = object.__getattribute__(self._adapter, "_normalize_model")
-                normalized_model = normalizer(raw_model)
-            except Exception:
-                return {"observed": False}
-        if normalized_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(normalized_model, str) or not normalized_model.strip():
-            return {"observed": False}
-        return {"observed": True, "model": normalized_model.strip()}
+        return constructor_model_contract(self._adapter)
 
     @staticmethod
     def _valid_constructor_model_contract(value: object) -> bool:
         """Return whether a persisted constructor-model contract is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        observed = value.get("observed")
-        if observed is not True:
-            return False
-        model = value.get("model")
-        return set(value) == {"observed", "model"} and (
-            model is None or isinstance(model, str) and bool(model.strip())
-        )
+        return valid_constructor_model_contract(value)
 
     def _runtime_execution_identity_contract(self) -> dict[str, Any]:
         """Return backend-specific resolved execution inputs, when observable.
@@ -1636,31 +1610,9 @@ class OrchestratorRunner:
         backend's private configuration model.
         """
 
-        provider_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "execution_identity_contract",
-            None,
-        )
-        if provider_descriptor is None:
-            return {"version": 1, "observed": False}
-
-        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
-        identity = provider()
-        if not isinstance(identity, Mapping):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
         try:
-            encoded = json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-            normalized_identity = json.loads(encoded)
-        except (TypeError, ValueError) as exc:
+            return runtime_execution_identity_contract(self._adapter)
+        except ValueError as exc:
             raise OrchestratorError(
                 message="Runtime returned an invalid execution identity contract",
                 details={
@@ -1668,61 +1620,16 @@ class OrchestratorRunner:
                     "cause": str(exc),
                 },
             ) from exc
-        if not isinstance(normalized_identity, dict):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        return {
-            "version": 1,
-            "observed": True,
-            "identity": normalized_identity,
-        }
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
         """Return whether a persisted backend execution identity is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        version = value.get("version")
-        observed = value.get("observed")
-        if (
-            isinstance(version, bool)
-            or not isinstance(version, int)
-            or version != 1
-            or not isinstance(observed, bool)
-        ):
-            return False
-        if not observed:
-            return set(value) == {"version", "observed"}
-        identity = value.get("identity")
-        if (
-            set(value) != {"version", "observed", "identity"}
-            or not isinstance(identity, Mapping)
-            or not identity
-        ):
-            return False
-        try:
-            json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError):
-            return False
-        return True
+        return valid_runtime_execution_identity_contract(value)
 
     @staticmethod
     def _runtime_execution_proves_effective_model(value: object) -> bool:
         """Return whether a backend identity observed a concrete model/profile."""
-        if not OrchestratorRunner._valid_runtime_execution_identity_contract(value):
-            return False
-        if not isinstance(value, Mapping) or value.get("observed") is not True:
-            return False
-        identity = value.get("identity")
-        return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+        return runtime_execution_proves_effective_model(value)
 
     def _validate_resume_handle_execution_identity(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -46,6 +46,7 @@ from ouroboros.core.execution_preferences import (
     execution_preferences_from_contract,
     resolve_execution_preferences,
 )
+from ouroboros.core.security import is_sensitive_value
 from ouroboros.core.seed import AcceptanceCriterionSpec, ac_text, ac_texts
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import (
@@ -94,6 +95,7 @@ from ouroboros.orchestrator.execution_authority import (
     constructor_model_contract,
     runtime_execution_identity_contract,
     runtime_execution_proves_effective_model,
+    runtime_routing_labels_contract,
     valid_constructor_model_contract,
     valid_runtime_execution_identity_contract,
 )
@@ -788,12 +790,13 @@ class OrchestratorRunner:
 
             self._model_router = build_model_router(
                 _economics_config,
-                runtime_backend=getattr(adapter, "runtime_backend", None),
+                runtime_backend=self._runtime_backend_contract(),
                 pinned_model=_model_pin,
                 base_tier_override=base_model_tier,
             )
         self._apply_efficiency_mode_to_router()
         self._execution_contract: dict[str, Any] | None = None
+        self._resolved_runtime_authority: ResolvedRuntimeAuthority | None = None
         self._execution_guidance: ExecutionGuidanceBundle | None = None
         # Opt-in shadow-replay baseline harness (frugality-proof AC5). Read ONCE
         # here next to the router build and threaded to the parallel executor.
@@ -991,7 +994,7 @@ class OrchestratorRunner:
                         "session_id": session_id,
                         "is_decomposed_child": False,
                         **investment_assessment.to_event_data(),
-                        "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+                        "runtime_backend": self._runtime_backend_contract(),
                         "call_site": "runner",
                     },
                 )
@@ -1020,7 +1023,7 @@ class OrchestratorRunner:
                             "effort_level": decision.level,
                             "effort_mode": decision.mode,
                             "base_reasoning_effort": self._reasoning_effort,
-                            "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+                            "runtime_backend": self._runtime_backend_contract(),
                             "investment_assessment": investment_assessment.to_event_data(),
                             "call_site": "runner",
                         },
@@ -1051,7 +1054,7 @@ class OrchestratorRunner:
                             "model_tier": model_decision.tier,
                             "model": model_decision.model,
                             "model_mode": model_decision.mode,
-                            "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+                            "runtime_backend": self._runtime_backend_contract(),
                             "call_site": "runner",
                         },
                     )
@@ -1237,7 +1240,9 @@ class OrchestratorRunner:
         runtimes — serialize by default and are raised only via
         ``OUROBOROS_MAX_CONCURRENCY``.
         """
-        resolved_limits = limits or resolve_backend_limits(self._adapter.runtime_backend)
+        resolved_limits = limits or resolve_backend_limits(
+            self._runtime_backend_contract() or "unknown"
+        )
         return plan_fan_out_concurrency(self._max_parallel_workers, resolved_limits)
 
     @property
@@ -1345,7 +1350,13 @@ class OrchestratorRunner:
     ) -> PolicyContext:
         """Return the policy context used for implementation tool catalogs."""
         return PolicyContext(
-            runtime_backend=runtime_backend or self._adapter.runtime_backend,
+            runtime_backend=(
+                runtime_backend
+                if isinstance(runtime_backend, str)
+                and runtime_backend.strip()
+                and not is_sensitive_value(runtime_backend)
+                else self._runtime_backend_contract()
+            ),
             session_role=PolicySessionRole.IMPLEMENTATION,
             execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
         )
@@ -1412,9 +1423,17 @@ class OrchestratorRunner:
         tool_catalog: SessionToolCatalog | None = None,
     ) -> RuntimeHandle | None:
         """Seed a runtime handle with startup metadata before execution begins."""
-        backend = (
-            runtime_handle.backend if runtime_handle is not None else None
-        ) or self._adapter.runtime_backend
+        inherited_backend = (
+            self._safe_backend_label(runtime_handle.backend)
+            if runtime_handle is not None
+            else None
+        )
+        # A resume handle with a missing or credential-shaped backend cannot be
+        # safely attributed to this run. Do not carry its raw label into runtime
+        # progress merely to retain a best-effort continuation; start fresh.
+        if runtime_handle is not None and inherited_backend is None:
+            return None
+        backend = inherited_backend or self._runtime_backend_contract()
         if not backend:
             return runtime_handle
 
@@ -1617,15 +1636,15 @@ class OrchestratorRunner:
         """
 
         try:
-            return runtime_execution_identity_contract(self._adapter)
-        except ValueError as exc:
+            return runtime_execution_identity_contract(
+                self._adapter,
+                include_process_local_nonce=False,
+            )
+        except ValueError:
             raise OrchestratorError(
                 message="Runtime returned an invalid execution identity contract",
-                details={
-                    "adapter_type": type(self._adapter).__name__,
-                    "cause": str(exc),
-                },
-            ) from exc
+                details={"invalid": "runtime execution identity"},
+            ) from None
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
@@ -1685,16 +1704,22 @@ class OrchestratorRunner:
         try:
             current_selector = provider(runtime_handle)
         except Exception as exc:
+            # Providers own this metadata hook. Its exception text can include
+            # command arguments, native session metadata, or credentials, so
+            # never reflect it through a durable resume diagnostic.
+            del exc
             raise OrchestratorError(
                 message="Cannot resume with invalid runtime selector metadata",
-                details={"cause": str(exc)},
-            ) from exc
+                details={"invalid": "runtime selector metadata"},
+            ) from None
         if persisted_selector != current_selector:
+            # Both values originated outside the runner: the persisted one is
+            # untrusted session data and the current one is provider-owned.
+            # A mismatch is actionable without echoing either selector.
             raise OrchestratorError(
                 message="Cannot resume with a different runtime handle selector",
                 details={
-                    "persisted_selector": persisted_selector,
-                    "current_selector": current_selector,
+                    "invalid": "runtime handle selector mismatch",
                     "hint": "Restore the original runtime handle metadata or start a new session.",
                 },
             )
@@ -1714,7 +1739,7 @@ class OrchestratorRunner:
         ):
             raise OrchestratorError(
                 message="Cannot resume with conflicting runtime session identity",
-                details={"persisted_runtime_identity": persisted_identity},
+                details={"invalid": "runtime session identity"},
             )
         current_identity = runtime_resume_identity_from_payload(
             runtime_handle.to_persisted_dict() if runtime_handle is not None else None
@@ -1723,8 +1748,7 @@ class OrchestratorRunner:
             raise OrchestratorError(
                 message="Cannot resume a different backend session",
                 details={
-                    "persisted_runtime_identity": dict(persisted_identity),
-                    "current_runtime_identity": current_identity,
+                    "invalid": "runtime session identity mismatch",
                     "hint": "Restore the original runtime session id or start a new session.",
                 },
             )
@@ -1741,8 +1765,7 @@ class OrchestratorRunner:
             raise OrchestratorError(
                 message="Cannot resume with a runtime handle from a different backend",
                 details={
-                    "persisted_handle_backend": runtime_handle.backend,
-                    "execution_runtime_backend": expected_backend,
+                    "invalid": "runtime handle backend mismatch",
                     "hint": "Restore the original runtime handle or start a new session.",
                 },
             )
@@ -1779,17 +1802,132 @@ class OrchestratorRunner:
 
     def _runtime_backend_contract(self) -> str | None:
         """Return the concrete runtime backend that owns this resumable run."""
-        runtime_backend = getattr(self._adapter, "runtime_backend", None)
-        if not isinstance(runtime_backend, str) or not runtime_backend.strip():
-            return None
-        return runtime_backend.strip()
+        runtime_backend = runtime_routing_labels_contract(self._adapter).get("runtime_backend")
+        return runtime_backend if isinstance(runtime_backend, str) else None
 
     def _llm_backend_contract(self) -> str | None:
         """Return the LLM backend used by analysis and runtime-adjacent calls."""
-        llm_backend = getattr(self._adapter, "llm_backend", None)
-        if not isinstance(llm_backend, str) or not llm_backend.strip():
+        llm_backend = runtime_routing_labels_contract(self._adapter).get("llm_backend")
+        return llm_backend if isinstance(llm_backend, str) else None
+
+    @staticmethod
+    def _safe_backend_label(value: object) -> str | None:
+        """Return one serializable backend label, or no label at all."""
+        if not isinstance(value, str):
             return None
-        return llm_backend.strip()
+        normalized = value.strip()
+        if not normalized or is_sensitive_value(value):
+            return None
+        return normalized
+
+    @staticmethod
+    def _runtime_routing_labels_from_contract(
+        routing_contract: Mapping[str, object],
+    ) -> dict[str, object] | None:
+        """Validate observed and explicitly-unobserved runtime labels.
+
+        A missing/sensitive runtime label is persisted as ``None`` plus an
+        explicit marker.  It is deliberately distinct from a malformed legacy
+        contract.  It can be used to bind the initial live adapter, but cannot
+        establish a durable identity for resume or proof-cohort reuse.
+        """
+        labels: dict[str, object] = {}
+        for field_name in ("runtime_backend", "llm_backend"):
+            value = routing_contract.get(field_name)
+            marker_name = f"{field_name}_unobserved"
+            marker = routing_contract.get(marker_name)
+            if marker is True:
+                if value is not None:
+                    return None
+                labels[field_name] = None
+                labels[marker_name] = True
+                continue
+            if (
+                marker is not None
+                or not isinstance(value, str)
+                or not value.strip()
+                or is_sensitive_value(value)
+            ):
+                return None
+            labels[field_name] = value.strip()
+        return labels
+
+    @staticmethod
+    def _contains_sensitive_contract_value(value: object) -> bool:
+        """Reject known credential shapes before any persisted value is echoed.
+
+        Resume contracts are durable, untrusted input. Several later mismatch
+        diagnostics include persisted subcontracts for legitimate operator
+        debugging, so inspecting a nested credential only at the individual
+        validator would leave another error path to expose it. Traverse the
+        envelope once, fail closed on known secret shapes, and keep the
+        resulting error deliberately value-free.
+        """
+        pending: list[object] = [value]
+        seen_containers: set[int] = set()
+        item_count = 0
+        while pending:
+            current = pending.pop()
+            item_count += 1
+            if item_count > 4_096:
+                return True
+            if isinstance(current, str):
+                if is_sensitive_value(current):
+                    return True
+                continue
+            if isinstance(current, Mapping):
+                current_id = id(current)
+                if current_id in seen_containers:
+                    continue
+                seen_containers.add(current_id)
+                for key, item in current.items():
+                    if isinstance(key, str) and is_sensitive_value(key):
+                        return True
+                    pending.append(item)
+                continue
+            if isinstance(current, (list, tuple)):
+                current_id = id(current)
+                if current_id in seen_containers:
+                    continue
+                seen_containers.add(current_id)
+                pending.extend(current)
+        return False
+
+    def _capture_runtime_authority(
+        self,
+        routing_contract: Mapping[str, object],
+    ) -> ResolvedRuntimeAuthority:
+        """Bind the live adapter at planning time without persisting hidden labels."""
+        try:
+            authority = ResolvedRuntimeAuthority.bind(self._adapter, routing_contract)
+        except ValueError:
+            raise OrchestratorError(
+                message="Cannot bind the runtime authority for execution",
+            ) from None
+        self._resolved_runtime_authority = authority
+        return authority
+
+    def _parallel_runtime_authority(
+        self,
+        routing_contract: Mapping[str, object],
+    ) -> ResolvedRuntimeAuthority:
+        """Return the planning-time binding and reject planning-to-dispatch drift."""
+        authority = self._resolved_runtime_authority
+        if authority is None:
+            # Defensive compatibility for callers that inject an execution
+            # contract directly rather than building/preparing one first.
+            return self._capture_runtime_authority(routing_contract)
+        if authority.data != dict(routing_contract):
+            raise OrchestratorError(
+                message="Parallel runtime authority does not match the planned contract",
+            )
+        try:
+            authority.require_adapter(self._adapter)
+        except ValueError:
+            raise OrchestratorError(
+                message="Parallel runtime authority drifted since planning",
+            ) from None
+        return authority
 
     def _permission_mode_contract(self) -> dict[str, Any]:
         """Return the normalized runtime authority level used for this run."""
@@ -1803,7 +1941,12 @@ class OrchestratorRunner:
         if not isinstance(value, Mapping) or value.get("observed") is not True:
             return False
         mode = value.get("mode")
-        return set(value) == {"observed", "mode"} and isinstance(mode, str) and bool(mode.strip())
+        return (
+            set(value) == {"observed", "mode"}
+            and isinstance(mode, str)
+            and bool(mode.strip())
+            and not is_sensitive_value(mode)
+        )
 
     def _guidance_root(self, guidance_ids: tuple[str, ...]) -> Path:
         """Return the project root used for declared execution guidance."""
@@ -1920,13 +2063,23 @@ class OrchestratorRunner:
         """Build the durable resolved inputs shared by resume and proof cohorting."""
         from ouroboros.orchestrator.model_routing import serialize_model_router
 
+        # The runner owns the execution permission policy.  Reapply it at the
+        # planning boundary so a mutable adapter cannot carry a stale
+        # construction-time permission into the authority snapshot.  Any later
+        # mutation is still detected by the planning-to-dispatch binding.
+        try:
+            self._forced_permission_mode = self._force_adapter_permission_mode(self._adapter)
+        except ValueError:
+            raise OrchestratorError(
+                message="Cannot force the runtime permission mode for execution",
+            ) from None
         guidance_bundle = self._ensure_new_run_guidance()
         routing_contract = serialize_model_router(self._model_router)
         routing_contract["constructor_model"] = self._constructor_model_contract()
         routing_contract["runtime_execution"] = self._runtime_execution_identity_contract()
-        routing_contract["runtime_backend"] = self._runtime_backend_contract()
-        routing_contract["llm_backend"] = self._llm_backend_contract()
+        routing_contract.update(runtime_routing_labels_contract(self._adapter))
         routing_contract["permission_mode"] = self._permission_mode_contract()
+        self._capture_runtime_authority(routing_contract)
         proof_contract: dict[str, Any] = {
             "protocol_version": FRUGALITY_PROOF_PROTOCOL_VERSION,
             "routing_fingerprint": self._routing_fingerprint(routing_contract),
@@ -1977,7 +2130,7 @@ class OrchestratorRunner:
                     "session_id": session_id,
                     "efficiency_mode": self._execution_preferences.efficiency_mode.value,
                     "frugality_assurance": (self._execution_preferences.frugality_assurance.value),
-                    "primary_runtime_backend": getattr(self._adapter, "runtime_backend", "unknown"),
+                    "primary_runtime_backend": self._runtime_backend_contract() or "unknown",
                     "primary_harness_label": type(self._adapter).__name__[:80],
                     "model_routing_enabled": self._model_router is not None,
                     "requested_model_tier": self._requested_model_tier,
@@ -2078,8 +2231,7 @@ class OrchestratorRunner:
                 raise OrchestratorError(
                     message="Cannot resume a legacy session with a different Seed identity",
                     details={
-                        "persisted_seed_id": persisted_seed_id,
-                        "current_seed_id": current_seed_id,
+                        "invalid": "legacy Seed identity mismatch",
                         "hint": "Resume with the original Seed, or start a new session.",
                     },
                 )
@@ -2095,8 +2247,7 @@ class OrchestratorRunner:
                 raise OrchestratorError(
                     message="Cannot resume a legacy session with a modified Seed goal",
                     details={
-                        "persisted_seed_goal": persisted_seed_goal,
-                        "current_seed_goal": current_seed_goal,
+                        "invalid": "legacy Seed goal mismatch",
                         "hint": "Resume with the original Seed, or start a new session.",
                     },
                 )
@@ -2113,30 +2264,30 @@ class OrchestratorRunner:
             if (
                 not isinstance(persisted_runtime_backend, str)
                 or not persisted_runtime_backend.strip()
+                or is_sensitive_value(persisted_runtime_backend)
                 or current_runtime_backend != persisted_runtime_backend
             ):
                 raise OrchestratorError(
                     message="Cannot resume a legacy session with a different runtime backend",
                     details={
-                        "persisted_runtime_backend": persisted_runtime_backend,
-                        "current_runtime_backend": current_runtime_backend,
+                        "invalid": "legacy runtime backend mismatch",
                         "hint": "Resume with the original runtime, or start a new session.",
                     },
                 )
 
         if "llm_backend" in start_identity:
             persisted_llm_backend = start_identity.get("llm_backend")
-            current_llm_backend = getattr(self._adapter, "llm_backend", None)
+            current_llm_backend = self._llm_backend_contract()
             if (
                 not isinstance(persisted_llm_backend, str)
                 or not persisted_llm_backend.strip()
+                or is_sensitive_value(persisted_llm_backend)
                 or current_llm_backend != persisted_llm_backend
             ):
                 raise OrchestratorError(
                     message="Cannot resume a legacy session with a different LLM backend",
                     details={
-                        "persisted_llm_backend": persisted_llm_backend,
-                        "current_llm_backend": current_llm_backend,
+                        "invalid": "legacy LLM backend mismatch",
                         "hint": "Resume with the original backend, or start a new session.",
                     },
                 )
@@ -2154,8 +2305,7 @@ class OrchestratorRunner:
                 raise OrchestratorError(
                     message="Cannot resume a legacy session from a different project workspace",
                     details={
-                        "persisted_workspace": persisted_workspace,
-                        "current_workspace": active_workspace,
+                        "invalid": "legacy workspace mismatch",
                         "hint": "Resume from the original project/workspace.",
                     },
                 )
@@ -2176,8 +2326,7 @@ class OrchestratorRunner:
                                 "Cannot resume a legacy session from a different project workspace"
                             ),
                             details={
-                                "persisted_workspace": persisted_cwd,
-                                "current_workspace": current_cwd,
+                                "invalid": "legacy workspace mismatch",
                                 "hint": "Resume from the original project/workspace.",
                             },
                         )
@@ -2195,6 +2344,16 @@ class OrchestratorRunner:
         malformed contract blocks resume; it is never reinterpreted as a legacy
         session or allowed to change models silently.
         """
+        # Session progress is durable, untrusted input. Current-format contracts
+        # are only one nested field: legacy workspace/runtime identity checkpoints
+        # can otherwise reach mismatch diagnostics before that field is inspected.
+        # Reject a credential-shaped value anywhere in the persisted envelope
+        # before any branch echoes an attacker-controlled detail.
+        if self._contains_sensitive_contract_value(progress):
+            raise OrchestratorError(
+                message="Cannot resume with an invalid execution contract",
+                details={"invalid": "sensitive persisted data"},
+            )
         if EXECUTION_CONTRACT_PROGRESS_KEY not in progress:
             self._validate_legacy_resume_identity(progress, seed=seed)
             self._execution_guidance = self._resolve_guidance_bundle(())
@@ -2204,6 +2363,12 @@ class OrchestratorRunner:
             # instead of drifting again with each environment/config change.
             return True
         raw_contract = progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
+
+        if self._contains_sensitive_contract_value(raw_contract):
+            raise OrchestratorError(
+                message="Cannot resume with an invalid execution contract",
+                details={"invalid": "sensitive contract data"},
+            )
 
         raw_version = raw_contract.get("version") if isinstance(raw_contract, Mapping) else None
         if (
@@ -2240,8 +2405,17 @@ class OrchestratorRunner:
         persisted_seed_fingerprint = raw_proof.get("seed_fingerprint")
         persisted_constructor_model = raw_routing.get("constructor_model")
         persisted_runtime_execution = raw_routing.get("runtime_execution")
-        persisted_runtime_backend = raw_routing.get("runtime_backend")
-        persisted_llm_backend = raw_routing.get("llm_backend")
+        persisted_routing_labels = self._runtime_routing_labels_from_contract(raw_routing)
+        persisted_runtime_backend = (
+            persisted_routing_labels.get("runtime_backend")
+            if persisted_routing_labels is not None
+            else None
+        )
+        persisted_llm_backend = (
+            persisted_routing_labels.get("llm_backend")
+            if persisted_routing_labels is not None
+            else None
+        )
         persisted_permission_mode = raw_routing.get("permission_mode")
         persisted_resume_workspace = raw_resume.get("workspace")
         valid_seed_fingerprint = (
@@ -2262,16 +2436,37 @@ class OrchestratorRunner:
             or (seed is not None and not valid_seed_fingerprint)
             or not self._valid_constructor_model_contract(persisted_constructor_model)
             or not self._valid_runtime_execution_identity_contract(persisted_runtime_execution)
-            or not isinstance(persisted_runtime_backend, str)
-            or not persisted_runtime_backend.strip()
-            or not isinstance(persisted_llm_backend, str)
-            or not persisted_llm_backend.strip()
+            or persisted_routing_labels is None
             or not self._valid_permission_mode_contract(persisted_permission_mode)
             or not isinstance(persisted_resume_workspace, Mapping)
         ):
             raise OrchestratorError(
                 message="Cannot resume with an invalid execution contract",
                 details={"invalid": "proof identity"},
+            )
+        assert persisted_routing_labels is not None
+
+        # An absent or credential-shaped backend label is intentionally not
+        # serialized.  Two different live adapters would otherwise both reduce
+        # to the same ``None + *_unobserved`` representation, which cannot
+        # prove that a resumed process owns the original runtime.  Do not make
+        # a secret fingerprint part of the durable contract merely to recover
+        # this comparison; fail closed instead.
+        unobserved_labels = [
+            field_name
+            for field_name in ("runtime_backend", "llm_backend")
+            if persisted_routing_labels.get(f"{field_name}_unobserved") is True
+        ]
+        if unobserved_labels:
+            raise OrchestratorError(
+                message="Cannot resume because runtime backend identity is unobserved",
+                details={
+                    "unobserved_labels": unobserved_labels,
+                    "hint": (
+                        "Resume with a runtime that exposes non-sensitive backend labels, "
+                        "or start a new session."
+                    ),
+                },
             )
 
         persisted_preferences = execution_preferences_from_contract(raw_preferences)
@@ -2308,8 +2503,7 @@ class OrchestratorRunner:
             raise OrchestratorError(
                 message="Cannot resume from a different project workspace",
                 details={
-                    "persisted_workspace": persisted_workspace,
-                    "current_workspace": active_workspace,
+                    "invalid": "project workspace mismatch",
                     "hint": "Resume from the original project/workspace.",
                 },
             )
@@ -2318,28 +2512,32 @@ class OrchestratorRunner:
             raise OrchestratorError(
                 message="Cannot resume from a different execution workspace",
                 details={
-                    "persisted_workspace": dict(persisted_resume_workspace),
-                    "current_workspace": active_resume_workspace,
+                    "invalid": "execution workspace mismatch",
                     "hint": "Resume from the exact original worktree and branch.",
                 },
             )
-        current_runtime_backend = self._runtime_backend_contract()
-        if current_runtime_backend != persisted_runtime_backend:
+        current_routing_labels = runtime_routing_labels_contract(self._adapter)
+        if current_routing_labels.get("runtime_backend") != persisted_runtime_backend or (
+            current_routing_labels.get("runtime_backend_unobserved")
+            != persisted_routing_labels.get("runtime_backend_unobserved")
+        ):
             raise OrchestratorError(
                 message="Cannot resume with a different runtime backend",
                 details={
                     "persisted_runtime_backend": persisted_runtime_backend,
-                    "current_runtime_backend": current_runtime_backend,
+                    "current_runtime_backend": current_routing_labels.get("runtime_backend"),
                     "hint": "Resume with the original runtime, or start a new session.",
                 },
             )
-        current_llm_backend = self._llm_backend_contract()
-        if current_llm_backend != persisted_llm_backend:
+        if current_routing_labels.get("llm_backend") != persisted_llm_backend or (
+            current_routing_labels.get("llm_backend_unobserved")
+            != persisted_routing_labels.get("llm_backend_unobserved")
+        ):
             raise OrchestratorError(
                 message="Cannot resume with a different LLM backend",
                 details={
                     "persisted_llm_backend": persisted_llm_backend,
-                    "current_llm_backend": current_llm_backend,
+                    "current_llm_backend": current_routing_labels.get("llm_backend"),
                     "hint": "Restore the original LLM backend or start a new session.",
                 },
             )
@@ -2404,6 +2602,7 @@ class OrchestratorRunner:
 
         if (
             restored_router is not None
+            and persisted_routing_labels.get("runtime_backend_unobserved") is not True
             and persisted_runtime_backend != restored_router.runtime_backend
         ):
             raise OrchestratorError(
@@ -2450,6 +2649,7 @@ class OrchestratorRunner:
             return self._execution_contract != raw_contract
 
         self._model_router = restored_router
+        self._capture_runtime_authority(raw_routing)
         # Preserve the exact persisted proof identity alongside the restored
         # router. Recomputing it from a resumed throwaway worktree would make the
         # same execution appear to be a different experiment.
@@ -2499,19 +2699,24 @@ class OrchestratorRunner:
                 return None
         else:
             return None
-        runtime_backend = routing_contract.get("runtime_backend")
-        llm_backend = routing_contract.get("llm_backend")
+        routing_labels = OrchestratorRunner._runtime_routing_labels_from_contract(
+            routing_contract
+        )
         permission_mode = routing_contract.get("permission_mode")
         constructor_model = routing_contract.get("constructor_model")
         runtime_execution = routing_contract.get("runtime_execution")
         if (
-            not isinstance(runtime_backend, str)
-            or not runtime_backend.strip()
-            or not isinstance(llm_backend, str)
-            or not llm_backend.strip()
+            routing_labels is None
             or not OrchestratorRunner._valid_permission_mode_contract(permission_mode)
             or not OrchestratorRunner._valid_constructor_model_contract(constructor_model)
             or not OrchestratorRunner._valid_runtime_execution_identity_contract(runtime_execution)
+        ):
+            return None
+        # An unobserved runtime/LLM label cannot establish a durable identity
+        # for either resume or a frugality proof cohort.
+        if (
+            routing_labels.get("runtime_backend_unobserved") is True
+            or routing_labels.get("llm_backend_unobserved") is True
         ):
             return None
         protocol_version = proof_contract.get("protocol_version")
@@ -2556,31 +2761,19 @@ class OrchestratorRunner:
     def _build_dependency_analyzer(self) -> DependencyAnalyzer:
         """Create a dependency analyzer wired to the active LLM backend when available.
 
-        Legacy ``AgentRuntime`` implementations (custom runtimes, test mocks)
-        predating the ``llm_backend`` Protocol addition in v0.28.6 may not
-        define the property. We probe it via ``getattr`` and degrade to a
-        structured-only ``DependencyAnalyzer`` when the attribute is absent,
-        preserving pre-v0.28.6 behavior for downstream Protocol implementers.
+        ``llm_backend`` is an optional analysis-specific override.  When it is
+        absent, fall back to the already validated runtime backend; both labels
+        are read through the same no-secret contract used for durable routing.
         """
         from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
 
-        # Legacy-compat: adapters predating the llm_backend Protocol addition
-        # (v0.28.6) lack this attribute. Fall back to structured-only analysis
-        # rather than raising AttributeError.
-        _llm_backend_sentinel = object()
-        llm_backend = getattr(self._adapter, "llm_backend", _llm_backend_sentinel)
-        if llm_backend is _llm_backend_sentinel:
+        backend = self._llm_backend_contract() or self._runtime_backend_contract()
+        if backend is None:
             log.info(
-                "orchestrator.runner.dependency_analyzer.legacy_adapter_without_llm_backend",
-                adapter_type=type(self._adapter).__name__,
+                "orchestrator.runner.dependency_analyzer.without_safe_backend",
             )
             return DependencyAnalyzer()
 
-        backend = (
-            llm_backend
-            if isinstance(llm_backend, str) and llm_backend
-            else (self._adapter.runtime_backend)
-        )
         cli_path = getattr(self._adapter, "cli_path", None)
         resolved_cli_path = cli_path if isinstance(cli_path, str) and cli_path else None
         try:
@@ -3876,8 +4069,8 @@ class OrchestratorRunner:
             seed_id=seed.metadata.seed_id,
             session_id=session_id,
             seed_goal=seed.goal,
-            runtime_backend=getattr(self._adapter, "runtime_backend", None),
-            llm_backend=getattr(self._adapter, "llm_backend", None),
+            runtime_backend=self._runtime_backend_contract(),
+            llm_backend=self._llm_backend_contract(),
             execution_contract=execution_contract,
         )
 
@@ -4711,10 +4904,11 @@ class OrchestratorRunner:
 
         # Cap fan-out to the connected backend's concurrency constraints so a
         # parallel dispatch never stampedes the LLM's rate/quota window (R3).
-        delivery_limits = resolve_backend_limits(self._adapter.runtime_backend)
+        runtime_backend = self._runtime_backend_contract() or "unknown"
+        delivery_limits = resolve_backend_limits(runtime_backend)
         effective_workers = self._plan_parallel_workers(delivery_limits)
         dispatch_rate_policy = ResolvedDispatchRatePolicy.resolve(
-            backend=self._adapter.runtime_backend,
+            backend=runtime_backend,
             self_governs_rate_limit=bool(getattr(self._adapter, "self_governs_rate_limit", False)),
             requests_per_minute=delivery_limits.requests_per_minute,
             tokens_per_minute=delivery_limits.tokens_per_minute,
@@ -4722,12 +4916,12 @@ class OrchestratorRunner:
         if effective_workers < self._max_parallel_workers:
             self._console.print(
                 f"[yellow]Fan-out capped to {effective_workers} worker(s) for backend "
-                f"'{self._adapter.runtime_backend}' (requested {self._max_parallel_workers}). "
+                f"'{runtime_backend}' (requested {self._max_parallel_workers}). "
                 f"Override with OUROBOROS_MAX_CONCURRENCY.[/yellow]"
             )
             log.info(
                 "orchestrator.runner.fan_out_capped",
-                runtime_backend=self._adapter.runtime_backend,
+                runtime_backend=runtime_backend,
                 requested_workers=self._max_parallel_workers,
                 effective_workers=effective_workers,
             )
@@ -4749,10 +4943,7 @@ class OrchestratorRunner:
         )
         if not isinstance(resolved_routing, Mapping):
             raise OrchestratorError(message="Parallel runtime authority is missing")
-        bound_runtime_authority = ResolvedRuntimeAuthority.bind(
-            self._adapter,
-            resolved_routing,
-        )
+        bound_runtime_authority = self._parallel_runtime_authority(resolved_routing)
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
             event_store=self._event_store,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -89,6 +89,7 @@ from ouroboros.orchestrator.events import (
     create_workflow_progress_event,
 )
 from ouroboros.orchestrator.execution_authority import (
+    ResolvedRuntimeAuthority,
     constructor_model_contract,
     runtime_execution_identity_contract,
     runtime_execution_proves_effective_model,
@@ -4722,6 +4723,24 @@ class OrchestratorRunner:
         # Execute in parallel. Reuse the base effort resolved once in __init__
         # (self._reasoning_effort) so a single runner instance has one consistent
         # effort source across its direct paths and the parallel executor.
+        from ouroboros.config import get_cross_harness_redispatch_enabled
+
+        cross_harness_redispatch = get_cross_harness_redispatch_enabled()
+        raw_execution_contract = self._execution_contract
+        if not isinstance(raw_execution_contract, Mapping):
+            raw_execution_contract = self._build_execution_contract(seed=seed)
+            self._execution_contract = raw_execution_contract
+        resolved_routing = raw_execution_contract.get("model_routing")
+        raw_resume = raw_execution_contract.get("resume")
+        workspace_identity = (
+            raw_resume.get("workspace") if isinstance(raw_resume, Mapping) else None
+        )
+        if not isinstance(resolved_routing, Mapping):
+            raise OrchestratorError(message="Parallel runtime authority is missing")
+        bound_runtime_authority = ResolvedRuntimeAuthority.bind(
+            self._adapter,
+            resolved_routing,
+        )
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
             event_store=self._event_store,
@@ -4740,8 +4759,13 @@ class OrchestratorRunner:
             run_verify_commands=self._run_verify_commands,
             verify_command_timeout_seconds=self._verify_command_timeout_seconds,
             ac_retry_attempts=self._ac_retry_attempts,
+            cross_harness_redispatch=cross_harness_redispatch,
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
+            resolved_routing_authority=bound_runtime_authority,
+            workspace_authority_identity=(
+                workspace_identity if isinstance(workspace_identity, Mapping) else None
+            ),
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1424,9 +1424,7 @@ class OrchestratorRunner:
     ) -> RuntimeHandle | None:
         """Seed a runtime handle with startup metadata before execution begins."""
         inherited_backend = (
-            self._safe_backend_label(runtime_handle.backend)
-            if runtime_handle is not None
-            else None
+            self._safe_backend_label(runtime_handle.backend) if runtime_handle is not None else None
         )
         # A resume handle with a missing or credential-shaped backend cannot be
         # safely attributed to this run. Do not carry its raw label into runtime
@@ -2699,9 +2697,7 @@ class OrchestratorRunner:
                 return None
         else:
             return None
-        routing_labels = OrchestratorRunner._runtime_routing_labels_from_contract(
-            routing_contract
-        )
+        routing_labels = OrchestratorRunner._runtime_routing_labels_from_contract(routing_contract)
         permission_mode = routing_contract.get("permission_mode")
         constructor_model = routing_contract.get("constructor_model")
         runtime_execution = routing_contract.get("runtime_execution")

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ouroboros.core.errors import PersistenceError
+from ouroboros.core.security import is_sensitive_value
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent, sanitize_event_data_for_persistence
 from ouroboros.observability.logging import get_logger
@@ -671,10 +672,21 @@ class SessionRepository:
         }
         if seed_goal:
             event_data["seed_goal"] = seed_goal
-        if runtime_backend:
-            event_data["runtime_backend"] = runtime_backend
-        if llm_backend:
-            event_data["llm_backend"] = llm_backend
+        # These labels are observability metadata, not credentials. Omit an
+        # untrusted label rather than persisting a credential-shaped value even
+        # when a caller bypasses the runner's normalized contract path.
+        if (
+            isinstance(runtime_backend, str)
+            and runtime_backend.strip()
+            and not is_sensitive_value(runtime_backend)
+        ):
+            event_data["runtime_backend"] = runtime_backend.strip()
+        if (
+            isinstance(llm_backend, str)
+            and llm_backend.strip()
+            and not is_sensitive_value(llm_backend)
+        ):
+            event_data["llm_backend"] = llm_backend.strip()
         if execution_contract is not None:
             event_data["execution_contract"] = sanitize_event_data_for_persistence(
                 dict(execution_contract)

--- a/src/ouroboros/orchestrator/skill_intercept.py
+++ b/src/ouroboros/orchestrator/skill_intercept.py
@@ -95,6 +95,22 @@ class SkillInterceptor:
 
     # -- public entry point -------------------------------------------------
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare the static policy that determines delegated skill dispatch."""
+        return {
+            "version": 1,
+            "configuration": {
+                "cwd": self._cwd,
+                "runtime_backend": self._runtime_backend,
+                "runtime_handle_backend": self._runtime_handle_backend,
+                "permission_mode": self._permission_mode,
+                "llm_backend": self._llm_backend,
+                "log_namespace": self._log_namespace,
+                "skills_dir": str(self._skills_dir) if self._skills_dir is not None else None,
+                "dispatch_protocol_version": 1,
+            },
+        }
+
     async def maybe_dispatch(
         self,
         prompt: str,

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -16,7 +16,7 @@ the SAME pool code — only the transport differs.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 import os
@@ -73,6 +73,16 @@ class LeaderDrivenWorkerTransport(Protocol):
     @property
     def backend_name(self) -> str:
         """Canonical backend id stamped into the emitted ``RuntimeHandle``."""
+        ...
+
+    def execution_identity_contract(self) -> Mapping[str, object]:
+        """Return the versioned static execution policy.
+
+        Shape: ``{"version": 1, "configuration": {...}}``. The configuration
+        owns all execution-relevant static state, including delegated-client
+        identity, but excludes credentials and live session state. Legacy
+        transports remain usable but receive process-local authority.
+        """
         ...
 
     async def spawn(
@@ -147,6 +157,10 @@ class LeaderDrivenWorkerRuntime:
         self._model_override_support = model_override_support
         self._targeted_resume = targeted_resume
         self._provider_name = runtime_backend
+
+    def execution_components(self) -> Mapping[str, object]:
+        """Declare the transport as this runtime's execution composition boundary."""
+        return {"transport": self._transport}
 
     # -- AgentRuntime Protocol properties ---------------------------------
 

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -162,6 +162,28 @@ class LeaderDrivenWorkerRuntime:
         """Declare the transport as this runtime's execution composition boundary."""
         return {"transport": self._transport}
 
+    def execution_identity_contract(self) -> Mapping[str, object]:
+        """Describe the static worker-runtime policy, excluding live sessions.
+
+        The transport itself is separately declared through
+        :meth:`execution_components`; this envelope records only the generic
+        adapter switches that alter how Ouroboros invokes that transport.  In
+        particular, neither the live worker pool nor a selected resume handle
+        belongs to the Foundation-A baseline.
+        """
+        return {
+            "version": 1,
+            "effective_model_observed": True,
+            "targeted_resume": self._targeted_resume,
+            "reasoning_effort_support": self._reasoning_effort_support.value,
+            "enforceable_reasoning_efforts": (
+                sorted(self._enforceable_reasoning_efforts)
+                if self._enforceable_reasoning_efforts is not None
+                else None
+            ),
+            "model_override_support": self._model_override_support.value,
+        }
+
     # -- AgentRuntime Protocol properties ---------------------------------
 
     @property

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -151,6 +151,8 @@ class TestSensitiveDetection:
         assert is_sensitive_value("hello world") is False
         assert is_sensitive_value("model-gpt-4") is False
         assert is_sensitive_value("quoted_secret_preview") is False
+        assert is_sensitive_value("Implement token budget accounting") is False
+        assert is_sensitive_value("Adopt an API-first design") is False
         assert is_sensitive_value(123) is False
 
     def test_diagnostic_text_with_embedded_secret_remains_sensitive(self) -> None:

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -20,6 +20,7 @@ from ouroboros.core.security import (
     is_sensitive_value,
     mask_api_key,
     mask_sensitive_value,
+    redact_sensitive_text,
     sanitize_for_logging,
     truncate_input,
     validate_api_key_format,
@@ -149,7 +150,20 @@ class TestSensitiveDetection:
         """Normal values are not flagged."""
         assert is_sensitive_value("hello world") is False
         assert is_sensitive_value("model-gpt-4") is False
+        assert is_sensitive_value("quoted_secret_preview") is False
         assert is_sensitive_value(123) is False
+
+    def test_diagnostic_text_with_embedded_secret_remains_sensitive(self) -> None:
+        """Global credential detection remains fail-closed for diagnostics."""
+        text = "command: deploy --api-key sk-live-SECRET123"
+        assert is_sensitive_value(text) is True
+        assert redact_sensitive_text(text) == "command: deploy --api-key [redacted]"
+
+    def test_compact_assignment_with_embedded_secret_remains_sensitive(self) -> None:
+        """Identity/configuration consumers must reject compact secret values."""
+        value = "key=" + "AIza" + "A" * 35
+        assert is_sensitive_value(value) is True
+        assert redact_sensitive_text(value) == "key=[redacted]"
 
 
 class TestMaskSensitiveValue:

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -16,6 +16,7 @@ from ouroboros.core.security import (
     MAX_SEED_FILE_SIZE,
     MAX_USER_RESPONSE_LENGTH,
     InputValidator,
+    is_sensitive_credential_field,
     is_sensitive_field,
     is_sensitive_value,
     mask_api_key,
@@ -101,6 +102,21 @@ class TestSensitiveDetection:
         assert is_sensitive_field("ANTHROPIC_API_KEY") is True
         assert is_sensitive_field("my_secret_value") is True
 
+    @pytest.mark.parametrize(
+        "field_name",
+        ("apiKeyValue", "accessTokenValue", "api_key", "auth", "authentication"),
+    )
+    def test_sensitive_credential_field_aliases(self, field_name: str) -> None:
+        """Durable-contract screening recognizes common credential aliases."""
+        assert is_sensitive_credential_field(field_name) is True
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ("token_estimator", "resume_token", "resumeTokenValue", "key_value"),
+    )
+    def test_semantic_or_protocol_fields_are_not_credential_aliases(self, field_name: str) -> None:
+        assert is_sensitive_credential_field(field_name) is False
+
     def test_non_sensitive_field_names(self) -> None:
         """Normal field names are not flagged."""
         assert is_sensitive_field("name") is False
@@ -155,17 +171,51 @@ class TestSensitiveDetection:
         assert is_sensitive_value("Implement token budget accounting") is False
         assert is_sensitive_value("token budget accounting") is False
         assert is_sensitive_value("Adopt an API-first design") is False
+        assert is_sensitive_value("Adopt API-first-design-for-internal-services") is False
         assert is_sensitive_value(123) is False
 
-    def test_generic_credential_prefixes_require_opaque_payloads(self) -> None:
+    def test_generic_credential_prefixes_require_structured_opaque_payloads(self) -> None:
+        payload = "a" * 14 + "123456"
         assert is_sensitive_value("api-" + "a" * 20) is True
-        assert is_sensitive_value("token " + "a" * 20) is True
+        assert is_sensitive_value("token " + payload) is True
+        assert is_sensitive_value("token internationalization") is False
+
+    def test_hyphenated_api_prose_remains_non_sensitive(self) -> None:
+        """A long API-first goal is semantic data, not a generic credential."""
+        value = "Adopt API-first-design-for-internal-services"
+        assert is_sensitive_value(value) is False
+        assert redact_sensitive_text(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ("PK-based authentication should remain durable", "secret_rotation_workflow"),
+    )
+    def test_ambiguous_security_prefix_prose_remains_non_sensitive(self, value: str) -> None:
+        """Bare ``pk-`` and ``secret_`` prefixes do not identify credentials."""
+        assert is_sensitive_value(value) is False
+        assert redact_sensitive_text(value) == value
 
     @pytest.mark.parametrize(
         ("value", "expected"),
         (
-            ("retry with token " + "a" * 20, "retry with token [redacted]"),
+            ("retry with token " + "a" * 14 + "123456", "retry with token [redacted]"),
             ("retry with api-" + "a" * 20, "retry with api-[redacted]"),
+            (
+                "retry with api-abcdefghij-klmnopqrst",
+                "retry with api-[redacted]",
+            ),
+            (
+                "retry with token abcdefghijklmnopqrst/uvwxyz",
+                "retry with token [redacted]",
+            ),
+            (
+                "retry with token abcdefghijklmnopqrst+uvwxyz",
+                "retry with token [redacted]",
+            ),
+            (
+                "retry with token \u200b" + "a" * 14 + "123456",
+                "retry with token \u200b[redacted]",
+            ),
         ),
     )
     def test_embedded_generic_credential_text_is_sensitive_and_redacted(
@@ -178,11 +228,34 @@ class TestSensitiveDetection:
         assert is_sensitive_value(value) is True
         assert redact_sensitive_text(value) == expected
 
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "Implement token internationalization",
+            "Implement token compartmentalization",
+            "Discuss token hyperparameterization",
+        ),
+    )
+    def test_long_semantic_token_words_remain_non_sensitive(self, value: str) -> None:
+        """Long natural-language words must survive replay unchanged."""
+        assert is_sensitive_value(value) is False
+        assert redact_sensitive_text(value) == value
+
     def test_diagnostic_text_with_embedded_secret_remains_sensitive(self) -> None:
         """Global credential detection remains fail-closed for diagnostics."""
         text = "command: deploy --api-key sk-live-SECRET123"
         assert is_sensitive_value(text) is True
         assert redact_sensitive_text(text) == "command: deploy --api-key [redacted]"
+
+    def test_embedded_stripe_and_pem_private_key_values_are_redacted(self) -> None:
+        """Credential shapes beyond prefix-only forms cannot reach diagnostics."""
+        stripe = "sk_live_" + "a" * 24
+        pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
+
+        assert is_sensitive_value(f"retry with {stripe}") is True
+        assert redact_sensitive_text(f"retry with {stripe}") == "retry with [redacted]"
+        assert is_sensitive_value(f"retry with {pem}") is True
+        assert redact_sensitive_text(f"retry with {pem}") == "retry with [redacted]"
 
     def test_compact_assignment_with_embedded_secret_remains_sensitive(self) -> None:
         """Identity/configuration consumers must reject compact secret values."""

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -161,6 +161,23 @@ class TestSensitiveDetection:
         assert is_sensitive_value("api-" + "a" * 20) is True
         assert is_sensitive_value("token " + "a" * 20) is True
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        (
+            ("retry with token " + "a" * 20, "retry with token [redacted]"),
+            ("retry with api-" + "a" * 20, "retry with api-[redacted]"),
+        ),
+    )
+    def test_embedded_generic_credential_text_is_sensitive_and_redacted(
+        self,
+        value: str,
+        expected: str,
+    ) -> None:
+        """A generic opaque token cannot evade detection inside diagnostic prose."""
+
+        assert is_sensitive_value(value) is True
+        assert redact_sensitive_text(value) == expected
+
     def test_diagnostic_text_with_embedded_secret_remains_sensitive(self) -> None:
         """Global credential detection remains fail-closed for diagnostics."""
         text = "command: deploy --api-key sk-live-SECRET123"

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -104,7 +104,7 @@ class TestSensitiveDetection:
 
     @pytest.mark.parametrize(
         "field_name",
-        ("apiKeyValue", "accessTokenValue", "api_key", "auth", "authentication"),
+        ("apiKeyValue", "accessTokenValue", "api_key", "auth", "authentication", "bearer"),
     )
     def test_sensitive_credential_field_aliases(self, field_name: str) -> None:
         """Durable-contract screening recognizes common credential aliases."""
@@ -129,6 +129,7 @@ class TestSensitiveDetection:
         assert is_sensitive_value("sk-1234567890") is True
         assert is_sensitive_value("Bearer token123") is True
         assert is_sensitive_value("ghp_abcdefghijklmnopqrstuvwxyz1234567890") is True
+        assert is_sensitive_value("rk_live_" + "a" * 32) is True
         assert is_sensitive_value("AIzaXXXXXXXXXXXXXXX") is True
 
     @pytest.mark.parametrize("separator", (":", "/", "_", "\u200b"))
@@ -250,10 +251,13 @@ class TestSensitiveDetection:
     def test_embedded_stripe_and_pem_private_key_values_are_redacted(self) -> None:
         """Credential shapes beyond prefix-only forms cannot reach diagnostics."""
         stripe = "sk_live_" + "a" * 24
+        restricted = "rk_live_" + "b" * 24
         pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
 
         assert is_sensitive_value(f"retry with {stripe}") is True
         assert redact_sensitive_text(f"retry with {stripe}") == "retry with [redacted]"
+        assert is_sensitive_value(f"retry with {restricted}") is True
+        assert redact_sensitive_text(f"retry with {restricted}") == "retry with [redacted]"
         assert is_sensitive_value(f"retry with {pem}") is True
         assert redact_sensitive_text(f"retry with {pem}") == "retry with [redacted]"
 

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -130,7 +130,24 @@ class TestSensitiveDetection:
         assert is_sensitive_value("Bearer token123") is True
         assert is_sensitive_value("ghp_abcdefghijklmnopqrstuvwxyz1234567890") is True
         assert is_sensitive_value("rk_live_" + "a" * 32) is True
+        assert is_sensitive_value("rk_test_" + "b" * 32) is True
         assert is_sensitive_value("AIzaXXXXXXXXXXXXXXX") is True
+
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "rk_live_",
+            "rk_test_",
+            "rk_live_fixture_name",
+            "rk_test_fixture_name",
+            "A note about rk_live_ keys",
+            "A note about rk_test_ keys",
+        ),
+    )
+    def test_short_restricted_key_labels_and_prose_are_not_sensitive(self, value: str) -> None:
+        """A restricted-key prefix needs an opaque payload before it is a credential."""
+        assert is_sensitive_value(value) is False
+        assert redact_sensitive_text(value) == value
 
     @pytest.mark.parametrize("separator", (":", "/", "_", "\u200b"))
     def test_sensitive_values_embedded_after_a_label(self, separator: str) -> None:
@@ -252,12 +269,15 @@ class TestSensitiveDetection:
         """Credential shapes beyond prefix-only forms cannot reach diagnostics."""
         stripe = "sk_live_" + "a" * 24
         restricted = "rk_live_" + "b" * 24
+        restricted_test = "rk_test_" + "c" * 24
         pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
 
         assert is_sensitive_value(f"retry with {stripe}") is True
         assert redact_sensitive_text(f"retry with {stripe}") == "retry with [redacted]"
         assert is_sensitive_value(f"retry with {restricted}") is True
         assert redact_sensitive_text(f"retry with {restricted}") == "retry with [redacted]"
+        assert is_sensitive_value(f"retry with {restricted_test}") is True
+        assert redact_sensitive_text(f"retry with {restricted_test}") == "retry with [redacted]"
         assert is_sensitive_value(f"retry with {pem}") is True
         assert redact_sensitive_text(f"retry with {pem}") == "retry with [redacted]"
 

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -151,9 +151,15 @@ class TestSensitiveDetection:
         assert is_sensitive_value("hello world") is False
         assert is_sensitive_value("model-gpt-4") is False
         assert is_sensitive_value("quoted_secret_preview") is False
+        assert is_sensitive_value("API-first design") is False
         assert is_sensitive_value("Implement token budget accounting") is False
+        assert is_sensitive_value("token budget accounting") is False
         assert is_sensitive_value("Adopt an API-first design") is False
         assert is_sensitive_value(123) is False
+
+    def test_generic_credential_prefixes_require_opaque_payloads(self) -> None:
+        assert is_sensitive_value("api-" + "a" * 20) is True
+        assert is_sensitive_value("token " + "a" * 20) is True
 
     def test_diagnostic_text_with_embedded_secret_remains_sensitive(self) -> None:
         """Global credential detection remains fail-closed for diagnostics."""

--- a/tests/unit/core/test_security.py
+++ b/tests/unit/core/test_security.py
@@ -8,6 +8,8 @@ Tests cover:
 - Sanitization for logging
 """
 
+import pytest
+
 from ouroboros.core.security import (
     MAX_INITIAL_CONTEXT_LENGTH,
     MAX_LLM_RESPONSE_LENGTH,
@@ -109,7 +111,39 @@ class TestSensitiveDetection:
         """Values that look like secrets are detected."""
         assert is_sensitive_value("sk-1234567890") is True
         assert is_sensitive_value("Bearer token123") is True
+        assert is_sensitive_value("ghp_abcdefghijklmnopqrstuvwxyz1234567890") is True
         assert is_sensitive_value("AIzaXXXXXXXXXXXXXXX") is True
+
+    @pytest.mark.parametrize("separator", (":", "/", "_", "\u200b"))
+    def test_sensitive_values_embedded_after_a_label(self, separator: str) -> None:
+        """A provider label cannot hide a credential-shaped token."""
+        secret = "ghp_" + "a" * 36
+        assert is_sensitive_value(f"claude{separator}{secret}") is True
+
+    @pytest.mark.parametrize(
+        "prefix",
+        (" \t", "\x00", "\u200b", "\ufeff", "\u2060", "\u034f", "\ufe0f"),
+    )
+    def test_sensitive_values_remain_sensitive_after_prefix_normalization(
+        self,
+        prefix: str,
+    ) -> None:
+        """Whitespace and invisible format prefixes cannot bypass detection."""
+        secret = "ghp_" + "a" * 36
+        assert is_sensitive_value(f"{prefix}{secret}\n") is True
+
+    @pytest.mark.parametrize(
+        "credential",
+        (
+            "glpat-sentinel-not-a-real-token-123456",
+            "hf_abcdefghijklmnopqrstuvwxyz123456",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZW50aW5lbCJ9.c2lnbmF0dXJl",
+        ),
+    )
+    def test_structured_sensitive_values(self, credential: str) -> None:
+        """Common provider/JWT forms are sensitive even under benign keys."""
+        assert is_sensitive_value(credential) is True
+        assert is_sensitive_value(f"provider:{credential}") is True
 
     def test_non_sensitive_values(self) -> None:
         """Normal values are not flagged."""
@@ -165,6 +199,12 @@ class TestSanitizeForLogging:
         result = sanitize_for_logging(data)
         assert "sk-" in result["some_field"]
         assert "abcdef" not in result["some_field"]  # Fully masked
+
+    def test_sanitize_whitespace_prefixed_sensitive_value(self) -> None:
+        """The full credential never survives a whitespace-prefixed value."""
+        secret = "ghp_" + "a" * 36
+        result = sanitize_for_logging({"some_field": f" \t{secret}"})
+        assert secret not in str(result)
 
 
 class TestTruncateInput:

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -433,8 +433,15 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
 def test_persistence_sanitizer_redacts_embedded_stripe_and_pem_credentials() -> None:
     """Benign keys cannot allow common credential formats into durable events."""
     stripe = "sk_live_" + "a" * 24
+    restricted = "rk_live_" + "b" * 24
+    bearer = "c" * 32
     pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
-    payload = {"detail": f"retry with {stripe}", "certificate": pem}
+    payload = {
+        "detail": f"retry with {stripe}",
+        "restricted_detail": f"retry with {restricted}",
+        "certificate": pem,
+        "bearer": bearer,
+    }
 
     persisted = BaseEvent(
         type="test.event.created",
@@ -444,6 +451,10 @@ def test_persistence_sanitizer_redacts_embedded_stripe_and_pem_credentials() -> 
     ).to_db_dict()["payload"]
 
     assert stripe not in persisted
+    assert restricted not in persisted
+    assert bearer not in persisted
     assert pem not in persisted
     assert persisted["detail"] == "retry with [redacted]"
+    assert persisted["restricted_detail"] == "retry with [redacted]"
     assert persisted["certificate"] == "[redacted]"
+    assert persisted["bearer"] == "<REDACTED>"

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from ouroboros.events.base import BaseEvent
+from ouroboros.events.base import BaseEvent, sanitize_event_data_for_persistence
 
 
 class TestBaseEventConstruction:
@@ -343,3 +343,41 @@ class TestBaseEventVersion:
         }
         event = BaseEvent.from_db_row(row)
         assert event.event_version == 0
+
+
+def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_keys() -> None:
+    """Persistence redacts credentials but preserves replay and dedupe keys."""
+    secret = "ghp_" + "a" * 36
+    payload = {
+        "runtime_backend": "\u034f" + secret,
+        "nested": {"label": "\u200b" + secret},
+        secret: "not-a-secret-value",
+        "api_key": "unprefixed-provider-credential-1234567890",
+        "semantic_ac_key": "ac_123",
+        "idempotency_key": "turn-1",
+        "correlation_key": "lane-1",
+        "safe": "claude",
+    }
+
+    sanitized = sanitize_event_data_for_persistence(payload)
+    persisted = BaseEvent(
+        type="test.event.created",
+        aggregate_type="test",
+        aggregate_id="event-sanitization",
+        data=payload,
+    ).to_db_dict()["payload"]
+
+    assert sanitized["runtime_backend"] == "<REDACTED>"
+    assert sanitized["nested"]["label"] == "<REDACTED>"
+    assert secret not in sanitized
+    assert sanitized["api_key"] == "<REDACTED>"
+    assert sanitized["semantic_ac_key"] == "ac_123"
+    assert sanitized["idempotency_key"] == "turn-1"
+    assert sanitized["correlation_key"] == "lane-1"
+    assert persisted["api_key"] == "<REDACTED>"
+    assert persisted["semantic_ac_key"] == "ac_123"
+    assert persisted["idempotency_key"] == "turn-1"
+    assert persisted["correlation_key"] == "lane-1"
+    assert "unprefixed-provider-credential-1234567890" not in str(persisted)
+    assert secret not in str(sanitized)
+    assert secret not in str(persisted)

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -381,3 +381,23 @@ def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_key
     assert "unprefixed-provider-credential-1234567890" not in str(persisted)
     assert secret not in str(sanitized)
     assert secret not in str(persisted)
+
+
+def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
+    """Natural-language data must not be mistaken for credential metadata."""
+    payload = {
+        "goal": "Implement token budget accounting",
+        "criterion": "Adopt an API-first design",
+    }
+
+    sanitized = sanitize_event_data_for_persistence(payload)
+    persisted = BaseEvent(
+        type="test.event.created",
+        aggregate_type="test",
+        aggregate_id="event-semantic-text",
+        data=payload,
+    ).to_db_dict()["payload"]
+
+    assert sanitized == payload
+    assert persisted["goal"] == payload["goal"]
+    assert persisted["criterion"] == payload["criterion"]

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -348,13 +348,17 @@ class TestBaseEventVersion:
 def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_keys() -> None:
     """Persistence redacts credentials but preserves replay and dedupe keys."""
     secret = "ghp_" + "a" * 36
-    generic_secret = "a" * 20
+    generic_secret = "a" * 14 + "123456"
     payload = {
         "runtime_backend": "\u034f" + secret,
         "nested": {"label": "\u200b" + secret},
         "detail": f"retry with token {generic_secret}",
         secret: "not-a-secret-value",
         "api_key": "unprefixed-provider-credential-1234567890",
+        "apiKeyValue": "opaque-provider-credential-1234567890",
+        "accessTokenValue": "opaque-provider-access-token-1234567890",
+        "auth": "opaque-provider-authentication-1234567890",
+        "authentication": "opaque-provider-authentication-1234567890",
         "semantic_ac_key": "ac_123",
         "idempotency_key": "turn-1",
         "correlation_key": "lane-1",
@@ -374,10 +378,18 @@ def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_key
     assert sanitized["detail"] == "retry with token [redacted]"
     assert secret not in sanitized
     assert sanitized["api_key"] == "<REDACTED>"
+    assert sanitized["apiKeyValue"] == "<REDACTED>"
+    assert sanitized["accessTokenValue"] == "<REDACTED>"
+    assert sanitized["auth"] == "<REDACTED>"
+    assert sanitized["authentication"] == "<REDACTED>"
     assert sanitized["semantic_ac_key"] == "ac_123"
     assert sanitized["idempotency_key"] == "turn-1"
     assert sanitized["correlation_key"] == "lane-1"
     assert persisted["api_key"] == "<REDACTED>"
+    assert persisted["apiKeyValue"] == "<REDACTED>"
+    assert persisted["accessTokenValue"] == "<REDACTED>"
+    assert persisted["auth"] == "<REDACTED>"
+    assert persisted["authentication"] == "<REDACTED>"
     assert persisted["semantic_ac_key"] == "ac_123"
     assert persisted["idempotency_key"] == "turn-1"
     assert persisted["correlation_key"] == "lane-1"
@@ -393,8 +405,11 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
     payload = {
         "goal": "Implement token budget accounting",
         "criterion": "Adopt an API-first design",
+        "hyphenated_criterion": "Adopt API-first-design-for-internal-services",
         "direct_goal": "token budget accounting",
         "direct_criterion": "API-first design",
+        "authentication_note": "PK-based authentication should remain durable",
+        "workflow": "secret_rotation_workflow",
     }
 
     sanitized = sanitize_event_data_for_persistence(payload)
@@ -408,5 +423,27 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
     assert sanitized == payload
     assert persisted["goal"] == payload["goal"]
     assert persisted["criterion"] == payload["criterion"]
+    assert persisted["hyphenated_criterion"] == payload["hyphenated_criterion"]
     assert persisted["direct_goal"] == payload["direct_goal"]
     assert persisted["direct_criterion"] == payload["direct_criterion"]
+    assert persisted["authentication_note"] == payload["authentication_note"]
+    assert persisted["workflow"] == payload["workflow"]
+
+
+def test_persistence_sanitizer_redacts_embedded_stripe_and_pem_credentials() -> None:
+    """Benign keys cannot allow common credential formats into durable events."""
+    stripe = "sk_live_" + "a" * 24
+    pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
+    payload = {"detail": f"retry with {stripe}", "certificate": pem}
+
+    persisted = BaseEvent(
+        type="test.event.created",
+        aggregate_type="test",
+        aggregate_id="event-credential-shapes",
+        data=payload,
+    ).to_db_dict()["payload"]
+
+    assert stripe not in persisted
+    assert pem not in persisted
+    assert persisted["detail"] == "retry with [redacted]"
+    assert persisted["certificate"] == "[redacted]"

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -410,6 +410,8 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
         "direct_criterion": "API-first design",
         "authentication_note": "PK-based authentication should remain durable",
         "workflow": "secret_rotation_workflow",
+        "restricted_key_label": "rk_live_fixture_name",
+        "restricted_key_prose": "A note about rk_live_ keys",
     }
 
     sanitized = sanitize_event_data_for_persistence(payload)
@@ -428,17 +430,21 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
     assert persisted["direct_criterion"] == payload["direct_criterion"]
     assert persisted["authentication_note"] == payload["authentication_note"]
     assert persisted["workflow"] == payload["workflow"]
+    assert persisted["restricted_key_label"] == payload["restricted_key_label"]
+    assert persisted["restricted_key_prose"] == payload["restricted_key_prose"]
 
 
 def test_persistence_sanitizer_redacts_embedded_stripe_and_pem_credentials() -> None:
     """Benign keys cannot allow common credential formats into durable events."""
     stripe = "sk_live_" + "a" * 24
     restricted = "rk_live_" + "b" * 24
+    restricted_test = "rk_test_" + "c" * 24
     bearer = "c" * 32
     pem = "-----BEGIN PRIVATE KEY-----\nprivate material\n-----END PRIVATE KEY-----"
     payload = {
         "detail": f"retry with {stripe}",
         "restricted_detail": f"retry with {restricted}",
+        "restricted_test_detail": f"retry with {restricted_test}",
         "certificate": pem,
         "bearer": bearer,
     }
@@ -452,9 +458,11 @@ def test_persistence_sanitizer_redacts_embedded_stripe_and_pem_credentials() -> 
 
     assert stripe not in persisted
     assert restricted not in persisted
+    assert restricted_test not in persisted
     assert bearer not in persisted
     assert pem not in persisted
     assert persisted["detail"] == "retry with [redacted]"
     assert persisted["restricted_detail"] == "retry with [redacted]"
+    assert persisted["restricted_test_detail"] == "retry with [redacted]"
     assert persisted["certificate"] == "[redacted]"
     assert persisted["bearer"] == "<REDACTED>"

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -388,6 +388,8 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
     payload = {
         "goal": "Implement token budget accounting",
         "criterion": "Adopt an API-first design",
+        "direct_goal": "token budget accounting",
+        "direct_criterion": "API-first design",
     }
 
     sanitized = sanitize_event_data_for_persistence(payload)
@@ -401,3 +403,5 @@ def test_persistence_sanitizer_preserves_benign_security_terms() -> None:
     assert sanitized == payload
     assert persisted["goal"] == payload["goal"]
     assert persisted["criterion"] == payload["criterion"]
+    assert persisted["direct_goal"] == payload["direct_goal"]
+    assert persisted["direct_criterion"] == payload["direct_criterion"]

--- a/tests/unit/events/test_base.py
+++ b/tests/unit/events/test_base.py
@@ -348,9 +348,11 @@ class TestBaseEventVersion:
 def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_keys() -> None:
     """Persistence redacts credentials but preserves replay and dedupe keys."""
     secret = "ghp_" + "a" * 36
+    generic_secret = "a" * 20
     payload = {
         "runtime_backend": "\u034f" + secret,
         "nested": {"label": "\u200b" + secret},
+        "detail": f"retry with token {generic_secret}",
         secret: "not-a-secret-value",
         "api_key": "unprefixed-provider-credential-1234567890",
         "semantic_ac_key": "ac_123",
@@ -369,6 +371,7 @@ def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_key
 
     assert sanitized["runtime_backend"] == "<REDACTED>"
     assert sanitized["nested"]["label"] == "<REDACTED>"
+    assert sanitized["detail"] == "retry with token [redacted]"
     assert secret not in sanitized
     assert sanitized["api_key"] == "<REDACTED>"
     assert sanitized["semantic_ac_key"] == "ac_123"
@@ -381,6 +384,8 @@ def test_persistence_sanitizer_redacts_credentials_without_dropping_protocol_key
     assert "unprefixed-provider-credential-1234567890" not in str(persisted)
     assert secret not in str(sanitized)
     assert secret not in str(persisted)
+    assert generic_secret not in str(sanitized)
+    assert generic_secret not in str(persisted)
 
 
 def test_persistence_sanitizer_preserves_benign_security_terms() -> None:

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -153,6 +153,8 @@ async def test_alternate_runtime_preserves_verification_policy(
         assert alt_executor._run_verify_commands is False
         assert alt_executor._verify_command_timeout_seconds == 7
         assert alt_executor._ac_retry_attempts == 0
+        assert alt_executor._dispatch_rate_policy.backend == "codex_cli"
+        assert alt_executor._dispatch_rate_policy.self_governs_rate_limit is True
         return _succeeded()
 
     monkeypatch.setattr(

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -17,11 +17,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.orchestrator import cross_harness_redispatch as chr
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.parallel_executor_models import ACExecutionResult
 
 
-def _make_executor(*, enabled: bool) -> ParallelACExecutor:
+def _make_executor(
+    *,
+    enabled: bool,
+    run_verify_commands: bool = True,
+    verify_command_timeout_seconds: int = 600,
+) -> ParallelACExecutor:
     adapter = MagicMock()
     adapter.runtime_backend = "claude"
     adapter.working_directory = "/tmp/work"
@@ -31,6 +37,8 @@ def _make_executor(*, enabled: bool) -> ParallelACExecutor:
         event_store=AsyncMock(),
         console=MagicMock(),
         enable_decomposition=False,
+        run_verify_commands=run_verify_commands,
+        verify_command_timeout_seconds=verify_command_timeout_seconds,
         cross_harness_redispatch=enabled,
     )
     return executor
@@ -118,6 +126,105 @@ async def test_alternate_runtime_is_created_with_forced_bypass(
 
     assert result is not None and result.success is True
     assert created_kwargs["permission_mode"] == "bypassPermissions"
+
+
+@pytest.mark.asyncio
+async def test_alternate_runtime_preserves_verification_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _make_executor(
+        enabled=True,
+        run_verify_commands=False,
+        verify_command_timeout_seconds=7,
+    )
+
+    def _fake_create_agent_runtime(**_kwargs: object) -> MagicMock:
+        runtime = MagicMock()
+        runtime.runtime_backend = "codex_cli"
+        runtime.working_directory = "/tmp/work"
+        runtime.permission_mode = "bypassPermissions"
+        runtime.self_governs_rate_limit = True
+        return runtime
+
+    async def _fake_execute_single_ac(
+        alt_executor: ParallelACExecutor,
+        **_kwargs: Any,
+    ) -> ACExecutionResult:
+        assert alt_executor._run_verify_commands is False
+        assert alt_executor._verify_command_timeout_seconds == 7
+        assert alt_executor._ac_retry_attempts == 0
+        return _succeeded()
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        _fake_create_agent_runtime,
+    )
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", _fake_execute_single_ac)
+
+    result = await executor._run_single_ac_on_backend(
+        "codex",
+        rerun_kwargs=_rerun_kwargs(),
+        retry_attempt=1,
+        decision=chr.AltHarnessDecision(
+            should_redispatch=True,
+            from_backend="claude",
+            to_backend="codex",
+            policy=None,
+            reason="test",
+        ),
+        runtime_identity=executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec-1",
+        ),
+        failure_class="fabrication_suspected",
+    )
+    assert result is not None and result.success is True
+
+
+@pytest.mark.asyncio
+async def test_alternate_redispatch_event_waits_for_authority_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _make_executor(enabled=True)
+    emit_event = AsyncMock()
+    monkeypatch.setattr(executor, "_safe_emit_event", emit_event)
+
+    class InvalidAuthorityRuntime:
+        capabilities = FULL_CAPABILITIES
+        runtime_backend = "codex_cli"
+        llm_backend = "codex"
+        permission_mode = "bypassPermissions"
+        working_directory = "/tmp/work"
+        self_governs_rate_limit = True
+        _model = None
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            raise ValueError("invalid runtime authority")
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        lambda **_kwargs: InvalidAuthorityRuntime(),
+    )
+
+    with pytest.raises(ValueError, match="invalid runtime authority"):
+        await executor._run_single_ac_on_backend(
+            "codex",
+            rerun_kwargs=_rerun_kwargs(),
+            retry_attempt=1,
+            decision=chr.AltHarnessDecision(
+                should_redispatch=True,
+                from_backend="claude",
+                to_backend="codex",
+                policy=None,
+                reason="test",
+            ),
+            runtime_identity=executor._resolve_ac_runtime_identity(
+                0,
+                execution_context_id="exec-1",
+            ),
+            failure_class="fabrication_suspected",
+        )
+    emit_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -208,7 +208,7 @@ async def test_alternate_redispatch_event_waits_for_authority_construction(
         lambda **_kwargs: InvalidAuthorityRuntime(),
     )
 
-    with pytest.raises(ValueError, match="invalid runtime authority"):
+    with pytest.raises(ValueError, match="runtime execution identity provider failed"):
         await executor._run_single_ac_on_backend(
             "codex",
             rerun_kwargs=_rerun_kwargs(),

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
@@ -10,9 +11,11 @@ from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
+    build_execution_policy_contract,
 )
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
@@ -92,6 +95,39 @@ class _SlottedRuntime:
             yield self.handler
 
 
+def _generation(label: str = "generation-a") -> dict[str, object]:
+    return {
+        "version": 1,
+        "kind": "test-snapshot-v1",
+        "digest": "sha256:" + hashlib.sha256(label.encode()).hexdigest(),
+    }
+
+
+def _policy(*, backend: str = "test-runtime", **overrides: object) -> dict[str, object]:
+    policy = build_execution_policy_contract(
+        decomposition_mode="preflight",
+        max_decomposition_depth=3,
+        max_concurrent=2,
+        execution_profile=None,
+        fat_harness_mode=False,
+        run_verify_commands=True,
+        verify_command_timeout_seconds=600,
+        ac_retry_attempts=2,
+        reasoning_effort=None,
+        model_router=None,
+        cross_harness_redispatch=False,
+        shadow_replay_enabled=False,
+        dispatch_rate_policy=ResolvedDispatchRatePolicy.resolve(
+            backend=backend,
+            self_governs_rate_limit=False,
+            requests_per_minute=None,
+            tokens_per_minute=None,
+        ).to_contract_data(),
+    )
+    policy.update(overrides)
+    return policy
+
+
 def _contract(
     *,
     runtime: _Runtime | None = None,
@@ -105,8 +141,8 @@ def _contract(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
         workspace=workspace,
-        execution_policy=policy or {"retry_attempts": 2},
-        workspace_generation=generation or {"tree": "generation-a"},
+        execution_policy=policy if policy is not None else _policy(),
+        workspace_generation=generation if generation is not None else _generation(),
         runtime_handle=runtime_handle,
     )
 
@@ -244,14 +280,93 @@ def test_undeclared_custom_verifier_is_process_local() -> None:
 def test_workspace_and_policy_drift_change_authority() -> None:
     baseline = _contract()
     assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
-    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+    assert baseline.fingerprint != _contract(policy=_policy(ac_retry_attempts=3)).fingerprint
 
 
 def test_workspace_generation_drift_changes_authority() -> None:
     assert (
-        _contract(generation={"tree": "a"}).fingerprint
-        != _contract(generation={"tree": "b"}).fingerprint
+        _contract(generation=_generation("a")).fingerprint
+        != _contract(generation=_generation("b")).fingerprint
     )
+
+
+def test_empty_workspace_generation_is_unobserved_and_not_portable() -> None:
+    contract = _contract(generation={})
+    assert contract.data["workspace"]["generation"] == {"observed": False}
+    assert contract.portable_across_processes is False
+
+
+def test_malformed_workspace_generation_is_rejected() -> None:
+    with pytest.raises(ValueError, match="workspace generation identity is invalid"):
+        _contract(generation={"version": 1, "kind": "test", "digest": "not-a-digest"})
+
+
+@pytest.mark.parametrize("missing_key", sorted(_policy()))
+def test_incomplete_execution_policy_is_rejected(missing_key: str) -> None:
+    policy = _policy()
+    del policy[missing_key]
+    with pytest.raises(ValueError, match="invalid execution policy"):
+        _contract(policy=policy)
+
+
+def test_dispatch_rate_policy_drift_changes_executor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    runtime.self_governs_rate_limit = False  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("OUROBOROS_TEST_RUNTIME_RPM", "1")
+    first = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+    monkeypatch.setenv("OUROBOROS_TEST_RUNTIME_RPM", "9")
+    second = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    first_policy = first.execution_authority.data["execution_policy"]["dispatch_rate"]
+    second_policy = second.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert first_policy["requests_per_minute"] == 1
+    assert second_policy["requests_per_minute"] == 9
+    assert first.execution_authority.fingerprint != second.execution_authority.fingerprint
+
+
+def test_self_governing_rate_policy_is_explicit_and_not_portable(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    runtime.self_governs_rate_limit = True  # type: ignore[attr-defined]
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+    rate_policy = executor.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert rate_policy["owner"] == "runtime"
+    assert rate_policy["observed"] is False
+    assert executor._dispatch_rate_gate.enabled is False
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_dispatch_rate_backend_must_match_runtime_backend() -> None:
+    policy = _policy()
+    rate_policy = dict(policy["dispatch_rate"])  # type: ignore[arg-type]
+    rate_policy["backend"] = "foreign-runtime"
+    policy["dispatch_rate"] = rate_policy
+    with pytest.raises(ValueError, match="disagrees with the runtime backend"):
+        _contract(policy=policy)
+
+
+def test_dispatch_rate_self_governance_must_match_runtime() -> None:
+    runtime = _Runtime()
+    runtime.self_governs_rate_limit = True  # type: ignore[attr-defined]
+    with pytest.raises(ValueError, match="disagrees with runtime self-governance"):
+        _contract(runtime=runtime, policy=_policy())
 
 
 def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
@@ -266,7 +381,7 @@ def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
         adapter=UnobservedRuntime(),
         verifier=None,
         workspace=None,
-        execution_policy={},
+        execution_policy=_policy(backend="legacy"),
     )
     assert contract.portable_across_processes is False
 
@@ -413,8 +528,8 @@ def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None
         adapter=runtime,
         verifier=None,
         workspace="/tmp/workspace-a",
-        workspace_generation={"tree": "a"},
-        execution_policy={},
+        workspace_generation=_generation("a"),
+        execution_policy=_policy(),
         resolved_routing=bound,
     )
     assert contract.data["runtime"]["execution_identity"]["identity"]["profile"] == "persisted"
@@ -440,8 +555,8 @@ def test_bound_runtime_authority_rejects_a_different_adapter_instance() -> None:
             adapter=replacement,
             verifier=None,
             workspace="/tmp/workspace-a",
-            workspace_generation={"tree": "a"},
-            execution_policy={},
+            workspace_generation=_generation("a"),
+            execution_policy=_policy(),
             resolved_routing=bound,
         )
 
@@ -466,8 +581,8 @@ def test_bound_runtime_authority_rejects_same_adapter_identity_drift() -> None:
             adapter=runtime,
             verifier=None,
             workspace="/tmp/workspace-a",
-            workspace_generation={"tree": "a"},
-            execution_policy={},
+            workspace_generation=_generation("a"),
+            execution_policy=_policy(),
             resolved_routing=bound,
         )
 

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from functools import wraps
 import gc
 import hashlib
+import json
 import os
 import random
 from types import MethodType, SimpleNamespace, coroutine
@@ -14,6 +15,8 @@ import weakref
 import pytest
 
 from ouroboros import codex_permissions
+from ouroboros.orchestrator import claude_worker_runtime as claude_worker_runtime_module
+from ouroboros.orchestrator import codex_cli_runtime as codex_cli_runtime_module
 from ouroboros.orchestrator import execution_authority as execution_authority_module
 from ouroboros.orchestrator import parallel_executor as parallel_executor_module
 from ouroboros.orchestrator import rate_limit as rate_limit_module
@@ -325,6 +328,97 @@ def test_runtime_identity_validators_reject_nested_credentials() -> None:
     )
 
 
+@pytest.mark.parametrize("section_name", ("executor", "workspace", "runtime", "verifier"))
+def test_contract_constructor_rejects_sensitive_data_in_every_authority_section(
+    section_name: str,
+) -> None:
+    """Deserialized authority JSON cannot bypass producer-side secret checks."""
+    secret = "ghp_" + "a" * 36
+    data = _contract().data
+    section = data[section_name]
+    assert isinstance(section, dict)
+    section["provider_credential"] = secret
+    canonical = json.dumps(
+        data,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+    with pytest.raises(ValueError, match="contains sensitive data") as exc_info:
+        ExecutionAuthorityContract(canonical)
+
+    assert secret not in str(exc_info.value)
+
+
+def test_contract_constructor_rejects_aliased_credential_field_even_with_benign_value() -> None:
+    """A credential alias itself is invalid in a durable authority section."""
+    data = _contract().data
+    runtime = data["runtime"]
+    assert isinstance(runtime, dict)
+    runtime["apiKeyValue"] = "opaque-provider-label"
+
+    with pytest.raises(ValueError, match="contains sensitive data"):
+        ExecutionAuthorityContract(
+            json.dumps(
+                data,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+        )
+
+
+def test_contract_constructor_rejects_credential_shaped_key_even_with_benign_value() -> None:
+    """Raw credential-shaped mapping keys cannot persist in authority JSON."""
+    data = _contract().data
+    runtime = data["runtime"]
+    assert isinstance(runtime, dict)
+    runtime["ghp_" + "a" * 36] = "opaque-provider-label"
+
+    with pytest.raises(ValueError, match="contains sensitive data"):
+        ExecutionAuthorityContract(
+            json.dumps(
+                data,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("section_name", "malformed"),
+    (
+        ("executor", {"version": 3}),
+        ("workspace", {"version": 1, "observed": False}),
+        ("runtime", {"version": 1, "runtime_backend": "test"}),
+        ("verifier", {"version": 1, "mode": "runtime_transcript"}),
+    ),
+)
+def test_contract_constructor_rejects_malformed_authority_envelopes(
+    section_name: str,
+    malformed: dict[str, object],
+) -> None:
+    """Every authority section must be structurally valid before fingerprinting."""
+    data = _contract().data
+    data[section_name] = malformed
+
+    with pytest.raises(ValueError, match=f"invalid {section_name}"):
+        ExecutionAuthorityContract(
+            json.dumps(
+                data,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+        )
+
+
 def test_runtime_authority_binds_nested_command_helper_globals(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -347,6 +441,84 @@ def test_runtime_authority_binds_nested_command_helper_globals(
     assert baseline != changed
     assert changed["implementation"]["stability"] == "durable"
     assert runtime._build_permission_args() == ["--sentinel-permission-flag"]
+
+
+def test_executor_rejects_post_construction_runtime_implementation_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """An executor cannot dispatch after its bound subprocess implementation changes."""
+    runtime = CodexCliRuntime(cli_path="/usr/bin/true", cwd=str(tmp_path))
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    async def altered_launch(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("altered subprocess launch")
+
+    monkeypatch.setattr(
+        codex_cli_runtime_module.asyncio,
+        "create_subprocess_exec",
+        altered_launch,
+    )
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_post_construction_runtime_subprocess_pipe_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Nested subprocess constants cannot change beneath a live authority."""
+    runtime = CodexCliRuntime(cli_path="/usr/bin/true", cwd=str(tmp_path))
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    monkeypatch.setattr(codex_cli_runtime_module.asyncio.subprocess, "PIPE", -999)
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+@pytest.mark.parametrize("member", ("create_subprocess_exec", "wait_for", "subprocess.PIPE"))
+def test_executor_rejects_post_construction_worker_subprocess_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    member: str,
+) -> None:
+    """Declared worker transports are rechecked before their subprocess effect."""
+    runtime = LeaderDrivenWorkerRuntime(
+        transport=ClaudeWorkerTransport(cli_path="/usr/bin/true"),
+        runtime_backend="claude_mcp",
+        llm_backend="claude",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        enable_decomposition=False,
+    )
+
+    async def altered_asyncio_member(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("altered asyncio member")
+
+    if member == "subprocess.PIPE":
+        monkeypatch.setattr(claude_worker_runtime_module.asyncio.subprocess, "PIPE", -999)
+    else:
+        monkeypatch.setattr(
+            claude_worker_runtime_module.asyncio,
+            member,
+            altered_asyncio_member,
+        )
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
 
 
 def _worker_contract(

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -536,6 +536,120 @@ def test_executor_rejects_mutated_atomic_verifier_closure(tmp_path) -> None:
         executor._require_execution_collaborators_intact()
 
 
+def test_executor_rejects_uninspectable_mutable_atomic_verifier_closure(tmp_path) -> None:
+    """A cyclic verifier closure cannot fall back to an allow-all identity check."""
+    state: dict[str, object] = {"passed": True}
+    state["cycle"] = state
+
+    def cyclic_closure_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=bool(state["passed"]))
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+        atomic_verifier=cyclic_closure_verifier,
+    )
+
+    state["passed"] = False
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_oversized_mutable_atomic_verifier_closure(tmp_path) -> None:
+    """An oversized verifier closure cannot fall back to an identity-only check."""
+    state: dict[str, object] = {f"item_{index}": index for index in range(257)}
+    state["passed"] = True
+
+    def oversized_closure_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=bool(state["passed"]))
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+        atomic_verifier=oversized_closure_verifier,
+    )
+
+    state["passed"] = False
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_mutated_atomic_verifier_default(tmp_path) -> None:
+    """A mutable default cannot change verifier behavior after construction."""
+
+    def default_verifier(
+        *,
+        verdict_state: dict[str, bool] | None = None,
+        **_: object,
+    ) -> VerifierVerdict:
+        assert verdict_state is not None
+        return VerifierVerdict(passed=verdict_state["passed"])
+
+    defaults = default_verifier.__kwdefaults__
+    assert defaults is not None
+    defaults["verdict_state"] = {"passed": True}
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+        atomic_verifier=default_verifier,
+    )
+
+    verdict_state = defaults["verdict_state"]
+    assert isinstance(verdict_state, dict)
+    verdict_state["passed"] = False
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_verifier_drift_after_legacy_checker_kwdefaults_tampering(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The legacy helper's mutable defaults cannot bypass the captured checker."""
+    state = {"passed": True}
+
+    def closure_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=state["passed"])
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+        atomic_verifier=closure_verifier,
+    )
+
+    legacy_checker = parallel_executor_module._live_callable_integrity_is_intact
+    assert legacy_checker.__kwdefaults__ is None
+    monkeypatch.setattr(
+        legacy_checker,
+        "__kwdefaults__",
+        {"_behavior_digest": lambda *_args, **_kwargs: "attacker-controlled"},
+    )
+    state["passed"] = False
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
 def test_executor_rejects_runtime_drift_when_global_integrity_helper_is_patched(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -559,6 +673,70 @@ def test_executor_rejects_runtime_drift_when_global_integrity_helper_is_patched(
         "_live_callable_integrity_is_intact",
         lambda *_args, **_kwargs: True,
     )
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_runtime_drift_after_legacy_checker_kwdefaults_tampering(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The old runtime predicate defaults are outside the executor's trust root."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    legacy_checker = parallel_executor_module._runtime_dispatch_integrity_is_intact
+    assert legacy_checker.__kwdefaults__ is None
+    monkeypatch.setattr(
+        legacy_checker,
+        "__kwdefaults__",
+        {"_callable_integrity_checker": lambda *_args, **_kwargs: True},
+    )
+
+    async def altered_execute_task(self: _Runtime, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(_Runtime, "execute_task", altered_execute_task)
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_runtime_drift_when_captured_runtime_checker_is_tampered(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A frozen runtime checker still verifies its nested checker identity."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    class _AllowAllChecker:
+        def __call__(self, *_args: object, **_kwargs: object) -> bool:
+            return True
+
+    object.__setattr__(
+        executor._runtime_dispatch_integrity_checker,
+        "callable_integrity_checker",
+        _AllowAllChecker(),
+    )
+
+    async def altered_execute_task(self: _Runtime, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(_Runtime, "execute_task", altered_execute_task)
 
     with pytest.raises(ValueError, match="runtime implementation drifted"):
         executor._require_execution_collaborators_intact()

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -383,6 +383,7 @@ def test_foundation_a_boundary_is_explicit_and_versioned() -> None:
     assert "leaf_dispatcher_implementation" in contract.data["boundary"]["portable_baseline"]
     assert "ac_runtime_handle_manager" in contract.data["boundary"]["per_attempt_capsule"]
     assert "selected_runtime_handle" in contract.data["boundary"]["per_attempt_capsule"]
+    assert "selected_ac_reasoning_effort" in contract.data["boundary"]["per_attempt_capsule"]
     assert "execution_event_emitter" in contract.data["boundary"]["volatile"]
     assert "session_signal_hub" in contract.data["boundary"]["volatile"]
 
@@ -1397,6 +1398,7 @@ def test_level_coordinator_is_explicitly_per_attempt_not_baseline_identity(
         "level_coordinator_behavior_and_session_state"
         in baseline.data["boundary"]["per_attempt_capsule"]
     )
+    assert "selected_ac_reasoning_effort" in baseline.data["boundary"]["per_attempt_capsule"]
 
 
 def test_handle_manager_and_event_emitter_are_explicitly_outside_foundation_a(

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,28 +1,55 @@
 from __future__ import annotations
 
+import asyncio
+from functools import wraps
+import gc
 import hashlib
 import os
-from types import MethodType
+import random
+from types import MethodType, SimpleNamespace, coroutine
 from unittest.mock import AsyncMock, MagicMock
+import weakref
 
 import pytest
 
+from ouroboros import codex_permissions
+from ouroboros.orchestrator import execution_authority as execution_authority_module
 from ouroboros.orchestrator import parallel_executor as parallel_executor_module
+from ouroboros.orchestrator import rate_limit as rate_limit_module
+from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
 from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.codex_mcp_runtime import CodexMcpWorkerTransport
+from ouroboros.orchestrator.coordinator import LevelCoordinator
+from ouroboros.orchestrator.evidence import verification as transcript_verification
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
     build_execution_policy_contract,
+    canonical_workspace_authority,
+    execution_authority_boundary_contract,
+    runtime_authority_contract,
+    runtime_execution_identity_contract,
+    valid_constructor_model_contract,
+    valid_runtime_execution_identity_contract,
 )
+from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
+from ouroboros.orchestrator.model_routing import ModelRouter, serialize_model_router
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.pi_runtime import PiRuntime
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
-from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
+from ouroboros.orchestrator.rate_limit import (
+    RateLimitGate,
+    ResolvedDispatchRatePolicy,
+    SharedRateLimitBucket,
+    build_rate_limit_gate,
+)
 from ouroboros.orchestrator.synapse import SessionSignalHub
 from ouroboros.orchestrator.verifier import VerifierVerdict
 from ouroboros.orchestrator.worker_runtime import LeaderDrivenWorkerRuntime
+
+_RATE_GATE_FACTORY_TEST_GLOBALS: dict[str, int] = {"limit": 9}
 
 
 class _Runtime:
@@ -67,6 +94,15 @@ class _Runtime:
                 runtime_handle.metadata.get("profile") if runtime_handle is not None else None
             )
         }
+
+
+class _SensitiveWatchdogRuntime(_Runtime):
+    def __init__(self, secret: str = "sk-sentinel-secret") -> None:
+        super().__init__()
+        self._secret = secret
+
+    def watchdog_identity_contract(self) -> dict[str, object]:
+        return {"connection_label": self._secret}
 
 
 class _Verifier:
@@ -219,6 +255,99 @@ def _contract(
     )
 
 
+def test_authority_policy_redacts_credentials_without_mutating_live_policy() -> None:
+    """Authority JSON may distinguish secrets, but must never serialize them."""
+    first_secret = "ghp_" + "a" * 36
+    second_secret = "ghp_" + "b" * 36
+
+    def contract_for(secret: str) -> tuple[ExecutionAuthorityContract, dict[str, object]]:
+        policy = _policy(reasoning_effort=secret)
+        policy["model_routing"] = serialize_model_router(
+            ModelRouter(
+                tier_models={"frugal": secret},
+                runtime_backend="claude",
+                child_tier="frugal",
+                base_tier="standard",
+                escalation_retry_threshold=1,
+            )
+        )
+        return _contract(policy=policy), policy
+
+    first, first_live_policy = contract_for(first_secret)
+    second, _ = contract_for(second_secret)
+
+    assert first_live_policy["reasoning_effort"] == first_secret
+    assert first_secret not in first.canonical_json
+    assert second_secret not in second.canonical_json
+    authority_policy = first.data["execution_policy"]
+    assert authority_policy["reasoning_effort"].startswith("redacted:sha256:")
+    router = authority_policy["model_routing"]["router"]
+    assert router["tier_models"]["frugal"].startswith("redacted:sha256:")
+    assert first.fingerprint != second.fingerprint
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    (" \t", "\x00", "\u200b", "\ufeff", "\u2060", "\u034f", "\ufe0f"),
+)
+def test_runtime_authority_marks_prefixed_credentials_unobserved(prefix: str) -> None:
+    """Normalization must not serialize a credential with a hidden prefix."""
+    runtime = _Runtime()
+    runtime_secret = "ghp_" + "a" * 36
+    llm_secret = "ghp_" + "b" * 36
+    runtime.runtime_backend = f"{prefix}{runtime_secret}"
+    runtime.llm_backend = f"{prefix}{llm_secret}"
+
+    authority = runtime_authority_contract(runtime)
+
+    assert authority["runtime_backend"] is None
+    assert authority["runtime_backend_unobserved"] is True
+    assert authority["llm_backend"] is None
+    assert authority["llm_backend_unobserved"] is True
+    assert runtime_secret not in str(authority)
+    assert llm_secret not in str(authority)
+
+
+def test_runtime_identity_validators_reject_nested_credentials() -> None:
+    secret = "ghp_" + "a" * 36
+
+    assert valid_constructor_model_contract({"observed": True, "model": secret}) is False
+    assert (
+        valid_runtime_execution_identity_contract(
+            {
+                "version": 1,
+                "observed": True,
+                "identity": {"effective_model_observed": True, "opaque": secret},
+            }
+        )
+        is False
+    )
+
+
+def test_runtime_authority_binds_nested_command_helper_globals(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A nested permission-table mutation changes runtime authority."""
+    runtime = CodexCliRuntime(
+        cli_path="/usr/bin/true",
+        cwd=str(tmp_path),
+        permission_mode="default",
+    )
+    baseline = runtime_authority_contract(runtime)
+    monkeypatch.setitem(
+        codex_permissions._SANDBOX_TO_CODEX_ARGS,
+        codex_permissions.SandboxClass.READ_ONLY,
+        ["--sentinel-permission-flag"],
+    )
+
+    changed = runtime_authority_contract(runtime)
+
+    assert baseline != changed
+    assert changed["implementation"]["stability"] == "durable"
+    assert runtime._build_permission_args() == ["--sentinel-permission-flag"]
+
+
 def _worker_contract(
     transport: object,
     *,
@@ -245,6 +374,49 @@ def test_runtime_profile_drift_changes_authority() -> None:
         _contract(runtime=_Runtime(profile="a")).fingerprint
         != _contract(runtime=_Runtime(profile="b")).fingerprint
     )
+
+
+def test_foundation_a_boundary_is_explicit_and_versioned() -> None:
+    contract = _contract()
+
+    assert contract.data["boundary"] == execution_authority_boundary_contract()
+    assert "leaf_dispatcher_implementation" in contract.data["boundary"]["portable_baseline"]
+    assert "ac_runtime_handle_manager" in contract.data["boundary"]["per_attempt_capsule"]
+    assert "selected_runtime_handle" in contract.data["boundary"]["per_attempt_capsule"]
+    assert "execution_event_emitter" in contract.data["boundary"]["volatile"]
+    assert "session_signal_hub" in contract.data["boundary"]["volatile"]
+
+
+def test_declared_live_component_cannot_upgrade_into_portable_baseline() -> None:
+    class DeclaredSignalHub(SessionSignalHub):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"version": 1, "configuration": {"protocol": "test"}}
+
+    first = ExecutionAuthorityContract.build(
+        adapter=_Runtime(),
+        verifier=None,
+        executor=_ExecutionOwner(),
+        executor_components={"session_signal_hub": DeclaredSignalHub()},
+        workspace="/tmp/workspace-a",
+        workspace_generation=_generation(),
+        execution_policy=_policy(),
+    )
+    second = ExecutionAuthorityContract.build(
+        adapter=_Runtime(),
+        verifier=None,
+        executor=_ExecutionOwner(),
+        executor_components={"session_signal_hub": DeclaredSignalHub()},
+        workspace="/tmp/workspace-a",
+        workspace_generation=_generation(),
+        execution_policy=_policy(),
+    )
+
+    component = first.data["executor"]["components"]["session_signal_hub"]
+    assert component["mode"] == "out_of_boundary"
+    assert component["boundary"] == "volatile"
+    assert component["stability"] == "process_local"
+    assert first.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
 
 
 def test_runtime_executable_and_watchdog_drift_change_authority() -> None:
@@ -535,9 +707,334 @@ def test_sensitive_runtime_identity_fails_closed_without_leaking() -> None:
 
     contract = _contract(runtime=SensitiveRuntime())
 
-    assert contract.data["runtime"]["execution_identity"] == {"version": 1, "observed": False}
+    identity = contract.data["runtime"]["execution_identity"]
+    assert identity["observed"] is False
+    assert isinstance(identity["instance_nonce"], str)
     assert contract.portable_across_processes is False
     assert "sentinel-secret" not in contract.canonical_json
+
+
+def test_sensitive_runtime_identity_value_fails_closed_without_leaking() -> None:
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "opaque": "sk-sentinel-secret",
+            }
+
+    contract = _contract(runtime=SensitiveRuntime())
+
+    identity = contract.data["runtime"]["execution_identity"]
+    assert identity["observed"] is False
+    assert isinstance(identity["instance_nonce"], str)
+    assert contract.portable_across_processes is False
+    assert "sk-sentinel-secret" not in contract.canonical_json
+
+
+def test_github_pat_runtime_identity_value_fails_closed_without_leaking() -> None:
+    credential = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "opaque": credential,
+            }
+
+    contract = _contract(runtime=SensitiveRuntime())
+
+    assert contract.data["runtime"]["execution_identity"]["observed"] is False
+    assert credential not in contract.canonical_json
+
+
+@pytest.mark.parametrize(
+    "credential",
+    (
+        "glpat-sentinel-not-a-real-token-123456",
+        "hf_abcdefghijklmnopqrstuvwxyz123456",
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZW50aW5lbCJ9.c2lnbmF0dXJl",
+    ),
+)
+def test_structured_credential_runtime_identity_fails_closed_without_leaking(
+    credential: str,
+) -> None:
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "opaque": credential,
+            }
+
+    contract = _contract(runtime=SensitiveRuntime())
+
+    assert contract.data["runtime"]["execution_identity"]["observed"] is False
+    assert credential not in contract.canonical_json
+
+
+def test_sensitive_runtime_identity_is_collision_resistant_per_runtime_instance() -> None:
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "opaque": "sk-sentinel-secret",
+            }
+
+    first_runtime = SensitiveRuntime()
+    first = runtime_execution_identity_contract(first_runtime)
+    same = runtime_execution_identity_contract(first_runtime)
+    second = runtime_execution_identity_contract(SensitiveRuntime())
+
+    assert first["observed"] is False
+    assert second["observed"] is False
+    assert first == same
+    assert first["instance_nonce"] != second["instance_nonce"]
+
+
+def test_process_local_nonce_is_stable_per_live_object_and_released_after_gc() -> None:
+    class MissingIdentityRuntime:
+        capabilities = FULL_CAPABILITIES
+        runtime_backend = "legacy"
+        llm_backend = "legacy"
+        permission_mode = "default"
+
+    runtime = MissingIdentityRuntime()
+    object_id = id(runtime)
+    first = runtime_execution_identity_contract(runtime)
+    second = runtime_execution_identity_contract(runtime)
+    runtime_reference = weakref.ref(runtime)
+
+    assert first == second
+    assert first["observed"] is False
+    assert first["instance_nonce"]
+
+    del runtime
+    gc.collect()
+
+    assert runtime_reference() is None
+    assert object_id not in execution_authority_module._PROCESS_LOCAL_RUNTIME_NONCES
+
+
+def test_credential_markers_never_egress_via_authority_metadata() -> None:
+    credential = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialLabelRuntime(_Runtime):
+        runtime_backend = credential
+        llm_backend = credential
+        permission_mode = credential
+        _model = credential
+
+    class LocalCredentialSkillRuntime(_Runtime):
+        _skill_dispatcher = None
+        _skills_dir = credential
+
+        async def _maybe_dispatch_skill_intercept(self, **_: object) -> None:
+            return None
+
+        async def _dispatch_skill_intercept_locally(self, **_: object) -> None:
+            return None
+
+    dynamic_runtime_type = type(f"Runtime_{credential}", (_Runtime,), {})
+    dynamic_runtime_type.__module__ = f"module_{credential}"
+
+    async def named_execute(self: _Runtime, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield self.profile
+
+    named_execute.__name__ = credential
+    named_execute.__qualname__ = credential
+    named_execute.__module__ = credential
+    dynamic_function_runtime = _Runtime()
+    dynamic_function_runtime.execute_task = MethodType(  # type: ignore[method-assign]
+        named_execute,
+        dynamic_function_runtime,
+    )
+
+    class CredentialComponentKeyRuntime(_Runtime):
+        def execution_components(self) -> dict[str, object]:
+            return {credential: _StableDispatcher()}
+
+    credential_exception = type(f"ProviderError_{credential}", (RuntimeError,), {})
+
+    class ExceptionNameRuntime(_Runtime):
+        def watchdog_identity_contract(self) -> dict[str, object]:
+            raise credential_exception()
+
+    contracts = (
+        _contract(runtime=CredentialLabelRuntime()),
+        _contract(runtime=LocalCredentialSkillRuntime()),
+        _contract(runtime=dynamic_runtime_type()),  # type: ignore[arg-type]
+        _contract(runtime=dynamic_function_runtime),
+        _contract(runtime=CredentialComponentKeyRuntime()),
+        _contract(runtime=ExceptionNameRuntime()),
+    )
+
+    assert all(credential not in contract.canonical_json for contract in contracts)
+
+
+def test_raising_runtime_identity_provider_blocks_construction_without_leaking() -> None:
+    class RaisingRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            raise RuntimeError("sk-sentinel-secret")
+
+    with pytest.raises(ValueError, match="runtime execution identity provider failed") as error:
+        _contract(runtime=RaisingRuntime())
+
+    assert "sentinel-secret" not in str(error.value)
+
+
+def test_sensitive_executable_command_policy_fails_closed_without_leaking() -> None:
+    class SensitiveExecutableRuntime(_Runtime):
+        def __init__(self, secret: str) -> None:
+            super().__init__()
+            self._secret = secret
+
+        def executable_identity_contract(self) -> dict[str, object]:
+            return {
+                "executable": None,
+                "launcher": None,
+                "command_policy": {"connection_label": self._secret},
+            }
+
+    contract = _contract(runtime=SensitiveExecutableRuntime("sk-sentinel-secret"))
+    changed = _contract(runtime=SensitiveExecutableRuntime("sk-another-secret"))
+
+    executable = contract.data["runtime"]["executable"]
+    assert executable["required"] is True
+    assert executable["observed"] is False
+    assert contract.portable_across_processes is False
+    assert contract.fingerprint != changed.fingerprint
+    assert "sk-sentinel-secret" not in contract.canonical_json
+
+
+def test_sensitive_watchdog_identity_fails_closed_without_leaking() -> None:
+    contract = _contract(runtime=_SensitiveWatchdogRuntime())
+    changed = _contract(runtime=_SensitiveWatchdogRuntime("sk-another-secret"))
+
+    watchdog = contract.data["runtime"]["watchdog"]
+    assert watchdog["required"] is True
+    assert watchdog["observed"] is False
+    assert contract.portable_across_processes is False
+    assert contract.fingerprint != changed.fingerprint
+    assert "sk-sentinel-secret" not in contract.canonical_json
+
+
+def test_runtime_handle_selector_values_are_outside_baseline_without_leaking() -> None:
+    class SensitiveHandleRuntime(_Runtime):
+        def resume_handle_execution_identity_contract(
+            self,
+            runtime_handle: RuntimeHandle | None,
+        ) -> dict[str, object]:
+            del runtime_handle
+            return {"connection_label": "sk-sentinel-secret"}
+
+    contract = _contract(
+        runtime=SensitiveHandleRuntime(),
+        runtime_handle=RuntimeHandle(backend="codex_cli"),
+    )
+
+    selector = contract.data["runtime"]["handle_selector"]
+    assert selector["mode"] == "declared"
+    assert selector["stability"] == "durable"
+    assert "sk-sentinel-secret" not in contract.canonical_json
+
+
+def test_provider_attribute_lookup_fail_closed_without_leaking() -> None:
+    class RaisingExecutableRuntime(_Runtime):
+        @property
+        def executable_identity_contract(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    class RaisingWatchdogRuntime(_Runtime):
+        @property
+        def watchdog_identity_contract(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    class RaisingHandleRuntime(_Runtime):
+        @property
+        def resume_handle_execution_identity_contract(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    executable_contract = _contract(runtime=RaisingExecutableRuntime())
+    watchdog_contract = _contract(runtime=RaisingWatchdogRuntime())
+    handle_contract = _contract(
+        runtime=RaisingHandleRuntime(),
+        runtime_handle=RuntimeHandle(backend="codex_cli"),
+    )
+
+    assert executable_contract.data["runtime"]["executable"]["observed"] is False
+    assert watchdog_contract.data["runtime"]["watchdog"]["observed"] is False
+    selector = handle_contract.data["runtime"]["handle_selector"]
+    assert selector["mode"] == "declared"
+    assert selector["stability"] == "process_local"
+    assert all(
+        "sentinel-secret" not in contract.canonical_json
+        for contract in (executable_contract, watchdog_contract, handle_contract)
+    )
+
+
+def test_fallback_runtime_attribute_errors_fail_closed_without_leaking() -> None:
+    class RaisingCliPathRuntime(_Runtime):
+        @property
+        def cli_path(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    class RaisingWatchdogFieldRuntime(_Runtime):
+        def __init__(self) -> None:
+            self.profile = "profile-a"
+            self._cli_path = None
+
+        @property
+        def _startup_output_timeout_seconds(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    class RaisingDispatcherRuntime(_Runtime):
+        @property
+        def _skill_dispatcher(self) -> object:
+            raise RuntimeError("sk-sentinel-secret")
+
+    executable_contract = _contract(runtime=RaisingCliPathRuntime())
+    watchdog_contract = _contract(runtime=RaisingWatchdogFieldRuntime())
+    dispatcher_contract = _contract(runtime=RaisingDispatcherRuntime())
+
+    assert executable_contract.data["runtime"]["executable"]["observed"] is False
+    assert watchdog_contract.data["runtime"]["watchdog"]["observed"] is False
+    assert dispatcher_contract.data["runtime"]["skill_dispatcher"]["stability"] == "process_local"
+    assert all(
+        "sentinel-secret" not in contract.canonical_json
+        for contract in (executable_contract, watchdog_contract, dispatcher_contract)
+    )
+
+
+def test_selected_runtime_handles_do_not_change_the_portable_baseline() -> None:
+    runtime = _Runtime()
+    first = _contract(
+        runtime=runtime,
+        runtime_handle=RuntimeHandle(backend="codex_cli", native_session_id="session-a"),
+    )
+    second = _contract(
+        runtime=runtime,
+        runtime_handle=RuntimeHandle(backend="codex_cli", native_session_id="session-b"),
+    )
+
+    assert first.fingerprint == second.fingerprint
+    selector = first.data["runtime"]["handle_selector"]
+    assert selector["mode"] == "declared"
+    assert selector["stability"] == "durable"
+
+
+def test_codex_watchdog_identity_is_digested_before_authority_serialization(tmp_path) -> None:
+    runtime = CodexCliRuntime(cli_path="/usr/bin/true", cwd=str(tmp_path), model="gpt-5")
+
+    contract = _contract(  # type: ignore[arg-type]
+        runtime=runtime,
+        policy=_policy(backend="codex_cli"),
+    )
+
+    watchdog = contract.data["runtime"]["watchdog"]
+    assert watchdog["required"] is True
+    assert watchdog["observed"] is True
+    assert watchdog["identity_digest"].startswith("sha256:")
+    assert "child_session_environment_names" not in contract.canonical_json
 
 
 def test_codex_transport_live_pool_is_excluded_from_static_identity() -> None:
@@ -612,6 +1109,125 @@ def test_workspace_and_policy_drift_change_authority() -> None:
     baseline = _contract()
     assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
     assert baseline.fingerprint != _contract(policy=_policy(ac_retry_attempts=3)).fingerprint
+
+
+def test_sensitive_direct_workspace_is_process_local_without_egress() -> None:
+    secret = "ghp_" + "a" * 36
+    workspace = f"/tmp/{secret}"
+
+    authority = canonical_workspace_authority(workspace, generation=_generation())
+    contract = _contract(workspace=workspace)
+
+    assert authority["observed"] is False
+    assert authority["identity"]["mode"] == "process_local"
+    assert authority["generation"] == {"observed": False}
+    assert contract.data["workspace"]["observed"] is False
+    assert contract.portable_across_processes is False
+    assert secret not in contract.canonical_json
+    assert secret not in str(authority)
+
+
+def test_workspace_symlink_to_sensitive_target_is_process_local_without_egress(tmp_path) -> None:
+    secret = "ghp_" + "a" * 36
+    target = tmp_path / secret
+    target.mkdir()
+    safe_link = tmp_path / "safe-workspace"
+    safe_link.symlink_to(target, target_is_directory=True)
+
+    authority = canonical_workspace_authority(str(safe_link), generation=_generation())
+    contract = _contract(workspace=str(safe_link))
+
+    assert authority["observed"] is False
+    assert contract.data["workspace"]["observed"] is False
+    assert contract.portable_across_processes is False
+    assert secret not in str(authority)
+    assert secret not in contract.canonical_json
+
+
+def test_workspace_identity_symlink_target_is_process_local_without_egress(tmp_path) -> None:
+    secret = "ghp_" + "a" * 36
+    target = tmp_path / secret
+    target.mkdir()
+    safe_link = tmp_path / "safe-repo-root"
+    safe_link.symlink_to(target, target_is_directory=True)
+    workspace = str(tmp_path / "workspace")
+    identity = {
+        "effective_cwd": workspace,
+        "repo_root": str(safe_link),
+        "worktree_path": str(tmp_path / "worktree"),
+        "branch": "authority-a",
+    }
+
+    contract = ExecutionAuthorityContract.build(
+        adapter=_Runtime(),
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=workspace,
+        workspace_identity=identity,
+        workspace_generation=_generation(),
+        execution_policy=_policy(),
+    )
+
+    assert contract.data["workspace"]["observed"] is False
+    assert contract.portable_across_processes is False
+    assert secret not in contract.canonical_json
+
+
+@pytest.mark.parametrize("field_name", ("effective_cwd", "repo_root", "worktree_path", "branch"))
+def test_sensitive_workspace_identity_fields_are_process_local_without_egress(
+    field_name: str,
+) -> None:
+    secret = "ghp_" + "a" * 36
+    workspace = "/tmp/workspace-a"
+    identity = {
+        "effective_cwd": workspace,
+        "repo_root": "/tmp/repo-a",
+        "worktree_path": "/tmp/worktree-a",
+        "branch": "authority-a",
+    }
+    identity[field_name] = f"/tmp/{secret}" if field_name != "branch" else f"branch-{secret}"
+    if field_name == "effective_cwd":
+        workspace = str(identity[field_name])
+
+    contract = ExecutionAuthorityContract.build(
+        adapter=_Runtime(),
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=workspace,
+        workspace_identity=identity,
+        workspace_generation=_generation(),
+        execution_policy=_policy(),
+    )
+
+    assert contract.data["workspace"]["observed"] is False
+    assert contract.portable_across_processes is False
+    assert secret not in contract.canonical_json
+
+
+def test_sensitive_workspace_generation_is_process_local_without_egress() -> None:
+    secret = "ghp_" + "a" * 36
+    contract = ExecutionAuthorityContract.build(
+        adapter=_Runtime(),
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace="/tmp/workspace-a",
+        workspace_generation={"version": 1, "kind": "test", "digest": secret},
+        execution_policy=_policy(),
+    )
+
+    assert contract.data["workspace"]["observed"] is False
+    assert contract.portable_across_processes is False
+    assert secret not in contract.canonical_json
+
+
+def test_normal_workspace_authority_remains_observed() -> None:
+    authority = canonical_workspace_authority("/tmp/workspace-a", generation=_generation())
+
+    assert authority["version"] == 1
+    assert authority["observed"] is True
+    assert authority["identity"]["mode"] == "direct"
+    assert authority["identity"]["effective_cwd"].endswith("/tmp/workspace-a")
+    assert authority["generation"] == {"observed": True, "identity": _generation()}
 
 
 def test_workspace_generation_drift_changes_authority() -> None:
@@ -718,10 +1334,13 @@ def test_leaf_dispatcher_replacement_changes_executor_authority(
     assert baseline.fingerprint != replaced.fingerprint
     component = replaced.data["executor"]["components"]["leaf_dispatcher"]
     assert component["mode"] == "static_type"
-    assert component["type"].endswith("._ReplacementLeafDispatcher")
+    # Dynamic module/class labels can contain provider-controlled text.  The
+    # baseline keeps only an opaque type digest while still differentiating the
+    # replacement implementation above.
+    assert component["type"].startswith("sha256:")
 
 
-def test_live_session_signal_hub_makes_executor_authority_process_local(tmp_path) -> None:
+def test_live_session_signal_hub_is_explicitly_volatile_not_baseline_identity(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
     kwargs = {
@@ -742,11 +1361,71 @@ def test_live_session_signal_hub_makes_executor_authority_process_local(tmp_path
         session_signal_hub=SessionSignalHub(),
     ).execution_authority  # type: ignore[arg-type]
 
-    assert baseline.fingerprint != with_hub.fingerprint
-    assert with_hub.portable_across_processes is False
-    component = with_hub.data["executor"]["components"]["session_signal_hub"]
-    assert component["mode"] == "live_instance"
-    assert component["stability"] == "process_local"
+    assert baseline.fingerprint == with_hub.fingerprint
+    assert "session_signal_hub" not in with_hub.data["executor"]["components"]
+    assert "session_signal_hub" in with_hub.data["boundary"]["volatile"]
+
+
+def test_level_coordinator_is_explicitly_per_attempt_not_baseline_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class SuppressingCoordinator(LevelCoordinator):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            self._reasoning_effort = "high"
+
+        @staticmethod
+        def detect_file_conflicts(_level_results: object) -> list[object]:
+            return []
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    monkeypatch.setattr(parallel_executor_module, "LevelCoordinator", SuppressingCoordinator)
+    changed = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint == changed.fingerprint
+    assert "level_coordinator" not in baseline.data["executor"]["components"]
+    assert (
+        "level_coordinator_behavior_and_session_state"
+        in baseline.data["boundary"]["per_attempt_capsule"]
+    )
+
+
+def test_handle_manager_and_event_emitter_are_explicitly_outside_foundation_a(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacingHandleManager(ACRuntimeHandleManager):
+        pass
+
+    class ReplacingEventEmitter(ExecutionEventEmitter):
+        pass
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    monkeypatch.setattr(parallel_executor_module, "ACRuntimeHandleManager", ReplacingHandleManager)
+    monkeypatch.setattr(parallel_executor_module, "ExecutionEventEmitter", ReplacingEventEmitter)
+    changed = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint == changed.fingerprint
+    boundary = changed.data["boundary"]
+    assert "ac_runtime_handle_manager" in boundary["per_attempt_capsule"]
+    assert "execution_event_emitter" in boundary["volatile"]
 
 
 def test_noncanonical_dispatch_rate_policy_is_rejected(tmp_path) -> None:
@@ -777,6 +1456,715 @@ def test_noncanonical_dispatch_rate_policy_is_rejected(tmp_path) -> None:
             task_cwd=str(tmp_path),
             dispatch_rate_policy=policy,
         )
+
+
+def test_dispatch_rate_gate_is_built_from_canonical_policy_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy(
+        backend="test-runtime",
+        owner="ouroboros",
+        observed=True,
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=23,
+        window_seconds=17.0,
+        heartbeat_seconds=3.0,
+        max_wait_seconds=11.0,
+    )
+
+    def altered_builder(_: ResolvedDispatchRatePolicy):
+        return build_rate_limit_gate(
+            "test-runtime",
+            request_limit=99,
+            token_limit=None,
+            window_seconds=1.0,
+            heartbeat_seconds=1.0,
+            max_wait_seconds=1.0,
+        )
+
+    monkeypatch.setattr(ResolvedDispatchRatePolicy, "build_gate", altered_builder)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        dispatch_rate_policy=policy,
+    )
+
+    bucket = executor._dispatch_rate_gate._bucket
+    assert bucket._request_limit == 1
+    assert bucket._token_limit == 23
+    assert bucket._window_seconds == 17.0
+    assert executor._dispatch_rate_gate._heartbeat_seconds == 3.0
+    assert executor._dispatch_rate_gate._max_wait_seconds == 11.0
+    rate_contract = executor.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert rate_contract["gate_algorithm_version"] == 1
+
+
+def test_actual_rate_gate_factory_drift_changes_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy(
+        backend="test-runtime",
+        owner="ouroboros",
+        observed=True,
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=23,
+        window_seconds=17.0,
+        heartbeat_seconds=3.0,
+        max_wait_seconds=11.0,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": policy,
+    }
+    baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    def replaced_factory(*_: object, **__: object):
+        return build_rate_limit_gate(
+            "test-runtime",
+            request_limit=99,
+            token_limit=None,
+            window_seconds=1.0,
+            heartbeat_seconds=1.0,
+            max_wait_seconds=1.0,
+        )
+
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", replaced_factory)
+    changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    changed_bucket = changed._dispatch_rate_gate._bucket
+    assert changed_bucket._request_limit == 99
+    assert changed_bucket._token_limit is None
+    assert changed_bucket._window_seconds == 1.0
+    assert changed.execution_authority.fingerprint != baseline.execution_authority.fingerprint
+    baseline_algorithm = baseline.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    changed_algorithm = changed.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    assert baseline_algorithm["observed"] is True
+    assert changed_algorithm["observed"] is False
+    assert baseline_algorithm != changed_algorithm
+
+
+def test_rate_gate_factory_restoring_global_cannot_hide_its_authority_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The factory capture must survive a replacement that restores the alias."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=23,
+    )
+    original_factory = rate_limit_module.build_rate_limit_gate
+
+    def restoring_factory(*args: object, **kwargs: object) -> RateLimitGate:
+        monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", original_factory)
+        return original_factory(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", restoring_factory)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        dispatch_rate_policy=policy,
+    )
+
+    rate_contract = executor.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert rate_limit_module.build_rate_limit_gate is original_factory
+    assert executor._dispatch_rate_gate._bucket._request_limit == 1
+    assert rate_contract["gate_algorithm"]["observed"] is False
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_rate_token_estimator_is_captured_and_in_place_drift_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """TPM accounting uses the same validated estimator captured in authority."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=100_000,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": policy,
+    }
+    baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    estimator = parallel_executor_module.estimate_runtime_request_tokens
+
+    def altered_estimator(_prompt: str, *, system_prompt: str | None = None) -> int:
+        del system_prompt
+        return 1
+
+    assert altered_estimator.__closure__ is None
+    monkeypatch.setattr(estimator, "__code__", altered_estimator.__code__)
+    changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    baseline_estimator = baseline.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "token_estimator"
+    ]
+    changed_estimator = changed.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "token_estimator"
+    ]
+    assert baseline_estimator["observed"] is True
+    assert changed_estimator["observed"] is False
+    assert baseline.execution_authority.fingerprint != changed.execution_authority.fingerprint
+
+    with pytest.raises(ValueError, match="token estimator drifted"):
+        asyncio.run(
+            baseline._await_dispatch_rate_budget(
+                prompt="a prompt that would otherwise consume TPM budget",
+                system_prompt=None,
+            )
+        )
+
+
+def test_in_place_rate_gate_factory_code_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """An object-identical factory with changed code cannot become portable."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=None,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": policy,
+    }
+    baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    factory = rate_limit_module.build_rate_limit_gate
+
+    def stochastic_factory(
+        runtime_backend,
+        *,
+        request_limit,
+        token_limit,
+        window_seconds=60.0,
+        max_wait_seconds=120.0,
+        heartbeat_seconds=30.0,
+        sleep=None,
+    ):
+        bucket = SharedRateLimitBucket(
+            runtime_backend=runtime_backend,
+            request_limit=random.choice((1, 99)),
+            token_limit=token_limit,
+            window_seconds=window_seconds,
+        )
+        return RateLimitGate(
+            bucket,
+            max_wait_seconds=max_wait_seconds,
+            heartbeat_seconds=heartbeat_seconds,
+            sleep=sleep,
+        )
+
+    assert stochastic_factory.__closure__ is None
+    monkeypatch.setattr(rate_limit_module, "random", random, raising=False)
+    monkeypatch.setattr(factory, "__code__", stochastic_factory.__code__)
+
+    random.seed(0)
+    first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    random.seed(1)
+    second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    assert factory is rate_limit_module.build_rate_limit_gate
+    assert (
+        first._dispatch_rate_gate._bucket._request_limit
+        != second._dispatch_rate_gate._bucket._request_limit
+    )
+    baseline_algorithm = baseline.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    first_algorithm = first.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    second_algorithm = second.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    assert baseline_algorithm["observed"] is True
+    assert first_algorithm["observed"] is False
+    assert second_algorithm["observed"] is False
+    assert first_algorithm != second_algorithm
+
+
+def test_in_place_rate_gate_factory_default_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutating the original factory's keyword defaults is declaration drift."""
+    factory = rate_limit_module.build_rate_limit_gate
+    kwdefaults = factory.__kwdefaults__
+    assert kwdefaults is not None
+
+    monkeypatch.setitem(kwdefaults, "window_seconds", 1.0)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_in_place_rate_gate_member_implementation_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gate member's code can drift without replacing its function object."""
+    member = rate_limit_module.SharedRateLimitBucket._tokens_in_window
+
+    def altered_tokens_in_window(self):
+        return 99
+
+    assert altered_tokens_in_window.__closure__ is None
+    monkeypatch.setattr(member, "__code__", altered_tokens_in_window.__code__)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_in_place_rate_gate_member_default_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact-declaration rule also binds original member defaults."""
+    member = rate_limit_module.RateLimitGate.acquire
+    kwdefaults = member.__kwdefaults__
+    assert kwdefaults is not None
+
+    monkeypatch.setitem(kwdefaults, "on_backoff", lambda _event: None)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_in_place_rate_gate_result_type_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Directly constructed gate result types cannot drift under a baseline."""
+    original_init = rate_limit_module.RateLimitSnapshot.__init__
+    offset = {"value": 99}
+
+    def altered_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        original_init(self, *args, **kwargs)
+        object.__setattr__(
+            self,
+            "requests_in_window",
+            self.requests_in_window + offset["value"],
+        )
+
+    monkeypatch.setattr(rate_limit_module.RateLimitSnapshot, "__init__", altered_init)
+    bucket = rate_limit_module.SharedRateLimitBucket(
+        runtime_backend="test-runtime",
+        request_limit=1,
+        token_limit=None,
+    )
+    assert bucket._snapshot().requests_in_window == 99
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_in_place_asyncio_lock_implementation_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed stdlib lock implementation cannot retain portable identity."""
+    member = rate_limit_module.asyncio.Lock.acquire
+
+    async def bypass_lock(self):
+        return True
+
+    assert bypass_lock.__closure__ is None
+    monkeypatch.setattr(member, "__code__", bypass_lock.__code__)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_in_place_asyncio_sleep_implementation_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed stdlib scheduling function cannot retain portable identity."""
+    sleep = rate_limit_module.asyncio.sleep
+
+    async def bypass_sleep(delay, result=None):
+        return result
+
+    assert bypass_sleep.__closure__ is None
+    monkeypatch.setattr(sleep, "__code__", bypass_sleep.__code__)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_asyncio_lock_global_dependency_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lock member's direct module global is part of the declaration."""
+    original_collections = rate_limit_module.asyncio.locks.collections
+    monkeypatch.setattr(
+        rate_limit_module.asyncio.locks,
+        "collections",
+        SimpleNamespace(deque=original_collections.deque),
+    )
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_asyncio_lock_module_member_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutating a direct module member used by a lock mixin fails closed."""
+    events = rate_limit_module.asyncio.events
+    original_get_running_loop = events._get_running_loop
+
+    def altered_get_running_loop():
+        return original_get_running_loop()
+
+    monkeypatch.setattr(events, "_get_running_loop", altered_get_running_loop)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_asyncio_lock_collections_member_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct collections member used by lock acquisition is declaration-bound."""
+    monkeypatch.setattr(rate_limit_module.asyncio.locks.collections, "deque", list)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_asyncio_sleep_module_member_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sleep's direct event-loop lookup is part of its imported declaration."""
+    events = rate_limit_module.asyncio.events
+    original_get_running_loop = events.get_running_loop
+
+    def altered_get_running_loop():
+        return original_get_running_loop()
+
+    monkeypatch.setattr(events, "get_running_loop", altered_get_running_loop)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_asyncio_sleep_global_function_drift_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sleep's direct helper function body is part of its declaration."""
+    helper = rate_limit_module.asyncio.tasks.__sleep0
+
+    @coroutine
+    def altered_sleep_zero():
+        if False:  # pragma: no cover - preserves the generator shape.
+            yield None
+        return None
+
+    assert altered_sleep_zero.__closure__ is None
+    monkeypatch.setattr(helper, "__code__", altered_sleep_zero.__code__)
+
+    algorithm = rate_limit_module.rate_limit_gate_algorithm_contract()
+    assert algorithm["observed"] is False
+
+
+def test_rate_gate_replacements_and_live_dependencies_are_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Replacement factories and live gate dependencies stay process-local."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy(
+        backend="test-runtime",
+        owner="ouroboros",
+        observed=True,
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=23,
+        window_seconds=17.0,
+        heartbeat_seconds=3.0,
+        max_wait_seconds=11.0,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": policy,
+    }
+
+    def closure_factory(limit: int):
+        def factory(*_: object, **__: object):
+            return build_rate_limit_gate(
+                "test-runtime",
+                request_limit=limit,
+                token_limit=None,
+                window_seconds=1.0,
+                heartbeat_seconds=1.0,
+                max_wait_seconds=1.0,
+            )
+
+        return factory
+
+    closure_nine = closure_factory(9)
+    closure_ninety_nine = closure_factory(99)
+    assert closure_nine.__code__ is closure_ninety_nine.__code__
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", closure_nine)
+    closure_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", closure_ninety_nine)
+    closure_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert closure_first._dispatch_rate_gate._bucket._request_limit == 9
+    assert closure_second._dispatch_rate_gate._bucket._request_limit == 99
+    assert closure_first.execution_authority.fingerprint != closure_second.execution_authority.fingerprint
+    closure_first_algorithm = closure_first.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    closure_second_algorithm = closure_second.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert closure_first_algorithm["observed"] is False
+    assert closure_second_algorithm["observed"] is False
+
+    def default_factory(limit: int):
+        def factory(*_: object, request_limit: int = limit, **__: object):
+            return build_rate_limit_gate(
+                "test-runtime",
+                request_limit=request_limit,
+                token_limit=None,
+                window_seconds=1.0,
+                heartbeat_seconds=1.0,
+                max_wait_seconds=1.0,
+            )
+
+        return factory
+
+    default_nine = default_factory(9)
+    default_ninety_nine = default_factory(99)
+    assert default_nine.__code__ is default_ninety_nine.__code__
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", default_nine)
+    default_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", default_ninety_nine)
+    default_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert default_first.execution_authority.fingerprint != default_second.execution_authority.fingerprint
+    default_first_algorithm = default_first.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    default_second_algorithm = default_second.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert default_first_algorithm["observed"] is False
+    assert default_second_algorithm["observed"] is False
+
+    monkeypatch.setitem(_RATE_GATE_FACTORY_TEST_GLOBALS, "limit", 9)
+
+    def global_factory(*_: object, **__: object):
+        return build_rate_limit_gate(
+            "test-runtime",
+            request_limit=_RATE_GATE_FACTORY_TEST_GLOBALS["limit"],
+            token_limit=None,
+            window_seconds=1.0,
+            heartbeat_seconds=1.0,
+            max_wait_seconds=1.0,
+        )
+
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", global_factory)
+    global_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    monkeypatch.setitem(_RATE_GATE_FACTORY_TEST_GLOBALS, "limit", 99)
+    global_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert global_first._dispatch_rate_gate._bucket._request_limit == 9
+    assert global_second._dispatch_rate_gate._bucket._request_limit == 99
+    assert global_first.execution_authority.fingerprint != global_second.execution_authority.fingerprint
+    global_first_algorithm = global_first.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    global_second_algorithm = global_second.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert global_first_algorithm["observed"] is False
+    assert global_second_algorithm["observed"] is False
+
+    monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", build_rate_limit_gate)
+    class_baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    original_bucket_init = rate_limit_module.SharedRateLimitBucket.__init__
+
+    def altered_bucket_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        original_bucket_init(self, *args, **kwargs)
+        self._request_limit = 99
+
+    monkeypatch.setattr(
+        rate_limit_module.SharedRateLimitBucket,
+        "__init__",
+        altered_bucket_init,
+    )
+    class_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert class_baseline._dispatch_rate_gate._bucket._request_limit == 1
+    assert class_changed._dispatch_rate_gate._bucket._request_limit == 99
+    assert class_baseline.execution_authority.fingerprint != class_changed.execution_authority.fingerprint
+
+    monkeypatch.setitem(_RATE_GATE_FACTORY_TEST_GLOBALS, "limit", 9)
+
+    @wraps(original_bucket_init)
+    def wrapped_bucket_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        original_bucket_init(self, *args, **kwargs)
+        self._request_limit = _RATE_GATE_FACTORY_TEST_GLOBALS["limit"]
+
+    monkeypatch.setattr(
+        rate_limit_module.SharedRateLimitBucket,
+        "__init__",
+        wrapped_bucket_init,
+    )
+    class_global_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    monkeypatch.setitem(_RATE_GATE_FACTORY_TEST_GLOBALS, "limit", 99)
+    class_global_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert class_global_first._dispatch_rate_gate._bucket._request_limit == 9
+    assert class_global_second._dispatch_rate_gate._bucket._request_limit == 99
+    assert class_global_first.execution_authority.fingerprint != class_global_second.execution_authority.fingerprint
+    first_algorithm = class_global_first.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    second_algorithm = class_global_second.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert first_algorithm["observed"] is False
+    assert second_algorithm["observed"] is False
+    assert first_algorithm != second_algorithm
+
+    monkeypatch.setattr(
+        rate_limit_module.SharedRateLimitBucket,
+        "__init__",
+        original_bucket_init,
+    )
+    original_monotonic = rate_limit_module.time.monotonic
+    monotonic_offset = {"value": 0.0}
+
+    def patched_monotonic() -> float:
+        return original_monotonic() + monotonic_offset["value"]
+
+    monkeypatch.setattr(rate_limit_module.time, "monotonic", patched_monotonic)
+    module_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    first_timestamp = module_first._dispatch_rate_gate._bucket._time()
+    monotonic_offset["value"] = 99.0
+    module_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    second_timestamp = module_second._dispatch_rate_gate._bucket._time()
+    assert second_timestamp - first_timestamp > 98.0
+    assert module_first.execution_authority.fingerprint != module_second.execution_authority.fingerprint
+    module_algorithm = module_first.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert module_algorithm["observed"] is False
+
+    monkeypatch.setattr(rate_limit_module.time, "monotonic", original_monotonic)
+    original_deque = rate_limit_module.deque
+    deque_offset = {"value": 0}
+
+    class OffsetDeque(list):
+        def append(self, item: tuple[float, int]) -> None:
+            super().append((item[0], item[1] + deque_offset["value"]))
+
+    monkeypatch.setattr(rate_limit_module, "deque", OffsetDeque)
+    deque_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    deque_first._dispatch_rate_gate._bucket._reservations.append((0.0, 1))
+    assert deque_first._dispatch_rate_gate._bucket._tokens_in_window() == 1
+    deque_offset["value"] = 99
+    deque_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    deque_second._dispatch_rate_gate._bucket._reservations.append((0.0, 1))
+    assert deque_second._dispatch_rate_gate._bucket._tokens_in_window() == 100
+    assert deque_first.execution_authority.fingerprint != deque_second.execution_authority.fingerprint
+    deque_algorithm = deque_first.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    assert deque_algorithm["observed"] is False
+
+    monkeypatch.setattr(rate_limit_module, "deque", original_deque)
+    descriptor_baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    original_gate_acquire = rate_limit_module.RateLimitGate.acquire
+
+    class InertAcquireDescriptor:
+        def __get__(self, _instance: object, _owner: object):
+            async def noop(*_args: object, **_kwargs: object) -> None:
+                return None
+
+            return noop
+
+    monkeypatch.setattr(rate_limit_module.RateLimitGate, "acquire", InertAcquireDescriptor())
+    descriptor_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert descriptor_baseline.execution_authority.fingerprint != descriptor_changed.execution_authority.fingerprint
+    descriptor_algorithm = descriptor_changed.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert descriptor_algorithm["observed"] is False
+
+    monkeypatch.setattr(rate_limit_module.RateLimitGate, "acquire", original_gate_acquire)
+    spoof_baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    class SpoofAcquireStaticMethod(staticmethod):
+        def __get__(self, _instance: object, _owner: object):
+            async def noop(*_args: object, **_kwargs: object) -> None:
+                return None
+
+            return noop
+
+    monkeypatch.setattr(
+        rate_limit_module.RateLimitGate,
+        "acquire",
+        SpoofAcquireStaticMethod(original_gate_acquire),
+    )
+    spoof_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert spoof_baseline.execution_authority.fingerprint != spoof_changed.execution_authority.fingerprint
+    spoof_algorithm = spoof_changed.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
+    assert spoof_algorithm["observed"] is False
+
+    monkeypatch.setattr(rate_limit_module.RateLimitGate, "acquire", original_gate_acquire)
+    raw_class_baseline = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+
+    def bypassing_getattribute(self: object, name: str):  # type: ignore[no-untyped-def]
+        if name == "acquire":
+            async def noop(*_args: object, **_kwargs: object) -> None:
+                return None
+
+            return noop
+        return object.__getattribute__(self, name)
+
+    monkeypatch.setattr(
+        rate_limit_module.RateLimitGate,
+        "__getattribute__",
+        bypassing_getattribute,
+        raising=False,
+    )
+    raw_class_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
+    assert raw_class_baseline.execution_authority.fingerprint != raw_class_changed.execution_authority.fingerprint
+    raw_class_algorithm = raw_class_changed.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
+    assert raw_class_algorithm["observed"] is False
 
 
 def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -> None:
@@ -864,13 +2252,10 @@ def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
     assert contract.portable_across_processes is False
 
 
-def test_runtime_handle_selector_changes_authority() -> None:
+def test_selected_runtime_handle_belongs_to_the_later_attempt_capsule() -> None:
     cheap = RuntimeHandle(backend="codex_cli", metadata={"profile": "cheap"})
     expensive = RuntimeHandle(backend="codex_cli", metadata={"profile": "expensive"})
-    assert (
-        _contract(runtime_handle=cheap).fingerprint
-        != _contract(runtime_handle=expensive).fingerprint
-    )
+    assert _contract(runtime_handle=cheap).fingerprint == _contract(runtime_handle=expensive).fingerprint
 
 
 def test_verifier_identity_provider_failure_degrades_to_process_local() -> None:
@@ -892,6 +2277,38 @@ def test_runtime_transcript_verifier_has_implementation_identity() -> None:
     assert verifier["implementation"]["stability"] == "durable"
 
 
+def test_runtime_transcript_helper_drift_changes_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = _contract().fingerprint
+
+    def always_support_claim(_value: str, _messages: tuple[object, ...]) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        transcript_verification,
+        "_runtime_messages_support_claim",
+        always_support_claim,
+    )
+    changed = _contract().fingerprint
+
+    assert baseline != changed
+
+
+def test_runtime_transcript_verdict_type_drift_changes_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ForgedVerdict:
+        def __init__(self, **_: object) -> None:
+            self.passed = True
+
+    baseline = _contract().fingerprint
+    monkeypatch.setattr(transcript_verification, "VerifierVerdict", ForgedVerdict)
+    changed = _contract().fingerprint
+
+    assert baseline != changed
+
+
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -908,7 +2325,10 @@ def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     authority = executor.execution_authority
     assert authority.fingerprint.startswith("sha256:")
     assert authority.data["workspace"]["identity"]["effective_cwd"] == str(tmp_path.resolve())
-    assert authority.data["runtime"]["execution_identity"]["identity"]["profile"] == "profile-a"
+    execution_identity = authority.data["runtime"]["execution_identity"]
+    assert execution_identity["effective_model_observed"] is True
+    assert execution_identity["identity_digest"].startswith("sha256:")
+    assert "profile-a" not in authority.canonical_json
     assert authority.data["execution_policy"]["ac_retry_attempts"] == 2
 
 
@@ -1011,7 +2431,10 @@ def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None
         execution_policy=_policy(),
         resolved_routing=bound,
     )
-    assert contract.data["runtime"]["execution_identity"]["identity"]["profile"] == "persisted"
+    identity = contract.data["runtime"]["execution_identity"]
+    assert identity["effective_model_observed"] is True
+    assert identity["identity_digest"].startswith("sha256:")
+    assert "persisted" not in contract.canonical_json
 
 
 def test_bound_runtime_authority_rejects_a_different_adapter_instance() -> None:
@@ -1064,6 +2487,65 @@ def test_bound_runtime_authority_rejects_same_adapter_identity_drift() -> None:
             execution_policy=_policy(),
             resolved_routing=bound,
         )
+
+
+def test_bound_runtime_authority_rejects_same_adapter_sensitive_label_drift() -> None:
+    runtime = _Runtime(profile="stable")
+    runtime.runtime_backend = "ghp_" + "a" * 36
+    runtime.llm_backend = "ghp_" + "b" * 36
+    resolved_routing = {
+        "runtime_backend": None,
+        "runtime_backend_unobserved": True,
+        "llm_backend": None,
+        "llm_backend_unobserved": True,
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": runtime.execution_identity_contract(),
+        },
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+    runtime.runtime_backend = "ghp_" + "c" * 36
+
+    with pytest.raises(ValueError, match="unobserved backend label"):
+        bound.require_adapter(runtime)
+
+
+def test_bound_runtime_authority_rejects_sensitive_execution_identity_drift() -> None:
+    """A hidden provider identity remains bound for the initial live dispatch."""
+
+    class SensitiveRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__(profile="stable")
+            self.provider_identity = "ghp_" + "a" * 36
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "provider_identity": self.provider_identity,
+            }
+
+    runtime = SensitiveRuntime()
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": runtime_execution_identity_contract(
+            runtime,
+            include_process_local_nonce=False,
+        ),
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+
+    assert resolved_routing["runtime_execution"] == {"version": 1, "observed": False}
+    assert runtime.provider_identity not in bound.canonical_json
+
+    runtime.provider_identity = "ghp_" + "b" * 36
+    with pytest.raises(ValueError, match="unobserved execution identity"):
+        bound.require_adapter(runtime)
 
 
 def test_resolved_runtime_authority_reads_effective_private_permission_mode() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from functools import wraps
 import gc
 import hashlib
@@ -870,6 +871,38 @@ def test_credential_markers_never_egress_via_authority_metadata() -> None:
     )
 
     assert all(credential not in contract.canonical_json for contract in contracts)
+
+
+def test_credential_shaped_runtime_capabilities_fail_closed_without_egress() -> None:
+    credential = "ghp_" + "a" * 36
+    runtime = _Runtime()
+    runtime.capabilities = replace(  # type: ignore[attr-defined]
+        FULL_CAPABILITIES,
+        enforceable_reasoning_efforts=frozenset({credential}),
+    )
+
+    contract = _contract(runtime=runtime)
+
+    capabilities = contract.data["runtime"]["capabilities"]
+    assert capabilities["observed"] is False
+    assert contract.portable_across_processes is False
+    assert credential not in contract.canonical_json
+
+
+def test_raising_runtime_capabilities_fail_closed_without_egress() -> None:
+    credential = "ghp_" + "b" * 36
+
+    class RaisingCapabilitiesRuntime(_Runtime):
+        @property
+        def capabilities(self) -> object:
+            raise RuntimeError(credential)
+
+    contract = _contract(runtime=RaisingCapabilitiesRuntime())
+
+    capabilities = contract.data["runtime"]["capabilities"]
+    assert capabilities["observed"] is False
+    assert contract.portable_across_processes is False
+    assert credential not in contract.canonical_json
 
 
 def test_raising_runtime_identity_provider_blocks_construction_without_leaking() -> None:
@@ -2235,6 +2268,44 @@ def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -
     assert first.fingerprint != second.fingerprint
 
 
+def test_populated_delegated_skill_handler_cache_changes_authority(tmp_path) -> None:
+    class FirstHandler:
+        async def handle(self, _arguments: object) -> None:
+            return None
+
+    class SecondHandler:
+        async def handle(self, _arguments: object) -> None:
+            return None
+
+    runtime = PiRuntime(cli_path="/usr/bin/true", cwd=tmp_path)
+    runtime._interceptor._builtin_mcp_handlers = {"ouroboros_help": FirstHandler()}
+    first = ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+
+    runtime._interceptor._builtin_mcp_handlers["ouroboros_help"] = SecondHandler()
+    second = ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+
+    component = first.data["runtime"]["skill_dispatcher"]["component"]
+    handler_cache = component["builtin_mcp_handler_cache"]
+    assert handler_cache["state"] == "populated"
+    assert handler_cache["stability"] == "process_local"
+    assert first.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
 def test_self_governing_rate_policy_is_explicit_and_not_portable(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -2265,6 +2336,51 @@ def test_dispatch_rate_self_governance_must_match_runtime() -> None:
     runtime.self_governs_rate_limit = True  # type: ignore[attr-defined]
     with pytest.raises(ValueError, match="disagrees with runtime self-governance"):
         _contract(runtime=runtime, policy=_policy())
+
+
+def test_dispatch_rate_policy_uses_normalized_runtime_backend(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.runtime_backend = " test-runtime "  # type: ignore[attr-defined]
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=None,
+        tokens_per_minute=None,
+    )
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        dispatch_rate_policy=policy,
+    )
+
+    assert executor._dispatch_rate_policy.backend == "test-runtime"
+
+
+def test_dispatch_rate_policy_uses_unknown_for_sensitive_runtime_backend(tmp_path) -> None:
+    credential = "ghp_" + "c" * 36
+    runtime = _Runtime()
+    runtime.runtime_backend = credential  # type: ignore[attr-defined]
+    runtime.working_directory = str(tmp_path)
+    policy = ResolvedDispatchRatePolicy.resolve(
+        backend="unknown",
+        self_governs_rate_limit=False,
+        requests_per_minute=None,
+        tokens_per_minute=None,
+    )
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        dispatch_rate_policy=policy,
+    )
+
+    assert executor._dispatch_rate_policy.backend == "unknown"
+    assert executor.execution_authority.portable_across_processes is False
+    assert credential not in executor.execution_authority.canonical_json
 
 
 def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
@@ -2342,6 +2458,22 @@ def test_runtime_transcript_verdict_type_drift_changes_authority(
     changed = _contract().fingerprint
 
     assert baseline != changed
+
+
+def test_runtime_transcript_verdict_post_init_drift_changes_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = _contract()
+
+    def accept_failed_verdict(self: VerifierVerdict) -> None:
+        object.__setattr__(self, "passed", True)
+
+    monkeypatch.setattr(VerifierVerdict, "__post_init__", accept_failed_verdict)
+    changed = _contract()
+
+    assert VerifierVerdict(passed=False, reasons=("missing evidence",)).passed is True
+    assert baseline.portable_across_processes is True
+    assert baseline.fingerprint != changed.fingerprint
 
 
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import os
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
 
-from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
-from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+import pytest
+
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ResolvedRuntimeAuthority,
+)
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import VerifierVerdict
@@ -17,13 +24,39 @@ class _Runtime:
     working_directory: str | None = None
     _model = None
 
-    def __init__(self, *, profile: str = "profile-a") -> None:
+    def __init__(
+        self,
+        *,
+        profile: str = "profile-a",
+        cli_path: str | None = None,
+        startup_timeout: float = 1.0,
+        idle_timeout: float = 2.0,
+    ) -> None:
         self.profile = profile
+        self._cli_path = cli_path
+        self._startup_output_timeout_seconds = startup_timeout
+        self._stdout_idle_timeout_seconds = idle_timeout
+        self._process_shutdown_timeout_seconds = 3.0
+        self._completed_process_group_shutdown_timeout_seconds = 0.2
 
     def execution_identity_contract(self) -> dict[str, object]:
         return {
             "profile": self.profile,
             "effective_model_observed": True,
+        }
+
+    async def execute_task(self, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    def resume_handle_execution_identity_contract(
+        self,
+        runtime_handle: RuntimeHandle | None,
+    ) -> dict[str, object]:
+        return {
+            "profile": (
+                runtime_handle.metadata.get("profile") if runtime_handle is not None else None
+            )
         }
 
 
@@ -38,18 +71,43 @@ class _Verifier:
         return VerifierVerdict(passed=True)
 
 
+class _SlottedRuntime:
+    __slots__ = ("handler",)
+
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory = None
+    _model = None
+
+    def __init__(self, handler: object) -> None:
+        self.handler = handler
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"effective_model_observed": True, "profile": "slotted"}
+
+    async def execute_task(self, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield self.handler
+
+
 def _contract(
     *,
     runtime: _Runtime | None = None,
     verifier: object | None = None,
     workspace: str = "/tmp/workspace-a",
     policy: dict[str, object] | None = None,
+    generation: dict[str, object] | None = None,
+    runtime_handle: RuntimeHandle | None = None,
 ) -> ExecutionAuthorityContract:
     return ExecutionAuthorityContract.build(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
         workspace=workspace,
         execution_policy=policy or {"retry_attempts": 2},
+        workspace_generation=generation or {"tree": "generation-a"},
+        runtime_handle=runtime_handle,
     )
 
 
@@ -60,6 +118,108 @@ def test_runtime_profile_drift_changes_authority() -> None:
     )
 
 
+def test_runtime_executable_and_watchdog_drift_change_authority() -> None:
+    baseline = _contract(runtime=_Runtime(cli_path="/bin/true"))
+    changed_executable = _contract(runtime=_Runtime(cli_path="/bin/false"))
+    changed_watchdog = _contract(
+        runtime=_Runtime(cli_path="/bin/true", startup_timeout=9.0, idle_timeout=99.0)
+    )
+    assert baseline.fingerprint != changed_executable.fingerprint
+    assert baseline.fingerprint != changed_watchdog.fingerprint
+
+
+def test_runtime_command_builder_override_changes_authority() -> None:
+    class CommandOne(_Runtime):
+        def _build_command(self) -> list[str]:
+            return ["cli", "one"]
+
+    class CommandTwo(_Runtime):
+        def _build_command(self) -> list[str]:
+            return ["cli", "two"]
+
+    assert (
+        _contract(runtime=CommandOne()).fingerprint != _contract(runtime=CommandTwo()).fingerprint
+    )
+
+
+def test_in_place_executable_generation_change_changes_authority(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+    previous = executable.stat()
+    executable.write_text("two", encoding="utf-8")
+    os.utime(
+        executable,
+        ns=(previous.st_atime_ns, max(executable.stat().st_mtime_ns, previous.st_mtime_ns + 1)),
+    )
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+    assert baseline.fingerprint != changed.fingerprint
+
+
+def test_executable_content_drift_changes_authority_with_restored_stat(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    previous = executable.stat()
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+    executable.write_text("two", encoding="utf-8")
+    os.utime(executable, ns=(previous.st_atime_ns, previous.st_mtime_ns))
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+    assert baseline.fingerprint != changed.fingerprint
+
+
+def test_runtime_execution_body_and_parser_drift_change_authority() -> None:
+    class ImplementationOne(_Runtime):
+        async def _execute_task_impl(self, **_: object):
+            if False:  # pragma: no cover - implementation identity only
+                yield "one"
+
+        def _parse_json_event(self, _line: str) -> str:
+            return "one"
+
+        def _convert_event(self, _event: object) -> str:
+            return "one"
+
+    class ImplementationTwo(_Runtime):
+        async def _execute_task_impl(self, **_: object):
+            if False:  # pragma: no cover - implementation identity only
+                yield "two"
+
+        def _parse_json_event(self, _line: str) -> str:
+            return "two"
+
+        def _convert_event(self, _event: object) -> str:
+            return "two"
+
+    assert (
+        _contract(runtime=ImplementationOne()).fingerprint
+        != _contract(runtime=ImplementationTwo()).fingerprint
+    )
+
+
+def test_instance_level_execution_override_is_process_local() -> None:
+    runtime = _Runtime()
+    baseline = _contract(runtime=runtime)
+
+    async def replacement(self: _Runtime, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield self.profile
+
+    runtime.execute_task = MethodType(replacement, runtime)  # type: ignore[method-assign]
+    overridden = _contract(runtime=runtime)
+    assert baseline.fingerprint != overridden.fingerprint
+    assert overridden.portable_across_processes is False
+
+
+def test_unobservable_slotted_instance_state_is_process_local() -> None:
+    runtime = _SlottedRuntime(lambda: "one")
+    baseline = _contract(runtime=runtime)  # type: ignore[arg-type]
+    runtime.handler = lambda: "two"
+    changed = _contract(runtime=runtime)  # type: ignore[arg-type]
+    assert baseline.fingerprint != changed.fingerprint
+    assert baseline.portable_across_processes is False
+    assert changed.portable_across_processes is False
+
+
 def test_verifier_identity_drift_changes_authority() -> None:
     first = _contract(verifier=_Verifier("judge-a"))
     same = _contract(verifier=_Verifier("judge-a"))
@@ -67,7 +227,7 @@ def test_verifier_identity_drift_changes_authority() -> None:
 
     assert first.fingerprint == same.fingerprint
     assert first.fingerprint != changed.fingerprint
-    assert first.reusable_across_processes is True
+    assert first.portable_across_processes is True
 
 
 def test_undeclared_custom_verifier_is_process_local() -> None:
@@ -77,7 +237,7 @@ def test_undeclared_custom_verifier_is_process_local() -> None:
     first = _contract(verifier=verifier)
     second = _contract(verifier=verifier)
 
-    assert first.reusable_across_processes is False
+    assert first.portable_across_processes is False
     assert first.fingerprint != second.fingerprint
 
 
@@ -85,6 +245,58 @@ def test_workspace_and_policy_drift_change_authority() -> None:
     baseline = _contract()
     assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
     assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_workspace_generation_drift_changes_authority() -> None:
+    assert (
+        _contract(generation={"tree": "a"}).fingerprint
+        != _contract(generation={"tree": "b"}).fingerprint
+    )
+
+
+def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
+    class UnobservedRuntime:
+        capabilities = FULL_CAPABILITIES
+        runtime_backend = "legacy"
+        llm_backend = None
+        permission_mode = None
+        working_directory = None
+
+    contract = ExecutionAuthorityContract.build(
+        adapter=UnobservedRuntime(),
+        verifier=None,
+        workspace=None,
+        execution_policy={},
+    )
+    assert contract.portable_across_processes is False
+
+
+def test_runtime_handle_selector_changes_authority() -> None:
+    cheap = RuntimeHandle(backend="codex_cli", metadata={"profile": "cheap"})
+    expensive = RuntimeHandle(backend="codex_cli", metadata={"profile": "expensive"})
+    assert (
+        _contract(runtime_handle=cheap).fingerprint
+        != _contract(runtime_handle=expensive).fingerprint
+    )
+
+
+def test_verifier_identity_provider_failure_degrades_to_process_local() -> None:
+    class RaisingVerifier:
+        def verification_identity_contract(self) -> dict[str, object]:
+            raise OSError("offline")
+
+        def __call__(self, **_: object) -> VerifierVerdict:
+            return VerifierVerdict(passed=True)
+
+    contract = _contract(verifier=RaisingVerifier())
+    assert contract.portable_across_processes is False
+    assert contract.data["verifier"]["behavioral_state"]["stability"] == "process_local"
+
+
+def test_runtime_transcript_verifier_has_implementation_identity() -> None:
+    verifier = _contract().data["verifier"]
+    assert verifier["mode"] == "runtime_transcript"
+    assert verifier["implementation"]["stability"] == "durable"
 
 
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
@@ -102,7 +314,7 @@ def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
 
     authority = executor.execution_authority
     assert authority.fingerprint.startswith("sha256:")
-    assert authority.data["workspace"]["effective_cwd"] == str(tmp_path.resolve())
+    assert authority.data["workspace"]["identity"]["effective_cwd"] == str(tmp_path.resolve())
     assert authority.data["runtime"]["execution_identity"]["identity"]["profile"] == "profile-a"
     assert authority.data["execution_policy"]["ac_retry_attempts"] == 2
 
@@ -123,3 +335,204 @@ def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
         ).execution_authority.fingerprint
 
     assert build(base_profile) != build(changed_profile)
+
+
+def test_transcript_verifier_wrapper_override_changes_executor_authority(tmp_path) -> None:
+    class OverriddenExecutor(ParallelACExecutor):
+        def _verify_atomic_evidence_against_runtime_messages(self, **kwargs: object):  # type: ignore[no-untyped-def]
+            return super()._verify_atomic_evidence_against_runtime_messages(**kwargs)  # type: ignore[arg-type]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "console": MagicMock(),
+        "task_cwd": str(tmp_path),
+        "execution_profile": load_profile("code"),
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    overridden = OverriddenExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    assert baseline != overridden
+
+
+def test_shadow_replay_binds_transcript_wrapper_with_custom_verifier(tmp_path) -> None:
+    class OverriddenExecutor(ParallelACExecutor):
+        def _verify_atomic_evidence_against_runtime_messages(self, **kwargs: object):  # type: ignore[no-untyped-def]
+            return super()._verify_atomic_evidence_against_runtime_messages(**kwargs)  # type: ignore[arg-type]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "console": MagicMock(),
+        "task_cwd": str(tmp_path),
+        "execution_profile": load_profile("code"),
+        "atomic_verifier": _Verifier("judge-a"),
+        "shadow_replay_enabled": True,
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    overridden = OverriddenExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    assert baseline != overridden
+
+
+def test_resolved_runtime_authority_rejects_adapter_mismatch() -> None:
+    runtime = _Runtime(profile="actual")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": {"profile": "fake", "effective_model_observed": True},
+        },
+    }
+    with pytest.raises(ValueError, match="runtime_execution"):
+        ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+
+
+def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None:
+    runtime = _Runtime(profile="persisted")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": runtime.execution_identity_contract(),
+    }
+    resolved_routing["runtime_execution"] = {
+        "version": 1,
+        "observed": True,
+        "identity": resolved_routing["runtime_execution"],
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+    contract = ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        workspace_generation={"tree": "a"},
+        execution_policy={},
+        resolved_routing=bound,
+    )
+    assert contract.data["runtime"]["execution_identity"]["identity"]["profile"] == "persisted"
+
+
+def test_bound_runtime_authority_rejects_a_different_adapter_instance() -> None:
+    original = _Runtime(profile="same")
+    replacement = _Runtime(profile="same")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": original.execution_identity_contract(),
+        },
+    }
+    bound = ResolvedRuntimeAuthority.bind(original, resolved_routing)
+    with pytest.raises(ValueError, match="different adapter"):
+        ExecutionAuthorityContract.build(
+            adapter=replacement,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation={"tree": "a"},
+            execution_policy={},
+            resolved_routing=bound,
+        )
+
+
+def test_bound_runtime_authority_rejects_same_adapter_identity_drift() -> None:
+    runtime = _Runtime(profile="before")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": runtime.execution_identity_contract(),
+        },
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+    runtime.profile = "after"
+    with pytest.raises(ValueError, match="drifted from active runtime_execution"):
+        ExecutionAuthorityContract.build(
+            adapter=runtime,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation={"tree": "a"},
+            execution_policy={},
+            resolved_routing=bound,
+        )
+
+
+def test_resolved_runtime_authority_reads_effective_private_permission_mode() -> None:
+    runtime = _Runtime()
+    runtime._permission_mode = "acceptEdits"  # type: ignore[attr-defined]
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": runtime.execution_identity_contract(),
+        },
+    }
+    with pytest.raises(ValueError, match="permission_mode"):
+        ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+
+
+def test_local_skill_fallback_is_process_local() -> None:
+    class LocalSkillRuntime(_Runtime):
+        _skill_dispatcher = None
+        _skills_dir = "/tmp/skills"
+
+        async def _maybe_dispatch_skill_intercept(self, **_: object) -> None:
+            return None
+
+        async def _dispatch_skill_intercept_locally(self, **_: object) -> None:
+            return None
+
+    contract = _contract(runtime=LocalSkillRuntime())
+    assert contract.portable_across_processes is False
+    assert contract.data["runtime"]["skill_dispatcher"]["mode"] == "local_fallback"
+
+
+def test_declared_callable_dispatcher_has_durable_implementation_identity() -> None:
+    class StableDispatcher:
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"dispatcher": "stable"}
+
+        async def __call__(self, **_: object) -> None:
+            return None
+
+    runtime = _Runtime()
+    runtime._skill_dispatcher = StableDispatcher()  # type: ignore[attr-defined]
+    contract = _contract(runtime=runtime)
+    dispatcher = contract.data["runtime"]["skill_dispatcher"]
+    assert dispatcher["stability"] == "durable"
+    assert dispatcher["implementation"]["stability"] == "durable"
+
+
+def test_dispatcher_identity_provider_failure_degrades_to_process_local() -> None:
+    class RaisingDispatcher:
+        @property
+        def execution_identity_contract(self) -> object:
+            raise OSError("offline")
+
+        async def __call__(self, **_: object) -> None:
+            return None
+
+    runtime = _Runtime()
+    runtime._skill_dispatcher = RaisingDispatcher()  # type: ignore[attr-defined]
+    contract = _contract(runtime=runtime)
+    assert contract.portable_across_processes is False
+    assert contract.data["runtime"]["skill_dispatcher"]["stability"] == "process_local"

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -2476,6 +2476,24 @@ def test_runtime_transcript_verdict_post_init_drift_changes_authority(
     assert baseline.fingerprint != changed.fingerprint
 
 
+def test_runtime_transcript_verdict_member_shape_drift_changes_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verdict = VerifierVerdict(passed=False, reasons=("missing evidence",))
+    baseline = _contract().fingerprint
+
+    def force_pass_read(self: VerifierVerdict, name: str) -> object:
+        if name == "passed":
+            return True
+        return object.__getattribute__(self, name)
+
+    monkeypatch.setattr(VerifierVerdict, "__getattribute__", force_pass_read)
+    changed = _contract().fingerprint
+
+    assert verdict.passed is True
+    assert baseline != changed
+
+
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -104,6 +104,17 @@ class _FailingHelperVerifier(_HelperVerifierBase):
         return False
 
 
+class _SelfReferentialVerifier:
+    def __init__(self) -> None:
+        self.helper = self
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": "self-referential"}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
 class _BypassDispatchRateExecutor(ParallelACExecutor):
     async def _await_dispatch_rate_budget(
         self,
@@ -531,6 +542,17 @@ def test_callable_verifier_helper_override_changes_authority() -> None:
     assert passing.fingerprint != failing.fingerprint
     assert passing.data["verifier"]["implementation"]["stability"] == "durable"
     assert failing.data["verifier"]["implementation"]["stability"] == "durable"
+
+
+def test_self_referential_callable_verifier_fails_closed_without_recursing() -> None:
+    first = _contract(verifier=_SelfReferentialVerifier())
+    second = _contract(verifier=_SelfReferentialVerifier())
+
+    assert first.fingerprint != second.fingerprint
+    assert first.portable_across_processes is False
+    implementation = first.data["verifier"]["implementation"]
+    assert implementation["stability"] == "process_local"
+    assert implementation["instance_overrides"]["helper"]["mode"] == "callable"
 
 
 def test_undeclared_custom_verifier_is_process_local() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -488,6 +488,82 @@ def test_executor_rejects_post_construction_runtime_subprocess_pipe_drift(
         executor._require_execution_collaborators_intact()
 
 
+def test_executor_rejects_dispatcher_drift_when_global_integrity_helper_is_patched(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A patched module helper cannot bypass a captured dispatcher guard."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    executor._leaf_dispatcher_factory = _ReplacementLeafDispatcher
+    monkeypatch.setattr(
+        parallel_executor_module,
+        "_live_callable_integrity_is_intact",
+        lambda *_args, **_kwargs: True,
+    )
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_mutated_atomic_verifier_closure(tmp_path) -> None:
+    """Mutable verifier closure state cannot drift after authority construction."""
+    state = {"passed": True}
+
+    def closure_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=state["passed"])
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+        atomic_verifier=closure_verifier,
+    )
+
+    state["passed"] = False
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_executor_rejects_runtime_drift_when_global_integrity_helper_is_patched(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Runtime dispatch still uses the construction-time checker dependency graph."""
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+        enable_decomposition=False,
+    )
+
+    async def altered_execute_task(self: _Runtime, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(_Runtime, "execute_task", altered_execute_task)
+    monkeypatch.setattr(
+        parallel_executor_module,
+        "_live_callable_integrity_is_intact",
+        lambda *_args, **_kwargs: True,
+    )
+
+    with pytest.raises(ValueError, match="runtime implementation drifted"):
+        executor._require_execution_collaborators_intact()
+
+
 @pytest.mark.parametrize("member", ("create_subprocess_exec", "wait_for", "subprocess.PIPE"))
 def test_executor_rejects_post_construction_worker_subprocess_drift(
     monkeypatch: pytest.MonkeyPatch,
@@ -988,8 +1064,14 @@ def test_process_local_nonce_is_stable_per_live_object_and_released_after_gc() -
     assert object_id not in execution_authority_module._PROCESS_LOCAL_RUNTIME_NONCES
 
 
-def test_credential_markers_never_egress_via_authority_metadata() -> None:
-    credential = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+@pytest.mark.parametrize(
+    "credential",
+    (
+        "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+        "rk_live_" + "a" * 32,
+    ),
+)
+def test_credential_markers_never_egress_via_authority_metadata(credential: str) -> None:
 
     class CredentialLabelRuntime(_Runtime):
         runtime_backend = credential
@@ -1045,8 +1127,11 @@ def test_credential_markers_never_egress_via_authority_metadata() -> None:
     assert all(credential not in contract.canonical_json for contract in contracts)
 
 
-def test_credential_shaped_runtime_capabilities_fail_closed_without_egress() -> None:
-    credential = "ghp_" + "a" * 36
+@pytest.mark.parametrize(
+    "credential",
+    ("ghp_" + "a" * 36, "rk_live_" + "b" * 36),
+)
+def test_credential_shaped_runtime_capabilities_fail_closed_without_egress(credential: str) -> None:
     runtime = _Runtime()
     runtime.capabilities = replace(  # type: ignore[attr-defined]
         FULL_CAPABILITIES,

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.execution_authority import (
     build_execution_policy_contract,
 )
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.pi_runtime import PiRuntime
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
@@ -75,6 +76,50 @@ class _Verifier:
 
     def __call__(self, **_: object) -> VerifierVerdict:
         return VerifierVerdict(passed=True)
+
+
+class _ExecutionOwner:
+    def execute(self) -> None:
+        """Stable test-only effect-owner implementation."""
+
+
+class _HelperVerifierBase:
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": "shared"}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=self._passed())
+
+    def _passed(self) -> bool:
+        raise NotImplementedError
+
+
+class _PassingHelperVerifier(_HelperVerifierBase):
+    def _passed(self) -> bool:
+        return True
+
+
+class _FailingHelperVerifier(_HelperVerifierBase):
+    def _passed(self) -> bool:
+        return False
+
+
+class _BypassDispatchRateExecutor(ParallelACExecutor):
+    async def _await_dispatch_rate_budget(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None,
+    ) -> None:
+        del prompt, system_prompt
+
+
+class _StableDispatcher:
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"dispatcher": "stable"}
+
+    async def __call__(self, **_: object) -> None:
+        return None
 
 
 class _SlottedRuntime:
@@ -143,6 +188,7 @@ def _contract(
     return ExecutionAuthorityContract.build(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
+        executor=_ExecutionOwner(),
         workspace=workspace,
         execution_policy=policy if policy is not None else _policy(),
         workspace_generation=generation if generation is not None else _generation(),
@@ -164,6 +210,7 @@ def _worker_contract(
     return ExecutionAuthorityContract.build(
         adapter=runtime,
         verifier=None,
+        executor=_ExecutionOwner(),
         workspace="/tmp/workspace-a",
         workspace_generation=_generation(),
         execution_policy=_policy(backend=backend),
@@ -336,6 +383,7 @@ def test_bundled_transport_identity_is_stable_and_binds_instance_override() -> N
         return ExecutionAuthorityContract.build(
             adapter=runtime,
             verifier=None,
+            executor=_ExecutionOwner(),
             workspace="/tmp/workspace-a",
             workspace_generation=_generation(),
             execution_policy=_policy(backend="claude_mcp"),
@@ -476,6 +524,15 @@ def test_verifier_identity_drift_changes_authority() -> None:
     assert first.portable_across_processes is True
 
 
+def test_callable_verifier_helper_override_changes_authority() -> None:
+    passing = _contract(verifier=_PassingHelperVerifier())
+    failing = _contract(verifier=_FailingHelperVerifier())
+
+    assert passing.fingerprint != failing.fingerprint
+    assert passing.data["verifier"]["implementation"]["stability"] == "durable"
+    assert failing.data["verifier"]["implementation"]["stability"] == "durable"
+
+
 def test_undeclared_custom_verifier_is_process_local() -> None:
     def verifier(**_: object) -> VerifierVerdict:
         return VerifierVerdict(passed=True)
@@ -545,6 +602,67 @@ def test_dispatch_rate_policy_drift_changes_executor_authority(
     assert first_policy["requests_per_minute"] == 1
     assert second_policy["requests_per_minute"] == 9
     assert first.execution_authority.fingerprint != second.execution_authority.fingerprint
+
+
+def test_executor_implementation_override_changes_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    rate_policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=None,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": rate_policy,
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    bypassed = _BypassDispatchRateExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.data["execution_policy"]["dispatch_rate"]["gate_enabled"] is True
+    assert baseline.fingerprint != bypassed.fingerprint
+    assert baseline.data["executor"]["stability"] == "durable"
+    assert bypassed.data["executor"]["stability"] == "durable"
+
+
+def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -> None:
+    first_runtime = PiRuntime(
+        cli_path="/usr/bin/true",
+        cwd=tmp_path,
+        skills_dir=tmp_path / "skills-a",
+    )
+    second_runtime = PiRuntime(
+        cli_path="/usr/bin/true",
+        cwd=tmp_path,
+        skills_dir=tmp_path / "skills-b",
+    )
+
+    first = ExecutionAuthorityContract.build(
+        adapter=first_runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+    second = ExecutionAuthorityContract.build(
+        adapter=second_runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+
+    skill_dispatcher = first.data["runtime"]["skill_dispatcher"]
+    assert skill_dispatcher["mode"] == "delegated"
+    assert skill_dispatcher["component"]["mode"] == "declared"
+    assert skill_dispatcher["stability"] == "durable"
+    assert first.fingerprint != second.fingerprint
 
 
 def test_self_governing_rate_policy_is_explicit_and_not_portable(tmp_path) -> None:
@@ -737,6 +855,7 @@ def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None
     contract = ExecutionAuthorityContract.build(
         adapter=runtime,
         verifier=None,
+        executor=_ExecutionOwner(),
         workspace="/tmp/workspace-a",
         workspace_generation=_generation("a"),
         execution_policy=_policy(),
@@ -832,15 +951,8 @@ def test_local_skill_fallback_is_process_local() -> None:
 
 
 def test_declared_callable_dispatcher_has_durable_implementation_identity() -> None:
-    class StableDispatcher:
-        def execution_identity_contract(self) -> dict[str, object]:
-            return {"dispatcher": "stable"}
-
-        async def __call__(self, **_: object) -> None:
-            return None
-
     runtime = _Runtime()
-    runtime._skill_dispatcher = StableDispatcher()  # type: ignore[attr-defined]
+    runtime._skill_dispatcher = _StableDispatcher()  # type: ignore[attr-defined]
     contract = _contract(runtime=runtime)
     dispatcher = contract.data["runtime"]["skill_dispatcher"]
     assert dispatcher["stability"] == "durable"

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
+from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
+from ouroboros.orchestrator.codex_mcp_runtime import CodexMcpWorkerTransport
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
@@ -17,6 +19,7 @@ from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from ouroboros.orchestrator.worker_runtime import LeaderDrivenWorkerRuntime
 
 
 class _Runtime:
@@ -147,6 +150,26 @@ def _contract(
     )
 
 
+def _worker_contract(
+    transport: object,
+    *,
+    backend: str,
+    llm_backend: str,
+) -> ExecutionAuthorityContract:
+    runtime = LeaderDrivenWorkerRuntime(
+        transport=transport,  # type: ignore[arg-type]
+        runtime_backend=backend,
+        llm_backend=llm_backend,
+    )
+    return ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend=backend),
+    )
+
+
 def test_runtime_profile_drift_changes_authority() -> None:
     assert (
         _contract(runtime=_Runtime(profile="a")).fingerprint
@@ -244,6 +267,193 @@ def test_instance_level_execution_override_is_process_local() -> None:
     overridden = _contract(runtime=runtime)
     assert baseline.fingerprint != overridden.fingerprint
     assert overridden.portable_across_processes is False
+
+    runtime.execute_task = None  # type: ignore[method-assign]
+    non_callable = _contract(runtime=runtime)
+    assert baseline.fingerprint != non_callable.fingerprint
+    assert non_callable.portable_across_processes is False
+
+    runtime_with_handler = _Runtime()
+    runtime_with_handler._handler = lambda: "one"  # type: ignore[attr-defined]
+    handler_contract = _contract(runtime=runtime_with_handler)
+    assert (
+        handler_contract.data["runtime"]["implementation"]["instance_overrides"]["_handler"]["mode"]
+        == "callable"
+    )
+    assert handler_contract.portable_across_processes is False
+
+
+def test_bundled_worker_transport_policy_changes_authority() -> None:
+    claude_first = _worker_contract(
+        ClaudeWorkerTransport(
+            cli_path="/usr/bin/true",
+            timeout=1,
+            disallowed_tools=("tool-a",),
+            persist_sessions=False,
+        ),
+        backend="claude_mcp",
+        llm_backend="claude",
+    )
+    claude_second = _worker_contract(
+        ClaudeWorkerTransport(
+            cli_path="/usr/bin/false",
+            timeout=9,
+            disallowed_tools=("tool-b",),
+            persist_sessions=True,
+        ),
+        backend="claude_mcp",
+        llm_backend="claude",
+    )
+    codex_first = _worker_contract(
+        CodexMcpWorkerTransport(cli_path="/usr/bin/true", idle_timeout=1),
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+    codex_second = _worker_contract(
+        CodexMcpWorkerTransport(cli_path="/usr/bin/false", idle_timeout=9),
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+
+    assert claude_first.fingerprint != claude_second.fingerprint
+    assert codex_first.fingerprint != codex_second.fingerprint
+    transport = claude_first.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert transport["mode"] == "declared"
+    assert transport["executable"]["observed"] is True
+
+
+def test_bundled_transport_identity_is_stable_and_binds_instance_override() -> None:
+    transport = ClaudeWorkerTransport(cli_path="/usr/bin/true")
+    runtime = LeaderDrivenWorkerRuntime(
+        transport=transport,
+        runtime_backend="claude_mcp",
+        llm_backend="claude",
+    )
+
+    def build() -> ExecutionAuthorityContract:
+        return ExecutionAuthorityContract.build(
+            adapter=runtime,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation=_generation(),
+            execution_policy=_policy(backend="claude_mcp"),
+        )
+
+    first = build()
+    assert first.fingerprint == build().fingerprint
+
+    transport.spawn = lambda **_: None  # type: ignore[method-assign]
+    overridden = build()
+    assert first.fingerprint != overridden.fingerprint
+    component = overridden.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert component["stability"] == "process_local"
+
+    transport.spawn = None  # type: ignore[method-assign]
+    non_callable = build()
+    assert first.fingerprint != non_callable.fingerprint
+    component = non_callable.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert component["instance_overrides"]["spawn"]["mode"] == "non_callable"
+
+
+def test_undeclared_transport_fails_closed_without_colliding() -> None:
+    class OpaqueTransport:
+        backend_name = "opaque"
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    first = _worker_contract(
+        OpaqueTransport(),
+        backend="opaque",
+        llm_backend="opaque",
+    )
+    second = _worker_contract(
+        OpaqueTransport(),
+        backend="opaque",
+        llm_backend="opaque",
+    )
+
+    assert first.fingerprint != second.fingerprint
+    component = first.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert first.portable_across_processes is False
+
+
+def test_malformed_transport_identity_fails_closed_without_leaking() -> None:
+    class MalformedTransport:
+        backend_name = "malformed"
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"version": True, "configuration": {"api_token": "sentinel-secret"}}
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    contract = _worker_contract(
+        MalformedTransport(),
+        backend="malformed",
+        llm_backend="malformed",
+    )
+    component = contract.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert "sentinel-secret" not in contract.canonical_json
+
+
+def test_sensitive_transport_identity_fails_closed_without_leaking() -> None:
+    class SensitiveTransport:
+        backend_name = "sensitive"
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "version": 1,
+                "configuration": {"api_token": "sentinel-secret"},
+            }
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    contract = _worker_contract(
+        SensitiveTransport(),
+        backend="sensitive",
+        llm_backend="sensitive",
+    )
+
+    component = contract.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert "identity_digest" not in component
+    assert "sentinel-secret" not in contract.canonical_json
+
+
+def test_codex_transport_live_pool_is_excluded_from_static_identity() -> None:
+    transport = CodexMcpWorkerTransport(cli_path="/usr/bin/true")
+    baseline = _worker_contract(
+        transport,
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+    transport._pool["session"] = object()  # type: ignore[assignment]
+    changed_live_state = _worker_contract(
+        transport,
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+
+    assert baseline.fingerprint == changed_live_state.fingerprint
 
 
 def test_unobservable_slotted_instance_state_is_process_local() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1941,7 +1941,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     closure_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     assert closure_first._dispatch_rate_gate._bucket._request_limit == 9
     assert closure_second._dispatch_rate_gate._bucket._request_limit == 99
-    assert closure_first.execution_authority.fingerprint != closure_second.execution_authority.fingerprint
+    assert (
+        closure_first.execution_authority.fingerprint
+        != closure_second.execution_authority.fingerprint
+    )
     closure_first_algorithm = closure_first.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -1971,7 +1974,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     default_first = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     monkeypatch.setattr(rate_limit_module, "build_rate_limit_gate", default_ninety_nine)
     default_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
-    assert default_first.execution_authority.fingerprint != default_second.execution_authority.fingerprint
+    assert (
+        default_first.execution_authority.fingerprint
+        != default_second.execution_authority.fingerprint
+    )
     default_first_algorithm = default_first.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -1999,10 +2005,13 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     global_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     assert global_first._dispatch_rate_gate._bucket._request_limit == 9
     assert global_second._dispatch_rate_gate._bucket._request_limit == 99
-    assert global_first.execution_authority.fingerprint != global_second.execution_authority.fingerprint
-    global_first_algorithm = global_first.execution_authority.data["execution_policy"]["dispatch_rate"][
-        "gate_algorithm"
-    ]
+    assert (
+        global_first.execution_authority.fingerprint
+        != global_second.execution_authority.fingerprint
+    )
+    global_first_algorithm = global_first.execution_authority.data["execution_policy"][
+        "dispatch_rate"
+    ]["gate_algorithm"]
     global_second_algorithm = global_second.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -2025,7 +2034,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     class_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     assert class_baseline._dispatch_rate_gate._bucket._request_limit == 1
     assert class_changed._dispatch_rate_gate._bucket._request_limit == 99
-    assert class_baseline.execution_authority.fingerprint != class_changed.execution_authority.fingerprint
+    assert (
+        class_baseline.execution_authority.fingerprint
+        != class_changed.execution_authority.fingerprint
+    )
 
     monkeypatch.setitem(_RATE_GATE_FACTORY_TEST_GLOBALS, "limit", 9)
 
@@ -2044,7 +2056,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     class_global_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     assert class_global_first._dispatch_rate_gate._bucket._request_limit == 9
     assert class_global_second._dispatch_rate_gate._bucket._request_limit == 99
-    assert class_global_first.execution_authority.fingerprint != class_global_second.execution_authority.fingerprint
+    assert (
+        class_global_first.execution_authority.fingerprint
+        != class_global_second.execution_authority.fingerprint
+    )
     first_algorithm = class_global_first.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -2073,10 +2088,13 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     module_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     second_timestamp = module_second._dispatch_rate_gate._bucket._time()
     assert second_timestamp - first_timestamp > 98.0
-    assert module_first.execution_authority.fingerprint != module_second.execution_authority.fingerprint
-    module_algorithm = module_first.execution_authority.data["execution_policy"][
-        "dispatch_rate"
-    ]["gate_algorithm"]
+    assert (
+        module_first.execution_authority.fingerprint
+        != module_second.execution_authority.fingerprint
+    )
+    module_algorithm = module_first.execution_authority.data["execution_policy"]["dispatch_rate"][
+        "gate_algorithm"
+    ]
     assert module_algorithm["observed"] is False
 
     monkeypatch.setattr(rate_limit_module.time, "monotonic", original_monotonic)
@@ -2095,7 +2113,9 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
     deque_second = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
     deque_second._dispatch_rate_gate._bucket._reservations.append((0.0, 1))
     assert deque_second._dispatch_rate_gate._bucket._tokens_in_window() == 100
-    assert deque_first.execution_authority.fingerprint != deque_second.execution_authority.fingerprint
+    assert (
+        deque_first.execution_authority.fingerprint != deque_second.execution_authority.fingerprint
+    )
     deque_algorithm = deque_first.execution_authority.data["execution_policy"]["dispatch_rate"][
         "gate_algorithm"
     ]
@@ -2114,7 +2134,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
 
     monkeypatch.setattr(rate_limit_module.RateLimitGate, "acquire", InertAcquireDescriptor())
     descriptor_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
-    assert descriptor_baseline.execution_authority.fingerprint != descriptor_changed.execution_authority.fingerprint
+    assert (
+        descriptor_baseline.execution_authority.fingerprint
+        != descriptor_changed.execution_authority.fingerprint
+    )
     descriptor_algorithm = descriptor_changed.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -2136,7 +2159,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
         SpoofAcquireStaticMethod(original_gate_acquire),
     )
     spoof_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
-    assert spoof_baseline.execution_authority.fingerprint != spoof_changed.execution_authority.fingerprint
+    assert (
+        spoof_baseline.execution_authority.fingerprint
+        != spoof_changed.execution_authority.fingerprint
+    )
     spoof_algorithm = spoof_changed.execution_authority.data["execution_policy"]["dispatch_rate"][
         "gate_algorithm"
     ]
@@ -2147,6 +2173,7 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
 
     def bypassing_getattribute(self: object, name: str):  # type: ignore[no-untyped-def]
         if name == "acquire":
+
             async def noop(*_args: object, **_kwargs: object) -> None:
                 return None
 
@@ -2160,7 +2187,10 @@ def test_rate_gate_replacements_and_live_dependencies_are_process_local(
         raising=False,
     )
     raw_class_changed = ParallelACExecutor(**kwargs)  # type: ignore[arg-type]
-    assert raw_class_baseline.execution_authority.fingerprint != raw_class_changed.execution_authority.fingerprint
+    assert (
+        raw_class_baseline.execution_authority.fingerprint
+        != raw_class_changed.execution_authority.fingerprint
+    )
     raw_class_algorithm = raw_class_changed.execution_authority.data["execution_policy"][
         "dispatch_rate"
     ]["gate_algorithm"]
@@ -2255,7 +2285,10 @@ def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
 def test_selected_runtime_handle_belongs_to_the_later_attempt_capsule() -> None:
     cheap = RuntimeHandle(backend="codex_cli", metadata={"profile": "cheap"})
     expensive = RuntimeHandle(backend="codex_cli", metadata={"profile": "expensive"})
-    assert _contract(runtime_handle=cheap).fingerprint == _contract(runtime_handle=expensive).fingerprint
+    assert (
+        _contract(runtime_handle=cheap).fingerprint
+        == _contract(runtime_handle=expensive).fingerprint
+    )
 
 
 def test_verifier_identity_provider_failure_degrades_to_process_local() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ouroboros.orchestrator import parallel_executor as parallel_executor_module
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
 from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
 from ouroboros.orchestrator.codex_mcp_runtime import CodexMcpWorkerTransport
@@ -19,6 +20,7 @@ from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.pi_runtime import PiRuntime
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
+from ouroboros.orchestrator.synapse import SessionSignalHub
 from ouroboros.orchestrator.verifier import VerifierVerdict
 from ouroboros.orchestrator.worker_runtime import LeaderDrivenWorkerRuntime
 
@@ -123,6 +125,16 @@ class _BypassDispatchRateExecutor(ParallelACExecutor):
         system_prompt: str | None,
     ) -> None:
         del prompt, system_prompt
+
+
+class _ReplacementLeafDispatcher:
+    """Distinct dispatch implementation for authority collision coverage."""
+
+    def __init__(self, executor: ParallelACExecutor) -> None:
+        self.executor = executor
+
+    async def stream(self, **_: object) -> None:
+        return None
 
 
 class _StableDispatcher:
@@ -282,6 +294,21 @@ def test_executable_content_drift_changes_authority_with_restored_stat(tmp_path)
     os.utime(executable, ns=(previous.st_atime_ns, previous.st_mtime_ns))
     changed = _contract(runtime=_Runtime(cli_path=str(executable)))
     assert baseline.fingerprint != changed.fingerprint
+
+
+def test_non_executable_runtime_target_fails_closed_and_changes_authority(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    os.chmod(executable, 0o755)
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+
+    os.chmod(executable, 0o644)
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+
+    assert baseline.fingerprint != changed.fingerprint
+    assert baseline.portable_across_processes is True
+    assert changed.data["runtime"]["executable"]["observed"] is False
+    assert changed.portable_across_processes is False
 
 
 def test_runtime_execution_body_and_parser_drift_change_authority() -> None:
@@ -498,6 +525,21 @@ def test_sensitive_transport_identity_fails_closed_without_leaking() -> None:
     assert "sentinel-secret" not in contract.canonical_json
 
 
+def test_sensitive_runtime_identity_fails_closed_without_leaking() -> None:
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "api_token": "sentinel-secret",
+            }
+
+    contract = _contract(runtime=SensitiveRuntime())
+
+    assert contract.data["runtime"]["execution_identity"] == {"version": 1, "observed": False}
+    assert contract.portable_across_processes is False
+    assert "sentinel-secret" not in contract.canonical_json
+
+
 def test_codex_transport_live_pool_is_excluded_from_static_identity() -> None:
     transport = CodexMcpWorkerTransport(cli_path="/usr/bin/true")
     baseline = _worker_contract(
@@ -649,6 +691,92 @@ def test_executor_implementation_override_changes_authority(tmp_path) -> None:
     assert baseline.fingerprint != bypassed.fingerprint
     assert baseline.data["executor"]["stability"] == "durable"
     assert bypassed.data["executor"]["stability"] == "durable"
+
+
+def test_leaf_dispatcher_replacement_changes_executor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": ResolvedDispatchRatePolicy.resolve(
+            backend="test-runtime",
+            self_governs_rate_limit=False,
+            requests_per_minute=1,
+            tokens_per_minute=None,
+        ),
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    monkeypatch.setattr(parallel_executor_module, "LeafDispatcher", _ReplacementLeafDispatcher)
+    replaced = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint != replaced.fingerprint
+    component = replaced.data["executor"]["components"]["leaf_dispatcher"]
+    assert component["mode"] == "static_type"
+    assert component["type"].endswith("._ReplacementLeafDispatcher")
+
+
+def test_live_session_signal_hub_makes_executor_authority_process_local(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": ResolvedDispatchRatePolicy.resolve(
+            backend="test-runtime",
+            self_governs_rate_limit=False,
+            requests_per_minute=1,
+            tokens_per_minute=None,
+        ),
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    with_hub = ParallelACExecutor(
+        **kwargs,
+        session_signal_hub=SessionSignalHub(),
+    ).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint != with_hub.fingerprint
+    assert with_hub.portable_across_processes is False
+    component = with_hub.data["executor"]["components"]["session_signal_hub"]
+    assert component["mode"] == "live_instance"
+    assert component["stability"] == "process_local"
+
+
+def test_noncanonical_dispatch_rate_policy_is_rejected(tmp_path) -> None:
+    class DormantRatePolicy(ResolvedDispatchRatePolicy):
+        def build_gate(self):  # type: ignore[no-untyped-def]
+            return ResolvedDispatchRatePolicy.resolve(
+                backend=self.backend,
+                self_governs_rate_limit=False,
+                requests_per_minute=None,
+                tokens_per_minute=None,
+            ).build_gate()
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = DormantRatePolicy(
+        backend="test-runtime",
+        owner="ouroboros",
+        observed=True,
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=None,
+    )
+
+    with pytest.raises(ValueError, match="canonical policy type"):
+        ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            task_cwd=str(tmp_path),
+            dispatch_rate_policy=policy,
+        )
 
 
 def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.verifier import VerifierVerdict
+
+
+class _Runtime:
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory: str | None = None
+    _model = None
+
+    def __init__(self, *, profile: str = "profile-a") -> None:
+        self.profile = profile
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {
+            "profile": self.profile,
+            "effective_model_observed": True,
+        }
+
+
+class _Verifier:
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": self.identity}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
+def _contract(
+    *,
+    runtime: _Runtime | None = None,
+    verifier: object | None = None,
+    workspace: str = "/tmp/workspace-a",
+    policy: dict[str, object] | None = None,
+) -> ExecutionAuthorityContract:
+    return ExecutionAuthorityContract.build(
+        adapter=runtime or _Runtime(),
+        verifier=verifier,  # type: ignore[arg-type]
+        workspace=workspace,
+        execution_policy=policy or {"retry_attempts": 2},
+    )
+
+
+def test_runtime_profile_drift_changes_authority() -> None:
+    assert (
+        _contract(runtime=_Runtime(profile="a")).fingerprint
+        != _contract(runtime=_Runtime(profile="b")).fingerprint
+    )
+
+
+def test_verifier_identity_drift_changes_authority() -> None:
+    first = _contract(verifier=_Verifier("judge-a"))
+    same = _contract(verifier=_Verifier("judge-a"))
+    changed = _contract(verifier=_Verifier("judge-b"))
+
+    assert first.fingerprint == same.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert first.reusable_across_processes is True
+
+
+def test_undeclared_custom_verifier_is_process_local() -> None:
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    first = _contract(verifier=verifier)
+    second = _contract(verifier=verifier)
+
+    assert first.reusable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_workspace_and_policy_drift_change_authority() -> None:
+    baseline = _contract()
+    assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
+    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=load_profile("code"),
+        atomic_verifier=_Verifier("judge-a"),
+        ac_retry_attempts=2,
+    )
+
+    authority = executor.execution_authority
+    assert authority.fingerprint.startswith("sha256:")
+    assert authority.data["workspace"]["effective_cwd"] == str(tmp_path.resolve())
+    assert authority.data["runtime"]["execution_identity"]["identity"]["profile"] == "profile-a"
+    assert authority.data["execution_policy"]["ac_retry_attempts"] == 2
+
+
+def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    base_profile = load_profile("code")
+    changed_profile = base_profile.model_copy(update={"profile": "code-v2"})
+
+    def build(profile: ExecutionProfile) -> str:
+        return ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            execution_profile=profile,
+        ).execution_authority.fingerprint
+
+    assert build(base_profile) != build(changed_profile)

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -35,7 +35,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
-from ouroboros.orchestrator.leaf_dispatcher import _correlated_tool_result_name
+from ouroboros.orchestrator.leaf_dispatcher import LeafDispatcher, _correlated_tool_result_name
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
     MAX_STALL_RETRIES,
@@ -229,6 +229,79 @@ def _make_executor() -> ParallelACExecutor:
     executor._emit_level_completed = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
     return executor
+
+
+def _authority_test_verifier(**_: object) -> VerifierVerdict:
+    return VerifierVerdict(passed=True, reasons=())
+
+
+def test_execution_authority_rejects_post_construction_leaf_dispatcher_replacement() -> None:
+    """Dispatch cannot switch away from the authority-bound leaf factory."""
+    executor = _make_executor()
+
+    class BypassDispatcher:
+        async def stream(self, **_: object) -> None:
+            raise AssertionError("must not be invoked after authority drift")
+
+    executor._leaf_dispatcher_factory = BypassDispatcher
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_execution_authority_rejects_post_construction_leaf_dispatcher_code_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-place dispatch implementation mutation cannot bypass authority."""
+    executor = _make_executor()
+
+    async def bypass_stream(self: object, **_: object) -> None:
+        raise AssertionError("must not be invoked after authority drift")
+
+    monkeypatch.setattr(LeafDispatcher.stream, "__code__", bypass_stream.__code__)
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_execution_authority_rejects_post_construction_atomic_verifier_replacement() -> None:
+    """Acceptance behavior cannot switch away from the authority-bound verifier."""
+    executor = ParallelACExecutor(
+        adapter=MagicMock(),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=_authority_test_verifier,
+    )
+
+    def bypass_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True, reasons=())
+
+    executor._atomic_verifier = bypass_verifier
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
+
+
+def test_execution_authority_rejects_post_construction_atomic_verifier_code_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-place verifier implementation mutation cannot bypass authority."""
+    executor = ParallelACExecutor(
+        adapter=MagicMock(),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=_authority_test_verifier,
+    )
+
+    def bypass_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True, reasons=())
+
+    monkeypatch.setattr(_authority_test_verifier, "__code__", bypass_verifier.__code__)
+
+    with pytest.raises(ValueError, match="execution collaborators drifted"):
+        executor._require_execution_collaborators_intact()
 
 
 def test_criterion_satisfied_by_exact_runtime_evidence() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -21,6 +21,7 @@ from ouroboros.core.seed import (
 )
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
+from ouroboros.orchestrator import rate_limit as rate_limit_module
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     AgentMessage,
@@ -56,7 +57,6 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
-from ouroboros.orchestrator.rate_limit import RateLimitGate, SharedRateLimitBucket
 from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
@@ -138,11 +138,11 @@ class TestDispatchRateGate:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
-        adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
-        executor = _make_rate_gate_executor(adapter)
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
 
-        # Swap in a deterministic gate (rpm=1, fake clock + sleep) to prove the
-        # executor's dispatch hook actually waits on the shared budget.
+        # Install deterministic collaborators *before* construction.  Replacing
+        # a gate after construction is intentionally no longer a supported test
+        # seam: the executor dispatches through its authority-bound capture.
         clock = {"now": 0.0}
         slept: list[float] = []
 
@@ -150,20 +150,55 @@ class TestDispatchRateGate:
             slept.append(seconds)
             clock["now"] += seconds
 
-        bucket = SharedRateLimitBucket(
-            runtime_backend="opencode",
-            request_limit=1,
-            token_limit=None,
-            time_provider=lambda: clock["now"],
-        )
-        executor._dispatch_rate_gate = RateLimitGate(
-            bucket, heartbeat_seconds=120.0, sleep=fake_sleep
-        )
+        monkeypatch.setattr(rate_limit_module.time, "monotonic", lambda: clock["now"])
+        monkeypatch.setattr(rate_limit_module.asyncio, "sleep", fake_sleep)
+        adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
+        executor = _make_rate_gate_executor(adapter)
 
         await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
         await executor._await_dispatch_rate_budget(prompt="b", system_prompt=None)
 
-        assert slept == [60.0]  # second dispatch waited a full window
+        assert slept == [30.0, 30.0]  # second dispatch waited one full window
+
+    @pytest.mark.asyncio
+    async def test_authority_bound_gate_rejects_post_construction_drift(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """A later gate-method replacement must not bypass the captured budget."""
+        monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
+        adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
+        executor = _make_rate_gate_executor(adapter)
+        invoked = False
+
+        async def bypass_acquire(*_args: object, **_kwargs: object) -> None:
+            nonlocal invoked
+            invoked = True
+
+        monkeypatch.setattr(rate_limit_module.RateLimitGate, "acquire", bypass_acquire)
+
+        with pytest.raises(ValueError, match="dispatch rate gate drifted"):
+            await executor._await_dispatch_rate_budget(prompt="hello", system_prompt=None)
+        assert invoked is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field_name", ("_request_limit", "_token_limit"))
+    async def test_authority_bound_gate_rejects_policy_field_mutation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Any,
+        field_name: str,
+    ) -> None:
+        """Mutable bucket policy fields remain bound after construction."""
+        monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
+        monkeypatch.setenv("OUROBOROS_OPENCODE_TPM", "10000")
+        adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
+        executor = _make_rate_gate_executor(adapter)
+        setattr(executor._dispatch_rate_gate._bucket, field_name, None)
+
+        with pytest.raises(ValueError, match="dispatch rate gate drifted"):
+            await executor._await_dispatch_rate_budget(prompt="hello", system_prompt=None)
 
 
 def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1419,7 +1419,10 @@ def test_unprotected_tail_pipe_is_form_mismatch_not_command_proof() -> None:
 def test_atomic_verifier_classifies_masked_test_command_as_form_mismatch() -> None:
     """Masked test commands are contract mismatches, not fabricated work."""
     profile = load_profile("code").model_copy(
-        update={"evidence_schema": EvidenceSchema(required=("commands_run",))}
+        update={
+            "evidence_schema": EvidenceSchema(required=("commands_run",)),
+            "must_produce": ("commands_run",),
+        }
     )
     executor = ParallelACExecutor(
         adapter=MagicMock(working_directory="/workspace"),

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -359,7 +360,15 @@ class TestWheelPackaging:
         repo_root = Path(__file__).resolve().parents[3]
         out = tmp_path / "dist"
         result = subprocess.run(
-            ["uv", "build", "--wheel", "--out-dir", str(out)],
+            [
+                "uv",
+                "build",
+                "--wheel",
+                "--python",
+                sys.executable,
+                "--out-dir",
+                str(out),
+            ],
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -17,6 +17,7 @@ from ouroboros.mcp.tools.execution_handlers import (
 )
 from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.execution_authority import ResolvedRuntimeAuthority
 from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
 from ouroboros.orchestrator.model_routing import (
     ModelRouter,
@@ -132,6 +133,264 @@ def test_router_contract_distinguishes_disabled_from_malformed() -> None:
         )
         assert recognized is False
         assert malformed is None
+
+
+def test_execution_contract_marks_an_unobserved_llm_backend_for_parallel_binding() -> None:
+    adapter = _adapter()
+    adapter.llm_backend = None
+    runner = OrchestratorRunner(adapter, AsyncMock(), MagicMock())
+
+    routing_contract = runner._build_execution_contract()["model_routing"]
+
+    assert routing_contract["llm_backend"] is None
+    assert routing_contract["llm_backend_unobserved"] is True
+    assert ResolvedRuntimeAuthority.bind(adapter, routing_contract).data == routing_contract
+
+
+def test_build_contract_captures_unobserved_label_before_parallel_dispatch() -> None:
+    runner = _runner()
+    runner._adapter.runtime_backend = "ghp_" + "a" * 36
+    runner._adapter.llm_backend = "ghp_" + "b" * 36
+    contract = runner._build_execution_contract()
+
+    runner._adapter.runtime_backend = "ghp_" + "c" * 36
+    runner._adapter.llm_backend = "ghp_" + "d" * 36
+
+    with pytest.raises(OrchestratorError, match="drifted since planning"):
+        runner._parallel_runtime_authority(contract["model_routing"])
+
+
+def test_resume_rejects_unobserved_llm_backend_without_cohort_reuse() -> None:
+    original = _runner()
+    original._adapter.llm_backend = None
+    persisted = original._build_execution_contract()
+
+    resumed = _runner()
+    resumed._adapter.llm_backend = None
+
+    with pytest.raises(OrchestratorError, match="backend identity is unobserved"):
+        resumed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+    assert (
+        OrchestratorRunner._proof_cohort_identity(
+            {"seed_id": "seed-1", EXECUTION_CONTRACT_PROGRESS_KEY: persisted}
+        )
+        is None
+    )
+
+    observed = _runner()
+    with pytest.raises(OrchestratorError, match="backend identity is unobserved"):
+        observed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+
+def test_resume_rejects_different_sensitive_runtime_labels_without_persisting_them() -> None:
+    original = _runner()
+    original_runtime = "ghp_" + "a" * 36
+    original_llm = "ghp_" + "b" * 36
+    original._adapter.runtime_backend = original_runtime
+    original._adapter.llm_backend = original_llm
+    persisted = original._build_execution_contract()
+
+    routing_contract = persisted["model_routing"]
+    assert routing_contract["runtime_backend"] is None
+    assert routing_contract["runtime_backend_unobserved"] is True
+    assert routing_contract["llm_backend"] is None
+    assert routing_contract["llm_backend_unobserved"] is True
+    assert original_runtime not in str(persisted)
+    assert original_llm not in str(persisted)
+
+    resumed = _runner()
+    resumed._adapter.runtime_backend = "ghp_" + "c" * 36
+    resumed._adapter.llm_backend = "ghp_" + "d" * 36
+
+    with pytest.raises(OrchestratorError, match="backend identity is unobserved"):
+        resumed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    (" \t", "\x00", "\u200b", "\ufeff", "\u2060", "\u034f", "\ufe0f", "claude:"),
+)
+def test_prefixed_sensitive_labels_never_egress_through_resume(prefix: str) -> None:
+    original = _runner()
+    runtime_secret = "ghp_" + "a" * 36
+    llm_secret = "ghp_" + "b" * 36
+    original._adapter.runtime_backend = f"{prefix}{runtime_secret}"
+    original._adapter.llm_backend = f"{prefix}{llm_secret}"
+    persisted = original._build_execution_contract()
+
+    routing_contract = persisted["model_routing"]
+    assert routing_contract["runtime_backend"] is None
+    assert routing_contract["runtime_backend_unobserved"] is True
+    assert routing_contract["llm_backend"] is None
+    assert routing_contract["llm_backend_unobserved"] is True
+    assert runtime_secret not in str(persisted)
+    assert llm_secret not in str(persisted)
+
+    resumed = _runner()
+    with pytest.raises(OrchestratorError, match="backend identity is unobserved") as exc_info:
+        resumed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+    assert runtime_secret not in str(exc_info.value)
+    assert llm_secret not in str(exc_info.value)
+    assert runtime_secret not in str(exc_info.value.details)
+    assert llm_secret not in str(exc_info.value.details)
+
+
+@pytest.mark.parametrize(
+    "field_name, value",
+    (
+        (
+            "runtime_execution",
+            {
+                "version": 1,
+                "observed": True,
+                "identity": {
+                    "effective_model_observed": True,
+                    "opaque": "ghp_" + "a" * 36,
+                },
+            },
+        ),
+        ("constructor_model", {"observed": True, "model": "ghp_" + "a" * 36}),
+        ("permission_mode", {"observed": True, "mode": "ghp_" + "a" * 36}),
+        ("runtime_backend", "ghp_" + "a" * 36),
+        ("runtime_backend", "claude:ghp_" + "a" * 36),
+        ("llm_backend", "ghp_" + "a" * 36),
+        ("llm_backend", "anthropic:ghp_" + "a" * 36),
+    ),
+)
+def test_resume_rejects_sensitive_persisted_routing_before_diagnostics(
+    field_name: str,
+    value: object,
+) -> None:
+    original = _runner()
+    persisted = original._build_execution_contract()
+    secret = "ghp_" + "a" * 36
+    routing_contract = persisted["model_routing"]
+    routing_contract[field_name] = value
+    persisted["frugality_proof"]["routing_fingerprint"] = OrchestratorRunner._routing_fingerprint(
+        routing_contract
+    )
+
+    with pytest.raises(OrchestratorError, match="invalid execution contract") as exc_info:
+        _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_routing_contract_validators_reject_sensitive_subcontracts() -> None:
+    secret = "ghp_" + "a" * 36
+
+    assert OrchestratorRunner._runtime_routing_labels_from_contract(
+        {"runtime_backend": secret, "llm_backend": "anthropic"}
+    ) is None
+    assert OrchestratorRunner._valid_permission_mode_contract(
+        {"observed": True, "mode": secret}
+    ) is False
+
+
+def test_runtime_identity_failure_does_not_egress_dynamic_adapter_type() -> None:
+    secret = "ghp_" + "a" * 36
+
+    def fail_identity(_self: object) -> dict[str, object]:
+        raise RuntimeError("identity provider failed")
+
+    dynamic_adapter = type(secret, (), {"execution_identity_contract": fail_identity})()
+    runner = _runner()
+    runner._adapter = dynamic_adapter
+
+    with pytest.raises(OrchestratorError, match="invalid execution identity contract") as exc_info:
+        runner._runtime_execution_identity_contract()
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_legacy_resume_rejects_compound_sensitive_backend_before_diagnostics() -> None:
+    runner = _runner()
+    secret = "ghp_" + "a" * 36
+
+    with pytest.raises(OrchestratorError, match="invalid execution contract") as exc_info:
+        runner._restore_execution_contract(
+            {
+                SESSION_START_IDENTITY_PROGRESS_KEY: {
+                    "runtime_backend": f"claude:{secret}",
+                },
+            },
+            seed=_seed(),
+        )
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+@pytest.mark.parametrize(
+    "location",
+    ("runtime_cwd", "runtime_identity", "seed_goal"),
+)
+def test_legacy_resume_preflight_rejects_sensitive_values_before_diagnostics(
+    location: str,
+) -> None:
+    secret = "ghp_" + "a" * 36
+    if location == "runtime_cwd":
+        progress = {"runtime": {"cwd": f"/tmp/{secret}"}}
+    elif location == "runtime_identity":
+        progress = {
+            SESSION_RUNTIME_IDENTITY_PROGRESS_KEY: {
+                "status": "bound",
+                "backend": "claude",
+                "id_kind": "native_session_id",
+                "id": secret,
+            }
+        }
+    else:
+        progress = {SESSION_START_IDENTITY_PROGRESS_KEY: {"seed_goal": secret}}
+
+    with pytest.raises(OrchestratorError, match="invalid execution contract") as exc_info:
+        _runner()._restore_execution_contract(progress, seed=_seed())
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_legacy_resume_does_not_egress_sensitive_current_seed_goal() -> None:
+    secret = "ghp_" + "a" * 36
+    progress = {SESSION_START_IDENTITY_PROGRESS_KEY: {"seed_goal": "original goal"}}
+
+    with pytest.raises(OrchestratorError, match="modified Seed goal") as exc_info:
+        _runner()._restore_execution_contract(progress, seed=_seed(goal=secret))
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_legacy_resume_does_not_egress_sensitive_current_workspace() -> None:
+    secret = "ghp_" + "a" * 36
+    runner = _runner(cwd=f"/tmp/{secret}")
+
+    with pytest.raises(OrchestratorError, match="different project workspace") as exc_info:
+        runner._restore_execution_contract(
+            {"runtime": {"cwd": "/tmp/original-workspace"}},
+            seed=_seed(),
+        )
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_current_contract_resume_does_not_egress_sensitive_current_workspace() -> None:
+    secret = "ghp_" + "a" * 36
+    original = _runner(cwd="/tmp/original-workspace")
+    persisted = original._build_execution_contract(seed=_seed())
+
+    with pytest.raises(OrchestratorError, match="different project workspace") as exc_info:
+        _runner(cwd=f"/tmp/{secret}")._restore_execution_contract(
+            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
+            seed=_seed(),
+        )
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
 
 
 @pytest.mark.parametrize(
@@ -679,6 +938,62 @@ def test_codex_default_resume_handle_matches_start_contract() -> None:
     )
 
 
+def test_resume_selector_provider_error_does_not_egress_provider_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "ghp_" + "a" * 36
+    runtime = CodexCliRuntime(
+        cli_path="/bin/echo",
+        model=None,
+        cwd="/tmp/project",
+    )
+    runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
+    runner._execution_contract = runner._build_execution_contract(seed=_seed())
+
+    def raise_selector_error(
+        _runtime: CodexCliRuntime,
+        _runtime_handle: RuntimeHandle | None,
+    ) -> dict[str, object]:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(
+        CodexCliRuntime,
+        "resume_handle_execution_identity_contract",
+        raise_selector_error,
+    )
+
+    with pytest.raises(OrchestratorError, match="invalid runtime selector metadata") as exc_info:
+        runner._validate_resume_handle_execution_identity(None)
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
+def test_resume_selector_mismatch_does_not_egress_selector_values() -> None:
+    secret = "ghp_" + "a" * 36
+    runtime = CodexCliRuntime(
+        cli_path="/bin/echo",
+        model=None,
+        cwd="/tmp/project",
+    )
+    runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
+    runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    identity = runner._execution_contract["model_routing"]["runtime_execution"]["identity"]
+    identity["resume_handle_selector"] = {"persisted": secret}
+
+    with pytest.raises(OrchestratorError, match="different runtime handle selector") as exc_info:
+        runner._validate_resume_handle_execution_identity(
+            RuntimeHandle(
+                backend="codex_cli",
+                native_session_id="thread-123",
+                metadata={"codex_profile": secret},
+            )
+        )
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
 @pytest.mark.parametrize("backend", ["codex_cli", "goose", "pi", "hermes_cli", "opencode"])
 def test_bound_runtime_identity_rejects_same_backend_thread_swap(backend: str) -> None:
     progress = {
@@ -700,6 +1015,27 @@ def test_bound_runtime_identity_rejects_same_backend_thread_swap(backend: str) -
         )
 
 
+def test_bound_runtime_identity_mismatch_does_not_egress_current_handle_value() -> None:
+    secret = "ghp_" + "a" * 36
+    progress = {
+        SESSION_RUNTIME_IDENTITY_PROGRESS_KEY: {
+            "status": "bound",
+            "backend": "claude",
+            "id_kind": "native_session_id",
+            "id": "thread-original",
+        }
+    }
+
+    with pytest.raises(OrchestratorError, match="different backend session") as exc_info:
+        OrchestratorRunner._validate_bound_runtime_resume_identity(
+            progress,
+            RuntimeHandle(backend="claude", native_session_id=secret),
+        )
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
 def test_non_codex_runtime_rejects_cross_backend_handle() -> None:
     runtime = GooseCliRuntime(
         cli_path="/bin/echo",
@@ -715,6 +1051,19 @@ def test_non_codex_runtime_rejects_cross_backend_handle() -> None:
                 native_session_id="claude-session",
             )
         )
+
+
+def test_runtime_handle_backend_mismatch_does_not_egress_handle_value() -> None:
+    secret = "ghp_" + "a" * 36
+    runner = _runner()
+    runtime_handle = RuntimeHandle(backend="claude", native_session_id="thread-123")
+    object.__setattr__(runtime_handle, "backend", secret)
+
+    with pytest.raises(OrchestratorError, match="handle from a different backend") as exc_info:
+        runner._validate_runtime_handle_backend(runtime_handle)
+
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
 
 
 def test_runtime_handle_permission_is_overwritten_to_bypass() -> None:
@@ -1398,3 +1747,36 @@ async def test_prepare_session_persists_same_execution_contract_in_start_and_pro
     assert persisted["frugality_proof"]["project_root"] == str(Path("/tmp/project").resolve())
     assert len(persisted["frugality_proof"]["routing_fingerprint"]) == 64
     assert len(persisted["frugality_proof"]["seed_fingerprint"]) == 64
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", (" \t", "\u200b", "\u034f", "claude:"))
+async def test_prepare_session_omits_sensitive_backend_labels_from_events(prefix: str) -> None:
+    store = AsyncMock()
+    events = []
+
+    async def _append(event) -> None:
+        events.append(event)
+
+    store.append.side_effect = _append
+    runtime_secret = "ghp_" + "a" * 36
+    llm_secret = "ghp_" + "b" * 36
+    adapter = _adapter()
+    adapter.runtime_backend = prefix + runtime_secret
+    adapter.llm_backend = prefix + llm_secret
+    runner = OrchestratorRunner(adapter, store, MagicMock())
+
+    result = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-sensitive-labels",
+        session_id="sess-sensitive-labels",
+    )
+
+    assert result.is_ok
+    start = next(event for event in events if event.type == "orchestrator.session.started")
+    assert "runtime_backend" not in start.data
+    assert "llm_backend" not in start.data
+    assert runtime_secret not in str(start.data)
+    assert llm_secret not in str(start.data)
+    assert runtime_secret not in str(start.to_db_dict())
+    assert llm_secret not in str(start.to_db_dict())

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -293,6 +293,26 @@ def test_routing_contract_validators_reject_sensitive_subcontracts() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    ("apiKeyValue", "accessTokenValue", "auth", "authentication"),
+)
+def test_resume_contract_screening_rejects_credential_aliases_without_echoing_them(
+    field_name: str,
+) -> None:
+    """Aliased credentials must not reach guidance mismatch diagnostics."""
+    secret = "opaque-provider-credential-1234567890"
+    persisted = _runner()._build_execution_contract()
+    persisted["guidance"] = {field_name: secret}
+
+    with pytest.raises(OrchestratorError, match="invalid execution contract") as exc_info:
+        _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+    assert exc_info.value.details == {"invalid": "sensitive persisted data"}
+    assert secret not in str(exc_info.value)
+    assert secret not in str(exc_info.value.details)
+
+
 def test_runtime_identity_failure_does_not_egress_dynamic_adapter_type() -> None:
     secret = "ghp_" + "a" * 36
 

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -281,12 +281,16 @@ def test_resume_rejects_sensitive_persisted_routing_before_diagnostics(
 def test_routing_contract_validators_reject_sensitive_subcontracts() -> None:
     secret = "ghp_" + "a" * 36
 
-    assert OrchestratorRunner._runtime_routing_labels_from_contract(
-        {"runtime_backend": secret, "llm_backend": "anthropic"}
-    ) is None
-    assert OrchestratorRunner._valid_permission_mode_contract(
-        {"observed": True, "mode": secret}
-    ) is False
+    assert (
+        OrchestratorRunner._runtime_routing_labels_from_contract(
+            {"runtime_backend": secret, "llm_backend": "anthropic"}
+        )
+        is None
+    )
+    assert (
+        OrchestratorRunner._valid_permission_mode_contract({"observed": True, "mode": secret})
+        is False
+    )
 
 
 def test_runtime_identity_failure_does_not_egress_dynamic_adapter_type() -> None:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2622,8 +2622,10 @@ class TestOrchestratorRunner:
         sample_seed: Seed,
     ) -> None:
         """Runner wiring should make profile-aware decomposition live in production."""
+        from ouroboros.orchestrator.backend_limits import resolve_backend_limits
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
+        mock_adapter.self_governs_rate_limit = False
         runner = OrchestratorRunner(
             mock_adapter,
             mock_event_store,
@@ -2672,6 +2674,10 @@ class TestOrchestratorRunner:
                 "ouroboros.orchestrator.parallel_executor.ParallelACExecutor",
                 _FakeParallelExecutor,
             ),
+            patch(
+                "ouroboros.orchestrator.runner.resolve_backend_limits",
+                wraps=resolve_backend_limits,
+            ) as resolve_limits,
         ):
             result = await runner._execute_parallel(
                 seed=sample_seed,
@@ -2693,6 +2699,10 @@ class TestOrchestratorRunner:
         resolved_routing = captured_init["resolved_routing_authority"]
         assert resolved_routing.data == runner._execution_contract["model_routing"]
         assert "workspace_authority_identity" in captured_init
+        dispatch_rate_policy = captured_init["dispatch_rate_policy"]
+        assert dispatch_rate_policy.backend == mock_adapter.runtime_backend
+        assert dispatch_rate_policy.self_governs_rate_limit is False
+        resolve_limits.assert_called_once_with(mock_adapter.runtime_backend)
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -780,9 +780,10 @@ class TestOrchestratorRunner:
             seed_id=sample_seed.metadata.seed_id,
             session_id="orch_prepared",
             seed_goal=sample_seed.goal,
-            # Backend is forwarded so the live dashboard can provider-tag the run.
-            runtime_backend=runner._adapter.runtime_backend,
-            llm_backend=runner._adapter.llm_backend,
+            # Backend labels use the serializable runtime contract, never a
+            # fabricated value exposed by a dynamic adapter mock.
+            runtime_backend=runner._runtime_backend_contract(),
+            llm_backend=runner._llm_backend_contract(),
             execution_contract=runner._execution_contract,
         )
 
@@ -914,6 +915,7 @@ class TestOrchestratorRunner:
         assert isinstance(resume_handle, RuntimeHandle)
         assert resume_handle.backend == "opencode"
         assert resume_handle.cwd == "/tmp/project"
+        assert resume_handle.approval_mode == "bypassPermissions"
         assert resume_handle.metadata["tool_catalog"][0]["name"] == "Read"
         assert resume_handle.metadata["tool_catalog"][0]["id"] == "builtin:Read"
         assert resume_handle.metadata["capability_graph"][0]["name"] == "Read"
@@ -3475,19 +3477,12 @@ class TestOrchestratorRunner:
         ):
             runner._build_dependency_analyzer()
 
-    def test_legacy_adapter_without_llm_backend_degrades_gracefully(
+    def test_legacy_adapter_without_llm_backend_uses_safe_runtime_fallback(
         self,
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
     ) -> None:
-        """Legacy adapters predating v0.28.6 (no llm_backend attr) fall back to structured-only.
-
-        Protects downstream Protocol implementers (custom runtimes, test mocks)
-        from the v0.28.6 AgentRuntime Protocol addition. Instead of raising
-        AttributeError at the call site, _build_dependency_analyzer returns a
-        structured-only DependencyAnalyzer, preserving pre-v0.28.6 behavior.
-        """
-        from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
+        """Legacy adapters safely reuse their observed runtime backend for analysis."""
 
         class LegacyAdapter:
             """Pre-v0.28.6 adapter stub without llm_backend attribute."""
@@ -3504,10 +3499,15 @@ class TestOrchestratorRunner:
         with patch("ouroboros.orchestrator.runner.create_llm_adapter") as mock_create_llm_adapter:
             analyzer = runner._build_dependency_analyzer()
 
-        # Must not attempt to wire an LLM adapter when the legacy runtime
-        # lacks llm_backend - that path is the breaking-change path.
-        mock_create_llm_adapter.assert_not_called()
-        assert isinstance(analyzer, DependencyAnalyzer)
+        assert analyzer is not None
+        mock_create_llm_adapter.assert_called_once_with(
+            backend="opencode",
+            permission_mode="bypassPermissions",
+            cli_path=None,
+            cwd="/tmp/project",
+            max_turns=1,
+            allowed_tools=[],
+        )
 
     @pytest.mark.asyncio
     async def test_execute_seed_uses_inherited_runtime_handle(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2690,6 +2690,9 @@ class TestOrchestratorRunner:
         assert profile.axis == "testable_unit"
         assert captured_init["fat_harness_mode"] is True
         assert captured_init["decomposition_mode"] == "preflight"
+        resolved_routing = captured_init["resolved_routing_authority"]
+        assert resolved_routing.data == runner._execution_contract["model_routing"]
+        assert "workspace_authority_identity" in captured_init
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from ouroboros.orchestrator.session import (
+    SESSION_START_IDENTITY_PROGRESS_KEY,
     SessionRepository,
     SessionStatus,
     SessionTracker,
 )
+from ouroboros.persistence.event_store import EventStore
 
 
 class TestSessionStatus:
@@ -200,6 +203,33 @@ class TestSessionRepository:
         assert result.is_ok
         event = mock_event_store.append.call_args[0][0]
         assert event.data["seed_goal"] == "Ship the OpenCode runtime"
+
+    @pytest.mark.asyncio
+    async def test_durable_replay_preserves_benign_seed_goal_with_token_word(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Natural-language goals must survive durable event sanitization verbatim."""
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'session.db'}")
+        await store.initialize()
+        try:
+            repository = SessionRepository(store)
+            goal = "Implement token rotation for session auth"
+
+            created = await repository.create_session(
+                execution_id="exec_token_goal",
+                seed_id="seed_token_goal",
+                session_id="orch_token_goal",
+                seed_goal=goal,
+            )
+            assert created.is_ok
+
+            restored = await repository.reconstruct_session("orch_token_goal")
+
+            assert restored.is_ok
+            assert restored.value.progress[SESSION_START_IDENTITY_PROGRESS_KEY]["seed_goal"] == goal
+        finally:
+            await store.close()
 
     @pytest.mark.asyncio
     async def test_create_session_with_custom_id(


### PR DESCRIPTION
## Summary

- Replaces closed #1682 with a finite, reviewable Foundation A execution-authority baseline.
- Binds execution effect owners and rejects authority drift without allowing credential-shaped provider values to enter durable contracts or events.
- Keeps the baseline identity-only: it does not authorize dispatch, result/checkpoint/trust reuse, or final acceptance.

## Changes

- Define the portable, per-attempt, and volatile collaborator boundary plus adversarial exit matrix.
- Bind executor, workspace, runtime, verifier, policy, dispatch-rate gate, and live-adapter routing identity fail closed.
- Redact credential-shaped event and session metadata; preserve replay protocol keys.
- Add same-adapter hidden runtime-identity drift protection using a keyed, nonserialized process-local binding.

## Verification

- `pytest -q tests/unit/orchestrator` — 3177 passed, 2 skipped
- `pytest -q tests/unit/core/test_security.py tests/unit/events/test_base.py` — 74 passed
- `ruff check src tests`, `mypy src`, and `git diff --check` passed
- Independent exact-head review: GO; no reproducible P1/P2 finding

## Notes

- Refs #1681
- Foundation B remains locked pending an `APPROVED` review decision on this PR.