### PR TITLE
fix(hooks): honor UserPromptSubmit JSON contract

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -285,9 +285,10 @@ def _extract_prompt(hook_input: str) -> str:
     if (
         isinstance(payload, dict)
         and payload.get("hook_event_name") == "UserPromptSubmit"
-        and "prompt" in payload
+        and isinstance(payload.get("session_id"), str)
+        and isinstance(payload.get("prompt"), str)
     ):
-        return str(payload.get("prompt") or "")
+        return payload["prompt"]
     return hook_input
 
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -8,8 +8,8 @@ IMPORTANT: If MCP is not configured (ooo setup not run),
 ALL ooo commands (except setup/help) redirect to setup first.
 
 Hook: UserPromptSubmit
-Input: User prompt text via stdin (piped by Claude Code)
-Output: Modified prompt with skill suggestion appended
+Input: JSON hook payload via stdin, with raw prompt text supported as a fallback
+Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
@@ -275,26 +275,52 @@ def detect_keywords(text: str) -> dict:
     return {"detected": False, "keyword": None, "suggested_skill": None}
 
 
-def main() -> None:
-    # Read user prompt from stdin
+def _extract_prompt(hook_input: str) -> str:
+    """Extract prompt text from a hook payload, falling back to raw stdin."""
     try:
-        user_input = sys.stdin.read().strip()
+        payload = json.loads(hook_input)
+    except ValueError:
+        return hook_input
+
+    if isinstance(payload, dict):
+        return str(payload.get("prompt") or "")
+    return hook_input
+
+
+def _emit_context(context: str) -> None:
+    """Emit a UserPromptSubmit response understood by Claude Code and Codex."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> None:
+    # Read the hook payload from stdin. Older integrations may still pipe raw text.
+    try:
+        hook_input = sys.stdin.read().strip()
     except Exception:
-        user_input = ""
+        hook_input = ""
+
+    user_input = _extract_prompt(hook_input)
 
     result = detect_keywords(user_input)
 
-    # First-time user: append welcome suggestion to their first message
+    # First-time user: add welcome context to their first message.
     if not result["detected"] and is_first_time():
         skill_name = "welcome"
-        print(f"""{user_input}
-
-<skill-suggestion>
+        _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS (use AskUserQuestion to let user choose):
 - /ouroboros:{skill_name} - First time using Ouroboros! Starting welcome experience.
 IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confirm or skip.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         return
 
     if result["detected"]:
@@ -303,25 +329,16 @@ IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confir
 
         # Gate check: if MCP not configured and skill requires it, redirect to setup
         if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured():
-            print(f"""{user_input}
-
-<skill-suggestion>
+            _emit_context("""<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         else:
             skill_name = skill.replace("/ouroboros:", "")
-            print(f"""{user_input}
-
-<skill-suggestion>
+            _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS:
 - /ouroboros:{skill_name} - Detected "{keyword}"
-</skill-suggestion>
-""")
-    else:
-        # Pass through unchanged when no keyword detected
-        print(user_input)
+</skill-suggestion>""")
 
 
 if __name__ == "__main__":

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -282,7 +282,11 @@ def _extract_prompt(hook_input: str) -> str:
     except ValueError:
         return hook_input
 
-    if isinstance(payload, dict):
+    if (
+        isinstance(payload, dict)
+        and payload.get("hook_event_name") == "UserPromptSubmit"
+        and "prompt" in payload
+    ):
         return str(payload.get("prompt") or "")
     return hook_input
 

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -1,6 +1,7 @@
 """Tests for keyword-detector.py — setup gate and routing behavior."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -325,3 +326,56 @@ class TestMainGate:
         out = capsys.readouterr().out
         assert "/ouroboros:setup" not in out
         assert "/ouroboros:resume-session" in out
+
+
+class TestHookProtocol:
+    """UserPromptSubmit input and output follow the shared hook JSON protocol."""
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_json_payload_detection_uses_only_prompt_field(self, _first, capsys):
+        payload = {
+            "session_id": "ooo status",
+            "prompt": "hello world",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        assert capsys.readouterr().out == ""
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_json_payload_match_emits_structured_context(self, _first, _mcp, capsys):
+        payload = {
+            "session_id": "test-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        assert output == {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    "<skill-suggestion>\n🎯 MATCHED SKILLS:\n"
+                    '- /ouroboros:status - Detected "ooo status"\n'
+                    "</skill-suggestion>"
+                ),
+            }
+        }
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_text_fallback_remains_supported(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "ooo qa"
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:qa" in context
+        assert "ooo qa" in context

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -390,3 +390,21 @@ class TestHookProtocol:
         output = json.loads(capsys.readouterr().out)
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:status" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_hook_shaped_raw_json_without_session_id_remains_prompt(self, _first, _mcp, capsys):
+        raw_prompt = json.dumps(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "explain this payload",
+                "command": "ooo status",
+            }
+        )
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = raw_prompt
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -379,3 +379,14 @@ class TestHookProtocol:
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:qa" in context
         assert "ooo qa" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_json_object_text_without_hook_marker_remains_prompt(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = '{"command": "ooo status"}'
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context


### PR DESCRIPTION
## Summary
- parse Codex and Claude `UserPromptSubmit` envelopes from stdin
- emit schema-valid `hookSpecificOutput.additionalContext` instead of echoing the hook payload
- stay silent when no suggestion applies
- preserve legacy raw-text prompts, including JSON-object-shaped prompt text

Closes #1694.

## Independent verification
1. Focused hook contract suite: `44 passed`
2. Full script unit suite plus Ruff: `220 passed`; lint and format checks passed
3. Fresh isolated Codex 0.145.0 marketplace install: `ooo status` loaded the bundled status skill and completed with the fixed hook installed

Additional direct probes confirmed zero stdout for an ordinary no-match prompt and schema-valid JSON for matched prompts.

## Credit
Retains the original bot-authored implementation commit from #1695 and adds the independent compatibility regression requested in that review.