### PR TITLE
feat(orchestrator): define finite execution authority boundary

### DIFF
--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -27,15 +27,25 @@ prove arbitrary Python behavior is portable.
 
 Only the closed built-in transcript verifier and an adapter whose *exact type*
 is in Foundation A's reviewed runtime implementation table can contribute
-durable identity. The runtime descriptor contains the adapter's explicit safe
-execution identity plus a bounded digest of the resolved CLI executable and a
-finite configuration table for its canonical working directory, timeouts,
-subprocess behavior, and child-session environment keys. It is represented by
-digests, never copied verbatim into
-authority JSON. A credential-shaped or malformed value makes that runtime
-component unobserved/process-local. An unknown adapter implementation, a custom
-skills directory, or a custom skill dispatcher is executable only as
-process-local state.
+durable identity. The initial portable runtime table contains only
+`CodexCliRuntime`; other built-in CLI backends remain executable but
+process-local until their backend-specific command settings have a complete
+reviewed finite descriptor. The runtime descriptor contains the adapter's
+explicit safe execution identity plus a bounded digest of the resolved CLI
+executable and a finite configuration table for its canonical working
+directory, timeouts, subprocess behavior, and child-session environment keys.
+It is represented by digests, never copied verbatim into authority JSON. A
+credential-shaped or malformed value makes that runtime component
+unobserved/process-local. An unknown adapter implementation, a custom skills
+directory, or a custom skill dispatcher is executable only as process-local
+state.
+
+Copilot adds its resolved `runtime_profile`/`--agent` selection to the live
+configuration table so in-process drift is rejected, but it is still
+process-local under the initial portable allowlist. Zcode is likewise
+process-local: its command can involve an external Electron/Node launch prefix
+before the configured script, so no portable claim is made until that whole
+launcher chain has a reviewed finite descriptor.
 
 A durable runtime also carries explicit observations for its reviewed
 implementation, direct dispatch root, executable, and configuration;
@@ -139,3 +149,5 @@ Tests must show that:
 9. unknown runtime implementations, custom skill directories/dispatchers, and
    hub-enabled executors remain process-local; executable or closed timeout
    configuration divergence changes a portable runtime fingerprint.
+10. Copilot profile/agent divergence is live-guarded; Copilot, Zcode, and
+    other non-Codex built-in runtime instances remain process-local.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -9,7 +9,7 @@ trust reuse, dispatch, routing, or final acceptance on its own.
 | Component | Foundation A treatment | Later owner |
 | --- | --- | --- |
 | `ParallelACExecutor`, `LeafDispatcher`, `LevelCoordinator`, verification gate, and rate-gate algorithm | Closed, versioned implementation descriptors | Foundation A |
-| Runtime adapter | Explicit runtime descriptor supplied by the adapter; values are represented as safe digests | Foundation A |
+| Runtime adapter | Exact reviewed built-in adapter type plus a finite execution descriptor (runtime identity, executable generation/content, and closed process configuration); values are represented as safe digests. Unknown adapters and custom skill settings are process-local. | Foundation A |
 | Workspace | Resolved path identity represented as a digest | Foundation A |
 | Built-in transcript verifier | Closed, versioned verifier descriptor | Foundation A |
 | Custom verifier | Exact object identity for this process only; never portable solely because it has Python code, a closure, defaults, globals, or an identity method | Foundation A / process local |
@@ -25,14 +25,22 @@ prove arbitrary Python behavior is portable.
 
 ## Supported portable forms
 
-Only the closed built-in transcript verifier and an adapter with an explicit,
-safe runtime identity descriptor can contribute durable identity. The runtime
-descriptor is canonical JSON under a strict size/depth budget and is represented
-by a digest, never copied verbatim into authority JSON. A credential-shaped or
-malformed value makes that runtime component unobserved/process-local.
-A durable runtime also carries an explicit observation that its direct dispatch
-root was finite and observable; `stability` alone cannot promote an otherwise
-process-local descriptor.
+Only the closed built-in transcript verifier and an adapter whose *exact type*
+is in Foundation A's reviewed runtime implementation table can contribute
+durable identity. The runtime descriptor contains the adapter's explicit safe
+execution identity plus a bounded digest of the resolved CLI executable and a
+finite configuration table for timeouts, subprocess behavior, and child-session
+environment keys. It is represented by digests, never copied verbatim into
+authority JSON. A credential-shaped or malformed value makes that runtime
+component unobserved/process-local. An unknown adapter implementation, a custom
+skills directory, or a custom skill dispatcher is executable only as
+process-local state.
+
+A durable runtime also carries explicit observations for its reviewed
+implementation, direct dispatch root, executable, and configuration;
+`stability` alone cannot promote an otherwise process-local descriptor. The
+live guard binds the direct `execute_task` root and code identity so it rejects
+post-construction dispatch drift before an executor-owned effect.
 
 The implementation versions in `execution_authority.py` are reviewed source
 constants. Changing the behavior of a closed component requires an explicit
@@ -44,7 +52,8 @@ as a substitute for that review.
 Before an atomic dispatch or verifier pass, the executor verifies only the
 enumerated live roots:
 
-1. adapter object identity and current finite runtime descriptor;
+1. adapter object identity, exact reviewed implementation, and current finite
+   runtime descriptor, including its direct `execute_task` root/code identity;
 2. verifier object identity and its captured finite descriptor;
 3. captured `LeafDispatcher` instance, direct `stream` callable, and default
    attribute-resolution root;
@@ -60,6 +69,12 @@ enumerated live roots:
 8. the six original executor entry functions used by internal orchestration:
    single-AC execution, atomic execution, rate admission, decomposition
    dispatch, verifier dispatch, and the shell/filesystem verification gate.
+
+The execution policy records whether a `session_signal_hub` is enabled. A
+non-`None` hub is volatile process state and forces the baseline process-local;
+the live guard retains its exact identity and rejects replacement before the
+next effect. This preserves current signal behavior without asserting that a
+hub can be reproduced across processes.
 
 A replacement root fails closed. Mutation inside an arbitrary custom callable
 is deliberately not treated as a portable identity claim; it is process-local
@@ -120,3 +135,6 @@ Tests must show that:
 7. `portable_across_processes` grants no reuse or acceptance semantics.
 8. shadow replay rejects entry-root drift before creating its isolated baseline
    runtime and invokes its verifier through the captured entry root.
+9. unknown runtime implementations, custom skill directories/dispatchers, and
+   hub-enabled executors remain process-local; executable or closed timeout
+   configuration divergence changes a portable runtime fingerprint.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -1,0 +1,103 @@
+# AC Runtime Execution Authority Boundary
+
+Foundation A creates one versioned, identity-only executor baseline. It is not
+an attempt capsule and it never authorizes result reuse, checkpoint reuse,
+trust reuse, dispatch, routing, or final acceptance on its own.
+
+## Finite ownership matrix
+
+| Component | Foundation A treatment | Later owner |
+| --- | --- | --- |
+| `ParallelACExecutor`, `LeafDispatcher`, `LevelCoordinator`, and rate-gate algorithm | Closed, versioned implementation descriptors | Foundation A |
+| Runtime adapter | Explicit runtime descriptor supplied by the adapter; values are represented as safe digests | Foundation A |
+| Workspace | Resolved path identity represented as a digest | Foundation A |
+| Built-in transcript verifier | Closed, versioned verifier descriptor | Foundation A |
+| Custom verifier | Exact object identity for this process only; never portable solely because it has Python code, a closure, defaults, globals, or an identity method | Foundation A / process local |
+| AC text, prompt, tool catalog, selected model/effort, runtime handle, checkpoint and session state | Excluded | Foundation C attempt capsule |
+| Event emitter/store, caches, queues, locks, signal hubs, module monkeypatches, arbitrary Python object graphs | Volatile and excluded | Foundation B or live process |
+
+The contract does **not** recursively inspect functions, descriptor methods,
+closures, globals, builtins, classes, or arbitrary object graphs. Those are not
+a finite authority surface. A custom verifier remains process-local even if it
+provides a descriptor; a descriptor can describe a configuration but cannot
+prove arbitrary Python behavior is portable.
+
+## Supported portable forms
+
+Only the closed built-in transcript verifier and an adapter with an explicit,
+safe runtime identity descriptor can contribute durable identity. The runtime
+descriptor is canonical JSON under a strict size/depth budget and is represented
+by a digest, never copied verbatim into authority JSON. A credential-shaped or
+malformed value makes that runtime component unobserved/process-local.
+
+The implementation versions in `execution_authority.py` are reviewed source
+constants. Changing the behavior of a closed component requires an explicit
+version bump and tests; no source, bytecode, or callable graph hashing is used
+as a substitute for that review.
+
+## Live-process guard
+
+Before an atomic dispatch or verifier pass, the executor verifies only the
+enumerated live roots:
+
+1. adapter object identity and current finite runtime descriptor;
+2. verifier object identity and its captured finite descriptor;
+3. captured `LeafDispatcher` instance, direct `stream` callable, and default
+   attribute-resolution root;
+4. captured `LevelCoordinator.run_review` root, binding, and default
+   attribute-resolution root;
+5. captured rate-gate `acquire` callable and default attribute-resolution root;
+6. adapter dispatch and attribute-resolution roots; and
+7. workspace and static policy descriptors; and
+8. the five original executor entry functions used by internal orchestration:
+   single-AC execution, atomic execution, rate admission, decomposition
+   dispatch, and verifier dispatch.
+
+A replacement root fails closed. Mutation inside an arbitrary custom callable
+is deliberately not treated as a portable identity claim; it is process-local
+and cannot later qualify a capsule, checkpoint, trust, or acceptance reuse.
+If a direct component installs a custom attribute-resolution hook before
+construction, it remains executable but the baseline is process-local. If a
+previously observed default hook changes after construction, the live guard
+rejects the effect before dispatch, verification, coordination, or rate
+admission.
+If a direct runtime-dispatch root cannot be observed, or the adapter installs a
+custom attribute-resolution hook, execution remains available but the baseline
+is explicitly process-local.
+
+For a portable baseline, internal orchestration calls those five captured
+functions directly rather than resolving `self._…` again. A post-construction
+class replacement, in-place code replacement, or instance shadow of an entry
+root fails closed before the next effect. If such a root is already nonstandard
+at construction, the executor remains executable only as process-local; it
+cannot advertise portable authority.
+
+Construction captures each of those callable entry roots directly. An opaque
+or non-callable entry cannot be captured and rejects construction rather than
+falling back to a later dynamic lookup. A `ParallelACExecutor` subclass is
+also process-local, including one that inherits all five entries unchanged:
+its concrete type is part of the closed portable set.
+
+This is a collaborator-integrity boundary, not a sandbox against arbitrary code
+running in the same Python process. Directly calling a monkeypatched private
+entry point, or deliberately introspecting and mutating private module closures,
+is outside the boundary. The guarantee applies to the executor's own unchanged
+orchestration path, where effects use the closed-root invocation path.
+
+## Exit matrix
+
+Tests must show that:
+
+1. workspace, adapter descriptor, static policy, verifier root, and dispatcher
+   root drift are rejected before dispatch or verification, including
+   post-construction `__getattribute__` replacement on direct effect owners;
+2. custom closures/defaults/globals do not enter the canonical authority JSON
+   and make the verifier process-local;
+3. reflective lookup and arbitrary object graphs cannot be made portable by
+   the implementation;
+4. credential-shaped provider data is absent from canonical authority JSON;
+5. per-attempt and volatile inputs do not alter the baseline; and
+6. post-construction class, code, and instance entry-root drift is rejected
+   from the internal execution path, while a pre-construction nonstandard root
+   is process-local; and
+7. `portable_across_processes` grants no reuse or acceptance semantics.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -8,12 +8,13 @@ trust reuse, dispatch, routing, or final acceptance on its own.
 
 | Component | Foundation A treatment | Later owner |
 | --- | --- | --- |
-| `ParallelACExecutor`, `LeafDispatcher`, `LevelCoordinator`, and rate-gate algorithm | Closed, versioned implementation descriptors | Foundation A |
+| `ParallelACExecutor`, `LeafDispatcher`, `LevelCoordinator`, verification gate, and rate-gate algorithm | Closed, versioned implementation descriptors | Foundation A |
 | Runtime adapter | Explicit runtime descriptor supplied by the adapter; values are represented as safe digests | Foundation A |
 | Workspace | Resolved path identity represented as a digest | Foundation A |
 | Built-in transcript verifier | Closed, versioned verifier descriptor | Foundation A |
 | Custom verifier | Exact object identity for this process only; never portable solely because it has Python code, a closure, defaults, globals, or an identity method | Foundation A / process local |
 | AC text, prompt, tool catalog, selected model/effort, runtime handle, checkpoint and session state | Excluded | Foundation C attempt capsule |
+| Shadow-replay isolated workspace | Ephemeral experiment input; process-local and never an acceptance workspace | Live process |
 | Event emitter/store, caches, queues, locks, signal hubs, module monkeypatches, arbitrary Python object graphs | Volatile and excluded | Foundation B or live process |
 
 The contract does **not** recursively inspect functions, descriptor methods,
@@ -29,6 +30,9 @@ safe runtime identity descriptor can contribute durable identity. The runtime
 descriptor is canonical JSON under a strict size/depth budget and is represented
 by a digest, never copied verbatim into authority JSON. A credential-shaped or
 malformed value makes that runtime component unobserved/process-local.
+A durable runtime also carries an explicit observation that its direct dispatch
+root was finite and observable; `stability` alone cannot promote an otherwise
+process-local descriptor.
 
 The implementation versions in `execution_authority.py` are reviewed source
 constants. Changing the behavior of a closed component requires an explicit
@@ -46,12 +50,15 @@ enumerated live roots:
    attribute-resolution root;
 4. captured `LevelCoordinator.run_review` root, binding, and default
    attribute-resolution root;
-5. captured rate-gate `acquire` callable and default attribute-resolution root;
+5. captured rate-gate `acquire` callable, timing scalars, sleep root, bucket
+   identity/configuration/time source, and direct admission roots
+   (`enabled`, `acquire`, and `force_reserve`), plus default attribute-resolution
+   roots;
 6. adapter dispatch and attribute-resolution roots; and
 7. workspace and static policy descriptors; and
-8. the five original executor entry functions used by internal orchestration:
+8. the six original executor entry functions used by internal orchestration:
    single-AC execution, atomic execution, rate admission, decomposition
-   dispatch, and verifier dispatch.
+   dispatch, verifier dispatch, and the shell/filesystem verification gate.
 
 A replacement root fails closed. Mutation inside an arbitrary custom callable
 is deliberately not treated as a portable identity claim; it is process-local
@@ -65,7 +72,7 @@ If a direct runtime-dispatch root cannot be observed, or the adapter installs a
 custom attribute-resolution hook, execution remains available but the baseline
 is explicitly process-local.
 
-For a portable baseline, internal orchestration calls those five captured
+For a portable baseline, internal orchestration calls those six captured
 functions directly rather than resolving `self._…` again. A post-construction
 class replacement, in-place code replacement, or instance shadow of an entry
 root fails closed before the next effect. If such a root is already nonstandard
@@ -75,8 +82,16 @@ cannot advertise portable authority.
 Construction captures each of those callable entry roots directly. An opaque
 or non-callable entry cannot be captured and rejects construction rather than
 falling back to a later dynamic lookup. A `ParallelACExecutor` subclass is
-also process-local, including one that inherits all five entries unchanged:
-its concrete type is part of the closed portable set.
+also process-local, including one that inherits all six entries unchanged:
+its concrete type is part of the closed portable set. Unhashable or
+equality-overriding subclasses remain executable as process-local instances.
+
+Shadow replay is an opt-in, non-authoritative cost experiment. Its isolated
+workspace is per-attempt process state rather than the live executor workspace,
+and its verdict never accepts the live AC. Before it creates a replay runtime it
+uses the same live-process guard; when it needs the transcript verifier it enters
+through the captured verifier-dispatch root rather than dynamically resolving
+`executor._run_atomic_verifier_pass`.
 
 This is a collaborator-integrity boundary, not a sandbox against arbitrary code
 running in the same Python process. Directly calling a monkeypatched private
@@ -88,8 +103,9 @@ orchestration path, where effects use the closed-root invocation path.
 
 Tests must show that:
 
-1. workspace, adapter descriptor, static policy, verifier root, and dispatcher
-   root drift are rejected before dispatch or verification, including
+1. workspace, adapter descriptor, static policy, verifier root/code, dispatcher
+   root, and rate-gate semantic drift are rejected before dispatch or
+   verification, including
    post-construction `__getattribute__` replacement on direct effect owners;
 2. custom closures/defaults/globals do not enter the canonical authority JSON
    and make the verifier process-local;
@@ -101,3 +117,5 @@ Tests must show that:
    from the internal execution path, while a pre-construction nonstandard root
    is process-local; and
 7. `portable_across_processes` grants no reuse or acceptance semantics.
+8. shadow replay rejects entry-root drift before creating its isolated baseline
+   runtime and invokes its verifier through the captured entry root.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -29,8 +29,9 @@ Only the closed built-in transcript verifier and an adapter whose *exact type*
 is in Foundation A's reviewed runtime implementation table can contribute
 durable identity. The runtime descriptor contains the adapter's explicit safe
 execution identity plus a bounded digest of the resolved CLI executable and a
-finite configuration table for timeouts, subprocess behavior, and child-session
-environment keys. It is represented by digests, never copied verbatim into
+finite configuration table for its canonical working directory, timeouts,
+subprocess behavior, and child-session environment keys. It is represented by
+digests, never copied verbatim into
 authority JSON. A credential-shaped or malformed value makes that runtime
 component unobserved/process-local. An unknown adapter implementation, a custom
 skills directory, or a custom skill dispatcher is executable only as

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -52,8 +52,9 @@ enumerated live roots:
    attribute-resolution root;
 5. captured rate-gate `acquire` callable, timing scalars, sleep root, bucket
    identity/configuration/time source, and direct admission roots
-   (`enabled`, `acquire`, and `force_reserve`), plus default attribute-resolution
-   roots;
+   (`enabled`, `acquire`, `force_reserve`, `_prune`, `_tokens_in_window`,
+   `_snapshot`, `_request_wait_seconds`, and `_token_wait_seconds`), plus
+   default attribute-resolution roots;
 6. adapter dispatch and attribute-resolution roots; and
 7. workspace and static policy descriptors; and
 8. the six original executor entry functions used by internal orchestration:
@@ -104,7 +105,7 @@ orchestration path, where effects use the closed-root invocation path.
 Tests must show that:
 
 1. workspace, adapter descriptor, static policy, verifier root/code, dispatcher
