### PR TITLE
fix(tui): truncate AC labels by display cell width

### DIFF
--- a/src/ouroboros/tui/cell_width.py
+++ b/src/ouroboros/tui/cell_width.py
@@ -1,0 +1,44 @@
+"""Helpers for fitting styled TUI text to terminal display cells."""
+
+from __future__ import annotations
+
+from rich.cells import cell_len, set_cell_size
+from rich.text import Text
+
+
+def truncate_to_cell_width(content: str, width: int) -> str:
+    """Truncate plain text to ``width`` terminal cells with an ASCII ellipsis."""
+    width = max(0, width)
+    if cell_len(content) <= width:
+        return content
+
+    ellipsis = "." * min(3, width)
+    content_width = width - cell_len(ellipsis)
+    return set_cell_size(content, content_width).rstrip() + ellipsis
+
+
+def fit_text(
+    content: str,
+    width: int,
+    *,
+    prefix: Text | None = None,
+    suffix: Text | None = None,
+    content_style: str | None = None,
+) -> Text:
+    """Fit content between fixed styled text while bounding the complete line."""
+    width = max(0, width)
+    prefix = prefix.copy() if prefix is not None else Text()
+    suffix = suffix.copy() if suffix is not None else Text()
+    content_width = max(0, width - prefix.cell_len - suffix.cell_len)
+
+    rendered = Text()
+    rendered.append_text(prefix)
+    rendered.append(truncate_to_cell_width(content, content_width), style=content_style)
+    rendered.append_text(suffix)
+
+    if rendered.cell_len > width:
+        rendered.truncate(width, overflow="crop")
+    return rendered
+
+
+__all__ = ["fit_text", "truncate_to_cell_width"]

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -31,6 +31,9 @@ from collections.abc import Mapping
 import contextlib
 from typing import TYPE_CHECKING, Any
 
+from rich.cells import cell_len
+from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
@@ -41,6 +44,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Label, Static, Tree
 from textual.widgets.tree import TreeNode
 
