### PR TITLE
feat(orchestrator): establish process-local execution authority

### DIFF
--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -46,12 +46,20 @@ globals, modules, environment maps, handler maps, cache contents, or opaque
 objects. Credential-shaped values are never serialized; they force the owning
 component to process-local.
 
-Every process-local component receives an opaque random nonce once per
-**authority generation**. `ExecutionAuthorityLiveBinding` retains that nonce
-for its same-instance integrity rechecks; a new executor/runtime capture gets a
-new nonce. Two instances may have similar visible configuration, but they
-cannot compare as a portable authority or accidentally authorize cross-process
-reuse.
+Every dynamically or unsafely identified process-local component receives an
+opaque random nonce once per **authority generation**.
+`ExecutionAuthorityLiveBinding` retains that nonce for its same-instance
+integrity rechecks; a new executor/runtime capture gets a new nonce. Two
+instances may have similar visible configuration, but they cannot compare as a
+portable authority or accidentally authorize cross-process reuse.
+
+More precisely, a nonce is attached to each component whose own identity is
+dynamic, unsafe, or otherwise not canonically observable. A valid declarative
+workspace or policy descriptor need not receive a separate nonce merely because
+another component makes the *whole* authority process-local. In Foundation A
+every current runtime is such a component, so its live nonce makes the complete
+authority generation process-local even when the workspace and policy retain
+their finite declarative descriptors.
 
 An authority generation additionally has a non-serializable live capability
 held in the process-local registry by session id. The persisted event contract
@@ -135,6 +143,12 @@ runtime-owned dynamic collaborator. If a `process_local` session has no live
 capability, resume terminates with a typed `process_local_resume_unavailable`
 outcome and an operator must start a new attempt; it must never silently fall
 back to a stale session, a cached pass, or a newly computed runtime descriptor.
+
+This is also a deployment boundary: a one-shot detached worker may retain an
+owner while it remains alive, but its handler-local runner and capability leave
+with that worker. A later request handled by a different worker therefore
+returns `process_local_resume_unavailable`; it is not a durable-resume path and
+must not attempt to recreate the prior owner from its stored correlation data.
 
 For a new process-local session, the runner validates/allocates the session id,
 registers the registry-minted capability, and acquires its PID-and-boot-time

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -1,0 +1,246 @@
+# AC Runtime Execution Authority Boundary
+
+## Status
+
+Proposed Foundation A replacement for the closed implementation PRs #1682,
+#1704, and #1705. This document deliberately selects the conservative first
+boundary: every currently supported CLI runtime is executable **only within
+its creating process**. No existing CLI runtime can claim portable execution
+identity until it is rebuilt around the sealed kernel described below.
+
+Foundation A is identity-only. It does not authorize result reuse, checkpoint
+reuse, trust reuse, dispatch, routing, acceptance, or cross-run learning.
+
+## Problem
+
+The prior designs tried to promote `CodexCliRuntime` to portable identity by
+binding its public `execute_task` method and an expanding set of configuration
+fields. That is not a finite effect boundary: the unchanged public method
+dynamically resolves `_execute_task_impl`, command builders, event handlers,
+local skill/MCP handlers, process hooks, and caches. Binding each newly found
+helper would turn Foundation A back into an unbounded inspection of a Python
+object graph.
+
+Consequently, an unchanged public `execute_task` could dispatch a changed
+post-construction helper while the contract was still marked portable. A
+portable claim made under those conditions is false and must not be an input to
+later reuse or acceptance decisions.
+
+## Foundation A contract
+
+`ExecutionAuthorityContract` is a canonical, digest-only snapshot with these
+components:
+
+| Component | Portable treatment | Process-local treatment |
+| --- | --- | --- |
+| Executor policy | Closed versioned declarative values owned by the executor | Invalid/unknown values add a live-instance nonce |
+| Workspace | Canonical workspace identity; a future portable kernel must also bind an immutable workspace generation | Missing/unsafe identity or a missing future generation adds a nonce |
+| Built-in verifier | Closed implementation version and declarative configuration | Custom, dynamic, or unsafe verifier adds a nonce |
+| Runtime | **No legacy CLI runtime is portable in Foundation A** | Runtime type and all runtime execution behavior are scoped to one live instance |
+| Prompt, AC, tool list, model override, effort, session/handle, checkpoint | Excluded; attempt input | Excluded; Foundation C owns it |
+| Event store, queues, locks, signal hubs, local handler caches, globals, closures, monkeypatches | Excluded | Live process state |
+
+The canonical JSON contains only safe, finite declarative values or their
+digests. It never recursively hashes callables, closures, descriptors,
+globals, modules, environment maps, handler maps, cache contents, or opaque
+objects. Credential-shaped values are never serialized; they force the owning
+component to process-local.
+
+Every process-local component receives an opaque random nonce once per
+**authority generation**. `ExecutionAuthorityLiveBinding` retains that nonce
+for its same-instance integrity rechecks; a new executor/runtime capture gets a
+new nonce. Two instances may have similar visible configuration, but they
+cannot compare as a portable authority or accidentally authorize cross-process
+reuse.
+
+An authority generation additionally has a non-serializable live capability
+held in the process-local registry by session id. The persisted event contract
+may record `scope: "process_local"` and a correlation id, but never contains
+that capability. Deserializing the correlation id in another process is
+evidence only: it cannot recreate the capability or authorize an effect.
+
+The registry alone mints generations and accepts registrations; it exposes no
+public "register this correlation id" or caller-constructed capability path.
+It records the exact minted object and its creating PID. After `fork`, the
+child replaces the registry state and lock, so inherited memory cannot act as
+a parent capability and cannot deadlock on a lock held by a vanished parent
+thread. A child must create a fresh authority generation for a fresh attempt.
+
+`portable_across_processes` is an identity-stability predicate only. It is
+false for every current CLI runtime. There is no
+`reusable_across_processes` alias: reuse is a later, separately authorized
+decision in Foundation C and the Final Gate.
+
+## Runtime rule
+
+`CodexCliRuntime`, `CopilotCliRuntime`, `ZcodeCLIRuntime`, and every custom or
+subclassed runtime remain fully executable. Their dynamic helpers, local skill
+interception, MCP-handler caches, profile loaders, environment reads, launcher
+chains, and resume recovery hooks are normal live-process behavior, not a
+portable authority declaration.
+
+Foundation A must not call a runtime's dynamic identity provider while
+constructing a portable witness. A runtime may expose a descriptor for logging
+or same-process diagnostics, but that descriptor cannot upgrade its stability.
+
+The supported legacy runtime catalog is the factory's complete set: Codex,
+OpenCode, Hermes, Gemini, Antigravity, Grok, Kiro, Copilot, Goose, Pi, GJC,
+Zcode, and all custom/subclassed adapters. Tests enumerate that catalog rather
+than relying on a prose list.
+
+The executor may still capture its own fixed entry functions to prevent an
+accidental internal dispatch through a replaced executor method. That is a
+local integrity check, not a proof that an arbitrary runtime's whole Python
+implementation is portable.
+
+## Future portable runtime: sealed execution kernel
+
+A future, separate proposal may admit one portable runtime only by introducing
+an explicit `SealedExecutionKernel`. It must not wrap or call the legacy
+runtime's dynamically resolved `self._...` helpers on the portable path.
+
+Its finite data and collaborators must be:
+
+1. an immutable `LaunchSpec` containing the canonical executable chain,
+   working directory, allowed child-environment snapshot, permissions, fixed
+   timeouts, and bounded process policy;
+2. a fixed parser/normalizer implementation table whose functions are captured
+   at kernel construction and invoked directly;
+3. a direct subprocess launcher collaborator captured at construction;
+4. no local skill interception, mutable MCP handler cache, session-signal hub,
+   arbitrary callback, or dynamic profile/config lookup on the portable path;
+5. a versioned closed implementation identifier, with reviewed source changes
+   requiring a version bump; and
+6. an immutable settled-workspace generation/snapshot, rather than a path-only
+   workspace identity; and
+7. a live guard that validates the kernel object and its exact finite
+   collaborators before it produces an executor-owned effect.
+
+Local interception and any unsupported configuration must route to the legacy
+process-local runtime instead. The sealed kernel is deliberately deferred; it
+is not simulated by a long allowlist of legacy helper methods.
+
+## Consumer rules
+
+Foundation B may attach an authority fingerprint to attempt and final-acceptance
+events as diagnostic attribution, but a process-local fingerprint or correlation
+id must never be used as an event-deduplication key, replay/idempotency key,
+trust key, reusable-result key, or final-acceptance key. Foundation B's
+replay-safe final event will have its own authority-generation semantics.
+
+The runner records the authority scope when a new run starts. On resume it must
+check the live generation capability **before** looking up
+`execution_identity_contract`, a resume-selector provider, or any other
+runtime-owned dynamic collaborator. If a `process_local` session has no live
+capability, resume terminates with a typed `process_local_resume_unavailable`
+outcome and an operator must start a new attempt; it must never silently fall
+back to a stale session, a cached pass, or a newly computed runtime descriptor.
+
+For a new process-local session, the runner validates/allocates the session id,
+registers the registry-minted capability, and acquires its PID-and-boot-time
+liveness lease **before** it persists the durable `RUNNING` tracker. If either
+registration or lease acquisition fails, no `RUNNING` tracker is published.
+The lease is liveness evidence only; it never transfers or reconstructs the
+opaque authority capability.
+
+Effectful execution atomically claims the live session capability. A second
+same-process caller receives `process_local_execution_in_progress` and must
+not terminalize or retire the original caller. `PAUSED` releases **only** that
+exclusive claim: its registry registration/capability and liveness lease remain
+held by the original owner. Terminal, cancellation, and setup-abort paths retire
+the registration, issuance, claim, and owned lease together.
+
+On a valid process-local resume, a foreign runner or observer must treat either
+a live registry registration or a live liveness lease as an active owner and
+return the non-terminal typed block
+`process_local_authority_held_elsewhere`. It produces the terminal
+`process_local_resume_unavailable` result only when **both** the matching
+registry registration and liveness lease are absent. This distinguishes an
+active process from a crashed/exited owner without treating a lock as portable
+authority.
+
+The MCP handler retains a paused process-local owner strongly. A same-handler
+resume selects the exact retained runner, adapter, and handler-owned
+`EventStore`; it does not reconstruct a fresh runtime or capability from the
+persisted correlation id. Because pausing releases the task-worktree lock, the
+handler restores that exact workspace and reacquires its lock before the
+retained runner resumes. The retained event store stays open while paused and
+is closed only after that runner reaches a terminal state.
+
+New process-local session ids must pass the canonical safe-id validation before
+registration or lease acquisition. For an old/corrupt persisted id that is not
+safe, heartbeat observers derive a containment-safe hashed lookup filename;
+they do not use the raw value as a path and cannot register it as a new
+authority. Heartbeat observers never delete stale or malformed lease records:
+their read is non-atomic, and removal could race with a new holder. Such a
+record simply cannot prove liveness.
+
+Contracts created before this schema have no Foundation A authority scope. They
+are not migrated into the new authority model: a runner that cannot prove a
+same-process generation rejects their resume explicitly. This is a deliberate
+fail-closed migration rule, not a claim that old persisted runtime descriptors
+were portable.
+
+Foundation C may support same-process capsule continuation for a process-local
+generation. Cross-process fresh-session continuation is locked behind the
+sealed-kernel prerequisite: until that kernel is approved, a process restart
+produces the explicit terminal/new-attempt path above. A later C sub-slice may
+enable cross-process continuation only when every component is portable and its
+capsule contract is independently valid.
+
+## Exit matrix
+
+The Foundation A implementation must demonstrate all of the following:
+
+1. exact current CLI runtimes, their subclasses, custom runtimes, custom
+   verifiers, local skill dispatch, local handler caches, and signal hubs are
+   process-local;
+2. changing `_execute_task_impl`, `_build_command`, a local handler cache, or
+   `execution_identity_contract` after capture never leaves a runtime marked
+   portable;
+3. no runtime descriptor, credential-shaped value, callable closure/global, or
+   cache contents appear in canonical authority JSON;
+4. two process-local runtime captures receive distinct fingerprints even when
+   configured alike, while a live binding retains its captured nonce for a
+   same-instance recheck;
+5. workspace, built-in verifier, and closed executor-policy divergence change
+   the identity; malformed or unsafe values fail closed to process-local;
+6. executor-owned fixed entry-root drift is rejected before its next owned
+   effect, while runtime helper drift is explicitly outside the portable
+   guarantee; and
+7. no public Foundation A API says or implies that a portable identity grants
+   reuse, dispatch, result, checkpoint, trust, routing, or final acceptance.
+8. a new run registers its non-serializable generation capability; same-process
+   resume retains it, while a reconstructed process-local contract without that
+   capability rejects before any dynamic runtime identity or resume-selector
+   provider is invoked;
+9. a correlation id, forged or deserialized generation, or forked child cannot
+   register a live authority; issuance and registration are registry-private
+   and PID-bound;
+10. only one caller may hold an effectful claim for a session, while a second
+    caller fails non-terminally and a live `RUNNING` holder is never
+    terminalized by an observer;
+11. a `RUNNING` tracker whose registry capability and liveness lease have both
+    disappeared takes the explicit terminal/new-attempt path;
+12. process-local authority data is attribution only and cannot be used by an
+    attempt/final-event reducer as a dedupe, replay, trust, or acceptance key;
+    and
+13. every runtime-factory backend and a subclass/custom adapter are classified
+    process-local, the boundary matrix lists `legacy_runtime_descriptor` only
+    under `process_local`, and legacy persisted contracts without the new scope
+    marker take the explicit fail-closed migration path.
+14. registry registration and the held liveness lease precede durable `RUNNING`
+    persistence; a failed lease acquisition rolls the registration back without
+    publishing a recoverable-looking session;
+15. `PAUSED` releases only the effect claim, and the same handler's retained
+    runner/adapter/EventStore resumes only after it has reacquired the paused
+    worktree lock; a concurrent or foreign resume returns a typed non-terminal
+    result without calling `mark_failed`; and
+16. heartbeat lookup is contained for unsafe legacy ids, while observers retain
+    stale/malformed lease files rather than deleting liveness evidence they did
+    not own.
+
+This exit matrix is intentionally narrower than an arbitrary-code sandbox and
+broader than a cosmetic fingerprint: it makes the only cross-process claim
+that Foundation A can currently prove, which is that it makes no such claim
+for legacy dynamic runtimes.

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -847,9 +847,35 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             result = await session_repo.reconstruct_session(tracker.session_id)
         except Exception:
             result = None
-        if result is not None and result.is_ok and result.value.status == SessionStatus.PAUSED:
-            self._remember_process_local_owner(result.value, runner)
+        terminal_record_observed = False
+        if result is not None and result.is_ok:
+            status = result.value.status
+            if status == SessionStatus.PAUSED:
+                self._remember_process_local_owner(result.value, runner)
+                if self._process_local_resume_owners.get(tracker.session_id) is runner:
+                    return True, None
+            elif status in (
+                SessionStatus.COMPLETED,
+                SessionStatus.CANCELLED,
+                SessionStatus.FAILED,
+            ):
+                # An explicit terminal record is the one durable observation
+                # that may evict a retained owner while its handler unwinds.
+                terminal_record_observed = True
+
+        raw_contract = tracker.progress.get("execution_contract")
+        # Read errors, Result.err, and RUNNING (or a future nonterminal state)
+        # are inconclusive during post-run reconciliation. Preserve the owner
+        # only while its opaque capability still proves it is live. A durable
+        # terminal record is intentionally the one exception.
+        if not terminal_record_observed and runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            self._remember_process_local_owner(tracker, runner)
             return self._process_local_resume_owners.get(tracker.session_id) is runner, None
+
         owned_event_store: EventStore | None = None
         if self._process_local_resume_owners.get(tracker.session_id) is runner:
             self._process_local_resume_owners.pop(tracker.session_id, None)

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -74,6 +74,11 @@ from ouroboros.orchestrator.adapter import (
     DELEGATED_PARENT_TRANSCRIPT_PATH_ARG,
     RuntimeHandle,
 )
+from ouroboros.orchestrator.execution_authority import (
+    _has_live_process_local_authority_registration,
+    valid_process_local_authority_contract,
+)
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.model_routing import tier_from_model_tier_arg
 from ouroboros.orchestrator.runner import OrchestratorRunner
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
@@ -82,6 +87,72 @@ from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
+
+
+_NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS = frozenset(
+    {
+        "process_local_execution_in_progress",
+        "process_local_authority_held_elsewhere",
+        "session_not_paused",
+    }
+)
+
+
+def _is_nonterminal_process_local_resume_error(error: object) -> bool:
+    """Return whether a runner error intentionally leaves its session live.
+
+    A process-local owner may be running in another adapter or process.  The
+    runner reports that as a typed non-terminal rejection; the background MCP
+    wrapper must preserve it rather than immediately writing ``mark_failed``
+    and undoing the runner's liveness protection.
+    """
+    details = getattr(error, "details", None)
+    return isinstance(details, Mapping) and (
+        details.get("resume_blocked") in _NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS
+    )
+
+
+def _process_local_authority_is_held_elsewhere(tracker: SessionTracker) -> bool:
+    """Check non-owning handler preflight before it touches a task worktree.
+
+    A handler can only resume a process-local session through its retained exact
+    runner.  If this handler has no such owner but the registry or PID lease is
+    still live, fail with the typed ownership result before a task-worktree lock
+    can obscure the authority outcome with a generic workspace error.
+    """
+    raw_contract = tracker.progress.get("execution_contract")
+    if not isinstance(raw_contract, Mapping):
+        return False
+    authority = raw_contract.get("foundation_a_authority")
+    if not valid_process_local_authority_contract(authority):
+        return False
+    return _has_live_process_local_authority_registration(
+        tracker.session_id,
+        tracker.execution_id,
+        authority,
+    ) or is_holder_alive(tracker.session_id)
+
+
+def _process_local_resume_block_error(
+    tracker: SessionTracker,
+    *,
+    resume_blocked: str,
+) -> MCPToolError:
+    """Build a typed, retryable MCP result for a live process-local owner."""
+    if resume_blocked == "process_local_execution_in_progress":
+        message = "This process-local session is already being resumed"
+    else:
+        message = "This process-local session is held by another live owner"
+    return MCPToolError(
+        message,
+        tool_name="ouroboros_execute_seed",
+        is_retriable=True,
+        details={
+            "session_id": tracker.session_id,
+            "execution_id": tracker.execution_id,
+            "resume_blocked": resume_blocked,
+        },
+    )
 
 
 def _resolve_execution_model(runtime_backend: str | None) -> str | None:
@@ -673,6 +744,120 @@ class ExecuteSeedHandler(BridgeAwareMixin):
     opencode_mode: str | None = field(default=None, repr=False)
     session_signal_hub: Any | None = field(default=None, repr=False)
     _background_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
+    _process_local_resume_owners: dict[str, OrchestratorRunner] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _process_local_owned_event_stores: dict[str, EventStore] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _process_local_resume_handoffs: set[str] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
+
+    async def _retained_process_local_owner(
+        self,
+        tracker: SessionTracker,
+    ) -> OrchestratorRunner | None:
+        """Return the exact in-memory runner that still owns a paused session.
+
+        This is an opaque owner handoff, not authority reconstruction: the
+        original runner retains the registry-minted capability and still has to
+        claim it before doing effects. A fresh MCP request may select that
+        retained object, but can never manufacture a runner, adapter, or
+        capability from durable correlation data.
+        """
+        owner = self._process_local_resume_owners.get(tracker.session_id)
+        if owner is None:
+            return None
+        raw_contract = tracker.progress.get("execution_contract")
+        if owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            return owner
+        owned_event_store: EventStore | None = None
+        if self._process_local_resume_owners.get(tracker.session_id) is owner:
+            self._process_local_resume_owners.pop(tracker.session_id, None)
+            owned_event_store = self._process_local_owned_event_stores.pop(
+                tracker.session_id,
+                None,
+            )
+        if owned_event_store is not None:
+            # The capability is already gone, so no terminal resume path can
+            # reach this handler-owned store. Close it here rather than losing
+            # the only reference while evicting the stale retained owner.
+            try:
+                close_result = owned_event_store.close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+            except Exception:
+                log.exception("mcp.tool.execute_seed.event_store_close_error")
+        return None
+
+    def _begin_process_local_resume_handoff(self, session_id: str) -> bool:
+        """Reserve same-handler worktree restoration for one retained owner."""
+        if session_id in self._process_local_resume_handoffs:
+            return False
+        self._process_local_resume_handoffs.add(session_id)
+        return True
+
+    def _finish_process_local_resume_handoff(self, session_id: str) -> None:
+        """Release the handler-local pre-resume gate after the runner settles."""
+        self._process_local_resume_handoffs.discard(session_id)
+
+    def _remember_process_local_owner(
+        self,
+        tracker: SessionTracker,
+        runner: OrchestratorRunner,
+        *,
+        owned_event_store: EventStore | None = None,
+    ) -> None:
+        """Keep a callable owner alive while its process-local lease is live."""
+        raw_contract = tracker.progress.get("execution_contract")
+        if runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            self._process_local_resume_owners[tracker.session_id] = runner
+            if owned_event_store is not None:
+                self._process_local_owned_event_stores[tracker.session_id] = owned_event_store
+
+    async def _reconcile_process_local_owner(
+        self,
+        *,
+        tracker: SessionTracker,
+        runner: OrchestratorRunner,
+        session_repo: SessionRepository,
+    ) -> tuple[bool, EventStore | None]:
+        """Retain a paused owner or release a terminal owner after a run.
+
+        Returns whether the runner remains retained and, only for a terminal
+        result, an internally owned store that can be closed after the caller
+        no longer needs it.
+        """
+        try:
+            result = await session_repo.reconstruct_session(tracker.session_id)
+        except Exception:
+            result = None
+        if result is not None and result.is_ok and result.value.status == SessionStatus.PAUSED:
+            self._remember_process_local_owner(result.value, runner)
+            return self._process_local_resume_owners.get(tracker.session_id) is runner, None
+        owned_event_store: EventStore | None = None
+        if self._process_local_resume_owners.get(tracker.session_id) is runner:
+            self._process_local_resume_owners.pop(tracker.session_id, None)
+            owned_event_store = self._process_local_owned_event_stores.pop(
+                tracker.session_id,
+                None,
+            )
+        return False, owned_event_store
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -1001,7 +1186,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             workspace: TaskWorkspace | None = None
             tracker = None
             launched = False
+            retained_after_run = False
+            retained_event_store_to_close: EventStore | None = None
             use_worktree = bool(arguments.get("use_worktree", True))
+            retained_owner: OrchestratorRunner | None = None
+            retained_resume_handoff = False
 
             try:
                 if is_resume and session_id:
@@ -1034,6 +1223,30 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 tool_name="ouroboros_execute_seed",
                             )
                         )
+                    retained_owner = await self._retained_process_local_owner(tracker)
+                    if retained_owner is not None:
+                        # Reserve this exact handler's pre-resume workspace handoff
+                        # before touching the worktree. Without this gate a second
+                        # same-handler resume can surface a generic lock error ahead
+                        # of the process-local exclusive-claim result.
+                        if not self._begin_process_local_resume_handoff(tracker.session_id):
+                            return Result.err(
+                                _process_local_resume_block_error(
+                                    tracker,
+                                    resume_blocked="process_local_execution_in_progress",
+                                )
+                            )
+                        retained_resume_handoff = True
+                    elif _process_local_authority_is_held_elsewhere(tracker):
+                        # This handler has no exact retained owner. Do not let a
+                        # foreign process-local capability fail later as a generic
+                        # worktree collision or create a fresh runtime first.
+                        return Result.err(
+                            _process_local_resume_block_error(
+                                tracker,
+                                resume_blocked="process_local_authority_held_elsewhere",
+                            )
+                        )
                     if use_worktree:
                         persisted = TaskWorkspace.from_progress_dict(
                             tracker.progress.get("workspace")
@@ -1052,6 +1265,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                     tool_name="ouroboros_execute_seed",
                                 )
                             )
+                        if retained_owner is not None:
+                            # The paused run releases its worktree lock. Restore
+                            # that exact workspace before resuming through the
+                            # retained runner so its resume identity check and
+                            # its next effect use a freshly held task lock.
+                            retained_owner._task_workspace = workspace
                 elif use_worktree:
                     try:
                         workspace = maybe_prepare_task_workspace(
@@ -1067,24 +1286,81 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
 
-                delegated_permission_mode = (
-                    inherited_runtime_handle.approval_mode
-                    if inherited_runtime_handle and inherited_runtime_handle.approval_mode
-                    else None
-                )
-                agent_adapter = create_agent_runtime(
-                    backend=self.agent_runtime_backend,
-                    model=_resolve_execution_model(self.agent_runtime_backend),
-                    cwd=Path(workspace.effective_cwd) if workspace else resolved_cwd,
-                    llm_backend=self.llm_backend,
-                    startup_output_timeout_seconds=0,
-                    stdout_idle_timeout_seconds=0,
-                    **(
-                        {"permission_mode": delegated_permission_mode}
-                        if delegated_permission_mode
-                        else {}
-                    ),
-                )
+                if retained_owner is not None:
+                    # Resume through the exact in-memory runner that owns the
+                    # opaque capability. Do not construct a fresh runtime or
+                    # create a fresh runner: either operation would turn a
+                    # same-process continuation into a foreign-adapter path.
+                    runner = retained_owner
+                    agent_adapter = runner._adapter
+                    if event_store is not runner._event_store:
+                        # A handler without an injected store opened this
+                        # short-lived observer connection solely to reconstruct
+                        # the tracker above. The retained runner's store is the
+                        # one that must survive the paused lifecycle.
+                        if owns_event_store:
+                            close_result = event_store.close()
+                            if inspect.isawaitable(close_result):
+                                await close_result
+                        event_store = runner._event_store
+                        owns_event_store = False
+                    session_repo = runner._session_repo
+                else:
+                    delegated_permission_mode = (
+                        inherited_runtime_handle.approval_mode
+                        if inherited_runtime_handle and inherited_runtime_handle.approval_mode
+                        else None
+                    )
+                    agent_adapter = create_agent_runtime(
+                        backend=self.agent_runtime_backend,
+                        model=_resolve_execution_model(self.agent_runtime_backend),
+                        cwd=Path(workspace.effective_cwd) if workspace else resolved_cwd,
+                        llm_backend=self.llm_backend,
+                        startup_output_timeout_seconds=0,
+                        stdout_idle_timeout_seconds=0,
+                        **(
+                            {"permission_mode": delegated_permission_mode}
+                            if delegated_permission_mode
+                            else {}
+                        ),
+                    )
+
+                    # Create checkpoint store for execution state persistence
+                    checkpoint_store = CheckpointStore()
+                    checkpoint_store.initialize()
+                    fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
+                    if is_resume:
+                        persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
+                        if isinstance(persisted_fat_harness_mode, bool):
+                            fat_harness_mode = persisted_fat_harness_mode
+                        else:
+                            # No persisted contract (historical session): mirror the
+                            # CLI resume semantics — verify-by-default unless the
+                            # seed opts out with execution_mode='legacy'.
+                            fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
+
+                    # Create orchestrator runner
+                    runner = OrchestratorRunner(
+                        adapter=agent_adapter,
+                        event_store=event_store,
+                        console=console,
+                        mcp_manager=self.mcp_manager,
+                        mcp_tool_prefix=self.mcp_tool_prefix,
+                        debug=False,
+                        enable_decomposition=True,
+                        inherited_runtime_handle=inherited_runtime_handle,
+                        inherited_tools=inherited_effective_tools,
+                        task_workspace=workspace,
+                        checkpoint_store=checkpoint_store,
+                        max_parallel_workers=max_parallel_workers,
+                        fat_harness_mode=fat_harness_mode,
+                        # Drive model-tier routing from the MCP model_tier arg
+                        # (small/medium/large → frugal/standard/frontier top-level tier).
+                        base_model_tier=base_model_tier_override,
+                        efficiency_mode=raw_efficiency_mode,
+                        frugality_assurance=raw_frugality_assurance,
+                        session_signal_hub=self.session_signal_hub,
+                    )
                 runtime_backend_attr = getattr(agent_adapter, "runtime_backend", None)
                 if not (isinstance(runtime_backend_attr, str) and runtime_backend_attr):
                     runtime_backend_attr = getattr(agent_adapter, "_runtime_backend", None)
@@ -1092,43 +1368,6 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     runtime_backend_attr
                     if isinstance(runtime_backend_attr, str) and runtime_backend_attr
                     else runtime_backend or "unknown"
-                )
-
-                # Create checkpoint store for execution state persistence
-                checkpoint_store = CheckpointStore()
-                checkpoint_store.initialize()
-                fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
-                if is_resume:
-                    persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
-                    if isinstance(persisted_fat_harness_mode, bool):
-                        fat_harness_mode = persisted_fat_harness_mode
-                    else:
-                        # No persisted contract (historical session): mirror the
-                        # CLI resume semantics — verify-by-default unless the
-                        # seed opts out with execution_mode='legacy'.
-                        fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
-
-                # Create orchestrator runner
-                runner = OrchestratorRunner(
-                    adapter=agent_adapter,
-                    event_store=event_store,
-                    console=console,
-                    mcp_manager=self.mcp_manager,
-                    mcp_tool_prefix=self.mcp_tool_prefix,
-                    debug=False,
-                    enable_decomposition=True,
-                    inherited_runtime_handle=inherited_runtime_handle,
-                    inherited_tools=inherited_effective_tools,
-                    task_workspace=workspace,
-                    checkpoint_store=checkpoint_store,
-                    max_parallel_workers=max_parallel_workers,
-                    fat_harness_mode=fat_harness_mode,
-                    # Drive model-tier routing from the MCP model_tier arg
-                    # (small/medium/large → frugal/standard/frontier top-level tier).
-                    base_model_tier=base_model_tier_override,
-                    efficiency_mode=raw_efficiency_mode,
-                    frugality_assurance=raw_frugality_assurance,
-                    session_signal_hub=self.session_signal_hub,
                 )
 
                 skip_qa = arguments.get("skip_qa", False)
@@ -1146,6 +1385,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
                     tracker = prepared.value
+                    self._remember_process_local_owner(
+                        tracker,
+                        runner,
+                        owned_event_store=event_store if owns_event_store else None,
+                    )
 
                 # Background execution coroutine — either awaited directly
                 # (synchronous=True) or wrapped in create_task (fire-and-forget).
@@ -1160,7 +1404,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     _session_repo: SessionRepository = session_repo,
                     _event_store: EventStore = event_store,
                     _owns_event_store: bool = owns_event_store,
+                    _retained_resume_handoff: bool = retained_resume_handoff,
                 ) -> None:
+                    nonlocal retained_after_run, retained_event_store_to_close
                     try:
                         if _resume_existing:
                             result = await _runner.resume_session(_tracker.session_id, _seed)
@@ -1176,6 +1422,13 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 session_id=_tracker.session_id,
                                 error=str(result.error),
                             )
+                            if _is_nonterminal_process_local_resume_error(result.error):
+                                log.info(
+                                    "mcp.tool.execute_seed.background_nonterminal_resume_block",
+                                    session_id=_tracker.session_id,
+                                    resume_blocked=result.error.details.get("resume_blocked"),
+                                )
+                                return
                             await _session_repo.mark_failed(
                                 _tracker.session_id,
                                 error_message=str(result.error),
@@ -1236,15 +1489,39 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         except Exception:
                             log.exception("mcp.tool.execute_seed.mark_failed_error")
                     finally:
+                        (
+                            retained_after_run,
+                            retained_event_store_to_close,
+                        ) = await self._reconcile_process_local_owner(
+                            tracker=_tracker,
+                            runner=_runner,
+                            session_repo=_session_repo,
+                        )
                         if _workspace is not None:
                             release_lock(_workspace.lock_path)
-                        if _owns_event_store:
+                        if _owns_event_store and not retained_after_run:
                             try:
                                 close_result = _event_store.close()
                                 if inspect.isawaitable(close_result):
                                     await close_result
+                                if retained_event_store_to_close is _event_store:
+                                    retained_event_store_to_close = None
                             except Exception:
                                 log.exception("mcp.tool.execute_seed.event_store_close_error")
+                        if (
+                            retained_event_store_to_close is not None
+                            and not retained_after_run
+                            and not synchronous
+                        ):
+                            try:
+                                close_result = retained_event_store_to_close.close()
+                                if inspect.isawaitable(close_result):
+                                    await close_result
+                                retained_event_store_to_close = None
+                            except Exception:
+                                log.exception("mcp.tool.execute_seed.event_store_close_error")
+                        if _retained_resume_handoff:
+                            self._finish_process_local_resume_handoff(_tracker.session_id)
 
                 session_status: SessionStatus | None = None
                 pause_metadata: dict[str, Any] = {}
@@ -1290,6 +1567,15 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     launched = True
                     self._background_tasks.add(task)
                     task.add_done_callback(self._background_tasks.discard)
+                    if retained_resume_handoff:
+                        # A task cancelled before its coroutine starts will not
+                        # execute the coroutine's ``finally`` block. The discard
+                        # is idempotent and covers that scheduling edge too.
+                        task.add_done_callback(
+                            lambda _task, _session_id=tracker.session_id: (
+                                self._finish_process_local_resume_handoff(_session_id)
+                            )
+                        )
                     status_label = "running"
                     success = None  # unknown yet
                     is_error = False
@@ -1376,13 +1662,24 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # after reconstruct_session has finished using the store.
                 if workspace is not None and (not launched or synchronous):
                     release_lock(workspace.lock_path)
-                if owns_event_store and (not launched or synchronous):
+                if owns_event_store and (not launched or synchronous) and not retained_after_run:
                     try:
                         close_result = event_store.close()
                         if inspect.isawaitable(close_result):
                             await close_result
+                        if retained_event_store_to_close is event_store:
+                            retained_event_store_to_close = None
                     except Exception:
                         log.exception("mcp.tool.execute_seed.event_store_close_error")
+                if retained_event_store_to_close is not None and not retained_after_run:
+                    try:
+                        close_result = retained_event_store_to_close.close()
+                        if inspect.isawaitable(close_result):
+                            await close_result
+                    except Exception:
+                        log.exception("mcp.tool.execute_seed.event_store_close_error")
+                if retained_resume_handoff and (not launched or synchronous):
+                    self._finish_process_local_resume_handoff(tracker.session_id)
         except Exception as e:
             log.error("mcp.tool.execute_seed.error", error=str(e))
             return Result.err(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,0 +1,2074 @@
+"""Finite execution-authority identity for the AC runtime.
+
+Foundation A deliberately identifies a small, explicit component boundary. It
+does not attempt to derive authority from an arbitrary Python callable graph:
+closures, globals, descriptors, module monkeypatches, caches, and runtime
+handles are volatile. A custom verifier can therefore be bound only to its
+exact live object for this process; it is never made portable by introspection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import inspect
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+from threading import RLock
+from typing import Any
+import uuid
+
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
+from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+EXECUTION_AUTHORITY_VERSION = 6
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 6
+
+_MAX_IDENTITY_DEPTH = 8
+_MAX_IDENTITY_ITEMS = 256
+_MAX_IDENTITY_SCALAR_CHARS = 8_192
+_MAX_IDENTITY_JSON_CHARS = 64_000
+_MAX_RUNTIME_EXECUTABLE_BYTES = 64 * 1024 * 1024
+
+# No legacy runtime is a portable implementation in Foundation A.  In
+# particular, a public CLI entry point that dynamically resolves ``self._...``
+# helpers cannot be promoted by adding an ever-growing helper manifest.  A
+# future sealed execution kernel may populate a separate reviewed table, but
+# the current table is intentionally empty.
+_CLOSED_RUNTIME_IMPLEMENTATIONS: dict[type[object], tuple[str, object, object]] = {}
+
+_EXECUTOR_COMPONENT_VERSIONS = {
+    "parallel_ac_executor": "parallel-ac-executor/v2",
+    "leaf_dispatcher": "leaf-dispatcher/v1",
+    "level_coordinator": "level-coordinator/v1",
+    "rate_limit_gate": "rate-limit-gate/v1",
+}
+_BUILTIN_TRANSCRIPT_VERIFIER = "runtime-transcript-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER = "structural-atomic-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER_CODE = structural_atomic_verifier.__code__
+_RATE_GATE_BUCKET_HELPER_NAMES = (
+    "_prune",
+    "_tokens_in_window",
+    "_snapshot",
+    "_request_wait_seconds",
+    "_token_wait_seconds",
+)
+
+
+_PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN = object()
+_SAFE_PROCESS_LOCAL_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
+
+
+class _ProcessLocalAuthorityGeneration:
+    """An opaque, unpickleable capability minted only by the local registry.
+
+    The correlation id is diagnostic data.  It is deliberately insufficient to
+    construct a usable generation: the registry records the exact object that
+    it minted and the PID that minted it.  This is a process-local lifecycle
+    primitive, not a boundary against code that can monkeypatch this module.
+    """
+
+    __slots__ = ("_correlation_id",)
+
+    def __init__(self, construction_token: object, correlation_id: str) -> None:
+        if construction_token is not _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN:
+            raise TypeError("process-local authority generations are registry-minted")
+        self._correlation_id = correlation_id
+
+    @property
+    def correlation_id(self) -> str:
+        """Return a diagnostics-only correlation id."""
+        return self._correlation_id
+
+    def __reduce__(self) -> object:
+        raise TypeError("process-local authority generations cannot be serialized")
+
+    def __copy__(self) -> object:
+        raise TypeError("process-local authority generations cannot be copied")
+
+    def __deepcopy__(self, memo: object) -> object:
+        del memo
+        raise TypeError("process-local authority generations cannot be copied")
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessLocalAuthorityIssuance:
+    """The registry-private mint record used to reject reconstructed objects."""
+
+    generation: _ProcessLocalAuthorityGeneration
+    correlation_id: str
+    creator_pid: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessLocalAuthorityRegistration:
+    """One exact live binding for a process-local session."""
+
+    execution_id: str
+    generation: _ProcessLocalAuthorityGeneration
+    adapter: object
+    creator_pid: int
+
+
+class _ProcessLocalAuthorityRegistry:
+    """Keep opaque Foundation A capabilities in one process and PID epoch."""
+
+    def __init__(self) -> None:
+        self._issued: dict[int, _ProcessLocalAuthorityIssuance] = {}
+        self._registrations: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        self._claims: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        self._lock = RLock()
+
+    @staticmethod
+    def _valid_session_or_execution_id(value: object, *, label: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"process-local authority requires a {label}")
+        if label == "session id" and _SAFE_PROCESS_LOCAL_SESSION_ID.fullmatch(value) is None:
+            raise ValueError("process-local authority requires a canonical safe session id")
+        return value
+
+    def mint(self) -> _ProcessLocalAuthorityGeneration:
+        """Mint an unforgeable-in-this-registry generation for one new run."""
+        generation = _ProcessLocalAuthorityGeneration(
+            _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN,
+            uuid.uuid4().hex,
+        )
+        issuance = _ProcessLocalAuthorityIssuance(
+            generation=generation,
+            correlation_id=generation.correlation_id,
+            creator_pid=os.getpid(),
+        )
+        with self._lock:
+            self._issued[id(generation)] = issuance
+        return generation
+
+    def _is_issued_here(self, generation: object) -> bool:
+        if not isinstance(generation, _ProcessLocalAuthorityGeneration):
+            return False
+        issuance = self._issued.get(id(generation))
+        return (
+            issuance is not None
+            and issuance.generation is generation
+            and issuance.correlation_id == generation.correlation_id
+            and issuance.creator_pid == os.getpid()
+        )
+
+    def contract(self, generation: _ProcessLocalAuthorityGeneration) -> dict[str, object]:
+        """Return persisted correlation data for an issued live generation."""
+        with self._lock:
+            if not self._is_issued_here(generation):
+                raise ValueError("process-local authority generation is not live in this process")
+            return {
+                "version": 1,
+                "scope": "process_local",
+                "correlation_id": generation.correlation_id,
+            }
+
+    def register(
+        self,
+        session_id: str,
+        execution_id: str,
+        generation: _ProcessLocalAuthorityGeneration,
+        adapter: object,
+    ) -> None:
+        """Bind an issued generation to exactly one session and adapter."""
+        session_id = self._valid_session_or_execution_id(session_id, label="session id")
+        execution_id = self._valid_session_or_execution_id(execution_id, label="execution id")
+        with self._lock:
+            if not self._is_issued_here(generation):
+                raise ValueError("process-local authority requires a registry-issued generation")
+            current = self._registrations.get(session_id)
+            registration = _ProcessLocalAuthorityRegistration(
+                execution_id=execution_id,
+                generation=generation,
+                adapter=adapter,
+                creator_pid=os.getpid(),
+            )
+            if current is not None and not (
+                current.execution_id == registration.execution_id
+                and current.generation is registration.generation
+                and current.adapter is registration.adapter
+                and current.creator_pid == registration.creator_pid
+            ):
+                raise ValueError("process-local authority session is already registered")
+            self._registrations[session_id] = registration
+
+    def live_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+        adapter: object,
+    ) -> _ProcessLocalAuthorityGeneration | None:
+        """Return the exact live generation only for this creating process."""
+        if not valid_process_local_authority_contract(value):
+            return None
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return None
+            return entry.generation
+
+    def has_live_registration(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> bool:
+        """Report a live local binding without making it transferable.
+
+        A different adapter in the same PID must not receive the capability,
+        but it also must not mistake the original adapter's live binding for a
+        crashed process and terminalize the persisted session.
+        """
+        if not valid_process_local_authority_contract(value):
+            return False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            return (
+                entry is not None
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+            )
+
+    def claim(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+        adapter: object,
+    ) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+        """Atomically claim one live session for effectful execution.
+
+        The bool reports an already-live authority that is currently claimed.
+        It is intentionally distinct from a missing capability: a concurrent
+        caller must not terminally invalidate the original active session.
+        """
+        if not valid_process_local_authority_contract(value):
+            return None, False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return None, False
+            claim = self._claims.get(session_id)
+            if claim is not None:
+                return None, True
+            self._claims[session_id] = entry
+            return entry.generation, False
+
+    def release(self, session_id: str, execution_id: str, adapter: object) -> None:
+        """Release a paused session's exclusive execution claim."""
+        with self._lock:
+            claim = self._claims.get(session_id)
+            if (
+                claim is not None
+                and claim.creator_pid == os.getpid()
+                and claim.execution_id == execution_id
+                and claim.adapter is adapter
+            ):
+                self._claims.pop(session_id, None)
+
+    def retire(self, session_id: str, execution_id: str, adapter: object) -> bool:
+        """Retire an exact session binding and report whether this owner did it."""
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+            ):
+                return False
+            self._registrations.pop(session_id, None)
+            self._claims.pop(session_id, None)
+            issuance = self._issued.get(id(entry.generation))
+            if issuance is not None and issuance.generation is entry.generation:
+                self._issued.pop(id(entry.generation), None)
+            return True
+
+    def discard(self, generation: _ProcessLocalAuthorityGeneration) -> None:
+        """Discard an unregistered generation after failed session preparation."""
+        with self._lock:
+            issuance = self._issued.get(id(generation))
+            if issuance is not None and issuance.generation is generation:
+                if not any(item.generation is generation for item in self._registrations.values()):
+                    self._issued.pop(id(generation), None)
+
+    def clear_after_fork(self) -> None:
+        """Do not let a fork inherit the parent process's capabilities."""
+        # This hook runs in a post-fork child.  A parent thread may have held
+        # the inherited lock at fork time, so acquiring it here can deadlock
+        # forever because that owner no longer exists in the child.
+        self._issued = {}
+        self._registrations = {}
+        self._claims = {}
+        self._lock = RLock()
+
+
+_PROCESS_LOCAL_AUTHORITY_REGISTRY = _ProcessLocalAuthorityRegistry()
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_PROCESS_LOCAL_AUTHORITY_REGISTRY.clear_after_fork)
+
+
+def _mint_process_local_authority_generation() -> _ProcessLocalAuthorityGeneration:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.mint()
+
+
+def _process_local_authority_contract(
+    generation: _ProcessLocalAuthorityGeneration,
+) -> dict[str, object]:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.contract(generation)
+
+
+def valid_process_local_authority_contract(value: object) -> bool:
+    """Return whether a persisted process-local correlation record is canonical."""
+    return (
+        isinstance(value, Mapping)
+        and set(value) == {"version", "scope", "correlation_id"}
+        and isinstance(value.get("version"), int)
+        and not isinstance(value.get("version"), bool)
+        and value.get("version") == 1
+        and value.get("scope") == "process_local"
+        and isinstance(value.get("correlation_id"), str)
+        and len(value["correlation_id"]) == 32
+        and all(character in "0123456789abcdef" for character in value["correlation_id"])
+    )
+
+
+def _register_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    generation: _ProcessLocalAuthorityGeneration,
+    adapter: object,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.register(session_id, execution_id, generation, adapter)
+
+
+def _live_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    value: object,
+    adapter: object,
+) -> _ProcessLocalAuthorityGeneration | None:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.live_generation(
+        session_id,
+        execution_id,
+        value,
+        adapter,
+    )
+
+
+def _has_live_process_local_authority_registration(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> bool:
+    """Report an in-process binding without exposing its capability object."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.has_live_registration(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
+def _claim_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    value: object,
+    adapter: object,
+) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.claim(
+        session_id,
+        execution_id,
+        value,
+        adapter,
+    )
+
+
+def _release_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    adapter: object,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.release(session_id, execution_id, adapter)
+
+
+def _retire_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    adapter: object,
+) -> bool:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
+
+
+def _discard_process_local_authority_generation(
+    generation: _ProcessLocalAuthorityGeneration,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.discard(generation)
+
+
+def _canonical_json(value: object, *, field: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} is not canonical JSON") from exc
+
+
+def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
+    normalized = json.loads(_canonical_json(value, field=field))
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{field} is not an object")
+    return normalized
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalized_identity_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _is_sensitive_identity_key(value: str) -> bool:
+    """Return whether an explicit identity key can carry a credential value."""
+    compact = _normalized_identity_key(value)
+    return (
+        any(
+            marker in compact
+            for marker in (
+                "apikey",
+                "credential",
+                "password",
+                "authorization",
+                "bearer",
+                "privatekey",
+                "clientsecret",
+                "secretkey",
+                "accesskey",
+                "authkey",
+                "signingkey",
+                "encryptionkey",
+                "accountkey",
+                "masterkey",
+                "connectionstring",
+                "accesstoken",
+                "refreshtoken",
+                "sessiontoken",
+            )
+        )
+        or compact.startswith("secret")
+        or compact.endswith(("token", "tokenvalue", "keyvalue", "secret", "secretvalue"))
+    )
+
+
+def _looks_like_credential(value: str) -> bool:
+    """Recognize opaque credential shapes without redacting ordinary prose."""
+    normalized = value.strip()
+    lowered = normalized.lower()
+    if normalized.startswith("AIza") and len(normalized) >= 35:
+        return True
+    if lowered.startswith(
+        (
+            "sk-",
+            "sk_live_",
+            "sk_test_",
+            "ghp_",
+            "github_pat_",
+            "rk_live_",
+            "rk_test_",
+            "xoxb-",
+            "xoxp-",
+        )
+    ):
+        return len(normalized) >= 16
+    if lowered.startswith("bearer "):
+        return len(normalized.split(maxsplit=1)[-1]) >= 16
+    return False
+
+
+def _project_explicit_identity(
+    value: object,
+    *,
+    field: str,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> object:
+    """Accept only bounded JSON data that is safe to digest.
+
+    This validates an *explicit descriptor*, not object implementation state.
+    Unsupported values make the corresponding component process-local.
+    """
+    if depth > _MAX_IDENTITY_DEPTH:
+        raise ValueError(f"{field} exceeds identity depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{field} contains a non-finite float")
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_IDENTITY_SCALAR_CHARS:
+            raise ValueError(f"{field} contains oversized text")
+        if _looks_like_credential(value):
+            raise ValueError(f"{field} contains credential-shaped text")
+        return value
+
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        raise ValueError(f"{field} contains cyclic state")
+    seen.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many mapping items")
+            projected: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{field} contains a non-string or empty key")
+                if len(key) > _MAX_IDENTITY_SCALAR_CHARS:
+                    raise ValueError(f"{field} contains an oversized key")
+                if _is_sensitive_identity_key(key):
+                    raise ValueError(f"{field} contains a credential-bearing key")
+                projected[key] = _project_explicit_identity(
+                    item,
+                    field=f"{field}.{key}",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return projected
+        if isinstance(value, (list, tuple)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many sequence items")
+            return [
+                _project_explicit_identity(
+                    item,
+                    field=f"{field}[{index}]",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+                for index, item in enumerate(value)
+            ]
+        raise ValueError(f"{field} is not canonical JSON data")
+    finally:
+        seen.remove(value_id)
+
+
+def _safe_identity_digest(value: object, *, field: str) -> str | None:
+    try:
+        projected = _project_explicit_identity(value, field=field)
+        encoded = _canonical_json(projected, field=field)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return None
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        return None
+    return _sha256(encoded)
+
+
+def _digest_descriptor(value: object, *, field: str) -> dict[str, object]:
+    digest = _safe_identity_digest(value, field=field)
+    if digest is None:
+        return {"observed": False}
+    return {"observed": True, "digest": digest}
+
+
+def _valid_digest_descriptor(value: object) -> bool:
+    if not isinstance(value, Mapping) or not isinstance(value.get("observed"), bool):
+        return False
+    if value.get("observed") is False:
+        return set(value) == {"observed"}
+    digest = value.get("digest")
+    return (
+        set(value) == {"observed", "digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def execution_authority_boundary_contract() -> dict[str, object]:
+    """Return the finite ownership matrix embedded in every baseline."""
+    return {
+        "version": EXECUTION_AUTHORITY_BOUNDARY_VERSION,
+        "portable": [
+            "executor_components",
+            "workspace_descriptor",
+            "static_execution_policy",
+            "built_in_verifier",
+        ],
+        "per_attempt": [
+            "ac",
+            "prompt",
+            "tool_catalog",
+            "selected_route",
+            "selected_effort",
+            "runtime_handle",
+            "checkpoint",
+            "session_state",
+        ],
+        "process_local": [
+            "legacy_runtime_descriptor",
+        ],
+        "volatile": [
+            "custom_callable_graph",
+            "event_store",
+            "event_emitter",
+            "cache",
+            "queue",
+            "lock",
+            "signal_hub",
+            "module_monkeypatch",
+        ],
+    }
+
+
+def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
+    """Return a digest-only identity for the effect-owning workspace."""
+    if not isinstance(workspace, str) or not workspace.strip():
+        return {"version": 1, "stability": "process_local", "observed": False}
+    try:
+        canonical = str(Path(workspace).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"version": 1, "stability": "process_local", "observed": False}
+    descriptor = _digest_descriptor(canonical, field="workspace identity")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_workspace_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    observed = value.get("observed")
+    stability = value.get("stability")
+    if observed is False:
+        return stability == "process_local" and set(value) == {"version", "stability", "observed"}
+    digest = value.get("identity_digest")
+    return (
+        observed is True
+        and stability == "durable"
+        and set(value) == {"version", "stability", "observed", "identity_digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def constructor_model_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized constructor-level model pin, when observable."""
+    try:
+        raw_model = inspect.getattr_static(adapter, "_model")
+    except AttributeError:
+        return {"observed": False}
+    if raw_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(raw_model, str):
+        return {"observed": False}
+
+    normalized_model: object = raw_model.strip() or None
+    normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
+    if normalizer_descriptor is not None:
+        try:
+            normalizer = object.__getattribute__(adapter, "_normalize_model")
+            normalized_model = normalizer(raw_model)
+        except Exception:
+            return {"observed": False}
+    if normalized_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(normalized_model, str) or not normalized_model.strip():
+        return {"observed": False}
+    return {"observed": True, "model": normalized_model.strip()}
+
+
+def valid_constructor_model_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    model = value.get("model")
+    return set(value) == {"observed", "model"} and (
+        model is None or isinstance(model, str) and bool(model.strip())
+    )
+
+
+def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
+    """Return the adapter's explicit execution identity for runner resume."""
+    provider_descriptor = inspect.getattr_static(type(adapter), "execution_identity_contract", None)
+    if provider_descriptor is None:
+        return {"version": 1, "observed": False}
+
+    provider = object.__getattribute__(adapter, "execution_identity_contract")
+    identity = provider()
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime execution identity contract is not a mapping")
+    normalized = _canonical_object(
+        dict(identity),
+        field="runtime execution identity contract",
+    )
+    # An empty object carries no execution identity. Treat it like a missing
+    # provider declaration instead of allowing a digest of ``{}`` to witness
+    # portability.
+    if not normalized:
+        return {"version": 1, "observed": False}
+    return {"version": 1, "observed": True, "identity": normalized}
+
+
+def valid_runtime_execution_identity_contract(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    version = value.get("version")
+    observed = value.get("observed")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != 1
+        or not isinstance(observed, bool)
+    ):
+        return False
+    if not observed:
+        return set(value) == {"version", "observed"}
+    identity = value.get("identity")
+    if set(value) != {"version", "observed", "identity"} or not isinstance(identity, Mapping):
+        return False
+    try:
+        _canonical_json(dict(identity), field="runtime execution identity contract")
+    except ValueError:
+        return False
+    return bool(identity)
+
+
+def runtime_execution_proves_effective_model(value: object) -> bool:
+    if not valid_runtime_execution_identity_contract(value):
+        return False
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    identity = value.get("identity")
+    return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+
+
+def _runtime_capabilities_descriptor(adapter: object) -> dict[str, object]:
+    try:
+        capabilities = runtime_capabilities_for(adapter)
+        value = {
+            "skill_dispatch": capabilities.skill_dispatch,
+            "targeted_resume": capabilities.targeted_resume,
+            "structured_output": capabilities.structured_output,
+            "system_prompt_support": capabilities.system_prompt_support.value,
+            "tool_restriction_support": capabilities.tool_restriction_support.value,
+            "permission_mode_support": capabilities.permission_mode_support.value,
+            "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+            "enforceable_reasoning_efforts": (
+                sorted(capabilities.enforceable_reasoning_efforts)
+                if capabilities.enforceable_reasoning_efforts is not None
+                else None
+            ),
+            "model_override_support": capabilities.model_override_support.value,
+            "subagent_orchestration": capabilities.subagent_orchestration.value,
+            "session_signals": capabilities.session_signals.to_event_data(),
+        }
+    except Exception:
+        return {"observed": False}
+    return _digest_descriptor(value, field="runtime capabilities")
+
+
+def _runtime_label_descriptor(adapter: object, name: str) -> dict[str, object]:
+    try:
+        value = object.__getattribute__(adapter, name)
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(value, str) or not value.strip():
+        return {"observed": False}
+    return _digest_descriptor(value.strip(), field=f"runtime {name}")
+
+
+def _runtime_implementation_descriptor(adapter: object) -> dict[str, object]:
+    """Return a reviewed identity for one exact built-in runtime type."""
+    runtime_type = type(adapter)
+    implementation = _CLOSED_RUNTIME_IMPLEMENTATIONS.get(runtime_type)
+    if implementation is None:
+        return {"observed": False}
+    version, expected_dispatch_root, expected_dispatch_code = implementation
+    dispatch_root = _static_callable_root(adapter, "execute_task")
+    if (
+        dispatch_root is not expected_dispatch_root
+        or _callable_code_identity(dispatch_root) is not expected_dispatch_code
+    ):
+        return {"observed": False}
+    return _digest_descriptor(
+        {
+            "type": f"{runtime_type.__module__}.{runtime_type.__qualname__}",
+            "version": version,
+        },
+        field="runtime implementation",
+    )
+
+
+def _runtime_executable_descriptor(adapter: object) -> dict[str, object]:
+    """Digest one bounded, resolved CLI executable without serializing its path."""
+    try:
+        configured_path = object.__getattribute__(adapter, "_cli_path")
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(configured_path, str) or not configured_path.strip():
+        return {"observed": False}
+
+    try:
+        candidate = Path(configured_path).expanduser()
+        if not candidate.is_absolute():
+            resolved_from_path = shutil.which(configured_path)
+            if resolved_from_path is None:
+                return {"observed": False}
+            candidate = Path(resolved_from_path)
+        executable_path = candidate.resolve(strict=True)
+        executable_stat = executable_path.stat()
+        executable_mode = stat.S_IMODE(executable_stat.st_mode)
+        if (
+            not stat.S_ISREG(executable_stat.st_mode)
+            or not executable_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            or executable_stat.st_size > _MAX_RUNTIME_EXECUTABLE_BYTES
+        ):
+            return {"observed": False}
+        digest = hashlib.sha256()
+        with executable_path.open("rb") as executable_file:
+            while chunk := executable_file.read(1024 * 1024):
+                digest.update(chunk)
+    except (OSError, ValueError):
+        return {"observed": False}
+
+    return _digest_descriptor(
+        {
+            "path": str(executable_path),
+            "generation": {
+                "device": executable_stat.st_dev,
+                "inode": executable_stat.st_ino,
+                "size": executable_stat.st_size,
+                "mtime_ns": executable_stat.st_mtime_ns,
+                "mode": executable_mode,
+            },
+            "content_digest": "sha256:" + digest.hexdigest(),
+        },
+        field="runtime executable",
+    )
+
+
+def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
+    """Digest the finite mutable execution settings of the CLI runtime family."""
+    runtime_type = type(adapter)
+    if runtime_type is ZcodeCLIRuntime:
+        # Zcode can launch an app-bundle Electron executable or a PATH-resolved
+        # Node executable before its configured script. That external launcher
+        # chain is not a finite portable descriptor in Foundation A.
+        return {"observed": False}
+
+    try:
+        skills_dir = object.__getattribute__(adapter, "_skills_dir")
+        skill_dispatcher = object.__getattribute__(adapter, "_skill_dispatcher")
+        if skills_dir is not None or skill_dispatcher is not None:
+            # User-provided skill directories and dispatchers are live behavior,
+            # not a closed portable component in Foundation A.
+            return {"observed": False}
+        cwd = object.__getattribute__(adapter, "_cwd")
+        startup_timeout = object.__getattribute__(adapter, "_startup_output_timeout_seconds")
+        stdout_timeout = object.__getattribute__(adapter, "_stdout_idle_timeout_seconds")
+        process_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_process_shutdown_timeout_seconds",
+        )
+        completed_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_completed_process_group_shutdown_timeout_seconds",
+        )
+        max_resume_retries = object.__getattribute__(adapter, "_max_resume_retries")
+        max_depth = object.__getattribute__(adapter, "_max_ouroboros_depth")
+        max_stderr_lines = object.__getattribute__(adapter, "_max_stderr_lines")
+        use_process_group = object.__getattribute__(adapter, "_use_process_group")
+        child_session_env_keys = object.__getattribute__(adapter, "_child_session_env_keys")
+        copilot_runtime_profile = (
+            object.__getattribute__(adapter, "_runtime_profile")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
+        copilot_agent = (
+            object.__getattribute__(adapter, "_copilot_agent")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
+    except (AttributeError, TypeError):
+        return {"observed": False}
+
+    timeouts = (
+        startup_timeout,
+        stdout_timeout,
+        process_shutdown_timeout,
+        completed_shutdown_timeout,
+    )
+    if (
+        not isinstance(cwd, str)
+        or not cwd.strip()
+        or not all(value is None or _is_finite_number(value) for value in timeouts)
+        or any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in (max_resume_retries, max_depth, max_stderr_lines)
+        )
+        or not isinstance(use_process_group, bool)
+        or not isinstance(child_session_env_keys, (tuple, list, frozenset))
+        or not all(isinstance(value, str) for value in child_session_env_keys)
+        or (
+            runtime_type is CopilotCliRuntime
+            and (
+                copilot_runtime_profile is not None
+                and (
+                    not isinstance(copilot_runtime_profile, str)
+                    or not copilot_runtime_profile.strip()
+                )
+                or copilot_agent is not None
+                and (not isinstance(copilot_agent, str) or not copilot_agent.strip())
+            )
+        )
+    ):
+        return {"observed": False}
+    try:
+        canonical_cwd = str(Path(cwd).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"observed": False}
+    configuration: dict[str, object] = {
+        "working_directory": canonical_cwd,
+        "startup_output_timeout_seconds": startup_timeout,
+        "stdout_idle_timeout_seconds": stdout_timeout,
+        "process_shutdown_timeout_seconds": process_shutdown_timeout,
+        "completed_process_group_shutdown_timeout_seconds": completed_shutdown_timeout,
+        "max_resume_retries": max_resume_retries,
+        "max_ouroboros_depth": max_depth,
+        "max_stderr_lines": max_stderr_lines,
+        "use_process_group": use_process_group,
+        "child_session_env_keys": sorted(child_session_env_keys),
+    }
+    if runtime_type is CopilotCliRuntime:
+        # Copilot translates the resolved runtime profile to an --agent flag.
+        # Bind the exact stored value that command construction consumes.
+        configuration["copilot"] = {
+            "runtime_profile": copilot_runtime_profile,
+            "resolved_agent": copilot_agent,
+        }
+    return _digest_descriptor(configuration, field="runtime execution configuration")
+
+
+def runtime_authority_contract(
+    adapter: object,
+    *,
+    force_process_local: bool = False,
+    instance_nonce: str | None = None,
+) -> dict[str, object]:
+    """Return a process-local descriptor without invoking runtime behavior.
+
+    Current CLI runtimes use dynamic instance helpers, handler caches,
+    configuration readers, and launcher chains.  Calling their identity or
+    capability providers while constructing an authority would itself re-open
+    an unbounded behavior surface.  They remain executable, but a fresh nonce
+    confines every capture to one live process until a separate sealed kernel
+    supplies a reviewed finite execution path.
+    """
+    del adapter, force_process_local
+    return {
+        "version": 5,
+        "stability": "process_local",
+        "portable_identity_observed": False,
+        "runtime_backend": {"observed": False},
+        "llm_backend": {"observed": False},
+        "permission_mode": {"observed": False},
+        "execution_identity": {"observed": False},
+        "capabilities": {"observed": False},
+        "implementation": {"observed": False},
+        "executable": {"observed": False},
+        "configuration": {"observed": False},
+        "self_governs_rate_limit": None,
+        "instance_nonce": instance_nonce or uuid.uuid4().hex,
+    }
+
+
+def _valid_runtime_authority(value: object) -> bool:
+    required = {
+        "version",
+        "stability",
+        "runtime_backend",
+        "llm_backend",
+        "permission_mode",
+        "execution_identity",
+        "capabilities",
+        "implementation",
+        "executable",
+        "configuration",
+        "self_governs_rate_limit",
+        "portable_identity_observed",
+        "instance_nonce",
+    }
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 5:
+        return False
+    if value.get("stability") not in {"durable", "process_local"}:
+        return False
+    if not all(
+        _valid_digest_descriptor(value.get(name))
+        for name in (
+            "runtime_backend",
+            "llm_backend",
+            "permission_mode",
+            "execution_identity",
+            "capabilities",
+            "implementation",
+            "executable",
+            "configuration",
+        )
+    ):
+        return False
+    self_governs_rate_limit = value.get("self_governs_rate_limit")
+    portable_identity_observed = value.get("portable_identity_observed")
+    if not isinstance(portable_identity_observed, bool):
+        return False
+    nonce = value.get("instance_nonce")
+    return (
+        value.get("stability") == "process_local"
+        and not portable_identity_observed
+        and self_governs_rate_limit is None
+        and isinstance(nonce, str)
+        and len(nonce) == 32
+    )
+
+
+def execution_policy_authority_contract(policy: Mapping[str, object]) -> dict[str, object]:
+    """Represent the explicit static policy by a safe digest only."""
+    descriptor = _digest_descriptor(dict(policy), field="execution policy")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_execution_policy_authority(value: object) -> bool:
+    return _valid_workspace_authority(value)
+
+
+def executor_authority_contract() -> dict[str, object]:
+    """Return the closed Foundation A implementation component registry."""
+    return {
+        "version": 1,
+        "stability": "durable",
+        "components": dict(_EXECUTOR_COMPONENT_VERSIONS),
+    }
+
+
+def verifier_authority_contract(
+    verifier: Verifier | None,
+    *,
+    instance_nonce: str | None = None,
+) -> dict[str, object]:
+    """Describe a verifier without inspecting arbitrary Python behavior."""
+    if verifier is None:
+        return {
+            "version": 1,
+            "mode": "runtime_transcript",
+            "stability": "durable",
+            "implementation": _BUILTIN_TRANSCRIPT_VERIFIER,
+        }
+    if (
+        verifier is structural_atomic_verifier
+        and getattr(verifier, "__code__", None) is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+    ):
+        return {
+            "version": 1,
+            "mode": "structural_atomic",
+            "stability": "durable",
+            "implementation": _BUILTIN_STRUCTURAL_VERIFIER,
+        }
+
+    return {
+        "version": 1,
+        "mode": "custom",
+        "stability": "process_local",
+        "instance_nonce": instance_nonce or uuid.uuid4().hex,
+        # A custom verifier can expose arbitrary dynamic behavior through a
+        # descriptor method.  Do not execute that method merely to describe it.
+        "configuration": {"observed": False},
+    }
+
+
+def _valid_verifier_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    mode = value.get("mode")
+    if mode in {"runtime_transcript", "structural_atomic"}:
+        return (
+            value.get("stability") == "durable"
+            and set(value) == {"version", "mode", "stability", "implementation"}
+            and isinstance(value.get("implementation"), str)
+        )
+    if mode != "custom":
+        return False
+    nonce = value.get("instance_nonce")
+    return (
+        value.get("stability") == "process_local"
+        and set(value) == {"version", "mode", "stability", "instance_nonce", "configuration"}
+        and isinstance(nonce, str)
+        and len(nonce) == 32
+        and _valid_digest_descriptor(value.get("configuration"))
+    )
+
+
+def _contains_sensitive_authority_data(value: object) -> bool:
+    if isinstance(value, str):
+        return _looks_like_credential(value)
+    if isinstance(value, Mapping):
+        return any(
+            _is_sensitive_identity_key(key) or _contains_sensitive_authority_data(item)
+            for key, item in value.items()
+            if isinstance(key, str)
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_sensitive_authority_data(item) for item in value)
+    return False
+
+
+def _unwrap_static_callable(value: object) -> object | None:
+    if isinstance(value, (staticmethod, classmethod)):
+        value = value.__func__
+    return value if callable(value) else None
+
+
+def _static_callable_root(value: object | None, member_name: str | None) -> object | None:
+    """Return one direct callable root without traversing its behavior graph."""
+    if value is None:
+        return None
+    try:
+        if member_name is not None:
+            return _unwrap_static_callable(inspect.getattr_static(value, member_name))
+        if inspect.isfunction(value) or inspect.isbuiltin(value) or inspect.ismethod(value):
+            return value
+        return _unwrap_static_callable(inspect.getattr_static(type(value), "__call__"))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _class_callable_root(value: object, member_name: str) -> object | None:
+    """Return a callable declared on an instance type, never its instance dict."""
+    try:
+        return _unwrap_static_callable(inspect.getattr_static(type(value), member_name))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _callable_code_identity(value: object | None) -> object | None:
+    """Return a direct Python-code root without traversing callable state."""
+    if not inspect.isfunction(value):
+        return None
+    try:
+        return value.__code__
+    except AttributeError:
+        return None
+
+
+def _static_property_getter_root(value: object | None, member_name: str) -> object | None:
+    """Return a direct property getter without invoking dynamic lookup."""
+    if value is None:
+        return None
+    try:
+        descriptor = inspect.getattr_static(type(value), member_name)
+    except (AttributeError, TypeError):
+        return None
+    if not isinstance(descriptor, property):
+        return None
+    getter = descriptor.fget
+    return getter if callable(getter) else None
+
+
+def _is_finite_number(value: object) -> bool:
+    """Accept the finite scalar knobs owned by the rate-gate algorithm."""
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _has_observable_runtime_dispatch_root(adapter: object) -> bool:
+    """Return whether a runtime exposes one direct, non-dynamic dispatch root."""
+    try:
+        dispatch_root = _static_callable_root(adapter, "execute_task")
+        return (
+            dispatch_root is not None
+            and dispatch_root is _class_callable_root(adapter, "execute_task")
+            and _callable_code_identity(dispatch_root) is not None
+            and _uses_default_instance_attribute_resolution(adapter)
+        )
+    except TypeError:
+        return False
+
+
+def _uses_default_instance_attribute_resolution(value: object) -> bool:
+    """Return whether instances have the closed default attribute lookup root.
+
+    A static method root alone is not sufficient when a class can redirect an
+    instance attribute through ``__getattribute__``. This is intentionally a
+    finite check of the direct effect-owner type, not inspection of arbitrary
+    instance state or callable graphs.
+    """
+    target_type = value if isinstance(value, type) else type(value)
+    try:
+        return target_type.__getattribute__ is object.__getattribute__
+    except (AttributeError, TypeError):
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityContract:
+    """Immutable, versioned Foundation A baseline and fingerprint."""
+
+    canonical_json: str
+
+    def __post_init__(self) -> None:
+        try:
+            decoded = json.loads(self.canonical_json)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("execution authority contract is invalid JSON") from exc
+        data = _canonical_object(decoded, field="execution authority contract")
+        required = {
+            "version",
+            "boundary",
+            "executor",
+            "workspace",
+            "runtime",
+            "verifier",
+            "execution_policy",
+        }
+        if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != required:
+            raise ValueError("execution authority contract has an invalid shape")
+        if data.get("boundary") != execution_authority_boundary_contract():
+            raise ValueError("execution authority contract has an invalid boundary")
+        if not executor_authority_contract() == data.get("executor"):
+            raise ValueError("execution authority contract has an invalid executor")
+        if not _valid_workspace_authority(data.get("workspace")):
+            raise ValueError("execution authority contract has an invalid workspace")
+        if not _valid_runtime_authority(data.get("runtime")):
+            raise ValueError("execution authority contract has an invalid runtime")
+        if not _valid_verifier_authority(data.get("verifier")):
+            raise ValueError("execution authority contract has an invalid verifier")
+        if not _valid_execution_policy_authority(data.get("execution_policy")):
+            raise ValueError("execution authority contract has an invalid execution policy")
+        if _contains_sensitive_authority_data(data):
+            raise ValueError("execution authority contract contains sensitive data")
+        if _canonical_json(data, field="execution authority contract") != self.canonical_json:
+            raise ValueError("execution authority contract is not canonical")
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        verifier_instance_nonce: str | None = None,
+        runtime_instance_nonce: str | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityContract:
+        data = {
+            "version": EXECUTION_AUTHORITY_VERSION,
+            "boundary": execution_authority_boundary_contract(),
+            "executor": executor_authority_contract(),
+            "workspace": canonical_workspace_authority(workspace),
+            "runtime": runtime_authority_contract(
+                adapter,
+                force_process_local=force_runtime_process_local,
+                instance_nonce=runtime_instance_nonce,
+            ),
+            "verifier": verifier_authority_contract(
+                verifier,
+                instance_nonce=verifier_instance_nonce,
+            ),
+            "execution_policy": execution_policy_authority_contract(execution_policy),
+        }
+        return cls(_canonical_json(data, field="execution authority contract"))
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256(self.canonical_json)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        value = json.loads(self.canonical_json)
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise ValueError("execution authority contract is not an object")
+        return value
+
+    @property
+    def portable_across_processes(self) -> bool:
+        """Return only an identity-stability property, never reuse authority."""
+        data = self.data
+        runtime = data.get("runtime")
+        return (
+            all(
+                isinstance(component, Mapping) and component.get("stability") == "durable"
+                for component in (
+                    data.get("executor"),
+                    data.get("workspace"),
+                    data.get("runtime"),
+                    data.get("verifier"),
+                    data.get("execution_policy"),
+                )
+            )
+            and isinstance(runtime, Mapping)
+            and runtime.get("portable_identity_observed") is True
+            and data.get("workspace", {}).get("observed") is True
+            and data.get("execution_policy", {}).get("observed") is True
+        )
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True)
+class ExecutionAuthorityLiveBinding:
+    """The finite live roots that must remain identical before an effect."""
+
+    contract: ExecutionAuthorityContract
+    executor: object | None
+    executor_attribute_resolution_observable: bool
+    adapter: object
+    runtime_instance_nonce: str | None
+    verifier: Verifier | None
+    session_signal_hub: object | None
+    dispatcher_type: object
+    dispatcher: object | None
+    dispatcher_executor: object | None
+    transcript_verifier: object
+    adapter_dispatch_root: object | None
+    adapter_dispatch_code: object | None
+    adapter_attribute_resolution_observable: bool
+    verifier_root: object | None
+    verifier_code: object | None
+    dispatcher_stream_root: object | None
+    dispatcher_stream_code: object | None
+    dispatcher_stream_callable: object | None
+    dispatcher_attribute_resolution_observable: bool
+    dispatcher_binding_observable: bool
+    transcript_verifier_root: object | None
+    transcript_verifier_code: object | None
+    coordinator: object | None
+    coordinator_review_callable: object | None
+    coordinator_review_root: object | None
+    coordinator_review_code: object | None
+    coordinator_adapter: object | None
+    coordinator_task_cwd: object | None
+    coordinator_reasoning_effort: object | None
+    coordinator_attribute_resolution_observable: bool
+    coordinator_binding_observable: bool
+    rate_gate: object
+    rate_gate_acquire_root: object | None
+    rate_gate_acquire_code: object | None
+    rate_gate_acquire_callable: object | None
+    rate_gate_attribute_resolution_observable: bool
+    rate_gate_max_wait_seconds: object | None
+    rate_gate_heartbeat_seconds: object | None
+    rate_gate_sleep: object | None
+    rate_gate_sleep_root: object | None
+    rate_gate_sleep_code: object | None
+    rate_gate_semantics_observable: bool
+    rate_gate_bucket: object | None
+    rate_gate_bucket_config: tuple[object, object, object, object] | None
+    rate_gate_bucket_attribute_resolution_observable: bool
+    rate_gate_bucket_time: object | None
+    rate_gate_bucket_time_root: object | None
+    rate_gate_bucket_time_code: object | None
+    rate_gate_bucket_enabled_root: object | None
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object | None
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object | None
+    rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
+    rate_gate_bucket_binding_observable: bool
+    verifier_instance_nonce: str | None
+    force_runtime_process_local: bool
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        executor: object | None = None,
+        session_signal_hub: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        expected_dispatcher_type: object | None = None,
+        expected_dispatcher_stream_root: object | None = None,
+        expected_dispatcher_stream_code: object | None = None,
+        expected_transcript_verifier: object | None = None,
+        expected_transcript_verifier_code: object | None = None,
+        expected_rate_gate_acquire_root: object | None = None,
+        expected_rate_gate_acquire_code: object | None = None,
+        expected_rate_gate_type: type[object] | None = None,
+        expected_rate_gate_sleep: object | None = None,
+        expected_rate_gate_sleep_code: object | None = None,
+        expected_rate_gate_bucket_type: type[object] | None = None,
+        expected_rate_gate_bucket_time: object | None = None,
+        expected_rate_gate_bucket_enabled_root: object | None = None,
+        expected_rate_gate_bucket_enabled_code: object | None = None,
+        expected_rate_gate_bucket_acquire_root: object | None = None,
+        expected_rate_gate_bucket_acquire_code: object | None = None,
+        expected_rate_gate_bucket_force_reserve_root: object | None = None,
+        expected_rate_gate_bucket_force_reserve_code: object | None = None,
+        expected_rate_gate_bucket_helper_roots: (
+            tuple[tuple[str, object | None, object | None], ...] | None
+        ) = None,
+        expected_coordinator_type: type[object] | None = None,
+        expected_coordinator_review_root: object | None = None,
+        expected_coordinator_review_code: object | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityLiveBinding:
+        executor_attribute_resolution_observable = (
+            executor is None or _uses_default_instance_attribute_resolution(executor)
+        )
+        adapter_dispatch_root = _static_callable_root(adapter, "execute_task")
+        adapter_dispatch_code = _callable_code_identity(adapter_dispatch_root)
+        adapter_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            adapter
+        )
+        verifier_root = _static_callable_root(verifier, None)
+        verifier_code = _callable_code_identity(verifier_root)
+        dispatcher_stream_root = _static_callable_root(dispatcher_type, "stream")
+        dispatcher_stream_code = _callable_code_identity(dispatcher_stream_root)
+        dispatcher_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            dispatcher_type
+        )
+        captured_dispatcher_executor: object | None = None
+        dispatcher_binding_observable = dispatcher is None
+        if dispatcher is not None:
+            try:
+                captured_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+                dispatcher_binding_observable = (
+                    type(dispatcher) is dispatcher_type
+                    and captured_dispatcher_executor is dispatcher_executor
+                )
+            except (AttributeError, TypeError):
+                dispatcher_binding_observable = False
+        transcript_verifier_root = _static_callable_root(transcript_verifier, None)
+        transcript_verifier_code = _callable_code_identity(transcript_verifier_root)
+        if coordinator_review_callable is None:
+            try:
+                candidate = coordinator.run_review if coordinator is not None else None
+                coordinator_review_callable = candidate if callable(candidate) else None
+            except (AttributeError, TypeError):
+                coordinator_review_callable = None
+        coordinator_review_root = _static_callable_root(coordinator, "run_review")
+        coordinator_review_code = _callable_code_identity(coordinator_review_root)
+        coordinator_adapter: object | None = None
+        coordinator_task_cwd: object | None = None
+        coordinator_reasoning_effort: object | None = None
+        coordinator_attribute_resolution_observable = (
+            coordinator is None or _uses_default_instance_attribute_resolution(coordinator)
+        )
+        coordinator_binding_observable = coordinator is None
+        if coordinator is not None:
+            try:
+                coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+                coordinator_binding_observable = (
+                    coordinator_adapter is adapter
+                    and (coordinator_task_cwd is None or isinstance(coordinator_task_cwd, str))
+                    and (
+                        coordinator_reasoning_effort is None
+                        or isinstance(coordinator_reasoning_effort, str)
+                    )
+                )
+            except (AttributeError, TypeError):
+                coordinator_binding_observable = False
+        rate_gate_acquire_root = _static_callable_root(rate_gate, "acquire")
+        rate_gate_acquire_code = _callable_code_identity(rate_gate_acquire_root)
+        rate_gate_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            rate_gate
+        )
+        rate_gate_max_wait_seconds: object | None = None
+        rate_gate_heartbeat_seconds: object | None = None
+        rate_gate_sleep: object | None = None
+        rate_gate_sleep_root: object | None = None
+        rate_gate_sleep_code: object | None = None
+        rate_gate_semantics_observable = False
+        rate_gate_bucket: object | None = None
+        rate_gate_bucket_config: tuple[object, object, object, object] | None = None
+        rate_gate_bucket_attribute_resolution_observable = False
+        rate_gate_bucket_time: object | None = None
+        rate_gate_bucket_time_root: object | None = None
+        rate_gate_bucket_time_code: object | None = None
+        rate_gate_bucket_enabled_root: object | None = None
+        rate_gate_bucket_enabled_code: object | None = None
+        rate_gate_bucket_acquire_root: object | None = None
+        rate_gate_bucket_acquire_code: object | None = None
+        rate_gate_bucket_force_reserve_root: object | None = None
+        rate_gate_bucket_force_reserve_code: object | None = None
+        rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...] = ()
+        rate_gate_bucket_binding_observable = False
+        try:
+            rate_gate_max_wait_seconds = object.__getattribute__(rate_gate, "_max_wait_seconds")
+            rate_gate_heartbeat_seconds = object.__getattribute__(rate_gate, "_heartbeat_seconds")
+            rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
+            rate_gate_sleep_root = _static_callable_root(rate_gate_sleep, None)
+            rate_gate_sleep_code = _callable_code_identity(rate_gate_sleep_root)
+            rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+            rate_gate_bucket_config = (
+                object.__getattribute__(rate_gate_bucket, "_runtime_backend"),
+                object.__getattribute__(rate_gate_bucket, "_request_limit"),
+                object.__getattribute__(rate_gate_bucket, "_token_limit"),
+                object.__getattribute__(rate_gate_bucket, "_window_seconds"),
+            )
+            rate_gate_bucket_attribute_resolution_observable = (
+                _uses_default_instance_attribute_resolution(rate_gate_bucket)
+            )
+            rate_gate_bucket_time = object.__getattribute__(rate_gate_bucket, "_time")
+            rate_gate_bucket_time_root = _static_callable_root(rate_gate_bucket_time, None)
+            rate_gate_bucket_time_code = _callable_code_identity(rate_gate_bucket_time_root)
+            rate_gate_bucket_enabled_root = _static_property_getter_root(
+                rate_gate_bucket,
+                "enabled",
+            )
+            rate_gate_bucket_enabled_code = _callable_code_identity(rate_gate_bucket_enabled_root)
+            rate_gate_bucket_acquire_root = _static_callable_root(rate_gate_bucket, "acquire")
+            rate_gate_bucket_acquire_code = _callable_code_identity(rate_gate_bucket_acquire_root)
+            rate_gate_bucket_force_reserve_root = _static_callable_root(
+                rate_gate_bucket,
+                "force_reserve",
+            )
+            rate_gate_bucket_force_reserve_code = _callable_code_identity(
+                rate_gate_bucket_force_reserve_root
+            )
+            bucket_helper_roots: list[tuple[str, object | None, object | None]] = []
+            for name in _RATE_GATE_BUCKET_HELPER_NAMES:
+                helper_root = _static_callable_root(rate_gate_bucket, name)
+                bucket_helper_roots.append(
+                    (name, helper_root, _callable_code_identity(helper_root))
+                )
+            rate_gate_bucket_helper_roots = tuple(bucket_helper_roots)
+            rate_gate_bucket_binding_observable = (
+                isinstance(rate_gate_bucket_config[0], str)
+                and (
+                    rate_gate_bucket_config[1] is None
+                    or isinstance(rate_gate_bucket_config[1], int)
+                    and not isinstance(rate_gate_bucket_config[1], bool)
+                )
+                and (
+                    rate_gate_bucket_config[2] is None
+                    or isinstance(rate_gate_bucket_config[2], int)
+                    and not isinstance(rate_gate_bucket_config[2], bool)
+                )
+                and _is_finite_number(rate_gate_bucket_config[3])
+            )
+            rate_gate_semantics_observable = (
+                _is_finite_number(rate_gate_max_wait_seconds)
+                and _is_finite_number(rate_gate_heartbeat_seconds)
+                and rate_gate_sleep_root is not None
+                and rate_gate_sleep_code is not None
+                and rate_gate_bucket_attribute_resolution_observable
+                and rate_gate_bucket_time_root is not None
+                and rate_gate_bucket_enabled_root is not None
+                and rate_gate_bucket_enabled_code is not None
+                and rate_gate_bucket_acquire_root is not None
+                and rate_gate_bucket_acquire_code is not None
+                and rate_gate_bucket_force_reserve_root is not None
+                and rate_gate_bucket_force_reserve_code is not None
+                and all(
+                    helper_root is not None and helper_code is not None
+                    for _, helper_root, helper_code in rate_gate_bucket_helper_roots
+                )
+            )
+        except (AttributeError, TypeError):
+            rate_gate_bucket = None
+            rate_gate_bucket_config = None
+        dispatcher_is_closed = (
+            expected_dispatcher_type is not None
+            and dispatcher_type is expected_dispatcher_type
+            and expected_dispatcher_stream_root is not None
+            and dispatcher_stream_root is expected_dispatcher_stream_root
+            and expected_dispatcher_stream_code is not None
+            and dispatcher_stream_code is expected_dispatcher_stream_code
+            and dispatcher_stream_callable is dispatcher_stream_root
+        )
+        transcript_is_closed = (
+            expected_transcript_verifier is not None
+            and transcript_verifier is expected_transcript_verifier
+            and transcript_verifier_root is expected_transcript_verifier
+            and expected_transcript_verifier_code is not None
+            and transcript_verifier_code is expected_transcript_verifier_code
+        )
+        rate_gate_is_closed = (
+            expected_rate_gate_type is not None
+            and type(rate_gate) is expected_rate_gate_type
+            and expected_rate_gate_acquire_root is not None
+            and rate_gate_acquire_root is expected_rate_gate_acquire_root
+            and expected_rate_gate_acquire_code is not None
+            and rate_gate_acquire_code is expected_rate_gate_acquire_code
+            and rate_gate_acquire_callable is rate_gate_acquire_root
+            and rate_gate_semantics_observable
+            and expected_rate_gate_sleep is not None
+            and rate_gate_sleep is expected_rate_gate_sleep
+            and expected_rate_gate_sleep_code is not None
+            and rate_gate_sleep_code is expected_rate_gate_sleep_code
+            and expected_rate_gate_bucket_type is not None
+            and type(rate_gate_bucket) is expected_rate_gate_bucket_type
+            and expected_rate_gate_bucket_time is not None
+            and rate_gate_bucket_time is expected_rate_gate_bucket_time
+            and expected_rate_gate_bucket_enabled_root is not None
+            and rate_gate_bucket_enabled_root is expected_rate_gate_bucket_enabled_root
+            and expected_rate_gate_bucket_enabled_code is not None
+            and rate_gate_bucket_enabled_code is expected_rate_gate_bucket_enabled_code
+            and expected_rate_gate_bucket_acquire_root is not None
+            and rate_gate_bucket_acquire_root is expected_rate_gate_bucket_acquire_root
+            and expected_rate_gate_bucket_acquire_code is not None
+            and rate_gate_bucket_acquire_code is expected_rate_gate_bucket_acquire_code
+            and expected_rate_gate_bucket_force_reserve_root is not None
+            and rate_gate_bucket_force_reserve_root is expected_rate_gate_bucket_force_reserve_root
+            and expected_rate_gate_bucket_force_reserve_code is not None
+            and rate_gate_bucket_force_reserve_code is expected_rate_gate_bucket_force_reserve_code
+            and expected_rate_gate_bucket_helper_roots is not None
+            and len(rate_gate_bucket_helper_roots) == len(expected_rate_gate_bucket_helper_roots)
+            and all(
+                name == expected_name and root is expected_root and code is expected_code
+                for (name, root, code), (
+                    expected_name,
+                    expected_root,
+                    expected_code,
+                ) in zip(
+                    rate_gate_bucket_helper_roots,
+                    expected_rate_gate_bucket_helper_roots,
+                    strict=True,
+                )
+            )
+        )
+        coordinator_is_closed = coordinator is None or (
+            expected_coordinator_type is not None
+            and type(coordinator) is expected_coordinator_type
+            and expected_coordinator_review_root is not None
+            and coordinator_review_root is expected_coordinator_review_root
+            and expected_coordinator_review_code is not None
+            and coordinator_review_code is expected_coordinator_review_code
+        )
+        # A dynamic attribute hook or a missing direct callable root has no
+        # finite implementation identity. Keep execution working, but do not
+        # upgrade that adapter to a portable authority claim.
+        force_runtime_process_local = force_runtime_process_local or (
+            session_signal_hub is not None
+            or not executor_attribute_resolution_observable
+            or adapter_dispatch_root is None
+            or adapter_dispatch_code is None
+            or not adapter_attribute_resolution_observable
+            or not dispatcher_is_closed
+            or not dispatcher_attribute_resolution_observable
+            or not dispatcher_binding_observable
+            or not transcript_is_closed
+            or (
+                coordinator is not None
+                and (
+                    coordinator_review_callable is None
+                    or not coordinator_is_closed
+                    or not coordinator_binding_observable
+                    or not coordinator_attribute_resolution_observable
+                )
+            )
+            or not rate_gate_is_closed
+            or not rate_gate_attribute_resolution_observable
+            or not rate_gate_semantics_observable
+            or not rate_gate_bucket_binding_observable
+        )
+        # A pristine structural verifier is the one built-in verifier with a
+        # durable implementation descriptor. If its code was already changed
+        # before construction, keep it executable as a custom, process-local
+        # verifier with one stable live-instance nonce instead of generating a
+        # new nonce on every guard check.
+        nonce = (
+            None
+            if verifier is None
+            or (
+                verifier is structural_atomic_verifier
+                and verifier_code is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+            )
+            else uuid.uuid4().hex
+        )
+        runtime_instance_nonce = uuid.uuid4().hex
+        contract = ExecutionAuthorityContract.build(
+            adapter=adapter,
+            verifier=verifier,
+            workspace=workspace,
+            execution_policy=execution_policy,
+            verifier_instance_nonce=nonce,
+            runtime_instance_nonce=runtime_instance_nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+        return cls(
+            contract=contract,
+            executor=executor,
+            executor_attribute_resolution_observable=executor_attribute_resolution_observable,
+            adapter=adapter,
+            runtime_instance_nonce=runtime_instance_nonce,
+            verifier=verifier,
+            session_signal_hub=session_signal_hub,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=captured_dispatcher_executor,
+            transcript_verifier=transcript_verifier,
+            adapter_dispatch_root=adapter_dispatch_root,
+            adapter_dispatch_code=adapter_dispatch_code,
+            adapter_attribute_resolution_observable=adapter_attribute_resolution_observable,
+            verifier_root=verifier_root,
+            verifier_code=verifier_code,
+            dispatcher_stream_root=dispatcher_stream_root,
+            dispatcher_stream_code=dispatcher_stream_code,
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            dispatcher_attribute_resolution_observable=(dispatcher_attribute_resolution_observable),
+            dispatcher_binding_observable=dispatcher_binding_observable,
+            transcript_verifier_root=transcript_verifier_root,
+            transcript_verifier_code=transcript_verifier_code,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+            coordinator_review_root=coordinator_review_root,
+            coordinator_review_code=coordinator_review_code,
+            coordinator_adapter=coordinator_adapter,
+            coordinator_task_cwd=coordinator_task_cwd,
+            coordinator_reasoning_effort=coordinator_reasoning_effort,
+            coordinator_attribute_resolution_observable=(
+                coordinator_attribute_resolution_observable
+            ),
+            coordinator_binding_observable=coordinator_binding_observable,
+            rate_gate=rate_gate,
+            rate_gate_acquire_root=rate_gate_acquire_root,
+            rate_gate_acquire_code=rate_gate_acquire_code,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            rate_gate_attribute_resolution_observable=rate_gate_attribute_resolution_observable,
+            rate_gate_max_wait_seconds=rate_gate_max_wait_seconds,
+            rate_gate_heartbeat_seconds=rate_gate_heartbeat_seconds,
+            rate_gate_sleep=rate_gate_sleep,
+            rate_gate_sleep_root=rate_gate_sleep_root,
+            rate_gate_sleep_code=rate_gate_sleep_code,
+            rate_gate_semantics_observable=rate_gate_semantics_observable,
+            rate_gate_bucket=rate_gate_bucket,
+            rate_gate_bucket_config=rate_gate_bucket_config,
+            rate_gate_bucket_attribute_resolution_observable=(
+                rate_gate_bucket_attribute_resolution_observable
+            ),
+            rate_gate_bucket_time=rate_gate_bucket_time,
+            rate_gate_bucket_time_root=rate_gate_bucket_time_root,
+            rate_gate_bucket_time_code=rate_gate_bucket_time_code,
+            rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+            rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+            rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+            rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+            rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+            rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+            rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
+            rate_gate_bucket_binding_observable=rate_gate_bucket_binding_observable,
+            verifier_instance_nonce=nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+
+    def is_intact(
+        self,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        session_signal_hub: object | None = None,
+        executor: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+    ) -> bool:
+        if executor is not self.executor:
+            return False
+        if adapter is not self.adapter or verifier is not self.verifier:
+            return False
+        if session_signal_hub is not self.session_signal_hub:
+            return False
+        if dispatcher_type is not self.dispatcher_type:
+            return False
+        if dispatcher is not self.dispatcher or dispatcher_executor is not self.dispatcher_executor:
+            return False
+        if dispatcher_stream_callable is not self.dispatcher_stream_callable:
+            return False
+        if transcript_verifier is not self.transcript_verifier:
+            return False
+        if coordinator is not self.coordinator:
+            return False
+        if coordinator_review_callable is not self.coordinator_review_callable:
+            return False
+        if rate_gate is not self.rate_gate:
+            return False
+        if rate_gate_acquire_callable is not self.rate_gate_acquire_callable:
+            return False
+        if (
+            self.executor_attribute_resolution_observable
+            and executor is not None
+            and not _uses_default_instance_attribute_resolution(executor)
+        ):
+            return False
+        if (
+            self.adapter_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(adapter)
+        ):
+            return False
+        if (
+            self.dispatcher_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(dispatcher_type)
+        ):
+            return False
+        if (
+            self.coordinator_attribute_resolution_observable
+            and coordinator is not None
+            and not _uses_default_instance_attribute_resolution(coordinator)
+        ):
+            return False
+        if (
+            self.rate_gate_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(rate_gate)
+        ):
+            return False
+        if (
+            self.rate_gate_bucket_attribute_resolution_observable
+            and self.rate_gate_bucket is not None
+            and not _uses_default_instance_attribute_resolution(self.rate_gate_bucket)
+        ):
+            return False
+        if self.rate_gate_semantics_observable:
+            try:
+                current_rate_gate_max_wait_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_max_wait_seconds",
+                )
+                current_rate_gate_heartbeat_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_heartbeat_seconds",
+                )
+                current_rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
+                current_rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+                current_rate_gate_bucket_config = (
+                    object.__getattribute__(current_rate_gate_bucket, "_runtime_backend"),
+                    object.__getattribute__(current_rate_gate_bucket, "_request_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_token_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_window_seconds"),
+                )
+                current_rate_gate_bucket_time = object.__getattribute__(
+                    current_rate_gate_bucket,
+                    "_time",
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                not _is_finite_number(current_rate_gate_max_wait_seconds)
+                or not _is_finite_number(current_rate_gate_heartbeat_seconds)
+                or current_rate_gate_max_wait_seconds != self.rate_gate_max_wait_seconds
+                or current_rate_gate_heartbeat_seconds != self.rate_gate_heartbeat_seconds
+                or current_rate_gate_sleep is not self.rate_gate_sleep
+                or _static_callable_root(current_rate_gate_sleep, None)
+                is not self.rate_gate_sleep_root
+                or _callable_code_identity(_static_callable_root(current_rate_gate_sleep, None))
+                is not self.rate_gate_sleep_code
+                or current_rate_gate_bucket is not self.rate_gate_bucket
+                or current_rate_gate_bucket_config != self.rate_gate_bucket_config
+                or current_rate_gate_bucket_time is not self.rate_gate_bucket_time
+                or _static_callable_root(current_rate_gate_bucket_time, None)
+                is not self.rate_gate_bucket_time_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket_time, None)
+                )
+                is not self.rate_gate_bucket_time_code
+                or _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                is not self.rate_gate_bucket_enabled_root
+                or _callable_code_identity(
+                    _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                )
+                is not self.rate_gate_bucket_enabled_code
+                or _static_callable_root(current_rate_gate_bucket, "acquire")
+                is not self.rate_gate_bucket_acquire_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "acquire")
+                )
+                is not self.rate_gate_bucket_acquire_code
+                or _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                is not self.rate_gate_bucket_force_reserve_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                )
+                is not self.rate_gate_bucket_force_reserve_code
+            ):
+                return False
+            for name, root, code in self.rate_gate_bucket_helper_roots:
+                current_root = _static_callable_root(current_rate_gate_bucket, name)
+                if current_root is not root or _callable_code_identity(current_root) is not code:
+                    return False
+        if (
+            self.adapter_dispatch_root is not None
+            and _static_callable_root(adapter, "execute_task") is not self.adapter_dispatch_root
+        ):
+            return False
+        if (
+            self.adapter_dispatch_code is not None
+            and _callable_code_identity(_static_callable_root(adapter, "execute_task"))
+            is not self.adapter_dispatch_code
+        ):
+            return False
+        if (
+            self.verifier_root is not None
+            and _static_callable_root(verifier, None) is not self.verifier_root
+        ):
+            return False
+        if (
+            self.verifier_code is not None
+            and _callable_code_identity(_static_callable_root(verifier, None))
+            is not self.verifier_code
+        ):
+            return False
+        if (
+            self.dispatcher_stream_root is not None
+            and _static_callable_root(dispatcher_type, "stream") is not self.dispatcher_stream_root
+        ):
+            return False
+        if (
+            self.dispatcher_stream_code is not None
+            and _callable_code_identity(_static_callable_root(dispatcher_type, "stream"))
+            is not self.dispatcher_stream_code
+        ):
+            return False
+        if self.dispatcher_binding_observable and dispatcher is not None:
+            try:
+                current_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+            except (AttributeError, TypeError):
+                return False
+            if current_dispatcher_executor is not self.dispatcher_executor:
+                return False
+        if (
+            self.transcript_verifier_root is not None
+            and _static_callable_root(transcript_verifier, None)
+            is not self.transcript_verifier_root
+        ):
+            return False
+        if (
+            self.transcript_verifier_code is not None
+            and _callable_code_identity(_static_callable_root(transcript_verifier, None))
+            is not self.transcript_verifier_code
+        ):
+            return False
+        if (
+            self.coordinator_review_root is not None
+            and _static_callable_root(coordinator, "run_review") is not self.coordinator_review_root
+        ):
+            return False
+        if (
+            self.coordinator_review_code is not None
+            and _callable_code_identity(_static_callable_root(coordinator, "run_review"))
+            is not self.coordinator_review_code
+        ):
+            return False
+        if self.coordinator_binding_observable and coordinator is not None:
+            try:
+                current_coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                current_coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                current_coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                current_coordinator_adapter is not self.coordinator_adapter
+                or current_coordinator_task_cwd != self.coordinator_task_cwd
+                or current_coordinator_reasoning_effort != self.coordinator_reasoning_effort
+            ):
+                return False
+        if (
+            self.rate_gate_acquire_root is not None
+            and _static_callable_root(rate_gate, "acquire") is not self.rate_gate_acquire_root
+        ):
+            return False
+        if (
+            self.rate_gate_acquire_code is not None
+            and _callable_code_identity(_static_callable_root(rate_gate, "acquire"))
+            is not self.rate_gate_acquire_code
+        ):
+            return False
+        try:
+            current = ExecutionAuthorityContract.build(
+                adapter=adapter,
+                verifier=verifier,
+                workspace=workspace,
+                execution_policy=execution_policy,
+                verifier_instance_nonce=self.verifier_instance_nonce,
+                runtime_instance_nonce=self.runtime_instance_nonce,
+                force_runtime_process_local=self.force_runtime_process_local,
+            )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return False
+        return current.canonical_json == self.contract.canonical_json
+
+
+__all__ = [
+    "EXECUTION_AUTHORITY_VERSION",
+    "ExecutionAuthorityContract",
+    "ExecutionAuthorityLiveBinding",
+    "canonical_workspace_authority",
+    "constructor_model_contract",
+    "execution_authority_boundary_contract",
+    "execution_policy_authority_contract",
+    "executor_authority_contract",
+    "runtime_authority_contract",
+    "runtime_execution_identity_contract",
+    "runtime_execution_proves_effective_model",
+    "valid_constructor_model_contract",
+    "valid_process_local_authority_contract",
+    "valid_runtime_execution_identity_contract",
+    "verifier_authority_contract",
+]

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -15,18 +15,53 @@ Any runtime can participate — just call acquire/release.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
+import re
+from threading import RLock
+
+try:  # pragma: no cover - exercised on Unix CI; fallback supports Windows imports
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None  # type: ignore[assignment]
 
 log = logging.getLogger(__name__)
 
 LOCK_DIR = Path.home() / ".ouroboros" / "locks"
+_LEASE_OPERATION_LOCK = RLock()
+_HELD_LEASE_FDS: dict[str, int] = {}
+_SAFE_LOCK_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 
 
 def _ensure_dir() -> Path:
     LOCK_DIR.mkdir(parents=True, exist_ok=True)
     return LOCK_DIR
+
+
+def _clear_held_leases_after_fork() -> None:
+    """Drop inherited lease descriptors in a post-fork child.
+
+    Advisory-lock state is tied to an open file description. If a child
+    retained a copied descriptor, a dead parent could leave its liveness lease
+    locked until the unrelated child exits. Do not acquire the inherited
+    RLock here: a vanished parent thread may have owned it at fork time.
+    """
+    global _HELD_LEASE_FDS, _LEASE_OPERATION_LOCK
+
+    inherited_fds = tuple(_HELD_LEASE_FDS.values())
+    _HELD_LEASE_FDS = {}
+    _LEASE_OPERATION_LOCK = RLock()
+    for fd in inherited_fds:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_clear_held_leases_after_fork)
 
 
 def _get_process_start_time(pid: int) -> float | None:
@@ -72,8 +107,14 @@ def _get_process_start_time(pid: int) -> float | None:
 
 
 def lock_path(session_id: str) -> Path:
-    """Return the lock file path for a given session."""
-    return _ensure_dir() / session_id
+    """Return a containment-safe lock path for a given session identifier."""
+    if isinstance(session_id, str) and _SAFE_LOCK_SESSION_ID.fullmatch(session_id) is not None:
+        return _ensure_dir() / session_id
+    # Old/corrupt persisted session ids still need an observer-safe lookup.
+    # New process-local registrations reject them before any effect or lease is
+    # created, while this digest prevents a legacy value from escaping LOCK_DIR.
+    raw = str(session_id).encode("utf-8", "surrogatepass")
+    return _ensure_dir() / f"__invalid_session_id__{hashlib.sha256(raw).hexdigest()}"
 
 
 def acquire(session_id: str) -> None:
@@ -87,7 +128,57 @@ def acquire(session_id: str) -> None:
     payload = f"{pid}:{start_time}" if start_time else str(pid)
 
     path = lock_path(session_id)
-    path.write_text(payload)
+    # Keep an advisory exclusive lock open for the holder's lifetime. This
+    # lets a later process safely distinguish a stale file (lock obtainable)
+    # from a live lease (lock busy) without overwriting or deleting the latter.
+    # The file payload remains human-readable diagnostic evidence; the held FD
+    # is the race-free ownership primitive.
+    with _LEASE_OPERATION_LOCK:
+        if session_id in _HELD_LEASE_FDS and is_owned_by_current_process(session_id):
+            return
+
+        path_existed = path.exists()
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+        lock_acquired = False
+        try:
+            if fcntl is not None:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    lock_acquired = True
+                except BlockingIOError as exc:
+                    raise OSError(f"session liveness lease is held: {session_id}") from exc
+            elif path_existed and not is_owned_by_current_process(session_id):
+                # On platforms without ``fcntl`` preserve safety by refusing
+                # to replace any extant lease rather than guessing it is stale.
+                raise OSError(f"session liveness lease is already held: {session_id}")
+
+            if (
+                path_existed
+                and is_holder_alive(session_id)
+                and not is_owned_by_current_process(session_id)
+            ):
+                raise OSError(f"session liveness lease is held: {session_id}")
+
+            if is_owned_by_current_process(session_id):
+                _HELD_LEASE_FDS[session_id] = fd
+                fd = -1  # ownership transferred to the process-lifetime registry
+                return
+
+            os.ftruncate(fd, 0)
+            os.write(fd, payload.encode("utf-8"))
+            os.fsync(fd)
+            _HELD_LEASE_FDS[session_id] = fd
+            fd = -1  # ownership transferred to the process-lifetime registry
+        except Exception:
+            if lock_acquired and fcntl is not None:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            raise
+        finally:
+            if fd >= 0:
+                os.close(fd)
     log.info(
         "session_lock.acquired",
         extra={"session_id": session_id, "pid": pid},
@@ -97,23 +188,40 @@ def acquire(session_id: str) -> None:
 def release(session_id: str) -> None:
     """Release a session lock when execution completes or is cancelled."""
     path = lock_path(session_id)
-    try:
-        path.unlink(missing_ok=True)
-        log.info(
-            "session_lock.released",
-            extra={"session_id": session_id},
-        )
-    except OSError:
-        pass
+    with _LEASE_OPERATION_LOCK:
+        fd = _HELD_LEASE_FDS.pop(session_id, None)
+        try:
+            path.unlink(missing_ok=True)
+            log.info(
+                "session_lock.released",
+                extra={"session_id": session_id},
+            )
+        except OSError:
+            pass
+        finally:
+            if fd is not None:
+                if fcntl is not None:
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
 
 def release_if_owned_by_current_process(session_id: str) -> bool:
     """Release a session lock only when the current process owns it."""
-    if not is_owned_by_current_process(session_id):
-        return False
+    # ``acquire`` cannot replace an extant lease, and this lock serializes two
+    # local cleanup paths. Once ownership has been checked, no other normal
+    # owner can create a replacement until this unlink has completed.
+    with _LEASE_OPERATION_LOCK:
+        if not is_owned_by_current_process(session_id):
+            return False
 
-    release(session_id)
-    return True
+        release(session_id)
+        return True
 
 
 def is_owned_by_current_process(session_id: str) -> bool:
@@ -182,7 +290,12 @@ def is_holder_alive(session_id: str) -> bool:
     2. The recorded PID is running
     3. The process start time matches (guards against PID recycling)
 
-    Returns False if no lock exists or the holder is confirmed dead.
+    Returns False if no lock exists or the holder is confirmed dead. This
+    observer never unlinks malformed or stale records: deleting after a
+    non-atomic read could remove a newly acquired lease from another process.
+    Stale filenames are harmless because session ids are unique; a caller that
+    deliberately reuses one must resolve it explicitly rather than overwrite
+    liveness evidence.
     """
     path = lock_path(session_id)
     if not path.exists():
@@ -200,19 +313,22 @@ def is_holder_alive(session_id: str) -> bool:
     except ValueError:
         return False
 
-    recorded_start = float(parts[1]) if len(parts) > 1 and parts[1] != "None" else None
-
-    if not is_process_identity_alive(pid, recorded_start):
-        release(session_id)  # Clean up stale lock
+    try:
+        recorded_start = float(parts[1]) if len(parts) > 1 and parts[1] != "None" else None
+    except ValueError:
+        # A malformed lease cannot prove that a compatible process owns this
+        # session. Treat it as unheld without deleting it: a fresh owner may
+        # have atomically replaced the observation between read and cleanup.
         return False
 
-    return True
+    return is_process_identity_alive(pid, recorded_start)
 
 
 def get_alive_sessions() -> set[str]:
     """Return session IDs with live lock holders.
 
-    Scans the lock directory, verifies each, and cleans up stale entries.
+    Scans the lock directory and verifies each entry without deleting stale
+    paths from an observer race.
     """
     alive: set[str] = set()
     lock_dir = _ensure_dir()

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -28,16 +28,19 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from functools import wraps
 import json
 import math
 import os
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, Any, Literal
+import time
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from weakref import ref
 
 import anyio
 from rich.console import Console
@@ -254,6 +257,10 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ExecutionAuthorityLiveBinding,
+)
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -273,6 +280,7 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
+    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -286,6 +294,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedMod
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
     RateLimitGate,
+    SharedRateLimitBucket,
     build_rate_limit_gate,
     estimate_runtime_request_tokens,
 )
@@ -318,6 +327,583 @@ if TYPE_CHECKING:
     from ouroboros.persistence.event_store import EventStore
 
 log = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _FoundationAClosedRoots:
+    """Original direct roots held by the executor constructor default."""
+
+    leaf_dispatcher_type: type[LeafDispatcher]
+    leaf_dispatcher_stream_root: Callable[..., Awaitable[None]]
+    leaf_dispatcher_stream_code: object
+    level_coordinator_type: type[LevelCoordinator]
+    level_coordinator_review_root: object
+    level_coordinator_review_code: object
+    rate_gate_factory: Callable[..., RateLimitGate]
+    rate_gate_type: type[RateLimitGate]
+    rate_gate_acquire_root: Callable[..., Awaitable[None]]
+    rate_gate_acquire_code: object
+    rate_gate_sleep: object
+    rate_gate_sleep_code: object | None
+    rate_gate_bucket_type: type[SharedRateLimitBucket]
+    rate_gate_bucket_time: object
+    rate_gate_bucket_enabled_root: object
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object
+    rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
+    transcript_verifier: Callable[..., VerifierVerdict]
+    transcript_verifier_code: object
+
+
+class _FoundationAInternalEntryRoots(NamedTuple):
+    """Closed entry functions used by the executor's own orchestration path."""
+
+    executor_type: type[object]
+    execute_single_ac_root: Callable[..., Any]
+    execute_single_ac_code: object
+    execute_atomic_ac_root: Callable[..., Any]
+    execute_atomic_ac_code: object
+    await_dispatch_rate_budget_root: Callable[..., Any]
+    await_dispatch_rate_budget_code: object
+    dispatch_decomposition_prompt_root: Callable[..., Any]
+    dispatch_decomposition_prompt_code: object
+    run_atomic_verifier_pass_root: Callable[..., Any]
+    run_atomic_verifier_pass_code: object
+    run_ac_verify_gate_root: Callable[..., Any]
+    run_ac_verify_gate_code: object
+
+
+# These names document the closed components. ``ParallelACExecutor.__init__``
+# receives a value-based default built from them below, so changing a mutable
+# module global after import cannot replace the roots it binds.
+_FOUNDATION_A_LEAF_DISPATCHER_TYPE = LeafDispatcher
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT = LeafDispatcher.stream
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE = LeafDispatcher.stream.__code__
+_FOUNDATION_A_LEVEL_COORDINATOR_TYPE = LevelCoordinator
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT = LevelCoordinator.run_review
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE = LevelCoordinator.run_review.__code__
+_FOUNDATION_A_RATE_GATE_FACTORY = build_rate_limit_gate
+_FOUNDATION_A_RATE_GATE_TYPE = RateLimitGate
+_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT = RateLimitGate.acquire
+_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE = RateLimitGate.acquire.__code__
+_FOUNDATION_A_RATE_GATE_SLEEP = asyncio.sleep
+_FOUNDATION_A_RATE_GATE_SLEEP_CODE = asyncio.sleep.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_TYPE = SharedRateLimitBucket
+_FOUNDATION_A_RATE_GATE_BUCKET_TIME = time.monotonic
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT = SharedRateLimitBucket.enabled.fget
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE = (
+    _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT.__code__
+    if _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT is not None
+    else None
+)
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT = SharedRateLimitBucket.acquire
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE = SharedRateLimitBucket.acquire.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT = SharedRateLimitBucket.force_reserve
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE = SharedRateLimitBucket.force_reserve.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS = (
+    ("_prune", SharedRateLimitBucket._prune, SharedRateLimitBucket._prune.__code__),
+    (
+        "_tokens_in_window",
+        SharedRateLimitBucket._tokens_in_window,
+        SharedRateLimitBucket._tokens_in_window.__code__,
+    ),
+    ("_snapshot", SharedRateLimitBucket._snapshot, SharedRateLimitBucket._snapshot.__code__),
+    (
+        "_request_wait_seconds",
+        SharedRateLimitBucket._request_wait_seconds,
+        SharedRateLimitBucket._request_wait_seconds.__code__,
+    ),
+    (
+        "_token_wait_seconds",
+        SharedRateLimitBucket._token_wait_seconds,
+        SharedRateLimitBucket._token_wait_seconds.__code__,
+    ),
+)
+_FOUNDATION_A_TRANSCRIPT_VERIFIER = _verify_atomic_evidence_against_runtime_messages
+_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE = _verify_atomic_evidence_against_runtime_messages.__code__
+_FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
+    leaf_dispatcher_type=_FOUNDATION_A_LEAF_DISPATCHER_TYPE,
+    leaf_dispatcher_stream_root=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT,
+    leaf_dispatcher_stream_code=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE,
+    level_coordinator_type=_FOUNDATION_A_LEVEL_COORDINATOR_TYPE,
+    level_coordinator_review_root=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT,
+    level_coordinator_review_code=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE,
+    rate_gate_factory=_FOUNDATION_A_RATE_GATE_FACTORY,
+    rate_gate_type=_FOUNDATION_A_RATE_GATE_TYPE,
+    rate_gate_acquire_root=_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT,
+    rate_gate_acquire_code=_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE,
+    rate_gate_sleep=_FOUNDATION_A_RATE_GATE_SLEEP,
+    rate_gate_sleep_code=_FOUNDATION_A_RATE_GATE_SLEEP_CODE,
+    rate_gate_bucket_type=_FOUNDATION_A_RATE_GATE_BUCKET_TYPE,
+    rate_gate_bucket_time=_FOUNDATION_A_RATE_GATE_BUCKET_TIME,
+    rate_gate_bucket_enabled_root=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT,
+    rate_gate_bucket_enabled_code=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE,
+    rate_gate_bucket_acquire_root=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT,
+    rate_gate_bucket_acquire_code=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE,
+    rate_gate_bucket_force_reserve_root=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT,
+    rate_gate_bucket_force_reserve_code=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE,
+    rate_gate_bucket_helper_roots=_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS,
+    transcript_verifier=_FOUNDATION_A_TRANSCRIPT_VERIFIER,
+    transcript_verifier_code=_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE,
+)
+
+
+def _bind_foundation_a_roots(
+    roots: _FoundationAClosedRoots,
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """Bind closed roots in a closure instead of a caller-controlled kwarg."""
+
+    # Extract every root while this decorator is applied at module import. Do
+    # not retain the dataclass bundle itself: ``frozen=True`` is not a Python
+    # memory-integrity boundary and ``object.__setattr__`` could otherwise
+    # poison the bundle before a later executor is constructed.
+    leaf_dispatcher_type = roots.leaf_dispatcher_type
+    leaf_dispatcher_stream_root = roots.leaf_dispatcher_stream_root
+    leaf_dispatcher_stream_code = roots.leaf_dispatcher_stream_code
+    level_coordinator_type = roots.level_coordinator_type
+    level_coordinator_review_root = roots.level_coordinator_review_root
+    level_coordinator_review_code = roots.level_coordinator_review_code
+    rate_gate_factory = roots.rate_gate_factory
+    rate_gate_type = roots.rate_gate_type
+    rate_gate_acquire_root = roots.rate_gate_acquire_root
+    rate_gate_acquire_code = roots.rate_gate_acquire_code
+    rate_gate_sleep = roots.rate_gate_sleep
+    rate_gate_sleep_code = roots.rate_gate_sleep_code
+    rate_gate_bucket_type = roots.rate_gate_bucket_type
+    rate_gate_bucket_time = roots.rate_gate_bucket_time
+    rate_gate_bucket_enabled_root = roots.rate_gate_bucket_enabled_root
+    rate_gate_bucket_enabled_code = roots.rate_gate_bucket_enabled_code
+    rate_gate_bucket_acquire_root = roots.rate_gate_bucket_acquire_root
+    rate_gate_bucket_acquire_code = roots.rate_gate_bucket_acquire_code
+    rate_gate_bucket_force_reserve_root = roots.rate_gate_bucket_force_reserve_root
+    rate_gate_bucket_force_reserve_code = roots.rate_gate_bucket_force_reserve_code
+    rate_gate_bucket_helper_roots = roots.rate_gate_bucket_helper_roots
+    transcript_verifier = roots.transcript_verifier
+    transcript_verifier_code = roots.transcript_verifier_code
+
+    def decorate(initializer: Callable[..., None]) -> Callable[..., None]:
+        @wraps(initializer)
+        def bound(self: object, *args: object, **kwargs: object) -> None:
+            initializer(
+                self,
+                *args,
+                **kwargs,
+                _foundation_a_roots=_FoundationAClosedRoots(
+                    leaf_dispatcher_type=leaf_dispatcher_type,
+                    leaf_dispatcher_stream_root=leaf_dispatcher_stream_root,
+                    leaf_dispatcher_stream_code=leaf_dispatcher_stream_code,
+                    level_coordinator_type=level_coordinator_type,
+                    level_coordinator_review_root=level_coordinator_review_root,
+                    level_coordinator_review_code=level_coordinator_review_code,
+                    rate_gate_factory=rate_gate_factory,
+                    rate_gate_type=rate_gate_type,
+                    rate_gate_acquire_root=rate_gate_acquire_root,
+                    rate_gate_acquire_code=rate_gate_acquire_code,
+                    rate_gate_sleep=rate_gate_sleep,
+                    rate_gate_sleep_code=rate_gate_sleep_code,
+                    rate_gate_bucket_type=rate_gate_bucket_type,
+                    rate_gate_bucket_time=rate_gate_bucket_time,
+                    rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+                    rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+                    rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+                    rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+                    rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+                    rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+                    rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
+                    transcript_verifier=transcript_verifier,
+                    transcript_verifier_code=transcript_verifier_code,
+                ),
+            )
+
+        return bound
+
+    return decorate
+
+
+_FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC = 0
+_FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC = 1
+_FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET = 2
+_FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT = 3
+_FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS = 4
+_FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE = 5
+
+
+def _foundation_a_internal_entry_root_specs(
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[tuple[str, Callable[..., Any], object], ...]:
+    """Return the small, versioned set of internal effect-entry roots."""
+
+    return (
+        ("_execute_single_ac", roots.execute_single_ac_root, roots.execute_single_ac_code),
+        ("_execute_atomic_ac", roots.execute_atomic_ac_root, roots.execute_atomic_ac_code),
+        (
+            "_await_dispatch_rate_budget",
+            roots.await_dispatch_rate_budget_root,
+            roots.await_dispatch_rate_budget_code,
+        ),
+        (
+            "_dispatch_decomposition_prompt",
+            roots.dispatch_decomposition_prompt_root,
+            roots.dispatch_decomposition_prompt_code,
+        ),
+        (
+            "_run_atomic_verifier_pass",
+            roots.run_atomic_verifier_pass_root,
+            roots.run_atomic_verifier_pass_code,
+        ),
+        (
+            "_run_ac_verify_gate",
+            roots.run_ac_verify_gate_root,
+            roots.run_ac_verify_gate_code,
+        ),
+    )
+
+
+def _capture_foundation_a_internal_entry_roots(
+    executor_type: type[object],
+) -> _FoundationAInternalEntryRoots:
+    """Capture finite direct entry functions from one concrete executor type."""
+
+    try:
+        execute_single_ac_root = type.__getattribute__(executor_type, "_execute_single_ac")
+        execute_atomic_ac_root = type.__getattribute__(executor_type, "_execute_atomic_ac")
+        await_dispatch_rate_budget_root = type.__getattribute__(
+            executor_type,
+            "_await_dispatch_rate_budget",
+        )
+        dispatch_decomposition_prompt_root = type.__getattribute__(
+            executor_type,
+            "_dispatch_decomposition_prompt",
+        )
+        run_atomic_verifier_pass_root = type.__getattribute__(
+            executor_type,
+            "_run_atomic_verifier_pass",
+        )
+        run_ac_verify_gate_root = type.__getattribute__(executor_type, "_run_ac_verify_gate")
+        return _FoundationAInternalEntryRoots(
+            executor_type=executor_type,
+            execute_single_ac_root=execute_single_ac_root,
+            execute_single_ac_code=object.__getattribute__(execute_single_ac_root, "__code__"),
+            execute_atomic_ac_root=execute_atomic_ac_root,
+            execute_atomic_ac_code=object.__getattribute__(execute_atomic_ac_root, "__code__"),
+            await_dispatch_rate_budget_root=await_dispatch_rate_budget_root,
+            await_dispatch_rate_budget_code=object.__getattribute__(
+                await_dispatch_rate_budget_root,
+                "__code__",
+            ),
+            dispatch_decomposition_prompt_root=dispatch_decomposition_prompt_root,
+            dispatch_decomposition_prompt_code=object.__getattribute__(
+                dispatch_decomposition_prompt_root,
+                "__code__",
+            ),
+            run_atomic_verifier_pass_root=run_atomic_verifier_pass_root,
+            run_atomic_verifier_pass_code=object.__getattribute__(
+                run_atomic_verifier_pass_root,
+                "__code__",
+            ),
+            run_ac_verify_gate_root=run_ac_verify_gate_root,
+            run_ac_verify_gate_code=object.__getattribute__(run_ac_verify_gate_root, "__code__"),
+        )
+    except (AttributeError, TypeError) as exc:
+        raise ValueError("execution authority internal entry roots are not bindable") from exc
+
+
+def _foundation_a_internal_entry_roots_are_closed(
+    roots: _FoundationAInternalEntryRoots,
+    expected_roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Return whether construction found the import-time executor entry set."""
+
+    return roots.executor_type is expected_roots.executor_type and all(
+        root is expected_root and code is expected_code
+        for (_, root, code), (_, expected_root, expected_code) in zip(
+            _foundation_a_internal_entry_root_specs(roots),
+            _foundation_a_internal_entry_root_specs(expected_roots),
+            strict=True,
+        )
+    )
+
+
+def _foundation_a_internal_entry_roots_are_current(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Check only direct implementation roots, never arbitrary callable state."""
+
+    try:
+        if type(executor) is not roots.executor_type:
+            return False
+        instance_values = object.__getattribute__(executor, "__dict__")
+        executor_type = type(executor)
+        for name, expected_root, expected_code in _foundation_a_internal_entry_root_specs(roots):
+            if name in instance_values:
+                return False
+            current_root = type.__getattribute__(executor_type, name)
+            if current_root is not expected_root:
+                return False
+            if object.__getattribute__(current_root, "__code__") is not expected_code:
+                return False
+    except (AttributeError, KeyError, TypeError):
+        return False
+    return True
+
+
+def _make_foundation_a_internal_entry_invokers(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[Callable[..., Any], ...]:
+    """Close direct function calls over the constructor's finite root snapshot."""
+
+    executor_ref = ref(executor)
+    execute_single_ac_root = roots.execute_single_ac_root
+    execute_atomic_ac_root = roots.execute_atomic_ac_root
+    await_dispatch_rate_budget_root = roots.await_dispatch_rate_budget_root
+    dispatch_decomposition_prompt_root = roots.dispatch_decomposition_prompt_root
+    run_atomic_verifier_pass_root = roots.run_atomic_verifier_pass_root
+    run_ac_verify_gate_root = roots.run_ac_verify_gate_root
+
+    def _require_captured_executor(current_executor: object) -> None:
+        if executor_ref() is not current_executor:
+            raise ValueError("execution authority entry root is unavailable")
+
+    def execute_single_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_single_ac_root(current_executor, **kwargs)
+
+    def execute_atomic_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_atomic_ac_root(current_executor, **kwargs)
+
+    def await_dispatch_rate_budget(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return await_dispatch_rate_budget_root(current_executor, **kwargs)
+
+    def dispatch_decomposition_prompt(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return dispatch_decomposition_prompt_root(current_executor, **kwargs)
+
+    def run_atomic_verifier_pass(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_atomic_verifier_pass_root(current_executor, **kwargs)
+
+    def run_ac_verify_gate(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_ac_verify_gate_root(current_executor, **kwargs)
+
+    return (
+        execute_single_ac,
+        execute_atomic_ac,
+        await_dispatch_rate_budget,
+        dispatch_decomposition_prompt,
+        run_atomic_verifier_pass,
+        run_ac_verify_gate,
+    )
+
+
+def _bind_foundation_a_internal_entry_roots(executor_type: type[Any]) -> type[Any]:
+    """Capture original internal entry functions after the class body is complete."""
+
+    expected_roots = _capture_foundation_a_internal_entry_roots(executor_type)
+    initializer = executor_type.__init__
+
+    @wraps(initializer)
+    def bound(self: object, *args: object, **kwargs: object) -> None:
+        if (
+            "_foundation_a_internal_entry_roots" in kwargs
+            or "_foundation_a_internal_entry_roots_are_closed" in kwargs
+        ):
+            raise TypeError("_foundation_a_internal_entry_roots is constructor-bound")
+        roots = _capture_foundation_a_internal_entry_roots(type(self))
+        initializer(
+            self,
+            *args,
+            **kwargs,
+            _foundation_a_internal_entry_roots=roots,
+            _foundation_a_internal_entry_roots_are_closed=(
+                _foundation_a_internal_entry_roots_are_closed(roots, expected_roots)
+            ),
+        )
+
+    executor_type.__init__ = bound
+    return executor_type
+
+
+def _make_execution_authority_guard(
+    executor: object,
+    *,
+    binding: ExecutionAuthorityLiveBinding,
+    workspace_builder: Callable[[], str | None],
+    policy_builder: Callable[[], dict[str, object]],
+    internal_entry_roots: _FoundationAInternalEntryRoots,
+) -> Callable[[object], None]:
+    """Capture Foundation A roots outside mutable executor instance fields."""
+
+    executor_ref = ref(executor)
+    binding_ref = ref(binding)
+    binding_is_intact = ExecutionAuthorityLiveBinding.is_intact
+    binding_is_intact_code = binding_is_intact.__code__
+    workspace_builder_root = workspace_builder.__func__
+    workspace_builder_code = workspace_builder_root.__code__
+    policy_builder_root = policy_builder.__func__
+    policy_builder_code = policy_builder_root.__code__
+    internal_entry_roots_are_current = _foundation_a_internal_entry_roots_are_current
+    internal_entry_roots_are_current_code = internal_entry_roots_are_current.__code__
+
+    def guard(current_executor: object) -> None:
+        captured_executor = executor_ref()
+        captured_binding = binding_ref()
+        if captured_executor is not current_executor or captured_binding is None:
+            raise ValueError("execution authority guard is unavailable")
+        authority_verifier = captured_binding.verifier
+        adapter = captured_binding.adapter
+        dispatcher_type = captured_binding.dispatcher_type
+        dispatcher = captured_binding.dispatcher
+        transcript_verifier = captured_binding.transcript_verifier
+        rate_gate = captured_binding.rate_gate
+        dispatcher_stream_callable = captured_binding.dispatcher_stream_callable
+        rate_gate_acquire_callable = captured_binding.rate_gate_acquire_callable
+        coordinator = captured_binding.coordinator
+        coordinator_review_callable = captured_binding.coordinator_review_callable
+        session_signal_hub = captured_binding.session_signal_hub
+        get_attribute = object.__getattribute__
+        if (
+            get_attribute(current_executor, "_execution_authority_live_binding")
+            is not captured_binding
+            or get_attribute(current_executor, "_authority_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_atomic_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_adapter") is not adapter
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_type")
+            is not dispatcher_type
+            or get_attribute(current_executor, "_authority_leaf_dispatcher") is not dispatcher
+            or get_attribute(current_executor, "_authority_transcript_verifier")
+            is not transcript_verifier
+            or get_attribute(current_executor, "_dispatch_rate_gate") is not rate_gate
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_stream")
+            is not dispatcher_stream_callable
+            or get_attribute(current_executor, "_authority_rate_gate_acquire_root")
+            is not rate_gate_acquire_callable
+            or get_attribute(current_executor, "_coordinator") is not coordinator
+            or get_attribute(current_executor, "_authority_coordinator_review")
+            is not coordinator_review_callable
+            or get_attribute(current_executor, "_session_signal_hub") is not session_signal_hub
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if (
+            binding_is_intact.__code__ is not binding_is_intact_code
+            or workspace_builder_root.__code__ is not workspace_builder_code
+            or policy_builder_root.__code__ is not policy_builder_code
+            or internal_entry_roots_are_current.__code__
+            is not internal_entry_roots_are_current_code
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if not internal_entry_roots_are_current(current_executor, internal_entry_roots):
+            raise ValueError("execution authority drifted before effect")
+        if not binding_is_intact(
+            captured_binding,
+            executor=current_executor,
+            adapter=adapter,
+            verifier=authority_verifier,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=current_executor,
+            transcript_verifier=transcript_verifier,
+            rate_gate=rate_gate,
+            workspace=workspace_builder_root(current_executor),
+            execution_policy=policy_builder_root(current_executor),
+            session_signal_hub=session_signal_hub,
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+        ):
+            raise ValueError("execution authority drifted before effect")
+
+    return guard
+
+
+def _make_execution_authority_registry() -> tuple[
+    Callable[[object, Callable[[object], None], tuple[Callable[..., Any], ...]], None],
+    Callable[[object], None],
+    Callable[..., Any],
+]:
+    """Keep guards and direct invokers in closure-only process state.
+
+    This is an integrity boundary for normal collaborators, not a Python
+    sandbox against code that deliberately introspects and mutates private
+    module closures in its own process.
+    """
+
+    # ``WeakKeyDictionary`` delegates identity to user-defined ``__hash__`` and
+    # ``__eq__``. Foundation A deliberately supports process-local executor
+    # subclasses, including unhashable and equality-overriding ones, so keep a
+    # private identity-keyed table instead. Every lookup verifies the weak
+    # referent before use, which also makes delayed cleanup and ``id`` reuse
+    # safe. Values retain only the guard/invokers; those retain weak executor
+    # references and therefore cannot keep an executor alive.
+    states: dict[
+        int,
+        tuple[
+            ref[object],
+            Callable[[object], None],
+            tuple[Callable[..., Any], ...],
+        ],
+    ] = {}
+
+    def _lookup(
+        executor: object,
+    ) -> tuple[Callable[[object], None], tuple[Callable[..., Any], ...]]:
+        executor_id = id(executor)
+        state = states.get(executor_id)
+        if state is None:
+            raise ValueError("execution authority guard is unavailable")
+        executor_ref, guard, invokers = state
+        if executor_ref() is not executor:
+            # The stale entry may await a weakref callback, or its integer key
+            # may have been reused. Never dispatch through either case.
+            if executor_ref() is None:
+                states.pop(executor_id, None)
+            raise ValueError("execution authority guard is unavailable")
+        return guard, invokers
+
+    def register(
+        executor: object,
+        guard: Callable[[object], None],
+        invokers: tuple[Callable[..., Any], ...],
+    ) -> None:
+        executor_id = id(executor)
+
+        def cleanup(executor_ref: ref[object]) -> None:
+            state = states.get(executor_id)
+            if state is not None and state[0] is executor_ref:
+                states.pop(executor_id, None)
+
+        executor_ref = ref(executor, cleanup)
+        states[executor_id] = (executor_ref, guard, invokers)
+
+    def invoke_guard(executor: object) -> None:
+        guard, _ = _lookup(executor)
+        guard(executor)
+
+    def invoke_entry(executor: object, entry_index: int, **kwargs: object) -> Any:
+        try:
+            guard, invokers = _lookup(executor)
+            invoker = invokers[entry_index]
+        except IndexError as exc:
+            raise ValueError("execution authority entry root is unavailable") from exc
+        guard(executor)
+        return invoker(executor, **kwargs)
+
+    return register, invoke_guard, invoke_entry
+
+
+(
+    _register_execution_authority_state,
+    _invoke_execution_authority_guard,
+    _invoke_execution_authority_entry,
+) = _make_execution_authority_registry()
 
 
 def _is_session_signal_application_acknowledgement(message: AgentMessage) -> bool:
@@ -874,9 +1460,11 @@ def render_parallel_completion_message(
 # =============================================================================
 
 
+@_bind_foundation_a_internal_entry_roots
 class ParallelACExecutor:
     """Executes ACs in parallel based on dependency graph."""
 
+    @_bind_foundation_a_roots(_FOUNDATION_A_CLOSED_ROOTS)
     def __init__(
         self,
         adapter: AgentRuntime,
@@ -900,6 +1488,9 @@ class ParallelACExecutor:
         cross_harness_redispatch: bool | None = None,
         shadow_replay_enabled: bool = False,
         session_signal_hub: SessionSignalHub | None = None,
+        _foundation_a_roots: _FoundationAClosedRoots = _FOUNDATION_A_CLOSED_ROOTS,
+        _foundation_a_internal_entry_roots: _FoundationAInternalEntryRoots | None = None,
+        _foundation_a_internal_entry_roots_are_closed: bool = False,
     ):
         """Initialize executor.
 
@@ -935,6 +1526,10 @@ class ParallelACExecutor:
                 today's single-dispatch behavior; real run paths (CLI `ooo run`
                 via the runner) pass the config value (default 2).
         """
+        if _foundation_a_internal_entry_roots is None:
+            raise ValueError("execution authority internal entry roots are unavailable")
+        internal_entry_roots = _foundation_a_internal_entry_roots
+
         self._adapter = adapter
         self._event_store = event_store
         self._console = console or Console()
@@ -946,6 +1541,7 @@ class ParallelACExecutor:
         )
         self._enable_decomposition = self._decomposition_mode != "off"
         self._max_decomposition_depth = max(0, max_decomposition_depth)
+        self._max_concurrent = max_concurrent
         approval_mode = getattr(adapter, "permission_mode", None)
         self._inherited_runtime_handle = (
             replace(inherited_runtime_handle, approval_mode=approval_mode.strip())
@@ -978,11 +1574,26 @@ class ParallelACExecutor:
         self._shadow_replay_enabled = shadow_replay_enabled
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
-        self._coordinator = LevelCoordinator(
+        # These exact objects are the finite effect-owner roots Foundation A
+        # can bind at runtime. Callable internals remain explicitly volatile;
+        # custom verifiers never become portable through graph inspection.
+        self._authority_verifier = atomic_verifier
+        self._authority_leaf_dispatcher_type = _foundation_a_roots.leaf_dispatcher_type
+        # Construct the leaf once through closed primitive roots, then call the
+        # captured stream implementation directly. A later class ``__init__``
+        # or instance ``stream`` hook cannot replace the immediate dispatcher
+        # effect after the authority check.
+        self._authority_leaf_dispatcher = object.__new__(self._authority_leaf_dispatcher_type)
+        object.__setattr__(self._authority_leaf_dispatcher, "_executor", self)
+        self._authority_leaf_dispatcher_stream = _foundation_a_roots.leaf_dispatcher_stream_root
+        self._authority_transcript_verifier = _foundation_a_roots.transcript_verifier
+        self._coordinator = _foundation_a_roots.level_coordinator_type(
             adapter,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=task_cwd,
         )
+        self._authority_coordinator = self._coordinator
+        self._authority_coordinator_review = self._coordinator.run_review
         self._semaphore = anyio.Semaphore(max_concurrent)
         self._ac_runtime_handle_manager = ACRuntimeHandleManager(
             adapter,
@@ -997,7 +1608,11 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
         self._execution_counters_lock = asyncio.Lock()
-        self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        self._dispatch_rate_gate = self._build_dispatch_rate_gate(
+            adapter,
+            rate_gate_factory=_foundation_a_roots.rate_gate_factory,
+        )
+        self._authority_rate_gate_acquire_root = _foundation_a_roots.rate_gate_acquire_root
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1015,9 +1630,161 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
+        workspace_builder = object.__getattribute__(
+            self,
+            "_execution_authority_workspace",
+        )
+        policy_builder = object.__getattribute__(
+            self,
+            "_execution_authority_policy",
+        )
+        binding = ExecutionAuthorityLiveBinding.capture(
+            executor=self,
+            adapter=adapter,
+            verifier=atomic_verifier,
+            dispatcher_type=self._authority_leaf_dispatcher_type,
+            dispatcher=self._authority_leaf_dispatcher,
+            dispatcher_executor=self,
+            transcript_verifier=self._authority_transcript_verifier,
+            rate_gate=self._dispatch_rate_gate,
+            workspace=workspace_builder(),
+            execution_policy=policy_builder(),
+            session_signal_hub=self._session_signal_hub,
+            dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
+            rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
+            coordinator=self._authority_coordinator,
+            coordinator_review_callable=self._authority_coordinator_review,
+            expected_dispatcher_type=_foundation_a_roots.leaf_dispatcher_type,
+            expected_dispatcher_stream_root=_foundation_a_roots.leaf_dispatcher_stream_root,
+            expected_dispatcher_stream_code=_foundation_a_roots.leaf_dispatcher_stream_code,
+            expected_transcript_verifier=_foundation_a_roots.transcript_verifier,
+            expected_transcript_verifier_code=_foundation_a_roots.transcript_verifier_code,
+            expected_rate_gate_acquire_root=_foundation_a_roots.rate_gate_acquire_root,
+            expected_rate_gate_acquire_code=_foundation_a_roots.rate_gate_acquire_code,
+            expected_rate_gate_type=_foundation_a_roots.rate_gate_type,
+            expected_rate_gate_sleep=_foundation_a_roots.rate_gate_sleep,
+            expected_rate_gate_sleep_code=_foundation_a_roots.rate_gate_sleep_code,
+            expected_rate_gate_bucket_type=_foundation_a_roots.rate_gate_bucket_type,
+            expected_rate_gate_bucket_time=_foundation_a_roots.rate_gate_bucket_time,
+            expected_rate_gate_bucket_enabled_root=(
+                _foundation_a_roots.rate_gate_bucket_enabled_root
+            ),
+            expected_rate_gate_bucket_enabled_code=(
+                _foundation_a_roots.rate_gate_bucket_enabled_code
+            ),
+            expected_rate_gate_bucket_acquire_root=(
+                _foundation_a_roots.rate_gate_bucket_acquire_root
+            ),
+            expected_rate_gate_bucket_acquire_code=(
+                _foundation_a_roots.rate_gate_bucket_acquire_code
+            ),
+            expected_rate_gate_bucket_force_reserve_root=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_root
+            ),
+            expected_rate_gate_bucket_force_reserve_code=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_code
+            ),
+            expected_rate_gate_bucket_helper_roots=(
+                _foundation_a_roots.rate_gate_bucket_helper_roots
+            ),
+            expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
+            expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,
+            expected_coordinator_review_code=_foundation_a_roots.level_coordinator_review_code,
+            force_runtime_process_local=(
+                not _foundation_a_internal_entry_roots_are_closed
+                or self._session_signal_hub is not None
+            ),
+        )
+        self._execution_authority_live_binding = binding
+        self._execution_authority = binding.contract
+        internal_entry_invokers = _make_foundation_a_internal_entry_invokers(
+            self,
+            internal_entry_roots,
+        )
+        _register_execution_authority_state(
+            self,
+            _make_execution_authority_guard(
+                self,
+                binding=binding,
+                workspace_builder=workspace_builder,
+                policy_builder=policy_builder,
+                internal_entry_roots=internal_entry_roots,
+            ),
+            internal_entry_invokers,
+        )
+
+    @property
+    def execution_authority(self) -> ExecutionAuthorityContract:
+        """Return the immutable authority snapshot used by this executor."""
+        return self._execution_authority
+
+    def _execution_authority_workspace(self) -> str | None:
+        """Return the finite effect-workspace root for Foundation A."""
+        get_attribute = object.__getattribute__
+        task_cwd = get_attribute(self, "_task_cwd")
+        adapter = get_attribute(self, "_adapter")
+        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        return workspace if isinstance(workspace, str) else None
+
+    def _execution_authority_policy(self) -> dict[str, object]:
+        """Return only static executor policy; attempt inputs stay excluded."""
+        get_attribute = object.__getattribute__
+        adapter = get_attribute(self, "_adapter")
+        coordinator = get_attribute(self, "_coordinator")
+        backend = getattr(adapter, "runtime_backend", None)
+        limits = resolve_backend_limits(backend if isinstance(backend, str) else None)
+        coordinator_effort = getattr(coordinator, "_reasoning_effort", None)
+        return {
+            "version": 1,
+            "decomposition_mode": get_attribute(self, "_decomposition_mode"),
+            "max_decomposition_depth": get_attribute(self, "_max_decomposition_depth"),
+            "max_concurrent": get_attribute(self, "_max_concurrent"),
+            "execution_profile": (
+                get_attribute(self, "_execution_profile").model_dump(mode="json")
+                if get_attribute(self, "_execution_profile") is not None
+                else None
+            ),
+            "fat_harness_mode": get_attribute(self, "_fat_harness_mode"),
+            "run_verify_commands": get_attribute(self, "_run_verify_commands"),
+            "verify_command_timeout_seconds": get_attribute(
+                self,
+                "_verify_command_timeout_seconds",
+            ),
+            "ac_retry_attempts": get_attribute(self, "_ac_retry_attempts"),
+            "reasoning_effort": get_attribute(self, "_reasoning_effort"),
+            "coordinator_reasoning_effort": coordinator_effort,
+            "model_routing": serialize_model_router(get_attribute(self, "_model_router")),
+            "cross_harness_redispatch": get_attribute(
+                self,
+                "_cross_harness_redispatch_enabled",
+            ),
+            "shadow_replay_enabled": get_attribute(self, "_shadow_replay_enabled"),
+            "session_signal_hub_enabled": get_attribute(self, "_session_signal_hub") is not None,
+            "dispatch_rate": {
+                "algorithm": "rate-limit-gate/v1",
+                "backend": backend if isinstance(backend, str) else None,
+                "self_governs_rate_limit": getattr(
+                    adapter,
+                    "self_governs_rate_limit",
+                    False,
+                ),
+                "requests_per_minute": limits.requests_per_minute,
+                "tokens_per_minute": limits.tokens_per_minute,
+            },
+        }
+
+    def _require_execution_authority_intact(self) -> None:
+        """Fail closed when an enumerated live effect-owner root drifts."""
+        _invoke_execution_authority_guard(self)
 
     @staticmethod
-    def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
+    def _build_dispatch_rate_gate(
+        adapter: AgentRuntime,
+        *,
+        rate_gate_factory: Callable[
+            ..., RateLimitGate
+        ] = _FOUNDATION_A_CLOSED_ROOTS.rate_gate_factory,
+    ) -> RateLimitGate:
         """Build the shared dispatch rate gate for non-self-governing backends.
 
         Ouroboros — not the runtime — paces delivery within the backend's
@@ -1032,10 +1799,14 @@ class ParallelACExecutor:
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
 
         if getattr(adapter, "self_governs_rate_limit", False):
-            return build_rate_limit_gate(backend, request_limit=None, token_limit=None)
+            return rate_gate_factory(
+                backend,
+                request_limit=None,
+                token_limit=None,
+            )
 
         limits = resolve_backend_limits(backend)
-        return build_rate_limit_gate(
+        return rate_gate_factory(
             backend,
             request_limit=limits.requests_per_minute,
             token_limit=limits.tokens_per_minute,
@@ -1054,9 +1825,7 @@ class ParallelACExecutor:
         workers (they share this executor's single gate instance) and logs each
         backoff for observability.
         """
-        if not self._dispatch_rate_gate.enabled:
-            return
-
+        _invoke_execution_authority_guard(self)
         estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
 
         def _log_backoff(backoff: RateLimitBackoff) -> None:
@@ -1072,7 +1841,14 @@ class ParallelACExecutor:
                 token_limit=backoff.snapshot.token_limit,
             )
 
-        await self._dispatch_rate_gate.acquire(estimated_tokens, on_backoff=_log_backoff)
+        await self._authority_rate_gate_acquire_root(
+            self._dispatch_rate_gate,
+            estimated_tokens,
+            on_backoff=_log_backoff,
+        )
+        # Rate admission can suspend. Revalidate before returning to a caller
+        # that will dispatch to the runtime immediately afterwards.
+        _invoke_execution_authority_guard(self)
 
     def _announce_param_degradations(
         self,
@@ -1564,7 +2340,9 @@ class ParallelACExecutor:
             async with self._semaphore:
                 try:
                     ac_criterion = seed.acceptance_criteria[ac_idx]
-                    batch_results[idx] = await self._execute_single_ac(
+                    batch_results[idx] = await _invoke_execution_authority_entry(
+                        self,
+                        _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                         ac_index=ac_idx,
                         ac_content=ac_text(ac_criterion),
                         session_id=session_id,
@@ -1893,7 +2671,12 @@ class ParallelACExecutor:
                         and (spec.verify_command or spec.expected_artifacts)
                     ):
                         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                        gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                        gate = await _invoke_execution_authority_entry(
+                            self,
+                            _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                            spec=spec,
+                            cwd=cwd,
+                        )
                         if not gate.passed:
                             executable.append(ac_idx)
                             log.info(
@@ -2211,7 +2994,8 @@ class ParallelACExecutor:
                             level=level_num,
                             conflicts=conflicts,
                         )
-                        review = await self._coordinator.run_review(
+                        _invoke_execution_authority_guard(self)
+                        review = await self._authority_coordinator_review(
                             execution_id=execution_id,
                             conflicts=conflicts,
                             level_context=level_ctx,
@@ -2488,7 +3272,9 @@ class ParallelACExecutor:
                     status="executing",
                     node_identity=child_node_identity,
                 )
-                sub_results[idx] = await self._execute_single_ac(
+                sub_results[idx] = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                     ac_index=ac_index * 100 + idx,
                     ac_content=sub_ac,
                     session_id=session_id,
@@ -2651,7 +3437,17 @@ class ParallelACExecutor:
         parent executor inherited a resumable handle.
         """
         self._announce_param_degradations(system_prompt=system_prompt, tools=[])
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        _invoke_execution_authority_guard(self)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
+        # Acquiring rate budget can suspend, so validate once more at the
+        # immediate effect boundary rather than assuming the pre-wait snapshot
+        # still applies.
+        _invoke_execution_authority_guard(self)
         response_text = ""
         async with asyncio.timeout(DECOMPOSITION_TIMEOUT_SECONDS):
             async for message in self._adapter.execute_task(
@@ -2689,7 +3485,9 @@ class ParallelACExecutor:
             f"## Bounded Attempt Trace\n{trace.summary}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt="You are a conservative execution-recovery classifier.",
             )
@@ -3115,7 +3913,9 @@ class ParallelACExecutor:
             "semantic_ac_key": semantic_ac_key,
         }
         while True:
-            atomic_result = await self._execute_atomic_ac(
+            atomic_result = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC,
                 ac_index=ac_index,
                 ac_content=ac_content,
                 session_id=session_id,
@@ -3469,7 +4269,7 @@ class ParallelACExecutor:
             task_cwd=self._task_cwd,
             execution_profile=self._execution_profile,
             fat_harness_mode=self._fat_harness_mode,
-            atomic_verifier=self._atomic_verifier,
+            atomic_verifier=self._authority_verifier,
             reasoning_effort=self._reasoning_effort,
             # The router's backend-mismatch guard makes it inert on a different
             # backend, so passing it to the alt-harness executor is safe.
@@ -3481,7 +4281,12 @@ class ParallelACExecutor:
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
         )
-        return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
+        return await _invoke_execution_authority_entry(
+            alt_executor,
+            _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
+            **rerun_kwargs,
+            retry_attempt=retry_attempt,
+        )
 
     @staticmethod
     def _parse_legacy_decomposition(
@@ -3568,7 +4373,9 @@ class ParallelACExecutor:
             f"{json.dumps(proposal.to_dict(), sort_keys=True)}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt=system_prompt,
                 independent_session=True,
@@ -3747,7 +4554,9 @@ Respond with either ATOMIC or the structured JSON object only.
             decompose_prompt += f"\n\n## Bounded Attempt Trace\n{bounded_trace}"
 
         try:
-            response_text = await self._dispatch_decomposition_prompt(
+            response_text = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=decompose_prompt,
                 system_prompt=decomposition_system_prompt,
             )
@@ -3805,7 +4614,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     min_sub_acs=min_sub_acs,
                     max_sub_acs=max_sub_acs,
                 )
-                repaired_text = await self._dispatch_decomposition_prompt(
+                repaired_text = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                     prompt=repair_prompt,
                     system_prompt=decomposition_system_prompt,
                 )
@@ -4286,7 +5097,12 @@ Respond with either ATOMIC or the structured JSON object only.
         self._announce_param_degradations(system_prompt=system_prompt, tools=tools)
         # Pace delivery within the backend's shared rate budget (dormant unless
         # an RPM/TPM is configured for this backend) before the stall-scoped run.
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
 
         investment_assessment = assess_investment(investment_spec)
         await self._event_emitter.emit_investment_assessed(
@@ -4484,7 +5300,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
-            await LeafDispatcher(self).stream(
+            _invoke_execution_authority_guard(self)
+            await self._authority_leaf_dispatcher_stream(
+                self._authority_leaf_dispatcher,
                 state=dispatch_state,
                 prompt=prompt,
                 tools=tools,
@@ -4586,7 +5404,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
-                        await LeafDispatcher(self).stream(
+                        _invoke_execution_authority_guard(self)
+                        await self._authority_leaf_dispatcher_stream(
+                            self._authority_leaf_dispatcher,
                             state=dispatch_state,
                             prompt=(
                                 render_inform_signal_prompt(queued_signal.signal)
@@ -4745,7 +5565,12 @@ Respond with either ATOMIC or the structured JSON object only.
             verify_gate_outcome: _VerifyGateOutcome | None = None
             if success and verify_gate_active and has_success_contract:
                 cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                verify_gate_outcome = await self._run_ac_verify_gate(spec=ac_spec, cwd=cwd)
+                verify_gate_outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=ac_spec,
+                    cwd=cwd,
+                )
 
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
@@ -4755,7 +5580,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 has_expected_artifacts=has_expected_artifacts,
                 verify_gate_active=verify_gate_active,
             )
-            verifier_verdict = self._run_atomic_verifier_pass(
+            verifier_verdict = _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
                 ac_content=ac_content,
                 final_message=final_message,
                 success=success,
@@ -5350,7 +6177,12 @@ Respond with either ATOMIC or the structured JSON object only.
                 outcome=cached_outcome,
             )
         else:
-            outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+            outcome = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                spec=spec,
+                cwd=cwd,
+            )
         if outcome.passed:
             if not result.success and not result.is_blocked and not result.is_invalid:
                 from ouroboros.events.base import BaseEvent
@@ -5564,7 +6396,12 @@ Respond with either ATOMIC or the structured JSON object only.
                     outcome=cached_outcome,
                 )
             else:
-                outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=spec,
+                    cwd=cwd,
+                )
             if not outcome.passed:
                 gated_out.add(ac_idx)
         return frozenset(gated_out)
@@ -6050,7 +6887,8 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return None
 
-        verifier = self._atomic_verifier
+        _invoke_execution_authority_guard(self)
+        verifier = self._authority_verifier
         try:
             effective_schema = _effective_evidence_schema_for_ac(
                 self._execution_profile,
@@ -6078,14 +6916,21 @@ Respond with either ATOMIC or the structured JSON object only.
                     record=scoped_evidence,
                 )
                 if verifier is not None and not force_runtime_transcript
-                else self._verify_atomic_evidence_against_runtime_messages(
+                # Do not route acceptance through the mutable executor wrapper.
+                # Foundation A captured this closed transcript verifier at
+                # construction and has just checked that binding above.
+                else self._authority_transcript_verifier(
                     messages=messages,
                     typed_evidence=scoped_evidence,
                     ac_content=ac_content,
+                    execution_profile=self._execution_profile,
+                    task_cwd=task_cwd_override or self._task_cwd,
+                    adapter_working_directory=(
+                        task_cwd_override or self._adapter.working_directory
+                    ),
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
                     verify_gate_active=verify_gate_active,
-                    task_cwd_override=task_cwd_override,
                 )
             )
         except VerifierContractError:
@@ -6108,7 +6953,7 @@ Respond with either ATOMIC or the structured JSON object only.
         verify_gate_active: bool = False,
         task_cwd_override: str | None = None,
     ) -> VerifierVerdict:
-        return _verify_atomic_evidence_against_runtime_messages(
+        return self._authority_transcript_verifier(
             messages=messages,
             typed_evidence=typed_evidence,
             ac_content=ac_content,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4211,6 +4211,23 @@ class OrchestratorRunner:
         # in a runner-wide mutable slot: concurrent preparations must not share
         # a capability or correlation id.
         authority_generation = self._begin_process_local_authority_generation()
+
+        def abort_process_local_preparation() -> None:
+            """Dispose every authority state reachable from an aborted prepare.
+
+            The registration may have completed before a later setup step
+            raises, while an earlier failure has only an unregistered issuance.
+            Both cleanup operations are idempotent and together leave no
+            capability or lease behind.
+            """
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            self._discard_process_local_authority(authority_generation)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+
         try:
             execution_contract = await asyncio.to_thread(
                 self._build_execution_contract,
@@ -4218,18 +4235,10 @@ class OrchestratorRunner:
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
-        except OrchestratorError as exc:
-            self._discard_process_local_authority(authority_generation)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
-            return Result.err(exc)
-        self._execution_contract = execution_contract
-
-        # Establish the exact capability and PID liveness lease before any
-        # durable RUNNING tracker can be reconstructed by an observer.  The
-        # resolved session id is allocated locally for that purpose rather
-        # than delegated to SessionRepository after its start event is written.
-        try:
+            # Establish the exact capability and PID liveness lease before any
+            # durable RUNNING tracker can be reconstructed by an observer. The
+            # resolved session id is allocated locally for that purpose rather
+            # than delegated to SessionRepository after its start event is written.
             self._register_process_local_authority(
                 session_id=resolved_session_id,
                 execution_id=exec_id,
@@ -4237,10 +4246,32 @@ class OrchestratorRunner:
                 generation=authority_generation,
             )
         except OrchestratorError as exc:
-            self._discard_process_local_authority(authority_generation)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            abort_process_local_preparation()
             return Result.err(exc)
+        except asyncio.CancelledError:
+            abort_process_local_preparation()
+            raise
+        except Exception as exc:
+            abort_process_local_preparation()
+            log.exception(
+                "orchestrator.runner.prepare_authority_failed",
+                execution_id=exec_id,
+                session_id=resolved_session_id,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to prepare process-local execution authority",
+                    details={
+                        "execution_id": exec_id,
+                        "session_id": resolved_session_id,
+                        "cause": type(exc).__name__,
+                    },
+                )
+            )
+        except BaseException:
+            abort_process_local_preparation()
+            raise
+        self._execution_contract = execution_contract
 
         try:
             session_result = await self._session_repo.create_session(
@@ -5611,53 +5642,65 @@ class OrchestratorRunner:
         # owner has crashed or exited and Foundation A must terminally reject it
         # rather than leave a restartable-looking RUNNING session stranded.
         if tracker.status != SessionStatus.PAUSED:
-            own_live_authority = self._has_live_process_local_authority(
-                session_id,
-                tracker.execution_id,
-                raw_contract,
-            )
-            held_elsewhere = (
-                not own_live_authority
-                and self._process_local_authority_held_elsewhere(
+            authority_generation, authority_claimed = (
+                self._claim_process_local_authority_generation(
                     session_id,
                     tracker.execution_id,
                     raw_contract,
                 )
             )
-            if not own_live_authority and not held_elsewhere:
-                error = await self._mark_process_local_resume_unavailable(
+            if authority_claimed:
+                # The current runner is already performing effects. Do not
+                # release its worktree or downgrade the typed nonterminal
+                # ownership result to a generic state error.
+                return Result.err(
+                    self._process_local_execution_in_progress_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            if authority_generation is not None:
+                # This runner still owns the live generation but the durable
+                # status is non-resumable. The probe claim was only for
+                # arbitration, so restore the pre-existing unclaimed state
+                # without touching its workspace or lease.
+                self._release_process_local_authority(
                     session_id=session_id,
                     execution_id=tracker.execution_id,
                 )
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
-                    session_id,
-                    session_registered=False,
+                return Result.err(
+                    OrchestratorError(
+                        message=(
+                            f"Session is not paused and cannot resume ({tracker.status.value})"
+                        ),
+                        details={
+                            "session_id": session_id,
+                            "status": tracker.status.value,
+                            "resume_blocked": "session_not_paused",
+                        },
+                    )
                 )
-                return Result.err(error)
-            if held_elsewhere:
+            if self._process_local_authority_held_elsewhere(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
                 return Result.err(
                     self._process_local_authority_held_elsewhere_error(
                         session_id,
                         tracker.execution_id,
                     )
                 )
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
-                retire_authority=False,
             )
-            return Result.err(
-                OrchestratorError(
-                    message=f"Session is not paused and cannot resume ({tracker.status.value})",
-                    details={
-                        "session_id": session_id,
-                        "status": tracker.status.value,
-                        "resume_blocked": "session_not_paused",
-                    },
-                )
-            )
+            return Result.err(error)
 
         # This is intentionally before Foundation A contract restoration,
         # resume-handle selection, and every runtime-owned identity provider.

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1287,8 +1287,11 @@ class OrchestratorRunner:
         """
         from ouroboros.orchestrator.heartbeat import acquire as acquire_lock
 
-        self._active_sessions[execution_id] = session_id
         acquire_lock(session_id)
+        # Do not publish an in-memory cancellation route before its liveness
+        # lease exists. A failed claim must not leave a routable, unowned
+        # session behind.
+        self._active_sessions[execution_id] = session_id
 
     def _unregister_session(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,23 @@ from ouroboros.orchestrator.events import (
     create_tool_called_event,
     create_workflow_progress_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    _claim_process_local_authority_generation,
+    _discard_process_local_authority_generation,
+    _has_live_process_local_authority_registration,
+    _live_process_local_authority_generation,
+    _mint_process_local_authority_generation,
+    _process_local_authority_contract,
+    _ProcessLocalAuthorityGeneration,
+    _register_process_local_authority_generation,
+    _release_process_local_authority_generation,
+    _retire_process_local_authority_generation,
+    constructor_model_contract,
+    runtime_execution_proves_effective_model,
+    valid_constructor_model_contract,
+    valid_process_local_authority_contract,
+    valid_runtime_execution_identity_contract,
+)
 from ouroboros.orchestrator.execution_guidance import (
     ExecutionGuidanceBundle,
     resolve_execution_guidance,
@@ -543,7 +560,7 @@ CANCELLATION_CHECK_INTERVAL = 5
 # most this many same-seed executions.
 FRUGALITY_PROOF_SESSION_LOOKBACK = 1000
 FRUGALITY_PROOF_MAX_COHORT_RUNS = 50
-EXECUTION_CONTRACT_VERSION = 1
+EXECUTION_CONTRACT_VERSION = 2
 FRUGALITY_PROOF_PROTOCOL_VERSION = 1
 EXECUTION_CONTRACT_PROGRESS_KEY = "execution_contract"
 FORCED_EXECUTION_PERMISSION_MODE = "bypassPermissions"
@@ -784,6 +801,9 @@ class OrchestratorRunner:
             )
         self._apply_efficiency_mode_to_router()
         self._execution_contract: dict[str, Any] | None = None
+        self._process_local_authorities: dict[
+            tuple[str, str], _ProcessLocalAuthorityGeneration
+        ] = {}
         self._execution_guidance: ExecutionGuidanceBundle | None = None
         # Opt-in shadow-replay baseline harness (frugality-proof AC5). Read ONCE
         # here next to the router build and threaded to the parallel executor.
@@ -1270,22 +1290,34 @@ class OrchestratorRunner:
         self._active_sessions[execution_id] = session_id
         acquire_lock(session_id)
 
-    def _unregister_session(self, execution_id: str, session_id: str) -> None:
+    def _unregister_session(
+        self,
+        execution_id: str,
+        session_id: str,
+        *,
+        release_liveness_lease: bool = True,
+    ) -> None:
         """Unregister a session after execution completes.
 
         Called at the end of execution (success, failure, or cancellation)
-        to clean up tracking state and remove the heartbeat file.
+        to clean up tracking state and normally remove the heartbeat file. A
+        deliberately paused process-local session keeps its liveness lease:
+        the claim is released so its original owner can resume it, while other
+        runners must still recognize that the live capability has not crashed.
 
         Args:
             execution_id: Execution ID to remove.
             session_id: Session ID to remove.
+            release_liveness_lease: Whether this lifecycle path is terminal and
+                may remove the PID liveness lease.
         """
         from ouroboros.orchestrator.heartbeat import (
             release_if_owned_by_current_process as release_lock,
         )
 
         self._active_sessions.pop(execution_id, None)
-        release_lock(session_id)
+        if release_liveness_lease:
+            release_lock(session_id)
 
     def _cleanup_pre_execution_state(
         self,
@@ -1293,8 +1325,19 @@ class OrchestratorRunner:
         session_id: str | None,
         *,
         session_registered: bool,
+        retire_authority: bool = True,
     ) -> None:
-        """Release pre-loop runner state after setup fails."""
+        """Release pre-loop runner state after an aborted execution path.
+
+        A setup failure or externally cancelled task does not leave a valid
+        same-process continuation.  Retire its live capability before releasing
+        bookkeeping so a stale tracker cannot become an alternate resume path.
+        """
+        if retire_authority and execution_id is not None and session_id is not None:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
         if session_registered and execution_id is not None and session_id is not None:
             self._unregister_session(execution_id, session_id)
         if self._task_workspace is not None:
@@ -1584,145 +1627,378 @@ class OrchestratorRunner:
         runtimes that expose no constructor model at all; current-format resume
         then fails closed because the effective pin cannot be verified.
         """
-        try:
-            raw_model = inspect.getattr_static(self._adapter, "_model")
-        except AttributeError:
-            return {"observed": False}
-        if raw_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(raw_model, str):
-            return {"observed": False}
-
-        normalized_model: object = raw_model.strip() or None
-        normalizer_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "_normalize_model",
-            None,
-        )
-        if normalizer_descriptor is not None:
-            try:
-                normalizer = object.__getattribute__(self._adapter, "_normalize_model")
-                normalized_model = normalizer(raw_model)
-            except Exception:
-                return {"observed": False}
-        if normalized_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(normalized_model, str) or not normalized_model.strip():
-            return {"observed": False}
-        return {"observed": True, "model": normalized_model.strip()}
+        return constructor_model_contract(self._adapter)
 
     @staticmethod
     def _valid_constructor_model_contract(value: object) -> bool:
         """Return whether a persisted constructor-model contract is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        observed = value.get("observed")
-        if observed is not True:
-            return False
-        model = value.get("model")
-        return set(value) == {"observed", "model"} and (
-            model is None or isinstance(model, str) and bool(model.strip())
-        )
+        return valid_constructor_model_contract(value)
 
     def _runtime_execution_identity_contract(self) -> dict[str, Any]:
-        """Return backend-specific resolved execution inputs, when observable.
+        """Return no cross-process identity for a legacy dynamic runtime.
 
-        The generic constructor-model pin is sufficient for runtimes whose
-        model is fully selected by ``_model``. Some runtimes have an additional
-        resolved execution profile, though: Codex can choose a provider/model
-        through ``runtime_profile`` / ``--profile`` while ``_model`` remains
-        ``None``. Bundled runtimes may expose ``execution_identity_contract`` to
-        persist those command-relevant inputs without teaching the runner every
-        backend's private configuration model.
+        Foundation A intentionally does not execute a runtime-owned identity
+        provider here.  That provider may itself resolve mutable helpers,
+        profile files, handler caches, or launcher state.  A live
+        process-local generation below controls same-process resume instead.
         """
-
-        provider_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "execution_identity_contract",
-            None,
-        )
-        if provider_descriptor is None:
-            return {"version": 1, "observed": False}
-
-        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
-        identity = provider()
-        if not isinstance(identity, Mapping):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        try:
-            encoded = json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-            normalized_identity = json.loads(encoded)
-        except (TypeError, ValueError) as exc:
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={
-                    "adapter_type": type(self._adapter).__name__,
-                    "cause": str(exc),
-                },
-            ) from exc
-        if not isinstance(normalized_identity, dict):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        return {
-            "version": 1,
-            "observed": True,
-            "identity": normalized_identity,
-        }
+        return {"version": 1, "observed": False}
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
         """Return whether a persisted backend execution identity is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        version = value.get("version")
-        observed = value.get("observed")
-        if (
-            isinstance(version, bool)
-            or not isinstance(version, int)
-            or version != 1
-            or not isinstance(observed, bool)
-        ):
-            return False
-        if not observed:
-            return set(value) == {"version", "observed"}
-        identity = value.get("identity")
-        if (
-            set(value) != {"version", "observed", "identity"}
-            or not isinstance(identity, Mapping)
-            or not identity
-        ):
-            return False
-        try:
-            json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError):
-            return False
-        return True
+        return valid_runtime_execution_identity_contract(value)
 
     @staticmethod
     def _runtime_execution_proves_effective_model(value: object) -> bool:
         """Return whether a backend identity observed a concrete model/profile."""
-        if not OrchestratorRunner._valid_runtime_execution_identity_contract(value):
+        return runtime_execution_proves_effective_model(value)
+
+    @staticmethod
+    def _begin_process_local_authority_generation() -> _ProcessLocalAuthorityGeneration:
+        """Mint one fresh live-only authority generation for a new session.
+
+        The generation is deliberately returned to the caller rather than kept
+        in a mutable runner-wide slot.  A single runner can prepare several
+        sessions concurrently, and each preparation must retain its exact
+        generation through contract creation and registry binding.
+        """
+        return _mint_process_local_authority_generation()
+
+    @staticmethod
+    def _process_local_authority_contract(
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> dict[str, object]:
+        """Build evidence-only scope data for one issued live generation."""
+        return _process_local_authority_contract(generation)
+
+    def _has_live_process_local_authority(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """Check live authority before restoring runtime-controlled state."""
+        if not isinstance(raw_contract, Mapping):
             return False
-        if not isinstance(value, Mapping) or value.get("observed") is not True:
+        authority = raw_contract.get("foundation_a_authority")
+        return (
+            _live_process_local_authority_generation(
+                session_id,
+                execution_id,
+                authority,
+                self._adapter,
+            )
+            is not None
+        )
+
+    def _has_live_process_local_authority_registration(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """See a local capability without granting another adapter its use.
+
+        This distinction lets an observer reject safely when another live
+        adapter owns the generation, instead of turning a valid paused or
+        transitioning session into a false crash recovery.
+        """
+        if not isinstance(raw_contract, Mapping):
             return False
-        identity = value.get("identity")
-        return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+        return _has_live_process_local_authority_registration(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+        )
+
+    def _process_local_authority_held_elsewhere(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """Return whether another live owner retains this process-local session.
+
+        A different adapter must never receive the opaque capability, but it
+        must also never turn a valid owner into a false crash-recovery path.
+        The in-process registration covers a foreign adapter in this PID; the
+        PID lease covers a holder in another process.  The exact adapter's own
+        capability is intentionally excluded so normal non-paused validation
+        continues to report the session state rather than an ownership error.
+        """
+        if self._has_live_process_local_authority(session_id, execution_id, raw_contract):
+            return False
+        if self._has_live_process_local_authority_registration(
+            session_id,
+            execution_id,
+            raw_contract,
+        ):
+            return True
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+
+        return is_holder_alive(session_id)
+
+    def _live_process_local_authority_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> _ProcessLocalAuthorityGeneration | None:
+        """Return the registry-issued generation for an already-live session."""
+        if not isinstance(raw_contract, Mapping):
+            return None
+        return _live_process_local_authority_generation(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+            self._adapter,
+        )
+
+    def _claim_process_local_authority_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+        """Claim a live capability before any effectful session work begins."""
+        if not isinstance(raw_contract, Mapping):
+            return None, False
+        return _claim_process_local_authority_generation(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+            self._adapter,
+        )
+
+    def _release_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Make a deliberately paused session resumable in this process again."""
+        _release_process_local_authority_generation(
+            session_id,
+            execution_id,
+            self._adapter,
+        )
+
+    def _register_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        execution_contract: Mapping[str, object],
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> None:
+        """Bind the persisted correlation record to its live process capability."""
+        authority = execution_contract.get("foundation_a_authority")
+        if (
+            not valid_process_local_authority_contract(authority)
+            or authority.get("correlation_id") != generation.correlation_id
+        ):
+            raise OrchestratorError(
+                message="Cannot create an invalid process-local execution authority",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "invalid": "foundation_a_authority",
+                },
+            )
+        from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+
+        try:
+            _register_process_local_authority_generation(
+                session_id,
+                execution_id,
+                generation,
+                self._adapter,
+            )
+        except ValueError as exc:
+            raise OrchestratorError(
+                message="Cannot register process-local execution authority",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "cause": str(exc),
+                },
+            ) from exc
+        self._process_local_authorities[(session_id, execution_id)] = generation
+        # Establish the cross-process liveness record as soon as a session owns
+        # a live capability, before a detached caller can observe its persisted
+        # RUNNING tracker.  It is a lease/liveness marker, never authority.
+        try:
+            acquire_session_lock(session_id)
+        except OSError as exc:
+            # A registry entry without its liveness lease would let another
+            # process misclassify a durable RUNNING tracker as crashed. Undo
+            # the exact binding before returning the setup failure.
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            raise OrchestratorError(
+                message="Cannot establish process-local execution liveness lease",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "cause": str(exc),
+                },
+            ) from exc
+
+    def _retire_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> bool:
+        """Discard a terminal session's capability only when this adapter owns it."""
+        retired = _retire_process_local_authority_generation(
+            session_id,
+            execution_id,
+            self._adapter,
+        )
+        if retired:
+            from ouroboros.orchestrator.heartbeat import (
+                release_if_owned_by_current_process as release_session_lock,
+            )
+
+            release_session_lock(session_id)
+        self._process_local_authorities.pop((session_id, execution_id), None)
+        return retired
+
+    def _discard_process_local_authority(
+        self,
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> None:
+        """Discard an unregistered capability after failed preparation."""
+        _discard_process_local_authority_generation(generation)
+
+    @staticmethod
+    def _process_local_resume_unavailable_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Return the explicit non-fallback outcome for a lost live generation."""
+        return OrchestratorError(
+            message=(
+                "Cannot resume this process-local execution after its live authority "
+                "generation is unavailable; start a new attempt."
+            ),
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_resume_unavailable",
+            },
+        )
+
+    @staticmethod
+    def _process_local_execution_in_progress_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Return the non-terminal outcome for a concurrent same-process claim."""
+        return OrchestratorError(
+            message="This process-local execution is already active in this process.",
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_execution_in_progress",
+            },
+        )
+
+    @staticmethod
+    def _process_local_authority_held_elsewhere_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Reject an observer without revoking another adapter's live binding."""
+        return OrchestratorError(
+            message=(
+                "This process-local execution is retained by another live runtime "
+                "adapter or process."
+            ),
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_authority_held_elsewhere",
+            },
+        )
+
+    async def _mark_process_local_resume_unavailable(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Terminally record a lost local capability without trying a fallback."""
+        error = self._process_local_resume_unavailable_error(session_id, execution_id)
+        try:
+            result = await self._session_repo.mark_failed(
+                session_id,
+                error.message,
+                error.details,
+            )
+            if result.is_err:
+                log.warning(
+                    "orchestrator.runner.process_local_resume_terminal_mark_failed",
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    error=str(result.error),
+                )
+        except Exception as exc:  # pragma: no cover - best-effort terminal record
+            log.warning(
+                "orchestrator.runner.process_local_resume_terminal_mark_raised",
+                session_id=session_id,
+                execution_id=execution_id,
+                error=str(exc),
+            )
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        return error
+
+    async def _mark_preparation_failed_best_effort(
+        self,
+        *,
+        tracker: SessionTracker,
+        message: str,
+        details: Mapping[str, Any],
+    ) -> str | None:
+        """Record a post-start preparation failure without masking cleanup.
+
+        ``create_session`` has already written a RUNNING durable tracker by
+        the time initial progress is persisted.  If that second write fails,
+        leave neither an apparently resumable RUNNING session nor a live
+        process-local capability behind.  A persistence failure while writing
+        this terminal state is reported as diagnostics, never allowed to skip
+        authority retirement.
+        """
+        try:
+            result = await self._session_repo.mark_failed(
+                tracker.session_id,
+                message,
+                dict(details),
+            )
+        except Exception as exc:  # pragma: no cover - defensive persistence boundary
+            log.warning(
+                "orchestrator.runner.prepare_terminal_mark_raised",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=str(exc),
+            )
+            return str(exc)
+        if result.is_err:
+            log.warning(
+                "orchestrator.runner.prepare_terminal_mark_failed",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=str(result.error),
+            )
+            return str(result.error)
+        return None
 
     def _validate_resume_handle_execution_identity(
         self,
@@ -2003,6 +2279,7 @@ class OrchestratorRunner:
         *,
         seed: Seed | None = None,
         seed_fingerprint: str | None = None,
+        authority_generation: _ProcessLocalAuthorityGeneration | None = None,
     ) -> dict[str, Any]:
         """Build the durable resolved inputs shared by resume and proof cohorting."""
         from ouroboros.orchestrator.model_routing import serialize_model_router
@@ -2026,8 +2303,22 @@ class OrchestratorRunner:
             resolved_seed_fingerprint = self._seed_semantics_fingerprint(seed)
         if resolved_seed_fingerprint is not None:
             proof_contract["seed_fingerprint"] = resolved_seed_fingerprint
+        if authority_generation is None:
+            # Diagnostics and contract-validation callers need attribution
+            # shape, not a live capability. Do not mint a registry issuance
+            # here: there is no session lifecycle that could register and
+            # retire it. The random correlation remains evidence-only, and
+            # cannot be claimed or registered without an explicit generation.
+            authority_contract: dict[str, object] = {
+                "version": 1,
+                "scope": "process_local",
+                "correlation_id": uuid4().hex,
+            }
+        else:
+            authority_contract = self._process_local_authority_contract(authority_generation)
         return {
             "version": EXECUTION_CONTRACT_VERSION,
+            "foundation_a_authority": authority_contract,
             "execution_preferences": self._execution_preferences.to_contract_data(),
             "model_routing": routing_contract,
             "frugality_proof": proof_contract,
@@ -2274,6 +2565,7 @@ class OrchestratorRunner:
         progress: Mapping[str, Any],
         *,
         seed: Seed | None = None,
+        authority_generation: _ProcessLocalAuthorityGeneration | None = None,
     ) -> bool:
         """Restore the persisted router unless this invocation explicitly overrides it.
 
@@ -2285,7 +2577,10 @@ class OrchestratorRunner:
         if EXECUTION_CONTRACT_PROGRESS_KEY not in progress:
             self._validate_legacy_resume_identity(progress, seed=seed)
             self._execution_guidance = self._resolve_guidance_bundle(())
-            self._execution_contract = self._build_execution_contract(seed=seed)
+            self._execution_contract = self._build_execution_contract(
+                seed=seed,
+                authority_generation=authority_generation,
+            )
             # One unavoidable recomputation migrates a legacy session. Persist the
             # resolved contract now so every later resume restores this exact policy
             # instead of drifting again with each environment/config change.
@@ -2308,14 +2603,18 @@ class OrchestratorRunner:
         raw_routing = raw_contract.get("model_routing")
         raw_resume = raw_contract.get("resume")
         raw_preferences = raw_contract.get("execution_preferences")
+        raw_authority = raw_contract.get("foundation_a_authority")
         if (
             not isinstance(raw_proof, Mapping)
             or not isinstance(raw_routing, Mapping)
             or not isinstance(raw_resume, Mapping)
+            or not valid_process_local_authority_contract(raw_authority)
         ):
             raise OrchestratorError(
                 message="Cannot resume with an invalid execution contract",
-                details={"missing": "frugality_proof, model_routing, or resume"},
+                details={
+                    "missing": "frugality_proof, model_routing, resume, or foundation_a_authority"
+                },
             )
 
         self._restore_guidance_contract(raw_contract)
@@ -2504,6 +2803,9 @@ class OrchestratorRunner:
         effective_model_observed = self._runtime_execution_proves_effective_model(
             persisted_runtime_execution
         )
+        process_local_authority = valid_process_local_authority_contract(
+            raw_contract.get("foundation_a_authority")
+        )
         model_override_support = getattr(
             getattr(self._adapter, "capabilities", None),
             "model_override_support",
@@ -2513,6 +2815,7 @@ class OrchestratorRunner:
             constructor_model_value is None
             and not effective_model_observed
             and not (restored_router is not None and model_override_support is ParamSupport.NATIVE)
+            and not process_local_authority
         ):
             raise OrchestratorError(
                 message="Cannot resume because the effective runtime model is unverifiable",
@@ -2530,10 +2833,18 @@ class OrchestratorRunner:
         self._execution_preferences = persisted_preferences
         self._shadow_replay_enabled = self._resolved_shadow_replay_enabled()
         if self._model_routing_override_explicit:
-            self._execution_contract = self._build_execution_contract(
+            replacement = self._build_execution_contract(
                 seed=seed,
                 seed_fingerprint=(persisted_seed_fingerprint if valid_seed_fingerprint else None),
+                authority_generation=authority_generation,
             )
+            # Only the public resume path reaches this branch with a live,
+            # registry-issued generation.  Preserve the persisted diagnostics
+            # in direct contract-validation calls so those calls cannot mint a
+            # replacement correlation id by accident.
+            if authority_generation is None:
+                replacement["foundation_a_authority"] = dict(raw_contract["foundation_a_authority"])
+            self._execution_contract = replacement
             return self._execution_contract != raw_contract
 
         self._model_router = restored_router
@@ -2552,11 +2863,8 @@ class OrchestratorRunner:
     def _proof_cohort_identity(
         event_data: Mapping[str, Any],
     ) -> tuple[str, str, str, int, str, str, str] | None:
-        """Extract the exact fail-closed identity tuple from a session start."""
-        raw_seed_id = event_data.get("seed_id")
+        """Reject cross-run proof cohorts for Foundation A process-local runs."""
         raw_contract = event_data.get(EXECUTION_CONTRACT_PROGRESS_KEY)
-        if not isinstance(raw_seed_id, str) or not raw_seed_id.strip():
-            return None
         if not isinstance(raw_contract, Mapping):
             return None
         raw_version = raw_contract.get("version")
@@ -2566,79 +2874,11 @@ class OrchestratorRunner:
             or raw_version != EXECUTION_CONTRACT_VERSION
         ):
             return None
-        proof_contract = raw_contract.get("frugality_proof")
-        if not isinstance(proof_contract, Mapping):
-            return None
-        routing_contract = raw_contract.get("model_routing")
-        if not isinstance(routing_contract, Mapping):
-            return None
-        guidance_contract = raw_contract.get("guidance")
-        if guidance_contract is None:
-            guidance_fingerprint = "legacy:no-declared-guidance"
-        elif isinstance(guidance_contract, Mapping):
-            guidance_fingerprint = guidance_contract.get("rendered_fragment_hash")
-            if (
-                guidance_contract.get("provenance_scope") != "ouroboros_declared_guidance_only"
-                or not isinstance(guidance_fingerprint, str)
-                or not guidance_fingerprint.startswith("sha256:")
-                or len(guidance_fingerprint) != 71
-            ):
-                return None
-        else:
-            return None
-        runtime_backend = routing_contract.get("runtime_backend")
-        llm_backend = routing_contract.get("llm_backend")
-        permission_mode = routing_contract.get("permission_mode")
-        constructor_model = routing_contract.get("constructor_model")
-        runtime_execution = routing_contract.get("runtime_execution")
-        if (
-            not isinstance(runtime_backend, str)
-            or not runtime_backend.strip()
-            or not isinstance(llm_backend, str)
-            or not llm_backend.strip()
-            or not OrchestratorRunner._valid_permission_mode_contract(permission_mode)
-            or not OrchestratorRunner._valid_constructor_model_contract(constructor_model)
-            or not OrchestratorRunner._valid_runtime_execution_identity_contract(runtime_execution)
-        ):
-            return None
-        protocol_version = proof_contract.get("protocol_version")
-        project_root = proof_contract.get("project_root")
-        workspace_path = proof_contract.get("workspace_path")
-        routing_fingerprint = proof_contract.get("routing_fingerprint")
-        seed_fingerprint = proof_contract.get("seed_fingerprint")
-        if (
-            isinstance(protocol_version, bool)
-            or not isinstance(protocol_version, int)
-            or protocol_version < 1
-        ):
-            return None
-        if not isinstance(project_root, str) or not project_root.strip():
-            return None
-        if not isinstance(workspace_path, str) or not workspace_path.strip():
-            return None
-        if (
-            not isinstance(routing_fingerprint, str)
-            or len(routing_fingerprint) != 64
-            or any(char not in "0123456789abcdef" for char in routing_fingerprint)
-        ):
-            return None
-        if routing_fingerprint != OrchestratorRunner._routing_fingerprint(routing_contract):
-            return None
-        if (
-            not isinstance(seed_fingerprint, str)
-            or len(seed_fingerprint) != 64
-            or any(char not in "0123456789abcdef" for char in seed_fingerprint)
-        ):
-            return None
-        return (
-            raw_seed_id.strip(),
-            project_root.strip(),
-            workspace_path.strip(),
-            protocol_version,
-            routing_fingerprint,
-            seed_fingerprint,
-            guidance_fingerprint,
-        )
+        # Foundation A's current correlation record is diagnostic attribution
+        # only.  It must not form a replay, idempotency, trust, or cross-run
+        # proof cohort key.  A future portable authority needs its own reviewed
+        # consumer rule rather than falling through this legacy proof path.
+        return None
 
     def _build_dependency_analyzer(self) -> DependencyAnalyzer:
         """Create a dependency analyzer wired to the active LLM backend when available.
@@ -3481,6 +3721,10 @@ class OrchestratorRunner:
             )
             for ev in session_events:
                 if ev.type in _terminal_event_types:
+                    self._retire_process_local_authority(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
                     log.info(
                         "orchestrator.runner.cancel_skipped_terminal",
                         execution_id=execution_id,
@@ -3522,6 +3766,10 @@ class OrchestratorRunner:
                 )
             )
 
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -3789,6 +4037,10 @@ class OrchestratorRunner:
 
         # Clean up session tracking
         self._unregister_session(execution_id, session_id)
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
 
@@ -3918,7 +4170,11 @@ class OrchestratorRunner:
         Returns:
             Result containing OrchestratorResult on success.
         """
-        session_result = await self.prepare_session(seed, execution_id=execution_id)
+        session_result = await self.prepare_session(
+            seed,
+            execution_id=execution_id,
+            session_id=session_id,
+        )
         if session_result.is_err:
             return Result.err(session_result.error)
 
@@ -3946,39 +4202,107 @@ class OrchestratorRunner:
         immediately and then start the actual runtime work asynchronously.
         """
         exec_id = execution_id or f"exec_{uuid4().hex[:12]}"
+        resolved_session_id = session_id or f"orch_{uuid4().hex[:12]}"
         self._execution_guidance = None
+        # A generation belongs to this one preparation call.  Do not store it
+        # in a runner-wide mutable slot: concurrent preparations must not share
+        # a capability or correlation id.
+        authority_generation = self._begin_process_local_authority_generation()
         try:
             execution_contract = await asyncio.to_thread(
                 self._build_execution_contract,
                 seed=seed,
+                authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
         except OrchestratorError as exc:
+            self._discard_process_local_authority(authority_generation)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
             return Result.err(exc)
         self._execution_contract = execution_contract
-        session_result = await self._session_repo.create_session(
-            execution_id=exec_id,
-            seed_id=seed.metadata.seed_id,
-            session_id=session_id,
-            seed_goal=seed.goal,
-            runtime_backend=getattr(self._adapter, "runtime_backend", None),
-            llm_backend=getattr(self._adapter, "llm_backend", None),
-            execution_contract=execution_contract,
-        )
+
+        # Establish the exact capability and PID liveness lease before any
+        # durable RUNNING tracker can be reconstructed by an observer.  The
+        # resolved session id is allocated locally for that purpose rather
+        # than delegated to SessionRepository after its start event is written.
+        try:
+            self._register_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+                execution_contract=execution_contract,
+                generation=authority_generation,
+            )
+        except OrchestratorError as exc:
+            self._discard_process_local_authority(authority_generation)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(exc)
+
+        try:
+            session_result = await self._session_repo.create_session(
+                execution_id=exec_id,
+                seed_id=seed.metadata.seed_id,
+                session_id=resolved_session_id,
+                seed_goal=seed.goal,
+                runtime_backend=getattr(self._adapter, "runtime_backend", None),
+                llm_backend=getattr(self._adapter, "llm_backend", None),
+                execution_contract=execution_contract,
+            )
+        except Exception as exc:
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(
+                OrchestratorError(
+                    message=f"Failed to create session: {exc}",
+                    details={"execution_id": exec_id, "session_id": resolved_session_id},
+                )
+            )
 
         if session_result.is_err:
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {session_result.error}",
-                    details={"execution_id": exec_id, "session_id": session_id},
+                    details={"execution_id": exec_id, "session_id": resolved_session_id},
                 )
             )
 
         tracker = session_result.value
+        if tracker.session_id != resolved_session_id or tracker.execution_id != exec_id:
+            # The registration and its early lease were established for the
+            # caller-supplied durable identity before ``create_session`` wrote
+            # ``session.started``.  Accepting a repository response for a
+            # different identity would attach that capability to a tracker that
+            # was never protected during publication.  This is a repository
+            # contract violation, not a reason to mutate or terminalize the
+            # unrelated returned tracker.
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(
+                OrchestratorError(
+                    message="Session repository returned an unexpected session identity",
+                    details={
+                        "expected_session_id": resolved_session_id,
+                        "expected_execution_id": exec_id,
+                        "returned_session_id": tracker.session_id,
+                        "returned_execution_id": tracker.execution_id,
+                    },
+                )
+            )
         initial_progress: dict[str, Any] = {
             "fat_harness_mode": self._fat_harness_mode,
             "messages_processed": 0,
@@ -3986,35 +4310,62 @@ class OrchestratorRunner:
         }
         if self._task_workspace is not None:
             initial_progress["workspace"] = self._task_workspace.to_progress_dict()
-        progress_result = await self._session_repo.track_progress(
-            tracker.session_id,
-            initial_progress,
-        )
-        if progress_result.is_err:
-            fail_result = await self._session_repo.mark_failed(
+        try:
+            progress_result = await self._session_repo.track_progress(
                 tracker.session_id,
-                "Failed to persist initial session contract",
-                {
-                    "execution_id": tracker.execution_id,
-                    "fat_harness_mode": self._fat_harness_mode,
-                    "cause": str(progress_result.error),
-                },
+                initial_progress,
+            )
+        except Exception as exc:
+            progress_exception_details: dict[str, Any] = {
+                "session_id": tracker.session_id,
+                "execution_id": tracker.execution_id,
+                "fat_harness_mode": self._fat_harness_mode,
+                "cause": str(exc),
+            }
+            terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                tracker=tracker,
+                message="Failed to persist initial session contract",
+                details=progress_exception_details,
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
             )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
-
-            details: dict[str, Any] = {
+            if terminal_mark_error is not None:
+                progress_exception_details["terminal_mark_error"] = terminal_mark_error
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist initial session contract",
+                    details=progress_exception_details,
+                )
+            )
+        if progress_result.is_err:
+            progress_result_details: dict[str, Any] = {
                 "session_id": tracker.session_id,
                 "execution_id": tracker.execution_id,
                 "fat_harness_mode": self._fat_harness_mode,
                 "cause": str(progress_result.error),
             }
-            if fail_result.is_err:
-                details["terminal_mark_error"] = str(fail_result.error)
+            terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                tracker=tracker,
+                message="Failed to persist initial session contract",
+                details=progress_result_details,
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+
+            if terminal_mark_error is not None:
+                progress_result_details["terminal_mark_error"] = terminal_mark_error
             return Result.err(
                 OrchestratorError(
                     message="Failed to persist initial session contract",
-                    details=details,
+                    details=progress_result_details,
                 )
             )
 
@@ -4038,30 +4389,73 @@ class OrchestratorRunner:
         set_console_logging(self._debug)
 
         raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
-        if raw_contract is not None:
-            if not isinstance(raw_contract, Mapping):
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
-                    tracker.session_id,
-                    session_registered=False,
+        if tracker.status in (
+            SessionStatus.COMPLETED,
+            SessionStatus.CANCELLED,
+            SessionStatus.FAILED,
+        ):
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=f"Session is in terminal state {tracker.status.value}, cannot execute",
+                    details={"session_id": tracker.session_id, "status": tracker.status.value},
                 )
+            )
+
+        # This API may execute only the tracker returned by ``prepare_session``.
+        # A legacy/reconstructed tracker with no contract is not a new-session
+        # shortcut: it has no Foundation A generation and must fail closed before
+        # prompts, tool setup, or any runtime-owned provider are consulted.
+        authority_generation, authority_claimed = self._claim_process_local_authority_generation(
+            tracker.session_id,
+            exec_id,
+            raw_contract,
+        )
+        if authority_claimed:
+            return Result.err(
+                self._process_local_execution_in_progress_error(
+                    tracker.session_id,
+                    tracker.execution_id,
+                )
+            )
+        if authority_generation is None:
+            if self._process_local_authority_held_elsewhere(
+                tracker.session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
                 return Result.err(
-                    OrchestratorError(
-                        message="Cannot execute with an invalid execution contract",
-                        details={"invalid": "execution_contract"},
+                    self._process_local_authority_held_elsewhere_error(
+                        tracker.session_id,
+                        tracker.execution_id,
                     )
                 )
-            try:
-                await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
-                self._execution_guidance_delivery_mode()
-            except OrchestratorError as exc:
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(
+                self._process_local_resume_unavailable_error(
                     tracker.session_id,
-                    session_registered=False,
+                    tracker.execution_id,
                 )
-                return Result.err(exc)
-            self._execution_contract = dict(raw_contract)
+            )
+        try:
+            await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
+            self._execution_guidance_delivery_mode()
+        except OrchestratorError as exc:
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(exc)
+        self._execution_contract = dict(raw_contract)
 
         log.info(
             "orchestrator.runner.execute_started",
@@ -4599,7 +4993,21 @@ class OrchestratorRunner:
             )
 
             # Clean up session tracking
-            self._unregister_session(exec_id, tracker.session_id)
+            if terminal_status != "paused":
+                self._retire_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                )
+            else:
+                self._release_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                )
+            self._unregister_session(
+                exec_id,
+                tracker.session_id,
+                release_liveness_lease=terminal_status != "paused",
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
@@ -4627,6 +5035,10 @@ class OrchestratorRunner:
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
             self._unregister_session(exec_id, tracker.session_id)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
@@ -4654,6 +5066,10 @@ class OrchestratorRunner:
             await self._session_repo.mark_failed(
                 tracker.session_id,
                 str(e),
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
             )
             await self._event_store.append(
                 create_execution_terminal_event(
@@ -5041,7 +5457,21 @@ class OrchestratorRunner:
         )
 
         # Clean up session tracking
-        self._unregister_session(exec_id, tracker.session_id)
+        if terminal_status != "paused":
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
+        else:
+            self._release_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
+        self._unregister_session(
+            exec_id,
+            tracker.session_id,
+            release_liveness_lease=terminal_status != "paused",
+        )
         await clear_cancellation(tracker.session_id)
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
@@ -5159,11 +5589,117 @@ class OrchestratorRunner:
                 )
             )
 
+        raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
+        if not isinstance(raw_contract, Mapping):
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            return Result.err(error)
+
+        # A RUNNING tracker with a current Foundation A contract belongs to an
+        # active process while its early liveness lease is held.  If the lease
+        # is gone and this process has no live registry capability, the prior
+        # owner has crashed or exited and Foundation A must terminally reject it
+        # rather than leave a restartable-looking RUNNING session stranded.
+        if tracker.status != SessionStatus.PAUSED:
+            own_live_authority = self._has_live_process_local_authority(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            )
+            held_elsewhere = (
+                not own_live_authority
+                and self._process_local_authority_held_elsewhere(
+                    session_id,
+                    tracker.execution_id,
+                    raw_contract,
+                )
+            )
+            if not own_live_authority and not held_elsewhere:
+                error = await self._mark_process_local_resume_unavailable(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._cleanup_pre_execution_state(
+                    tracker.execution_id,
+                    session_id,
+                    session_registered=False,
+                )
+                return Result.err(error)
+            if held_elsewhere:
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+                retire_authority=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=f"Session is not paused and cannot resume ({tracker.status.value})",
+                    details={
+                        "session_id": session_id,
+                        "status": tracker.status.value,
+                        "resume_blocked": "session_not_paused",
+                    },
+                )
+            )
+
+        # This is intentionally before Foundation A contract restoration,
+        # resume-handle selection, and every runtime-owned identity provider.
+        # The durable correlation id cannot recreate this process's capability.
+        authority_generation, authority_claimed = self._claim_process_local_authority_generation(
+            session_id,
+            tracker.execution_id,
+            raw_contract,
+        )
+        if authority_claimed:
+            return Result.err(
+                self._process_local_execution_in_progress_error(
+                    session_id,
+                    tracker.execution_id,
+                )
+            )
+        if authority_generation is None:
+            if self._process_local_authority_held_elsewhere(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            return Result.err(error)
+
         try:
             execution_contract_changed = await asyncio.to_thread(
                 self._restore_execution_contract,
                 tracker.progress,
                 seed=seed,
+                authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
         except OrchestratorError as exc:
@@ -5257,6 +5793,13 @@ Note: This is a resumed session. Please continue from where execution was interr
                 activity_map=resume_strategy.get_activity_map(),
             )
             await self._replay_workflow_state(session_id, state_tracker)
+        except asyncio.CancelledError:
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=session_registered,
+            )
+            raise
         except Exception as e:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
@@ -5516,7 +6059,21 @@ Note: This is a resumed session. Please continue from where execution was interr
             await clear_cancellation(session_id)
 
             # Clean up session tracking
-            self._unregister_session(tracker.execution_id, session_id)
+            if terminal_status != "paused":
+                self._retire_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+            else:
+                self._release_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+            self._unregister_session(
+                tracker.execution_id,
+                session_id,
+                release_liveness_lease=terminal_status != "paused",
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
@@ -5532,6 +6089,22 @@ Note: This is a resumed session. Please continue from where execution was interr
                 )
             )
 
+        except asyncio.CancelledError:
+            if await is_cancellation_requested(session_id):
+                return await self._handle_cancellation(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=messages_processed,
+                    start_time=start_time,
+                )
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._unregister_session(tracker.execution_id, session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            raise
         except Exception as e:
             log.exception(
                 "orchestrator.runner.resume_failed",
@@ -5550,6 +6123,11 @@ Note: This is a resumed session. Please continue from where execution was interr
                     status="failed",
                     error_message=str(e),
                 )
+            )
+            await self._session_repo.mark_failed(session_id, str(e))
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
             )
             await self._report_frugality_retrospective(
                 execution_id=tracker.execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4035,21 +4035,20 @@ class OrchestratorRunner:
             duration_seconds=duration,
         )
 
-        # Clear the in-memory cancellation flag so it doesn't linger
-        await clear_cancellation(session_id)
-
-        # Clean up session tracking
-        self._unregister_session(execution_id, session_id)
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
-        )
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
-
-        # Only mark cancelled if not already in a terminal state
+        # Determine and durably publish the terminal state *before* withdrawing
+        # the process-local capability or its heartbeat.  A RUNNING tracker
+        # with neither liveness signal is indistinguishable from a crashed
+        # owner to another process, so releasing first can cause a concurrent
+        # observer to terminalize this deliberate cancellation as lost
+        # authority.  It would also make a persistence failure report a
+        # cancellation that the durable session never recorded.
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
+        # An unreadable snapshot cannot prove that a terminal state already
+        # exists.  Continue through ``mark_cancelled`` while retaining the live
+        # owner; that append is the authoritative terminal write and preserves
+        # the legacy best-effort reconstruction posture without ever releasing
+        # a RUNNING session first.
         session_already_terminal = session_result.is_ok and session_result.value.status in _terminal
         if session_already_terminal:
             terminal_status = session_result.value.status
@@ -4065,19 +4064,31 @@ class OrchestratorRunner:
                 )
             except Exception:
                 execution_terminal_events = []
-            if not execution_terminal_events:
-                await self._event_store.append(
-                    create_execution_terminal_event(
-                        execution_id=execution_id,
-                        session_id=session_id,
-                        status=terminal_status.value,
-                        summary=summary if terminal_status == SessionStatus.COMPLETED else None,
-                        error_message=(
-                            final_message if terminal_status != SessionStatus.COMPLETED else None
-                        ),
-                        messages_processed=messages_processed,
+            await clear_cancellation(session_id)
+            try:
+                if not execution_terminal_events:
+                    await self._event_store.append(
+                        create_execution_terminal_event(
+                            execution_id=execution_id,
+                            session_id=session_id,
+                            status=terminal_status.value,
+                            summary=summary if terminal_status == SessionStatus.COMPLETED else None,
+                            error_message=(
+                                final_message
+                                if terminal_status != SessionStatus.COMPLETED
+                                else None
+                            ),
+                            messages_processed=messages_processed,
+                        )
                     )
+            finally:
+                self._retire_process_local_authority(
+                    session_id=session_id,
+                    execution_id=execution_id,
                 )
+                self._unregister_session(execution_id, session_id)
+                if self._task_workspace is not None:
+                    release_lock(self._task_workspace.lock_path)
             await self._report_frugality_retrospective(
                 execution_id=execution_id,
                 session_id=session_id,
@@ -4095,28 +4106,67 @@ class OrchestratorRunner:
                 )
             )
 
-        cancel_result = await self._session_repo.mark_cancelled(
-            session_id,
-            reason="Cancellation detected during execution",
-            cancelled_by="runner",
-        )
+        try:
+            cancel_result = await self._session_repo.mark_cancelled(
+                session_id,
+                reason="Cancellation detected during execution",
+                cancelled_by="runner",
+            )
+        except Exception as exc:
+            log.warning(
+                "orchestrator.runner.mark_cancelled_raised",
+                session_id=session_id,
+                error=str(exc),
+            )
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist cancellation; process-local authority remains live",
+                    details={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "cause": str(exc),
+                    },
+                )
+            )
         if cancel_result is not None and cancel_result.is_err:
             log.warning(
                 "orchestrator.runner.mark_cancelled_failed",
                 session_id=session_id,
                 error=str(cancel_result.error),
             )
-
-        # Mirror cancellation into execution stream for TUI.
-        await self._event_store.append(
-            create_execution_terminal_event(
-                execution_id=execution_id,
-                session_id=session_id,
-                status="cancelled",
-                error_message="Execution cancelled by external request",
-                messages_processed=messages_processed,
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist cancellation; process-local authority remains live",
+                    details={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "cause": str(cancel_result.error),
+                    },
+                )
             )
-        )
+
+        # The session is now terminal.  It is safe to clear the request and
+        # retire the live capability; the execution-stream mirror is useful to
+        # projections but no longer determines whether cleanup is safe.
+        await clear_cancellation(session_id)
+        try:
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    status="cancelled",
+                    error_message="Execution cancelled by external request",
+                    messages_processed=messages_processed,
+                )
+            )
+        finally:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            self._unregister_session(execution_id, session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -4283,13 +4333,14 @@ class OrchestratorRunner:
                 llm_backend=getattr(self._adapter, "llm_backend", None),
                 execution_contract=execution_contract,
             )
+        except asyncio.CancelledError:
+            # Registration and its liveness lease precede durable publication.
+            # A caller cancelling this await must not strand that live
+            # generation even when the repository did not return a tracker.
+            abort_process_local_preparation()
+            raise
         except Exception as exc:
-            self._retire_process_local_authority(
-                session_id=resolved_session_id,
-                execution_id=exec_id,
-            )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            abort_process_local_preparation()
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {exc}",
@@ -4349,6 +4400,24 @@ class OrchestratorRunner:
                 tracker.session_id,
                 initial_progress,
             )
+        except asyncio.CancelledError:
+            # ``create_session`` has already made a RUNNING tracker durable.
+            # Record its terminal preparation failure before withdrawing the
+            # process-local lease, then re-raise the caller's cancellation.
+            try:
+                await self._mark_preparation_failed_best_effort(
+                    tracker=tracker,
+                    message="Session preparation cancelled before initial contract was persisted",
+                    details={
+                        "session_id": tracker.session_id,
+                        "execution_id": tracker.execution_id,
+                        "fat_harness_mode": self._fat_harness_mode,
+                        "cause": "CancelledError",
+                    },
+                )
+            finally:
+                abort_process_local_preparation()
+            raise
         except Exception as exc:
             progress_exception_details: dict[str, Any] = {
                 "session_id": tracker.session_id,
@@ -4482,6 +4551,17 @@ class OrchestratorRunner:
         try:
             await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
             self._execution_guidance_delivery_mode()
+        except asyncio.CancelledError:
+            # The exclusive generation was claimed before contract restoration.
+            # A raw task cancellation must release that claim (and its lease)
+            # even though it intentionally does not write a terminal session
+            # record; callers still receive the original cancellation.
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            raise
         except OrchestratorError as exc:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
@@ -5748,6 +5828,16 @@ class OrchestratorRunner:
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
+        except asyncio.CancelledError:
+            # Resume claims the exact live generation before restoration. Do
+            # not leave it permanently claimed if the caller cancels during
+            # this otherwise pre-effect setup window.
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            raise
         except OrchestratorError as exc:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,

--- a/src/ouroboros/orchestrator/shadow_replay.py
+++ b/src/ouroboros/orchestrator/shadow_replay.py
@@ -313,6 +313,14 @@ async def _run_shadow_replay_inner(
         )
         return
 
+    # This experiment has its own ephemeral workspace and never decides the
+    # live AC's acceptance, but it still must not sidestep the executor's six
+    # captured entry roots. Import lazily to avoid the module cycle: the
+    # executor imports this harness at module load time.
+    from ouroboros.orchestrator.parallel_executor import _invoke_execution_authority_guard
+
+    _invoke_execution_authority_guard(executor)
+
     router = executor._model_router
     if router is None:
         # Model routing dormant → no parent tier to price the baseline at.
@@ -619,7 +627,17 @@ async def _baseline_semantically_accepted(
         has_expected_artifacts=has_expected_artifacts,
         verify_gate_active=verify_gate_active,
     )
-    verifier_verdict = executor._run_atomic_verifier_pass(
+    # Do not look up ``executor._run_atomic_verifier_pass`` dynamically here.
+    # The live executor registered a constructor-captured root, and the registry
+    # both revalidates that root and invokes it directly.
+    from ouroboros.orchestrator.parallel_executor import (
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
+        _invoke_execution_authority_entry,
+    )
+
+    verifier_verdict = _invoke_execution_authority_entry(
+        executor,
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
         ac_content=ac_content,
         final_message=terminal.content,
         success=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,30 @@ os.environ["_TYPER_FORCE_DISABLE_TERMINAL"] = "1"
 os.environ["OUROBOROS_DASHBOARD"] = "0"
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_heartbeat_locks_per_test_worker(tmp_path_factory):
+    """Keep xdist workers from competing over illustrative session IDs.
+
+    Unit tests intentionally use short deterministic IDs (for example
+    ``sess_1``). Production's liveness lease correctly rejects those IDs when
+    two independent processes own them concurrently, but xdist workers are
+    independent processes too. Give each worker a private lock directory while
+    preserving real lease semantics within that worker.
+    """
+    from ouroboros.orchestrator import heartbeat
+
+    previous_lock_dir = heartbeat.LOCK_DIR
+    heartbeat.LOCK_DIR = tmp_path_factory.mktemp("heartbeat-locks")
+    try:
+        yield
+    finally:
+        # A cancellation-focused test may deliberately leave a session alive.
+        # Close those descriptors before pytest tears down the worker.
+        for session_id in tuple(heartbeat._HELD_LEASE_FDS):
+            heartbeat.release(session_id)
+        heartbeat.LOCK_DIR = previous_lock_dir
+
+
 @pytest.fixture(autouse=True)
 def block_runner_real_llm_adapter(monkeypatch):
     """Block execute_seed's dependency analysis from spawning real agent CLIs.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -513,15 +513,30 @@ def mock_execution_id() -> str:
 
 @pytest.fixture
 async def persisted_session(
-    event_store: Any, mock_session_id: str, mock_execution_id: str, sample_seed: Seed
+    event_store: Any,
+    mock_claude_agent_adapter: MockClaudeAgentAdapter,
+    mock_session_id: str,
+    mock_execution_id: str,
+    sample_seed: Seed,
+    temp_dir: Path,
 ) -> dict[str, Any]:
-    """Create a persisted session in the event store for resumption testing."""
+    """Create a paused session that retains its creating-process capability."""
+    from ouroboros.orchestrator.runner import OrchestratorRunner
     from ouroboros.orchestrator.session import SessionRepository
 
+    # Resume validation requires a concrete constructor-level model pin. The
+    # real CLI adapters expose ``_model``; this minimal E2E adapter does not.
+    mock_claude_agent_adapter._model = "test-model"
+    runner = OrchestratorRunner(
+        adapter=mock_claude_agent_adapter,
+        event_store=event_store,
+        console=MagicMock(),
+        task_cwd=str(temp_dir),
+    )
     repo = SessionRepository(event_store)
-    result = await repo.create_session(
+    result = await runner.prepare_session(
+        sample_seed,
         execution_id=mock_execution_id,
-        seed_id=sample_seed.metadata.seed_id,
         session_id=mock_session_id,
     )
 
@@ -533,10 +548,14 @@ async def persisted_session(
     # Track some progress
     await repo.track_progress(mock_session_id, {"step": 1, "message": "Started"})
     await repo.track_progress(mock_session_id, {"step": 2, "message": "In progress"})
+    pause_result = await repo.mark_paused(mock_session_id, reason="Test interruption")
+    if pause_result.is_err:
+        raise RuntimeError(f"Failed to pause test session: {pause_result.error}")
 
     return {
         "session_id": mock_session_id,
         "execution_id": mock_execution_id,
         "seed_id": sample_seed.metadata.seed_id,
         "tracker": tracker,
+        "runner": runner,
     }

--- a/tests/e2e/test_session_persistence.py
+++ b/tests/e2e/test_session_persistence.py
@@ -314,21 +314,17 @@ class TestSessionReconstruction:
 class TestSessionResumption:
     """Test session resumption functionality."""
 
-    async def test_resume_running_session(
+    async def test_same_process_paused_session_resumes(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test resuming a running session."""
+        """A paused session resumes only through its creating process."""
         mock_claude_agent_adapter.add_successful_execution(final_message="Resumed and completed")
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],
@@ -338,21 +334,17 @@ class TestSessionResumption:
         assert result.is_ok
         assert result.value.success
 
-    async def test_resume_preserves_session_id(
+    async def test_same_process_resume_preserves_session_id(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test that resuming preserves the original session ID."""
+        """Same-process resume preserves the original session ID."""
         mock_claude_agent_adapter.add_successful_execution()
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],
@@ -407,14 +399,43 @@ class TestSessionResumption:
 
         assert result.is_err
 
-    async def test_resume_accumulates_messages(
+    async def test_legacy_running_session_is_terminally_rejected(
+        self,
+        event_store: EventStore,
+        sample_seed: Seed,
+        mock_claude_agent_adapter: MockClaudeAgentAdapter,
+    ) -> None:
+        """A persisted legacy RUNNING tracker cannot recreate local authority."""
+        repo = SessionRepository(event_store)
+        session_id = "legacy_running_session"
+        create_result = await repo.create_session(
+            execution_id="exec_legacy_running",
+            seed_id=sample_seed.metadata.seed_id,
+            session_id=session_id,
+        )
+        assert create_result.is_ok
+
+        runner = OrchestratorRunner(
+            adapter=mock_claude_agent_adapter,
+            event_store=event_store,
+            console=MagicMock(),
+        )
+        result = await runner.resume_session(session_id, sample_seed)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+        reconstructed = await repo.reconstruct_session(session_id)
+        assert reconstructed.is_ok
+        assert reconstructed.value.status == SessionStatus.FAILED
+
+    async def test_same_process_resume_accumulates_messages(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test that resuming accumulates message count correctly."""
+        """Same-process resume accumulates its persisted message count."""
         # The persisted_session fixture tracks 2 progress events
         initial_messages = 2
 
@@ -432,11 +453,7 @@ class TestSessionResumption:
         ]
         mock_claude_agent_adapter.add_execution_sequence(messages)
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -168,6 +168,9 @@ class TestExecuteSeedHandler:
             def __init__(self, *args: object, fat_harness_mode: bool, **kwargs: object) -> None:
                 captured_modes.append(fat_harness_mode)
 
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
+
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(fresh_tracker)
 
@@ -295,6 +298,9 @@ class TestExecuteSeedHandler:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
+
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(tracker)
 
@@ -379,6 +385,9 @@ class TestExecuteSeedHandler:
         class FakeRunner:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
+
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
 
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(running_tracker)

--- a/tests/unit/orchestrator/parallel_executor_test_support.py
+++ b/tests/unit/orchestrator/parallel_executor_test_support.py
@@ -1,0 +1,50 @@
+"""Test-only seams for exercising captured parallel-executor entry roots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+
+
+class ProcessLocalTestExecutor(ParallelACExecutor):
+    """Constructor-time test double whose entry roots stay process-local.
+
+    Production execution captures its finite internal entry roots when the
+    executor is constructed. Tests that need controllable leaf behavior use
+    this explicit subclass instead of mutating a production executor's roots
+    after construction.
+    """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", value)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", value)
+            return
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", None)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", None)
+            return
+        object.__delattr__(self, name)
+
+    async def _execute_single_ac(self, *args: Any, **kwargs: Any) -> Any:
+        calls = getattr(self, "_test_single_ac_calls", None)
+        if isinstance(calls, list):
+            calls.append(dict(kwargs))
+        runner = getattr(self, "_test_single_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_single_ac(*args, **kwargs)
+
+    async def _execute_atomic_ac(self, *args: Any, **kwargs: Any) -> Any:
+        runner = getattr(self, "_test_atomic_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_atomic_ac(*args, **kwargs)

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,0 +1,1748 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+import gc
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock
+import weakref
+
+import pytest
+
+from ouroboros.backends import runtime_backend_choices
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    execution_authority_boundary_contract,
+)
+import ouroboros.orchestrator.parallel_executor as parallel_executor_module
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
+from ouroboros.orchestrator.runtime_factory import create_agent_runtime
+from ouroboros.orchestrator.verifier import VerifierVerdict, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+
+class _Runtime:
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory: str | None = None
+    _model = None
+
+    def __init__(self, *, profile: str = "profile-a") -> None:
+        self.profile = profile
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {
+            "profile": self.profile,
+            "effective_model_observed": True,
+        }
+
+    async def execute_task(self, **_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+
+class _DynamicDispatchRuntime:
+    """A runtime whose dispatch entrypoint cannot be statically bound."""
+
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "dynamic-runtime"
+    llm_backend = "dynamic-llm"
+    permission_mode = "bypassPermissions"
+    self_governs_rate_limit = False
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"kind": "dynamic-runtime/v1", "effective_model_observed": True}
+
+    def __getattr__(self, name: str) -> object:
+        if name == "execute_task":
+
+            async def dispatch(**_: object) -> AsyncIterator[object]:
+                if False:  # pragma: no cover - identity-only stand-in
+                    yield None
+
+            return dispatch
+        raise AttributeError(name)
+
+
+class _Verifier:
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": self.identity}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
+def _contract(
+    *,
+    runtime: object | None = None,
+    verifier: object | None = None,
+    workspace: str = "/tmp/workspace-a",
+    policy: dict[str, object] | None = None,
+) -> ExecutionAuthorityContract:
+    return ExecutionAuthorityContract.build(
+        adapter=runtime or _Runtime(),
+        verifier=verifier,  # type: ignore[arg-type]
+        workspace=workspace,
+        execution_policy=policy or {"retry_attempts": 2},
+    )
+
+
+def test_legacy_runtime_authority_never_invokes_dynamic_identity_provider() -> None:
+    class ExplodingRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            raise AssertionError("Foundation A must not execute legacy runtime providers")
+
+    authority = _contract(runtime=ExplodingRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+
+
+def test_legacy_runtime_captures_are_process_local_and_unique() -> None:
+    first = _contract(runtime=_Runtime(profile="a"))
+    second = _contract(runtime=_Runtime(profile="b"))
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_custom_verifier_is_never_promoted_to_portable_authority() -> None:
+    first = _contract(verifier=_Verifier("judge-a"))
+    same = _contract(verifier=_Verifier("judge-a"))
+    changed = _contract(verifier=_Verifier("judge-b"))
+
+    assert first.fingerprint != same.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert first.portable_across_processes is False
+    assert "judge-a" not in first.canonical_json
+
+
+def test_undeclared_custom_verifier_is_process_local() -> None:
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    first = _contract(verifier=verifier)
+    second = _contract(verifier=verifier)
+
+    assert first.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_workspace_and_policy_drift_change_authority() -> None:
+    baseline = _contract()
+    assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
+    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_builtin_verifier_does_not_make_legacy_runtime_portable() -> None:
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+    assert authority.data["verifier"] == {
+        "implementation": "structural-atomic-verifier/v1",
+        "mode": "structural_atomic",
+        "stability": "durable",
+        "version": 1,
+    }
+
+
+def test_complete_runtime_factory_catalog_is_process_local() -> None:
+    """Every shipped runtime backend stays below Foundation A portability."""
+    expected_backends = {
+        "claude",
+        "claude_mcp",
+        "codex",
+        "codex_mcp",
+        "copilot",
+        "gemini",
+        "zcode",
+        "hermes",
+        "kiro",
+        "opencode",
+        "goose",
+        "pi",
+        "gjc",
+        "antigravity",
+        "grok",
+    }
+    assert set(runtime_backend_choices()) == expected_backends
+
+    for backend in sorted(expected_backends):
+        runtime = create_agent_runtime(
+            backend=backend,
+            cli_path=sys.executable,
+            cwd="/tmp",
+            permission_mode="bypassPermissions",
+            model="test-model",
+            llm_backend="test-llm",
+        )
+        authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+        assert authority.portable_across_processes is False, backend
+        assert authority.data["runtime"]["stability"] == "process_local", backend
+
+
+def test_boundary_contract_marks_legacy_runtime_descriptor_process_local() -> None:
+    boundary = execution_authority_boundary_contract()
+
+    assert "legacy_runtime_descriptor" in boundary["process_local"]
+    assert "legacy_runtime_descriptor" not in boundary["portable"]
+    assert "runtime_descriptor" not in boundary["portable"]
+
+
+def test_unknown_runtime_implementation_stays_process_local_and_unique() -> None:
+    class AlternateRuntime(_Runtime):
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            if False:  # pragma: no cover - implementation identity only
+                yield None
+
+    first = _contract(runtime=_Runtime())
+    second = _contract(runtime=AlternateRuntime())
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_runtime_type_name_spoof_cannot_claim_closed_implementation() -> None:
+    class SpoofedCodexRuntime(CodexCliRuntime):
+        pass
+
+    SpoofedCodexRuntime.__module__ = CodexCliRuntime.__module__
+    SpoofedCodexRuntime.__qualname__ = CodexCliRuntime.__qualname__
+    runtime = SpoofedCodexRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_preconstruction_builtin_dispatch_patch_stays_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def altered_execute_task(*_: object, **__: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(CodexCliRuntime, "execute_task", altered_execute_task)
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_legacy_codex_runtime_never_serializes_runtime_configuration() -> None:
+    baseline = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            stdout_idle_timeout_seconds=30,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    assert baseline.portable_across_processes is False
+    assert baseline.data["runtime"]["configuration"] == {"observed": False}
+    assert "/tmp" not in baseline.canonical_json
+
+
+def test_closed_codex_runtime_custom_skill_configuration_stays_process_local(
+    tmp_path,
+) -> None:
+    custom_skills = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skills_dir=tmp_path,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    custom_dispatcher = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skill_dispatcher=MagicMock(),
+        ),
+        verifier=structural_atomic_verifier,
+    )
+
+    assert custom_skills.portable_across_processes is False
+    assert custom_dispatcher.portable_across_processes is False
+
+
+def test_legacy_codex_dynamic_helpers_and_cache_cannot_gain_portability() -> None:
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+    before = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    async def injected_impl(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - must never be invoked during capture
+            yield None
+
+    def exploding_provider() -> dict[str, object]:
+        raise AssertionError("legacy identity provider must not run")
+
+    runtime._execute_task_impl = injected_impl  # type: ignore[method-assign]
+    runtime._build_command = lambda **_: ["injected"]  # type: ignore[method-assign]
+    runtime._builtin_mcp_handlers = {"injected": object()}
+    runtime.execution_identity_contract = exploding_provider  # type: ignore[method-assign]
+    after = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    for authority in (before, after):
+        assert authority.portable_across_processes is False
+        assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+        assert authority.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_copilot_runtime_is_process_local_even_when_profile_changes() -> None:
+    plain = _contract(
+        runtime=CopilotCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    worker_runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+        runtime_profile="worker",
+    )
+    worker = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+
+    assert plain.portable_across_processes is False
+    assert worker.portable_across_processes is False
+    assert plain.data["runtime"]["configuration"] == {"observed": False}
+    assert worker.data["runtime"]["configuration"] == {"observed": False}
+
+    worker_runtime._copilot_agent = "different-agent"
+    changed = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+    assert changed.portable_across_processes is False
+    assert changed.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_zcode_runtime_with_external_launcher_chain_stays_process_local() -> None:
+    runtime = ZcodeCLIRuntime(cli_path=sys.executable, cwd="/tmp")
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_credential_shaped_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert secret not in authority.canonical_json
+
+
+def test_stripe_credential_shaped_runtime_identity_becomes_process_local() -> None:
+    secret = "sk_" + "live_abcdefghijklmnopqrstuvwxyz123456"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_credential_alias_in_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "apiKeyValue": secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+@pytest.mark.parametrize(
+    "key_name",
+    (
+        "secretKey",
+        "secret_access_key",
+        "awsSecretAccessKey",
+        "accountKey",
+        "connectionString",
+        "masterKey",
+    ),
+)
+def test_secret_key_alias_in_runtime_identity_becomes_process_local(
+    key_name: str,
+) -> None:
+    secret = "opaque-provider-credential"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                key_name: secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_custom_verifier_credential_alias_never_enters_authority_json() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialVerifier(_Verifier):
+        def verification_identity_contract(self) -> dict[str, object]:
+            return {"apiKeyValue": secret}
+
+    authority = _contract(verifier=CredentialVerifier("ignored"))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["verifier"]["configuration"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_contract_deserialization_rejects_credential_shaped_member() -> None:
+    authority = _contract(verifier=structural_atomic_verifier)
+    data = authority.data
+    data["verifier"]["implementation"] = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    with pytest.raises(ValueError, match="sensitive"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_contract_deserialization_rejects_promoted_process_local_runtime() -> None:
+    authority = _contract(runtime=_DynamicDispatchRuntime())
+    data = authority.data
+    assert data["runtime"]["portable_identity_observed"] is False
+    data["runtime"]["stability"] = "durable"
+
+    with pytest.raises(ValueError, match="invalid runtime"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_empty_runtime_identity_stays_process_local() -> None:
+    class EmptyIdentityRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {}
+
+    authority = _contract(runtime=EmptyIdentityRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+
+
+def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=load_profile("code"),
+        atomic_verifier=_Verifier("judge-a"),
+        ac_retry_attempts=2,
+    )
+
+    authority = executor.execution_authority
+    assert authority.fingerprint.startswith("sha256:")
+    assert authority.data["workspace"]["identity_digest"].startswith("sha256:")
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["execution_policy"]["identity_digest"].startswith("sha256:")
+
+
+def test_session_signal_hub_is_process_local_and_cannot_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    hub = MagicMock()
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        session_signal_hub=hub,
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    assert executor._execution_authority_policy()["session_signal_hub_enabled"] is True
+    executor._require_execution_authority_intact()
+
+    executor._session_signal_hub = MagicMock()
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_keeps_copilot_agent_drift_process_local(tmp_path) -> None:
+    runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd=tmp_path,
+        runtime_profile="worker",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+    runtime._copilot_agent = "different-agent"
+    executor._require_execution_authority_intact()
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_execution_authority_registry_does_not_keep_executor_alive(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor_ref = weakref.ref(executor)
+
+    del executor
+    gc.collect()
+    gc.collect()
+
+    assert executor_ref() is None
+
+
+def test_public_constructor_rejects_caller_supplied_closed_roots(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    with pytest.raises(TypeError, match="multiple values"):
+        ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type, call-arg]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            _foundation_a_roots=object(),  # type: ignore[call-arg]
+        )
+
+
+def test_constructor_closure_ignores_a_poisoned_global_roots_bundle(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    roots = parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS
+    original_verifier = roots.transcript_verifier
+    original_verifier_code = roots.transcript_verifier_code
+
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=False, reasons=("poisoned root",))
+
+    object.__setattr__(roots, "transcript_verifier", injected_verifier)
+    object.__setattr__(roots, "transcript_verifier_code", injected_verifier.__code__)
+    try:
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+        )
+    finally:
+        object.__setattr__(roots, "transcript_verifier", original_verifier)
+        object.__setattr__(roots, "transcript_verifier_code", original_verifier_code)
+
+    assert executor._authority_transcript_verifier is original_verifier
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    base_profile = load_profile("code")
+    changed_profile = base_profile.model_copy(update={"profile": "code-v2"})
+
+    def build(profile: ExecutionProfile) -> str:
+        return ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            execution_profile=profile,
+        ).execution_authority.fingerprint
+
+    assert build(base_profile) != build(changed_profile)
+
+
+def test_runtime_mutation_cannot_promote_process_local_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    runtime.profile = "changed"
+
+    # A legacy runtime's dynamic profile is intentionally outside the finite
+    # portable descriptor.  It remains executable in this process, but cannot
+    # become portable merely because the visible value changed or remained
+    # stable.  Executor-owned root drift is covered separately below.
+    executor._require_execution_authority_intact()
+    assert executor.execution_authority.portable_across_processes is False
+    assert _contract(runtime=runtime).portable_across_processes is False
+
+
+def test_executor_rejects_replaced_verifier_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=_Verifier("first"),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._atomic_verifier = _Verifier("replacement")
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._authority_leaf_dispatcher_type = object
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_runtime_dispatch_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_execute_task(self: _Runtime, **_: object) -> AsyncIterator[object]:
+        del self
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(_Runtime, "execute_task", replacement_execute_task)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_method_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        executor._authority_leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_coordinator_review_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_review(**_: object) -> object:
+        return object()
+
+    monkeypatch.setattr(executor._coordinator, "run_review", replacement_review)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_coordinator_adapter_drift_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    replacement = _Runtime(profile="replacement")
+    replacement.working_directory = str(tmp_path)
+    executor._coordinator._adapter = replacement  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_its_own_attribute_resolution_drift_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class EvilRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    evil_runtime = EvilRuntime()
+    evil_runtime.working_directory = str(tmp_path)
+    original_getattribute = ParallelACExecutor.__getattribute__
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_require_execution_authority_intact":
+            return lambda: None
+        if name == "_adapter":
+            return evil_runtime
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "__getattribute__",
+        redirected_getattribute,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._dispatch_decomposition_prompt(
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert evil_runtime.dispatched is False
+
+
+def test_executor_rejects_postconstruction_runtime_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    original_getattribute = _Runtime.__getattribute__
+
+    async def injected_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - must remain unreachable
+            yield None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "execute_task":
+            return injected_dispatch
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(_Runtime, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_dispatcher_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_getattribute = dispatcher_type.__getattribute__
+
+    async def injected_stream(**_: object) -> None:
+        return None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "stream":
+            return injected_stream
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(dispatcher_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_coordinator_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    coordinator_type = type(executor._coordinator)
+    original_getattribute = coordinator_type.__getattribute__
+    replacement_adapter = object()
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_adapter":
+            return replacement_adapter
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(coordinator_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_rate_gate_attribute_resolution_drift_before_admission(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    gate_type = type(executor._dispatch_rate_gate)
+    original_getattribute = gate_type.__getattribute__
+    injected_calls: list[int] = []
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        injected_calls.append(1)
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "acquire":
+            return injected_acquire
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(gate_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert injected_calls == []
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_replaced_rate_gate_bucket_before_admission(tmp_path) -> None:
+    class EvilBucket:
+        def __init__(self, original: object) -> None:
+            self._runtime_backend = object.__getattribute__(original, "_runtime_backend")
+            self._request_limit = object.__getattribute__(original, "_request_limit")
+            self._token_limit = object.__getattribute__(original, "_token_limit")
+            self._window_seconds = object.__getattribute__(original, "_window_seconds")
+            self.called = False
+
+        async def acquire(self, _: int) -> object:
+            self.called = True
+            return (0.0, object())
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    original_bucket = object.__getattribute__(executor._dispatch_rate_gate, "_bucket")
+    evil_bucket = EvilBucket(original_bucket)
+    object.__setattr__(executor._dispatch_rate_gate, "_bucket", evil_bucket)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert evil_bucket.called is False
+
+
+@pytest.mark.parametrize(
+    ("attribute", "replacement"),
+    (("_max_wait_seconds", 0.0), ("_heartbeat_seconds", 0.0)),
+)
+def test_executor_rejects_rate_gate_scalar_semantic_drift(
+    tmp_path,
+    attribute: str,
+    replacement: float,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    object.__setattr__(executor._dispatch_rate_gate, attribute, replacement)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_wait_collaborator_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_sleep(_: float) -> None:
+        return None
+
+    object.__setattr__(executor._dispatch_rate_gate, "_sleep", injected_sleep)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_bucket_time_and_method_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    bucket = executor._dispatch_rate_gate._bucket
+
+    object.__setattr__(bucket, "_time", lambda: 0.0)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+    object.__setattr__(bucket, "_time", parallel_executor_module.time.monotonic)
+
+    async def injected_force_reserve(*_: object, **__: object) -> object:
+        return object()
+
+    monkeypatch.setattr(type(bucket), "force_reserve", injected_force_reserve)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_bucket_helper_code_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    def injected_prune(self: object, now: float) -> None:
+        del self, now
+
+    bucket_type = type(executor._dispatch_rate_gate._bucket)
+    monkeypatch.setattr(bucket_type._prune, "__code__", injected_prune.__code__)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_captured_leaf_dispatch_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_stream(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_leaf_dispatcher_stream = injected_stream
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_captured_rate_gate_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_rate_gate_acquire_root = injected_acquire
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_reuses_closed_leaf_dispatcher_after_late_init_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    captured_dispatcher = executor._authority_leaf_dispatcher
+
+    def injected_init(self: object, _: object) -> None:
+        object.__setattr__(self, "_executor", object())
+
+    monkeypatch.setattr(executor._authority_leaf_dispatcher_type, "__init__", injected_init)
+
+    executor._require_execution_authority_intact()
+    assert executor._authority_leaf_dispatcher is captured_dispatcher
+    assert object.__getattribute__(captured_dispatcher, "_executor") is executor
+
+
+def test_executor_uses_closed_import_time_dispatcher_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementDispatcher:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LeafDispatcher", ReplacementDispatcher)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_leaf_dispatcher_type is not ReplacementDispatcher
+    executor._require_execution_authority_intact()
+
+
+def test_executor_uses_closed_import_time_coordinator_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementCoordinator:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LevelCoordinator", ReplacementCoordinator)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert type(executor._coordinator) is not ReplacementCoordinator
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_dispatcher_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_rate_gate_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_acquire(self: object, *_: object, **__: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module.RateLimitGate,
+        "acquire",
+        replacement_acquire,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_coordinator_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_review(self: object, **_: object) -> object:
+        del self
+        return object()
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.level_coordinator_type,
+        "run_review",
+        replacement_review,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_transcript_alias_patch_uses_closed_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("injected verifier must not become the closed root",),
+        )
+
+    monkeypatch.setattr(
+        parallel_executor_module,
+        "_FOUNDATION_A_TRANSCRIPT_VERIFIER",
+        injected_verifier,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_reflective_custom_verifier_remains_process_local_without_graph_introspection() -> None:
+    mutable_state = {"passed": True}
+
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=mutable_state["passed"])
+
+    authority = _contract(verifier=verifier)
+
+    assert authority.portable_across_processes is False
+    assert "mutable_state" not in authority.canonical_json
+    assert "passed" not in authority.canonical_json
+
+
+def test_uninspectable_runtime_dispatch_root_stays_process_local() -> None:
+    class Dispatcher:
+        async def stream(self, **_: object) -> None:
+            return None
+
+    class RateGate:
+        async def acquire(self, *_: object, **__: object) -> None:
+            return None
+
+    def transcript_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    from ouroboros.orchestrator.execution_authority import ExecutionAuthorityLiveBinding
+
+    binding = ExecutionAuthorityLiveBinding.capture(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        dispatcher_type=Dispatcher,
+        transcript_verifier=transcript_verifier,
+        rate_gate=RateGate(),
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert binding.adapter_dispatch_root is None
+    assert binding.contract.portable_across_processes is False
+    assert binding.contract.data["runtime"]["stability"] == "process_local"
+
+
+def test_instance_level_runtime_dispatch_callable_stays_process_local() -> None:
+    class InstanceDispatchRuntime(_Runtime):
+        def __init__(self, dispatch: object) -> None:
+            super().__init__()
+            self.execute_task = dispatch  # type: ignore[method-assign]
+
+    async def first_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    async def second_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    first = _contract(runtime=InstanceDispatchRuntime(first_dispatch))
+    second = _contract(runtime=InstanceDispatchRuntime(second_dispatch))
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.data["runtime"]["stability"] == "process_local"
+    assert second.data["runtime"]["stability"] == "process_local"
+
+
+def test_direct_contract_with_uninspectable_runtime_stays_process_local() -> None:
+    authority = ExecutionAuthorityContract.build(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+
+
+def test_captured_transcript_verifier_ignores_replaced_executor_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    profile = load_profile("code").model_copy(
+        update={"evidence_schema": EvidenceSchema(required=())}
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=profile,
+        fat_harness_mode=True,
+    )
+
+    def replaced_wrapper(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("replacement wrapper must not decide acceptance",),
+        )
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "_verify_atomic_evidence_against_runtime_messages",
+        replaced_wrapper,
+    )
+
+    verdict = executor._run_atomic_verifier_pass(
+        ac_content="No transcript proof is required.",
+        final_message="done",
+        success=True,
+        messages=(),
+        typed_evidence=parallel_executor_module.EvidenceRecord(data={}),
+        typed_validation=parallel_executor_module.ValidationResult(ok=True),
+    )
+
+    assert verdict is not None
+    assert verdict.passed is True
+
+
+def test_executor_rejects_in_place_dispatcher_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_code = dispatcher_type.stream.__code__
+
+    async def injected_stream(self: object, **_: object) -> None:
+        del self
+
+    dispatcher_type.stream.__code__ = injected_stream.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        dispatcher_type.stream.__code__ = original_code
+
+
+def test_executor_rejects_in_place_structural_verifier_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=structural_atomic_verifier,
+    )
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
+def test_preconstruction_structural_verifier_code_drift_is_process_local() -> None:
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        authority = _contract(verifier=structural_atomic_verifier)
+        assert authority.portable_across_processes is False
+        assert authority.data["verifier"]["stability"] == "process_local"
+
+        runtime = _Runtime()
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd="/tmp/workspace-a",
+            atomic_verifier=structural_atomic_verifier,
+        )
+        assert executor.execution_authority.portable_across_processes is False
+        executor._require_execution_authority_intact()
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
+@pytest.mark.parametrize(
+    "entry_name",
+    (
+        "_execute_single_ac",
+        "_execute_atomic_ac",
+        "_await_dispatch_rate_budget",
+        "_dispatch_decomposition_prompt",
+        "_run_atomic_verifier_pass",
+        "_run_ac_verify_gate",
+    ),
+)
+def test_executor_rejects_postconstruction_internal_entry_root_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    entry_name: str,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, entry_name, injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_instance_shadow_of_internal_entry_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(**_: object) -> object:
+        return None
+
+    object.__setattr__(executor, "_execute_single_ac", injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_preconstruction_internal_entry_root_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_executor_subclass_is_process_local_even_when_it_inherits_entry_roots(tmp_path) -> None:
+    class SubclassedExecutor(ParallelACExecutor):
+        pass
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = SubclassedExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_unhashable_executor_subclass_remains_executable_and_process_local(tmp_path) -> None:
+    class UnhashableExecutor(ParallelACExecutor):
+        __hash__ = None  # type: ignore[assignment]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = UnhashableExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_equality_overriding_executor_subclasses_keep_distinct_registry_entries(tmp_path) -> None:
+    class EqualExecutor(ParallelACExecutor):
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqualExecutor)
+
+        __hash__ = object.__hash__
+
+    first_runtime = _Runtime(profile="first")
+    first_runtime.working_directory = str(tmp_path)
+    second_runtime = _Runtime(profile="second")
+    second_runtime.working_directory = str(tmp_path)
+    first = EqualExecutor(
+        adapter=first_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    second = EqualExecutor(
+        adapter=second_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert first == second
+    first._require_execution_authority_intact()
+    second._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_runtime_does_not_reopen_captured_executor_entry_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _DynamicDispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+    injected = False
+
+    async def injected_entry(*_: object, **__: object) -> str:
+        nonlocal injected
+        injected = True
+        return '{"cause":"TOO_BIG","reason":"injected","evidence_refs":[]}'
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+
+    result = await executor._request_bounce_classification(
+        trace=parallel_executor_module.DecompositionTraceSummary(summary="bounded evidence"),
+    )
+
+    assert result == (
+        parallel_executor_module.BounceCause.UNKNOWN,
+        "Bounce classifier returned no admissible cause.",
+        (),
+        False,
+    )
+    assert injected is False
+
+
+@pytest.mark.asyncio
+async def test_internal_execution_path_rejects_entry_replacement_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        runtime.dispatched = True
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", injected_entry)
+    seed = MagicMock()
+    seed.acceptance_criteria = ("Do not dispatch",)
+    seed.goal = "Keep the runtime closed"
+
+    results = await executor._execute_ac_batch(
+        seed=seed,
+        batch_indices=[0],
+        session_id="session",
+        execution_id="execution",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        level_contexts=[],
+        ac_retry_attempts={0: 0},
+    )
+
+    assert isinstance(results[0], ValueError)
+    assert runtime.dispatched is False
+
+
+@pytest.mark.asyncio
+async def test_executor_root_drift_rejects_before_decomposition_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - should remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_decomposition_entry(*_: object, **__: object) -> object:
+        runtime.dispatched = True
+        return None
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "_dispatch_decomposition_prompt",
+        injected_decomposition_entry,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await parallel_executor_module._invoke_execution_authority_entry(
+            executor,
+            parallel_executor_module._FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert runtime.dispatched is False

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -1129,7 +1129,7 @@ def _consumer_runner(fabricated: list) -> tuple[OrchestratorRunner, list, MagicM
 
 class TestFrugalityProofConsumer:
     @pytest.mark.asyncio
-    async def test_same_seed_recent_runs_form_cohort_without_mixing_other_seed(self) -> None:
+    async def test_process_local_authority_never_pools_runs_into_a_proof_cohort(self) -> None:
         runner, appended, _console = _consumer_runner([])
         store = runner._event_store
         cohort_seed = Seed(
@@ -1254,8 +1254,9 @@ class TestFrugalityProofConsumer:
                     baseline=100,
                 )
             ]
-        # If this different seed leaked into the cohort it would change both the
-        # row count and aggregate reduction.
+        # A process-local Foundation A contract must not become a cross-run proof
+        # key, even when another run has the same Seed and identical visible
+        # durable fields.
         events_by_execution["run-other"] = [
             event
             for ac in range(20)
@@ -1278,23 +1279,14 @@ class TestFrugalityProofConsumer:
         emitted = [e for e in appended if e.type == "execution.frugality_proof.evaluated"]
         assert len(emitted) == 1
         data = emitted[0].data
-        assert data["seed_id"] == "seed-proof"
-        assert data["cohort_execution_ids"] == ["run-2", "run-1", "run-0"]
-        assert data["status"] == ProofStatus.PASS.value
-        assert data["counted_rows"] == 21
-        assert data["runs"] == 3
-        assert data["token_reduction_pct"] == pytest.approx(50.0)
-        assert all(
-            call.args[0]
-            not in {
-                "run-other",
-                "run-other-project",
-                "run-other-routing",
-                "run-edited-seed",
-                "run-legacy",
-            }
-            for call in store.query_execution_related_events.await_args_list
-        )
+        assert data["seed_id"] is None
+        assert data["cohort_execution_ids"] == ["run-2"]
+        assert data["status"] == ProofStatus.INSUFFICIENT_SAMPLE.value
+        assert data["counted_rows"] == 7
+        assert data["runs"] == 1
+        assert [call.args[0] for call in store.query_execution_related_events.await_args_list] == [
+            "run-2"
+        ]
 
     @pytest.mark.asyncio
     async def test_missing_current_proof_identity_is_current_only(self) -> None:

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -443,16 +443,12 @@ class TestCancellationErrorScenarios:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_failed_still_returns_result(
+    async def test_handle_cancellation_mark_failed_retains_live_owner(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """If mark_cancelled fails during handling, the result is still returned.
-
-        The _handle_cancellation method logs a warning but still returns an
-        OrchestratorResult. This ensures the execution stops even if persistence fails.
-        """
+        """A failed terminal write must not release a still-RUNNING owner."""
         runner._register_session("exec_fail", "sess_fail")
         await request_cancellation("sess_fail")
         self._mock_running_session(runner, "sess_fail")
@@ -479,26 +475,25 @@ class TestCancellationErrorScenarios:
                 error=str(PersistenceError("DB write failed")),
             )
 
-        # Should still return a valid cancellation result
-        assert result.is_ok
-        assert result.value.success is False
-        assert result.value.messages_processed == 7
-        # Cleanup should still happen even if persistence failed
-        assert not await is_cancellation_requested("sess_fail")
-        assert "exec_fail" not in runner.active_sessions
+        # Reporting cancellation while the durable tracker is still RUNNING
+        # would let another process misclassify it as a crashed owner. Keep the
+        # in-memory route, heartbeat, and request live for a retry instead.
+        assert result.is_err
+        assert result.error.message == (
+            "Failed to persist cancellation; process-local authority remains live"
+        )
+        assert await is_cancellation_requested("sess_fail")
+        assert runner.active_sessions["exec_fail"] == "sess_fail"
+        await clear_cancellation("sess_fail")
+        runner._unregister_session("exec_fail", "sess_fail")
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_raises_still_propagates(
+    async def test_handle_cancellation_mark_raises_retains_live_owner(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """If mark_cancelled raises an exception, it propagates (not swallowed).
-
-        Unlike _check_cancellation which degrades gracefully, _handle_cancellation
-        does NOT catch exceptions from mark_cancelled because the execution is
-        already stopping.
-        """
+        """An exception during terminal persistence retains the retryable owner."""
         runner._register_session("exec_raise", "sess_raise")
         self._mock_running_session(runner, "sess_raise")
 
@@ -507,18 +502,17 @@ class TestCancellationErrorScenarios:
             "mark_cancelled",
             side_effect=RuntimeError("Unexpected DB crash"),
         ):
-            with pytest.raises(RuntimeError, match="Unexpected DB crash"):
-                await runner._handle_cancellation(
-                    session_id="sess_raise",
-                    execution_id="exec_raise",
-                    messages_processed=3,
-                    start_time=datetime.now(UTC),
-                )
+            result = await runner._handle_cancellation(
+                session_id="sess_raise",
+                execution_id="exec_raise",
+                messages_processed=3,
+                start_time=datetime.now(UTC),
+            )
 
-        # Despite the exception, registry and session should have been
-        # cleaned up before mark_cancelled was called
-        assert not await is_cancellation_requested("sess_raise")
-        assert "exec_raise" not in runner.active_sessions
+        assert result.is_err
+        assert result.error.details["cause"] == "Unexpected DB crash"
+        assert runner.active_sessions["exec_raise"] == "sess_raise"
+        runner._unregister_session("exec_raise", "sess_raise")
 
     @pytest.mark.asyncio
     async def test_cancel_session_directly_event_store_replay_error(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -23,6 +23,7 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.runner import (
     CANCELLATION_CHECK_INTERVAL,
+    EXECUTION_CONTRACT_PROGRESS_KEY,
     ExecutionCancelledError,
     OrchestratorRunner,
     clear_cancellation,
@@ -100,6 +101,27 @@ def sample_seed():
         ontology_schema=OntologySchema(name="Test", description="Test"),
         metadata=SeedMetadata(ambiguity_score=0.1),
     )
+
+
+def _attach_live_process_local_contract(
+    runner: OrchestratorRunner,
+    tracker: SessionTracker,
+    seed: Any,
+) -> SessionTracker:
+    """Give direct precreated-session tests their creating-process capability."""
+    if not isinstance(getattr(runner._adapter, "llm_backend", None), str):
+        runner._adapter.llm_backend = "test-llm"
+    if not isinstance(getattr(runner._adapter, "_model", None), str):
+        runner._adapter._model = "test-model"
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    return tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
 
 
 # =============================================================================
@@ -565,7 +587,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_boundary", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         call_count = 0
 
@@ -605,7 +633,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_full", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             with patch.object(runner._session_repo, "mark_completed", return_value=Result.ok(None)):
@@ -637,7 +671,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_int", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def tracking_check(session_id):
             check_points.append(len(check_points) + 1)
@@ -670,7 +710,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_unreg", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_check(session_id):
             return True  # Always cancel
@@ -699,6 +745,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_task_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
             stream_started.set()
@@ -777,6 +824,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_terminal_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
         completed_tracker = tracker.with_status(SessionStatus.COMPLETED)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -839,6 +887,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_unrequested_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
             stream_started.set()
@@ -898,7 +947,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_partial", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         call_count = 0
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,7 +28,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
+from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict, LevelCoordinator
 from ouroboros.orchestrator.decomposition_policy import DecompositionDisposition
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
@@ -56,8 +56,8 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
-from ouroboros.orchestrator.rate_limit import RateLimitGate, SharedRateLimitBucket
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def test_stall_timeout_default_allows_realistic_test_suites() -> None:
@@ -134,15 +134,18 @@ class TestDispatchRateGate:
         await executor._await_dispatch_rate_budget(prompt="hello", system_prompt=None)
 
     @pytest.mark.asyncio
-    async def test_await_dispatch_rate_budget_paces_through_active_gate(
+    async def test_await_dispatch_rate_budget_rejects_postconstruction_gate_semantic_drift(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
         adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
         executor = _make_rate_gate_executor(adapter)
 
-        # Swap in a deterministic gate (rpm=1, fake clock + sleep) to prove the
-        # executor's dispatch hook actually waits on the shared budget.
+        # Replacing behavior-changing collaborators after construction is no
+        # longer a valid deterministic-test seam: the authority guard must
+        # reject it before rate admission. RateLimitGate itself owns separate
+        # deterministic timing tests with injected collaborators at creation.
         clock = {"now": 0.0}
         slept: list[float] = []
 
@@ -150,20 +153,14 @@ class TestDispatchRateGate:
             slept.append(seconds)
             clock["now"] += seconds
 
-        bucket = SharedRateLimitBucket(
-            runtime_backend="opencode",
-            request_limit=1,
-            token_limit=None,
-            time_provider=lambda: clock["now"],
-        )
-        executor._dispatch_rate_gate = RateLimitGate(
-            bucket, heartbeat_seconds=120.0, sleep=fake_sleep
-        )
+        executor._dispatch_rate_gate._bucket._time = lambda: clock["now"]
+        executor._dispatch_rate_gate._sleep = fake_sleep
+        executor._dispatch_rate_gate._heartbeat_seconds = 120.0
 
-        await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
-        await executor._await_dispatch_rate_budget(prompt="b", system_prompt=None)
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
 
-        assert slept == [60.0]  # second dispatch waited a full window
+        assert slept == []
 
 
 def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:
@@ -182,7 +179,7 @@ def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:
 
 def _make_executor() -> ParallelACExecutor:
     """Create an executor with mocked dependencies and muted event emitters."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -8371,7 +8368,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_decomposed_ac_inlines_sub_ac_dispatch_into_single_ac(self) -> None:
         """Decomposed execution should recurse through _execute_single_ac without a helper path."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8391,24 +8388,21 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
-        with patch.object(
-            executor,
-            "_execute_single_ac",
-            wraps=executor._execute_single_ac,
-        ) as execute_single_ac_spy:
-            result = await executor._execute_single_ac(
-                ac_index=1,
-                ac_content="Implement parser workflow",
-                session_id="sess_decompose",
-                tools=["Read", "Edit"],
-                tool_catalog=None,
-                system_prompt="system",
-                seed_goal="Ship parser workflow",
-                depth=0,
-                execution_id="exec_decompose",
-            )
+        executor._test_single_ac_calls = []
+        result = await executor._execute_single_ac(
+            ac_index=1,
+            ac_content="Implement parser workflow",
+            session_id="sess_decompose",
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship parser workflow",
+            depth=0,
+            execution_id="exec_decompose",
+        )
 
         assert hasattr(executor, "_execute_sub_acs") is False
         assert result.success is True
@@ -8420,23 +8414,23 @@ class TestParallelACExecutor:
         assert [sub_result.depth for sub_result in result.sub_results] == [1, 1]
         assert [
             (
-                int(call.kwargs["ac_index"]),
-                str(call.kwargs["ac_content"]),
-                int(call.kwargs["depth"]),
+                int(call["ac_index"]),
+                str(call["ac_content"]),
+                int(call["depth"]),
             )
-            for call in execute_single_ac_spy.await_args_list
+            for call in executor._test_single_ac_calls
         ] == [
             (1, "Implement parser workflow", 0),
             (100, "Extract parser", 1),
             (101, "Wire parser", 1),
         ]
         assert executor._try_decompose_ac.await_count == 3
-        assert executor._execute_atomic_ac.await_count == 2
+        assert execute_atomic_ac.await_count == 2
 
     @pytest.mark.asyncio
     async def test_top_level_decomposition_preserves_sub_ac_runtime_identity(self) -> None:
         """First-level decomposed children should still execute with sub-AC runtime metadata."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8456,7 +8450,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         await executor._execute_single_ac(
             ac_index=1,
@@ -8477,7 +8472,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["parent_ac_index"]),
                 int(call.kwargs["sub_ac_index"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, True, 1, 0),
             (101, True, 1, 1),
@@ -8486,7 +8481,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_depth_three_forces_atomic_without_further_decomposition(self) -> None:
         """Depth 2 may still recurse, but depth 3 must execute atomically."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8509,7 +8504,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=0,
@@ -8535,8 +8531,8 @@ class TestParallelACExecutor:
             True,
         ]
         executor._try_decompose_ac.assert_awaited_once()
-        assert executor._execute_atomic_ac.await_count == 2
-        assert [call.kwargs["depth"] for call in executor._execute_atomic_ac.await_args_list] == [
+        assert execute_atomic_ac.await_count == 2
+        assert [call.kwargs["depth"] for call in execute_atomic_ac.await_args_list] == [
             3,
             3,
         ]
@@ -8732,7 +8728,7 @@ class TestParallelACExecutor:
         """Leaf retries should not re-run composite decomposition or sibling dispatch."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8765,7 +8761,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=1,
@@ -8789,7 +8786,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["depth"]),
                 int(call.kwargs["retry_attempt"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, 1, 0),
             (100, 1, 1),
@@ -8802,7 +8799,7 @@ class TestParallelACExecutor:
             if call.args and call.args[0].type == "execution.ac.stall_detected"
         ]
         assert len(stall_events) == 1
-        first_leaf_identity = executor._execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
+        first_leaf_identity = execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
         assert (
             stall_events[0].aggregate_id == f"exec_atomic_retry_scope_{first_leaf_identity.node_id}"
         )
@@ -8819,7 +8816,7 @@ class TestParallelACExecutor:
         """Single-AC execution should convert an unrecoverable stall into a normal failure."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8840,7 +8837,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=2,
@@ -8857,10 +8855,9 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error == f"Stalled (no activity for {STALL_TIMEOUT_SECONDS:.0f}s)"
         assert result.retry_attempt == MAX_STALL_RETRIES
-        assert executor._execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
+        assert execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
         assert [
-            int(call.kwargs["retry_attempt"])
-            for call in executor._execute_atomic_ac.await_args_list
+            int(call.kwargs["retry_attempt"]) for call in execute_atomic_ac.await_args_list
         ] == list(range(MAX_STALL_RETRIES + 1))
 
         stall_events = [
@@ -10853,7 +10850,10 @@ class TestParallelACExecutor:
         assert result.stages[1].outcome == StageExecutionOutcome.PARTIAL
 
     @pytest.mark.asyncio
-    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(self) -> None:
+    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Coordinator reconciliation should persist level-scoped events and artifacts only."""
         seed = _make_seed(
             "Update the shared module imports",
@@ -10866,48 +10866,51 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            conflicts_detected=(
+                FileConflict(
+                    file_path="src/shared.py",
+                    ac_indices=(0, 1),
+                    resolved=True,
+                    resolution_description="Merged by coordinator",
+                ),
+            ),
+            review_summary="Resolved shared.py conflict",
+            fixes_applied=("Merged overlapping import edits",),
+            warnings_for_next_level=("Verify shared.py integration paths",),
+            duration_seconds=1.5,
+            session_id="coord-session-1",
+            session_scope_id="level_1_coordinator",
+            session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
+            final_output=(
+                '{"review_summary":"Resolved shared.py conflict",'
+                '"fixes_applied":["Merged overlapping import edits"],'
+                '"warnings_for_next_level":["Verify shared.py integration paths"],'
+                '"conflicts_resolved":["src/shared.py"]}'
+            ),
+            messages=(
+                AgentMessage(
+                    type="assistant",
+                    content="Inspecting shared file",
+                    tool_name="Read",
+                    data={"tool_input": {"file_path": "src/shared.py"}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Reconciling overlap",
+                    data={"thinking": "Merge the import changes without changing behavior."},
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                conflicts_detected=(
-                    FileConflict(
-                        file_path="src/shared.py",
-                        ac_indices=(0, 1),
-                        resolved=True,
-                        resolution_description="Merged by coordinator",
-                    ),
-                ),
-                review_summary="Resolved shared.py conflict",
-                fixes_applied=("Merged overlapping import edits",),
-                warnings_for_next_level=("Verify shared.py integration paths",),
-                duration_seconds=1.5,
-                session_id="coord-session-1",
-                session_scope_id="level_1_coordinator",
-                session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
-                final_output=(
-                    '{"review_summary":"Resolved shared.py conflict",'
-                    '"fixes_applied":["Merged overlapping import edits"],'
-                    '"warnings_for_next_level":["Verify shared.py integration paths"],'
-                    '"conflicts_resolved":["src/shared.py"]}'
-                ),
-                messages=(
-                    AgentMessage(
-                        type="assistant",
-                        content="Inspecting shared file",
-                        tool_name="Read",
-                        data={"tool_input": {"file_path": "src/shared.py"}},
-                    ),
-                    AgentMessage(
-                        type="assistant",
-                        content="Reconciling overlap",
-                        data={"thinking": "Merge the import changes without changing behavior."},
-                    ),
-                ),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
@@ -10982,7 +10985,10 @@ class TestParallelACExecutor:
         )
 
     @pytest.mark.asyncio
-    async def test_returns_reconciled_level_contexts_for_retry_handoff(self) -> None:
+    async def test_returns_reconciled_level_contexts_for_retry_handoff(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Completed stage contexts should be returned for retry workspace handoff."""
         seed = _make_seed(
             "Land the shared runtime update",
@@ -10995,17 +11001,20 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            review_summary="Reconciled shared workspace",
+            fixes_applied=("Merged shared.py edits",),
+            warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                review_summary="Reconciled shared workspace",
-                fixes_applied=("Merged shared.py edits",),
-                warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ACExecutionResult,
     ParallelACExecutor,
 )
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 class _AtomicDecompositionRuntime:
@@ -66,7 +67,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
     depth: int,
 ) -> None:
     """Nested AC execution should stop recursing once decomposition returns ATOMIC."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -81,7 +82,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             reasons=("explicit_atomic",),
         )
     )
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         return_value=ACExecutionResult(
             ac_index=depth + 1,
             ac_content=f"Atomic at depth {depth}",
@@ -90,31 +91,27 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             depth=depth,
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=depth + 1,
-            ac_content=f"Atomic at depth {depth}",
-            session_id=f"sess_atomic_depth_{depth}",
-            tools=["Read"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Preserve ATOMIC termination",
-            depth=depth,
-            execution_id=f"exec_atomic_depth_{depth}",
-        )
+    result = await executor._execute_single_ac(
+        ac_index=depth + 1,
+        ac_content=f"Atomic at depth {depth}",
+        session_id=f"sess_atomic_depth_{depth}",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Preserve ATOMIC termination",
+        depth=depth,
+        execution_id=f"exec_atomic_depth_{depth}",
+    )
 
     assert result.success is True
     assert result.is_decomposed is False
     assert result.depth == depth
     executor._try_decompose_ac.assert_awaited_once()
-    executor._execute_atomic_ac.assert_awaited_once()
-    assert len(execute_single_ac_spy.await_args_list) == 1
-    assert execute_single_ac_spy.await_args.kwargs["depth"] == depth
+    execute_atomic_ac.assert_awaited_once()
+    assert [call["depth"] for call in executor._test_single_ac_calls] == [depth]
 
 
 class _CapturingDecompositionRuntime:

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, ExecutionStage, S
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
 from ouroboros.orchestrator.verifier import RetryAdmission, VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def _failed_result(*, failure_class: str = "SCOPE_CREEP") -> ACExecutionResult:
@@ -65,8 +66,8 @@ def _trusted_split(node_id: str) -> DecompositionDecisionRecord:
     )
 
 
-def _executor(*, max_depth: int = 3) -> ParallelACExecutor:
-    return ParallelACExecutor(
+def _executor(*, max_depth: int = 3) -> ProcessLocalTestExecutor:
+    return ProcessLocalTestExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -263,7 +264,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-restored", ac_index=0)
     executor._decomposition_decisions[node.node_id] = _trusted_split(node.node_id)
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         side_effect=lambda **kwargs: ACExecutionResult(
             ac_index=kwargs["ac_index"],
             ac_content=kwargs["ac_content"],
@@ -271,6 +272,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
             depth=kwargs["depth"],
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
     executor._try_decompose_ac = AsyncMock()
     executor._request_bounce_classification = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
@@ -288,7 +290,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     )
 
     assert result.is_decomposed is True
-    assert executor._execute_atomic_ac.await_count == 2
+    assert execute_atomic_ac.await_count == 2
     executor._try_decompose_ac.assert_not_awaited()
     executor._request_bounce_classification.assert_not_awaited()
 

--- a/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
+++ b/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ouroboros.core.seed import AcceptanceCriterionSpec, InvestmentSpec
-from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 @pytest.mark.asyncio
 async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic() -> None:
     """Composite ACs should keep recursing until the soft depth safety net is reached."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -41,7 +42,9 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             depth=int(kwargs["depth"]),
         )
 
-    executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
     investment = InvestmentSpec(
         difficulty="high",
         stakes="high",
@@ -54,24 +57,19 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         investment=investment,
     )
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=1,
-            ac_content="Root composite AC",
-            session_id="sess_recursive_depth",
-            tools=["Read", "Edit"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Support recursive decomposition",
-            depth=0,
-            execution_id="exec_recursive_depth",
-            ac_spec=parent_spec,
-            investment_spec=investment,
-        )
+    result = await executor._execute_single_ac(
+        ac_index=1,
+        ac_content="Root composite AC",
+        session_id="sess_recursive_depth",
+        tools=["Read", "Edit"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Support recursive decomposition",
+        depth=0,
+        execution_id="exec_recursive_depth",
+        ac_spec=parent_spec,
+        investment_spec=investment,
+    )
 
     assert result.success is True
     assert result.is_decomposed is True
@@ -95,11 +93,11 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
 
     assert [
         (
-            int(call.kwargs["ac_index"]),
-            str(call.kwargs["ac_content"]),
-            int(call.kwargs["depth"]),
+            int(call["ac_index"]),
+            str(call["ac_content"]),
+            int(call["depth"]),
         )
-        for call in execute_single_ac_spy.await_args_list
+        for call in executor._test_single_ac_calls
     ] == [
         (1, "Root composite AC", 0),
         (100, "Composite depth 1", 1),
@@ -112,7 +110,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
     assert executor._try_decompose_ac.await_count == 5
     assert [
         (int(call.kwargs["ac_index"]), int(call.kwargs["depth"]))
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (1000000, 3),
         (1000001, 3),
@@ -120,8 +118,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (101, 1),
     ]
     assert [
-        call.kwargs["node_identity"].display_path
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["node_identity"].display_path for call in execute_atomic_ac.await_args_list
     ] == [
         "2.1.1.1",
         "2.1.1.2",
@@ -133,7 +130,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             call.kwargs["parent_ac_index"],
             call.kwargs["sub_ac_index"],
         )
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (None, None),
         (None, None),
@@ -141,9 +138,6 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (1, 1),
     ]
     assert all(
-        call.kwargs["investment_spec"] is investment
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["investment_spec"] is investment for call in execute_atomic_ac.await_args_list
     )
-    assert all(
-        call.kwargs["ac_spec"] is None for call in executor._execute_atomic_ac.await_args_list
-    )
+    assert all(call.kwargs["ac_spec"] is None for call in execute_atomic_ac.await_args_list)

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1,0 +1,1243 @@
+"""Foundation A process-local authority lifecycle regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pickle
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+from ouroboros.orchestrator import heartbeat
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
+from ouroboros.orchestrator.execution_authority import _PROCESS_LOCAL_AUTHORITY_REGISTRY
+from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+from ouroboros.orchestrator.runner import (
+    EXECUTION_CONTRACT_PROGRESS_KEY,
+    OrchestratorError,
+    OrchestratorResult,
+    OrchestratorRunner,
+)
+from ouroboros.orchestrator.session import SessionStatus, SessionTracker
+
+
+class _CountingRuntime:
+    """Runtime double that records forbidden resume-provider lookups."""
+
+    runtime_backend = "process-local-test"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    capabilities = FULL_CAPABILITIES
+    working_directory = "/tmp"
+    _model = "test-model"
+
+    def __init__(self) -> None:
+        self.identity_provider_calls = 0
+        self.resume_selector_calls = 0
+        self.execute_calls = 0
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        self.identity_provider_calls += 1
+        raise AssertionError("process-local resume must not ask a runtime identity provider")
+
+    def resume_handle_execution_identity_contract(self, _: object) -> dict[str, object]:
+        self.resume_selector_calls += 1
+        raise AssertionError("process-local resume must not ask a resume selector provider")
+
+    async def execute_task(self, **_: object):
+        self.execute_calls += 1
+        if False:  # pragma: no cover - process-local guard must stop first
+            yield AgentMessage(type="result", content="unreachable")
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Keep authority process-local",
+        acceptance_criteria=("Do not reuse a lost runtime capability",),
+        ontology_schema=OntologySchema(name="Authority", description="Process-local authority"),
+        metadata=SeedMetadata(seed_id="seed-process-local-authority"),
+    )
+
+
+def _runner(runtime: _CountingRuntime | None = None) -> OrchestratorRunner:
+    return OrchestratorRunner(runtime or _CountingRuntime(), AsyncMock(), MagicMock())
+
+
+async def _prepare(
+    runner: OrchestratorRunner,
+    *,
+    session_id: str,
+    execution_id: str,
+) -> SessionTracker:
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(return_value=Result.ok(tracker)),
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        prepared = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+    assert prepared.is_ok
+    return prepared.value
+
+
+def _paused(tracker: SessionTracker) -> SessionTracker:
+    return tracker.with_status(SessionStatus.PAUSED)
+
+
+class _HandlerEventStore:
+    """Minimal handler store double for process-local resume routing."""
+
+    async def initialize(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_registers_an_opaque_live_generation() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-prepared-local",
+        execution_id="exec-prepared-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation = runner._process_local_authorities[(tracker.session_id, tracker.execution_id)]
+
+    try:
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        with pytest.raises(TypeError, match="cannot be serialized"):
+            pickle.dumps(generation)
+        with pytest.raises(TypeError, match="registry-minted"):
+            type(generation)(object(), generation.correlation_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+
+
+@pytest.mark.asyncio
+async def test_forged_correlation_cannot_register_or_resume_in_a_fresh_runner() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-forged-local",
+        execution_id="exec-forged-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    restarted_runtime = _CountingRuntime()
+    restarted = _runner(restarted_runtime)
+    forged = restarted._begin_process_local_authority_generation()
+    # Simulate a caller that has persisted diagnostics and tampers with a new
+    # locally minted object.  The registry's mint record still retains the
+    # original random correlation, so this cannot become a live authority.
+    object.__setattr__(
+        forged,
+        "_correlation_id",
+        contract["foundation_a_authority"]["correlation_id"],
+    )
+
+    try:
+        with pytest.raises(OrchestratorError, match="Cannot register"):
+            restarted._register_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                execution_contract=contract,
+                generation=forged,
+            )
+
+        paused = _paused(tracker)
+        restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
+        restarted._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+        restore = MagicMock(side_effect=AssertionError("restore must not run"))
+        restarted._restore_execution_contract = restore
+
+        result = await restarted.resume_session(paused.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        assert restarted_runtime.identity_provider_calls == 0
+        assert restarted_runtime.resume_selector_calls == 0
+        assert restarted_runtime.execute_calls == 0
+        restore.assert_not_called()
+    finally:
+        restarted._discard_process_local_authority(forged)
+        original._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_forked_child_cannot_use_parent_process_local_authority() -> None:
+    if not hasattr(os, "fork"):
+        pytest.skip("fork is unavailable on this platform")
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-fork-local",
+        execution_id="exec-fork-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    read_fd, write_fd = os.pipe()
+
+    try:
+        child_pid = os.fork()
+        if child_pid == 0:  # pragma: no cover - executed in an isolated child
+            try:
+                os.close(read_fd)
+                live = runner._has_live_process_local_authority(
+                    tracker.session_id,
+                    tracker.execution_id,
+                    contract,
+                )
+                os.write(write_fd, b"1" if live else b"0")
+            finally:
+                os.close(write_fd)
+                os._exit(0)
+        os.close(write_fd)
+        observed = os.read(read_fd, 1)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.WIFEXITED(status)
+        assert observed == b"0"
+    finally:
+        try:
+            os.close(read_fd)
+        except OSError:
+            pass
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_preparations_get_distinct_live_generations() -> None:
+    runner = _runner()
+
+    async def create_session(**kwargs: object) -> Result[SessionTracker, object]:
+        return Result.ok(
+            SessionTracker.create(
+                str(kwargs["execution_id"]),
+                str(kwargs["seed_id"]),
+                session_id=str(kwargs["session_id"]),
+            )
+        )
+
+    with (
+        patch.object(runner._session_repo, "create_session", create_session),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        first_result, second_result = await asyncio.gather(
+            runner.prepare_session(
+                _seed(),
+                session_id="session-concurrent-one",
+                execution_id="exec-concurrent-one",
+            ),
+            runner.prepare_session(
+                _seed(),
+                session_id="session-concurrent-two",
+                execution_id="exec-concurrent-two",
+            ),
+        )
+    assert first_result.is_ok
+    assert second_result.is_ok
+    first = first_result.value
+    second = second_result.value
+    first_contract = first.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    second_contract = second.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+
+    try:
+        assert (
+            first_contract["foundation_a_authority"]["correlation_id"]
+            != second_contract["foundation_a_authority"]["correlation_id"]
+        )
+        assert runner._has_live_process_local_authority(
+            first.session_id,
+            first.execution_id,
+            first_contract,
+        )
+        assert runner._has_live_process_local_authority(
+            second.session_id,
+            second.execution_id,
+            second_contract,
+        )
+    finally:
+        for tracker in (first, second):
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+
+
+@pytest.mark.asyncio
+async def test_legacy_precreated_tracker_fails_before_tool_setup() -> None:
+    runtime = _CountingRuntime()
+    runner = _runner(runtime)
+    tracker = SessionTracker.create(
+        "exec-legacy-local",
+        _seed().metadata.seed_id,
+        session_id="session-legacy-local",
+    )
+    get_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+    runner._get_merged_tools = get_tools
+
+    result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+    assert runtime.identity_provider_calls == 0
+    assert runtime.resume_selector_calls == 0
+    assert runtime.execute_calls == 0
+    get_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stale_running_tracker_after_process_loss_terminally_fails_closed() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-stale-running-local",
+        execution_id="exec-stale-running-local",
+    )
+    restarted = _runner(_CountingRuntime())
+    restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    restarted._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    # Simulate the creating process exiting: both its registry entry and its
+    # early liveness lease disappear before another process observes RUNNING.
+    original._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    result = await restarted.resume_session(tracker.session_id, _seed())
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+    restarted._session_repo.mark_failed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_running_tracker_is_not_terminalized_by_another_runner() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-live-running-local",
+        execution_id="exec-live-running-local",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+    finally:
+        original._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+    observer._session_repo.mark_failed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_precreated_tracker_retires_a_stale_live_authority() -> None:
+    runner = _runner()
+    prepared = await _prepare(
+        runner,
+        session_id="session-terminal-local",
+        execution_id="exec-terminal-local",
+    )
+    contract = prepared.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    terminal = prepared.with_status(SessionStatus.COMPLETED)
+    get_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+    runner._get_merged_tools = get_tools
+
+    result = await runner.execute_precreated_session(_seed(), terminal, parallel=False)
+
+    assert result.is_err
+    assert not runner._has_live_process_local_authority(
+        prepared.session_id,
+        prepared.execution_id,
+        contract,
+    )
+    get_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_precreated_execution_claim_allows_only_one_effectful_caller() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-exclusive-local",
+        execution_id="exec-exclusive-local",
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    tool_catalog = assemble_session_tool_catalog(["Read"])
+
+    async def block_tool_setup(**_: object):
+        entered.set()
+        await release.wait()
+        return ["Read"], None, tool_catalog
+
+    runner._get_merged_tools = block_tool_setup
+    first = asyncio.create_task(runner.execute_precreated_session(_seed(), tracker, parallel=False))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    second = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+    assert second.is_err
+    assert second.error.details["resume_blocked"] == "process_local_execution_in_progress"
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    release.set()
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+
+
+def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
+    runner = _runner()
+    contract = runner._build_execution_contract(seed=_seed())
+
+    assert (
+        runner._proof_cohort_identity(
+            {
+                "seed_id": _seed().metadata.seed_id,
+                EXECUTION_CONTRACT_PROGRESS_KEY: contract,
+            }
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_publishes_liveness_before_a_running_tracker_is_observable() -> None:
+    """An observer interleaved in create_session cannot false-terminalize it."""
+    creator = _runner()
+    observer = _runner(_CountingRuntime())
+    observed_result: Result[object, OrchestratorError] | None = None
+
+    async def create_session(**kwargs: object) -> Result[SessionTracker, object]:
+        nonlocal observed_result
+        tracker = SessionTracker.create(
+            str(kwargs["execution_id"]),
+            str(kwargs["seed_id"]),
+            session_id=str(kwargs["session_id"]),
+        ).with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: dict(kwargs["execution_contract"])})
+        observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+        observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+        observed_result = await observer.resume_session(tracker.session_id, _seed())
+        return Result.ok(tracker)
+
+    with (
+        patch.object(creator._session_repo, "create_session", create_session),
+        patch.object(
+            creator._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        prepared = await creator.prepare_session(
+            _seed(),
+            execution_id="exec-publish-race",
+            session_id="session-publish-race",
+        )
+
+    try:
+        assert prepared.is_ok
+        assert observed_result is not None and observed_result.is_err
+        assert (
+            observed_result.error.details["resume_blocked"]
+            == "process_local_authority_held_elsewhere"
+        )
+        observer._session_repo.mark_failed.assert_not_awaited()
+    finally:
+        creator._retire_process_local_authority(
+            session_id="session-publish-race",
+            execution_id="exec-publish-race",
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_rolls_back_when_heartbeat_acquire_fails() -> None:
+    runner = _runner()
+    session_id = "session-heartbeat-acquire-failure"
+    execution_id = "exec-heartbeat-acquire-failure"
+
+    with patch(
+        "ouroboros.orchestrator.heartbeat.acquire",
+        side_effect=OSError("lock directory unavailable"),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    assert result.error.message == "Cannot establish process-local execution liveness lease"
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_progress_exception_terminalizes_then_retires_authority() -> None:
+    runner = _runner()
+    session_id = "session-progress-exception"
+    execution_id = "exec-progress-exception"
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    with (
+        patch.object(
+            runner._session_repo, "create_session", AsyncMock(return_value=Result.ok(tracker))
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(side_effect=OSError("event store unavailable")),
+        ),
+        patch.object(runner._session_repo, "mark_failed", mark_failed),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    mark_failed.assert_awaited_once()
+    assert not runner._has_live_process_local_authority(
+        session_id,
+        execution_id,
+        tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY),
+    )
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_rejects_mismatched_repository_tracker_and_retires_lease() -> None:
+    runner = _runner()
+    returned = SessionTracker.create(
+        "exec-other",
+        _seed().metadata.seed_id,
+        session_id="session-other",
+    )
+    session_id = "session-expected"
+    execution_id = "exec-expected"
+
+    with patch.object(
+        runner._session_repo,
+        "create_session",
+        AsyncMock(return_value=Result.ok(returned)),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    assert result.error.message == "Session repository returned an unexpected session identity"
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_foreign_paused_resume_rejects_without_terminalizing_live_owner() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-foreign-paused",
+        execution_id="exec-foreign-paused",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(_paused(tracker)))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        observer._session_repo.mark_failed.assert_not_awaited()
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_precreated_running_tracker_rejects_without_revoking_owner() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-foreign-precreated",
+        execution_id="exec-foreign-precreated",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._get_merged_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+
+    try:
+        result = await observer.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        observer._get_merged_tools.assert_not_awaited()
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_observer_cannot_terminalize_paused_transition_before_claim_release() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-paused-transition",
+        execution_id="exec-paused-transition",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, claimed = owner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert claimed is False
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(_paused(tracker)))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        observer._session_repo.mark_failed.assert_not_awaited()
+        assert heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        owner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_paused_unregister_keeps_liveness_lease_until_terminal_retirement() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-paused-lease",
+        execution_id="exec-paused-lease",
+    )
+
+    try:
+        runner._register_session(tracker.execution_id, tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(
+            tracker.execution_id,
+            tracker.session_id,
+            release_liveness_lease=False,
+        )
+
+        assert tracker.execution_id not in runner.active_sessions
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_execute_handler_resumes_with_the_retained_process_local_runner(
+    tmp_path,
+) -> None:
+    """A same-process MCP resume must reuse its original live capability owner."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-retained",
+        execution_id="exec-handler-retained",
+    )
+    paused_tracker = _paused(tracker)
+    handler_store = _HandlerEventStore()
+    handler = ExecuteSeedHandler(event_store=handler_store)
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    resumed = AsyncMock(
+        return_value=Result.ok(
+            OrchestratorResult(
+                success=False,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Still paused",
+            )
+        )
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch.object(runner, "resume_session", resumed),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "paused"
+        resumed.assert_awaited_once()
+        assert resumed.await_args.args[0] == paused_tracker.session_id
+        assert resumed.await_args.args[1].metadata.seed_id == _seed().metadata.seed_id
+        create_runtime.assert_not_called()
+        assert handler._process_local_resume_owners[paused_tracker.session_id] is runner
+        assert (
+            handler._process_local_owned_event_stores[paused_tracker.session_id]
+            is runner._event_store
+        )
+        runner._event_store.close.assert_not_awaited()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_owned_store_closes_after_terminal_resume(tmp_path) -> None:
+    """The original internally owned store survives pause and closes at terminal state."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-terminal",
+        execution_id="exec-handler-terminal",
+    )
+    paused_tracker = _paused(tracker)
+    completed_tracker = paused_tracker.with_status(SessionStatus.COMPLETED)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    resumed = AsyncMock(
+        return_value=Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Completed",
+            )
+        )
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch.object(runner, "resume_session", resumed),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(
+                    side_effect=[
+                        Result.ok(completed_tracker),
+                        Result.ok(completed_tracker),
+                    ]
+                ),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "completed"
+        create_runtime.assert_not_called()
+        runner._event_store.close.assert_awaited_once()
+        assert paused_tracker.session_id not in handler._process_local_resume_owners
+        assert paused_tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_keeps_concurrent_resume_nonterminal(tmp_path) -> None:
+    """A concurrent retained resume must preserve the paused owner and not fail it."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-concurrent",
+        execution_id="exec-handler-concurrent",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(paused_tracker, runner)
+    in_progress = OrchestratorError(
+        "already claimed",
+        details={"resume_blocked": "process_local_execution_in_progress"},
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+    mark_failed = AsyncMock()
+
+    try:
+        with (
+            patch.object(
+                runner,
+                "resume_session",
+                AsyncMock(return_value=Result.err(in_progress)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch.object(runner._session_repo, "mark_failed", mark_failed),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "paused"
+        create_runtime.assert_not_called()
+        mark_failed.assert_not_awaited()
+        assert handler._process_local_resume_owners[paused_tracker.session_id] is runner
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_returns_typed_concurrent_block_before_worktree_restore(
+    tmp_path,
+) -> None:
+    """A second same-handler resume must not degrade into a worktree-lock error."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-worktree-concurrent",
+        execution_id="exec-handler-worktree-concurrent",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(paused_tracker, runner)
+    workspace = SimpleNamespace(
+        effective_cwd=str(tmp_path),
+        worktree_path=str(tmp_path),
+        branch="ooo/process-local",
+        lock_path=str(tmp_path / "task.lock"),
+    )
+    entered_resume = asyncio.Event()
+    release_resume = asyncio.Event()
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    async def blocking_resume(*_: object) -> Result:
+        entered_resume.set()
+        await release_resume.wait()
+        return Result.ok(
+            OrchestratorResult(
+                success=False,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Still paused",
+            )
+        )
+
+    arguments = {
+        "session_id": paused_tracker.session_id,
+        "seed_content": yaml.safe_dump(_seed().to_dict()),
+        "cwd": str(tmp_path),
+        "use_worktree": True,
+        "skip_qa": True,
+    }
+    try:
+        with (
+            patch.object(runner, "resume_session", AsyncMock(side_effect=blocking_resume)),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.maybe_restore_task_workspace",
+                return_value=workspace,
+            ) as restore_workspace,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("retained resume must not construct a fresh runtime"),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            first = asyncio.create_task(handler.handle(arguments, synchronous=True))
+            await asyncio.wait_for(entered_resume.wait(), timeout=1)
+            second = await handler.handle(arguments, synchronous=True)
+
+            assert second.is_err
+            assert second.error.details["resume_blocked"] == "process_local_execution_in_progress"
+            restore_workspace.assert_called_once()
+
+            release_resume.set()
+            first_result = await first
+
+        assert first_result.is_ok
+        assert paused_tracker.session_id not in handler._process_local_resume_handoffs
+    finally:
+        release_resume.set()
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_handler_returns_typed_block_before_worktree_restore(tmp_path) -> None:
+    """A foreign live owner must not be obscured by task-worktree acquisition."""
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-handler-foreign-worktree",
+        execution_id="exec-handler-foreign-worktree",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.maybe_restore_task_workspace",
+                side_effect=AssertionError("foreign authority must block before workspace restore"),
+            ) as restore_workspace,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError(
+                    "foreign authority must block before runtime construction"
+                ),
+            ) as create_runtime,
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": True,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        restore_workspace.assert_not_called()
+        create_runtime.assert_not_called()
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_retained_owner_closes_its_handler_owned_event_store() -> None:
+    """Evicting an owner that lost its capability must not leak its store."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-stale-store",
+        execution_id="exec-handler-stale-store",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+
+    try:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+        retained = await handler._retained_process_local_owner(paused_tracker)
+
+        assert retained is None
+        runner._event_store.close.assert_awaited_once()
+        assert paused_tracker.session_id not in handler._process_local_resume_owners
+        assert paused_tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+def test_malformed_heartbeat_timestamp_is_unheld_and_never_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    heartbeat.lock_path("malformed-heartbeat").write_text(f"{os.getpid()}:not-a-float")
+
+    assert heartbeat.is_holder_alive("malformed-heartbeat") is False
+    assert heartbeat.lock_path("malformed-heartbeat").exists()
+
+
+def test_heartbeat_observer_never_deletes_a_lease_replaced_during_stale_check(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "stale-observer-race"
+    path = heartbeat.lock_path(session_id)
+    path.write_text("999999:0")
+    current_pid, current_start = heartbeat.current_process_identity()
+    fresh = f"{current_pid}:{current_start}" if current_start is not None else str(current_pid)
+
+    def replace_with_fresh_lease(_: int, __: float | None) -> bool:
+        path.write_text(fresh)
+        return False
+
+    monkeypatch.setattr(heartbeat, "is_process_identity_alive", replace_with_fresh_lease)
+
+    assert heartbeat.is_holder_alive(session_id) is False
+    assert path.read_text() == fresh
+
+
+def test_heartbeat_acquire_never_overwrites_an_existing_foreign_lease(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "exclusive-lease"
+    path = heartbeat.lock_path(session_id)
+    path.write_text("999999:0")
+
+    if heartbeat.fcntl is None:
+        pytest.skip("advisory lease locks are unavailable on this platform")
+
+    with (
+        patch.object(heartbeat.fcntl, "flock", side_effect=BlockingIOError),
+        pytest.raises(OSError, match="held"),
+    ):
+        heartbeat.acquire(session_id)
+
+    assert path.read_text() == "999999:0"
+
+
+@pytest.mark.parametrize("unsafe_session_id", ("..", "../../outside", "child/name", r"child\name"))
+def test_heartbeat_lock_path_is_contained_for_unsafe_legacy_session_ids(
+    tmp_path,
+    monkeypatch,
+    unsafe_session_id: str,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+
+    path = heartbeat.lock_path(unsafe_session_id)
+
+    assert path.parent == tmp_path
+    assert path.name.startswith("__invalid_session_id__")
+
+
+def test_heartbeat_fork_cleanup_closes_inherited_lease_descriptors(tmp_path, monkeypatch) -> None:
+    """The post-fork hook must not let a child keep the parent's advisory lock."""
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "fork-inherited-lease"
+    heartbeat.acquire(session_id)
+    inherited_fd = heartbeat._HELD_LEASE_FDS[session_id]
+
+    try:
+        heartbeat._clear_held_leases_after_fork()
+
+        assert session_id not in heartbeat._HELD_LEASE_FDS
+        with pytest.raises(OSError):
+            os.fstat(inherited_fd)
+    finally:
+        heartbeat.release(session_id)
+
+
+def test_diagnostic_contract_builds_do_not_leak_registry_issuances() -> None:
+    runner = _runner()
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    for _ in range(25):
+        contract = runner._build_execution_contract(seed=_seed())
+        assert contract["foundation_a_authority"]["scope"] == "process_local"
+
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -380,6 +380,51 @@ async def test_live_running_tracker_is_not_terminalized_by_another_runner() -> N
 
 
 @pytest.mark.asyncio
+async def test_same_owner_running_resume_preserves_its_worktree_and_claim() -> None:
+    """A concurrent resume must not release an active owner's workspace."""
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-live-running-owner",
+        execution_id="exec-live-running-owner",
+    )
+    owner._task_workspace = SimpleNamespace(lock_path="/tmp/process-local-running.lock")
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = owner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    owner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    owner._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            result = await owner.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_execution_in_progress"
+        release_lock_mock.assert_not_called()
+        owner._session_repo.mark_failed.assert_not_awaited()
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        owner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_terminal_precreated_tracker_retires_a_stale_live_authority() -> None:
     runner = _runner()
     prepared = await _prepare(
@@ -523,6 +568,56 @@ async def test_prepare_rolls_back_when_heartbeat_acquire_fails() -> None:
     assert result.error.message == "Cannot establish process-local execution liveness lease"
     assert (session_id, execution_id) not in runner._process_local_authorities
     assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_discards_issuance_and_releases_workspace() -> None:
+    """Cancellation before durable publication cannot leak a live generation."""
+    runner = _runner()
+    workspace = SimpleNamespace(lock_path="/tmp/process-local-prepare-cancel.lock")
+    runner._task_workspace = workspace
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id="exec-prepare-cancel",
+            session_id="session-prepare-cancel",
+        )
+
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+    release_lock_mock.assert_called_once_with(workspace.lock_path)
+
+
+@pytest.mark.asyncio
+async def test_prepare_unexpected_error_discards_issuance_and_releases_workspace() -> None:
+    """Unexpected pre-registration errors follow the same fail-closed cleanup."""
+    runner = _runner()
+    workspace = SimpleNamespace(lock_path="/tmp/process-local-prepare-error.lock")
+    runner._task_workspace = workspace
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch.object(runner, "_build_execution_contract", side_effect=RuntimeError("boom")),
+        patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-prepare-error",
+            session_id="session-prepare-error",
+        )
+
+    assert result.is_err
+    assert result.error.message == "Failed to prepare process-local execution authority"
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+    release_lock_mock.assert_called_once_with(workspace.lock_path)
 
 
 @pytest.mark.asyncio
@@ -1145,6 +1240,55 @@ async def test_stale_retained_owner_closes_its_handler_owned_event_store() -> No
         handler._process_local_resume_owners.clear()
         handler._process_local_owned_event_stores.clear()
         handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reconstruction", ("raises", "error", "running"))
+async def test_reconcile_retains_live_owner_on_inconclusive_reconstruction(
+    reconstruction: str,
+) -> None:
+    """Read failures and nonterminal snapshots cannot evict a live owner."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id=f"session-handler-inconclusive-{reconstruction}",
+        execution_id=f"exec-handler-inconclusive-{reconstruction}",
+    )
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    session_repo = MagicMock()
+    if reconstruction == "raises":
+        session_repo.reconstruct_session = AsyncMock(side_effect=OSError("observer unavailable"))
+    elif reconstruction == "error":
+        session_repo.reconstruct_session = AsyncMock(
+            return_value=Result.err("observer unavailable")
+        )
+    else:
+        session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+
+    try:
+        retained, event_store_to_close = await handler._reconcile_process_local_owner(
+            tracker=tracker,
+            runner=runner,
+            session_repo=session_repo,
+        )
+
+        assert retained is True
+        assert event_store_to_close is None
+        assert handler._process_local_resume_owners[tracker.session_id] is runner
+        assert handler._process_local_owned_event_stores[tracker.session_id] is runner._event_store
+        runner._event_store.close.assert_not_awaited()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+from ouroboros.core.errors import PersistenceError
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
@@ -23,6 +24,9 @@ from ouroboros.orchestrator.runner import (
     OrchestratorError,
     OrchestratorResult,
     OrchestratorRunner,
+    clear_cancellation,
+    is_cancellation_requested,
+    request_cancellation,
 )
 from ouroboros.orchestrator.session import SessionStatus, SessionTracker
 
@@ -485,6 +489,150 @@ async def test_precreated_execution_claim_allows_only_one_effectful_caller() -> 
     )
 
 
+@pytest.mark.asyncio
+async def test_precreated_setup_cancellation_releases_its_authority_claim() -> None:
+    """A raw cancellation during post-claim setup cannot permanently block resume."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-precreated-setup-cancel",
+        execution_id="exec-precreated-setup-cancel",
+    )
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_setup_cancellation_releases_its_authority_claim() -> None:
+    """A raw cancellation during resume restoration cannot leave ``_claims`` set."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-resume-setup-cancel",
+        execution_id="exec-resume-setup-cancel",
+    )
+    paused = _paused(tracker)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.resume_session(paused.session_id, _seed())
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_cooperative_cancellation_persists_terminal_before_retiring_authority() -> None:
+    """The live owner remains observable until durable cancellation succeeds."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-terminal-order",
+        execution_id="exec-cancel-terminal-order",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._report_frugality_retrospective = AsyncMock()
+
+    async def mark_cancelled(*_: object, **__: object) -> Result[None, object]:
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        return Result.ok(None)
+
+    runner._session_repo.mark_cancelled = mark_cancelled
+    await request_cancellation(tracker.session_id)
+
+    result = await runner._handle_cancellation(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        messages_processed=0,
+        start_time=tracker.start_time,
+    )
+
+    assert result.is_ok
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_cooperative_cancellation_retains_authority_when_terminal_write_fails() -> None:
+    """A failed durable cancellation cannot be reported after liveness is withdrawn."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-terminal-failure",
+        execution_id="exec-cancel-terminal-failure",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._session_repo.mark_cancelled = AsyncMock(
+        return_value=Result.err(PersistenceError("durable cancellation unavailable"))
+    )
+    await request_cancellation(tracker.session_id)
+
+    try:
+        result = await runner._handle_cancellation(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+            messages_processed=0,
+            start_time=tracker.start_time,
+        )
+
+        assert result.is_err
+        assert result.error.message == (
+            "Failed to persist cancellation; process-local authority remains live"
+        )
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id in runner.active_sessions
+        assert await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
     runner = _runner()
     contract = runner._build_execution_contract(seed=_seed())
@@ -594,6 +742,71 @@ async def test_prepare_cancellation_discards_issuance_and_releases_workspace() -
 
     assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
     release_lock_mock.assert_called_once_with(workspace.lock_path)
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_after_registration_retires_lease() -> None:
+    """Cancellation in ``create_session`` cannot strand its early lease."""
+    runner = _runner()
+    session_id = "session-prepare-create-cancel"
+    execution_id = "exec-prepare-create-cancel"
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_after_publication_terminalizes_then_retires() -> None:
+    """A cancelled initial-progress write cannot leave RUNNING without an owner."""
+    runner = _runner()
+    session_id = "session-prepare-progress-cancel"
+    execution_id = "exec-prepare-progress-cancel"
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(return_value=Result.ok(tracker)),
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch.object(runner._session_repo, "mark_failed", mark_failed),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    mark_failed.assert_awaited_once()
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ouroboros.config.models import OuroborosConfig
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.worktree import TaskWorkspace
 from ouroboros.events.base import BaseEvent
@@ -98,6 +97,18 @@ def _workspace(*, durable_id: str, worktree_path: Path, repo_root: Path) -> Task
         branch=f"ooo/{durable_id}",
         lock_path=str(worktree_path.parent / ".locks" / f"{durable_id}.json"),
     )
+
+
+def _assert_process_local_runtime_contract(contract: dict[str, object]) -> None:
+    """Legacy adapters never contribute a durable runtime execution identity."""
+    routing = contract["model_routing"]
+    assert isinstance(routing, dict)
+    assert routing["runtime_execution"] == {"version": 1, "observed": False}
+    authority = contract["foundation_a_authority"]
+    assert isinstance(authority, dict)
+    assert authority["version"] == 1
+    assert authority["scope"] == "process_local"
+    assert isinstance(authority["correlation_id"], str)
 
 
 @pytest.fixture(autouse=True)
@@ -348,7 +359,7 @@ def test_constructor_model_pin_is_persisted_and_mismatch_is_rejected() -> None:
         )
 
 
-def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> None:
+def test_codex_dynamic_profiles_do_not_create_a_portable_resume_identity() -> None:
     original_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -359,7 +370,7 @@ def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> N
     original_runtime._resolved_fallback_model = "resolved-fallback-model"
     original_runtime._resolved_fallback_profile = None
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(seed=_seed())
 
     resumed_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
@@ -370,33 +381,21 @@ def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> N
     resumed_runtime._codex_profile = "zep-proxy-b"
     resumed_runtime._resolved_fallback_model = "resolved-fallback-model"
     resumed_runtime._resolved_fallback_profile = None
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    persisted_identity = persisted["model_routing"]["runtime_execution"]["identity"]
-    assert persisted_identity == {
-        "codex_config_fingerprint": original_runtime._codex_config_fingerprint,
-        "codex_profile": "zep-proxy-a",
-        "effective_model_observed": True,
-        "fallback_model": "resolved-fallback-model",
-        "fallback_profile": "zep-proxy-a",
-        "kind": "codex_cli_v1",
-        "llm_backend": "codex",
-        "profile_resolution_fingerprint": (original_runtime._profile_resolution_fingerprint),
-        "resume_handle_selector": {
-            "backend": "codex_cli",
-            "kind": "agent_runtime",
-            "selectors": {},
-        },
-        "runtime_profile": "zep-runtime",
-    }
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
+    assert (
+        original_contract["foundation_a_authority"]["correlation_id"]
+        != resumed_contract["foundation_a_authority"]["correlation_id"]
+    )
 
 
-def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
+def test_codex_resolved_fallback_state_stays_out_of_durable_runtime_identity() -> None:
     original_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -404,7 +403,7 @@ def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
     )
     original_runtime._resolved_fallback_model = "gpt-original"
     original_runtime._resolved_fallback_profile = None
-    persisted = OrchestratorRunner(
+    original_contract = OrchestratorRunner(
         original_runtime,
         AsyncMock(),
         MagicMock(),
@@ -417,16 +416,17 @@ def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
     )
     resumed_runtime._resolved_fallback_model = "gpt-changed"
     resumed_runtime._resolved_fallback_profile = None
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
 
-def test_codex_profile_name_alone_does_not_prove_an_effective_model(
+def test_codex_profile_name_alone_stays_process_local(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -441,18 +441,10 @@ def test_codex_profile_name_alone_does_not_prove_an_effective_model(
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     persisted = runner._build_execution_contract(seed=_seed())
 
-    assert (
-        persisted["model_routing"]["runtime_execution"]["identity"]["effective_model_observed"]
-        is False
-    )
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
-def test_non_codex_subclass_does_not_inherit_codex_profile_as_model_identity(
+def test_non_codex_runtime_does_not_inherit_codex_profile_as_model_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -466,17 +458,7 @@ def test_non_codex_subclass_does_not_inherit_codex_profile_as_model_identity(
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     persisted = runner._build_execution_contract(seed=_seed())
 
-    assert persisted["model_routing"]["runtime_execution"]["identity"] == {
-        "kind": "goose_v1",
-        "fallback_model": None,
-        "effective_model_observed": False,
-        "llm_backend": "goose",
-    }
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
 def test_runtime_model_sentinel_is_not_persisted_as_a_constructor_pin(
@@ -498,14 +480,10 @@ def test_runtime_model_sentinel_is_not_persisted_as_a_constructor_pin(
         "observed": True,
         "model": None,
     }
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
-def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
+def test_codex_profile_file_changes_do_not_create_a_portable_runtime_identity(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -526,7 +504,7 @@ def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
     )
     original_runtime._codex_profile = "stable-name"
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(seed=_seed())
 
     profile_path.write_text('model_provider = "proxy-b"\n', encoding="utf-8")
     resumed_runtime = CodexCliRuntime(
@@ -535,16 +513,17 @@ def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
         cwd="/tmp/project",
     )
     resumed_runtime._codex_profile = "stable-name"
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
 
-def test_codex_home_drift_is_rejected_for_persisted_thread_store(
+def test_codex_home_changes_do_not_create_a_portable_runtime_identity(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -558,7 +537,7 @@ def test_codex_home_drift_is_rejected_for_persisted_thread_store(
         model=None,
         cwd="/tmp/project",
     )
-    persisted = OrchestratorRunner(
+    original_contract = OrchestratorRunner(
         original_runtime,
         AsyncMock(),
         MagicMock(),
@@ -570,62 +549,33 @@ def test_codex_home_drift_is_rejected_for_persisted_thread_store(
         model=None,
         cwd="/tmp/project",
     )
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
-
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
-
-
-def test_codex_implementation_role_mapping_drift_is_rejected() -> None:
-    original_config = OuroborosConfig(
-        llm_profiles={
-            "standard": {"providers": {"codex": {"profile": "stable"}}},
-            "frontier": {"providers": {"codex": {"profile": "changed"}}},
-        },
-        llm_role_profiles={
-            "agent_runtime": "standard",
-            "agent_runtime_implementation": "standard",
-        },
-    )
-    drifted_config = original_config.model_copy(
-        update={
-            "llm_role_profiles": {
-                "agent_runtime": "standard",
-                "agent_runtime_implementation": "frontier",
-            }
-        }
-    )
-
-    with patch("ouroboros.providers.profiles.load_config", return_value=original_config):
-        original_runtime = CodexCliRuntime(
-            cli_path="/bin/echo",
-            model=None,
-            cwd="/tmp/project",
-        )
-    persisted = OrchestratorRunner(
-        original_runtime,
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
         AsyncMock(),
         MagicMock(),
     )._build_execution_contract(seed=_seed())
 
-    with patch("ouroboros.providers.profiles.load_config", return_value=drifted_config):
-        resumed_runtime = CodexCliRuntime(
-            cli_path="/bin/echo",
-            model=None,
-            cwd="/tmp/project",
-        )
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
-    assert original_runtime._resolved_fallback_profile == "stable"
-    assert resumed_runtime._resolved_fallback_profile == "stable"
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+
+def test_contract_build_never_asks_codex_for_dynamic_execution_identity() -> None:
+    runtime = CodexCliRuntime(
+        cli_path="/bin/echo",
+        model=None,
+        cwd="/tmp/project",
+    )
+    provider = MagicMock(side_effect=AssertionError("dynamic provider must not run"))
+    runtime.execution_identity_contract = provider  # type: ignore[method-assign]
+
+    contract = OrchestratorRunner(
+        runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
+
+    _assert_process_local_runtime_contract(contract)
+    provider.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -647,7 +597,7 @@ def test_codex_implementation_role_mapping_drift_is_rejected() -> None:
         ),
     ],
 )
-def test_codex_resume_handle_cannot_inject_command_selection(
+def test_process_local_runtime_never_recomputes_a_resume_handle_selector(
     runtime_handle: RuntimeHandle,
 ) -> None:
     runtime = CodexCliRuntime(
@@ -657,12 +607,15 @@ def test_codex_resume_handle_cannot_inject_command_selection(
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    provider = MagicMock(side_effect=AssertionError("selector provider must not run"))
+    runtime.resume_handle_execution_identity_contract = provider  # type: ignore[method-assign]
 
-    with pytest.raises(OrchestratorError, match="different runtime handle selector"):
-        runner._validate_resume_handle_execution_identity(runtime_handle)
+    runner._validate_resume_handle_execution_identity(runtime_handle)
+
+    provider.assert_not_called()
 
 
-def test_codex_default_resume_handle_matches_start_contract() -> None:
+def test_process_local_runtime_default_handle_requires_no_persisted_selector() -> None:
     runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -670,6 +623,8 @@ def test_codex_default_resume_handle_matches_start_contract() -> None:
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    provider = MagicMock(side_effect=AssertionError("selector provider must not run"))
+    runtime.resume_handle_execution_identity_contract = provider  # type: ignore[method-assign]
 
     runner._validate_resume_handle_execution_identity(
         RuntimeHandle(
@@ -677,6 +632,7 @@ def test_codex_default_resume_handle_matches_start_contract() -> None:
             native_session_id="thread-123",
         )
     )
+    provider.assert_not_called()
 
 
 @pytest.mark.parametrize("backend", ["codex_cli", "goose", "pi", "hermes_cli", "opencode"])
@@ -784,7 +740,7 @@ def test_kill_switched_resume_cannot_drift_to_a_new_constructor_model(
         )
 
 
-def test_unpinned_kill_switched_runtime_cannot_resume_without_effective_identity(
+def test_unpinned_kill_switched_runtime_is_limited_to_process_local_resume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -795,16 +751,14 @@ def test_unpinned_kill_switched_runtime_cannot_resume_without_effective_identity
         "observed": True,
         "model": None,
     }
-    assert persisted["model_routing"]["runtime_execution"] == {
-        "version": 1,
-        "observed": False,
-    }
-
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        _runner(constructor_model=None)._restore_execution_contract(
+    _assert_process_local_runtime_contract(persisted)
+    assert (
+        original._restore_execution_contract(
             {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
             seed=_seed(),
         )
+        is False
+    )
 
 
 def test_kill_switched_contract_still_rejects_cross_backend_resume(
@@ -947,7 +901,7 @@ def test_first_legacy_resume_migrates_resolved_contract() -> None:
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_changed_seed_identity_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_seed_identity_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -972,12 +926,12 @@ async def test_legacy_resume_rejects_changed_seed_identity_before_dispatch() -> 
     result = await runner.resume_session("legacy-seed-mismatch", changed_seed)
 
     assert result.is_err
-    assert "different Seed identity" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_changed_seed_goal_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_seed_goal_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -1002,12 +956,12 @@ async def test_legacy_resume_rejects_changed_seed_goal_before_dispatch() -> None
     )
 
     assert result.is_err
-    assert "modified Seed goal" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_cross_backend_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_backend_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -1030,7 +984,7 @@ async def test_legacy_resume_rejects_cross_backend_before_dispatch() -> None:
     result = await runner.resume_session("legacy-backend-mismatch", _seed())
 
     assert result.is_err
-    assert "different runtime backend" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -39,6 +39,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelExecutionResult
 from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
 from ouroboros.orchestrator.runner import (
+    EXECUTION_CONTRACT_PROGRESS_KEY,
     OrchestratorError,
     OrchestratorResult,
     OrchestratorRunner,
@@ -61,6 +62,29 @@ def _task_workspace() -> TaskWorkspace:
         branch="ooo/orch_test",
         lock_path="/tmp/worktree/.locks/repo/orch_test.json",
     )
+
+
+def _attach_live_process_local_contract(
+    runner: OrchestratorRunner,
+    tracker: SessionTracker,
+    seed: Seed,
+    *,
+    session_id: str,
+) -> SessionTracker:
+    """Build the same-process capability required by resume-focused tests."""
+    if not isinstance(getattr(runner._adapter, "llm_backend", None), str):
+        runner._adapter.llm_backend = "test-llm"
+    if not isinstance(getattr(runner._adapter, "_model", None), str):
+        runner._adapter._model = "test-model"
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    return tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
 
 
 def test_seed_investment_detection_supports_legacy_string_criteria(sample_seed: Seed) -> None:
@@ -664,7 +688,13 @@ class TestOrchestratorRunner:
         from ouroboros.core.types import Result
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -723,7 +753,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -770,21 +806,27 @@ class TestOrchestratorRunner:
                 session_id="orch_prepared",
             )
 
-        assert result.is_ok
-        assert result.value.session_id == tracker.session_id
-        assert result.value.progress["fat_harness_mode"] is False
-        assert result.value.messages_processed == 0
-        assert runner._execution_contract is not None
-        create_session.assert_awaited_once_with(
-            execution_id="exec_prepared",
-            seed_id=sample_seed.metadata.seed_id,
-            session_id="orch_prepared",
-            seed_goal=sample_seed.goal,
-            # Backend is forwarded so the live dashboard can provider-tag the run.
-            runtime_backend=runner._adapter.runtime_backend,
-            llm_backend=runner._adapter.llm_backend,
-            execution_contract=runner._execution_contract,
-        )
+        try:
+            assert result.is_ok
+            assert result.value.session_id == tracker.session_id
+            assert result.value.progress["fat_harness_mode"] is False
+            assert result.value.messages_processed == 0
+            assert runner._execution_contract is not None
+            create_session.assert_awaited_once_with(
+                execution_id="exec_prepared",
+                seed_id=sample_seed.metadata.seed_id,
+                session_id="orch_prepared",
+                seed_goal=sample_seed.goal,
+                # Backend is forwarded so the live dashboard can provider-tag the run.
+                runtime_backend=runner._adapter.runtime_backend,
+                llm_backend=runner._adapter.llm_backend,
+                execution_contract=runner._execution_contract,
+            )
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
     @pytest.mark.asyncio
     async def test_prepare_session_fails_when_initial_contract_cannot_persist(
@@ -828,6 +870,7 @@ class TestOrchestratorRunner:
             "orch_prepared",
             "Failed to persist initial session contract",
             {
+                "session_id": "orch_prepared",
                 "execution_id": "exec_prepared",
                 "fat_harness_mode": False,
                 "cause": "store unavailable",
@@ -862,7 +905,11 @@ class TestOrchestratorRunner:
 
         assert result.is_ok
         assert result.value == orchestrator_result
-        prepare_session.assert_awaited_once_with(sample_seed, execution_id="exec_delegated")
+        prepare_session.assert_awaited_once_with(
+            sample_seed,
+            execution_id="exec_delegated",
+            session_id=None,
+        )
         execute_precreated.assert_awaited_once_with(
             seed=sample_seed,
             tracker=tracker,
@@ -898,7 +945,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -954,7 +1007,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1167,7 +1226,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1255,7 +1320,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1316,7 +1387,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_failed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1342,6 +1419,12 @@ class TestOrchestratorRunner:
             "exec_usage_limit",
             sample_seed.metadata.seed_id,
             session_id="sess_usage_limit",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
         )
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -1416,7 +1499,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         mark_failed = AsyncMock(return_value=Result.ok(None))
 
@@ -1500,7 +1589,11 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
             fat_harness_mode=False,
         )
-        tracker = SessionTracker.create("exec_setup", sample_seed.metadata.seed_id)
+        tracker = SessionTracker.create(
+            "exec_setup",
+            sample_seed.metadata.seed_id,
+            session_id="orch_setup",
+        )
 
         with (
             patch.object(runner._session_repo, "create_session", return_value=Result.ok(tracker)),
@@ -1515,7 +1608,11 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.execute_seed(sample_seed, execution_id="exec_setup")
+            result = await runner.execute_seed(
+                sample_seed,
+                execution_id="exec_setup",
+                session_id=tracker.session_id,
+            )
 
         assert result.is_err
         unregister_mock.assert_called_once_with("exec_setup", tracker.session_id)
@@ -1539,7 +1636,11 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
             fat_harness_mode=False,
         )
-        tracker = SessionTracker.create("exec_tools", sample_seed.metadata.seed_id)
+        tracker = SessionTracker.create(
+            "exec_tools",
+            sample_seed.metadata.seed_id,
+            session_id="orch_tools",
+        )
 
         with (
             patch.object(runner._session_repo, "create_session", return_value=Result.ok(tracker)),
@@ -1547,7 +1648,11 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.execute_seed(sample_seed, execution_id="exec_tools")
+            result = await runner.execute_seed(
+                sample_seed,
+                execution_id="exec_tools",
+                session_id=tracker.session_id,
+            )
 
         assert result.is_err
         unregister_mock.assert_called_once_with("exec_tools", tracker.session_id)
@@ -1630,9 +1735,8 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
-
         with (
             patch.object(
                 runner._session_repo,
@@ -1686,7 +1790,7 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
 
         with (
@@ -1728,7 +1832,13 @@ class TestOrchestratorRunner:
             fat_harness_mode=False,
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_tool_setup",
         )
 
         with (
@@ -1741,10 +1851,10 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_tool_setup", sample_seed)
 
         assert result.is_err
-        unregister_mock.assert_called_once_with("exec_resume", "sess_resume")
+        unregister_mock.assert_called_once_with("exec_resume", "sess_resume_tool_setup")
         release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
 
     @pytest.mark.asyncio
@@ -1775,7 +1885,13 @@ class TestOrchestratorRunner:
     ) -> None:
         """Recoverable resume bootstrap failures should not poison the session."""
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_recoverable",
         )
         runtime_handle = RuntimeHandle(backend="codex_cli", native_session_id="thread-123")
 
@@ -1816,7 +1932,7 @@ class TestOrchestratorRunner:
                 AsyncMock(return_value=False),
             ) as retrospective,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_recoverable", sample_seed)
 
         assert result.is_ok
         assert result.value.success is False
@@ -1824,6 +1940,10 @@ class TestOrchestratorRunner:
         mark_paused.assert_awaited_once()
         mark_failed.assert_not_called()
         retrospective.assert_not_awaited()
+        runner._retire_process_local_authority(
+            session_id="sess_resume_recoverable",
+            execution_id=running_tracker.execution_id,
+        )
 
     def test_recoverable_failure_ignores_ordinary_429(
         self,
@@ -2189,6 +2309,12 @@ class TestOrchestratorRunner:
         paused_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
             SessionStatus.PAUSED
         )
+        paused_tracker = _attach_live_process_local_contract(
+            runner,
+            paused_tracker,
+            sample_seed,
+            session_id="sess_resume_paused",
+        )
         runtime_handle = RuntimeHandle(backend="codex_cli", native_session_id="thread-123")
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -2214,7 +2340,7 @@ class TestOrchestratorRunner:
                 AsyncMock(return_value=Result.ok(None)),
             ) as mark_completed,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_paused", sample_seed)
 
         assert result.is_ok
         assert result.value.success is True
@@ -2317,9 +2443,15 @@ class TestOrchestratorRunner:
             native_session_id="sess_runtime",
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
         running_tracker = running_tracker.with_progress({"runtime": runtime_handle.to_dict()})
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_runtime_handle",
+        )
 
         captured_kwargs: dict[str, Any] = {}
 
@@ -2344,7 +2476,7 @@ class TestOrchestratorRunner:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_completed", mock_mark_completed),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_runtime_handle", sample_seed)
 
         assert result.is_ok
         resume_handle = captured_kwargs["resume_handle"]
@@ -2479,13 +2611,19 @@ class TestOrchestratorRunner:
         """Resume should rebuild workflow state from persisted progress before streaming."""
         runtime_handle = RuntimeHandle(backend="opencode", native_session_id="oc-session-123")
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
         running_tracker = running_tracker.with_progress(
             {
                 "runtime": runtime_handle.to_dict(),
                 "messages_processed": 4,
             }
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_progress",
         )
 
         async def mock_reconstruct(*args: Any, **kwargs: Any):
@@ -2507,7 +2645,7 @@ class TestOrchestratorRunner:
             BaseEvent(
                 type="orchestrator.progress.updated",
                 aggregate_type="session",
-                aggregate_id="sess_resume",
+                aggregate_id="sess_resume_progress",
                 data={
                     "message_type": "assistant",
                     "content_preview": "[AC_COMPLETE: 1] Finished the first criterion.",
@@ -2524,7 +2662,7 @@ class TestOrchestratorRunner:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_completed", mock_mark_completed),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_progress", sample_seed)
 
         assert result.is_ok
         workflow_events = [
@@ -2782,6 +2920,12 @@ class TestOrchestratorRunner:
             fat_harness_mode=True,
         )
         tracker = SessionTracker.create("exec_profile_prompt", sample_seed.metadata.seed_id)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2838,6 +2982,12 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            single_ac_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2893,6 +3043,12 @@ class TestOrchestratorRunner:
         )
         tracker = SessionTracker.create("exec_investment_single", investment_seed.metadata.seed_id)
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2946,6 +3102,12 @@ class TestOrchestratorRunner:
             investment_seed.metadata.seed_id,
         )
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3004,6 +3166,12 @@ class TestOrchestratorRunner:
             investment_seed.metadata.seed_id,
         )
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3049,6 +3217,12 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3084,6 +3258,12 @@ class TestOrchestratorRunner:
 
         tracker = SessionTracker.create("exec_forced", sample_seed.metadata.seed_id)
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3537,7 +3717,13 @@ class TestOrchestratorRunner:
         from ouroboros.core.types import Result
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4225,7 +4411,13 @@ class TestOrchestratorRunnerWithMCP:
 
         # Mock session creation
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4378,7 +4570,13 @@ class TestCancellationPolling:
         mock_event_store.query_events = AsyncMock(side_effect=[[], [cancel_event]])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_cancelled(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4420,7 +4618,13 @@ class TestCancellationPolling:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4458,11 +4662,17 @@ class TestCancellationPolling:
 
         mock_adapter.execute_task = mock_execute
 
-        cancel_event = create_session_cancelled_event("sess_resume", "User requested")
+        cancel_event = create_session_cancelled_event("sess_resume_cancelled", "User requested")
         mock_event_store.query_events = AsyncMock(return_value=[cancel_event])
 
         running_tracker = SessionTracker.create("exec_resume", "seed_1").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_cancelled",
         )
 
         async def mock_reconstruct(*args: Any, **kwargs: Any):
@@ -4475,7 +4685,7 @@ class TestCancellationPolling:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_cancelled", mock_mark_cancelled),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_cancelled", sample_seed)
 
         assert result.is_ok
         assert result.value.success is False

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -608,7 +608,11 @@ class TestInFlightCancellation:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            tracker = SessionTracker.create("exec_test", sample_seed.metadata.seed_id)
+            tracker = SessionTracker.create(
+                str(kwargs["execution_id"]),
+                str(kwargs["seed_id"]),
+                session_id=str(kwargs["session_id"]),
+            )
             return Result.ok(tracker)
 
         # Set up the cancellation to trigger at the right time
@@ -661,7 +665,13 @@ class TestInFlightCancellation:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_test", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def tracking_check(session_id):
             check_calls.append(session_id)
@@ -725,7 +735,13 @@ class TestSessionLifecycleTracking:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_test", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             with patch.object(runner._session_repo, "mark_completed", return_value=Result.ok(None)):
@@ -757,7 +773,13 @@ class TestSessionLifecycleTracking:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_crash", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             result = await runner.execute_seed(

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -173,6 +173,30 @@ class TestSessionRegistration:
         assert "exec_1" in runner.active_sessions
         assert runner.active_sessions["exec_1"] == "sess_1"
 
+    def test_register_session_does_not_publish_when_lease_acquisition_fails(
+        self,
+        runner: OrchestratorRunner,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """A rejected foreign lease must not leave a cancel route behind."""
+        from ouroboros.orchestrator import heartbeat
+
+        monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+        path = heartbeat.lock_path("sess_held_elsewhere")
+        path.write_text("999999:0")
+
+        if heartbeat.fcntl is None:
+            pytest.skip("requires advisory file locks")
+
+        with (
+            patch.object(heartbeat.fcntl, "flock", side_effect=BlockingIOError),
+            pytest.raises(OSError, match="liveness lease is held"),
+        ):
+            runner._register_session("exec_held_elsewhere", "sess_held_elsewhere")
+
+        assert "exec_held_elsewhere" not in runner.active_sessions
+
     def test_unregister_session(self, runner: OrchestratorRunner) -> None:
         """Test unregistering a session."""
         runner._register_session("exec_1", "sess_1")

--- a/tests/unit/orchestrator/test_runner_execution_guidance.py
+++ b/tests/unit/orchestrator/test_runner_execution_guidance.py
@@ -110,7 +110,7 @@ def test_resume_rejects_changed_guidance_content(tmp_path: Path) -> None:
         )
 
 
-def test_proof_cohort_identity_includes_guidance_hash(tmp_path: Path) -> None:
+def test_process_local_contract_never_forms_a_guidance_proof_cohort(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     guided, _store = _runner(tmp_path, ("team",))
     unguided, _store = _runner(tmp_path, ())
@@ -128,10 +128,8 @@ def test_proof_cohort_identity_includes_guidance_hash(tmp_path: Path) -> None:
         }
     )
 
-    assert guided_identity is not None
-    assert unguided_identity is not None
-    assert guided_identity != unguided_identity
-    assert guided_identity[-1] != unguided_identity[-1]
+    assert guided_identity is None
+    assert unguided_identity is None
 
 
 @pytest.mark.asyncio
@@ -155,18 +153,31 @@ async def test_each_new_run_reloads_declared_guidance(tmp_path: Path) -> None:
             AsyncMock(return_value=Result.ok(None)),
         ),
     ):
-        first = await runner.prepare_session(_seed(), execution_id="exec-one")
+        first = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-one",
+            session_id=trackers[0].session_id,
+        )
         assert first.is_ok
         assert runner._execution_contract is not None
         first_hash = runner._execution_contract["guidance"]["rendered_fragment_hash"]
 
         path.write_text("Second version.\n", encoding="utf-8")
-        second = await runner.prepare_session(_seed(), execution_id="exec-two")
+        second = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-two",
+            session_id=trackers[1].session_id,
+        )
         assert second.is_ok
         assert runner._execution_contract is not None
         second_hash = runner._execution_contract["guidance"]["rendered_fragment_hash"]
 
     assert first_hash != second_hash
+    for tracker in trackers:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 def test_legacy_contract_resumes_without_newly_configured_guidance(tmp_path: Path) -> None:
@@ -312,7 +323,12 @@ async def test_execute_seed_delivers_guidance_to_adapter_system_prompt(tmp_path:
         ),
         patch.object(runner, "_evaluate_frugality_proof", AsyncMock()),
     ):
-        result = await runner.execute_seed(_seed(), parallel=False)
+        result = await runner.execute_seed(
+            _seed(),
+            execution_id=tracker.execution_id,
+            session_id=tracker.session_id,
+            parallel=False,
+        )
 
     assert result.is_ok
     assert call_order.index("orchestrator.guidance.injected") < call_order.index(
@@ -335,6 +351,15 @@ async def test_parallel_execution_receives_declared_guidance(tmp_path: Path) -> 
         seed.metadata.seed_id,
         session_id="sess-guidance-parallel",
     )
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    tracker = tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
     expected = Result.ok(
         OrchestratorResult(
             success=True,
@@ -344,23 +369,29 @@ async def test_parallel_execution_receives_declared_guidance(tmp_path: Path) -> 
     )
     tool_catalog = assemble_session_tool_catalog(["Read"])
 
-    with (
-        patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
-        patch.object(
-            runner,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
-    ):
-        result = await runner.execute_precreated_session(seed, tracker, parallel=True)
+    try:
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, tool_catalog)),
+            ),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(seed, tracker, parallel=True)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
     assert result is expected
     assert sentinel in execute.await_args.kwargs["system_prompt"]
 
 
 @pytest.mark.asyncio
-async def test_fresh_runner_executes_precreated_session_with_persisted_guidance(
+async def test_fresh_runner_rejects_precreated_session_with_persisted_guidance(
     tmp_path: Path,
 ) -> None:
     sentinel = "GUIDANCE_SENTINEL_PRECREATED"
@@ -394,62 +425,41 @@ async def test_fresh_runner_executes_precreated_session_with_persisted_guidance(
     assert prepared.is_ok
 
     executing_runner, _store = _runner(tmp_path, ())
-    captured: dict[str, Any] = {}
+    get_tools = AsyncMock(side_effect=AssertionError("fresh runner must stop before setup"))
+    executing_runner._get_merged_tools = get_tools
 
-    async def execute_task(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
-        del args
-        captured.update(kwargs)
-        yield AgentMessage(
-            type="result",
-            content="[TASK_COMPLETE]",
-            data={"subtype": "success"},
-        )
-
-    executing_runner._adapter.execute_task = execute_task
-    tool_catalog = assemble_session_tool_catalog(["Read"])
-    with (
-        patch.object(
-            executing_runner._session_repo,
-            "track_progress",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            executing_runner._session_repo,
-            "mark_completed",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            executing_runner,
-            "_check_startup_cancellation",
-            AsyncMock(return_value=False),
-        ),
-        patch.object(
-            executing_runner,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(executing_runner, "_evaluate_frugality_proof", AsyncMock()),
-    ):
+    try:
         result = await executing_runner.execute_precreated_session(
             seed,
             prepared.value,
             parallel=False,
         )
+    finally:
+        preparing_runner._retire_process_local_authority(
+            session_id=prepared.value.session_id,
+            execution_id=prepared.value.execution_id,
+        )
 
-    assert result.is_ok
-    assert executing_runner._project_guidance_ids == ()
-    assert sentinel in captured["system_prompt"]
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+    get_tools.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_path: Path) -> None:
+async def test_same_process_resume_delivers_persisted_guidance_to_adapter_system_prompt(
+    tmp_path: Path,
+) -> None:
     sentinel = "GUIDANCE_SENTINEL_RESUME"
     _write_guidance(tmp_path, "team", f"Preserve project conventions. {sentinel}\n")
     original, _store = _runner(tmp_path, ("team",))
     seed = _seed()
-    persisted_contract = original._build_execution_contract(seed=seed)
+    generation = original._begin_process_local_authority_generation()
+    persisted_contract = original._build_execution_contract(
+        seed=seed,
+        authority_generation=generation,
+    )
 
-    resumed, event_store = _runner(tmp_path, ())
+    resumed, event_store = original, _store
     event_store.replay = AsyncMock(return_value=[])
     tracker = SessionTracker.create(
         "exec-guidance-resume",
@@ -461,6 +471,12 @@ async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_p
             EXECUTION_CONTRACT_PROGRESS_KEY: persisted_contract,
             "messages_processed": 0,
         }
+    )
+    resumed._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=persisted_contract,
+        generation=generation,
     )
     captured: dict[str, Any] = {}
 
@@ -475,33 +491,39 @@ async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_p
 
     resumed._adapter.execute_task = execute_task
     tool_catalog = assemble_session_tool_catalog(["Read"])
-    with (
-        patch.object(
-            resumed._session_repo,
-            "reconstruct_session",
-            AsyncMock(return_value=Result.ok(tracker)),
-        ),
-        patch.object(
-            resumed._session_repo,
-            "track_progress",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            resumed._session_repo,
-            "mark_completed",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            resumed,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(resumed, "_evaluate_frugality_proof", AsyncMock()),
-    ):
-        result = await resumed.resume_session(tracker.session_id, seed)
+    try:
+        with (
+            patch.object(
+                resumed._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(tracker)),
+            ),
+            patch.object(
+                resumed._session_repo,
+                "track_progress",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch.object(
+                resumed._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch.object(
+                resumed,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, tool_catalog)),
+            ),
+            patch.object(resumed, "_evaluate_frugality_proof", AsyncMock()),
+        ):
+            result = await resumed.resume_session(tracker.session_id, seed)
+    finally:
+        resumed._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
     assert result.is_ok
-    assert resumed._project_guidance_ids == ()
+    assert resumed._project_guidance_ids == ("team",)
     assert sentinel in captured["system_prompt"]
     guidance_events = [
         call.args[0]

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -527,6 +527,48 @@ class TestShadowReplayHarness:
         assert data["is_decomposed_child"] is True
 
     @pytest.mark.asyncio
+    async def test_verifier_entry_drift_stops_shadow_replay_before_baseline_effect(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = MagicMock()
+        monkeypatch.setattr("ouroboros.orchestrator.runtime_factory.create_agent_runtime", factory)
+        store, events = _capturing_event_store()
+        executor = _executor_with_router(task_cwd=str(tmp_path), store=store)
+        injected = False
+
+        def injected_verifier(**_: object) -> object:
+            nonlocal injected
+            injected = True
+            return object()
+
+        monkeypatch.setattr(
+            ParallelACExecutor,
+            "_run_atomic_verifier_pass",
+            injected_verifier,
+        )
+
+        with isolated_workspace(str(tmp_path)) as isolated_cwd:
+            assert isolated_cwd is not None
+            await run_shadow_replay(
+                executor,
+                runtime_identity=_identity(),
+                execution_id="exec_frugal",
+                session_id="sess",
+                ac_index=1,
+                is_sub_ac=True,
+                prompt="do the thing",
+                system_prompt="system",
+                tools=["Read"],
+                decomposition_trustworthy=True,
+                ac_content="Implement a thing",
+                isolated_cwd=isolated_cwd,
+            )
+
+        factory.assert_not_called()
+        assert injected is False
+        assert _shadow_events(events) == []
+
+    @pytest.mark.asyncio
     async def test_runtime_without_strict_isolation_contract_is_never_executed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Replaces the closed portable-identity experiments with the conservative Foundation A boundary from RFC #1681: every current CLI runtime is executable only within its creating process.

- Introduces a registry-minted, non-serializable process-local authority generation plus PID liveness lease.
- Requires the live capability before resume, preserves typed nonterminal ownership blocks, and fails a lost capability closed.
- Retains the exact paused handler runner/adapter/EventStore, reacquires the task worktree before resume, and cleans terminal or stale stores.
- Documents the finite boundary and adversarial exit matrix; legacy dynamic runtime behavior cannot promote itself to portable authority.

## Verification

- `uv run --no-sync pytest tests/unit/orchestrator` — 3133 passed, 1 skipped
- `uv run --no-sync pytest tests/e2e/test_session_persistence.py` — 24 passed
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`
- `uv run --no-sync mypy src/ouroboros`
- `git diff --check`

## Review notes

Two independent Stage-1 reviews passed after adversarial lifecycle regressions. A broader MCP-tool run has 11 failures in unchanged Auto/OpenCode-plugin tests; the first two are reproducible on clean `origin/main`, so they are not attributed to this Foundation A diff.

Ref: #1681