-   root, and rate-gate semantic drift are rejected before dispatch or
+   root, and rate-gate semantic/helper drift are rejected before dispatch or
    verification, including
    post-construction `__getattribute__` replacement on direct effect owners;
 2. custom closures/defaults/globals do not enter the canonical authority JSON

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,0 +1,1236 @@
+"""Finite execution-authority identity for the AC runtime.
+
+Foundation A deliberately identifies a small, explicit component boundary. It
+does not attempt to derive authority from an arbitrary Python callable graph:
+closures, globals, descriptors, module monkeypatches, caches, and runtime
+handles are volatile. A custom verifier can therefore be bound only to its
+exact live object for this process; it is never made portable by introspection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import inspect
+import json
+import math
+from pathlib import Path
+import re
+from typing import Any
+import uuid
+
+from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
+from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
+
+EXECUTION_AUTHORITY_VERSION = 1
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 1
+
+_MAX_IDENTITY_DEPTH = 8
+_MAX_IDENTITY_ITEMS = 256
+_MAX_IDENTITY_SCALAR_CHARS = 8_192
+_MAX_IDENTITY_JSON_CHARS = 64_000
+
+_EXECUTOR_COMPONENT_VERSIONS = {
+    "parallel_ac_executor": "parallel-ac-executor/v1",
+    "leaf_dispatcher": "leaf-dispatcher/v1",
+    "level_coordinator": "level-coordinator/v1",
+    "rate_limit_gate": "rate-limit-gate/v1",
+}
+_BUILTIN_TRANSCRIPT_VERIFIER = "runtime-transcript-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER = "structural-atomic-verifier/v1"
+
+
+def _canonical_json(value: object, *, field: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} is not canonical JSON") from exc
+
+
+def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
+    normalized = json.loads(_canonical_json(value, field=field))
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{field} is not an object")
+    return normalized
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalized_identity_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _is_sensitive_identity_key(value: str) -> bool:
+    """Return whether an explicit identity key can carry a credential value."""
+    compact = _normalized_identity_key(value)
+    return any(
+        marker in compact
+        for marker in (
+            "apikey",
+            "credential",
+            "password",
+            "authorization",
+            "bearer",
+            "privatekey",
+            "clientsecret",
+        )
+    ) or compact.endswith(("token", "tokenvalue", "keyvalue", "secret"))
+
+
+def _looks_like_credential(value: str) -> bool:
+    """Recognize opaque credential shapes without redacting ordinary prose."""
+    normalized = value.strip()
+    lowered = normalized.lower()
+    if normalized.startswith("AIza") and len(normalized) >= 35:
+        return True
+    if lowered.startswith(
+        (
+            "sk-",
+            "sk_live_",
+            "sk_test_",
+            "ghp_",
+            "github_pat_",
+            "rk_live_",
+            "rk_test_",
+            "xoxb-",
+            "xoxp-",
+        )
+    ):
+        return len(normalized) >= 16
+    if lowered.startswith("bearer "):
+        return len(normalized.split(maxsplit=1)[-1]) >= 16
+    return False
+
+
+def _project_explicit_identity(
+    value: object,
+    *,
+    field: str,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> object:
+    """Accept only bounded JSON data that is safe to digest.
+
+    This validates an *explicit descriptor*, not object implementation state.
+    Unsupported values make the corresponding component process-local.
+    """
+    if depth > _MAX_IDENTITY_DEPTH:
+        raise ValueError(f"{field} exceeds identity depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{field} contains a non-finite float")
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_IDENTITY_SCALAR_CHARS:
+            raise ValueError(f"{field} contains oversized text")
+        if _looks_like_credential(value):
+            raise ValueError(f"{field} contains credential-shaped text")
+        return value
+
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        raise ValueError(f"{field} contains cyclic state")
+    seen.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many mapping items")
+            projected: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{field} contains a non-string or empty key")
+                if len(key) > _MAX_IDENTITY_SCALAR_CHARS:
+                    raise ValueError(f"{field} contains an oversized key")
+                if _is_sensitive_identity_key(key):
+                    raise ValueError(f"{field} contains a credential-bearing key")
+                projected[key] = _project_explicit_identity(
+                    item,
+                    field=f"{field}.{key}",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return projected
+        if isinstance(value, (list, tuple)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many sequence items")
+            return [
+                _project_explicit_identity(
+                    item,
+                    field=f"{field}[{index}]",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+                for index, item in enumerate(value)
+            ]
+        raise ValueError(f"{field} is not canonical JSON data")
+    finally:
+        seen.remove(value_id)
+
+
+def _safe_identity_digest(value: object, *, field: str) -> str | None:
+    try:
+        projected = _project_explicit_identity(value, field=field)
+        encoded = _canonical_json(projected, field=field)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return None
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        return None
+    return _sha256(encoded)
+
+
+def _digest_descriptor(value: object, *, field: str) -> dict[str, object]:
+    digest = _safe_identity_digest(value, field=field)
+    if digest is None:
+        return {"observed": False}
+    return {"observed": True, "digest": digest}
+
+
+def _valid_digest_descriptor(value: object) -> bool:
+    if not isinstance(value, Mapping) or not isinstance(value.get("observed"), bool):
+        return False
+    if value.get("observed") is False:
+        return set(value) == {"observed"}
+    digest = value.get("digest")
+    return (
+        set(value) == {"observed", "digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def execution_authority_boundary_contract() -> dict[str, object]:
+    """Return the finite ownership matrix embedded in every baseline."""
+    return {
+        "version": EXECUTION_AUTHORITY_BOUNDARY_VERSION,
+        "portable": [
+            "executor_components",
+            "runtime_descriptor",
+            "workspace_descriptor",
+            "static_execution_policy",
+            "built_in_verifier",
+        ],
+        "per_attempt": [
+            "ac",
+            "prompt",
+            "tool_catalog",
+            "selected_route",
+            "selected_effort",
+            "runtime_handle",
+            "checkpoint",
+            "session_state",
+        ],
+        "volatile": [
+            "custom_callable_graph",
+            "event_store",
+            "event_emitter",
+            "cache",
+            "queue",
+            "lock",
+            "signal_hub",
+            "module_monkeypatch",
+        ],
+    }
+
+
+def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
+    """Return a digest-only identity for the effect-owning workspace."""
+    if not isinstance(workspace, str) or not workspace.strip():
+        return {"version": 1, "stability": "process_local", "observed": False}
+    try:
+        canonical = str(Path(workspace).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"version": 1, "stability": "process_local", "observed": False}
+    descriptor = _digest_descriptor(canonical, field="workspace identity")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_workspace_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    observed = value.get("observed")
+    stability = value.get("stability")
+    if observed is False:
+        return stability == "process_local" and set(value) == {"version", "stability", "observed"}
+    digest = value.get("identity_digest")
+    return (
+        observed is True
+        and stability == "durable"
+        and set(value) == {"version", "stability", "observed", "identity_digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def constructor_model_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized constructor-level model pin, when observable."""
+    try:
+        raw_model = inspect.getattr_static(adapter, "_model")
+    except AttributeError:
+        return {"observed": False}
+    if raw_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(raw_model, str):
+        return {"observed": False}
+
+    normalized_model: object = raw_model.strip() or None
+    normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
+    if normalizer_descriptor is not None:
+        try:
+            normalizer = object.__getattribute__(adapter, "_normalize_model")
+            normalized_model = normalizer(raw_model)
+        except Exception:
+            return {"observed": False}
+    if normalized_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(normalized_model, str) or not normalized_model.strip():
+        return {"observed": False}
+    return {"observed": True, "model": normalized_model.strip()}
+
+
+def valid_constructor_model_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    model = value.get("model")
+    return set(value) == {"observed", "model"} and (
+        model is None or isinstance(model, str) and bool(model.strip())
+    )
+
+
+def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
+    """Return the adapter's explicit execution identity for runner resume."""
+    provider_descriptor = inspect.getattr_static(type(adapter), "execution_identity_contract", None)
+    if provider_descriptor is None:
+        return {"version": 1, "observed": False}
+
+    provider = object.__getattribute__(adapter, "execution_identity_contract")
+    identity = provider()
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime execution identity contract is not a mapping")
+    normalized = _canonical_object(
+        dict(identity),
+        field="runtime execution identity contract",
+    )
+    return {"version": 1, "observed": True, "identity": normalized}
+
+
+def valid_runtime_execution_identity_contract(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    version = value.get("version")
+    observed = value.get("observed")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != 1
+        or not isinstance(observed, bool)
+    ):
+        return False
+    if not observed:
+        return set(value) == {"version", "observed"}
+    identity = value.get("identity")
+    if set(value) != {"version", "observed", "identity"} or not isinstance(identity, Mapping):
+        return False
+    try:
+        _canonical_json(dict(identity), field="runtime execution identity contract")
+    except ValueError:
+        return False
+    return bool(identity)
+
+
+def runtime_execution_proves_effective_model(value: object) -> bool:
+    if not valid_runtime_execution_identity_contract(value):
+        return False
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    identity = value.get("identity")
+    return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+
+
+def _runtime_capabilities_descriptor(adapter: object) -> dict[str, object]:
+    try:
+        capabilities = runtime_capabilities_for(adapter)
+        value = {
+            "skill_dispatch": capabilities.skill_dispatch,
+            "targeted_resume": capabilities.targeted_resume,
+            "structured_output": capabilities.structured_output,
+            "system_prompt_support": capabilities.system_prompt_support.value,
+            "tool_restriction_support": capabilities.tool_restriction_support.value,
+            "permission_mode_support": capabilities.permission_mode_support.value,
+            "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+            "enforceable_reasoning_efforts": (
+                sorted(capabilities.enforceable_reasoning_efforts)
+                if capabilities.enforceable_reasoning_efforts is not None
+                else None
+            ),
+            "model_override_support": capabilities.model_override_support.value,
+            "subagent_orchestration": capabilities.subagent_orchestration.value,
+            "session_signals": capabilities.session_signals.to_event_data(),
+        }
+    except Exception:
+        return {"observed": False}
+    return _digest_descriptor(value, field="runtime capabilities")
+
+
+def _runtime_label_descriptor(adapter: object, name: str) -> dict[str, object]:
+    try:
+        value = object.__getattribute__(adapter, name)
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(value, str) or not value.strip():
+        return {"observed": False}
+    return _digest_descriptor(value.strip(), field=f"runtime {name}")
+
+
+def runtime_authority_contract(
+    adapter: object,
+    *,
+    force_process_local: bool = False,
+) -> dict[str, object]:
+    """Return a finite, digest-only runtime descriptor.
+
+    The runner's resume identity remains a separate API. This authority payload
+    never serializes provider-controlled identity values or capabilities.
+    """
+    # This public descriptor builder must retain the finite live-root rule used
+    # by ``ExecutionAuthorityLiveBinding``. A runtime with only dynamic
+    # ``execute_task`` lookup remains executable, but cannot claim portability.
+    if not force_process_local:
+        force_process_local = not _has_observable_runtime_dispatch_root(adapter)
+    try:
+        execution = runtime_execution_identity_contract(adapter)
+        execution_descriptor = (
+            _digest_descriptor(execution["identity"], field="runtime execution identity")
+            if execution.get("observed") is True
+            else {"observed": False}
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        execution_descriptor = {"observed": False}
+    capabilities = _runtime_capabilities_descriptor(adapter)
+    runtime_backend = _runtime_label_descriptor(adapter, "runtime_backend")
+    llm_backend = _runtime_label_descriptor(adapter, "llm_backend")
+    permission_mode = _runtime_label_descriptor(adapter, "permission_mode")
+    try:
+        self_governs_rate_limit = object.__getattribute__(adapter, "self_governs_rate_limit")
+    except (AttributeError, TypeError):
+        self_governs_rate_limit = False
+    stable = (
+        runtime_backend["observed"] is True
+        and execution_descriptor["observed"] is True
+        and capabilities["observed"] is True
+        and isinstance(self_governs_rate_limit, bool)
+        and not force_process_local
+    )
+    return {
+        "version": 1,
+        "stability": "durable" if stable else "process_local",
+        "runtime_backend": runtime_backend,
+        "llm_backend": llm_backend,
+        "permission_mode": permission_mode,
+        "execution_identity": execution_descriptor,
+        "capabilities": capabilities,
+        "self_governs_rate_limit": (
+            self_governs_rate_limit if isinstance(self_governs_rate_limit, bool) else None
+        ),
+    }
+
+
+def _valid_runtime_authority(value: object) -> bool:
+    required = {
+        "version",
+        "stability",
+        "runtime_backend",
+        "llm_backend",
+        "permission_mode",
+        "execution_identity",
+        "capabilities",
+        "self_governs_rate_limit",
+    }
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 1:
+        return False
+    if value.get("stability") not in {"durable", "process_local"}:
+        return False
+    if not all(
+        _valid_digest_descriptor(value.get(name))
+        for name in (
+            "runtime_backend",
+            "llm_backend",
+            "permission_mode",
+            "execution_identity",
+            "capabilities",
+        )
+    ):
+        return False
+    return value.get("self_governs_rate_limit") is None or isinstance(
+        value.get("self_governs_rate_limit"), bool
+    )
+
+
+def execution_policy_authority_contract(policy: Mapping[str, object]) -> dict[str, object]:
+    """Represent the explicit static policy by a safe digest only."""
+    descriptor = _digest_descriptor(dict(policy), field="execution policy")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_execution_policy_authority(value: object) -> bool:
+    return _valid_workspace_authority(value)
+
+
+def executor_authority_contract() -> dict[str, object]:
+    """Return the closed Foundation A implementation component registry."""
+    return {
+        "version": 1,
+        "stability": "durable",
+        "components": dict(_EXECUTOR_COMPONENT_VERSIONS),
+    }
+
+
+def verifier_authority_contract(
+    verifier: Verifier | None,
+    *,
+    instance_nonce: str | None = None,
+) -> dict[str, object]:
+    """Describe a verifier without inspecting arbitrary Python behavior."""
+    if verifier is None:
+        return {
+            "version": 1,
+            "mode": "runtime_transcript",
+            "stability": "durable",
+            "implementation": _BUILTIN_TRANSCRIPT_VERIFIER,
+        }
+    if verifier is structural_atomic_verifier:
+        return {
+            "version": 1,
+            "mode": "structural_atomic",
+            "stability": "durable",
+            "implementation": _BUILTIN_STRUCTURAL_VERIFIER,
+        }
+
+    configuration: dict[str, object] = {"observed": False}
+    try:
+        descriptor = inspect.getattr_static(verifier, "verification_identity_contract", None)
+        if descriptor is not None:
+            provider = object.__getattribute__(verifier, "verification_identity_contract")
+            if callable(provider):
+                value = provider()
+                if isinstance(value, Mapping):
+                    configuration = _digest_descriptor(
+                        dict(value),
+                        field="custom verifier identity",
+                    )
+    except Exception:
+        configuration = {"observed": False}
+    return {
+        "version": 1,
+        "mode": "custom",
+        "stability": "process_local",
+        "instance_nonce": instance_nonce or uuid.uuid4().hex,
+        "configuration": configuration,
+    }
+
+
+def _valid_verifier_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    mode = value.get("mode")
+    if mode in {"runtime_transcript", "structural_atomic"}:
+        return (
+            value.get("stability") == "durable"
+            and set(value) == {"version", "mode", "stability", "implementation"}
+            and isinstance(value.get("implementation"), str)
+        )
+    if mode != "custom":
+        return False
+    nonce = value.get("instance_nonce")
+    return (
+        value.get("stability") == "process_local"
+        and set(value) == {"version", "mode", "stability", "instance_nonce", "configuration"}
+        and isinstance(nonce, str)
+        and len(nonce) == 32
+        and _valid_digest_descriptor(value.get("configuration"))
+    )
+
+
+def _contains_sensitive_authority_data(value: object) -> bool:
+    if isinstance(value, str):
+        return _looks_like_credential(value)
+    if isinstance(value, Mapping):
+        return any(
+            _is_sensitive_identity_key(key) or _contains_sensitive_authority_data(item)
+            for key, item in value.items()
+            if isinstance(key, str)
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_sensitive_authority_data(item) for item in value)
+    return False
+
+
+def _unwrap_static_callable(value: object) -> object | None:
+    if isinstance(value, (staticmethod, classmethod)):
+        value = value.__func__
+    return value if callable(value) else None
+
+
+def _static_callable_root(value: object | None, member_name: str | None) -> object | None:
+    """Return one direct callable root without traversing its behavior graph."""
+    if value is None:
+        return None
+    try:
+        if member_name is not None:
+            return _unwrap_static_callable(inspect.getattr_static(value, member_name))
+        if inspect.isfunction(value) or inspect.isbuiltin(value) or inspect.ismethod(value):
+            return value
+        return _unwrap_static_callable(inspect.getattr_static(type(value), "__call__"))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _class_callable_root(value: object, member_name: str) -> object | None:
+    """Return a callable declared on an instance type, never its instance dict."""
+    try:
+        return _unwrap_static_callable(inspect.getattr_static(type(value), member_name))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _callable_code_identity(value: object | None) -> object | None:
+    """Return a direct Python-code root without traversing callable state."""
+    if not inspect.isfunction(value):
+        return None
+    try:
+        return value.__code__
+    except AttributeError:
+        return None
+
+
+def _has_observable_runtime_dispatch_root(adapter: object) -> bool:
+    """Return whether a runtime exposes one direct, non-dynamic dispatch root."""
+    try:
+        dispatch_root = _static_callable_root(adapter, "execute_task")
+        return (
+            dispatch_root is not None
+            and dispatch_root is _class_callable_root(adapter, "execute_task")
+            and _callable_code_identity(dispatch_root) is not None
+            and _uses_default_instance_attribute_resolution(adapter)
+        )
+    except TypeError:
+        return False
+
+
+def _uses_default_instance_attribute_resolution(value: object) -> bool:
+    """Return whether instances have the closed default attribute lookup root.
+
+    A static method root alone is not sufficient when a class can redirect an
+    instance attribute through ``__getattribute__``. This is intentionally a
+    finite check of the direct effect-owner type, not inspection of arbitrary
+    instance state or callable graphs.
+    """
+    target_type = value if isinstance(value, type) else type(value)
+    try:
+        return target_type.__getattribute__ is object.__getattribute__
+    except (AttributeError, TypeError):
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityContract:
+    """Immutable, versioned Foundation A baseline and fingerprint."""
+
+    canonical_json: str
+
+    def __post_init__(self) -> None:
+        try:
+            decoded = json.loads(self.canonical_json)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("execution authority contract is invalid JSON") from exc
+        data = _canonical_object(decoded, field="execution authority contract")
+        required = {
+            "version",
+            "boundary",
+            "executor",
+            "workspace",
+            "runtime",
+            "verifier",
+            "execution_policy",
+        }
+        if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != required:
+            raise ValueError("execution authority contract has an invalid shape")
+        if data.get("boundary") != execution_authority_boundary_contract():
+            raise ValueError("execution authority contract has an invalid boundary")
+        if not executor_authority_contract() == data.get("executor"):
+            raise ValueError("execution authority contract has an invalid executor")
+        if not _valid_workspace_authority(data.get("workspace")):
+            raise ValueError("execution authority contract has an invalid workspace")
+        if not _valid_runtime_authority(data.get("runtime")):
+            raise ValueError("execution authority contract has an invalid runtime")
+        if not _valid_verifier_authority(data.get("verifier")):
+            raise ValueError("execution authority contract has an invalid verifier")
+        if not _valid_execution_policy_authority(data.get("execution_policy")):
+            raise ValueError("execution authority contract has an invalid execution policy")
+        if _contains_sensitive_authority_data(data):
+            raise ValueError("execution authority contract contains sensitive data")
+        if _canonical_json(data, field="execution authority contract") != self.canonical_json:
+            raise ValueError("execution authority contract is not canonical")
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        verifier_instance_nonce: str | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityContract:
+        data = {
+            "version": EXECUTION_AUTHORITY_VERSION,
+            "boundary": execution_authority_boundary_contract(),
+            "executor": executor_authority_contract(),
+            "workspace": canonical_workspace_authority(workspace),
+            "runtime": runtime_authority_contract(
+                adapter,
+                force_process_local=force_runtime_process_local,
+            ),
+            "verifier": verifier_authority_contract(
+                verifier,
+                instance_nonce=verifier_instance_nonce,
+            ),
+            "execution_policy": execution_policy_authority_contract(execution_policy),
+        }
+        return cls(_canonical_json(data, field="execution authority contract"))
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256(self.canonical_json)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        value = json.loads(self.canonical_json)
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise ValueError("execution authority contract is not an object")
+        return value
+
+    @property
+    def portable_across_processes(self) -> bool:
+        """Return only an identity-stability property, never reuse authority."""
+        data = self.data
+        return (
+            all(
+                isinstance(component, Mapping) and component.get("stability") == "durable"
+                for component in (
+                    data.get("executor"),
+                    data.get("workspace"),
+                    data.get("runtime"),
+                    data.get("verifier"),
+                    data.get("execution_policy"),
+                )
+            )
+            and data.get("workspace", {}).get("observed") is True
+            and data.get("execution_policy", {}).get("observed") is True
+        )
+
+    @property
+    def reusable_across_processes(self) -> bool:
+        """Backward-compatible alias for the identity-only portability flag."""
+        return self.portable_across_processes
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityLiveBinding:
+    """The finite live roots that must remain identical before an effect."""
+
+    contract: ExecutionAuthorityContract
+    executor: object | None
+    executor_attribute_resolution_observable: bool
+    adapter: object
+    verifier: Verifier | None
+    dispatcher_type: object
+    dispatcher: object | None
+    dispatcher_executor: object | None
+    transcript_verifier: object
+    adapter_dispatch_root: object | None
+    adapter_dispatch_code: object | None
+    adapter_attribute_resolution_observable: bool
+    verifier_root: object | None
+    dispatcher_stream_root: object | None
+    dispatcher_stream_code: object | None
+    dispatcher_stream_callable: object | None
+    dispatcher_attribute_resolution_observable: bool
+    dispatcher_binding_observable: bool
+    transcript_verifier_root: object | None
+    transcript_verifier_code: object | None
+    coordinator: object | None
+    coordinator_review_callable: object | None
+    coordinator_review_root: object | None
+    coordinator_review_code: object | None
+    coordinator_adapter: object | None
+    coordinator_task_cwd: object | None
+    coordinator_reasoning_effort: object | None
+    coordinator_attribute_resolution_observable: bool
+    coordinator_binding_observable: bool
+    rate_gate: object
+    rate_gate_acquire_root: object | None
+    rate_gate_acquire_code: object | None
+    rate_gate_acquire_callable: object | None
+    rate_gate_attribute_resolution_observable: bool
+    rate_gate_bucket: object | None
+    rate_gate_bucket_config: tuple[object, object, object, object] | None
+    rate_gate_bucket_binding_observable: bool
+    verifier_instance_nonce: str | None
+    force_runtime_process_local: bool
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        executor: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        expected_dispatcher_type: object | None = None,
+        expected_dispatcher_stream_root: object | None = None,
+        expected_dispatcher_stream_code: object | None = None,
+        expected_transcript_verifier: object | None = None,
+        expected_transcript_verifier_code: object | None = None,
+        expected_rate_gate_acquire_root: object | None = None,
+        expected_rate_gate_acquire_code: object | None = None,
+        expected_coordinator_type: type[object] | None = None,
+        expected_coordinator_review_root: object | None = None,
+        expected_coordinator_review_code: object | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityLiveBinding:
+        executor_attribute_resolution_observable = (
+            executor is None or _uses_default_instance_attribute_resolution(executor)
+        )
+        adapter_dispatch_root = _static_callable_root(adapter, "execute_task")
+        adapter_dispatch_code = _callable_code_identity(adapter_dispatch_root)
+        adapter_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            adapter
+        )
+        verifier_root = _static_callable_root(verifier, None)
+        dispatcher_stream_root = _static_callable_root(dispatcher_type, "stream")
+        dispatcher_stream_code = _callable_code_identity(dispatcher_stream_root)
+        dispatcher_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            dispatcher_type
+        )
+        captured_dispatcher_executor: object | None = None
+        dispatcher_binding_observable = dispatcher is None
+        if dispatcher is not None:
+            try:
+                captured_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+                dispatcher_binding_observable = (
+                    type(dispatcher) is dispatcher_type
+                    and captured_dispatcher_executor is dispatcher_executor
+                )
+            except (AttributeError, TypeError):
+                dispatcher_binding_observable = False
+        transcript_verifier_root = _static_callable_root(transcript_verifier, None)
+        transcript_verifier_code = _callable_code_identity(transcript_verifier_root)
+        if coordinator_review_callable is None:
+            try:
+                candidate = coordinator.run_review if coordinator is not None else None
+                coordinator_review_callable = candidate if callable(candidate) else None
+            except (AttributeError, TypeError):
+                coordinator_review_callable = None
+        coordinator_review_root = _static_callable_root(coordinator, "run_review")
+        coordinator_review_code = _callable_code_identity(coordinator_review_root)
+        coordinator_adapter: object | None = None
+        coordinator_task_cwd: object | None = None
+        coordinator_reasoning_effort: object | None = None
+        coordinator_attribute_resolution_observable = (
+            coordinator is None or _uses_default_instance_attribute_resolution(coordinator)
+        )
+        coordinator_binding_observable = coordinator is None
+        if coordinator is not None:
+            try:
+                coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+                coordinator_binding_observable = (
+                    coordinator_adapter is adapter
+                    and (coordinator_task_cwd is None or isinstance(coordinator_task_cwd, str))
+                    and (
+                        coordinator_reasoning_effort is None
+                        or isinstance(coordinator_reasoning_effort, str)
+                    )
+                )
+            except (AttributeError, TypeError):
+                coordinator_binding_observable = False
+        rate_gate_acquire_root = _static_callable_root(rate_gate, "acquire")
+        rate_gate_acquire_code = _callable_code_identity(rate_gate_acquire_root)
+        rate_gate_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            rate_gate
+        )
+        rate_gate_bucket: object | None = None
+        rate_gate_bucket_config: tuple[object, object, object, object] | None = None
+        rate_gate_bucket_binding_observable = False
+        try:
+            rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+            rate_gate_bucket_config = (
+                object.__getattribute__(rate_gate_bucket, "_runtime_backend"),
+                object.__getattribute__(rate_gate_bucket, "_request_limit"),
+                object.__getattribute__(rate_gate_bucket, "_token_limit"),
+                object.__getattribute__(rate_gate_bucket, "_window_seconds"),
+            )
+            rate_gate_bucket_binding_observable = (
+                isinstance(rate_gate_bucket_config[0], str)
+                and (
+                    rate_gate_bucket_config[1] is None
+                    or isinstance(rate_gate_bucket_config[1], int)
+                )
+                and (
+                    rate_gate_bucket_config[2] is None
+                    or isinstance(rate_gate_bucket_config[2], int)
+                )
+                and isinstance(rate_gate_bucket_config[3], float)
+            )
+        except (AttributeError, TypeError):
+            rate_gate_bucket = None
+            rate_gate_bucket_config = None
+        dispatcher_is_closed = (
+            expected_dispatcher_type is not None
+            and dispatcher_type is expected_dispatcher_type
+            and expected_dispatcher_stream_root is not None
+            and dispatcher_stream_root is expected_dispatcher_stream_root
+            and expected_dispatcher_stream_code is not None
+            and dispatcher_stream_code is expected_dispatcher_stream_code
+            and dispatcher_stream_callable is dispatcher_stream_root
+        )
+        transcript_is_closed = (
+            expected_transcript_verifier is not None
+            and transcript_verifier is expected_transcript_verifier
+            and transcript_verifier_root is expected_transcript_verifier
+            and expected_transcript_verifier_code is not None
+            and transcript_verifier_code is expected_transcript_verifier_code
+        )
+        rate_gate_is_closed = (
+            expected_rate_gate_acquire_root is not None
+            and rate_gate_acquire_root is expected_rate_gate_acquire_root
+            and expected_rate_gate_acquire_code is not None
+            and rate_gate_acquire_code is expected_rate_gate_acquire_code
+            and rate_gate_acquire_callable is rate_gate_acquire_root
+        )
+        coordinator_is_closed = coordinator is None or (
+            expected_coordinator_type is not None
+            and type(coordinator) is expected_coordinator_type
+            and expected_coordinator_review_root is not None
+            and coordinator_review_root is expected_coordinator_review_root
+            and expected_coordinator_review_code is not None
+            and coordinator_review_code is expected_coordinator_review_code
+        )
+        # A dynamic attribute hook or a missing direct callable root has no
+        # finite implementation identity. Keep execution working, but do not
+        # upgrade that adapter to a portable authority claim.
+        force_runtime_process_local = force_runtime_process_local or (
+            not executor_attribute_resolution_observable
+            or adapter_dispatch_root is None
+            or adapter_dispatch_code is None
+            or not adapter_attribute_resolution_observable
+            or not dispatcher_is_closed
+            or not dispatcher_attribute_resolution_observable
+            or not dispatcher_binding_observable
+            or not transcript_is_closed
+            or (
+                coordinator is not None
+                and (
+                    coordinator_review_callable is None
+                    or not coordinator_is_closed
+                    or not coordinator_binding_observable
+                    or not coordinator_attribute_resolution_observable
+                )
+            )
+            or not rate_gate_is_closed
+            or not rate_gate_attribute_resolution_observable
+            or not rate_gate_bucket_binding_observable
+        )
+        nonce = (
+            None if verifier is None or verifier is structural_atomic_verifier else uuid.uuid4().hex
+        )
+        contract = ExecutionAuthorityContract.build(
+            adapter=adapter,
+            verifier=verifier,
+            workspace=workspace,
+            execution_policy=execution_policy,
+            verifier_instance_nonce=nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+        return cls(
+            contract=contract,
+            executor=executor,
+            executor_attribute_resolution_observable=executor_attribute_resolution_observable,
+            adapter=adapter,
+            verifier=verifier,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=captured_dispatcher_executor,
+            transcript_verifier=transcript_verifier,
+            adapter_dispatch_root=adapter_dispatch_root,
+            adapter_dispatch_code=adapter_dispatch_code,
+            adapter_attribute_resolution_observable=adapter_attribute_resolution_observable,
+            verifier_root=verifier_root,
+            dispatcher_stream_root=dispatcher_stream_root,
+            dispatcher_stream_code=dispatcher_stream_code,
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            dispatcher_attribute_resolution_observable=(dispatcher_attribute_resolution_observable),
+            dispatcher_binding_observable=dispatcher_binding_observable,
+            transcript_verifier_root=transcript_verifier_root,
+            transcript_verifier_code=transcript_verifier_code,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+            coordinator_review_root=coordinator_review_root,
+            coordinator_review_code=coordinator_review_code,
+            coordinator_adapter=coordinator_adapter,
+            coordinator_task_cwd=coordinator_task_cwd,
+            coordinator_reasoning_effort=coordinator_reasoning_effort,
+            coordinator_attribute_resolution_observable=(
+                coordinator_attribute_resolution_observable
+            ),
+            coordinator_binding_observable=coordinator_binding_observable,
+            rate_gate=rate_gate,
+            rate_gate_acquire_root=rate_gate_acquire_root,
+            rate_gate_acquire_code=rate_gate_acquire_code,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            rate_gate_attribute_resolution_observable=rate_gate_attribute_resolution_observable,
+            rate_gate_bucket=rate_gate_bucket,
+            rate_gate_bucket_config=rate_gate_bucket_config,
+            rate_gate_bucket_binding_observable=rate_gate_bucket_binding_observable,
+            verifier_instance_nonce=nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+
+    def is_intact(
+        self,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        executor: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+    ) -> bool:
+        if executor is not self.executor:
+            return False
+        if adapter is not self.adapter or verifier is not self.verifier:
+            return False
+        if dispatcher_type is not self.dispatcher_type:
+            return False
+        if dispatcher is not self.dispatcher or dispatcher_executor is not self.dispatcher_executor:
+            return False
+        if dispatcher_stream_callable is not self.dispatcher_stream_callable:
+            return False
+        if transcript_verifier is not self.transcript_verifier:
+            return False
+        if coordinator is not self.coordinator:
+            return False
+        if coordinator_review_callable is not self.coordinator_review_callable:
+            return False
+        if rate_gate is not self.rate_gate:
+            return False
+        if rate_gate_acquire_callable is not self.rate_gate_acquire_callable:
+            return False
+        if (
+            self.executor_attribute_resolution_observable
+            and executor is not None
+            and not _uses_default_instance_attribute_resolution(executor)
+        ):
+            return False
+        if (
+            self.adapter_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(adapter)
+        ):
+            return False
+        if (
+            self.dispatcher_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(dispatcher_type)
+        ):
+            return False
+        if (
+            self.coordinator_attribute_resolution_observable
+            and coordinator is not None
+            and not _uses_default_instance_attribute_resolution(coordinator)
+        ):
+            return False
+        if (
+            self.rate_gate_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(rate_gate)
+        ):
+            return False
+        if self.rate_gate_bucket_binding_observable:
+            try:
+                current_rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+                current_rate_gate_bucket_config = (
+                    object.__getattribute__(current_rate_gate_bucket, "_runtime_backend"),
+                    object.__getattribute__(current_rate_gate_bucket, "_request_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_token_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_window_seconds"),
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                current_rate_gate_bucket is not self.rate_gate_bucket
+                or current_rate_gate_bucket_config != self.rate_gate_bucket_config
+            ):
+                return False
+        if (
+            self.adapter_dispatch_root is not None
+            and _static_callable_root(adapter, "execute_task") is not self.adapter_dispatch_root
+        ):
+            return False
+        if (
+            self.adapter_dispatch_code is not None
+            and _callable_code_identity(_static_callable_root(adapter, "execute_task"))
+            is not self.adapter_dispatch_code
+        ):
+            return False
+        if (
+            self.verifier_root is not None
+            and _static_callable_root(verifier, None) is not self.verifier_root
+        ):
+            return False
+        if (
+            self.dispatcher_stream_root is not None
+            and _static_callable_root(dispatcher_type, "stream") is not self.dispatcher_stream_root
+        ):
+            return False
+        if (
+            self.dispatcher_stream_code is not None
+            and _callable_code_identity(_static_callable_root(dispatcher_type, "stream"))
+            is not self.dispatcher_stream_code
+        ):
+            return False
+        if self.dispatcher_binding_observable and dispatcher is not None:
+            try:
+                current_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+            except (AttributeError, TypeError):
+                return False
+            if current_dispatcher_executor is not self.dispatcher_executor:
+                return False
+        if (
+            self.transcript_verifier_root is not None
+            and _static_callable_root(transcript_verifier, None)
+            is not self.transcript_verifier_root
+        ):
+            return False
+        if (
+            self.transcript_verifier_code is not None
+            and _callable_code_identity(_static_callable_root(transcript_verifier, None))
+            is not self.transcript_verifier_code
+        ):
+            return False
+        if (
+            self.coordinator_review_root is not None
+            and _static_callable_root(coordinator, "run_review") is not self.coordinator_review_root
+        ):
+            return False
+        if (
+            self.coordinator_review_code is not None
+            and _callable_code_identity(_static_callable_root(coordinator, "run_review"))
+            is not self.coordinator_review_code
+        ):
+            return False
+        if self.coordinator_binding_observable and coordinator is not None:
+            try:
+                current_coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                current_coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                current_coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                current_coordinator_adapter is not self.coordinator_adapter
+                or current_coordinator_task_cwd != self.coordinator_task_cwd
+                or current_coordinator_reasoning_effort != self.coordinator_reasoning_effort
+            ):
+                return False
+        if (
+            self.rate_gate_acquire_root is not None
+            and _static_callable_root(rate_gate, "acquire") is not self.rate_gate_acquire_root
+        ):
+            return False
+        if (
+            self.rate_gate_acquire_code is not None
+            and _callable_code_identity(_static_callable_root(rate_gate, "acquire"))
+            is not self.rate_gate_acquire_code
+        ):
+            return False
+        try:
+            current = ExecutionAuthorityContract.build(
+                adapter=adapter,
+                verifier=verifier,
+                workspace=workspace,
+                execution_policy=execution_policy,
+                verifier_instance_nonce=self.verifier_instance_nonce,
+                force_runtime_process_local=self.force_runtime_process_local,
+            )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return False
+        return current.canonical_json == self.contract.canonical_json
+
+
+__all__ = [
+    "EXECUTION_AUTHORITY_VERSION",
+    "ExecutionAuthorityContract",
+    "ExecutionAuthorityLiveBinding",
+    "canonical_workspace_authority",
+    "constructor_model_contract",
+    "execution_authority_boundary_contract",
+    "execution_policy_authority_contract",
+    "executor_authority_contract",
+    "runtime_authority_contract",
+    "runtime_execution_identity_contract",
+    "runtime_execution_proves_effective_model",
+    "valid_constructor_model_contract",
+    "valid_runtime_execution_identity_contract",
+    "verifier_authority_contract",
+]

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -40,6 +40,13 @@ _EXECUTOR_COMPONENT_VERSIONS = {
 _BUILTIN_TRANSCRIPT_VERIFIER = "runtime-transcript-verifier/v1"
 _BUILTIN_STRUCTURAL_VERIFIER = "structural-atomic-verifier/v1"
 _BUILTIN_STRUCTURAL_VERIFIER_CODE = structural_atomic_verifier.__code__
+_RATE_GATE_BUCKET_HELPER_NAMES = (
+    "_prune",
+    "_tokens_in_window",
+    "_snapshot",
+    "_request_wait_seconds",
+    "_token_wait_seconds",
+)
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -896,6 +903,7 @@ class ExecutionAuthorityLiveBinding:
     rate_gate_bucket_acquire_code: object | None
     rate_gate_bucket_force_reserve_root: object | None
     rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
     rate_gate_bucket_binding_observable: bool
     verifier_instance_nonce: str | None
     force_runtime_process_local: bool
@@ -936,6 +944,9 @@ class ExecutionAuthorityLiveBinding:
         expected_rate_gate_bucket_acquire_code: object | None = None,
         expected_rate_gate_bucket_force_reserve_root: object | None = None,
         expected_rate_gate_bucket_force_reserve_code: object | None = None,
+        expected_rate_gate_bucket_helper_roots: (
+            tuple[tuple[str, object | None, object | None], ...] | None
+        ) = None,
         expected_coordinator_type: type[object] | None = None,
         expected_coordinator_review_root: object | None = None,
         expected_coordinator_review_code: object | None = None,
@@ -1025,6 +1036,7 @@ class ExecutionAuthorityLiveBinding:
         rate_gate_bucket_acquire_code: object | None = None
         rate_gate_bucket_force_reserve_root: object | None = None
         rate_gate_bucket_force_reserve_code: object | None = None
+        rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...] = ()
         rate_gate_bucket_binding_observable = False
         try:
             rate_gate_max_wait_seconds = object.__getattribute__(rate_gate, "_max_wait_seconds")
@@ -1059,6 +1071,13 @@ class ExecutionAuthorityLiveBinding:
             rate_gate_bucket_force_reserve_code = _callable_code_identity(
                 rate_gate_bucket_force_reserve_root
             )
+            bucket_helper_roots: list[tuple[str, object | None, object | None]] = []
+            for name in _RATE_GATE_BUCKET_HELPER_NAMES:
+                helper_root = _static_callable_root(rate_gate_bucket, name)
+                bucket_helper_roots.append(
+                    (name, helper_root, _callable_code_identity(helper_root))
+                )
+            rate_gate_bucket_helper_roots = tuple(bucket_helper_roots)
             rate_gate_bucket_binding_observable = (
                 isinstance(rate_gate_bucket_config[0], str)
                 and (
@@ -1086,6 +1105,10 @@ class ExecutionAuthorityLiveBinding:
                 and rate_gate_bucket_acquire_code is not None
                 and rate_gate_bucket_force_reserve_root is not None
                 and rate_gate_bucket_force_reserve_code is not None
+                and all(
+                    helper_root is not None and helper_code is not None
+                    for _, helper_root, helper_code in rate_gate_bucket_helper_roots
+                )
             )
         except (AttributeError, TypeError):
             rate_gate_bucket = None
@@ -1135,6 +1158,20 @@ class ExecutionAuthorityLiveBinding:
             and rate_gate_bucket_force_reserve_root is expected_rate_gate_bucket_force_reserve_root
             and expected_rate_gate_bucket_force_reserve_code is not None
             and rate_gate_bucket_force_reserve_code is expected_rate_gate_bucket_force_reserve_code
+            and expected_rate_gate_bucket_helper_roots is not None
+            and len(rate_gate_bucket_helper_roots) == len(expected_rate_gate_bucket_helper_roots)
+            and all(
+                name == expected_name and root is expected_root and code is expected_code
+                for (name, root, code), (
+                    expected_name,
+                    expected_root,
+                    expected_code,
+                ) in zip(
+                    rate_gate_bucket_helper_roots,
+                    expected_rate_gate_bucket_helper_roots,
+                    strict=True,
+                )
+            )
         )
         coordinator_is_closed = coordinator is None or (
             expected_coordinator_type is not None
@@ -1170,8 +1207,19 @@ class ExecutionAuthorityLiveBinding:
             or not rate_gate_semantics_observable
             or not rate_gate_bucket_binding_observable
         )
+        # A pristine structural verifier is the one built-in verifier with a
+        # durable implementation descriptor. If its code was already changed
+        # before construction, keep it executable as a custom, process-local
+        # verifier with one stable live-instance nonce instead of generating a
+        # new nonce on every guard check.
         nonce = (
-            None if verifier is None or verifier is structural_atomic_verifier else uuid.uuid4().hex
+            None
+            if verifier is None
+            or (
+                verifier is structural_atomic_verifier
+                and verifier_code is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+            )
+            else uuid.uuid4().hex
         )
         contract = ExecutionAuthorityContract.build(
             adapter=adapter,
@@ -1239,6 +1287,7 @@ class ExecutionAuthorityLiveBinding:
             rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
             rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
             rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+            rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
             rate_gate_bucket_binding_observable=rate_gate_bucket_binding_observable,
             verifier_instance_nonce=nonce,
             force_runtime_process_local=force_runtime_process_local,
@@ -1378,6 +1427,10 @@ class ExecutionAuthorityLiveBinding:
                 is not self.rate_gate_bucket_force_reserve_code
             ):
                 return False
+            for name, root, code in self.rate_gate_bucket_helper_roots:
+                current_root = _static_callable_root(current_rate_gate_bucket, name)
+                if current_root is not root or _callable_code_identity(current_root) is not code:
+                    return False
         if (
             self.adapter_dispatch_root is not None
             and _static_callable_root(adapter, "execute_task") is not self.adapter_dispatch_root

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -17,19 +17,71 @@ import json
 import math
 from pathlib import Path
 import re
+import shutil
+import stat
 from typing import Any
 import uuid
 
+from ouroboros.orchestrator.antigravity_cli_runtime import AntigravityCLIRuntime
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+from ouroboros.orchestrator.grok_cli_runtime import GrokCliRuntime
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
-EXECUTION_AUTHORITY_VERSION = 2
-EXECUTION_AUTHORITY_BOUNDARY_VERSION = 2
+EXECUTION_AUTHORITY_VERSION = 3
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 3
 
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
+_MAX_RUNTIME_EXECUTABLE_BYTES = 64 * 1024 * 1024
+
+# A portable runtime must be an exact built-in adapter implementation. This
+# table retains the real type object and its import-time dispatch root/code;
+# module/qualname strings are mutable and therefore cannot prove identity.
+# Adding or changing an implementation requires a version bump and review.
+_CLOSED_RUNTIME_IMPLEMENTATIONS: dict[type[object], tuple[str, object, object]] = {
+    AntigravityCLIRuntime: (
+        "antigravity-cli-runtime/v1",
+        AntigravityCLIRuntime.execute_task,
+        AntigravityCLIRuntime.execute_task.__code__,
+    ),
+    CodexCliRuntime: (
+        "codex-cli-runtime/v1",
+        CodexCliRuntime.execute_task,
+        CodexCliRuntime.execute_task.__code__,
+    ),
+    CopilotCliRuntime: (
+        "copilot-cli-runtime/v1",
+        CopilotCliRuntime.execute_task,
+        CopilotCliRuntime.execute_task.__code__,
+    ),
+    GeminiCLIRuntime: (
+        "gemini-cli-runtime/v1",
+        GeminiCLIRuntime.execute_task,
+        GeminiCLIRuntime.execute_task.__code__,
+    ),
+    GooseCliRuntime: (
+        "goose-cli-runtime/v1",
+        GooseCliRuntime.execute_task,
+        GooseCliRuntime.execute_task.__code__,
+    ),
+    GrokCliRuntime: (
+        "grok-cli-runtime/v1",
+        GrokCliRuntime.execute_task,
+        GrokCliRuntime.execute_task.__code__,
+    ),
+    ZcodeCLIRuntime: (
+        "zcode-cli-runtime/v1",
+        ZcodeCLIRuntime.execute_task,
+        ZcodeCLIRuntime.execute_task.__code__,
+    ),
+}
 
 _EXECUTOR_COMPONENT_VERSIONS = {
     "parallel_ac_executor": "parallel-ac-executor/v2",
@@ -430,10 +482,141 @@ def _runtime_label_descriptor(adapter: object, name: str) -> dict[str, object]:
     return _digest_descriptor(value.strip(), field=f"runtime {name}")
 
 
+def _runtime_implementation_descriptor(adapter: object) -> dict[str, object]:
+    """Return a reviewed identity for one exact built-in runtime type."""
+    runtime_type = type(adapter)
+    implementation = _CLOSED_RUNTIME_IMPLEMENTATIONS.get(runtime_type)
+    if implementation is None:
+        return {"observed": False}
+    version, expected_dispatch_root, expected_dispatch_code = implementation
+    dispatch_root = _static_callable_root(adapter, "execute_task")
+    if (
+        dispatch_root is not expected_dispatch_root
+        or _callable_code_identity(dispatch_root) is not expected_dispatch_code
+    ):
+        return {"observed": False}
+    return _digest_descriptor(
+        {
+            "type": f"{runtime_type.__module__}.{runtime_type.__qualname__}",
+            "version": version,
+        },
+        field="runtime implementation",
+    )
+
+
+def _runtime_executable_descriptor(adapter: object) -> dict[str, object]:
+    """Digest one bounded, resolved CLI executable without serializing its path."""
+    try:
+        configured_path = object.__getattribute__(adapter, "_cli_path")
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(configured_path, str) or not configured_path.strip():
+        return {"observed": False}
+
+    try:
+        candidate = Path(configured_path).expanduser()
+        if not candidate.is_absolute():
+            resolved_from_path = shutil.which(configured_path)
+            if resolved_from_path is None:
+                return {"observed": False}
+            candidate = Path(resolved_from_path)
+        executable_path = candidate.resolve(strict=True)
+        executable_stat = executable_path.stat()
+        executable_mode = stat.S_IMODE(executable_stat.st_mode)
+        if (
+            not stat.S_ISREG(executable_stat.st_mode)
+            or not executable_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            or executable_stat.st_size > _MAX_RUNTIME_EXECUTABLE_BYTES
+        ):
+            return {"observed": False}
+        digest = hashlib.sha256()
+        with executable_path.open("rb") as executable_file:
+            while chunk := executable_file.read(1024 * 1024):
+                digest.update(chunk)
+    except (OSError, ValueError):
+        return {"observed": False}
+
+    return _digest_descriptor(
+        {
+            "path": str(executable_path),
+            "generation": {
+                "device": executable_stat.st_dev,
+                "inode": executable_stat.st_ino,
+                "size": executable_stat.st_size,
+                "mtime_ns": executable_stat.st_mtime_ns,
+                "mode": executable_mode,
+            },
+            "content_digest": "sha256:" + digest.hexdigest(),
+        },
+        field="runtime executable",
+    )
+
+
+def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
+    """Digest the finite mutable execution settings of the CLI runtime family."""
+    try:
+        skills_dir = object.__getattribute__(adapter, "_skills_dir")
+        skill_dispatcher = object.__getattribute__(adapter, "_skill_dispatcher")
+        if skills_dir is not None or skill_dispatcher is not None:
+            # User-provided skill directories and dispatchers are live behavior,
+            # not a closed portable component in Foundation A.
+            return {"observed": False}
+        startup_timeout = object.__getattribute__(adapter, "_startup_output_timeout_seconds")
+        stdout_timeout = object.__getattribute__(adapter, "_stdout_idle_timeout_seconds")
+        process_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_process_shutdown_timeout_seconds",
+        )
+        completed_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_completed_process_group_shutdown_timeout_seconds",
+        )
+        max_resume_retries = object.__getattribute__(adapter, "_max_resume_retries")
+        max_depth = object.__getattribute__(adapter, "_max_ouroboros_depth")
+        max_stderr_lines = object.__getattribute__(adapter, "_max_stderr_lines")
+        use_process_group = object.__getattribute__(adapter, "_use_process_group")
+        child_session_env_keys = object.__getattribute__(adapter, "_child_session_env_keys")
+    except (AttributeError, TypeError):
+        return {"observed": False}
+
+    timeouts = (
+        startup_timeout,
+        stdout_timeout,
+        process_shutdown_timeout,
+        completed_shutdown_timeout,
+    )
+    if (
+        not all(value is None or _is_finite_number(value) for value in timeouts)
+        or any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in (max_resume_retries, max_depth, max_stderr_lines)
+        )
+        or not isinstance(use_process_group, bool)
+        or not isinstance(child_session_env_keys, (tuple, list, frozenset))
+        or not all(isinstance(value, str) for value in child_session_env_keys)
+    ):
+        return {"observed": False}
+    return _digest_descriptor(
+        {
+            "startup_output_timeout_seconds": startup_timeout,
+            "stdout_idle_timeout_seconds": stdout_timeout,
+            "process_shutdown_timeout_seconds": process_shutdown_timeout,
+            "completed_process_group_shutdown_timeout_seconds": completed_shutdown_timeout,
+            "max_resume_retries": max_resume_retries,
+            "max_ouroboros_depth": max_depth,
+            "max_stderr_lines": max_stderr_lines,
+            "use_process_group": use_process_group,
+            "child_session_env_keys": sorted(child_session_env_keys),
+        },
+        field="runtime execution configuration",
+    )
+
+
 def runtime_authority_contract(
     adapter: object,
     *,
     force_process_local: bool = False,
+    instance_nonce: str | None = None,
 ) -> dict[str, object]:
     """Return a finite, digest-only runtime descriptor.
 
@@ -460,6 +643,9 @@ def runtime_authority_contract(
     runtime_backend = _runtime_label_descriptor(adapter, "runtime_backend")
     llm_backend = _runtime_label_descriptor(adapter, "llm_backend")
     permission_mode = _runtime_label_descriptor(adapter, "permission_mode")
+    implementation = _runtime_implementation_descriptor(adapter)
+    executable = _runtime_executable_descriptor(adapter)
+    configuration = _runtime_configuration_descriptor(adapter)
     try:
         self_governs_rate_limit = object.__getattribute__(adapter, "self_governs_rate_limit")
     except (AttributeError, TypeError):
@@ -471,11 +657,14 @@ def runtime_authority_contract(
         and permission_mode["observed"] is True
         and execution_descriptor["observed"] is True
         and capabilities["observed"] is True
+        and implementation["observed"] is True
+        and executable["observed"] is True
+        and configuration["observed"] is True
         and isinstance(self_governs_rate_limit, bool)
         and not force_process_local
     )
     return {
-        "version": 2,
+        "version": 3,
         "stability": "durable" if portable_identity_observed else "process_local",
         # This is an explicit semantic witness, not a cosmetic copy of the
         # stability label. A durable runtime must have a finite direct dispatch
@@ -486,8 +675,14 @@ def runtime_authority_contract(
         "permission_mode": permission_mode,
         "execution_identity": execution_descriptor,
         "capabilities": capabilities,
+        "implementation": implementation,
+        "executable": executable,
+        "configuration": configuration,
         "self_governs_rate_limit": (
             self_governs_rate_limit if isinstance(self_governs_rate_limit, bool) else None
+        ),
+        "instance_nonce": (
+            None if portable_identity_observed else instance_nonce or uuid.uuid4().hex
         ),
     }
 
@@ -501,10 +696,14 @@ def _valid_runtime_authority(value: object) -> bool:
         "permission_mode",
         "execution_identity",
         "capabilities",
+        "implementation",
+        "executable",
+        "configuration",
         "self_governs_rate_limit",
         "portable_identity_observed",
+        "instance_nonce",
     }
-    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 2:
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 3:
         return False
     if value.get("stability") not in {"durable", "process_local"}:
         return False
@@ -516,6 +715,9 @@ def _valid_runtime_authority(value: object) -> bool:
             "permission_mode",
             "execution_identity",
             "capabilities",
+            "implementation",
+            "executable",
+            "configuration",
         )
     ):
         return False
@@ -531,6 +733,9 @@ def _valid_runtime_authority(value: object) -> bool:
             "permission_mode",
             "execution_identity",
             "capabilities",
+            "implementation",
+            "executable",
+            "configuration",
         )
     )
     if value.get("stability") == "durable":
@@ -538,9 +743,14 @@ def _valid_runtime_authority(value: object) -> bool:
             portable_identity_observed
             and descriptors_are_observed
             and isinstance(self_governs_rate_limit, bool)
+            and value.get("instance_nonce") is None
         )
-    return not portable_identity_observed and (
-        self_governs_rate_limit is None or isinstance(self_governs_rate_limit, bool)
+    nonce = value.get("instance_nonce")
+    return (
+        not portable_identity_observed
+        and (self_governs_rate_limit is None or isinstance(self_governs_rate_limit, bool))
+        and isinstance(nonce, str)
+        and len(nonce) == 32
     )
 
 
@@ -788,6 +998,7 @@ class ExecutionAuthorityContract:
         workspace: str | None,
         execution_policy: Mapping[str, object],
         verifier_instance_nonce: str | None = None,
+        runtime_instance_nonce: str | None = None,
         force_runtime_process_local: bool = False,
     ) -> ExecutionAuthorityContract:
         data = {
@@ -798,6 +1009,7 @@ class ExecutionAuthorityContract:
             "runtime": runtime_authority_contract(
                 adapter,
                 force_process_local=force_runtime_process_local,
+                instance_nonce=runtime_instance_nonce,
             ),
             "verifier": verifier_authority_contract(
                 verifier,
@@ -854,7 +1066,9 @@ class ExecutionAuthorityLiveBinding:
     executor: object | None
     executor_attribute_resolution_observable: bool
     adapter: object
+    runtime_instance_nonce: str | None
     verifier: Verifier | None
+    session_signal_hub: object | None
     dispatcher_type: object
     dispatcher: object | None
     dispatcher_executor: object | None
@@ -920,6 +1134,7 @@ class ExecutionAuthorityLiveBinding:
         workspace: str | None,
         execution_policy: Mapping[str, object],
         executor: object | None = None,
+        session_signal_hub: object | None = None,
         dispatcher: object | None = None,
         dispatcher_executor: object | None = None,
         dispatcher_stream_callable: object | None = None,
@@ -1185,7 +1400,8 @@ class ExecutionAuthorityLiveBinding:
         # finite implementation identity. Keep execution working, but do not
         # upgrade that adapter to a portable authority claim.
         force_runtime_process_local = force_runtime_process_local or (
-            not executor_attribute_resolution_observable
+            session_signal_hub is not None
+            or not executor_attribute_resolution_observable
             or adapter_dispatch_root is None
             or adapter_dispatch_code is None
             or not adapter_attribute_resolution_observable
@@ -1221,12 +1437,14 @@ class ExecutionAuthorityLiveBinding:
             )
             else uuid.uuid4().hex
         )
+        runtime_instance_nonce = uuid.uuid4().hex
         contract = ExecutionAuthorityContract.build(
             adapter=adapter,
             verifier=verifier,
             workspace=workspace,
             execution_policy=execution_policy,
             verifier_instance_nonce=nonce,
+            runtime_instance_nonce=runtime_instance_nonce,
             force_runtime_process_local=force_runtime_process_local,
         )
         return cls(
@@ -1234,7 +1452,9 @@ class ExecutionAuthorityLiveBinding:
             executor=executor,
             executor_attribute_resolution_observable=executor_attribute_resolution_observable,
             adapter=adapter,
+            runtime_instance_nonce=runtime_instance_nonce,
             verifier=verifier,
+            session_signal_hub=session_signal_hub,
             dispatcher_type=dispatcher_type,
             dispatcher=dispatcher,
             dispatcher_executor=captured_dispatcher_executor,
@@ -1303,6 +1523,7 @@ class ExecutionAuthorityLiveBinding:
         rate_gate: object,
         workspace: str | None,
         execution_policy: Mapping[str, object],
+        session_signal_hub: object | None = None,
         executor: object | None = None,
         coordinator: object | None = None,
         coordinator_review_callable: object | None = None,
@@ -1314,6 +1535,8 @@ class ExecutionAuthorityLiveBinding:
         if executor is not self.executor:
             return False
         if adapter is not self.adapter or verifier is not self.verifier:
+            return False
+        if session_signal_hub is not self.session_signal_hub:
             return False
         if dispatcher_type is not self.dispatcher_type:
             return False
@@ -1528,6 +1751,7 @@ class ExecutionAuthorityLiveBinding:
                 workspace=workspace,
                 execution_policy=execution_policy,
                 verifier_instance_nonce=self.verifier_instance_nonce,
+                runtime_instance_nonce=self.runtime_instance_nonce,
                 force_runtime_process_local=self.force_runtime_process_local,
             )
         except (AttributeError, KeyError, TypeError, ValueError):

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -22,18 +22,14 @@ import stat
 from typing import Any
 import uuid
 
-from ouroboros.orchestrator.antigravity_cli_runtime import AntigravityCLIRuntime
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
-from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
-from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
-from ouroboros.orchestrator.grok_cli_runtime import GrokCliRuntime
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
 from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
-EXECUTION_AUTHORITY_VERSION = 3
-EXECUTION_AUTHORITY_BOUNDARY_VERSION = 3
+EXECUTION_AUTHORITY_VERSION = 4
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 4
 
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
@@ -41,45 +37,18 @@ _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
 _MAX_RUNTIME_EXECUTABLE_BYTES = 64 * 1024 * 1024
 
-# A portable runtime must be an exact built-in adapter implementation. This
-# table retains the real type object and its import-time dispatch root/code;
+# A portable runtime must be an exact, fully-reviewed built-in adapter. This
+# initial Foundation A allowlist intentionally admits only Codex. Other CLI
+# backends retain backend-specific command/profile/launcher behavior and remain
+# process-local until each has its own complete finite descriptor. The table
+# retains the real type object and its import-time dispatch root/code;
 # module/qualname strings are mutable and therefore cannot prove identity.
 # Adding or changing an implementation requires a version bump and review.
 _CLOSED_RUNTIME_IMPLEMENTATIONS: dict[type[object], tuple[str, object, object]] = {
-    AntigravityCLIRuntime: (
-        "antigravity-cli-runtime/v1",
-        AntigravityCLIRuntime.execute_task,
-        AntigravityCLIRuntime.execute_task.__code__,
-    ),
     CodexCliRuntime: (
         "codex-cli-runtime/v1",
         CodexCliRuntime.execute_task,
         CodexCliRuntime.execute_task.__code__,
-    ),
-    CopilotCliRuntime: (
-        "copilot-cli-runtime/v1",
-        CopilotCliRuntime.execute_task,
-        CopilotCliRuntime.execute_task.__code__,
-    ),
-    GeminiCLIRuntime: (
-        "gemini-cli-runtime/v1",
-        GeminiCLIRuntime.execute_task,
-        GeminiCLIRuntime.execute_task.__code__,
-    ),
-    GooseCliRuntime: (
-        "goose-cli-runtime/v1",
-        GooseCliRuntime.execute_task,
-        GooseCliRuntime.execute_task.__code__,
-    ),
-    GrokCliRuntime: (
-        "grok-cli-runtime/v1",
-        GrokCliRuntime.execute_task,
-        GrokCliRuntime.execute_task.__code__,
-    ),
-    ZcodeCLIRuntime: (
-        "zcode-cli-runtime/v1",
-        ZcodeCLIRuntime.execute_task,
-        ZcodeCLIRuntime.execute_task.__code__,
     ),
 }
 
@@ -554,6 +523,13 @@ def _runtime_executable_descriptor(adapter: object) -> dict[str, object]:
 
 def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
     """Digest the finite mutable execution settings of the CLI runtime family."""
+    runtime_type = type(adapter)
+    if runtime_type is ZcodeCLIRuntime:
+        # Zcode can launch an app-bundle Electron executable or a PATH-resolved
+        # Node executable before its configured script. That external launcher
+        # chain is not a finite portable descriptor in Foundation A.
+        return {"observed": False}
+
     try:
         skills_dir = object.__getattribute__(adapter, "_skills_dir")
         skill_dispatcher = object.__getattribute__(adapter, "_skill_dispatcher")
@@ -577,6 +553,16 @@ def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
         max_stderr_lines = object.__getattribute__(adapter, "_max_stderr_lines")
         use_process_group = object.__getattribute__(adapter, "_use_process_group")
         child_session_env_keys = object.__getattribute__(adapter, "_child_session_env_keys")
+        copilot_runtime_profile = (
+            object.__getattribute__(adapter, "_runtime_profile")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
+        copilot_agent = (
+            object.__getattribute__(adapter, "_copilot_agent")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
     except (AttributeError, TypeError):
         return {"observed": False}
 
@@ -597,27 +583,44 @@ def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
         or not isinstance(use_process_group, bool)
         or not isinstance(child_session_env_keys, (tuple, list, frozenset))
         or not all(isinstance(value, str) for value in child_session_env_keys)
+        or (
+            runtime_type is CopilotCliRuntime
+            and (
+                copilot_runtime_profile is not None
+                and (
+                    not isinstance(copilot_runtime_profile, str)
+                    or not copilot_runtime_profile.strip()
+                )
+                or copilot_agent is not None
+                and (not isinstance(copilot_agent, str) or not copilot_agent.strip())
+            )
+        )
     ):
         return {"observed": False}
     try:
         canonical_cwd = str(Path(cwd).expanduser().resolve(strict=False))
     except (OSError, ValueError):
         return {"observed": False}
-    return _digest_descriptor(
-        {
-            "working_directory": canonical_cwd,
-            "startup_output_timeout_seconds": startup_timeout,
-            "stdout_idle_timeout_seconds": stdout_timeout,
-            "process_shutdown_timeout_seconds": process_shutdown_timeout,
-            "completed_process_group_shutdown_timeout_seconds": completed_shutdown_timeout,
-            "max_resume_retries": max_resume_retries,
-            "max_ouroboros_depth": max_depth,
-            "max_stderr_lines": max_stderr_lines,
-            "use_process_group": use_process_group,
-            "child_session_env_keys": sorted(child_session_env_keys),
-        },
-        field="runtime execution configuration",
-    )
+    configuration: dict[str, object] = {
+        "working_directory": canonical_cwd,
+        "startup_output_timeout_seconds": startup_timeout,
+        "stdout_idle_timeout_seconds": stdout_timeout,
+        "process_shutdown_timeout_seconds": process_shutdown_timeout,
+        "completed_process_group_shutdown_timeout_seconds": completed_shutdown_timeout,
+        "max_resume_retries": max_resume_retries,
+        "max_ouroboros_depth": max_depth,
+        "max_stderr_lines": max_stderr_lines,
+        "use_process_group": use_process_group,
+        "child_session_env_keys": sorted(child_session_env_keys),
+    }
+    if runtime_type is CopilotCliRuntime:
+        # Copilot translates the resolved runtime profile to an --agent flag.
+        # Bind the exact stored value that command construction consumes.
+        configuration["copilot"] = {
+            "runtime_profile": copilot_runtime_profile,
+            "resolved_agent": copilot_agent,
+        }
+    return _digest_descriptor(configuration, field="runtime execution configuration")
 
 
 def runtime_authority_contract(
@@ -672,7 +675,7 @@ def runtime_authority_contract(
         and not force_process_local
     )
     return {
-        "version": 3,
+        "version": 4,
         "stability": "durable" if portable_identity_observed else "process_local",
         # This is an explicit semantic witness, not a cosmetic copy of the
         # stability label. A durable runtime must have a finite direct dispatch
@@ -711,7 +714,7 @@ def _valid_runtime_authority(value: object) -> bool:
         "portable_identity_observed",
         "instance_nonce",
     }
-    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 3:
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 4:
         return False
     if value.get("stability") not in {"durable", "process_local"}:
         return False

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -561,6 +561,7 @@ def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
             # User-provided skill directories and dispatchers are live behavior,
             # not a closed portable component in Foundation A.
             return {"observed": False}
+        cwd = object.__getattribute__(adapter, "_cwd")
         startup_timeout = object.__getattribute__(adapter, "_startup_output_timeout_seconds")
         stdout_timeout = object.__getattribute__(adapter, "_stdout_idle_timeout_seconds")
         process_shutdown_timeout = object.__getattribute__(
@@ -586,7 +587,9 @@ def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
         completed_shutdown_timeout,
     )
     if (
-        not all(value is None or _is_finite_number(value) for value in timeouts)
+        not isinstance(cwd, str)
+        or not cwd.strip()
+        or not all(value is None or _is_finite_number(value) for value in timeouts)
         or any(
             not isinstance(value, int) or isinstance(value, bool) or value < 0
             for value in (max_resume_retries, max_depth, max_stderr_lines)
@@ -596,8 +599,13 @@ def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
         or not all(isinstance(value, str) for value in child_session_env_keys)
     ):
         return {"observed": False}
+    try:
+        canonical_cwd = str(Path(cwd).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"observed": False}
     return _digest_descriptor(
         {
+            "working_directory": canonical_cwd,
             "startup_output_timeout_seconds": startup_timeout,
             "stdout_idle_timeout_seconds": stdout_timeout,
             "process_shutdown_timeout_seconds": process_shutdown_timeout,

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -23,8 +23,8 @@ import uuid
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
 
-EXECUTION_AUTHORITY_VERSION = 1
-EXECUTION_AUTHORITY_BOUNDARY_VERSION = 1
+EXECUTION_AUTHORITY_VERSION = 2
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 2
 
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
@@ -32,13 +32,14 @@ _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
 
 _EXECUTOR_COMPONENT_VERSIONS = {
-    "parallel_ac_executor": "parallel-ac-executor/v1",
+    "parallel_ac_executor": "parallel-ac-executor/v2",
     "leaf_dispatcher": "leaf-dispatcher/v1",
     "level_coordinator": "level-coordinator/v1",
     "rate_limit_gate": "rate-limit-gate/v1",
 }
 _BUILTIN_TRANSCRIPT_VERIFIER = "runtime-transcript-verifier/v1"
 _BUILTIN_STRUCTURAL_VERIFIER = "structural-atomic-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER_CODE = structural_atomic_verifier.__code__
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -72,18 +73,33 @@ def _normalized_identity_key(value: str) -> str:
 def _is_sensitive_identity_key(value: str) -> bool:
     """Return whether an explicit identity key can carry a credential value."""
     compact = _normalized_identity_key(value)
-    return any(
-        marker in compact
-        for marker in (
-            "apikey",
-            "credential",
-            "password",
-            "authorization",
-            "bearer",
-            "privatekey",
-            "clientsecret",
+    return (
+        any(
+            marker in compact
+            for marker in (
+                "apikey",
+                "credential",
+                "password",
+                "authorization",
+                "bearer",
+                "privatekey",
+                "clientsecret",
+                "secretkey",
+                "accesskey",
+                "authkey",
+                "signingkey",
+                "encryptionkey",
+                "accountkey",
+                "masterkey",
+                "connectionstring",
+                "accesstoken",
+                "refreshtoken",
+                "sessiontoken",
+            )
         )
-    ) or compact.endswith(("token", "tokenvalue", "keyvalue", "secret"))
+        or compact.startswith("secret")
+        or compact.endswith(("token", "tokenvalue", "keyvalue", "secret", "secretvalue"))
+    )
 
 
 def _looks_like_credential(value: str) -> bool:
@@ -331,6 +347,11 @@ def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
         dict(identity),
         field="runtime execution identity contract",
     )
+    # An empty object carries no execution identity. Treat it like a missing
+    # provider declaration instead of allowing a digest of ``{}`` to witness
+    # portability.
+    if not normalized:
+        return {"version": 1, "observed": False}
     return {"version": 1, "observed": True, "identity": normalized}
 
 
@@ -415,13 +436,15 @@ def runtime_authority_contract(
     # This public descriptor builder must retain the finite live-root rule used
     # by ``ExecutionAuthorityLiveBinding``. A runtime with only dynamic
     # ``execute_task`` lookup remains executable, but cannot claim portability.
+    dispatch_root_observed = _has_observable_runtime_dispatch_root(adapter)
     if not force_process_local:
-        force_process_local = not _has_observable_runtime_dispatch_root(adapter)
+        force_process_local = not dispatch_root_observed
     try:
         execution = runtime_execution_identity_contract(adapter)
         execution_descriptor = (
             _digest_descriptor(execution["identity"], field="runtime execution identity")
-            if execution.get("observed") is True
+            if valid_runtime_execution_identity_contract(execution)
+            and execution.get("observed") is True
             else {"observed": False}
         )
     except (AttributeError, KeyError, TypeError, ValueError):
@@ -434,16 +457,23 @@ def runtime_authority_contract(
         self_governs_rate_limit = object.__getattribute__(adapter, "self_governs_rate_limit")
     except (AttributeError, TypeError):
         self_governs_rate_limit = False
-    stable = (
-        runtime_backend["observed"] is True
+    portable_identity_observed = (
+        dispatch_root_observed
+        and runtime_backend["observed"] is True
+        and llm_backend["observed"] is True
+        and permission_mode["observed"] is True
         and execution_descriptor["observed"] is True
         and capabilities["observed"] is True
         and isinstance(self_governs_rate_limit, bool)
         and not force_process_local
     )
     return {
-        "version": 1,
-        "stability": "durable" if stable else "process_local",
+        "version": 2,
+        "stability": "durable" if portable_identity_observed else "process_local",
+        # This is an explicit semantic witness, not a cosmetic copy of the
+        # stability label. A durable runtime must have a finite direct dispatch
+        # root as well as observed descriptor components.
+        "portable_identity_observed": portable_identity_observed,
         "runtime_backend": runtime_backend,
         "llm_backend": llm_backend,
         "permission_mode": permission_mode,
@@ -465,8 +495,9 @@ def _valid_runtime_authority(value: object) -> bool:
         "execution_identity",
         "capabilities",
         "self_governs_rate_limit",
+        "portable_identity_observed",
     }
-    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 1:
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 2:
         return False
     if value.get("stability") not in {"durable", "process_local"}:
         return False
@@ -481,8 +512,28 @@ def _valid_runtime_authority(value: object) -> bool:
         )
     ):
         return False
-    return value.get("self_governs_rate_limit") is None or isinstance(
-        value.get("self_governs_rate_limit"), bool
+    self_governs_rate_limit = value.get("self_governs_rate_limit")
+    portable_identity_observed = value.get("portable_identity_observed")
+    if not isinstance(portable_identity_observed, bool):
+        return False
+    descriptors_are_observed = all(
+        isinstance(value.get(name), Mapping) and value[name].get("observed") is True
+        for name in (
+            "runtime_backend",
+            "llm_backend",
+            "permission_mode",
+            "execution_identity",
+            "capabilities",
+        )
+    )
+    if value.get("stability") == "durable":
+        return (
+            portable_identity_observed
+            and descriptors_are_observed
+            and isinstance(self_governs_rate_limit, bool)
+        )
+    return not portable_identity_observed and (
+        self_governs_rate_limit is None or isinstance(self_governs_rate_limit, bool)
     )
 
 
@@ -525,7 +576,10 @@ def verifier_authority_contract(
             "stability": "durable",
             "implementation": _BUILTIN_TRANSCRIPT_VERIFIER,
         }
-    if verifier is structural_atomic_verifier:
+    if (
+        verifier is structural_atomic_verifier
+        and getattr(verifier, "__code__", None) is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+    ):
         return {
             "version": 1,
             "mode": "structural_atomic",
@@ -628,6 +682,25 @@ def _callable_code_identity(value: object | None) -> object | None:
         return value.__code__
     except AttributeError:
         return None
+
+
+def _static_property_getter_root(value: object | None, member_name: str) -> object | None:
+    """Return a direct property getter without invoking dynamic lookup."""
+    if value is None:
+        return None
+    try:
+        descriptor = inspect.getattr_static(type(value), member_name)
+    except (AttributeError, TypeError):
+        return None
+    if not isinstance(descriptor, property):
+        return None
+    getter = descriptor.fget
+    return getter if callable(getter) else None
+
+
+def _is_finite_number(value: object) -> bool:
+    """Accept the finite scalar knobs owned by the rate-gate algorithm."""
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
 
 
 def _has_observable_runtime_dispatch_root(adapter: object) -> bool:
@@ -742,6 +815,7 @@ class ExecutionAuthorityContract:
     def portable_across_processes(self) -> bool:
         """Return only an identity-stability property, never reuse authority."""
         data = self.data
+        runtime = data.get("runtime")
         return (
             all(
                 isinstance(component, Mapping) and component.get("stability") == "durable"
@@ -753,6 +827,8 @@ class ExecutionAuthorityContract:
                     data.get("execution_policy"),
                 )
             )
+            and isinstance(runtime, Mapping)
+            and runtime.get("portable_identity_observed") is True
             and data.get("workspace", {}).get("observed") is True
             and data.get("execution_policy", {}).get("observed") is True
         )
@@ -763,7 +839,7 @@ class ExecutionAuthorityContract:
         return self.portable_across_processes
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class ExecutionAuthorityLiveBinding:
     """The finite live roots that must remain identical before an effect."""
 
@@ -780,6 +856,7 @@ class ExecutionAuthorityLiveBinding:
     adapter_dispatch_code: object | None
     adapter_attribute_resolution_observable: bool
     verifier_root: object | None
+    verifier_code: object | None
     dispatcher_stream_root: object | None
     dispatcher_stream_code: object | None
     dispatcher_stream_callable: object | None
@@ -801,8 +878,24 @@ class ExecutionAuthorityLiveBinding:
     rate_gate_acquire_code: object | None
     rate_gate_acquire_callable: object | None
     rate_gate_attribute_resolution_observable: bool
+    rate_gate_max_wait_seconds: object | None
+    rate_gate_heartbeat_seconds: object | None
+    rate_gate_sleep: object | None
+    rate_gate_sleep_root: object | None
+    rate_gate_sleep_code: object | None
+    rate_gate_semantics_observable: bool
     rate_gate_bucket: object | None
     rate_gate_bucket_config: tuple[object, object, object, object] | None
+    rate_gate_bucket_attribute_resolution_observable: bool
+    rate_gate_bucket_time: object | None
+    rate_gate_bucket_time_root: object | None
+    rate_gate_bucket_time_code: object | None
+    rate_gate_bucket_enabled_root: object | None
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object | None
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object | None
+    rate_gate_bucket_force_reserve_code: object | None
     rate_gate_bucket_binding_observable: bool
     verifier_instance_nonce: str | None
     force_runtime_process_local: bool
@@ -832,6 +925,17 @@ class ExecutionAuthorityLiveBinding:
         expected_transcript_verifier_code: object | None = None,
         expected_rate_gate_acquire_root: object | None = None,
         expected_rate_gate_acquire_code: object | None = None,
+        expected_rate_gate_type: type[object] | None = None,
+        expected_rate_gate_sleep: object | None = None,
+        expected_rate_gate_sleep_code: object | None = None,
+        expected_rate_gate_bucket_type: type[object] | None = None,
+        expected_rate_gate_bucket_time: object | None = None,
+        expected_rate_gate_bucket_enabled_root: object | None = None,
+        expected_rate_gate_bucket_enabled_code: object | None = None,
+        expected_rate_gate_bucket_acquire_root: object | None = None,
+        expected_rate_gate_bucket_acquire_code: object | None = None,
+        expected_rate_gate_bucket_force_reserve_root: object | None = None,
+        expected_rate_gate_bucket_force_reserve_code: object | None = None,
         expected_coordinator_type: type[object] | None = None,
         expected_coordinator_review_root: object | None = None,
         expected_coordinator_review_code: object | None = None,
@@ -846,6 +950,7 @@ class ExecutionAuthorityLiveBinding:
             adapter
         )
         verifier_root = _static_callable_root(verifier, None)
+        verifier_code = _callable_code_identity(verifier_root)
         dispatcher_stream_root = _static_callable_root(dispatcher_type, "stream")
         dispatcher_stream_code = _callable_code_identity(dispatcher_stream_root)
         dispatcher_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
@@ -902,10 +1007,31 @@ class ExecutionAuthorityLiveBinding:
         rate_gate_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
             rate_gate
         )
+        rate_gate_max_wait_seconds: object | None = None
+        rate_gate_heartbeat_seconds: object | None = None
+        rate_gate_sleep: object | None = None
+        rate_gate_sleep_root: object | None = None
+        rate_gate_sleep_code: object | None = None
+        rate_gate_semantics_observable = False
         rate_gate_bucket: object | None = None
         rate_gate_bucket_config: tuple[object, object, object, object] | None = None
+        rate_gate_bucket_attribute_resolution_observable = False
+        rate_gate_bucket_time: object | None = None
+        rate_gate_bucket_time_root: object | None = None
+        rate_gate_bucket_time_code: object | None = None
+        rate_gate_bucket_enabled_root: object | None = None
+        rate_gate_bucket_enabled_code: object | None = None
+        rate_gate_bucket_acquire_root: object | None = None
+        rate_gate_bucket_acquire_code: object | None = None
+        rate_gate_bucket_force_reserve_root: object | None = None
+        rate_gate_bucket_force_reserve_code: object | None = None
         rate_gate_bucket_binding_observable = False
         try:
+            rate_gate_max_wait_seconds = object.__getattribute__(rate_gate, "_max_wait_seconds")
+            rate_gate_heartbeat_seconds = object.__getattribute__(rate_gate, "_heartbeat_seconds")
+            rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
+            rate_gate_sleep_root = _static_callable_root(rate_gate_sleep, None)
+            rate_gate_sleep_code = _callable_code_identity(rate_gate_sleep_root)
             rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
             rate_gate_bucket_config = (
                 object.__getattribute__(rate_gate_bucket, "_runtime_backend"),
@@ -913,17 +1039,53 @@ class ExecutionAuthorityLiveBinding:
                 object.__getattribute__(rate_gate_bucket, "_token_limit"),
                 object.__getattribute__(rate_gate_bucket, "_window_seconds"),
             )
+            rate_gate_bucket_attribute_resolution_observable = (
+                _uses_default_instance_attribute_resolution(rate_gate_bucket)
+            )
+            rate_gate_bucket_time = object.__getattribute__(rate_gate_bucket, "_time")
+            rate_gate_bucket_time_root = _static_callable_root(rate_gate_bucket_time, None)
+            rate_gate_bucket_time_code = _callable_code_identity(rate_gate_bucket_time_root)
+            rate_gate_bucket_enabled_root = _static_property_getter_root(
+                rate_gate_bucket,
+                "enabled",
+            )
+            rate_gate_bucket_enabled_code = _callable_code_identity(rate_gate_bucket_enabled_root)
+            rate_gate_bucket_acquire_root = _static_callable_root(rate_gate_bucket, "acquire")
+            rate_gate_bucket_acquire_code = _callable_code_identity(rate_gate_bucket_acquire_root)
+            rate_gate_bucket_force_reserve_root = _static_callable_root(
+                rate_gate_bucket,
+                "force_reserve",
+            )
+            rate_gate_bucket_force_reserve_code = _callable_code_identity(
+                rate_gate_bucket_force_reserve_root
+            )
             rate_gate_bucket_binding_observable = (
                 isinstance(rate_gate_bucket_config[0], str)
                 and (
                     rate_gate_bucket_config[1] is None
                     or isinstance(rate_gate_bucket_config[1], int)
+                    and not isinstance(rate_gate_bucket_config[1], bool)
                 )
                 and (
                     rate_gate_bucket_config[2] is None
                     or isinstance(rate_gate_bucket_config[2], int)
+                    and not isinstance(rate_gate_bucket_config[2], bool)
                 )
-                and isinstance(rate_gate_bucket_config[3], float)
+                and _is_finite_number(rate_gate_bucket_config[3])
+            )
+            rate_gate_semantics_observable = (
+                _is_finite_number(rate_gate_max_wait_seconds)
+                and _is_finite_number(rate_gate_heartbeat_seconds)
+                and rate_gate_sleep_root is not None
+                and rate_gate_sleep_code is not None
+                and rate_gate_bucket_attribute_resolution_observable
+                and rate_gate_bucket_time_root is not None
+                and rate_gate_bucket_enabled_root is not None
+                and rate_gate_bucket_enabled_code is not None
+                and rate_gate_bucket_acquire_root is not None
+                and rate_gate_bucket_acquire_code is not None
+                and rate_gate_bucket_force_reserve_root is not None
+                and rate_gate_bucket_force_reserve_code is not None
             )
         except (AttributeError, TypeError):
             rate_gate_bucket = None
@@ -945,11 +1107,34 @@ class ExecutionAuthorityLiveBinding:
             and transcript_verifier_code is expected_transcript_verifier_code
         )
         rate_gate_is_closed = (
-            expected_rate_gate_acquire_root is not None
+            expected_rate_gate_type is not None
+            and type(rate_gate) is expected_rate_gate_type
+            and expected_rate_gate_acquire_root is not None
             and rate_gate_acquire_root is expected_rate_gate_acquire_root
             and expected_rate_gate_acquire_code is not None
             and rate_gate_acquire_code is expected_rate_gate_acquire_code
             and rate_gate_acquire_callable is rate_gate_acquire_root
+            and rate_gate_semantics_observable
+            and expected_rate_gate_sleep is not None
+            and rate_gate_sleep is expected_rate_gate_sleep
+            and expected_rate_gate_sleep_code is not None
+            and rate_gate_sleep_code is expected_rate_gate_sleep_code
+            and expected_rate_gate_bucket_type is not None
+            and type(rate_gate_bucket) is expected_rate_gate_bucket_type
+            and expected_rate_gate_bucket_time is not None
+            and rate_gate_bucket_time is expected_rate_gate_bucket_time
+            and expected_rate_gate_bucket_enabled_root is not None
+            and rate_gate_bucket_enabled_root is expected_rate_gate_bucket_enabled_root
+            and expected_rate_gate_bucket_enabled_code is not None
+            and rate_gate_bucket_enabled_code is expected_rate_gate_bucket_enabled_code
+            and expected_rate_gate_bucket_acquire_root is not None
+            and rate_gate_bucket_acquire_root is expected_rate_gate_bucket_acquire_root
+            and expected_rate_gate_bucket_acquire_code is not None
+            and rate_gate_bucket_acquire_code is expected_rate_gate_bucket_acquire_code
+            and expected_rate_gate_bucket_force_reserve_root is not None
+            and rate_gate_bucket_force_reserve_root is expected_rate_gate_bucket_force_reserve_root
+            and expected_rate_gate_bucket_force_reserve_code is not None
+            and rate_gate_bucket_force_reserve_code is expected_rate_gate_bucket_force_reserve_code
         )
         coordinator_is_closed = coordinator is None or (
             expected_coordinator_type is not None
@@ -982,6 +1167,7 @@ class ExecutionAuthorityLiveBinding:
             )
             or not rate_gate_is_closed
             or not rate_gate_attribute_resolution_observable
+            or not rate_gate_semantics_observable
             or not rate_gate_bucket_binding_observable
         )
         nonce = (
@@ -1009,6 +1195,7 @@ class ExecutionAuthorityLiveBinding:
             adapter_dispatch_code=adapter_dispatch_code,
             adapter_attribute_resolution_observable=adapter_attribute_resolution_observable,
             verifier_root=verifier_root,
+            verifier_code=verifier_code,
             dispatcher_stream_root=dispatcher_stream_root,
             dispatcher_stream_code=dispatcher_stream_code,
             dispatcher_stream_callable=dispatcher_stream_callable,
@@ -1032,8 +1219,26 @@ class ExecutionAuthorityLiveBinding:
             rate_gate_acquire_code=rate_gate_acquire_code,
             rate_gate_acquire_callable=rate_gate_acquire_callable,
             rate_gate_attribute_resolution_observable=rate_gate_attribute_resolution_observable,
+            rate_gate_max_wait_seconds=rate_gate_max_wait_seconds,
+            rate_gate_heartbeat_seconds=rate_gate_heartbeat_seconds,
+            rate_gate_sleep=rate_gate_sleep,
+            rate_gate_sleep_root=rate_gate_sleep_root,
+            rate_gate_sleep_code=rate_gate_sleep_code,
+            rate_gate_semantics_observable=rate_gate_semantics_observable,
             rate_gate_bucket=rate_gate_bucket,
             rate_gate_bucket_config=rate_gate_bucket_config,
+            rate_gate_bucket_attribute_resolution_observable=(
+                rate_gate_bucket_attribute_resolution_observable
+            ),
+            rate_gate_bucket_time=rate_gate_bucket_time,
+            rate_gate_bucket_time_root=rate_gate_bucket_time_root,
+            rate_gate_bucket_time_code=rate_gate_bucket_time_code,
+            rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+            rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+            rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+            rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+            rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+            rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
             rate_gate_bucket_binding_observable=rate_gate_bucket_binding_observable,
             verifier_instance_nonce=nonce,
             force_runtime_process_local=force_runtime_process_local,
@@ -1104,8 +1309,23 @@ class ExecutionAuthorityLiveBinding:
             and not _uses_default_instance_attribute_resolution(rate_gate)
         ):
             return False
-        if self.rate_gate_bucket_binding_observable:
+        if (
+            self.rate_gate_bucket_attribute_resolution_observable
+            and self.rate_gate_bucket is not None
+            and not _uses_default_instance_attribute_resolution(self.rate_gate_bucket)
+        ):
+            return False
+        if self.rate_gate_semantics_observable:
             try:
+                current_rate_gate_max_wait_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_max_wait_seconds",
+                )
+                current_rate_gate_heartbeat_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_heartbeat_seconds",
+                )
+                current_rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
                 current_rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
                 current_rate_gate_bucket_config = (
                     object.__getattribute__(current_rate_gate_bucket, "_runtime_backend"),
@@ -1113,11 +1333,49 @@ class ExecutionAuthorityLiveBinding:
                     object.__getattribute__(current_rate_gate_bucket, "_token_limit"),
                     object.__getattribute__(current_rate_gate_bucket, "_window_seconds"),
                 )
+                current_rate_gate_bucket_time = object.__getattribute__(
+                    current_rate_gate_bucket,
+                    "_time",
+                )
             except (AttributeError, TypeError):
                 return False
             if (
-                current_rate_gate_bucket is not self.rate_gate_bucket
+                not _is_finite_number(current_rate_gate_max_wait_seconds)
+                or not _is_finite_number(current_rate_gate_heartbeat_seconds)
+                or current_rate_gate_max_wait_seconds != self.rate_gate_max_wait_seconds
+                or current_rate_gate_heartbeat_seconds != self.rate_gate_heartbeat_seconds
+                or current_rate_gate_sleep is not self.rate_gate_sleep
+                or _static_callable_root(current_rate_gate_sleep, None)
+                is not self.rate_gate_sleep_root
+                or _callable_code_identity(_static_callable_root(current_rate_gate_sleep, None))
+                is not self.rate_gate_sleep_code
+                or current_rate_gate_bucket is not self.rate_gate_bucket
                 or current_rate_gate_bucket_config != self.rate_gate_bucket_config
+                or current_rate_gate_bucket_time is not self.rate_gate_bucket_time
+                or _static_callable_root(current_rate_gate_bucket_time, None)
+                is not self.rate_gate_bucket_time_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket_time, None)
+                )
+                is not self.rate_gate_bucket_time_code
+                or _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                is not self.rate_gate_bucket_enabled_root
+                or _callable_code_identity(
+                    _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                )
+                is not self.rate_gate_bucket_enabled_code
+                or _static_callable_root(current_rate_gate_bucket, "acquire")
+                is not self.rate_gate_bucket_acquire_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "acquire")
+                )
+                is not self.rate_gate_bucket_acquire_code
+                or _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                is not self.rate_gate_bucket_force_reserve_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                )
+                is not self.rate_gate_bucket_force_reserve_code
             ):
                 return False
         if (
@@ -1134,6 +1392,12 @@ class ExecutionAuthorityLiveBinding:
         if (
             self.verifier_root is not None
             and _static_callable_root(verifier, None) is not self.verifier_root
+        ):
+            return False
+        if (
+            self.verifier_code is not None
+            and _callable_code_identity(_static_callable_root(verifier, None))
+            is not self.verifier_code
         ):
             return False
         if (

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -28,7 +28,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -37,7 +37,8 @@ import math
 import os
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from weakref import WeakKeyDictionary
 
 import anyio
 from rich.console import Console
@@ -254,6 +255,10 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ExecutionAuthorityLiveBinding,
+)
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -273,6 +278,7 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
+    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -318,6 +324,428 @@ if TYPE_CHECKING:
     from ouroboros.persistence.event_store import EventStore
 
 log = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _FoundationAClosedRoots:
+    """Original direct roots held by the executor constructor default."""
+
+    leaf_dispatcher_type: type[LeafDispatcher]
+    leaf_dispatcher_stream_root: Callable[..., Awaitable[None]]
+    leaf_dispatcher_stream_code: object
+    level_coordinator_type: type[LevelCoordinator]
+    level_coordinator_review_root: object
+    level_coordinator_review_code: object
+    rate_gate_factory: Callable[..., RateLimitGate]
+    rate_gate_acquire_root: Callable[..., Awaitable[None]]
+    rate_gate_acquire_code: object
+    transcript_verifier: Callable[..., VerifierVerdict]
+    transcript_verifier_code: object
+
+
+class _FoundationAInternalEntryRoots(NamedTuple):
+    """Closed entry functions used by the executor's own orchestration path."""
+
+    executor_type: type[object]
+    execute_single_ac_root: Callable[..., Any]
+    execute_single_ac_code: object
+    execute_atomic_ac_root: Callable[..., Any]
+    execute_atomic_ac_code: object
+    await_dispatch_rate_budget_root: Callable[..., Any]
+    await_dispatch_rate_budget_code: object
+    dispatch_decomposition_prompt_root: Callable[..., Any]
+    dispatch_decomposition_prompt_code: object
+    run_atomic_verifier_pass_root: Callable[..., Any]
+    run_atomic_verifier_pass_code: object
+
+
+# These names document the closed components. ``ParallelACExecutor.__init__``
+# receives a value-based default built from them below, so changing a mutable
+# module global after import cannot replace the roots it binds.
+_FOUNDATION_A_LEAF_DISPATCHER_TYPE = LeafDispatcher
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT = LeafDispatcher.stream
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE = LeafDispatcher.stream.__code__
+_FOUNDATION_A_LEVEL_COORDINATOR_TYPE = LevelCoordinator
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT = LevelCoordinator.run_review
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE = LevelCoordinator.run_review.__code__
+_FOUNDATION_A_RATE_GATE_FACTORY = build_rate_limit_gate
+_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT = RateLimitGate.acquire
+_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE = RateLimitGate.acquire.__code__
+_FOUNDATION_A_TRANSCRIPT_VERIFIER = _verify_atomic_evidence_against_runtime_messages
+_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE = _verify_atomic_evidence_against_runtime_messages.__code__
+_FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
+    leaf_dispatcher_type=_FOUNDATION_A_LEAF_DISPATCHER_TYPE,
+    leaf_dispatcher_stream_root=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT,
+    leaf_dispatcher_stream_code=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE,
+    level_coordinator_type=_FOUNDATION_A_LEVEL_COORDINATOR_TYPE,
+    level_coordinator_review_root=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT,
+    level_coordinator_review_code=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE,
+    rate_gate_factory=_FOUNDATION_A_RATE_GATE_FACTORY,
+    rate_gate_acquire_root=_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT,
+    rate_gate_acquire_code=_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE,
+    transcript_verifier=_FOUNDATION_A_TRANSCRIPT_VERIFIER,
+    transcript_verifier_code=_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE,
+)
+
+
+def _bind_foundation_a_roots(
+    roots: _FoundationAClosedRoots,
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """Bind closed roots in a closure instead of a caller-controlled kwarg."""
+
+    # Extract every root while this decorator is applied at module import. Do
+    # not retain the dataclass bundle itself: ``frozen=True`` is not a Python
+    # memory-integrity boundary and ``object.__setattr__`` could otherwise
+    # poison the bundle before a later executor is constructed.
+    leaf_dispatcher_type = roots.leaf_dispatcher_type
+    leaf_dispatcher_stream_root = roots.leaf_dispatcher_stream_root
+    leaf_dispatcher_stream_code = roots.leaf_dispatcher_stream_code
+    level_coordinator_type = roots.level_coordinator_type
+    level_coordinator_review_root = roots.level_coordinator_review_root
+    level_coordinator_review_code = roots.level_coordinator_review_code
+    rate_gate_factory = roots.rate_gate_factory
+    rate_gate_acquire_root = roots.rate_gate_acquire_root
+    rate_gate_acquire_code = roots.rate_gate_acquire_code
+    transcript_verifier = roots.transcript_verifier
+    transcript_verifier_code = roots.transcript_verifier_code
+
+    def decorate(initializer: Callable[..., None]) -> Callable[..., None]:
+        def bound(self: object, *args: object, **kwargs: object) -> None:
+            initializer(
+                self,
+                *args,
+                **kwargs,
+                _foundation_a_roots=_FoundationAClosedRoots(
+                    leaf_dispatcher_type=leaf_dispatcher_type,
+                    leaf_dispatcher_stream_root=leaf_dispatcher_stream_root,
+                    leaf_dispatcher_stream_code=leaf_dispatcher_stream_code,
+                    level_coordinator_type=level_coordinator_type,
+                    level_coordinator_review_root=level_coordinator_review_root,
+                    level_coordinator_review_code=level_coordinator_review_code,
+                    rate_gate_factory=rate_gate_factory,
+                    rate_gate_acquire_root=rate_gate_acquire_root,
+                    rate_gate_acquire_code=rate_gate_acquire_code,
+                    transcript_verifier=transcript_verifier,
+                    transcript_verifier_code=transcript_verifier_code,
+                ),
+            )
+
+        return bound
+
+    return decorate
+
+
+_FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC = 0
+_FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC = 1
+_FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET = 2
+_FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT = 3
+_FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS = 4
+
+
+def _foundation_a_internal_entry_root_specs(
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[tuple[str, Callable[..., Any], object], ...]:
+    """Return the small, versioned set of internal effect-entry roots."""
+
+    return (
+        ("_execute_single_ac", roots.execute_single_ac_root, roots.execute_single_ac_code),
+        ("_execute_atomic_ac", roots.execute_atomic_ac_root, roots.execute_atomic_ac_code),
+        (
+            "_await_dispatch_rate_budget",
+            roots.await_dispatch_rate_budget_root,
+            roots.await_dispatch_rate_budget_code,
+        ),
+        (
+            "_dispatch_decomposition_prompt",
+            roots.dispatch_decomposition_prompt_root,
+            roots.dispatch_decomposition_prompt_code,
+        ),
+        (
+            "_run_atomic_verifier_pass",
+            roots.run_atomic_verifier_pass_root,
+            roots.run_atomic_verifier_pass_code,
+        ),
+    )
+
+
+def _capture_foundation_a_internal_entry_roots(
+    executor_type: type[object],
+) -> _FoundationAInternalEntryRoots:
+    """Capture finite direct entry functions from one concrete executor type."""
+
+    try:
+        execute_single_ac_root = type.__getattribute__(executor_type, "_execute_single_ac")
+        execute_atomic_ac_root = type.__getattribute__(executor_type, "_execute_atomic_ac")
+        await_dispatch_rate_budget_root = type.__getattribute__(
+            executor_type,
+            "_await_dispatch_rate_budget",
+        )
+        dispatch_decomposition_prompt_root = type.__getattribute__(
+            executor_type,
+            "_dispatch_decomposition_prompt",
+        )
+        run_atomic_verifier_pass_root = type.__getattribute__(
+            executor_type,
+            "_run_atomic_verifier_pass",
+        )
+        return _FoundationAInternalEntryRoots(
+            executor_type=executor_type,
+            execute_single_ac_root=execute_single_ac_root,
+            execute_single_ac_code=object.__getattribute__(execute_single_ac_root, "__code__"),
+            execute_atomic_ac_root=execute_atomic_ac_root,
+            execute_atomic_ac_code=object.__getattribute__(execute_atomic_ac_root, "__code__"),
+            await_dispatch_rate_budget_root=await_dispatch_rate_budget_root,
+            await_dispatch_rate_budget_code=object.__getattribute__(
+                await_dispatch_rate_budget_root,
+                "__code__",
+            ),
+            dispatch_decomposition_prompt_root=dispatch_decomposition_prompt_root,
+            dispatch_decomposition_prompt_code=object.__getattribute__(
+                dispatch_decomposition_prompt_root,
+                "__code__",
+            ),
+            run_atomic_verifier_pass_root=run_atomic_verifier_pass_root,
+            run_atomic_verifier_pass_code=object.__getattribute__(
+                run_atomic_verifier_pass_root,
+                "__code__",
+            ),
+        )
+    except (AttributeError, TypeError) as exc:
+        raise ValueError("execution authority internal entry roots are not bindable") from exc
+
+
+def _foundation_a_internal_entry_roots_are_closed(
+    roots: _FoundationAInternalEntryRoots,
+    expected_roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Return whether construction found the import-time executor entry set."""
+
+    return roots.executor_type is expected_roots.executor_type and all(
+        root is expected_root and code is expected_code
+        for (_, root, code), (_, expected_root, expected_code) in zip(
+            _foundation_a_internal_entry_root_specs(roots),
+            _foundation_a_internal_entry_root_specs(expected_roots),
+            strict=True,
+        )
+    )
+
+
+def _foundation_a_internal_entry_roots_are_current(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Check only direct implementation roots, never arbitrary callable state."""
+
+    try:
+        if type(executor) is not roots.executor_type:
+            return False
+        instance_values = object.__getattribute__(executor, "__dict__")
+        executor_type = type(executor)
+        for name, expected_root, expected_code in _foundation_a_internal_entry_root_specs(roots):
+            if name in instance_values:
+                return False
+            current_root = type.__getattribute__(executor_type, name)
+            if current_root is not expected_root:
+                return False
+            if object.__getattribute__(current_root, "__code__") is not expected_code:
+                return False
+    except (AttributeError, KeyError, TypeError):
+        return False
+    return True
+
+
+def _make_foundation_a_internal_entry_invokers(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[Callable[..., Any], ...]:
+    """Close direct function calls over the constructor's finite root snapshot."""
+
+    execute_single_ac_root = roots.execute_single_ac_root
+    execute_atomic_ac_root = roots.execute_atomic_ac_root
+    await_dispatch_rate_budget_root = roots.await_dispatch_rate_budget_root
+    dispatch_decomposition_prompt_root = roots.dispatch_decomposition_prompt_root
+    run_atomic_verifier_pass_root = roots.run_atomic_verifier_pass_root
+
+    def execute_single_ac(**kwargs: object) -> Any:
+        return execute_single_ac_root(executor, **kwargs)
+
+    def execute_atomic_ac(**kwargs: object) -> Any:
+        return execute_atomic_ac_root(executor, **kwargs)
+
+    def await_dispatch_rate_budget(**kwargs: object) -> Any:
+        return await_dispatch_rate_budget_root(executor, **kwargs)
+
+    def dispatch_decomposition_prompt(**kwargs: object) -> Any:
+        return dispatch_decomposition_prompt_root(executor, **kwargs)
+
+    def run_atomic_verifier_pass(**kwargs: object) -> Any:
+        return run_atomic_verifier_pass_root(executor, **kwargs)
+
+    return (
+        execute_single_ac,
+        execute_atomic_ac,
+        await_dispatch_rate_budget,
+        dispatch_decomposition_prompt,
+        run_atomic_verifier_pass,
+    )
+
+
+def _bind_foundation_a_internal_entry_roots(executor_type: type[Any]) -> type[Any]:
+    """Capture original internal entry functions after the class body is complete."""
+
+    expected_roots = _capture_foundation_a_internal_entry_roots(executor_type)
+    initializer = executor_type.__init__
+
+    def bound(self: object, *args: object, **kwargs: object) -> None:
+        if (
+            "_foundation_a_internal_entry_roots" in kwargs
+            or "_foundation_a_internal_entry_roots_are_closed" in kwargs
+        ):
+            raise TypeError("_foundation_a_internal_entry_roots is constructor-bound")
+        roots = _capture_foundation_a_internal_entry_roots(type(self))
+        initializer(
+            self,
+            *args,
+            **kwargs,
+            _foundation_a_internal_entry_roots=roots,
+            _foundation_a_internal_entry_roots_are_closed=(
+                _foundation_a_internal_entry_roots_are_closed(roots, expected_roots)
+            ),
+        )
+
+    executor_type.__init__ = bound
+    return executor_type
+
+
+def _make_execution_authority_guard(
+    executor: object,
+    *,
+    binding: ExecutionAuthorityLiveBinding,
+    authority_verifier: Verifier | None,
+    adapter: object,
+    dispatcher_type: object,
+    dispatcher: object,
+    transcript_verifier: object,
+    rate_gate: object,
+    dispatcher_stream_callable: Callable[..., Awaitable[None]],
+    rate_gate_acquire_callable: Callable[..., Awaitable[None]],
+    coordinator: object,
+    coordinator_review_callable: object,
+    workspace_builder: Callable[[], str | None],
+    policy_builder: Callable[[], dict[str, object]],
+    internal_entry_roots: _FoundationAInternalEntryRoots,
+) -> Callable[[], None]:
+    """Capture Foundation A roots outside mutable executor instance fields."""
+
+    binding_is_intact = ExecutionAuthorityLiveBinding.is_intact
+    binding_is_intact_code = binding_is_intact.__code__
+    workspace_builder_root = workspace_builder.__func__
+    workspace_builder_code = workspace_builder_root.__code__
+    policy_builder_root = policy_builder.__func__
+    policy_builder_code = policy_builder_root.__code__
+    internal_entry_roots_are_current = _foundation_a_internal_entry_roots_are_current
+    internal_entry_roots_are_current_code = internal_entry_roots_are_current.__code__
+
+    def guard() -> None:
+        get_attribute = object.__getattribute__
+        if (
+            get_attribute(executor, "_execution_authority_live_binding") is not binding
+            or get_attribute(executor, "_authority_verifier") is not authority_verifier
+            or get_attribute(executor, "_atomic_verifier") is not authority_verifier
+            or get_attribute(executor, "_adapter") is not adapter
+            or get_attribute(executor, "_authority_leaf_dispatcher_type") is not dispatcher_type
+            or get_attribute(executor, "_authority_leaf_dispatcher") is not dispatcher
+            or get_attribute(executor, "_authority_transcript_verifier") is not transcript_verifier
+            or get_attribute(executor, "_dispatch_rate_gate") is not rate_gate
+            or get_attribute(executor, "_authority_leaf_dispatcher_stream")
+            is not dispatcher_stream_callable
+            or get_attribute(executor, "_authority_rate_gate_acquire_root")
+            is not rate_gate_acquire_callable
+            or get_attribute(executor, "_coordinator") is not coordinator
+            or get_attribute(executor, "_authority_coordinator_review")
+            is not coordinator_review_callable
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if (
+            binding_is_intact.__code__ is not binding_is_intact_code
+            or workspace_builder_root.__code__ is not workspace_builder_code
+            or policy_builder_root.__code__ is not policy_builder_code
+            or internal_entry_roots_are_current.__code__
+            is not internal_entry_roots_are_current_code
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if not internal_entry_roots_are_current(executor, internal_entry_roots):
+            raise ValueError("execution authority drifted before effect")
+        if not binding_is_intact(
+            binding,
+            executor=executor,
+            adapter=adapter,
+            verifier=authority_verifier,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=executor,
+            transcript_verifier=transcript_verifier,
+            rate_gate=rate_gate,
+            workspace=workspace_builder(),
+            execution_policy=policy_builder(),
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+        ):
+            raise ValueError("execution authority drifted before effect")
+
+    return guard
+
+
+def _make_execution_authority_registry() -> tuple[
+    Callable[[object, Callable[[], None], tuple[Callable[..., Any], ...]], None],
+    Callable[[object], None],
+    Callable[..., Any],
+]:
+    """Keep guards and direct invokers in closure-only process state.
+
+    This is an integrity boundary for normal collaborators, not a Python
+    sandbox against code that deliberately introspects and mutates private
+    module closures in its own process.
+    """
+
+    states: WeakKeyDictionary[
+        object,
+        tuple[Callable[[], None], tuple[Callable[..., Any], ...]],
+    ] = WeakKeyDictionary()
+
+    def register(
+        executor: object,
+        guard: Callable[[], None],
+        invokers: tuple[Callable[..., Any], ...],
+    ) -> None:
+        states[executor] = (guard, invokers)
+
+    def invoke_guard(executor: object) -> None:
+        try:
+            guard = states[executor][0]
+        except KeyError as exc:
+            raise ValueError("execution authority guard is unavailable") from exc
+        guard()
+
+    def invoke_entry(executor: object, entry_index: int, **kwargs: object) -> Any:
+        try:
+            guard, invokers = states[executor]
+            invoker = invokers[entry_index]
+        except (IndexError, KeyError) as exc:
+            raise ValueError("execution authority entry root is unavailable") from exc
+        guard()
+        return invoker(**kwargs)
+
+    return register, invoke_guard, invoke_entry
+
+
+(
+    _register_execution_authority_state,
+    _invoke_execution_authority_guard,
+    _invoke_execution_authority_entry,
+) = _make_execution_authority_registry()
 
 
 def _is_session_signal_application_acknowledgement(message: AgentMessage) -> bool:
@@ -874,9 +1302,11 @@ def render_parallel_completion_message(
 # =============================================================================
 
 
+@_bind_foundation_a_internal_entry_roots
 class ParallelACExecutor:
     """Executes ACs in parallel based on dependency graph."""
 
+    @_bind_foundation_a_roots(_FOUNDATION_A_CLOSED_ROOTS)
     def __init__(
         self,
         adapter: AgentRuntime,
@@ -900,6 +1330,9 @@ class ParallelACExecutor:
         cross_harness_redispatch: bool | None = None,
         shadow_replay_enabled: bool = False,
         session_signal_hub: SessionSignalHub | None = None,
+        _foundation_a_roots: _FoundationAClosedRoots = _FOUNDATION_A_CLOSED_ROOTS,
+        _foundation_a_internal_entry_roots: _FoundationAInternalEntryRoots | None = None,
+        _foundation_a_internal_entry_roots_are_closed: bool = False,
     ):
         """Initialize executor.
 
@@ -935,6 +1368,10 @@ class ParallelACExecutor:
                 today's single-dispatch behavior; real run paths (CLI `ooo run`
                 via the runner) pass the config value (default 2).
         """
+        if _foundation_a_internal_entry_roots is None:
+            raise ValueError("execution authority internal entry roots are unavailable")
+        internal_entry_roots = _foundation_a_internal_entry_roots
+
         self._adapter = adapter
         self._event_store = event_store
         self._console = console or Console()
@@ -946,6 +1383,7 @@ class ParallelACExecutor:
         )
         self._enable_decomposition = self._decomposition_mode != "off"
         self._max_decomposition_depth = max(0, max_decomposition_depth)
+        self._max_concurrent = max_concurrent
         approval_mode = getattr(adapter, "permission_mode", None)
         self._inherited_runtime_handle = (
             replace(inherited_runtime_handle, approval_mode=approval_mode.strip())
@@ -978,11 +1416,26 @@ class ParallelACExecutor:
         self._shadow_replay_enabled = shadow_replay_enabled
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
-        self._coordinator = LevelCoordinator(
+        # These exact objects are the finite effect-owner roots Foundation A
+        # can bind at runtime. Callable internals remain explicitly volatile;
+        # custom verifiers never become portable through graph inspection.
+        self._authority_verifier = atomic_verifier
+        self._authority_leaf_dispatcher_type = _foundation_a_roots.leaf_dispatcher_type
+        # Construct the leaf once through closed primitive roots, then call the
+        # captured stream implementation directly. A later class ``__init__``
+        # or instance ``stream`` hook cannot replace the immediate dispatcher
+        # effect after the authority check.
+        self._authority_leaf_dispatcher = object.__new__(self._authority_leaf_dispatcher_type)
+        object.__setattr__(self._authority_leaf_dispatcher, "_executor", self)
+        self._authority_leaf_dispatcher_stream = _foundation_a_roots.leaf_dispatcher_stream_root
+        self._authority_transcript_verifier = _foundation_a_roots.transcript_verifier
+        self._coordinator = _foundation_a_roots.level_coordinator_type(
             adapter,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=task_cwd,
         )
+        self._authority_coordinator = self._coordinator
+        self._authority_coordinator_review = self._coordinator.run_review
         self._semaphore = anyio.Semaphore(max_concurrent)
         self._ac_runtime_handle_manager = ACRuntimeHandleManager(
             adapter,
@@ -997,7 +1450,11 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
         self._execution_counters_lock = asyncio.Lock()
-        self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        self._dispatch_rate_gate = self._build_dispatch_rate_gate(
+            adapter,
+            rate_gate_factory=_foundation_a_roots.rate_gate_factory,
+        )
+        self._authority_rate_gate_acquire_root = _foundation_a_roots.rate_gate_acquire_root
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1015,9 +1472,140 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
+        workspace_builder = object.__getattribute__(
+            self,
+            "_execution_authority_workspace",
+        )
+        policy_builder = object.__getattribute__(
+            self,
+            "_execution_authority_policy",
+        )
+        binding = ExecutionAuthorityLiveBinding.capture(
+            executor=self,
+            adapter=adapter,
+            verifier=atomic_verifier,
+            dispatcher_type=self._authority_leaf_dispatcher_type,
+            dispatcher=self._authority_leaf_dispatcher,
+            dispatcher_executor=self,
+            transcript_verifier=self._authority_transcript_verifier,
+            rate_gate=self._dispatch_rate_gate,
+            workspace=workspace_builder(),
+            execution_policy=policy_builder(),
+            dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
+            rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
+            coordinator=self._authority_coordinator,
+            coordinator_review_callable=self._authority_coordinator_review,
+            expected_dispatcher_type=_foundation_a_roots.leaf_dispatcher_type,
+            expected_dispatcher_stream_root=_foundation_a_roots.leaf_dispatcher_stream_root,
+            expected_dispatcher_stream_code=_foundation_a_roots.leaf_dispatcher_stream_code,
+            expected_transcript_verifier=_foundation_a_roots.transcript_verifier,
+            expected_transcript_verifier_code=_foundation_a_roots.transcript_verifier_code,
+            expected_rate_gate_acquire_root=_foundation_a_roots.rate_gate_acquire_root,
+            expected_rate_gate_acquire_code=_foundation_a_roots.rate_gate_acquire_code,
+            expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
+            expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,
+            expected_coordinator_review_code=_foundation_a_roots.level_coordinator_review_code,
+            force_runtime_process_local=not _foundation_a_internal_entry_roots_are_closed,
+        )
+        self._execution_authority_live_binding = binding
+        self._execution_authority = binding.contract
+        internal_entry_invokers = _make_foundation_a_internal_entry_invokers(
+            self,
+            internal_entry_roots,
+        )
+        _register_execution_authority_state(
+            self,
+            _make_execution_authority_guard(
+                self,
+                binding=binding,
+                authority_verifier=self._authority_verifier,
+                adapter=self._adapter,
+                dispatcher_type=self._authority_leaf_dispatcher_type,
+                dispatcher=self._authority_leaf_dispatcher,
+                transcript_verifier=self._authority_transcript_verifier,
+                rate_gate=self._dispatch_rate_gate,
+                dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
+                rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
+                coordinator=self._coordinator,
+                coordinator_review_callable=self._authority_coordinator_review,
+                workspace_builder=workspace_builder,
+                policy_builder=policy_builder,
+                internal_entry_roots=internal_entry_roots,
+            ),
+            internal_entry_invokers,
+        )
+
+    @property
+    def execution_authority(self) -> ExecutionAuthorityContract:
+        """Return the immutable authority snapshot used by this executor."""
+        return self._execution_authority
+
+    def _execution_authority_workspace(self) -> str | None:
+        """Return the finite effect-workspace root for Foundation A."""
+        get_attribute = object.__getattribute__
+        task_cwd = get_attribute(self, "_task_cwd")
+        adapter = get_attribute(self, "_adapter")
+        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        return workspace if isinstance(workspace, str) else None
+
+    def _execution_authority_policy(self) -> dict[str, object]:
+        """Return only static executor policy; attempt inputs stay excluded."""
+        get_attribute = object.__getattribute__
+        adapter = get_attribute(self, "_adapter")
+        coordinator = get_attribute(self, "_coordinator")
+        backend = getattr(adapter, "runtime_backend", None)
+        limits = resolve_backend_limits(backend if isinstance(backend, str) else None)
+        coordinator_effort = getattr(coordinator, "_reasoning_effort", None)
+        return {
+            "version": 1,
+            "decomposition_mode": get_attribute(self, "_decomposition_mode"),
+            "max_decomposition_depth": get_attribute(self, "_max_decomposition_depth"),
+            "max_concurrent": get_attribute(self, "_max_concurrent"),
+            "execution_profile": (
+                get_attribute(self, "_execution_profile").model_dump(mode="json")
+                if get_attribute(self, "_execution_profile") is not None
+                else None
+            ),
+            "fat_harness_mode": get_attribute(self, "_fat_harness_mode"),
+            "run_verify_commands": get_attribute(self, "_run_verify_commands"),
+            "verify_command_timeout_seconds": get_attribute(
+                self,
+                "_verify_command_timeout_seconds",
+            ),
+            "ac_retry_attempts": get_attribute(self, "_ac_retry_attempts"),
+            "reasoning_effort": get_attribute(self, "_reasoning_effort"),
+            "coordinator_reasoning_effort": coordinator_effort,
+            "model_routing": serialize_model_router(get_attribute(self, "_model_router")),
+            "cross_harness_redispatch": get_attribute(
+                self,
+                "_cross_harness_redispatch_enabled",
+            ),
+            "shadow_replay_enabled": get_attribute(self, "_shadow_replay_enabled"),
+            "dispatch_rate": {
+                "algorithm": "rate-limit-gate/v1",
+                "backend": backend if isinstance(backend, str) else None,
+                "self_governs_rate_limit": getattr(
+                    adapter,
+                    "self_governs_rate_limit",
+                    False,
+                ),
+                "requests_per_minute": limits.requests_per_minute,
+                "tokens_per_minute": limits.tokens_per_minute,
+            },
+        }
+
+    def _require_execution_authority_intact(self) -> None:
+        """Fail closed when an enumerated live effect-owner root drifts."""
+        _invoke_execution_authority_guard(self)
 
     @staticmethod
-    def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
+    def _build_dispatch_rate_gate(
+        adapter: AgentRuntime,
+        *,
+        rate_gate_factory: Callable[
+            ..., RateLimitGate
+        ] = _FOUNDATION_A_CLOSED_ROOTS.rate_gate_factory,
+    ) -> RateLimitGate:
         """Build the shared dispatch rate gate for non-self-governing backends.
 
         Ouroboros — not the runtime — paces delivery within the backend's
@@ -1032,10 +1620,14 @@ class ParallelACExecutor:
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
 
         if getattr(adapter, "self_governs_rate_limit", False):
-            return build_rate_limit_gate(backend, request_limit=None, token_limit=None)
+            return rate_gate_factory(
+                backend,
+                request_limit=None,
+                token_limit=None,
+            )
 
         limits = resolve_backend_limits(backend)
-        return build_rate_limit_gate(
+        return rate_gate_factory(
             backend,
             request_limit=limits.requests_per_minute,
             token_limit=limits.tokens_per_minute,
@@ -1054,9 +1646,7 @@ class ParallelACExecutor:
         workers (they share this executor's single gate instance) and logs each
         backoff for observability.
         """
-        if not self._dispatch_rate_gate.enabled:
-            return
-
+        _invoke_execution_authority_guard(self)
         estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
 
         def _log_backoff(backoff: RateLimitBackoff) -> None:
@@ -1072,7 +1662,14 @@ class ParallelACExecutor:
                 token_limit=backoff.snapshot.token_limit,
             )
 
-        await self._dispatch_rate_gate.acquire(estimated_tokens, on_backoff=_log_backoff)
+        await self._authority_rate_gate_acquire_root(
+            self._dispatch_rate_gate,
+            estimated_tokens,
+            on_backoff=_log_backoff,
+        )
+        # Rate admission can suspend. Revalidate before returning to a caller
+        # that will dispatch to the runtime immediately afterwards.
+        _invoke_execution_authority_guard(self)
 
     def _announce_param_degradations(
         self,
@@ -1564,7 +2161,9 @@ class ParallelACExecutor:
             async with self._semaphore:
                 try:
                     ac_criterion = seed.acceptance_criteria[ac_idx]
-                    batch_results[idx] = await self._execute_single_ac(
+                    batch_results[idx] = await _invoke_execution_authority_entry(
+                        self,
+                        _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                         ac_index=ac_idx,
                         ac_content=ac_text(ac_criterion),
                         session_id=session_id,
@@ -2211,7 +2810,8 @@ class ParallelACExecutor:
                             level=level_num,
                             conflicts=conflicts,
                         )
-                        review = await self._coordinator.run_review(
+                        _invoke_execution_authority_guard(self)
+                        review = await self._authority_coordinator_review(
                             execution_id=execution_id,
                             conflicts=conflicts,
                             level_context=level_ctx,
@@ -2488,7 +3088,9 @@ class ParallelACExecutor:
                     status="executing",
                     node_identity=child_node_identity,
                 )
-                sub_results[idx] = await self._execute_single_ac(
+                sub_results[idx] = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                     ac_index=ac_index * 100 + idx,
                     ac_content=sub_ac,
                     session_id=session_id,
@@ -2651,7 +3253,17 @@ class ParallelACExecutor:
         parent executor inherited a resumable handle.
         """
         self._announce_param_degradations(system_prompt=system_prompt, tools=[])
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        _invoke_execution_authority_guard(self)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
+        # Acquiring rate budget can suspend, so validate once more at the
+        # immediate effect boundary rather than assuming the pre-wait snapshot
+        # still applies.
+        _invoke_execution_authority_guard(self)
         response_text = ""
         async with asyncio.timeout(DECOMPOSITION_TIMEOUT_SECONDS):
             async for message in self._adapter.execute_task(
@@ -2689,7 +3301,9 @@ class ParallelACExecutor:
             f"## Bounded Attempt Trace\n{trace.summary}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt="You are a conservative execution-recovery classifier.",
             )
@@ -3115,7 +3729,9 @@ class ParallelACExecutor:
             "semantic_ac_key": semantic_ac_key,
         }
         while True:
-            atomic_result = await self._execute_atomic_ac(
+            atomic_result = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC,
                 ac_index=ac_index,
                 ac_content=ac_content,
                 session_id=session_id,
@@ -3469,7 +4085,7 @@ class ParallelACExecutor:
             task_cwd=self._task_cwd,
             execution_profile=self._execution_profile,
             fat_harness_mode=self._fat_harness_mode,
-            atomic_verifier=self._atomic_verifier,
+            atomic_verifier=self._authority_verifier,
             reasoning_effort=self._reasoning_effort,
             # The router's backend-mismatch guard makes it inert on a different
             # backend, so passing it to the alt-harness executor is safe.
@@ -3481,7 +4097,12 @@ class ParallelACExecutor:
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
         )
-        return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
+        return await _invoke_execution_authority_entry(
+            alt_executor,
+            _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
+            **rerun_kwargs,
+            retry_attempt=retry_attempt,
+        )
 
     @staticmethod
     def _parse_legacy_decomposition(
@@ -3568,7 +4189,9 @@ class ParallelACExecutor:
             f"{json.dumps(proposal.to_dict(), sort_keys=True)}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt=system_prompt,
                 independent_session=True,
@@ -3747,7 +4370,9 @@ Respond with either ATOMIC or the structured JSON object only.
             decompose_prompt += f"\n\n## Bounded Attempt Trace\n{bounded_trace}"
 
         try:
-            response_text = await self._dispatch_decomposition_prompt(
+            response_text = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=decompose_prompt,
                 system_prompt=decomposition_system_prompt,
             )
@@ -3805,7 +4430,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     min_sub_acs=min_sub_acs,
                     max_sub_acs=max_sub_acs,
                 )
-                repaired_text = await self._dispatch_decomposition_prompt(
+                repaired_text = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                     prompt=repair_prompt,
                     system_prompt=decomposition_system_prompt,
                 )
@@ -4286,7 +4913,12 @@ Respond with either ATOMIC or the structured JSON object only.
         self._announce_param_degradations(system_prompt=system_prompt, tools=tools)
         # Pace delivery within the backend's shared rate budget (dormant unless
         # an RPM/TPM is configured for this backend) before the stall-scoped run.
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
 
         investment_assessment = assess_investment(investment_spec)
         await self._event_emitter.emit_investment_assessed(
@@ -4484,7 +5116,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
-            await LeafDispatcher(self).stream(
+            _invoke_execution_authority_guard(self)
+            await self._authority_leaf_dispatcher_stream(
+                self._authority_leaf_dispatcher,
                 state=dispatch_state,
                 prompt=prompt,
                 tools=tools,
@@ -4586,7 +5220,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
-                        await LeafDispatcher(self).stream(
+                        _invoke_execution_authority_guard(self)
+                        await self._authority_leaf_dispatcher_stream(
+                            self._authority_leaf_dispatcher,
                             state=dispatch_state,
                             prompt=(
                                 render_inform_signal_prompt(queued_signal.signal)
@@ -4755,7 +5391,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 has_expected_artifacts=has_expected_artifacts,
                 verify_gate_active=verify_gate_active,
             )
-            verifier_verdict = self._run_atomic_verifier_pass(
+            verifier_verdict = _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
                 ac_content=ac_content,
                 final_message=final_message,
                 success=success,
@@ -6050,7 +6688,8 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return None
 
-        verifier = self._atomic_verifier
+        _invoke_execution_authority_guard(self)
+        verifier = self._authority_verifier
         try:
             effective_schema = _effective_evidence_schema_for_ac(
                 self._execution_profile,
@@ -6078,14 +6717,21 @@ Respond with either ATOMIC or the structured JSON object only.
                     record=scoped_evidence,
                 )
                 if verifier is not None and not force_runtime_transcript
-                else self._verify_atomic_evidence_against_runtime_messages(
+                # Do not route acceptance through the mutable executor wrapper.
+                # Foundation A captured this closed transcript verifier at
+                # construction and has just checked that binding above.
+                else self._authority_transcript_verifier(
                     messages=messages,
                     typed_evidence=scoped_evidence,
                     ac_content=ac_content,
+                    execution_profile=self._execution_profile,
+                    task_cwd=task_cwd_override or self._task_cwd,
+                    adapter_working_directory=(
+                        task_cwd_override or self._adapter.working_directory
+                    ),
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
                     verify_gate_active=verify_gate_active,
-                    task_cwd_override=task_cwd_override,
                 )
             )
         except VerifierContractError:
@@ -6108,7 +6754,7 @@ Respond with either ATOMIC or the structured JSON object only.
         verify_gate_active: bool = False,
         task_cwd_override: str | None = None,
     ) -> VerifierVerdict:
-        return _verify_atomic_evidence_against_runtime_messages(
+        return self._authority_transcript_verifier(
             messages=messages,
             typed_evidence=typed_evidence,
             ac_content=ac_content,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -767,6 +767,7 @@ def _make_execution_authority_guard(
         rate_gate_acquire_callable = captured_binding.rate_gate_acquire_callable
         coordinator = captured_binding.coordinator
         coordinator_review_callable = captured_binding.coordinator_review_callable
+        session_signal_hub = captured_binding.session_signal_hub
         get_attribute = object.__getattribute__
         if (
             get_attribute(current_executor, "_execution_authority_live_binding")
@@ -787,6 +788,7 @@ def _make_execution_authority_guard(
             or get_attribute(current_executor, "_coordinator") is not coordinator
             or get_attribute(current_executor, "_authority_coordinator_review")
             is not coordinator_review_callable
+            or get_attribute(current_executor, "_session_signal_hub") is not session_signal_hub
         ):
             raise ValueError("execution authority drifted before effect")
         if (
@@ -811,6 +813,7 @@ def _make_execution_authority_guard(
             rate_gate=rate_gate,
             workspace=workspace_builder_root(current_executor),
             execution_policy=policy_builder_root(current_executor),
+            session_signal_hub=session_signal_hub,
             dispatcher_stream_callable=dispatcher_stream_callable,
             rate_gate_acquire_callable=rate_gate_acquire_callable,
             coordinator=coordinator,
@@ -1646,6 +1649,7 @@ class ParallelACExecutor:
             rate_gate=self._dispatch_rate_gate,
             workspace=workspace_builder(),
             execution_policy=policy_builder(),
+            session_signal_hub=self._session_signal_hub,
             dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
             rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
             coordinator=self._authority_coordinator,
@@ -1686,7 +1690,10 @@ class ParallelACExecutor:
             expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
             expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,
             expected_coordinator_review_code=_foundation_a_roots.level_coordinator_review_code,
-            force_runtime_process_local=not _foundation_a_internal_entry_roots_are_closed,
+            force_runtime_process_local=(
+                not _foundation_a_internal_entry_roots_are_closed
+                or self._session_signal_hub is not None
+            ),
         )
         self._execution_authority_live_binding = binding
         self._execution_authority = binding.contract
@@ -1752,6 +1759,7 @@ class ParallelACExecutor:
                 "_cross_harness_redispatch_enabled",
             ),
             "shadow_replay_enabled": get_attribute(self, "_shadow_replay_enabled"),
+            "session_signal_hub_enabled": get_attribute(self, "_session_signal_hub") is not None,
             "dispatch_rate": {
                 "algorithm": "rate-limit-gate/v1",
                 "backend": backend if isinstance(backend, str) else None,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -32,13 +32,15 @@ from collections.abc import Awaitable, Callable, Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from functools import wraps
 import json
 import math
 import os
 from pathlib import Path
 import re
+import time
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
-from weakref import WeakKeyDictionary
+from weakref import ref
 
 import anyio
 from rich.console import Console
@@ -292,6 +294,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedMod
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
     RateLimitGate,
+    SharedRateLimitBucket,
     build_rate_limit_gate,
     estimate_runtime_request_tokens,
 )
@@ -337,8 +340,19 @@ class _FoundationAClosedRoots:
     level_coordinator_review_root: object
     level_coordinator_review_code: object
     rate_gate_factory: Callable[..., RateLimitGate]
+    rate_gate_type: type[RateLimitGate]
     rate_gate_acquire_root: Callable[..., Awaitable[None]]
     rate_gate_acquire_code: object
+    rate_gate_sleep: object
+    rate_gate_sleep_code: object | None
+    rate_gate_bucket_type: type[SharedRateLimitBucket]
+    rate_gate_bucket_time: object
+    rate_gate_bucket_enabled_root: object
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object
+    rate_gate_bucket_force_reserve_code: object | None
     transcript_verifier: Callable[..., VerifierVerdict]
     transcript_verifier_code: object
 
@@ -357,6 +371,8 @@ class _FoundationAInternalEntryRoots(NamedTuple):
     dispatch_decomposition_prompt_code: object
     run_atomic_verifier_pass_root: Callable[..., Any]
     run_atomic_verifier_pass_code: object
+    run_ac_verify_gate_root: Callable[..., Any]
+    run_ac_verify_gate_code: object
 
 
 # These names document the closed components. ``ParallelACExecutor.__init__``
@@ -369,8 +385,23 @@ _FOUNDATION_A_LEVEL_COORDINATOR_TYPE = LevelCoordinator
 _FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT = LevelCoordinator.run_review
 _FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE = LevelCoordinator.run_review.__code__
 _FOUNDATION_A_RATE_GATE_FACTORY = build_rate_limit_gate
+_FOUNDATION_A_RATE_GATE_TYPE = RateLimitGate
 _FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT = RateLimitGate.acquire
 _FOUNDATION_A_RATE_GATE_ACQUIRE_CODE = RateLimitGate.acquire.__code__
+_FOUNDATION_A_RATE_GATE_SLEEP = asyncio.sleep
+_FOUNDATION_A_RATE_GATE_SLEEP_CODE = asyncio.sleep.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_TYPE = SharedRateLimitBucket
+_FOUNDATION_A_RATE_GATE_BUCKET_TIME = time.monotonic
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT = SharedRateLimitBucket.enabled.fget
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE = (
+    _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT.__code__
+    if _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT is not None
+    else None
+)
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT = SharedRateLimitBucket.acquire
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE = SharedRateLimitBucket.acquire.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT = SharedRateLimitBucket.force_reserve
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE = SharedRateLimitBucket.force_reserve.__code__
 _FOUNDATION_A_TRANSCRIPT_VERIFIER = _verify_atomic_evidence_against_runtime_messages
 _FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE = _verify_atomic_evidence_against_runtime_messages.__code__
 _FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
@@ -381,8 +412,19 @@ _FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
     level_coordinator_review_root=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT,
     level_coordinator_review_code=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE,
     rate_gate_factory=_FOUNDATION_A_RATE_GATE_FACTORY,
+    rate_gate_type=_FOUNDATION_A_RATE_GATE_TYPE,
     rate_gate_acquire_root=_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT,
     rate_gate_acquire_code=_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE,
+    rate_gate_sleep=_FOUNDATION_A_RATE_GATE_SLEEP,
+    rate_gate_sleep_code=_FOUNDATION_A_RATE_GATE_SLEEP_CODE,
+    rate_gate_bucket_type=_FOUNDATION_A_RATE_GATE_BUCKET_TYPE,
+    rate_gate_bucket_time=_FOUNDATION_A_RATE_GATE_BUCKET_TIME,
+    rate_gate_bucket_enabled_root=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT,
+    rate_gate_bucket_enabled_code=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE,
+    rate_gate_bucket_acquire_root=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT,
+    rate_gate_bucket_acquire_code=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE,
+    rate_gate_bucket_force_reserve_root=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT,
+    rate_gate_bucket_force_reserve_code=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE,
     transcript_verifier=_FOUNDATION_A_TRANSCRIPT_VERIFIER,
     transcript_verifier_code=_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE,
 )
@@ -404,12 +446,24 @@ def _bind_foundation_a_roots(
     level_coordinator_review_root = roots.level_coordinator_review_root
     level_coordinator_review_code = roots.level_coordinator_review_code
     rate_gate_factory = roots.rate_gate_factory
+    rate_gate_type = roots.rate_gate_type
     rate_gate_acquire_root = roots.rate_gate_acquire_root
     rate_gate_acquire_code = roots.rate_gate_acquire_code
+    rate_gate_sleep = roots.rate_gate_sleep
+    rate_gate_sleep_code = roots.rate_gate_sleep_code
+    rate_gate_bucket_type = roots.rate_gate_bucket_type
+    rate_gate_bucket_time = roots.rate_gate_bucket_time
+    rate_gate_bucket_enabled_root = roots.rate_gate_bucket_enabled_root
+    rate_gate_bucket_enabled_code = roots.rate_gate_bucket_enabled_code
+    rate_gate_bucket_acquire_root = roots.rate_gate_bucket_acquire_root
+    rate_gate_bucket_acquire_code = roots.rate_gate_bucket_acquire_code
+    rate_gate_bucket_force_reserve_root = roots.rate_gate_bucket_force_reserve_root
+    rate_gate_bucket_force_reserve_code = roots.rate_gate_bucket_force_reserve_code
     transcript_verifier = roots.transcript_verifier
     transcript_verifier_code = roots.transcript_verifier_code
 
     def decorate(initializer: Callable[..., None]) -> Callable[..., None]:
+        @wraps(initializer)
         def bound(self: object, *args: object, **kwargs: object) -> None:
             initializer(
                 self,
@@ -423,8 +477,19 @@ def _bind_foundation_a_roots(
                     level_coordinator_review_root=level_coordinator_review_root,
                     level_coordinator_review_code=level_coordinator_review_code,
                     rate_gate_factory=rate_gate_factory,
+                    rate_gate_type=rate_gate_type,
                     rate_gate_acquire_root=rate_gate_acquire_root,
                     rate_gate_acquire_code=rate_gate_acquire_code,
+                    rate_gate_sleep=rate_gate_sleep,
+                    rate_gate_sleep_code=rate_gate_sleep_code,
+                    rate_gate_bucket_type=rate_gate_bucket_type,
+                    rate_gate_bucket_time=rate_gate_bucket_time,
+                    rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+                    rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+                    rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+                    rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+                    rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+                    rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
                     transcript_verifier=transcript_verifier,
                     transcript_verifier_code=transcript_verifier_code,
                 ),
@@ -440,6 +505,7 @@ _FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC = 1
 _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET = 2
 _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT = 3
 _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS = 4
+_FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE = 5
 
 
 def _foundation_a_internal_entry_root_specs(
@@ -465,6 +531,11 @@ def _foundation_a_internal_entry_root_specs(
             roots.run_atomic_verifier_pass_root,
             roots.run_atomic_verifier_pass_code,
         ),
+        (
+            "_run_ac_verify_gate",
+            roots.run_ac_verify_gate_root,
+            roots.run_ac_verify_gate_code,
+        ),
     )
 
 
@@ -488,6 +559,7 @@ def _capture_foundation_a_internal_entry_roots(
             executor_type,
             "_run_atomic_verifier_pass",
         )
+        run_ac_verify_gate_root = type.__getattribute__(executor_type, "_run_ac_verify_gate")
         return _FoundationAInternalEntryRoots(
             executor_type=executor_type,
             execute_single_ac_root=execute_single_ac_root,
@@ -509,6 +581,8 @@ def _capture_foundation_a_internal_entry_roots(
                 run_atomic_verifier_pass_root,
                 "__code__",
             ),
+            run_ac_verify_gate_root=run_ac_verify_gate_root,
+            run_ac_verify_gate_code=object.__getattribute__(run_ac_verify_gate_root, "__code__"),
         )
     except (AttributeError, TypeError) as exc:
         raise ValueError("execution authority internal entry roots are not bindable") from exc
@@ -560,26 +634,41 @@ def _make_foundation_a_internal_entry_invokers(
 ) -> tuple[Callable[..., Any], ...]:
     """Close direct function calls over the constructor's finite root snapshot."""
 
+    executor_ref = ref(executor)
     execute_single_ac_root = roots.execute_single_ac_root
     execute_atomic_ac_root = roots.execute_atomic_ac_root
     await_dispatch_rate_budget_root = roots.await_dispatch_rate_budget_root
     dispatch_decomposition_prompt_root = roots.dispatch_decomposition_prompt_root
     run_atomic_verifier_pass_root = roots.run_atomic_verifier_pass_root
+    run_ac_verify_gate_root = roots.run_ac_verify_gate_root
 
-    def execute_single_ac(**kwargs: object) -> Any:
-        return execute_single_ac_root(executor, **kwargs)
+    def _require_captured_executor(current_executor: object) -> None:
+        if executor_ref() is not current_executor:
+            raise ValueError("execution authority entry root is unavailable")
 
-    def execute_atomic_ac(**kwargs: object) -> Any:
-        return execute_atomic_ac_root(executor, **kwargs)
+    def execute_single_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_single_ac_root(current_executor, **kwargs)
 
-    def await_dispatch_rate_budget(**kwargs: object) -> Any:
-        return await_dispatch_rate_budget_root(executor, **kwargs)
+    def execute_atomic_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_atomic_ac_root(current_executor, **kwargs)
 
-    def dispatch_decomposition_prompt(**kwargs: object) -> Any:
-        return dispatch_decomposition_prompt_root(executor, **kwargs)
+    def await_dispatch_rate_budget(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return await_dispatch_rate_budget_root(current_executor, **kwargs)
 
-    def run_atomic_verifier_pass(**kwargs: object) -> Any:
-        return run_atomic_verifier_pass_root(executor, **kwargs)
+    def dispatch_decomposition_prompt(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return dispatch_decomposition_prompt_root(current_executor, **kwargs)
+
+    def run_atomic_verifier_pass(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_atomic_verifier_pass_root(current_executor, **kwargs)
+
+    def run_ac_verify_gate(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_ac_verify_gate_root(current_executor, **kwargs)
 
     return (
         execute_single_ac,
@@ -587,6 +676,7 @@ def _make_foundation_a_internal_entry_invokers(
         await_dispatch_rate_budget,
         dispatch_decomposition_prompt,
         run_atomic_verifier_pass,
+        run_ac_verify_gate,
     )
 
 
@@ -596,6 +686,7 @@ def _bind_foundation_a_internal_entry_roots(executor_type: type[Any]) -> type[An
     expected_roots = _capture_foundation_a_internal_entry_roots(executor_type)
     initializer = executor_type.__init__
 
+    @wraps(initializer)
     def bound(self: object, *args: object, **kwargs: object) -> None:
         if (
             "_foundation_a_internal_entry_roots" in kwargs
@@ -621,22 +712,14 @@ def _make_execution_authority_guard(
     executor: object,
     *,
     binding: ExecutionAuthorityLiveBinding,
-    authority_verifier: Verifier | None,
-    adapter: object,
-    dispatcher_type: object,
-    dispatcher: object,
-    transcript_verifier: object,
-    rate_gate: object,
-    dispatcher_stream_callable: Callable[..., Awaitable[None]],
-    rate_gate_acquire_callable: Callable[..., Awaitable[None]],
-    coordinator: object,
-    coordinator_review_callable: object,
     workspace_builder: Callable[[], str | None],
     policy_builder: Callable[[], dict[str, object]],
     internal_entry_roots: _FoundationAInternalEntryRoots,
-) -> Callable[[], None]:
+) -> Callable[[object], None]:
     """Capture Foundation A roots outside mutable executor instance fields."""
 
+    executor_ref = ref(executor)
+    binding_ref = ref(binding)
     binding_is_intact = ExecutionAuthorityLiveBinding.is_intact
     binding_is_intact_code = binding_is_intact.__code__
     workspace_builder_root = workspace_builder.__func__
@@ -646,23 +729,40 @@ def _make_execution_authority_guard(
     internal_entry_roots_are_current = _foundation_a_internal_entry_roots_are_current
     internal_entry_roots_are_current_code = internal_entry_roots_are_current.__code__
 
-    def guard() -> None:
+    def guard(current_executor: object) -> None:
+        captured_executor = executor_ref()
+        captured_binding = binding_ref()
+        if captured_executor is not current_executor or captured_binding is None:
+            raise ValueError("execution authority guard is unavailable")
+        authority_verifier = captured_binding.verifier
+        adapter = captured_binding.adapter
+        dispatcher_type = captured_binding.dispatcher_type
+        dispatcher = captured_binding.dispatcher
+        transcript_verifier = captured_binding.transcript_verifier
+        rate_gate = captured_binding.rate_gate
+        dispatcher_stream_callable = captured_binding.dispatcher_stream_callable
+        rate_gate_acquire_callable = captured_binding.rate_gate_acquire_callable
+        coordinator = captured_binding.coordinator
+        coordinator_review_callable = captured_binding.coordinator_review_callable
         get_attribute = object.__getattribute__
         if (
-            get_attribute(executor, "_execution_authority_live_binding") is not binding
-            or get_attribute(executor, "_authority_verifier") is not authority_verifier
-            or get_attribute(executor, "_atomic_verifier") is not authority_verifier
-            or get_attribute(executor, "_adapter") is not adapter
-            or get_attribute(executor, "_authority_leaf_dispatcher_type") is not dispatcher_type
-            or get_attribute(executor, "_authority_leaf_dispatcher") is not dispatcher
-            or get_attribute(executor, "_authority_transcript_verifier") is not transcript_verifier
-            or get_attribute(executor, "_dispatch_rate_gate") is not rate_gate
-            or get_attribute(executor, "_authority_leaf_dispatcher_stream")
+            get_attribute(current_executor, "_execution_authority_live_binding")
+            is not captured_binding
+            or get_attribute(current_executor, "_authority_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_atomic_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_adapter") is not adapter
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_type")
+            is not dispatcher_type
+            or get_attribute(current_executor, "_authority_leaf_dispatcher") is not dispatcher
+            or get_attribute(current_executor, "_authority_transcript_verifier")
+            is not transcript_verifier
+            or get_attribute(current_executor, "_dispatch_rate_gate") is not rate_gate
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_stream")
             is not dispatcher_stream_callable
-            or get_attribute(executor, "_authority_rate_gate_acquire_root")
+            or get_attribute(current_executor, "_authority_rate_gate_acquire_root")
             is not rate_gate_acquire_callable
-            or get_attribute(executor, "_coordinator") is not coordinator
-            or get_attribute(executor, "_authority_coordinator_review")
+            or get_attribute(current_executor, "_coordinator") is not coordinator
+            or get_attribute(current_executor, "_authority_coordinator_review")
             is not coordinator_review_callable
         ):
             raise ValueError("execution authority drifted before effect")
@@ -674,20 +774,20 @@ def _make_execution_authority_guard(
             is not internal_entry_roots_are_current_code
         ):
             raise ValueError("execution authority drifted before effect")
-        if not internal_entry_roots_are_current(executor, internal_entry_roots):
+        if not internal_entry_roots_are_current(current_executor, internal_entry_roots):
             raise ValueError("execution authority drifted before effect")
         if not binding_is_intact(
-            binding,
-            executor=executor,
+            captured_binding,
+            executor=current_executor,
             adapter=adapter,
             verifier=authority_verifier,
             dispatcher_type=dispatcher_type,
             dispatcher=dispatcher,
-            dispatcher_executor=executor,
+            dispatcher_executor=current_executor,
             transcript_verifier=transcript_verifier,
             rate_gate=rate_gate,
-            workspace=workspace_builder(),
-            execution_policy=policy_builder(),
+            workspace=workspace_builder_root(current_executor),
+            execution_policy=policy_builder_root(current_executor),
             dispatcher_stream_callable=dispatcher_stream_callable,
             rate_gate_acquire_callable=rate_gate_acquire_callable,
             coordinator=coordinator,
@@ -699,7 +799,7 @@ def _make_execution_authority_guard(
 
 
 def _make_execution_authority_registry() -> tuple[
-    Callable[[object, Callable[[], None], tuple[Callable[..., Any], ...]], None],
+    Callable[[object, Callable[[object], None], tuple[Callable[..., Any], ...]], None],
     Callable[[object], None],
     Callable[..., Any],
 ]:
@@ -710,33 +810,65 @@ def _make_execution_authority_registry() -> tuple[
     module closures in its own process.
     """
 
-    states: WeakKeyDictionary[
-        object,
-        tuple[Callable[[], None], tuple[Callable[..., Any], ...]],
-    ] = WeakKeyDictionary()
+    # ``WeakKeyDictionary`` delegates identity to user-defined ``__hash__`` and
+    # ``__eq__``. Foundation A deliberately supports process-local executor
+    # subclasses, including unhashable and equality-overriding ones, so keep a
+    # private identity-keyed table instead. Every lookup verifies the weak
+    # referent before use, which also makes delayed cleanup and ``id`` reuse
+    # safe. Values retain only the guard/invokers; those retain weak executor
+    # references and therefore cannot keep an executor alive.
+    states: dict[
+        int,
+        tuple[
+            ref[object],
+            Callable[[object], None],
+            tuple[Callable[..., Any], ...],
+        ],
+    ] = {}
+
+    def _lookup(
+        executor: object,
+    ) -> tuple[Callable[[object], None], tuple[Callable[..., Any], ...]]:
+        executor_id = id(executor)
+        state = states.get(executor_id)
+        if state is None:
+            raise ValueError("execution authority guard is unavailable")
+        executor_ref, guard, invokers = state
+        if executor_ref() is not executor:
+            # The stale entry may await a weakref callback, or its integer key
+            # may have been reused. Never dispatch through either case.
+            if executor_ref() is None:
+                states.pop(executor_id, None)
+            raise ValueError("execution authority guard is unavailable")
+        return guard, invokers
 
     def register(
         executor: object,
-        guard: Callable[[], None],
+        guard: Callable[[object], None],
         invokers: tuple[Callable[..., Any], ...],
     ) -> None:
-        states[executor] = (guard, invokers)
+        executor_id = id(executor)
+
+        def cleanup(executor_ref: ref[object]) -> None:
+            state = states.get(executor_id)
+            if state is not None and state[0] is executor_ref:
+                states.pop(executor_id, None)
+
+        executor_ref = ref(executor, cleanup)
+        states[executor_id] = (executor_ref, guard, invokers)
 
     def invoke_guard(executor: object) -> None:
-        try:
-            guard = states[executor][0]
-        except KeyError as exc:
-            raise ValueError("execution authority guard is unavailable") from exc
-        guard()
+        guard, _ = _lookup(executor)
+        guard(executor)
 
     def invoke_entry(executor: object, entry_index: int, **kwargs: object) -> Any:
         try:
-            guard, invokers = states[executor]
+            guard, invokers = _lookup(executor)
             invoker = invokers[entry_index]
-        except (IndexError, KeyError) as exc:
+        except IndexError as exc:
             raise ValueError("execution authority entry root is unavailable") from exc
-        guard()
-        return invoker(**kwargs)
+        guard(executor)
+        return invoker(executor, **kwargs)
 
     return register, invoke_guard, invoke_entry
 
@@ -1502,6 +1634,29 @@ class ParallelACExecutor:
             expected_transcript_verifier_code=_foundation_a_roots.transcript_verifier_code,
             expected_rate_gate_acquire_root=_foundation_a_roots.rate_gate_acquire_root,
             expected_rate_gate_acquire_code=_foundation_a_roots.rate_gate_acquire_code,
+            expected_rate_gate_type=_foundation_a_roots.rate_gate_type,
+            expected_rate_gate_sleep=_foundation_a_roots.rate_gate_sleep,
+            expected_rate_gate_sleep_code=_foundation_a_roots.rate_gate_sleep_code,
+            expected_rate_gate_bucket_type=_foundation_a_roots.rate_gate_bucket_type,
+            expected_rate_gate_bucket_time=_foundation_a_roots.rate_gate_bucket_time,
+            expected_rate_gate_bucket_enabled_root=(
+                _foundation_a_roots.rate_gate_bucket_enabled_root
+            ),
+            expected_rate_gate_bucket_enabled_code=(
+                _foundation_a_roots.rate_gate_bucket_enabled_code
+            ),
+            expected_rate_gate_bucket_acquire_root=(
+                _foundation_a_roots.rate_gate_bucket_acquire_root
+            ),
+            expected_rate_gate_bucket_acquire_code=(
+                _foundation_a_roots.rate_gate_bucket_acquire_code
+            ),
+            expected_rate_gate_bucket_force_reserve_root=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_root
+            ),
+            expected_rate_gate_bucket_force_reserve_code=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_code
+            ),
             expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
             expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,
             expected_coordinator_review_code=_foundation_a_roots.level_coordinator_review_code,
@@ -1518,16 +1673,6 @@ class ParallelACExecutor:
             _make_execution_authority_guard(
                 self,
                 binding=binding,
-                authority_verifier=self._authority_verifier,
-                adapter=self._adapter,
-                dispatcher_type=self._authority_leaf_dispatcher_type,
-                dispatcher=self._authority_leaf_dispatcher,
-                transcript_verifier=self._authority_transcript_verifier,
-                rate_gate=self._dispatch_rate_gate,
-                dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
-                rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
-                coordinator=self._coordinator,
-                coordinator_review_callable=self._authority_coordinator_review,
                 workspace_builder=workspace_builder,
                 policy_builder=policy_builder,
                 internal_entry_roots=internal_entry_roots,
@@ -2492,7 +2637,12 @@ class ParallelACExecutor:
                         and (spec.verify_command or spec.expected_artifacts)
                     ):
                         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                        gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                        gate = await _invoke_execution_authority_entry(
+                            self,
+                            _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                            spec=spec,
+                            cwd=cwd,
+                        )
                         if not gate.passed:
                             executable.append(ac_idx)
                             log.info(
@@ -5381,7 +5531,12 @@ Respond with either ATOMIC or the structured JSON object only.
             verify_gate_outcome: _VerifyGateOutcome | None = None
             if success and verify_gate_active and has_success_contract:
                 cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                verify_gate_outcome = await self._run_ac_verify_gate(spec=ac_spec, cwd=cwd)
+                verify_gate_outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=ac_spec,
+                    cwd=cwd,
+                )
 
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
@@ -5988,7 +6143,12 @@ Respond with either ATOMIC or the structured JSON object only.
                 outcome=cached_outcome,
             )
         else:
-            outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+            outcome = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                spec=spec,
+                cwd=cwd,
+            )
         if outcome.passed:
             if not result.success and not result.is_blocked and not result.is_invalid:
                 from ouroboros.events.base import BaseEvent
@@ -6202,7 +6362,12 @@ Respond with either ATOMIC or the structured JSON object only.
                     outcome=cached_outcome,
                 )
             else:
-                outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=spec,
+                    cwd=cwd,
+                )
             if not outcome.passed:
                 gated_out.add(ac_idx)
         return frozenset(gated_out)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -353,6 +353,7 @@ class _FoundationAClosedRoots:
     rate_gate_bucket_acquire_code: object | None
     rate_gate_bucket_force_reserve_root: object
     rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
     transcript_verifier: Callable[..., VerifierVerdict]
     transcript_verifier_code: object
 
@@ -402,6 +403,25 @@ _FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT = SharedRateLimitBucket.acquire
 _FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE = SharedRateLimitBucket.acquire.__code__
 _FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT = SharedRateLimitBucket.force_reserve
 _FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE = SharedRateLimitBucket.force_reserve.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS = (
+    ("_prune", SharedRateLimitBucket._prune, SharedRateLimitBucket._prune.__code__),
+    (
+        "_tokens_in_window",
+        SharedRateLimitBucket._tokens_in_window,
+        SharedRateLimitBucket._tokens_in_window.__code__,
+    ),
+    ("_snapshot", SharedRateLimitBucket._snapshot, SharedRateLimitBucket._snapshot.__code__),
+    (
+        "_request_wait_seconds",
+        SharedRateLimitBucket._request_wait_seconds,
+        SharedRateLimitBucket._request_wait_seconds.__code__,
+    ),
+    (
+        "_token_wait_seconds",
+        SharedRateLimitBucket._token_wait_seconds,
+        SharedRateLimitBucket._token_wait_seconds.__code__,
+    ),
+)
 _FOUNDATION_A_TRANSCRIPT_VERIFIER = _verify_atomic_evidence_against_runtime_messages
 _FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE = _verify_atomic_evidence_against_runtime_messages.__code__
 _FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
@@ -425,6 +445,7 @@ _FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
     rate_gate_bucket_acquire_code=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE,
     rate_gate_bucket_force_reserve_root=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT,
     rate_gate_bucket_force_reserve_code=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE,
+    rate_gate_bucket_helper_roots=_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS,
     transcript_verifier=_FOUNDATION_A_TRANSCRIPT_VERIFIER,
     transcript_verifier_code=_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE,
 )
@@ -459,6 +480,7 @@ def _bind_foundation_a_roots(
     rate_gate_bucket_acquire_code = roots.rate_gate_bucket_acquire_code
     rate_gate_bucket_force_reserve_root = roots.rate_gate_bucket_force_reserve_root
     rate_gate_bucket_force_reserve_code = roots.rate_gate_bucket_force_reserve_code
+    rate_gate_bucket_helper_roots = roots.rate_gate_bucket_helper_roots
     transcript_verifier = roots.transcript_verifier
     transcript_verifier_code = roots.transcript_verifier_code
 
@@ -490,6 +512,7 @@ def _bind_foundation_a_roots(
                     rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
                     rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
                     rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+                    rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
                     transcript_verifier=transcript_verifier,
                     transcript_verifier_code=transcript_verifier_code,
                 ),
@@ -1656,6 +1679,9 @@ class ParallelACExecutor:
             ),
             expected_rate_gate_bucket_force_reserve_code=(
                 _foundation_a_roots.rate_gate_bucket_force_reserve_code
+            ),
+            expected_rate_gate_bucket_helper_roots=(
+                _foundation_a_roots.rate_gate_bucket_helper_roots
             ),
             expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
             expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,13 @@ from ouroboros.orchestrator.events import (
     create_tool_called_event,
     create_workflow_progress_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    constructor_model_contract,
+    runtime_execution_identity_contract,
+    runtime_execution_proves_effective_model,
+    valid_constructor_model_contract,
+    valid_runtime_execution_identity_contract,
+)
 from ouroboros.orchestrator.execution_guidance import (
     ExecutionGuidanceBundle,
     resolve_execution_guidance,
@@ -1584,45 +1591,12 @@ class OrchestratorRunner:
         runtimes that expose no constructor model at all; current-format resume
         then fails closed because the effective pin cannot be verified.
         """
-        try:
-            raw_model = inspect.getattr_static(self._adapter, "_model")
-        except AttributeError:
-            return {"observed": False}
-        if raw_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(raw_model, str):
-            return {"observed": False}
-
-        normalized_model: object = raw_model.strip() or None
-        normalizer_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "_normalize_model",
-            None,
-        )
-        if normalizer_descriptor is not None:
-            try:
-                normalizer = object.__getattribute__(self._adapter, "_normalize_model")
-                normalized_model = normalizer(raw_model)
-            except Exception:
-                return {"observed": False}
-        if normalized_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(normalized_model, str) or not normalized_model.strip():
-            return {"observed": False}
-        return {"observed": True, "model": normalized_model.strip()}
+        return constructor_model_contract(self._adapter)
 
     @staticmethod
     def _valid_constructor_model_contract(value: object) -> bool:
         """Return whether a persisted constructor-model contract is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        observed = value.get("observed")
-        if observed is not True:
-            return False
-        model = value.get("model")
-        return set(value) == {"observed", "model"} and (
-            model is None or isinstance(model, str) and bool(model.strip())
-        )
+        return valid_constructor_model_contract(value)
 
     def _runtime_execution_identity_contract(self) -> dict[str, Any]:
         """Return backend-specific resolved execution inputs, when observable.
@@ -1636,31 +1610,9 @@ class OrchestratorRunner:
         backend's private configuration model.
         """
 
-        provider_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "execution_identity_contract",
-            None,
-        )
-        if provider_descriptor is None:
-            return {"version": 1, "observed": False}
-
-        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
-        identity = provider()
-        if not isinstance(identity, Mapping):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
         try:
-            encoded = json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-            normalized_identity = json.loads(encoded)
-        except (TypeError, ValueError) as exc:
+            return runtime_execution_identity_contract(self._adapter)
+        except ValueError as exc:
             raise OrchestratorError(
                 message="Runtime returned an invalid execution identity contract",
                 details={
@@ -1668,61 +1620,16 @@ class OrchestratorRunner:
                     "cause": str(exc),
                 },
             ) from exc
-        if not isinstance(normalized_identity, dict):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        return {
-            "version": 1,
-            "observed": True,
-            "identity": normalized_identity,
-        }
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
         """Return whether a persisted backend execution identity is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        version = value.get("version")
-        observed = value.get("observed")
-        if (
-            isinstance(version, bool)
-            or not isinstance(version, int)
-            or version != 1
-            or not isinstance(observed, bool)
-        ):
-            return False
-        if not observed:
-            return set(value) == {"version", "observed"}
-        identity = value.get("identity")
-        if (
-            set(value) != {"version", "observed", "identity"}
-            or not isinstance(identity, Mapping)
-            or not identity
-        ):
-            return False
-        try:
-            json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError):
-            return False
-        return True
+        return valid_runtime_execution_identity_contract(value)
 
     @staticmethod
     def _runtime_execution_proves_effective_model(value: object) -> bool:
         """Return whether a backend identity observed a concrete model/profile."""
-        if not OrchestratorRunner._valid_runtime_execution_identity_contract(value):
-            return False
-        if not isinstance(value, Mapping) or value.get("observed") is not True:
-            return False
-        identity = value.get("identity")
-        return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+        return runtime_execution_proves_effective_model(value)
 
     def _validate_resume_handle_execution_identity(
         self,

--- a/src/ouroboros/orchestrator/shadow_replay.py
+++ b/src/ouroboros/orchestrator/shadow_replay.py
@@ -313,6 +313,14 @@ async def _run_shadow_replay_inner(
         )
         return
 
+    # This experiment has its own ephemeral workspace and never decides the
+    # live AC's acceptance, but it still must not sidestep the executor's five
+    # captured entry roots. Import lazily to avoid the module cycle: the
+    # executor imports this harness at module load time.
+    from ouroboros.orchestrator.parallel_executor import _invoke_execution_authority_guard
+
+    _invoke_execution_authority_guard(executor)
+
     router = executor._model_router
     if router is None:
         # Model routing dormant → no parent tier to price the baseline at.
@@ -619,7 +627,17 @@ async def _baseline_semantically_accepted(
         has_expected_artifacts=has_expected_artifacts,
         verify_gate_active=verify_gate_active,
     )
-    verifier_verdict = executor._run_atomic_verifier_pass(
+    # Do not look up ``executor._run_atomic_verifier_pass`` dynamically here.
+    # The live executor registered a constructor-captured root, and the registry
+    # both revalidates that root and invokes it directly.
+    from ouroboros.orchestrator.parallel_executor import (
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
+        _invoke_execution_authority_entry,
+    )
+
+    verifier_verdict = _invoke_execution_authority_entry(
+        executor,
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
         ac_content=ac_content,
         final_message=terminal.content,
         success=True,

--- a/src/ouroboros/orchestrator/shadow_replay.py
+++ b/src/ouroboros/orchestrator/shadow_replay.py
@@ -314,7 +314,7 @@ async def _run_shadow_replay_inner(
         return
 
     # This experiment has its own ephemeral workspace and never decides the
-    # live AC's acceptance, but it still must not sidestep the executor's five
+    # live AC's acceptance, but it still must not sidestep the executor's six
     # captured entry roots. Import lazily to avoid the module cycle: the
     # executor imports this harness at module load time.
     from ouroboros.orchestrator.parallel_executor import _invoke_execution_authority_guard

--- a/tests/unit/orchestrator/parallel_executor_test_support.py
+++ b/tests/unit/orchestrator/parallel_executor_test_support.py
@@ -1,0 +1,50 @@
+"""Test-only seams for exercising captured parallel-executor entry roots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+
+
+class ProcessLocalTestExecutor(ParallelACExecutor):
+    """Constructor-time test double whose entry roots stay process-local.
+
+    Production execution captures its finite internal entry roots when the
+    executor is constructed. Tests that need controllable leaf behavior use
+    this explicit subclass instead of mutating a production executor's roots
+    after construction.
+    """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", value)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", value)
+            return
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", None)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", None)
+            return
+        object.__delattr__(self, name)
+
+    async def _execute_single_ac(self, *args: Any, **kwargs: Any) -> Any:
+        calls = getattr(self, "_test_single_ac_calls", None)
+        if isinstance(calls, list):
+            calls.append(dict(kwargs))
+        runner = getattr(self, "_test_single_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_single_ac(*args, **kwargs)
+
+    async def _execute_atomic_ac(self, *args: Any, **kwargs: Any) -> Any:
+        runner = getattr(self, "_test_atomic_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_atomic_ac(*args, **kwargs)

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,0 +1,1182 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+import ouroboros.orchestrator.parallel_executor as parallel_executor_module
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
+from ouroboros.orchestrator.verifier import VerifierVerdict, structural_atomic_verifier
+
+
+class _Runtime:
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory: str | None = None
+    _model = None
+
+    def __init__(self, *, profile: str = "profile-a") -> None:
+        self.profile = profile
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {
+            "profile": self.profile,
+            "effective_model_observed": True,
+        }
+
+    async def execute_task(self, **_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+
+class _DynamicDispatchRuntime:
+    """A runtime whose dispatch entrypoint cannot be statically bound."""
+
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "dynamic-runtime"
+    llm_backend = "dynamic-llm"
+    permission_mode = "bypassPermissions"
+    self_governs_rate_limit = False
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"kind": "dynamic-runtime/v1", "effective_model_observed": True}
+
+    def __getattr__(self, name: str) -> object:
+        if name == "execute_task":
+
+            async def dispatch(**_: object) -> AsyncIterator[object]:
+                if False:  # pragma: no cover - identity-only stand-in
+                    yield None
+
+            return dispatch
+        raise AttributeError(name)
+
+
+class _Verifier:
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": self.identity}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
+def _contract(
+    *,
+    runtime: _Runtime | None = None,
+    verifier: object | None = None,
+    workspace: str = "/tmp/workspace-a",
+    policy: dict[str, object] | None = None,
+) -> ExecutionAuthorityContract:
+    return ExecutionAuthorityContract.build(
+        adapter=runtime or _Runtime(),
+        verifier=verifier,  # type: ignore[arg-type]
+        workspace=workspace,
+        execution_policy=policy or {"retry_attempts": 2},
+    )
+
+
+def test_runtime_profile_drift_changes_authority() -> None:
+    assert (
+        _contract(runtime=_Runtime(profile="a")).fingerprint
+        != _contract(runtime=_Runtime(profile="b")).fingerprint
+    )
+
+
+def test_custom_verifier_is_never_promoted_to_portable_authority() -> None:
+    first = _contract(verifier=_Verifier("judge-a"))
+    same = _contract(verifier=_Verifier("judge-a"))
+    changed = _contract(verifier=_Verifier("judge-b"))
+
+    assert first.fingerprint != same.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert first.portable_across_processes is False
+    assert "judge-a" not in first.canonical_json
+
+
+def test_undeclared_custom_verifier_is_process_local() -> None:
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    first = _contract(verifier=verifier)
+    second = _contract(verifier=verifier)
+
+    assert first.reusable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_workspace_and_policy_drift_change_authority() -> None:
+    baseline = _contract()
+    assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
+    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_closed_builtin_verifier_can_be_portable() -> None:
+    authority = _contract(verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is True
+    assert authority.data["verifier"] == {
+        "implementation": "structural-atomic-verifier/v1",
+        "mode": "structural_atomic",
+        "stability": "durable",
+        "version": 1,
+    }
+
+
+def test_credential_shaped_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert secret not in authority.canonical_json
+
+
+def test_stripe_credential_shaped_runtime_identity_becomes_process_local() -> None:
+    secret = "sk_" + "live_abcdefghijklmnopqrstuvwxyz123456"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_credential_alias_in_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "apiKeyValue": secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_custom_verifier_credential_alias_never_enters_authority_json() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialVerifier(_Verifier):
+        def verification_identity_contract(self) -> dict[str, object]:
+            return {"apiKeyValue": secret}
+
+    authority = _contract(verifier=CredentialVerifier("ignored"))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["verifier"]["configuration"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_contract_deserialization_rejects_credential_shaped_member() -> None:
+    authority = _contract(verifier=structural_atomic_verifier)
+    data = authority.data
+    data["verifier"]["implementation"] = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    with pytest.raises(ValueError, match="sensitive"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=load_profile("code"),
+        atomic_verifier=_Verifier("judge-a"),
+        ac_retry_attempts=2,
+    )
+
+    authority = executor.execution_authority
+    assert authority.fingerprint.startswith("sha256:")
+    assert authority.data["workspace"]["identity_digest"].startswith("sha256:")
+    assert authority.data["runtime"]["execution_identity"]["digest"].startswith("sha256:")
+    assert authority.data["execution_policy"]["identity_digest"].startswith("sha256:")
+
+
+def test_public_constructor_rejects_caller_supplied_closed_roots(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    with pytest.raises(TypeError, match="multiple values"):
+        ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type, call-arg]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            _foundation_a_roots=object(),  # type: ignore[call-arg]
+        )
+
+
+def test_constructor_closure_ignores_a_poisoned_global_roots_bundle(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    roots = parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS
+    original_verifier = roots.transcript_verifier
+    original_verifier_code = roots.transcript_verifier_code
+
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=False, reasons=("poisoned root",))
+
+    object.__setattr__(roots, "transcript_verifier", injected_verifier)
+    object.__setattr__(roots, "transcript_verifier_code", injected_verifier.__code__)
+    try:
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+        )
+    finally:
+        object.__setattr__(roots, "transcript_verifier", original_verifier)
+        object.__setattr__(roots, "transcript_verifier_code", original_verifier_code)
+
+    assert executor._authority_transcript_verifier is original_verifier
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is True
+
+
+def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    base_profile = load_profile("code")
+    changed_profile = base_profile.model_copy(update={"profile": "code-v2"})
+
+    def build(profile: ExecutionProfile) -> str:
+        return ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            execution_profile=profile,
+        ).execution_authority.fingerprint
+
+    assert build(base_profile) != build(changed_profile)
+
+
+def test_executor_rejects_runtime_descriptor_drift_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    runtime.profile = "changed"
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_verifier_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=_Verifier("first"),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._atomic_verifier = _Verifier("replacement")
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._authority_leaf_dispatcher_type = object
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_runtime_dispatch_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_execute_task(self: _Runtime, **_: object) -> AsyncIterator[object]:
+        del self
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(_Runtime, "execute_task", replacement_execute_task)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_method_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        executor._authority_leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_coordinator_review_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_review(**_: object) -> object:
+        return object()
+
+    monkeypatch.setattr(executor._coordinator, "run_review", replacement_review)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_coordinator_adapter_drift_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    replacement = _Runtime(profile="replacement")
+    replacement.working_directory = str(tmp_path)
+    executor._coordinator._adapter = replacement  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_its_own_attribute_resolution_drift_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class EvilRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    evil_runtime = EvilRuntime()
+    evil_runtime.working_directory = str(tmp_path)
+    original_getattribute = ParallelACExecutor.__getattribute__
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_require_execution_authority_intact":
+            return lambda: None
+        if name == "_adapter":
+            return evil_runtime
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "__getattribute__",
+        redirected_getattribute,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._dispatch_decomposition_prompt(
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert evil_runtime.dispatched is False
+
+
+def test_executor_rejects_postconstruction_runtime_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is True
+
+    original_getattribute = _Runtime.__getattribute__
+
+    async def injected_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - must remain unreachable
+            yield None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "execute_task":
+            return injected_dispatch
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(_Runtime, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_dispatcher_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is True
+
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_getattribute = dispatcher_type.__getattribute__
+
+    async def injected_stream(**_: object) -> None:
+        return None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "stream":
+            return injected_stream
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(dispatcher_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_coordinator_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is True
+
+    coordinator_type = type(executor._coordinator)
+    original_getattribute = coordinator_type.__getattribute__
+    replacement_adapter = object()
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_adapter":
+            return replacement_adapter
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(coordinator_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_rate_gate_attribute_resolution_drift_before_admission(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is True
+
+    gate_type = type(executor._dispatch_rate_gate)
+    original_getattribute = gate_type.__getattribute__
+    injected_calls: list[int] = []
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        injected_calls.append(1)
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "acquire":
+            return injected_acquire
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(gate_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert injected_calls == []
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_replaced_rate_gate_bucket_before_admission(tmp_path) -> None:
+    class EvilBucket:
+        def __init__(self, original: object) -> None:
+            self._runtime_backend = object.__getattribute__(original, "_runtime_backend")
+            self._request_limit = object.__getattribute__(original, "_request_limit")
+            self._token_limit = object.__getattribute__(original, "_token_limit")
+            self._window_seconds = object.__getattribute__(original, "_window_seconds")
+            self.called = False
+
+        async def acquire(self, _: int) -> object:
+            self.called = True
+            return (0.0, object())
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    original_bucket = object.__getattribute__(executor._dispatch_rate_gate, "_bucket")
+    evil_bucket = EvilBucket(original_bucket)
+    object.__setattr__(executor._dispatch_rate_gate, "_bucket", evil_bucket)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert evil_bucket.called is False
+
+
+def test_executor_rejects_replaced_captured_leaf_dispatch_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_stream(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_leaf_dispatcher_stream = injected_stream
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_captured_rate_gate_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_rate_gate_acquire_root = injected_acquire
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_reuses_closed_leaf_dispatcher_after_late_init_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    captured_dispatcher = executor._authority_leaf_dispatcher
+
+    def injected_init(self: object, _: object) -> None:
+        object.__setattr__(self, "_executor", object())
+
+    monkeypatch.setattr(executor._authority_leaf_dispatcher_type, "__init__", injected_init)
+
+    executor._require_execution_authority_intact()
+    assert executor._authority_leaf_dispatcher is captured_dispatcher
+    assert object.__getattribute__(captured_dispatcher, "_executor") is executor
+
+
+def test_executor_uses_closed_import_time_dispatcher_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementDispatcher:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LeafDispatcher", ReplacementDispatcher)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_leaf_dispatcher_type is not ReplacementDispatcher
+    executor._require_execution_authority_intact()
+
+
+def test_executor_uses_closed_import_time_coordinator_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementCoordinator:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LevelCoordinator", ReplacementCoordinator)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert type(executor._coordinator) is not ReplacementCoordinator
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_dispatcher_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_rate_gate_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_acquire(self: object, *_: object, **__: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module.RateLimitGate,
+        "acquire",
+        replacement_acquire,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_coordinator_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_review(self: object, **_: object) -> object:
+        del self
+        return object()
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.level_coordinator_type,
+        "run_review",
+        replacement_review,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_transcript_alias_patch_uses_closed_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("injected verifier must not become the closed root",),
+        )
+
+    monkeypatch.setattr(
+        parallel_executor_module,
+        "_FOUNDATION_A_TRANSCRIPT_VERIFIER",
+        injected_verifier,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is True
+    executor._require_execution_authority_intact()
+
+
+def test_reflective_custom_verifier_remains_process_local_without_graph_introspection() -> None:
+    mutable_state = {"passed": True}
+
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=mutable_state["passed"])
+
+    authority = _contract(verifier=verifier)
+
+    assert authority.portable_across_processes is False
+    assert "mutable_state" not in authority.canonical_json
+    assert "passed" not in authority.canonical_json
+
+
+def test_uninspectable_runtime_dispatch_root_stays_process_local() -> None:
+    class Dispatcher:
+        async def stream(self, **_: object) -> None:
+            return None
+
+    class RateGate:
+        async def acquire(self, *_: object, **__: object) -> None:
+            return None
+
+    def transcript_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    from ouroboros.orchestrator.execution_authority import ExecutionAuthorityLiveBinding
+
+    binding = ExecutionAuthorityLiveBinding.capture(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        dispatcher_type=Dispatcher,
+        transcript_verifier=transcript_verifier,
+        rate_gate=RateGate(),
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert binding.adapter_dispatch_root is None
+    assert binding.contract.portable_across_processes is False
+    assert binding.contract.data["runtime"]["stability"] == "process_local"
+
+
+def test_instance_level_runtime_dispatch_callable_stays_process_local() -> None:
+    class InstanceDispatchRuntime(_Runtime):
+        def __init__(self, dispatch: object) -> None:
+            super().__init__()
+            self.execute_task = dispatch  # type: ignore[method-assign]
+
+    async def first_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    async def second_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    first = _contract(runtime=InstanceDispatchRuntime(first_dispatch))
+    second = _contract(runtime=InstanceDispatchRuntime(second_dispatch))
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.data["runtime"]["stability"] == "process_local"
+    assert second.data["runtime"]["stability"] == "process_local"
+
+
+def test_direct_contract_with_uninspectable_runtime_stays_process_local() -> None:
+    authority = ExecutionAuthorityContract.build(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+
+
+def test_captured_transcript_verifier_ignores_replaced_executor_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    profile = load_profile("code").model_copy(
+        update={"evidence_schema": EvidenceSchema(required=())}
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=profile,
+        fat_harness_mode=True,
+    )
+
+    def replaced_wrapper(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("replacement wrapper must not decide acceptance",),
+        )
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "_verify_atomic_evidence_against_runtime_messages",
+        replaced_wrapper,
+    )
+
+    verdict = executor._run_atomic_verifier_pass(
+        ac_content="No transcript proof is required.",
+        final_message="done",
+        success=True,
+        messages=(),
+        typed_evidence=parallel_executor_module.EvidenceRecord(data={}),
+        typed_validation=parallel_executor_module.ValidationResult(ok=True),
+    )
+
+    assert verdict is not None
+    assert verdict.passed is True
+
+
+def test_executor_rejects_in_place_dispatcher_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_code = dispatcher_type.stream.__code__
+
+    async def injected_stream(self: object, **_: object) -> None:
+        del self
+
+    dispatcher_type.stream.__code__ = injected_stream.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        dispatcher_type.stream.__code__ = original_code
+
+
+@pytest.mark.parametrize(
+    "entry_name",
+    (
+        "_execute_single_ac",
+        "_execute_atomic_ac",
+        "_await_dispatch_rate_budget",
+        "_dispatch_decomposition_prompt",
+        "_run_atomic_verifier_pass",
+    ),
+)
+def test_executor_rejects_postconstruction_internal_entry_root_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    entry_name: str,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, entry_name, injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_instance_shadow_of_internal_entry_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(**_: object) -> object:
+        return None
+
+    object.__setattr__(executor, "_execute_single_ac", injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_preconstruction_internal_entry_root_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_executor_subclass_is_process_local_even_when_it_inherits_entry_roots(tmp_path) -> None:
+    class SubclassedExecutor(ParallelACExecutor):
+        pass
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = SubclassedExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+
+
+@pytest.mark.asyncio
+async def test_dynamic_runtime_does_not_reopen_captured_executor_entry_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _DynamicDispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+    injected = False
+
+    async def injected_entry(*_: object, **__: object) -> str:
+        nonlocal injected
+        injected = True
+        return '{"cause":"TOO_BIG","reason":"injected","evidence_refs":[]}'
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+
+    result = await executor._request_bounce_classification(
+        trace=parallel_executor_module.DecompositionTraceSummary(summary="bounded evidence"),
+    )
+
+    assert result == (
+        parallel_executor_module.BounceCause.UNKNOWN,
+        "Bounce classifier returned no admissible cause.",
+        (),
+        False,
+    )
+    assert injected is False
+
+
+@pytest.mark.asyncio
+async def test_internal_execution_path_rejects_entry_replacement_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        runtime.dispatched = True
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", injected_entry)
+    seed = MagicMock()
+    seed.acceptance_criteria = ("Do not dispatch",)
+    seed.goal = "Keep the runtime closed"
+
+    results = await executor._execute_ac_batch(
+        seed=seed,
+        batch_indices=[0],
+        session_id="session",
+        execution_id="execution",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        level_contexts=[],
+        ac_retry_attempts={0: 0},
+    )
+
+    assert isinstance(results[0], ValueError)
+    assert runtime.dispatched is False
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_authority_drift_before_decomposition_dispatch(tmp_path) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - should remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    runtime.profile = "drifted"
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._dispatch_decomposition_prompt(
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert runtime.dispatched is False

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 import gc
 import json
+import shutil
+import sys
 from unittest.mock import AsyncMock, MagicMock
 import weakref
 
 import pytest
 
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
 import ouroboros.orchestrator.parallel_executor as parallel_executor_module
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
@@ -74,7 +77,7 @@ class _Verifier:
 
 def _contract(
     *,
-    runtime: _Runtime | None = None,
+    runtime: object | None = None,
     verifier: object | None = None,
     workspace: str = "/tmp/workspace-a",
     policy: dict[str, object] | None = None,
@@ -123,7 +126,12 @@ def test_workspace_and_policy_drift_change_authority() -> None:
 
 
 def test_closed_builtin_verifier_can_be_portable() -> None:
-    authority = _contract(verifier=structural_atomic_verifier)
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
 
     assert authority.portable_across_processes is True
     assert authority.data["verifier"] == {
@@ -132,6 +140,121 @@ def test_closed_builtin_verifier_can_be_portable() -> None:
         "stability": "durable",
         "version": 1,
     }
+
+
+def test_unknown_runtime_implementation_stays_process_local_and_unique() -> None:
+    class AlternateRuntime(_Runtime):
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            if False:  # pragma: no cover - implementation identity only
+                yield None
+
+    first = _contract(runtime=_Runtime())
+    second = _contract(runtime=AlternateRuntime())
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_runtime_type_name_spoof_cannot_claim_closed_implementation() -> None:
+    class SpoofedCodexRuntime(CodexCliRuntime):
+        pass
+
+    SpoofedCodexRuntime.__module__ = CodexCliRuntime.__module__
+    SpoofedCodexRuntime.__qualname__ = CodexCliRuntime.__qualname__
+    runtime = SpoofedCodexRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_preconstruction_builtin_dispatch_patch_stays_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def altered_execute_task(*_: object, **__: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(CodexCliRuntime, "execute_task", altered_execute_task)
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_closed_codex_runtime_binds_executable_and_timeout_configuration() -> None:
+    baseline = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            stdout_idle_timeout_seconds=30,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    timeout_changed = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            stdout_idle_timeout_seconds=31,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+
+    assert baseline.portable_across_processes is True
+    assert timeout_changed.portable_across_processes is True
+    assert baseline.fingerprint != timeout_changed.fingerprint
+
+    alternate_executable = shutil.which("true")
+    if alternate_executable is not None and alternate_executable != sys.executable:
+        executable_changed = _contract(
+            runtime=CodexCliRuntime(
+                cli_path=alternate_executable,
+                model="test-model",
+                cwd="/tmp",
+                stdout_idle_timeout_seconds=30,
+            ),
+            verifier=structural_atomic_verifier,
+        )
+        assert executable_changed.portable_across_processes is True
+        assert baseline.fingerprint != executable_changed.fingerprint
+
+
+def test_closed_codex_runtime_custom_skill_configuration_stays_process_local(
+    tmp_path,
+) -> None:
+    custom_skills = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skills_dir=tmp_path,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    custom_dispatcher = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skill_dispatcher=MagicMock(),
+        ),
+        verifier=structural_atomic_verifier,
+    )
+
+    assert custom_skills.portable_across_processes is False
+    assert custom_dispatcher.portable_across_processes is False
 
 
 def test_credential_shaped_runtime_identity_becomes_process_local_without_egress() -> None:
@@ -265,6 +388,27 @@ def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     assert authority.data["execution_policy"]["identity_digest"].startswith("sha256:")
 
 
+def test_session_signal_hub_is_process_local_and_cannot_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    hub = MagicMock()
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        session_signal_hub=hub,
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    assert executor._execution_authority_policy()["session_signal_hub_enabled"] is True
+    executor._require_execution_authority_intact()
+
+    executor._session_signal_hub = MagicMock()
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
 def test_execution_authority_registry_does_not_keep_executor_alive(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -322,7 +466,7 @@ def test_constructor_closure_ignores_a_poisoned_global_roots_bundle(tmp_path) ->
 
     assert executor._authority_transcript_verifier is original_verifier
     assert executor._authority_transcript_verifier is not injected_verifier
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
 
 
 def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
@@ -550,7 +694,7 @@ def test_executor_rejects_postconstruction_runtime_attribute_resolution_drift(
         console=MagicMock(),
         task_cwd=str(tmp_path),
     )
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
 
     original_getattribute = _Runtime.__getattribute__
 
@@ -581,7 +725,7 @@ def test_executor_rejects_postconstruction_dispatcher_attribute_resolution_drift
         console=MagicMock(),
         task_cwd=str(tmp_path),
     )
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
 
     dispatcher_type = executor._authority_leaf_dispatcher_type
     original_getattribute = dispatcher_type.__getattribute__
@@ -612,7 +756,7 @@ def test_executor_rejects_postconstruction_coordinator_attribute_resolution_drif
         console=MagicMock(),
         task_cwd=str(tmp_path),
     )
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
 
     coordinator_type = type(executor._coordinator)
     original_getattribute = coordinator_type.__getattribute__
@@ -642,7 +786,7 @@ async def test_executor_rejects_rate_gate_attribute_resolution_drift_before_admi
         console=MagicMock(),
         task_cwd=str(tmp_path),
     )
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
 
     gate_type = type(executor._dispatch_rate_gate)
     original_getattribute = gate_type.__getattribute__
@@ -997,7 +1141,7 @@ def test_preconstruction_transcript_alias_patch_uses_closed_root(
     )
 
     assert executor._authority_transcript_verifier is not injected_verifier
-    assert executor.execution_authority.portable_across_processes is True
+    assert executor.execution_authority.portable_across_processes is False
     executor._require_execution_authority_intact()
 
 

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -216,6 +216,18 @@ def test_closed_codex_runtime_binds_executable_and_timeout_configuration() -> No
     assert timeout_changed.portable_across_processes is True
     assert baseline.fingerprint != timeout_changed.fingerprint
 
+    working_directory_changed = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/",
+            stdout_idle_timeout_seconds=30,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    assert working_directory_changed.portable_across_processes is True
+    assert baseline.fingerprint != working_directory_changed.fingerprint
+
     alternate_executable = shutil.which("true")
     if alternate_executable is not None and alternate_executable != sys.executable:
         executable_changed = _contract(

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -767,6 +767,29 @@ def test_executor_rejects_rate_gate_bucket_time_and_method_drift(
         executor._require_execution_authority_intact()
 
 
+def test_executor_rejects_rate_gate_bucket_helper_code_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    def injected_prune(self: object, now: float) -> None:
+        del self, now
+
+    bucket_type = type(executor._dispatch_rate_gate._bucket)
+    monkeypatch.setattr(bucket_type._prune, "__code__", injected_prune.__code__)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
 def test_executor_rejects_replaced_captured_leaf_dispatch_root(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -1169,6 +1192,17 @@ def test_preconstruction_structural_verifier_code_drift_is_process_local() -> No
         authority = _contract(verifier=structural_atomic_verifier)
         assert authority.portable_across_processes is False
         assert authority.data["verifier"]["stability"] == "process_local"
+
+        runtime = _Runtime()
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd="/tmp/workspace-a",
+            atomic_verifier=structural_atomic_verifier,
+        )
+        assert executor.execution_authority.portable_across_processes is False
+        executor._require_execution_authority_intact()
     finally:
         structural_atomic_verifier.__code__ = original_code
 

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -12,11 +12,13 @@ import pytest
 
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
 from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
 import ouroboros.orchestrator.parallel_executor as parallel_executor_module
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import VerifierVerdict, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
 
 class _Runtime:
@@ -269,6 +271,41 @@ def test_closed_codex_runtime_custom_skill_configuration_stays_process_local(
     assert custom_dispatcher.portable_across_processes is False
 
 
+def test_copilot_runtime_binds_resolved_profile_agent() -> None:
+    plain = _contract(
+        runtime=CopilotCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    worker_runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+        runtime_profile="worker",
+    )
+    worker = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+
+    assert plain.portable_across_processes is False
+    assert worker.portable_across_processes is False
+    assert plain.data["runtime"]["configuration"] != worker.data["runtime"]["configuration"]
+
+    worker_runtime._copilot_agent = "different-agent"
+    changed = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+    assert changed.data["runtime"]["configuration"] != worker.data["runtime"]["configuration"]
+
+
+def test_zcode_runtime_with_external_launcher_chain_stays_process_local() -> None:
+    runtime = ZcodeCLIRuntime(cli_path=sys.executable, cwd="/tmp")
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["configuration"] == {"observed": False}
+
+
 def test_credential_shaped_runtime_identity_becomes_process_local_without_egress() -> None:
     secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
     authority = _contract(runtime=_Runtime(profile=secret))
@@ -417,6 +454,28 @@ def test_session_signal_hub_is_process_local_and_cannot_drift(tmp_path) -> None:
     executor._require_execution_authority_intact()
 
     executor._session_signal_hub = MagicMock()
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_copilot_agent_drift(tmp_path) -> None:
+    runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd=tmp_path,
+        runtime_profile="worker",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+    runtime._copilot_agent = "different-agent"
     with pytest.raises(ValueError, match="execution authority drifted"):
         executor._require_execution_authority_intact()
 

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+import gc
 import json
 from unittest.mock import AsyncMock, MagicMock
+import weakref
 
 import pytest
 
@@ -167,6 +169,37 @@ def test_credential_alias_in_runtime_identity_becomes_process_local_without_egre
     assert secret not in authority.canonical_json
 
 
+@pytest.mark.parametrize(
+    "key_name",
+    (
+        "secretKey",
+        "secret_access_key",
+        "awsSecretAccessKey",
+        "accountKey",
+        "connectionString",
+        "masterKey",
+    ),
+)
+def test_secret_key_alias_in_runtime_identity_becomes_process_local(
+    key_name: str,
+) -> None:
+    secret = "opaque-provider-credential"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                key_name: secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
 def test_custom_verifier_credential_alias_never_enters_authority_json() -> None:
     secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
 
@@ -190,6 +223,28 @@ def test_contract_deserialization_rejects_credential_shaped_member() -> None:
         ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
 
 
+def test_contract_deserialization_rejects_promoted_process_local_runtime() -> None:
+    authority = _contract(runtime=_DynamicDispatchRuntime())
+    data = authority.data
+    assert data["runtime"]["portable_identity_observed"] is False
+    data["runtime"]["stability"] = "durable"
+
+    with pytest.raises(ValueError, match="invalid runtime"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_empty_runtime_identity_stays_process_local() -> None:
+    class EmptyIdentityRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {}
+
+    authority = _contract(runtime=EmptyIdentityRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+
+
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -208,6 +263,24 @@ def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
     assert authority.data["workspace"]["identity_digest"].startswith("sha256:")
     assert authority.data["runtime"]["execution_identity"]["digest"].startswith("sha256:")
     assert authority.data["execution_policy"]["identity_digest"].startswith("sha256:")
+
+
+def test_execution_authority_registry_does_not_keep_executor_alive(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor_ref = weakref.ref(executor)
+
+    del executor
+    gc.collect()
+    gc.collect()
+
+    assert executor_ref() is None
 
 
 def test_public_constructor_rejects_caller_supplied_closed_roots(tmp_path) -> None:
@@ -623,6 +696,77 @@ async def test_executor_rejects_replaced_rate_gate_bucket_before_admission(tmp_p
     assert evil_bucket.called is False
 
 
+@pytest.mark.parametrize(
+    ("attribute", "replacement"),
+    (("_max_wait_seconds", 0.0), ("_heartbeat_seconds", 0.0)),
+)
+def test_executor_rejects_rate_gate_scalar_semantic_drift(
+    tmp_path,
+    attribute: str,
+    replacement: float,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    object.__setattr__(executor._dispatch_rate_gate, attribute, replacement)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_wait_collaborator_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_sleep(_: float) -> None:
+        return None
+
+    object.__setattr__(executor._dispatch_rate_gate, "_sleep", injected_sleep)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_bucket_time_and_method_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    bucket = executor._dispatch_rate_gate._bucket
+
+    object.__setattr__(bucket, "_time", lambda: 0.0)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+    object.__setattr__(bucket, "_time", parallel_executor_module.time.monotonic)
+
+    async def injected_force_reserve(*_: object, **__: object) -> object:
+        return object()
+
+    monkeypatch.setattr(type(bucket), "force_reserve", injected_force_reserve)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
 def test_executor_rejects_replaced_captured_leaf_dispatch_root(tmp_path) -> None:
     runtime = _Runtime()
     runtime.working_directory = str(tmp_path)
@@ -977,6 +1121,58 @@ def test_executor_rejects_in_place_dispatcher_code_drift(tmp_path) -> None:
         dispatcher_type.stream.__code__ = original_code
 
 
+def test_executor_rejects_in_place_structural_verifier_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=structural_atomic_verifier,
+    )
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
+def test_preconstruction_structural_verifier_code_drift_is_process_local() -> None:
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        authority = _contract(verifier=structural_atomic_verifier)
+        assert authority.portable_across_processes is False
+        assert authority.data["verifier"]["stability"] == "process_local"
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
 @pytest.mark.parametrize(
     "entry_name",
     (
@@ -985,6 +1181,7 @@ def test_executor_rejects_in_place_dispatcher_code_drift(tmp_path) -> None:
         "_await_dispatch_rate_budget",
         "_dispatch_decomposition_prompt",
         "_run_atomic_verifier_pass",
+        "_run_ac_verify_gate",
     ),
 )
 def test_executor_rejects_postconstruction_internal_entry_root_drift(
@@ -1064,6 +1261,52 @@ def test_executor_subclass_is_process_local_even_when_it_inherits_entry_roots(tm
     )
 
     assert executor.execution_authority.portable_across_processes is False
+
+
+def test_unhashable_executor_subclass_remains_executable_and_process_local(tmp_path) -> None:
+    class UnhashableExecutor(ParallelACExecutor):
+        __hash__ = None  # type: ignore[assignment]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = UnhashableExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_equality_overriding_executor_subclasses_keep_distinct_registry_entries(tmp_path) -> None:
+    class EqualExecutor(ParallelACExecutor):
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqualExecutor)
+
+        __hash__ = object.__hash__
+
+    first_runtime = _Runtime(profile="first")
+    first_runtime.working_directory = str(tmp_path)
+    second_runtime = _Runtime(profile="second")
+    second_runtime.working_directory = str(tmp_path)
+    first = EqualExecutor(
+        adapter=first_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    second = EqualExecutor(
+        adapter=second_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert first == second
+    first._require_execution_authority_intact()
+    second._require_execution_authority_intact()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,7 +28,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
+from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict, LevelCoordinator
 from ouroboros.orchestrator.decomposition_policy import DecompositionDisposition
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
@@ -56,8 +56,8 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
-from ouroboros.orchestrator.rate_limit import RateLimitGate, SharedRateLimitBucket
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def test_stall_timeout_default_allows_realistic_test_suites() -> None:
@@ -138,11 +138,12 @@ class TestDispatchRateGate:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
         adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
         executor = _make_rate_gate_executor(adapter)
 
-        # Swap in a deterministic gate (rpm=1, fake clock + sleep) to prove the
-        # executor's dispatch hook actually waits on the shared budget.
+        # Keep the authority-bound gate object and direct callable intact, but
+        # give its mutable clock/sleep state deterministic test doubles.
         clock = {"now": 0.0}
         slept: list[float] = []
 
@@ -150,15 +151,9 @@ class TestDispatchRateGate:
             slept.append(seconds)
             clock["now"] += seconds
 
-        bucket = SharedRateLimitBucket(
-            runtime_backend="opencode",
-            request_limit=1,
-            token_limit=None,
-            time_provider=lambda: clock["now"],
-        )
-        executor._dispatch_rate_gate = RateLimitGate(
-            bucket, heartbeat_seconds=120.0, sleep=fake_sleep
-        )
+        executor._dispatch_rate_gate._bucket._time = lambda: clock["now"]
+        executor._dispatch_rate_gate._sleep = fake_sleep
+        executor._dispatch_rate_gate._heartbeat_seconds = 120.0
 
         await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
         await executor._await_dispatch_rate_budget(prompt="b", system_prompt=None)
@@ -182,7 +177,7 @@ def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:
 
 def _make_executor() -> ParallelACExecutor:
     """Create an executor with mocked dependencies and muted event emitters."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -8371,7 +8366,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_decomposed_ac_inlines_sub_ac_dispatch_into_single_ac(self) -> None:
         """Decomposed execution should recurse through _execute_single_ac without a helper path."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8391,24 +8386,21 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
-        with patch.object(
-            executor,
-            "_execute_single_ac",
-            wraps=executor._execute_single_ac,
-        ) as execute_single_ac_spy:
-            result = await executor._execute_single_ac(
-                ac_index=1,
-                ac_content="Implement parser workflow",
-                session_id="sess_decompose",
-                tools=["Read", "Edit"],
-                tool_catalog=None,
-                system_prompt="system",
-                seed_goal="Ship parser workflow",
-                depth=0,
-                execution_id="exec_decompose",
-            )
+        executor._test_single_ac_calls = []
+        result = await executor._execute_single_ac(
+            ac_index=1,
+            ac_content="Implement parser workflow",
+            session_id="sess_decompose",
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship parser workflow",
+            depth=0,
+            execution_id="exec_decompose",
+        )
 
         assert hasattr(executor, "_execute_sub_acs") is False
         assert result.success is True
@@ -8420,23 +8412,23 @@ class TestParallelACExecutor:
         assert [sub_result.depth for sub_result in result.sub_results] == [1, 1]
         assert [
             (
-                int(call.kwargs["ac_index"]),
-                str(call.kwargs["ac_content"]),
-                int(call.kwargs["depth"]),
+                int(call["ac_index"]),
+                str(call["ac_content"]),
+                int(call["depth"]),
             )
-            for call in execute_single_ac_spy.await_args_list
+            for call in executor._test_single_ac_calls
         ] == [
             (1, "Implement parser workflow", 0),
             (100, "Extract parser", 1),
             (101, "Wire parser", 1),
         ]
         assert executor._try_decompose_ac.await_count == 3
-        assert executor._execute_atomic_ac.await_count == 2
+        assert execute_atomic_ac.await_count == 2
 
     @pytest.mark.asyncio
     async def test_top_level_decomposition_preserves_sub_ac_runtime_identity(self) -> None:
         """First-level decomposed children should still execute with sub-AC runtime metadata."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8456,7 +8448,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         await executor._execute_single_ac(
             ac_index=1,
@@ -8477,7 +8470,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["parent_ac_index"]),
                 int(call.kwargs["sub_ac_index"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, True, 1, 0),
             (101, True, 1, 1),
@@ -8486,7 +8479,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_depth_three_forces_atomic_without_further_decomposition(self) -> None:
         """Depth 2 may still recurse, but depth 3 must execute atomically."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8509,7 +8502,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=0,
@@ -8535,8 +8529,8 @@ class TestParallelACExecutor:
             True,
         ]
         executor._try_decompose_ac.assert_awaited_once()
-        assert executor._execute_atomic_ac.await_count == 2
-        assert [call.kwargs["depth"] for call in executor._execute_atomic_ac.await_args_list] == [
+        assert execute_atomic_ac.await_count == 2
+        assert [call.kwargs["depth"] for call in execute_atomic_ac.await_args_list] == [
             3,
             3,
         ]
@@ -8732,7 +8726,7 @@ class TestParallelACExecutor:
         """Leaf retries should not re-run composite decomposition or sibling dispatch."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8765,7 +8759,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=1,
@@ -8789,7 +8784,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["depth"]),
                 int(call.kwargs["retry_attempt"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, 1, 0),
             (100, 1, 1),
@@ -8802,7 +8797,7 @@ class TestParallelACExecutor:
             if call.args and call.args[0].type == "execution.ac.stall_detected"
         ]
         assert len(stall_events) == 1
-        first_leaf_identity = executor._execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
+        first_leaf_identity = execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
         assert (
             stall_events[0].aggregate_id == f"exec_atomic_retry_scope_{first_leaf_identity.node_id}"
         )
@@ -8819,7 +8814,7 @@ class TestParallelACExecutor:
         """Single-AC execution should convert an unrecoverable stall into a normal failure."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8840,7 +8835,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=2,
@@ -8857,10 +8853,9 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error == f"Stalled (no activity for {STALL_TIMEOUT_SECONDS:.0f}s)"
         assert result.retry_attempt == MAX_STALL_RETRIES
-        assert executor._execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
+        assert execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
         assert [
-            int(call.kwargs["retry_attempt"])
-            for call in executor._execute_atomic_ac.await_args_list
+            int(call.kwargs["retry_attempt"]) for call in execute_atomic_ac.await_args_list
         ] == list(range(MAX_STALL_RETRIES + 1))
 
         stall_events = [
@@ -10853,7 +10848,10 @@ class TestParallelACExecutor:
         assert result.stages[1].outcome == StageExecutionOutcome.PARTIAL
 
     @pytest.mark.asyncio
-    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(self) -> None:
+    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Coordinator reconciliation should persist level-scoped events and artifacts only."""
         seed = _make_seed(
             "Update the shared module imports",
@@ -10866,48 +10864,51 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            conflicts_detected=(
+                FileConflict(
+                    file_path="src/shared.py",
+                    ac_indices=(0, 1),
+                    resolved=True,
+                    resolution_description="Merged by coordinator",
+                ),
+            ),
+            review_summary="Resolved shared.py conflict",
+            fixes_applied=("Merged overlapping import edits",),
+            warnings_for_next_level=("Verify shared.py integration paths",),
+            duration_seconds=1.5,
+            session_id="coord-session-1",
+            session_scope_id="level_1_coordinator",
+            session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
+            final_output=(
+                '{"review_summary":"Resolved shared.py conflict",'
+                '"fixes_applied":["Merged overlapping import edits"],'
+                '"warnings_for_next_level":["Verify shared.py integration paths"],'
+                '"conflicts_resolved":["src/shared.py"]}'
+            ),
+            messages=(
+                AgentMessage(
+                    type="assistant",
+                    content="Inspecting shared file",
+                    tool_name="Read",
+                    data={"tool_input": {"file_path": "src/shared.py"}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Reconciling overlap",
+                    data={"thinking": "Merge the import changes without changing behavior."},
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                conflicts_detected=(
-                    FileConflict(
-                        file_path="src/shared.py",
-                        ac_indices=(0, 1),
-                        resolved=True,
-                        resolution_description="Merged by coordinator",
-                    ),
-                ),
-                review_summary="Resolved shared.py conflict",
-                fixes_applied=("Merged overlapping import edits",),
-                warnings_for_next_level=("Verify shared.py integration paths",),
-                duration_seconds=1.5,
-                session_id="coord-session-1",
-                session_scope_id="level_1_coordinator",
-                session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
-                final_output=(
-                    '{"review_summary":"Resolved shared.py conflict",'
-                    '"fixes_applied":["Merged overlapping import edits"],'
-                    '"warnings_for_next_level":["Verify shared.py integration paths"],'
-                    '"conflicts_resolved":["src/shared.py"]}'
-                ),
-                messages=(
-                    AgentMessage(
-                        type="assistant",
-                        content="Inspecting shared file",
-                        tool_name="Read",
-                        data={"tool_input": {"file_path": "src/shared.py"}},
-                    ),
-                    AgentMessage(
-                        type="assistant",
-                        content="Reconciling overlap",
-                        data={"thinking": "Merge the import changes without changing behavior."},
-                    ),
-                ),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
@@ -10982,7 +10983,10 @@ class TestParallelACExecutor:
         )
 
     @pytest.mark.asyncio
-    async def test_returns_reconciled_level_contexts_for_retry_handoff(self) -> None:
+    async def test_returns_reconciled_level_contexts_for_retry_handoff(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Completed stage contexts should be returned for retry workspace handoff."""
         seed = _make_seed(
             "Land the shared runtime update",
@@ -10995,17 +10999,20 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            review_summary="Reconciled shared workspace",
+            fixes_applied=("Merged shared.py edits",),
+            warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                review_summary="Reconciled shared workspace",
-                fixes_applied=("Merged shared.py edits",),
-                warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -134,7 +134,7 @@ class TestDispatchRateGate:
         await executor._await_dispatch_rate_budget(prompt="hello", system_prompt=None)
 
     @pytest.mark.asyncio
-    async def test_await_dispatch_rate_budget_paces_through_active_gate(
+    async def test_await_dispatch_rate_budget_rejects_postconstruction_gate_semantic_drift(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
@@ -142,8 +142,10 @@ class TestDispatchRateGate:
         adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
         executor = _make_rate_gate_executor(adapter)
 
-        # Keep the authority-bound gate object and direct callable intact, but
-        # give its mutable clock/sleep state deterministic test doubles.
+        # Replacing behavior-changing collaborators after construction is no
+        # longer a valid deterministic-test seam: the authority guard must
+        # reject it before rate admission. RateLimitGate itself owns separate
+        # deterministic timing tests with injected collaborators at creation.
         clock = {"now": 0.0}
         slept: list[float] = []
 
@@ -155,10 +157,10 @@ class TestDispatchRateGate:
         executor._dispatch_rate_gate._sleep = fake_sleep
         executor._dispatch_rate_gate._heartbeat_seconds = 120.0
 
-        await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
-        await executor._await_dispatch_rate_budget(prompt="b", system_prompt=None)
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
 
-        assert slept == [60.0]  # second dispatch waited a full window
+        assert slept == []
 
 
 def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ACExecutionResult,
     ParallelACExecutor,
 )
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 class _AtomicDecompositionRuntime:
@@ -66,7 +67,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
     depth: int,
 ) -> None:
     """Nested AC execution should stop recursing once decomposition returns ATOMIC."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -81,7 +82,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             reasons=("explicit_atomic",),
         )
     )
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         return_value=ACExecutionResult(
             ac_index=depth + 1,
             ac_content=f"Atomic at depth {depth}",
@@ -90,31 +91,27 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             depth=depth,
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=depth + 1,
-            ac_content=f"Atomic at depth {depth}",
-            session_id=f"sess_atomic_depth_{depth}",
-            tools=["Read"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Preserve ATOMIC termination",
-            depth=depth,
-            execution_id=f"exec_atomic_depth_{depth}",
-        )
+    result = await executor._execute_single_ac(
+        ac_index=depth + 1,
+        ac_content=f"Atomic at depth {depth}",
+        session_id=f"sess_atomic_depth_{depth}",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Preserve ATOMIC termination",
+        depth=depth,
+        execution_id=f"exec_atomic_depth_{depth}",
+    )
 
     assert result.success is True
     assert result.is_decomposed is False
     assert result.depth == depth
     executor._try_decompose_ac.assert_awaited_once()
-    executor._execute_atomic_ac.assert_awaited_once()
-    assert len(execute_single_ac_spy.await_args_list) == 1
-    assert execute_single_ac_spy.await_args.kwargs["depth"] == depth
+    execute_atomic_ac.assert_awaited_once()
+    assert [call["depth"] for call in executor._test_single_ac_calls] == [depth]
 
 
 class _CapturingDecompositionRuntime:

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, ExecutionStage, S
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
 from ouroboros.orchestrator.verifier import RetryAdmission, VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def _failed_result(*, failure_class: str = "SCOPE_CREEP") -> ACExecutionResult:
@@ -65,8 +66,8 @@ def _trusted_split(node_id: str) -> DecompositionDecisionRecord:
     )
 
 
-def _executor(*, max_depth: int = 3) -> ParallelACExecutor:
-    return ParallelACExecutor(
+def _executor(*, max_depth: int = 3) -> ProcessLocalTestExecutor:
+    return ProcessLocalTestExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -263,7 +264,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-restored", ac_index=0)
     executor._decomposition_decisions[node.node_id] = _trusted_split(node.node_id)
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         side_effect=lambda **kwargs: ACExecutionResult(
             ac_index=kwargs["ac_index"],
             ac_content=kwargs["ac_content"],
@@ -271,6 +272,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
             depth=kwargs["depth"],
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
     executor._try_decompose_ac = AsyncMock()
     executor._request_bounce_classification = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
@@ -288,7 +290,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     )
 
     assert result.is_decomposed is True
-    assert executor._execute_atomic_ac.await_count == 2
+    assert execute_atomic_ac.await_count == 2
     executor._try_decompose_ac.assert_not_awaited()
     executor._request_bounce_classification.assert_not_awaited()
 

--- a/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
+++ b/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ouroboros.core.seed import AcceptanceCriterionSpec, InvestmentSpec
-from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 @pytest.mark.asyncio
 async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic() -> None:
     """Composite ACs should keep recursing until the soft depth safety net is reached."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -41,7 +42,9 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             depth=int(kwargs["depth"]),
         )
 
-    executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
     investment = InvestmentSpec(
         difficulty="high",
         stakes="high",
@@ -54,24 +57,19 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         investment=investment,
     )
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=1,
-            ac_content="Root composite AC",
-            session_id="sess_recursive_depth",
-            tools=["Read", "Edit"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Support recursive decomposition",
-            depth=0,
-            execution_id="exec_recursive_depth",
-            ac_spec=parent_spec,
-            investment_spec=investment,
-        )
+    result = await executor._execute_single_ac(
+        ac_index=1,
+        ac_content="Root composite AC",
+        session_id="sess_recursive_depth",
+        tools=["Read", "Edit"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Support recursive decomposition",
+        depth=0,
+        execution_id="exec_recursive_depth",
+        ac_spec=parent_spec,
+        investment_spec=investment,
+    )
 
     assert result.success is True
     assert result.is_decomposed is True
@@ -95,11 +93,11 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
 
     assert [
         (
-            int(call.kwargs["ac_index"]),
-            str(call.kwargs["ac_content"]),
-            int(call.kwargs["depth"]),
+            int(call["ac_index"]),
+            str(call["ac_content"]),
+            int(call["depth"]),
         )
-        for call in execute_single_ac_spy.await_args_list
+        for call in executor._test_single_ac_calls
     ] == [
         (1, "Root composite AC", 0),
         (100, "Composite depth 1", 1),
@@ -112,7 +110,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
     assert executor._try_decompose_ac.await_count == 5
     assert [
         (int(call.kwargs["ac_index"]), int(call.kwargs["depth"]))
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (1000000, 3),
         (1000001, 3),
@@ -120,8 +118,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (101, 1),
     ]
     assert [
-        call.kwargs["node_identity"].display_path
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["node_identity"].display_path for call in execute_atomic_ac.await_args_list
     ] == [
         "2.1.1.1",
         "2.1.1.2",
@@ -133,7 +130,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             call.kwargs["parent_ac_index"],
             call.kwargs["sub_ac_index"],
         )
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (None, None),
         (None, None),
@@ -141,9 +138,6 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (1, 1),
     ]
     assert all(
-        call.kwargs["investment_spec"] is investment
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["investment_spec"] is investment for call in execute_atomic_ac.await_args_list
     )
-    assert all(
-        call.kwargs["ac_spec"] is None for call in executor._execute_atomic_ac.await_args_list
-    )
+    assert all(call.kwargs["ac_spec"] is None for call in execute_atomic_ac.await_args_list)

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -527,6 +527,48 @@ class TestShadowReplayHarness:
         assert data["is_decomposed_child"] is True
 
     @pytest.mark.asyncio
+    async def test_verifier_entry_drift_stops_shadow_replay_before_baseline_effect(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = MagicMock()
+        monkeypatch.setattr("ouroboros.orchestrator.runtime_factory.create_agent_runtime", factory)
+        store, events = _capturing_event_store()
+        executor = _executor_with_router(task_cwd=str(tmp_path), store=store)
+        injected = False
+
+        def injected_verifier(**_: object) -> object:
+            nonlocal injected
+            injected = True
+            return object()
+
+        monkeypatch.setattr(
+            ParallelACExecutor,
+            "_run_atomic_verifier_pass",
+            injected_verifier,
+        )
+
+        with isolated_workspace(str(tmp_path)) as isolated_cwd:
+            assert isolated_cwd is not None
+            await run_shadow_replay(
+                executor,
+                runtime_identity=_identity(),
+                execution_id="exec_frugal",
+                session_id="sess",
+                ac_index=1,
+                is_sub_ac=True,
+                prompt="do the thing",
+                system_prompt="system",
+                tools=["Read"],
+                decomposition_trustworthy=True,
+                ac_content="Implement a thing",
+                isolated_cwd=isolated_cwd,
+            )
+
+        factory.assert_not_called()
+        assert injected is False
+        assert _shadow_events(events) == []
+
+    @pytest.mark.asyncio
     async def test_runtime_without_strict_isolation_contract_is_never_executed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- define a finite, versioned Foundation A execution-authority boundary instead of deriving portable authority from arbitrary Python callable graphs
- bind the closed executor, dispatcher, coordinator, rate-gate, workspace, runtime descriptor, static policy, and built-in verifier components
- capture the five internal effect-entry roots at construction; post-construction class/code/instance drift fails closed before an effect
- make custom verifiers, subclasses, nonstandard constructor-time entries, and volatile collaborators explicitly process-local
- document the portable/per-attempt/volatile component matrix and adversarial exit criteria

## Scope

This is an identity-only Foundation A baseline. It does not authorize dispatch reuse, result/checkpoint/trust reuse, routing, or final acceptance. Foundation B remains locked pending an explicit `APPROVED` review of this PR.

## Validation

- `pytest -q tests/unit/orchestrator` — 3066 passed, 2 skipped
- focused authority/executor/decomposition suite — 355 passed
- Ruff check and format check
- `mypy src/ouroboros` — 467 source files, no issues
- `git diff --check`

## Review request

Please review exact head `6b14222c2689da1cf23b767802ec5066838d43b0` only. In particular, assess the finite component table and the captured-entry fail-closed behavior; do not infer portable authority from custom Python behavior.

Refs #1681