+from ouroboros.tui.cell_width import fit_text
 from ouroboros.tui.events import (
     ACUpdated,
     AgentThinkingUpdated,
@@ -89,6 +93,7 @@ _TOOL_ACTIVITY_FALLBACK_LABELS = {
 }
 
 _MODEL_SHORT_PREFIXES = ("claude-", "us.anthropic.", "anthropic.")
+_FALLBACK_TREE_CONTENT_WIDTH = 40
 
 
 def _compact_tokens(value: float) -> str:
@@ -457,6 +462,7 @@ class SelectableACTree(Static):
         if tree_data:
             self.tree_data = tree_data
         self._node_map: dict[str, dict[str, Any]] = {}
+        self._tree_node_map: dict[str, TreeNode[dict[str, Any]]] = {}
         self._active_tools: dict[str, str] = {}
 
     def compose(self) -> ComposeResult:
@@ -467,6 +473,93 @@ class SelectableACTree(Static):
 
     def on_mount(self) -> None:
         self._rebuild_tree()
+        self.call_after_refresh(self._resync_labels_for_current_width)
+
+    @staticmethod
+    def _display_depth(node: TreeNode[dict[str, Any]]) -> int:
+        """Return a node's rendered depth below the visible Seed root."""
+        depth = 0
+        parent = node.parent
+        while isinstance(parent, TreeNode):
+            depth += 1
+            parent = parent.parent
+        return depth
+
+    @staticmethod
+    def _badge_suffix(node_data: Mapping[str, Any], activity: str = "") -> Text:
+        """Build provider, model, token, and activity suffixes as styled text."""
+        suffix = Text()
+
+        provider = node_data.get("provider")
+        if isinstance(provider, str) and provider:
+            suffix.append(f" [{provider}]", style="dim cyan")
+
+        model = node_data.get("model")
+        tier = node_data.get("model_tier")
+        if isinstance(model, str) and model:
+            suffix.append(f" ⚡{_short_model(model)}", style="dim")
+        elif isinstance(tier, str) and tier:
+            suffix.append(f" ⚡{tier}", style="dim")
+
+        tokens = node_data.get("tokens")
+        if isinstance(tokens, (int, float)) and not isinstance(tokens, bool) and tokens > 0:
+            suffix.append(f" {_compact_tokens(float(tokens))}", style="dim")
+
+        if activity:
+            suffix.append(f" · {activity}", style="dim italic")
+        return suffix
+
+    def _tree_label_width(
+        self,
+        tree: Tree[dict[str, Any]],
+        *,
+        display_depth: int,
+        allow_expand: bool,
+        fixed_label_width: int,
+    ) -> int:
+        """Return label width after guides and the expand/collapse glyph."""
+        tree_width = getattr(tree.scrollable_content_region, "width", 0)
+        if not isinstance(tree_width, int) or tree_width <= 0:
+            tree_width = getattr(tree.size, "width", 0)
+        if isinstance(tree_width, int) and tree_width > 0:
+            guide_levels = display_depth if tree.show_root else max(0, display_depth - 1)
+            guide_width = guide_levels * tree.guide_depth
+            toggle_width = cell_len(tree.ICON_NODE_EXPANDED) if allow_expand else 0
+            return max(0, tree_width - guide_width - toggle_width)
+        return fixed_label_width + _FALLBACK_TREE_CONTENT_WIDTH
+
+    def _format_node_label(
+        self,
+        tree: Tree[dict[str, Any]],
+        node_data: Mapping[str, Any],
+        *,
+        display_depth: int,
+        allow_expand: bool,
+    ) -> Text:
+        """Format one complete tree label within its rendered row budget."""
+        status = str(node_data.get("status", "pending"))
+        prefix = Text.from_markup(STATUS_ICONS.get(status, "○"))
+        prefix.append(" ")
+
+        activity = self._active_tools.get(str(node_data.get("id", "")))
+        if not activity:
+            activity = self._activity_from_node(node_data)
+        if status not in {"executing", "running"}:
+            activity = ""
+
+        suffix = self._badge_suffix(node_data, activity)
+        label_width = self._tree_label_width(
+            tree,
+            display_depth=display_depth,
+            allow_expand=allow_expand,
+            fixed_label_width=prefix.cell_len + suffix.cell_len,
+        )
+        return fit_text(
+            str(node_data.get("content", "")),
+            label_width,
+            prefix=prefix,
+            suffix=suffix,
+        )
 
     def _rebuild_tree(self) -> None:
         try:
@@ -475,9 +568,10 @@ class SelectableACTree(Static):
             return
 
         tree.clear()
-        tree.root.label = "[bold]Seed[/]"
+        tree.root.label = Text("Seed", style="bold")
         tree.root.data = {"id": "seed", "content": "Seed", "status": "executing", "depth": 0}
         self._node_map = {"seed": tree.root.data}
+        self._tree_node_map = {"seed": tree.root}
 
         if not self.tree_data:
             return
@@ -504,44 +598,56 @@ class SelectableACTree(Static):
                 continue
 
             child_data = nodes[child_id]
-            status = child_data.get("status", "pending")
-            content = child_data.get("content", "")[:40]
-            icon = STATUS_ICONS.get(status, "○")
-
-            label = f"{icon} {content}"
-            if len(child_data.get("content", "")) > 40:
-                label += "..."
-
-            # Provider identity from the shared board projection (runtime_backend
-            # per node) — gives the TUI the multi-provider view the web Kanban has.
-            provider = child_data.get("provider")
-            if isinstance(provider, str) and provider:
-                label += f" [dim cyan]\\[{provider}][/]"
-
-            # Frugality telemetry: model-tier badge (model family, vendor prefix
-            # stripped) + compact token spend, both stamped from TUIState.
-            model = child_data.get("model")
-            tier = child_data.get("model_tier")
-            if isinstance(model, str) and model:
-                label += f" [dim]⚡{_short_model(model)}[/]"
-            elif isinstance(tier, str) and tier:
-                label += f" [dim]⚡{tier}[/]"
-            tokens = child_data.get("tokens")
-            if isinstance(tokens, (int, float)) and not isinstance(tokens, bool) and tokens > 0:
-                label += f" [dim]{_compact_tokens(float(tokens))}[/]"
-
-            # P2: Show inline tool activity for executing nodes
-            activity = self._active_tools.get(child_id) or self._activity_from_node(child_data)
-            if activity and status in ("executing", "running"):
-                label += f"\n     [dim italic]{activity}[/]"
-
-            child_node = parent.add(label, data=child_data)
+            child_ids = child_data.get("children_ids", [])
+            display_depth = self._display_depth(parent) + 1
+            allow_expand = bool(child_ids)
+            label = self._format_node_label(
+                parent.tree,
+                child_data,
+                display_depth=display_depth,
+                allow_expand=allow_expand,
+            )
+            if allow_expand:
+                child_node = parent.add(label, data=child_data)
+            else:
+                child_node = parent.add_leaf(label, data=child_data)
             self._node_map[child_id] = child_data
+            self._tree_node_map[child_id] = child_node
 
             # Recursively add grandchildren
-            if child_data.get("children_ids"):
+            if child_ids:
                 self._add_children(child_node, child_data, nodes)
                 child_node.expand()
+
+    def _resync_labels_for_current_width(self) -> None:
+        """Reformat rendered nodes after layout or terminal width changes."""
+        try:
+            tree = self.query_one("#ac-tree", Tree)
+        except NoMatches:
+            return
+
+        for node_id, tree_node in self._tree_node_map.items():
+            if node_id == "seed":
+                tree_node.set_label(Text("Seed", style="bold"))
+                continue
+            node_data = self._node_map.get(node_id)
+            if node_data is None:
+                continue
+            tree_node.set_label(
+                self._format_node_label(
+                    tree,
+                    node_data,
+                    display_depth=self._display_depth(tree_node),
+                    allow_expand=tree_node.allow_expand,
+                )
+            )
+        # TreeNode.set_label refreshes a row but does not recompute virtual width.
+        tree._invalidate()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Recalculate labels after Textual measures a new tree width."""
+        del event
+        self.call_after_refresh(self._resync_labels_for_current_width)
 
     def update_tree(self, tree_data: dict[str, Any]) -> None:
         self.tree_data = tree_data

--- a/src/ouroboros/tui/widgets/ac_progress.py
+++ b/src/ouroboros/tui/widgets/ac_progress.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Label, ProgressBar, Static
+
+from ouroboros.tui.cell_width import fit_text
 
 if TYPE_CHECKING:
     pass
@@ -33,6 +37,8 @@ STATUS_STYLES = {
     "completed": "green",
     "failed": "red",
 }
+
+_FALLBACK_CONTENT_WIDTH = 45
 
 
 @dataclass
@@ -199,11 +205,12 @@ class ACProgressWidget(Widget):
             )
             yield Static(remaining_text, classes="progress-footer")
 
-    def _render_ac_item(self, ac: ACProgressItem) -> Static:
+    def _render_ac_item(self, ac: ACProgressItem, *, max_width: int | None = None) -> Static:
         """Render a single AC item.
 
         Args:
             ac: AC progress item to render.
+            max_width: Optional total row width for direct tests.
 
         Returns:
             Static widget with formatted AC line.
@@ -211,24 +218,34 @@ class ACProgressWidget(Widget):
         icon = STATUS_ICONS.get(ac.status, "○")
         style = STATUS_STYLES.get(ac.status, "dim")
 
-        # Truncate content
-        content = ac.content[:45] + "..." if len(ac.content) > 45 else ac.content
+        prefix = Text(" ")
+        prefix.append(icon, style=style)
+        prefix.append(f"  {ac.index}. ")
 
-        # Build label
-        label = f" [{style}]{icon}[/{style}]  {ac.index}. {content}"
-
-        # Add elapsed time
+        suffix = Text()
         if ac.elapsed_display:
             if ac.status == "in_progress":
-                label += f"  [yellow dim][{ac.elapsed_display}...][/yellow dim]"
+                suffix.append(f"  [{ac.elapsed_display}...]", style="yellow dim")
             else:
-                label += f"  [dim][{ac.elapsed_display}][/dim]"
+                suffix.append(f"  [{ac.elapsed_display}]", style="dim")
+
+        if max_width is None:
+            max_width = self.size.width
+            if max_width <= 0:
+                max_width = prefix.cell_len + _FALLBACK_CONTENT_WIDTH + suffix.cell_len
+
+        label = fit_text(ac.content, max_width, prefix=prefix, suffix=suffix)
 
         classes = "ac-item current" if ac.is_current else "ac-item"
         return Static(label, classes=classes)
 
     def watch_acceptance_criteria(self, _new_criteria: list[ACProgressItem]) -> None:
         """React to acceptance_criteria changes."""
+        self.refresh(recompose=True)
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Recompose rows against the newly measured content width."""
+        del event
         self.refresh(recompose=True)
 
     def watch_completed_count(self, _new_count: int) -> None:

--- a/src/ouroboros/tui/widgets/ac_tree.py
+++ b/src/ouroboros/tui/widgets/ac_tree.py
@@ -11,11 +11,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.cells import cell_len
+from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Label, Static, Tree
 from textual.widgets.tree import TreeNode
+
+from ouroboros.tui.cell_width import truncate_to_cell_width
 
 # Status display configuration
 STATUS_ICONS = {
@@ -26,6 +31,9 @@ STATUS_ICONS = {
     "completed": "[green][OK][/green]",
     "failed": "[red][X][/red]",
 }
+
+_FALLBACK_NODE_CONTENT_WIDTH = 50
+_FALLBACK_ROOT_CONTENT_WIDTH = 30
 
 
 class ACTreeWidget(Widget):
@@ -119,6 +127,52 @@ class ACTreeWidget(Widget):
         self.tree_data = tree_data or {}
         self.current_ac_id = current_ac_id
 
+    @staticmethod
+    def _display_depth(node: TreeNode[str]) -> int:
+        """Return a node's rendered depth below the visible tree root."""
+        depth = 0
+        parent = node.parent
+        while isinstance(parent, TreeNode):
+            depth += 1
+            parent = parent.parent
+        return depth
+
+    def _tree_label_width(
+        self,
+        *,
+        display_depth: int,
+        allow_expand: bool,
+        fixed_label_width: int,
+        fallback_content_width: int,
+    ) -> int:
+        """Return the label budget after Tree guides and toggle glyphs."""
+        tree = self._tree_widget
+        tree_width = getattr(getattr(tree, "scrollable_content_region", None), "width", 0)
+        if not isinstance(tree_width, int) or tree_width <= 0:
+            tree_width = getattr(getattr(tree, "size", None), "width", 0)
+        if tree is not None and isinstance(tree_width, int) and tree_width > 0:
+            guide_levels = display_depth if tree.show_root else max(0, display_depth - 1)
+            guide_width = guide_levels * tree.guide_depth
+            toggle_width = cell_len(tree.ICON_NODE_EXPANDED) if allow_expand else 0
+            return max(0, tree_width - guide_width - toggle_width)
+        return fixed_label_width + fallback_content_width
+
+    def _format_root_label(
+        self,
+        content: str,
+        *,
+        max_width: int | None = None,
+    ) -> str:
+        """Format the visible root within its toggle-aware row budget."""
+        if max_width is None:
+            max_width = self._tree_label_width(
+                display_depth=0,
+                allow_expand=True,
+                fixed_label_width=0,
+                fallback_content_width=_FALLBACK_ROOT_CONTENT_WIDTH,
+            )
+        return truncate_to_cell_width(content, max_width)
+
     def compose(self) -> ComposeResult:
         """Compose the widget layout."""
         yield Label("AC Decomposition Tree", classes="header")
@@ -131,7 +185,7 @@ class ACTreeWidget(Widget):
             root_id = self.tree_data.get("root_id")
             root_label = "AC Tree"
             if root_id and root_id in nodes:
-                root_label = nodes[root_id].get("content", "AC Tree")[:30]
+                root_label = self._format_root_label(str(nodes[root_id].get("content", "AC Tree")))
 
             tree: Tree[str] = Tree(root_label)
             tree.show_root = True
@@ -169,27 +223,47 @@ class ACTreeWidget(Widget):
         self,
         node_data: dict[str, Any],
         is_current: bool = False,
+        *,
+        display_depth: int = 1,
+        allow_expand: bool | None = None,
+        max_width: int | None = None,
     ) -> str:
         """Format display label for a tree node.
 
         Args:
             node_data: Data for the node.
             is_current: Whether this is the currently executing AC.
+            display_depth: Rendered depth below the visible tree root.
+            allow_expand: Whether Textual prepends an expand/collapse glyph.
+            max_width: Optional label-only width for direct tests.
 
         Returns:
             Formatted label with status icon and content.
         """
         status = node_data.get("status", "pending")
