### PR TITLE
fix(config): persist stage routing from null profiles

### DIFF
--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import shutil
-from typing import Annotated
+from typing import Annotated, get_args, get_origin
 
 import typer
 import yaml
@@ -645,10 +645,16 @@ def _validate_key_path(keys: list[str]) -> str | None:
         # If not the last key, drill into the sub-model
         if i < len(keys) - 1:
             annotation = field_info.annotation
-            # Unwrap Optional, etc.
-            origin = getattr(annotation, "__origin__", None)
-            if origin is not None:
-                # Not a plain model type — can't drill further
+            # Unwrap Optional[T] / T | None so nested model fields remain
+            # schema-validated instead of falling through to Pydantic's
+            # default extra-field handling.
+            args = get_args(annotation)
+            non_none_args = tuple(arg for arg in args if arg is not type(None))
+            if len(non_none_args) == 1 and len(non_none_args) != len(args):
+                annotation = non_none_args[0]
+            # Generic containers have dynamic child keys; their value-level
+            # validators and the post-write load check enforce those entries.
+            if get_origin(annotation) is not None:
                 break
             if isinstance(annotation, type) and hasattr(annotation, "model_fields"):
                 model = annotation

--- a/src/ouroboros/config_tui/persistence.py
+++ b/src/ouroboros/config_tui/persistence.py
@@ -59,7 +59,10 @@ def apply_config_values(values: Mapping[str, Any]) -> None:
             raise ConfigWriteError(error)
         target = data
         for part in keys[:-1]:
-            node = target.setdefault(part, {})
+            node = target.get(part)
+            if node is None:
+                node = {}
+                target[part] = node
             if not isinstance(node, dict):
                 msg = f"Cannot set nested key: {key} ({part!r} is not a section)"
                 raise ConfigWriteError(msg)

--- a/tests/unit/config_tui/test_persistence.py
+++ b/tests/unit/config_tui/test_persistence.py
@@ -45,6 +45,44 @@ def test_apply_valid_values_persists(config_dir: Path) -> None:
     assert data["clarification"]["default_model"] == "my-model"
 
 
+def test_apply_nested_value_promotes_null_section(config_dir: Path) -> None:
+    (config_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "orchestrator": {
+                    "runtime_backend": "codex",
+                    "runtime_profile": None,
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    persistence.apply_config_values(
+        {
+            "orchestrator.runtime_profile.stages.interview": "codex",
+            "clarification.default_model": "my-model",
+        }
+    )
+
+    data = _read(config_dir)
+    assert data["orchestrator"]["runtime_profile"] == {"stages": {"interview": "codex"}}
+    assert data["clarification"]["default_model"] == "my-model"
+
+
+def test_apply_nested_value_rejects_scalar_section(config_dir: Path) -> None:
+    original = "orchestrator:\n  runtime_profile: worker\n"
+    (config_dir / "config.yaml").write_text(original)
+
+    with pytest.raises(
+        persistence.ConfigWriteError,
+        match=r"'runtime_profile' is not a section",
+    ):
+        persistence.apply_config_values({"orchestrator.runtime_profile.stages.interview": "codex"})
+
+    assert (config_dir / "config.yaml").read_text() == original
+
+
 def test_apply_none_deletes_stage_override(config_dir: Path) -> None:
     persistence.apply_config_values({"orchestrator.runtime_profile.stages.execute": "codex"})
     persistence.apply_config_values({"orchestrator.runtime_profile.stages.execute": None})

--- a/tests/unit/config_tui/test_persistence.py
+++ b/tests/unit/config_tui/test_persistence.py
@@ -96,6 +96,18 @@ def test_unknown_key_rejected_without_writing(config_dir: Path) -> None:
     assert not (config_dir / "config.yaml").exists()
 
 
+def test_unknown_runtime_profile_child_rejected_when_section_is_null(config_dir: Path) -> None:
+    original = "orchestrator:\n  runtime_profile: null\n"
+    (config_dir / "config.yaml").write_text(original)
+
+    with pytest.raises(persistence.ConfigWriteError, match="Unknown config key"):
+        persistence.apply_config_values(
+            {"orchestrator.runtime_profile.not_a_real_key_xyz": "value"}
+        )
+
+    assert (config_dir / "config.yaml").read_text() == original
+
+
 def test_invalid_value_rolls_back_file(config_dir: Path) -> None:
     persistence.apply_config_values({"orchestrator.runtime_backend": "codex"})
     before = (config_dir / "config.yaml").read_text()


### PR DESCRIPTION
## Summary
- promote a valid `runtime_profile: null` node to a mapping when the settings GUI writes a per-stage runtime
- preserve sibling configuration and reject scalar intermediate nodes without modifying the file
- unwrap optional Pydantic models during shared key-path validation so unknown `runtime_profile` children cannot slip through extra-field ignoring

Closes #1672.

## Verification
1. Regression test failed before the optional-model validator fix and now passes
2. Config TUI persistence suite: 12 passed
3. Config, config TUI, and CLI suites: 1,646 passed; one unchanged terminal autodetection test failed because `/bin/gnome-terminal` exists in this Linux environment
4. Direct schema probes confirmed valid stage paths pass and unknown optional-model children fail
5. Ruff lint, format check, and `git diff --check` passed

## Credit
Retains the original bot-authored implementation commit from #1673 and adds the independent schema-path correction required by its maintainer review.