-        content = node_data.get("content", "Unknown")
+        content = str(node_data.get("content", "Unknown"))
         is_atomic = node_data.get("is_atomic", False)
-
-        # Truncate content for display
-        display_content = content[:50] + "..." if len(content) > 50 else content
 
         # Build label with status icon
         status_icon = STATUS_ICONS.get(status, "[ ]")
         if is_atomic and status in {"atomic", "pending"}:
             status_icon = STATUS_ICONS["atomic"]
+
+        prefix = Text.from_markup(status_icon)
+        prefix.append(" ")
+        if allow_expand is None:
+            allow_expand = bool(node_data.get("children_ids"))
+        if max_width is None:
+            max_width = self._tree_label_width(
+                display_depth=display_depth,
+                allow_expand=allow_expand,
+                fixed_label_width=prefix.cell_len,
+                fallback_content_width=_FALLBACK_NODE_CONTENT_WIDTH,
+            )
+        display_content = truncate_to_cell_width(
+            content,
+            max(0, max_width - prefix.cell_len),
+        )
 
         # Highlight current AC
         if is_current:
@@ -214,10 +288,16 @@ class ACTreeWidget(Widget):
         """
         node_id = node_data.get("id", "")
         is_current = node_id == self.current_ac_id
-        label = self._format_node_label(node_data, is_current)
 
         # Add to tree
         child_ids = node_data.get("children_ids", [])
+        display_depth = self._display_depth(parent) + 1
+        label = self._format_node_label(
+            node_data,
+            is_current,
+            display_depth=display_depth,
+            allow_expand=bool(child_ids),
+        )
         if child_ids:
             # Has children - add as expandable node
             tree_node = parent.add(label, data=node_id)
@@ -279,7 +359,14 @@ class ACTreeWidget(Widget):
             if ac_id in nodes:
                 node_data = nodes[ac_id]
                 is_current = ac_id == new_id
-                tree_node.set_label(self._format_node_label(node_data, is_current))
+                tree_node.set_label(
+                    self._format_node_label(
+                        node_data,
+                        is_current,
+                        display_depth=self._display_depth(tree_node),
+                        allow_expand=tree_node.allow_expand,
+                    )
+                )
 
     def update_tree(
         self,
@@ -339,8 +426,56 @@ class ACTreeWidget(Widget):
             node_data = nodes.get(node_id)
             if not isinstance(node_data, dict):
                 continue
+            if node_id == tree_data.get("root_id"):
+                tree_node.set_label(
+                    self._format_root_label(str(node_data.get("content", "AC Tree")))
+                )
+                continue
             is_current = node_id == self.current_ac_id
-            tree_node.set_label(self._format_node_label(node_data, is_current))
+            tree_node.set_label(
+                self._format_node_label(
+                    node_data,
+                    is_current,
+                    display_depth=self._display_depth(tree_node),
+                    allow_expand=tree_node.allow_expand,
+                )
+            )
+
+    def _resync_labels_for_current_width(self) -> None:
+        """Reapply root and child labels against the current Tree viewport."""
+        if self._tree_widget is None or not self._node_map:
+            return
+
+        data = self._tree_data_cache or self.tree_data
+        nodes = data.get("nodes")
+        if not isinstance(nodes, dict):
+            return
+
+        root_id = data.get("root_id")
+        for node_id, tree_node in self._node_map.items():
+            node_data = nodes.get(node_id)
+            if not isinstance(node_data, dict):
+                continue
+            if node_id == root_id:
+                tree_node.set_label(
+                    self._format_root_label(str(node_data.get("content", "AC Tree")))
+                )
+                continue
+            tree_node.set_label(
+                self._format_node_label(
+                    node_data,
+                    node_id == self.current_ac_id,
+                    display_depth=self._display_depth(tree_node),
+                    allow_expand=tree_node.allow_expand,
+                )
+            )
+        # TreeNode.set_label refreshes a row but does not recompute virtual width.
+        self._tree_widget._invalidate()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Recalculate labels after Textual measures a new tree width."""
+        del event
+        self._resync_labels_for_current_width()
 
     def update_node_status(self, ac_id: str, status: str) -> None:
         """Update status of a single node without recompose.
@@ -365,7 +500,15 @@ class ACTreeWidget(Widget):
         if ac_id in self._node_map and self._tree_widget:
             node_data = new_nodes[ac_id]
             is_current = ac_id == self.current_ac_id
-            self._node_map[ac_id].set_label(self._format_node_label(node_data, is_current))
+            tree_node = self._node_map[ac_id]
+            tree_node.set_label(
+                self._format_node_label(
+                    node_data,
+                    is_current,
+                    display_depth=self._display_depth(tree_node),
+                    allow_expand=tree_node.allow_expand,
+                )
+            )
 
         # Update reactive data (watch will skip recompose since tree exists)
         self.tree_data = new_data
@@ -407,7 +550,12 @@ class ACTreeWidget(Widget):
 
             # Update parent node label to show decomposed status
             self._node_map[parent_ac_id].set_label(
-                self._format_node_label(parent_data, parent_ac_id == self.current_ac_id)
+                self._format_node_label(
+                    parent_data,
+                    parent_ac_id == self.current_ac_id,
+                    display_depth=self._display_depth(parent_tree_node),
+                    allow_expand=parent_tree_node.allow_expand,
+                )
             )
 
         # Add children to tree widget and data
@@ -420,8 +568,17 @@ class ACTreeWidget(Widget):
             nodes[child_id] = child_data
 
             # Add to tree widget
-            label = self._format_node_label(child_data, child_id == self.current_ac_id)
-            child_tree_node = parent_tree_node.add_leaf(label, data=child_id)
+            child_ids = child_data.get("children_ids", [])
+            label = self._format_node_label(
+                child_data,
+                child_id == self.current_ac_id,
+                display_depth=self._display_depth(parent_tree_node) + 1,
+                allow_expand=bool(child_ids),
+            )
+            if child_ids:
+                child_tree_node = parent_tree_node.add(label, data=child_id)
+            else:
+                child_tree_node = parent_tree_node.add_leaf(label, data=child_id)
             self._node_map[child_id] = child_tree_node
 
         # Expand parent to show new children
@@ -455,7 +612,15 @@ class ACTreeWidget(Widget):
         if ac_id in self._node_map and self._tree_widget:
             node_data = new_nodes[ac_id]
             is_current = ac_id == self.current_ac_id
-            self._node_map[ac_id].set_label(self._format_node_label(node_data, is_current))
+            tree_node = self._node_map[ac_id]
+            tree_node.set_label(
+                self._format_node_label(
+                    node_data,
+                    is_current,
+                    display_depth=self._display_depth(tree_node),
+                    allow_expand=tree_node.allow_expand,
+                )
+            )
 
         # Update reactive data (watch will skip recompose since tree exists)
         self.tree_data = new_data

--- a/tests/unit/tui/test_display_width.py
+++ b/tests/unit/tui/test_display_width.py
@@ -1,0 +1,316 @@
+"""Mounted regressions for terminal-cell-aware TUI labels."""
+
+from __future__ import annotations
+
+import pytest
+from rich.cells import cell_len
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets import Static, Tree
+
+from ouroboros.tui.cell_width import fit_text, truncate_to_cell_width
+from ouroboros.tui.screens.dashboard_v3 import SelectableACTree
+from ouroboros.tui.widgets.ac_progress import ACProgressItem, ACProgressWidget
+from ouroboros.tui.widgets.ac_tree import ACTreeWidget
+
+
+def _tree_line_widths(tree: Tree[object]) -> list[int]:
+    """Return each unscrolled tree row's full display width."""
+    return [
+        tree.get_label_width(line.node) + line._get_guide_width(tree.guide_depth, tree.show_root)
+        for line in tree._tree_lines
+    ]
+
+
+def _tree_viewport_width(tree: Tree[object]) -> int:
+    """Return the row width left after Tree scrollbars and padding."""
+    return tree.scrollable_content_region.width
+
+
+class _SelectableTreeApp(App[None]):
+    def __init__(self, tree_data: dict[str, object]) -> None:
+        super().__init__()
+        self._tree_data = tree_data
+
+    def compose(self) -> ComposeResult:
+        yield SelectableACTree(self._tree_data)
+
+
+class _LegacyTreeApp(App[None]):
+    def __init__(self, tree_data: dict[str, object]) -> None:
+        super().__init__()
+        self._tree_data = tree_data
+
+    def compose(self) -> ComposeResult:
+        yield ACTreeWidget(self._tree_data)
+
+
+class _ProgressApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield ACProgressWidget(
+            [
+                ACProgressItem(
+                    index=123,
+                    content="한글🙂" * 40,
+                    status="in_progress",
+                    elapsed_display="1m 05s",
+                )
+            ],
+            total_count=1,
+        )
+
+
+@pytest.mark.parametrize("content", ["한글" * 20, "🙂" * 20, "e\u0301" * 40])
+def test_truncate_to_cell_width_handles_unicode_and_tiny_widths(content: str) -> None:
+    for width in range(31):
+        rendered = truncate_to_cell_width(content, width)
+        assert cell_len(rendered) <= width
+
+
+def test_fit_text_reserves_styled_prefix_and_suffix() -> None:
+    prefix = Text("⚡ 123. ", style="yellow")
+    suffix = Text(" [1m 05s]", style="dim")
+
+    rendered = fit_text("검증🙂" * 20, 24, prefix=prefix, suffix=suffix)
+
+    assert rendered.cell_len <= 24
+    assert rendered.plain.startswith(prefix.plain)
+    assert rendered.plain.endswith(suffix.plain)
+    assert "..." in rendered.plain
+
+
+@pytest.mark.asyncio
+async def test_selectable_tree_fits_guides_toggle_content_and_badges() -> None:
+    tree_data = {
+        "root_id": "root",
+        "nodes": {
+            "root": {"id": "root", "content": "Root", "children_ids": ["parent"]},
+            "parent": {
+                "id": "parent",
+                "content": "한글🙂" * 40,
+                "status": "executing",
+                "children_ids": ["child"],
+                "provider": "codex",
+                "model": "claude-haiku-4-5",
+                "tokens": 1200,
+            },
+            "child": {
+                "id": "child",
+                "content": "검증🙂" * 40,
+                "status": "pending",
+                "children_ids": [],
+                "provider": "claude",
+                "model_tier": "frugal",
+                "tokens": 999,
+            },
+        },
+    }
+
+    app = _SelectableTreeApp(tree_data)
+    async with app.run_test(size=(72, 20)) as pilot:
+        await pilot.pause()
+        tree = app.query_one("#ac-tree", Tree)
+
+        assert tree.virtual_size.width <= tree.size.width
+        assert all(width <= tree.size.width for width in _tree_line_widths(tree))
+
+        parent = tree.root.children[0]
+        child = parent.children[0]
+        assert "..." in parent.label.plain
+        assert parent.label.plain.endswith("[codex] ⚡haiku 1.2k")
+        assert child.label.plain.endswith("[claude] ⚡frugal 999")
+
+
+@pytest.mark.asyncio
+async def test_selectable_tree_reflows_content_when_terminal_resizes() -> None:
+    content = "W" * 200
+    tree_data = {
+        "root_id": "root",
+        "nodes": {
+            "root": {"id": "root", "content": "Root", "children_ids": ["child"]},
+            "child": {
+                "id": "child",
+                "content": content,
+                "status": "pending",
+                "children_ids": [],
+            },
+        },
+    }
+
+    app = _SelectableTreeApp(tree_data)
+    async with app.run_test(size=(120, 20)) as pilot:
+        await pilot.pause()
+        tree = app.query_one("#ac-tree", Tree)
+        wide_label = tree.root.children[0].label.plain
+
+        assert wide_label.count("W") > 40
+
+        await pilot.resize_terminal(56, 20)
+        tree = app.query_one("#ac-tree", Tree)
+        narrow_label = tree.root.children[0].label.plain
+
+        assert narrow_label.count("W") < wide_label.count("W")
+        assert tree.virtual_size.width <= tree.size.width
+        assert all(width <= tree.size.width for width in _tree_line_widths(tree))
+
+
+@pytest.mark.asyncio
+async def test_selectable_tree_reserves_vertical_scrollbar_gutter() -> None:
+    child_ids = [f"child_{index}" for index in range(30)]
+    nodes: dict[str, object] = {
+        "root": {"id": "root", "content": "Root", "children_ids": child_ids}
+    }
+    nodes.update(
+        {
+            child_id: {
+                "id": child_id,
+                "content": "X" * 200,
+                "status": "pending",
+                "children_ids": [],
+                "provider": "codex",
+                "model": "claude-haiku-4-5",
+                "tokens": 1200,
+            }
+            for child_id in child_ids
+        }
+    )
+
+    app = _SelectableTreeApp({"root_id": "root", "nodes": nodes})
+    async with app.run_test(size=(72, 20)) as pilot:
+        await pilot.pause()
+        tree = app.query_one("#ac-tree", Tree)
+        viewport_width = _tree_viewport_width(tree)
+
+        assert tree.show_vertical_scrollbar
+        assert viewport_width < tree.size.width
+        assert tree.virtual_size.width <= viewport_width
+        assert tree.max_scroll_x == 0
+        assert all(width <= viewport_width for width in _tree_line_widths(tree))
+
+
+@pytest.mark.asyncio
+async def test_legacy_tree_reflows_root_and_child_to_viewport() -> None:
+    tree_data = {
+        "root_id": "root",
+        "nodes": {
+            "root": {
+                "id": "root",
+                "content": "R" * 200,
+                "status": "pending",
+                "children_ids": ["child"],
+            },
+            "child": {
+                "id": "child",
+                "content": "C" * 200,
+                "status": "pending",
+                "children_ids": [],
+            },
+        },
+    }
+
+    app = _LegacyTreeApp(tree_data)
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        tree = app.query_one(Tree)
+        wide_root = tree.root.label.plain
+        wide_child = tree.root.children[0].label.plain
+
+        assert wide_root.count("R") > 30
+        assert wide_child.count("C") > 50
+
+        await pilot.resize_terminal(52, 24)
+        tree = app.query_one(Tree)
+
+        assert tree.root.label.plain.count("R") < wide_root.count("R")
+        assert tree.root.children[0].label.plain.count("C") < wide_child.count("C")
+        assert tree.virtual_size.width <= tree.size.width
+        assert all(width <= tree.size.width for width in _tree_line_widths(tree))
+
+
+@pytest.mark.asyncio
+async def test_legacy_tree_incremental_root_update_keeps_root_within_viewport() -> None:
+    tree_data = {
+        "root_id": "root",
+        "nodes": {
+            "root": {
+                "id": "root",
+                "content": "Short root",
+                "status": "pending",
+                "children_ids": ["child"],
+            },
+            "child": {
+                "id": "child",
+                "content": "Short child",
+                "status": "pending",
+                "children_ids": [],
+            },
+        },
+    }
+
+    app = _LegacyTreeApp(tree_data)
+    async with app.run_test(size=(52, 18)) as pilot:
+        await pilot.pause()
+        widget = app.query_one(ACTreeWidget)
+        tree = app.query_one(Tree)
+
+        updated_data = {
+            "root_id": "root",
+            "nodes": {
+                "root": {
+                    "id": "root",
+                    "content": "한글🙂" * 60,
+                    "status": "pending",
+                    "children_ids": ["child"],
+                },
+                "child": {
+                    "id": "child",
+                    "content": "Short child",
+                    "status": "pending",
+                    "children_ids": [],
+                },
+            },
+        }
+        widget.update_tree(updated_data)
+        await pilot.pause()
+
+        assert "..." in tree.root.label.plain
+        assert cell_len(tree.root.label.plain) <= tree.size.width
+        assert tree.virtual_size.width <= tree.size.width
+        assert all(width <= tree.size.width for width in _tree_line_widths(tree))
+
+
+@pytest.mark.asyncio
+async def test_legacy_tree_deep_narrow_labels_fit_with_guides_and_toggles() -> None:
+    node_ids = [f"node_{index}" for index in range(8)]
+    nodes: dict[str, object] = {}
+    for index, node_id in enumerate(node_ids):
+        child_ids = [node_ids[index + 1]] if index + 1 < len(node_ids) else []
+        nodes[node_id] = {
+            "id": node_id,
+            "content": "深い階層🙂" * 30,
+            "status": "pending",
+            "children_ids": child_ids,
+        }
+
+    app = _LegacyTreeApp({"root_id": node_ids[0], "nodes": nodes})
+    async with app.run_test(size=(44, 24)) as pilot:
+        await pilot.pause()
+        tree = app.query_one(Tree)
+
+        assert tree.virtual_size.width <= tree.size.width
+        assert tree.max_scroll_x == 0
+        assert all(width <= tree.size.width for width in _tree_line_widths(tree))
+        assert any("..." in line.node.label.plain for line in tree._tree_lines)
+
+
+@pytest.mark.asyncio
+async def test_progress_row_reserves_status_index_and_elapsed_suffix() -> None:
+    app = _ProgressApp()
+    async with app.run_test(size=(60, 12)) as pilot:
+        await pilot.pause()
+        item = app.query_one(".ac-item", Static)
+        rendered = item.render()
+
+        assert rendered.cell_length <= item.size.width
+        assert rendered.plain.endswith("[1m 05s...]")
+        assert "..." in rendered.plain

--- a/tests/unit/tui/test_widgets.py
+++ b/tests/unit/tui/test_widgets.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+from rich.text import Text
+
 from ouroboros.tui.widgets.ac_progress import ACProgressItem, ACProgressWidget
 from ouroboros.tui.widgets.ac_tree import ACTreeWidget
 from ouroboros.tui.widgets.phase_progress import PhaseIndicator, PhaseProgressWidget
@@ -378,7 +380,7 @@ class TestACTreeWidget:
         label = widget._format_node_label(node_data)
 
         assert "..." in label
-        assert long_content[:50] in label
+        assert Text.from_markup(label).cell_len <= 54
 
     def test_mark_node_atomic(self) -> None:
         """Test marking a node as atomic."""


### PR DESCRIPTION
## Summary
- truncate AC progress, tree-node, and root labels by Rich display-cell width
- derive label budgets from the mounted widget width with safe unmounted fallbacks
- relabel or recompose on resize, including CJK, emoji, combining marks, and widths below the ellipsis length

## Validation
- `PYTHONPATH="$PWD/src" ../ouroboros/.venv/bin/pytest -q tests/unit/tui`
- `PYTHONPATH="$PWD/src" ../ouroboros/.venv/bin/mypy src/ouroboros/tui/widgets/ac_progress.py src/ouroboros/tui/widgets/ac_tree.py`
- Ruff check and format check
- `git diff --check`

Independent of RFC #1681 Foundation sequencing.