### PR TITLE
fix(hooks): honor UserPromptSubmit JSON contract

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 import re
 import sys
+import tomllib
 
 
 def _configure_utf8_stdio() -> None:
@@ -156,12 +157,18 @@ KEYWORD_MAP = [
 
 
 def is_mcp_configured() -> bool:
-    """Check if MCP server is registered in ~/.claude/mcp.json."""
+    """Check if the Ouroboros MCP server is registered for Claude or Codex."""
     try:
-        mcp_path = Path.home() / ".claude" / "mcp.json"
-        if not mcp_path.exists():
+        claude_path = Path.home() / ".claude" / "mcp.json"
+        if claude_path.exists() and "ouroboros" in claude_path.read_text():
+            return True
+
+        codex_path = Path.home() / ".codex" / "config.toml"
+        if not codex_path.exists():
             return False
-        return "ouroboros" in mcp_path.read_text()
+        codex_config = tomllib.loads(codex_path.read_text())
+        mcp_servers = codex_config.get("mcp_servers")
+        return isinstance(mcp_servers, dict) and isinstance(mcp_servers.get("ouroboros"), dict)
     except Exception:
         return False
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -285,9 +285,10 @@ def _extract_prompt(hook_input: str) -> str:
     if (
         isinstance(payload, dict)
         and payload.get("hook_event_name") == "UserPromptSubmit"
-        and "prompt" in payload
+        and isinstance(payload.get("session_id"), str)
+        and isinstance(payload.get("prompt"), str)
     ):
-        return str(payload.get("prompt") or "")
+        return payload["prompt"]
     return hook_input
 
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -13,6 +13,7 @@ Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
+import os
 from pathlib import Path
 import re
 import sys
@@ -160,36 +161,94 @@ KEYWORD_MAP = [
 ]
 
 
+def _usable_mcp_transport(server: object) -> bool:
+    if not isinstance(server, dict) or server.get("enabled") is False:
+        return False
+    return any(
+        isinstance(server.get(key), str) and bool(server[key].strip()) for key in ("command", "url")
+    )
+
+
+def _fallback_codex_mcp_configured(config_text: str) -> bool:
+    in_ouroboros_section = False
+    section_count = 0
+    transport_found = False
+    enabled = True
+    multiline_delimiter: str | None = None
+
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if multiline_delimiter is not None:
+            if line.count(multiline_delimiter) % 2 == 1:
+                multiline_delimiter = None
+            continue
+        for delimiter in ('"""', "'''"):
+            if line.count(delimiter) % 2 == 1:
+                multiline_delimiter = delimiter
+                line = line.split(delimiter, 1)[0].strip()
+                break
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("["):
+            if line in ("[mcp_servers.ouroboros]", '[mcp_servers."ouroboros"]'):
+                section_count += 1
+                in_ouroboros_section = True
+            else:
+                in_ouroboros_section = False
+            continue
+        if not in_ouroboros_section:
+            continue
+        match = re.fullmatch(r"(command|url|enabled)\s*=\s*(.+)", line)
+        if match is None:
+            continue
+        key, raw_value = match.groups()
+        raw_value = raw_value.strip()
+        if key == "enabled":
+            enabled = raw_value.split("#", 1)[0].strip() == "true"
+        elif (
+            len(raw_value) >= 2
+            and raw_value[0] == raw_value[-1]
+            and raw_value[0] in ('"', "'")
+            and bool(raw_value[1:-1].strip())
+        ):
+            transport_found = True
+
+    return section_count == 1 and enabled and transport_found
+
+
 def _codex_mcp_configured(config_text: str) -> bool:
     if _toml_loads is not None:
         codex_config = _toml_loads(config_text)
         mcp_servers = codex_config.get("mcp_servers")
-        return isinstance(mcp_servers, dict) and isinstance(mcp_servers.get("ouroboros"), dict)
-
-    in_ouroboros_section = False
-    for raw_line in config_text.splitlines():
-        line = raw_line.split("#", 1)[0].strip()
-        if not line:
-            continue
-        if line.startswith("["):
-            in_ouroboros_section = line == "[mcp_servers.ouroboros]"
-            continue
-        if in_ouroboros_section and re.match(r"^(command|url)\s*=\s*.+$", line):
-            return True
-    return False
-
-
-def is_mcp_configured() -> bool:
-    """Check if the Ouroboros MCP server is registered for Claude or Codex."""
-    try:
-        claude_path = Path.home() / ".claude" / "mcp.json"
-        if claude_path.exists() and "ouroboros" in claude_path.read_text():
-            return True
-
-        codex_path = Path.home() / ".codex" / "config.toml"
-        if not codex_path.exists():
+        if not isinstance(mcp_servers, dict):
             return False
-        return _codex_mcp_configured(codex_path.read_text())
+        return _usable_mcp_transport(mcp_servers.get("ouroboros"))
+    return _fallback_codex_mcp_configured(config_text)
+
+
+def _claude_mcp_configured(config_text: str) -> bool:
+    claude_config = json.loads(config_text)
+    if not isinstance(claude_config, dict):
+        return False
+    mcp_servers = claude_config.get("mcpServers")
+    if not isinstance(mcp_servers, dict):
+        return False
+    return _usable_mcp_transport(mcp_servers.get("ouroboros"))
+
+
+def is_mcp_configured(host: str | None = None) -> bool:
+    """Check the active host's Ouroboros MCP registration."""
+    try:
+        if host in (None, "claude"):
+            claude_path = Path.home() / ".claude" / "mcp.json"
+            if claude_path.exists() and _claude_mcp_configured(claude_path.read_text()):
+                return True
+            if host == "claude":
+                return False
+
+        codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+        codex_path = codex_home / "config.toml"
+        return codex_path.exists() and _codex_mcp_configured(codex_path.read_text())
     except Exception:
         return False
 
@@ -303,12 +362,12 @@ def detect_keywords(text: str) -> dict:
     return {"detected": False, "keyword": None, "suggested_skill": None}
 
 
-def _extract_prompt(hook_input: str) -> str:
-    """Extract prompt text from a hook payload, falling back to raw stdin."""
+def _extract_prompt_and_host(hook_input: str) -> tuple[str, str | None]:
+    """Extract prompt and identify the hook host from its envelope."""
     try:
         payload = json.loads(hook_input)
     except (ValueError, RecursionError):
-        return hook_input
+        return hook_input, None
 
     if (
         isinstance(payload, dict)
@@ -316,8 +375,14 @@ def _extract_prompt(hook_input: str) -> str:
         and isinstance(payload.get("session_id"), str)
         and isinstance(payload.get("prompt"), str)
     ):
-        return payload["prompt"]
-    return hook_input
+        host = "codex" if isinstance(payload.get("turn_id"), str) else "claude"
+        return payload["prompt"], host
+    return hook_input, None
+
+
+def _extract_prompt(hook_input: str) -> str:
+    """Extract prompt text from a hook payload, falling back to raw stdin."""
+    return _extract_prompt_and_host(hook_input)[0]
 
 
 def _emit_context(context: str) -> None:
@@ -342,7 +407,7 @@ def main() -> None:
     except Exception:
         hook_input = ""
 
-    user_input = _extract_prompt(hook_input)
+    user_input, host = _extract_prompt_and_host(hook_input)
 
     result = detect_keywords(user_input)
 
@@ -361,7 +426,7 @@ IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confir
         keyword = result["keyword"]
 
         # Gate check: if MCP not configured and skill requires it, redirect to setup
-        if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured():
+        if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured(host):
             _emit_context("""<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -16,7 +16,11 @@ import json
 from pathlib import Path
 import re
 import sys
-import tomllib
+
+try:
+    from tomllib import loads as _toml_loads
+except ModuleNotFoundError:  # Python 3.10 hook hosts
+    _toml_loads = None
 
 
 def _configure_utf8_stdio() -> None:
@@ -156,6 +160,25 @@ KEYWORD_MAP = [
 ]
 
 
+def _codex_mcp_configured(config_text: str) -> bool:
+    if _toml_loads is not None:
+        codex_config = _toml_loads(config_text)
+        mcp_servers = codex_config.get("mcp_servers")
+        return isinstance(mcp_servers, dict) and isinstance(mcp_servers.get("ouroboros"), dict)
+
+    in_ouroboros_section = False
+    for raw_line in config_text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("["):
+            in_ouroboros_section = line == "[mcp_servers.ouroboros]"
+            continue
+        if in_ouroboros_section and re.match(r"^(command|url)\s*=\s*.+$", line):
+            return True
+    return False
+
+
 def is_mcp_configured() -> bool:
     """Check if the Ouroboros MCP server is registered for Claude or Codex."""
     try:
@@ -166,9 +189,7 @@ def is_mcp_configured() -> bool:
         codex_path = Path.home() / ".codex" / "config.toml"
         if not codex_path.exists():
             return False
-        codex_config = tomllib.loads(codex_path.read_text())
-        mcp_servers = codex_config.get("mcp_servers")
-        return isinstance(mcp_servers, dict) and isinstance(mcp_servers.get("ouroboros"), dict)
+        return _codex_mcp_configured(codex_path.read_text())
     except Exception:
         return False
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -8,8 +8,8 @@ IMPORTANT: If MCP is not configured (ooo setup not run),
 ALL ooo commands (except setup/help) redirect to setup first.
 
 Hook: UserPromptSubmit
-Input: User prompt text via stdin (piped by Claude Code)
-Output: Modified prompt with skill suggestion appended
+Input: JSON hook payload via stdin, with raw prompt text supported as a fallback
+Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
@@ -275,26 +275,52 @@ def detect_keywords(text: str) -> dict:
     return {"detected": False, "keyword": None, "suggested_skill": None}
 
 
-def main() -> None:
-    # Read user prompt from stdin
+def _extract_prompt(hook_input: str) -> str:
+    """Extract prompt text from a hook payload, falling back to raw stdin."""
     try:
-        user_input = sys.stdin.read().strip()
+        payload = json.loads(hook_input)
+    except ValueError:
+        return hook_input
+
+    if isinstance(payload, dict):
+        return str(payload.get("prompt") or "")
+    return hook_input
+
+
+def _emit_context(context: str) -> None:
+    """Emit a UserPromptSubmit response understood by Claude Code and Codex."""
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> None:
+    # Read the hook payload from stdin. Older integrations may still pipe raw text.
+    try:
+        hook_input = sys.stdin.read().strip()
     except Exception:
-        user_input = ""
+        hook_input = ""
+
+    user_input = _extract_prompt(hook_input)
 
     result = detect_keywords(user_input)
 
-    # First-time user: append welcome suggestion to their first message
+    # First-time user: add welcome context to their first message.
     if not result["detected"] and is_first_time():
         skill_name = "welcome"
-        print(f"""{user_input}
-
-<skill-suggestion>
+        _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS (use AskUserQuestion to let user choose):
 - /ouroboros:{skill_name} - First time using Ouroboros! Starting welcome experience.
 IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confirm or skip.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         return
 
     if result["detected"]:
@@ -303,25 +329,16 @@ IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confir
 
         # Gate check: if MCP not configured and skill requires it, redirect to setup
         if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured():
-            print(f"""{user_input}
-
-<skill-suggestion>
+            _emit_context("""<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         else:
             skill_name = skill.replace("/ouroboros:", "")
-            print(f"""{user_input}
-
-<skill-suggestion>
+            _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS:
 - /ouroboros:{skill_name} - Detected "{keyword}"
-</skill-suggestion>
-""")
-    else:
-        # Pass through unchanged when no keyword detected
-        print(user_input)
+</skill-suggestion>""")
 
 
 if __name__ == "__main__":

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -279,7 +279,7 @@ def _extract_prompt(hook_input: str) -> str:
     """Extract prompt text from a hook payload, falling back to raw stdin."""
     try:
         payload = json.loads(hook_input)
-    except ValueError:
+    except (ValueError, RecursionError):
         return hook_input
 
     if (

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -282,7 +282,11 @@ def _extract_prompt(hook_input: str) -> str:
     except ValueError:
         return hook_input
 
-    if isinstance(payload, dict):
+    if (
+        isinstance(payload, dict)
+        and payload.get("hook_event_name") == "UserPromptSubmit"
+        and "prompt" in payload
+    ):
         return str(payload.get("prompt") or "")
     return hook_input
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -169,6 +169,25 @@ def _usable_mcp_transport(server: object) -> bool:
     )
 
 
+def _strip_toml_comment(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(line):
+        if quote is not None:
+            if quote == '"' and character == "\\" and not escaped:
+                escaped = True
+                continue
+            if character == quote and not escaped:
+                quote = None
+            escaped = False
+            continue
+        if character == "#":
+            return line[:index]
+        if character in ('"', "'"):
+            quote = character
+    return line
+
+
 def _fallback_codex_mcp_configured(config_text: str) -> bool:
     in_ouroboros_section = False
     section_count = 0
@@ -182,6 +201,7 @@ def _fallback_codex_mcp_configured(config_text: str) -> bool:
             if line.count(multiline_delimiter) % 2 == 1:
                 multiline_delimiter = None
             continue
+        line = _strip_toml_comment(raw_line).strip()
         for delimiter in ('"""', "'''"):
             if line.count(delimiter) % 2 == 1:
                 multiline_delimiter = delimiter

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -13,15 +13,10 @@ Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
-import os
 from pathlib import Path
 import re
+import subprocess
 import sys
-
-try:
-    from tomllib import loads as _toml_loads
-except ModuleNotFoundError:  # Python 3.10 hook hosts
-    _toml_loads = None
 
 
 def _configure_utf8_stdio() -> None:
@@ -169,81 +164,20 @@ def _usable_mcp_transport(server: object) -> bool:
     )
 
 
-def _strip_toml_comment(line: str) -> str:
-    quote: str | None = None
-    escaped = False
-    for index, character in enumerate(line):
-        if quote is not None:
-            if quote == '"' and character == "\\" and not escaped:
-                escaped = True
-                continue
-            if character == quote and not escaped:
-                quote = None
-            escaped = False
-            continue
-        if character == "#":
-            return line[:index]
-        if character in ('"', "'"):
-            quote = character
-    return line
-
-
-def _fallback_codex_mcp_configured(config_text: str) -> bool:
-    in_ouroboros_section = False
-    section_count = 0
-    transport_found = False
-    enabled = True
-    multiline_delimiter: str | None = None
-
-    for raw_line in config_text.splitlines():
-        line = raw_line.strip()
-        if multiline_delimiter is not None:
-            if line.count(multiline_delimiter) % 2 == 1:
-                multiline_delimiter = None
-            continue
-        line = _strip_toml_comment(raw_line).strip()
-        for delimiter in ('"""', "'''"):
-            if line.count(delimiter) % 2 == 1:
-                multiline_delimiter = delimiter
-                line = line.split(delimiter, 1)[0].strip()
-                break
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("["):
-            if line in ("[mcp_servers.ouroboros]", '[mcp_servers."ouroboros"]'):
-                section_count += 1
-                in_ouroboros_section = True
-            else:
-                in_ouroboros_section = False
-            continue
-        if not in_ouroboros_section:
-            continue
-        match = re.fullmatch(r"(command|url|enabled)\s*=\s*(.+)", line)
-        if match is None:
-            continue
-        key, raw_value = match.groups()
-        raw_value = raw_value.strip()
-        if key == "enabled":
-            enabled = raw_value.split("#", 1)[0].strip() == "true"
-        elif (
-            len(raw_value) >= 2
-            and raw_value[0] == raw_value[-1]
-            and raw_value[0] in ('"', "'")
-            and bool(raw_value[1:-1].strip())
-        ):
-            transport_found = True
-
-    return section_count == 1 and enabled and transport_found
-
-
-def _codex_mcp_configured(config_text: str) -> bool:
-    if _toml_loads is not None:
-        codex_config = _toml_loads(config_text)
-        mcp_servers = codex_config.get("mcp_servers")
-        if not isinstance(mcp_servers, dict):
-            return False
-        return _usable_mcp_transport(mcp_servers.get("ouroboros"))
-    return _fallback_codex_mcp_configured(config_text)
+def _codex_mcp_configured() -> bool:
+    result = subprocess.run(
+        ["codex", "mcp", "get", "ouroboros", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=3,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    server = json.loads(result.stdout)
+    if not isinstance(server, dict) or server.get("enabled") is not True:
+        return False
+    return _usable_mcp_transport(server.get("transport"))
 
 
 def _claude_mcp_configured(config_text: str) -> bool:
@@ -261,14 +195,14 @@ def is_mcp_configured(host: str | None = None) -> bool:
     try:
         if host in (None, "claude"):
             claude_path = Path.home() / ".claude" / "mcp.json"
-            if claude_path.exists() and _claude_mcp_configured(claude_path.read_text()):
+            if claude_path.exists() and _claude_mcp_configured(
+                claude_path.read_text(encoding="utf-8")
+            ):
                 return True
             if host == "claude":
                 return False
 
-        codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
-        codex_path = codex_home / "config.toml"
-        return codex_path.exists() and _codex_mcp_configured(codex_path.read_text())
+        return _codex_mcp_configured()
     except Exception:
         return False
 

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -13,6 +13,7 @@ Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
+import os
 from pathlib import Path
 import re
 import subprocess
@@ -164,6 +165,16 @@ def _usable_mcp_transport(server: object) -> bool:
     )
 
 
+def _codex_subprocess_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    codex_home = environment.get("CODEX_HOME", "").strip()
+    if codex_home:
+        environment["CODEX_HOME"] = str(Path(codex_home).expanduser())
+    else:
+        environment.pop("CODEX_HOME", None)
+    return environment
+
+
 def _codex_mcp_configured() -> bool:
     result = subprocess.run(
         ["codex", "mcp", "get", "ouroboros", "--json"],
@@ -171,6 +182,7 @@ def _codex_mcp_configured() -> bool:
         text=True,
         timeout=3,
         check=False,
+        env=_codex_subprocess_environment(),
     )
     if result.returncode != 0:
         return False

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -13,10 +13,8 @@ Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
-import os
 from pathlib import Path
 import re
-import subprocess
 import sys
 
 
@@ -165,33 +163,6 @@ def _usable_mcp_transport(server: object) -> bool:
     )
 
 
-def _codex_subprocess_environment() -> dict[str, str]:
-    environment = os.environ.copy()
-    codex_home = environment.get("CODEX_HOME", "").strip()
-    if codex_home:
-        environment["CODEX_HOME"] = str(Path(codex_home).expanduser())
-    else:
-        environment.pop("CODEX_HOME", None)
-    return environment
-
-
-def _codex_mcp_configured() -> bool:
-    result = subprocess.run(
-        ["codex", "mcp", "get", "ouroboros", "--json"],
-        capture_output=True,
-        text=True,
-        timeout=3,
-        check=False,
-        env=_codex_subprocess_environment(),
-    )
-    if result.returncode != 0:
-        return False
-    server = json.loads(result.stdout)
-    if not isinstance(server, dict) or server.get("enabled") is not True:
-        return False
-    return _usable_mcp_transport(server.get("transport"))
-
-
 def _claude_mcp_configured(config_text: str) -> bool:
     claude_config = json.loads(config_text)
     if not isinstance(claude_config, dict):
@@ -203,18 +174,14 @@ def _claude_mcp_configured(config_text: str) -> bool:
 
 
 def is_mcp_configured(host: str | None = None) -> bool:
-    """Check the active host's Ouroboros MCP registration."""
+    """Check the legacy Claude host's Ouroboros MCP registration."""
+    if host not in (None, "claude"):
+        return False
     try:
-        if host in (None, "claude"):
-            claude_path = Path.home() / ".claude" / "mcp.json"
-            if claude_path.exists() and _claude_mcp_configured(
-                claude_path.read_text(encoding="utf-8")
-            ):
-                return True
-            if host == "claude":
-                return False
-
-        return _codex_mcp_configured()
+        claude_path = Path.home() / ".claude" / "mcp.json"
+        return claude_path.exists() and _claude_mcp_configured(
+            claude_path.read_text(encoding="utf-8")
+        )
     except Exception:
         return False
 
@@ -333,7 +300,7 @@ def _extract_prompt_and_host(hook_input: str) -> tuple[str, str | None]:
     try:
         payload = json.loads(hook_input)
     except (ValueError, RecursionError):
-        return hook_input, None
+        return hook_input, "claude"
 
     if (
         isinstance(payload, dict)
@@ -343,7 +310,7 @@ def _extract_prompt_and_host(hook_input: str) -> tuple[str, str | None]:
     ):
         host = "codex" if isinstance(payload.get("turn_id"), str) else "claude"
         return payload["prompt"], host
-    return hook_input, None
+    return hook_input, "claude"
 
 
 def _extract_prompt(hook_input: str) -> str:
@@ -391,8 +358,11 @@ IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confir
         skill = result["suggested_skill"]
         keyword = result["keyword"]
 
-        # Gate check: if MCP not configured and skill requires it, redirect to setup
-        if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured(host):
+        # Codex hook payloads do not expose the parent session's --profile/-c
+        # layers. Reconstructing state in a child CLI can contradict the active
+        # session, so only the legacy Claude path applies the setup gate.
+        needs_setup = host != "codex" and not is_mcp_configured("claude")
+        if skill not in SETUP_BYPASS_SKILLS and needs_setup:
             _emit_context("""<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -319,7 +319,9 @@ def configured_default_model(backend: str) -> str | None:
         if capability.name == "codex":
             import tomllib
 
-            config_path = Path.home() / ".codex" / "config.toml"
+            from ouroboros.cli.commands.mcp_doctor import _codex_home_from_env
+
+            config_path = _codex_home_from_env().absolute() / "config.toml"
             if not config_path.exists():
                 return None
             data = tomllib.loads(config_path.read_text())

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -242,10 +242,10 @@ _CODEX_BACKENDS = frozenset({"codex", "codex_cli"})
 
 
 def _codex_home_from_env() -> Path:
-    """Return the Codex home directory implied by the current environment."""
+    """Return CODEX_HOME using the same literal path semantics as Codex CLI."""
     codex_home = os.environ.get("CODEX_HOME", "").strip()
     if codex_home:
-        return Path(codex_home).expanduser()
+        return Path(codex_home)
     return Path.home() / ".codex"
 
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -720,7 +720,7 @@ def _active_codex_home() -> Path:
     """Resolve the one Codex home used by every setup artifact."""
     from .mcp_doctor import _codex_home_from_env
 
-    return _codex_home_from_env()
+    return _codex_home_from_env().absolute()
 
 
 def _register_codex_mcp_server(*, mode: CodexMcpMode = "auto") -> None:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -716,17 +716,22 @@ def _codex_uses_profile_v2(codex_path: str | None = None) -> bool:
     return False
 
 
+def _active_codex_home() -> Path:
+    """Resolve the one Codex home used by every setup artifact."""
+    from .mcp_doctor import _codex_home_from_env
+
+    return _codex_home_from_env()
+
+
 def _register_codex_mcp_server(*, mode: CodexMcpMode = "auto") -> None:
     """Register the Ouroboros MCP/env hookup in the active Codex home."""
     import tomllib
-
-    from .mcp_doctor import _codex_home_from_env
 
     if mode == "preserve":
         print_info("Preserved Codex MCP config.")
         return
 
-    codex_config = _codex_home_from_env() / "config.toml"
+    codex_config = _active_codex_home() / "config.toml"
     codex_config.parent.mkdir(parents=True, exist_ok=True)
 
     if codex_config.exists():
@@ -936,7 +941,7 @@ def _register_codex_default_profiles(*, codex_path: str | None = None) -> None:
     """Register default Codex profile anchors for Ouroboros task profiles."""
     import tomllib
 
-    codex_config = Path.home() / ".codex" / "config.toml"
+    codex_config = _active_codex_home() / "config.toml"
     codex_config.parent.mkdir(parents=True, exist_ok=True)
     raw = codex_config.read_text(encoding="utf-8") if codex_config.exists() else ""
 
@@ -999,10 +1004,10 @@ def _register_codex_default_profiles(*, codex_path: str | None = None) -> None:
 
 
 def _register_codex_worker_profile(*, codex_path: str | None = None) -> None:
-    """Register the managed Codex worker profile in ~/.codex/config.toml."""
+    """Register the managed Codex worker profile in the active Codex home."""
     import tomllib
 
-    codex_config = Path.home() / ".codex" / "config.toml"
+    codex_config = _active_codex_home() / "config.toml"
     codex_config.parent.mkdir(parents=True, exist_ok=True)
 
     if codex_config.exists():
@@ -1176,16 +1181,19 @@ def _install_codex_default_llm_profiles(
 def _print_codex_config_guidance(config_path: Path) -> None:
     """Explain where Codex users should configure Ouroboros vs. Codex settings."""
     print_info(f"Configure Ouroboros runtime and per-role model overrides in {config_path}.")
+    codex_home = _active_codex_home()
     print_info(
-        "Use ~/.codex/config.toml for the Codex MCP/env hookup. Codex profile-v2 anchors live in ~/.codex/<profile>.config.toml on current Codex CLI releases."
+        f"Use {codex_home / 'config.toml'} for the Codex MCP/env hookup. "
+        f"Codex profile-v2 anchors live in {codex_home}/<profile>.config.toml "
+        "on current Codex CLI releases."
     )
 
 
 def _install_codex_artifacts() -> None:
-    """Install packaged Ouroboros rules and skills into ~/.codex/."""
+    """Install packaged Ouroboros rules and skills into the active Codex home."""
     from ouroboros.codex import install_codex_artifacts
 
-    codex_dir = Path.home() / ".codex"
+    codex_dir = _active_codex_home()
 
     try:
         result = install_codex_artifacts(codex_dir=codex_dir, prune=True)
@@ -1246,10 +1254,10 @@ def _setup_codex(codex_path: str, *, mcp_mode: CodexMcpMode = "auto") -> None:
             f"Installed Ouroboros role profile defaults for {len(added_role_profiles)} roles."
         )
 
-    # Install Codex-native rules and skills into ~/.codex/
+    # Install Codex-native rules and skills into the active Codex home.
     _install_codex_artifacts()
 
-    # Register MCP server in Codex config (~/.codex/config.toml)
+    # Register MCP server and profiles in the active Codex home.
     _register_codex_mcp_server(mode=mcp_mode)
     _register_codex_default_profiles(codex_path=codex_path)
     _register_codex_worker_profile(codex_path=codex_path)
@@ -3330,7 +3338,7 @@ def refresh_artifacts() -> None:
 
     refreshed: list[str] = []
 
-    codex_dir = Path.home() / ".codex"
+    codex_dir = _active_codex_home()
     if codex_dir.exists() or shutil.which("codex"):
         from ouroboros.codex import install_codex_artifacts
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -717,14 +717,16 @@ def _codex_uses_profile_v2(codex_path: str | None = None) -> bool:
 
 
 def _register_codex_mcp_server(*, mode: CodexMcpMode = "auto") -> None:
-    """Register the Ouroboros MCP/env hookup in ~/.codex/config.toml."""
+    """Register the Ouroboros MCP/env hookup in the active Codex home."""
     import tomllib
+
+    from .mcp_doctor import _codex_home_from_env
 
     if mode == "preserve":
         print_info("Preserved Codex MCP config.")
         return
 
-    codex_config = Path.home() / ".codex" / "config.toml"
+    codex_config = _codex_home_from_env() / "config.toml"
     codex_config.parent.mkdir(parents=True, exist_ok=True)
 
     if codex_config.exists():

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -58,6 +58,15 @@ def _managed_codex_profile_names() -> set[str]:
     return {*_CODEX_DEFAULT_PROFILE_SECTIONS, _CODEX_WORKER_PROFILE_NAME}
 
 
+def _is_managed_codex_header(header: str) -> bool:
+    if header == "[mcp_servers.ouroboros]" or header.startswith("[mcp_servers.ouroboros."):
+        return True
+    return any(
+        header == f"[profiles.{name}]" or header.startswith(f"[profiles.{name}.")
+        for name in _managed_codex_profile_names()
+    )
+
+
 def _remove_claude_mcp(dry_run: bool) -> bool:
     """Remove ouroboros entry from ~/.claude/mcp.json."""
     mcp_path = Path.home() / ".claude" / "mcp.json"
@@ -99,20 +108,7 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
         print_warning(f"{codex_config} is unreadable — skipping.")
         return False
 
-    managed_profile_headers = {f"[profiles.{name}]" for name in _managed_codex_profile_names()}
-    managed_profile_prefixes = tuple(
-        f"[profiles.{name}." for name in _managed_codex_profile_names()
-    )
-
-    def is_managed_header(header: str) -> bool:
-        return (
-            header == "[mcp_servers.ouroboros]"
-            or header.startswith("[mcp_servers.ouroboros.")
-            or header in managed_profile_headers
-            or header.startswith(managed_profile_prefixes)
-        )
-
-    if not any(is_managed_header(line.strip()) for line in raw.splitlines()):
+    if not any(_is_managed_codex_header(line.strip()) for line in raw.splitlines()):
         return False
 
     if dry_run:
@@ -134,7 +130,7 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
             continue
         in_comment_block = False
 
-        if is_managed_header(stripped):
+        if _is_managed_codex_header(stripped):
             skip = True
             continue
         if skip:
@@ -481,12 +477,7 @@ def uninstall(
     try:
         if codex_config.exists():
             codex_text = codex_config.read_text()
-            managed_profile_headers = {
-                f"[profiles.{name}]" for name in _managed_codex_profile_names()
-            }
-            if "[mcp_servers.ouroboros]" in codex_text or any(
-                header in codex_text for header in managed_profile_headers
-            ):
+            if any(_is_managed_codex_header(line.strip()) for line in codex_text.splitlines()):
                 targets.append(f"Codex MCP/profile config ({codex_config})")
     except OSError:
         targets.append(f"Codex MCP/profile config ({codex_config} — may be unreadable)")

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -98,13 +98,18 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
     except OSError:
         print_warning(f"{codex_config} is unreadable — skipping.")
         return False
+
     managed_profile_headers = {f"[profiles.{name}]" for name in _managed_codex_profile_names()}
+    managed_profile_prefixes = tuple(
+        f"[profiles.{name}." for name in _managed_codex_profile_names()
+    )
 
     def is_managed_header(header: str) -> bool:
         return (
             header == "[mcp_servers.ouroboros]"
             or header.startswith("[mcp_servers.ouroboros.")
             or header in managed_profile_headers
+            or header.startswith(managed_profile_prefixes)
         )
 
     if not any(is_managed_header(line.strip()) for line in raw.splitlines()):
@@ -579,16 +584,16 @@ def uninstall(
             failed.append("~/.claude/mcp.json")
 
     if not _remove_codex_mcp(dry_run=False):
-        if any("codex/config.toml" in t for t in targets):
-            failed.append("~/.codex/config.toml")
+        if any(t.startswith("Codex MCP/profile config (") for t in targets):
+            failed.append(str(codex_config))
 
     if not _remove_opencode_mcp(dry_run=False):
         if any("OpenCode MCP" in t for t in targets):
             failed.append("OpenCode MCP config")
 
     if not _remove_codex_artifacts(dry_run=False):
-        if any("Codex rules" in t for t in targets):
-            failed.append("~/.codex/ rules/skills")
+        if any(t.startswith("Codex profiles, rules, and skills (") for t in targets):
+            failed.append(f"{codex_dir} profiles/rules/skills")
 
     if not _remove_claude_md_block(cwd, dry_run=False):
         if any("CLAUDE.md" in t for t in targets):

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -46,6 +46,18 @@ app = typer.Typer(
 # Failures are reported via print_warning — never raise.
 
 
+def _active_codex_home() -> Path:
+    from .mcp_doctor import _codex_home_from_env
+
+    return _codex_home_from_env().absolute()
+
+
+def _managed_codex_profile_names() -> set[str]:
+    from .setup import _CODEX_DEFAULT_PROFILE_SECTIONS, _CODEX_WORKER_PROFILE_NAME
+
+    return {*_CODEX_DEFAULT_PROFILE_SECTIONS, _CODEX_WORKER_PROFILE_NAME}
+
+
 def _remove_claude_mcp(dry_run: bool) -> bool:
     """Remove ouroboros entry from ~/.claude/mcp.json."""
     mcp_path = Path.home() / ".claude" / "mcp.json"
@@ -76,21 +88,30 @@ def _remove_claude_mcp(dry_run: bool) -> bool:
 
 
 def _remove_codex_mcp(dry_run: bool) -> bool:
-    """Remove ouroboros MCP section from ~/.codex/config.toml."""
-    codex_config = Path.home() / ".codex" / "config.toml"
+    """Remove the Ouroboros MCP section from the active Codex home."""
+    codex_config = _active_codex_home() / "config.toml"
     if not codex_config.exists():
         return False
 
     try:
         raw = codex_config.read_text()
     except OSError:
-        print_warning("~/.codex/config.toml is unreadable — skipping.")
+        print_warning(f"{codex_config} is unreadable — skipping.")
         return False
-    if "[mcp_servers.ouroboros]" not in raw:
+    managed_profile_headers = {f"[profiles.{name}]" for name in _managed_codex_profile_names()}
+
+    def is_managed_header(header: str) -> bool:
+        return (
+            header == "[mcp_servers.ouroboros]"
+            or header.startswith("[mcp_servers.ouroboros.")
+            or header in managed_profile_headers
+        )
+
+    if not any(is_managed_header(line.strip()) for line in raw.splitlines()):
         return False
 
     if dry_run:
-        print_info("[dry-run] Would remove ouroboros from ~/.codex/config.toml")
+        print_info(f"[dry-run] Would remove ouroboros from {codex_config}")
         return True
 
     lines = raw.splitlines()
@@ -108,7 +129,7 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
             continue
         in_comment_block = False
 
-        if stripped == "[mcp_servers.ouroboros]" or stripped.startswith("[mcp_servers.ouroboros."):
+        if is_managed_header(stripped):
             skip = True
             continue
         if skip:
@@ -129,9 +150,9 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
     try:
         codex_config.write_text(cleaned)
     except OSError:
-        print_warning("Could not write ~/.codex/config.toml — skipping.")
+        print_warning(f"Could not write {codex_config} — skipping.")
         return False
-    print_success("Removed ouroboros from ~/.codex/config.toml")
+    print_success(f"Removed ouroboros from {codex_config}")
     return True
 
 
@@ -141,14 +162,22 @@ def _remove_codex_artifacts(dry_run: bool) -> bool:
     Returns True only if ALL existing artifacts were removed successfully.
     Returns False if any artifact could not be removed.
     """
-    codex_dir = Path.home() / ".codex"
+    codex_dir = _active_codex_home()
     try:
         with resolve_packaged_codex_assets() as assets:
             managed_relative_paths = set(assets.managed_relative_install_paths)
     except FileNotFoundError:
         managed_relative_paths = {Path("rules") / CODEX_RULE_FILENAME}
     managed_relative_paths.add(Path("skills") / "ouroboros")  # legacy setup path
+    managed_relative_paths.update(
+        Path(f"{name}.config.toml") for name in _managed_codex_profile_names()
+    )
 
+    profile_paths = [
+        codex_dir / relative_path
+        for relative_path in managed_relative_paths
+        if len(relative_path.parts) == 1 and (codex_dir / relative_path).exists()
+    ]
     rule_paths = [
         codex_dir / relative_path
         for relative_path in managed_relative_paths
@@ -161,6 +190,18 @@ def _remove_codex_artifacts(dry_run: bool) -> bool:
     ]
     had_work = False
     all_ok = True
+
+    for profile_path in profile_paths:
+        had_work = True
+        if dry_run:
+            print_info(f"[dry-run] Would remove {profile_path}")
+        else:
+            try:
+                profile_path.unlink()
+                print_success(f"Removed {profile_path}")
+            except OSError:
+                print_warning(f"Could not remove {profile_path} — skipping.")
+                all_ok = False
 
     for rules_path in rule_paths:
         had_work = True
@@ -431,12 +472,19 @@ def uninstall(
         except (json.JSONDecodeError, OSError):
             targets.append("MCP server registration (~/.claude/mcp.json — may be malformed)")
 
-    codex_config = Path.home() / ".codex" / "config.toml"
+    codex_config = _active_codex_home() / "config.toml"
     try:
-        if codex_config.exists() and "[mcp_servers.ouroboros]" in codex_config.read_text():
-            targets.append("Codex MCP config (~/.codex/config.toml)")
+        if codex_config.exists():
+            codex_text = codex_config.read_text()
+            managed_profile_headers = {
+                f"[profiles.{name}]" for name in _managed_codex_profile_names()
+            }
+            if "[mcp_servers.ouroboros]" in codex_text or any(
+                header in codex_text for header in managed_profile_headers
+            ):
+                targets.append(f"Codex MCP/profile config ({codex_config})")
     except OSError:
-        targets.append("Codex MCP config (~/.codex/config.toml — may be unreadable)")
+        targets.append(f"Codex MCP/profile config ({codex_config} — may be unreadable)")
 
     opencode_config = _find_opencode_config()
     try:
@@ -447,15 +495,18 @@ def uninstall(
     except (json.JSONDecodeError, OSError):
         targets.append(f"OpenCode MCP config ({opencode_config} — may be malformed)")
 
-    codex_dir = Path.home() / ".codex"
+    codex_dir = _active_codex_home()
     try:
         with resolve_packaged_codex_assets() as assets:
             managed_relative_paths = set(assets.managed_relative_install_paths)
     except FileNotFoundError:
         managed_relative_paths = {Path("rules") / CODEX_RULE_FILENAME}
     managed_relative_paths.add(Path("skills") / "ouroboros")
+    managed_relative_paths.update(
+        Path(f"{name}.config.toml") for name in _managed_codex_profile_names()
+    )
     if any((codex_dir / relative_path).exists() for relative_path in managed_relative_paths):
-        targets.append("Codex rules and skills (~/.codex/)")
+        targets.append(f"Codex profiles, rules, and skills ({codex_dir})")
 
     cwd = Path.cwd()
     claude_md = cwd / "CLAUDE.md"

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -205,6 +205,16 @@ def test_configured_default_model_codex(monkeypatch, tmp_path) -> None:
     assert mc.configured_default_model("codex") == "gpt-9-codex"
 
 
+def test_configured_default_model_codex_honors_literal_custom_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", "~/custom-codex")
+    config_path = tmp_path / "~" / "custom-codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text('model = "gpt-9-custom"\n')
+
+    assert mc.configured_default_model("codex") == "gpt-9-custom"
+
+
 def test_configured_default_model_missing_file(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(mc.Path, "home", classmethod(lambda _cls: tmp_path))
     assert mc.configured_default_model("hermes") is None

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -18,6 +18,7 @@ from typer.testing import CliRunner
 
 from ouroboros.cli.commands.mcp_doctor import (
     CheckResult,
+    _codex_home_from_env,
     check_claude_agent_sdk_import,
     check_codex_oauth_auth,
     check_event_store,
@@ -306,6 +307,11 @@ class TestCheckLitellmImport:
 
 
 class TestCheckCodexOauthAuth:
+    def test_codex_home_preserves_literal_path_semantics(self, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", "~/custom-codex")
+
+        assert _codex_home_from_env() == Path("~/custom-codex")
+
     def test_passes_when_codex_auth_json_exists_without_openai_key(self, tmp_path, monkeypatch):
         codex_home = tmp_path / "codex-home"
         codex_home.mkdir()

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -83,10 +83,13 @@ class TestCodexSetup:
         assert 'command = "uvx"' in contents
         assert 'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]' in contents
 
-    def test_register_codex_mcp_server_honors_codex_home(self, tmp_path: Path) -> None:
+    def test_register_codex_mcp_server_honors_codex_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         default_home = tmp_path / "home"
         default_home.mkdir()
-        codex_home = default_home / "custom-codex"
+        monkeypatch.chdir(tmp_path)
+        codex_home = tmp_path / "~" / "custom-codex"
 
         with (
             patch("pathlib.Path.home", return_value=default_home),

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -82,6 +82,25 @@ class TestCodexSetup:
         assert 'command = "uvx"' in contents
         assert 'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]' in contents
 
+    def test_register_codex_mcp_server_honors_codex_home(self, tmp_path: Path) -> None:
+        default_home = tmp_path / "home"
+        default_home.mkdir()
+        codex_home = tmp_path / "custom-codex"
+
+        with (
+            patch("pathlib.Path.home", return_value=default_home),
+            patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=True),
+            patch(
+                "ouroboros.cli.commands.setup._is_source_tree_ouroboros_build",
+                return_value=False,
+            ),
+            patch("ouroboros.cli.commands.setup.importlib_metadata.version", return_value="0.38.2"),
+        ):
+            setup_cmd._register_codex_mcp_server()
+
+        assert (codex_home / "config.toml").exists()
+        assert not (default_home / ".codex" / "config.toml").exists()
+
     def test_register_codex_mcp_server_uses_direct_executable_for_dev_build(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -85,11 +85,15 @@ class TestCodexSetup:
     def test_register_codex_mcp_server_honors_codex_home(self, tmp_path: Path) -> None:
         default_home = tmp_path / "home"
         default_home.mkdir()
-        codex_home = tmp_path / "custom-codex"
+        codex_home = default_home / "custom-codex"
 
         with (
             patch("pathlib.Path.home", return_value=default_home),
-            patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=True),
+            patch.dict(
+                os.environ,
+                {"HOME": str(default_home), "CODEX_HOME": "~/custom-codex"},
+                clear=True,
+            ),
             patch(
                 "ouroboros.cli.commands.setup._is_source_tree_ouroboros_build",
                 return_value=False,

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -99,10 +100,26 @@ class TestCodexSetup:
                 return_value=False,
             ),
             patch("ouroboros.cli.commands.setup.importlib_metadata.version", return_value="0.38.2"),
+            patch(
+                "ouroboros.codex.install_codex_artifacts",
+                return_value=SimpleNamespace(
+                    rules_path=codex_home / "AGENTS.md",
+                    skill_paths=[codex_home / "skills" / "ouroboros"],
+                ),
+            ) as install_artifacts,
         ):
             setup_cmd._register_codex_mcp_server()
+            setup_cmd._register_codex_default_profiles()
+            setup_cmd._register_codex_worker_profile()
+            setup_cmd._install_codex_artifacts()
 
-        assert (codex_home / "config.toml").exists()
+        config_path = codex_home / "config.toml"
+        assert config_path.exists()
+        contents = config_path.read_text(encoding="utf-8")
+        assert "[mcp_servers.ouroboros]" in contents
+        assert "[profiles.ouroboros-fast]" in contents
+        assert "[profiles.ouroboros-worker]" in contents
+        install_artifacts.assert_called_once_with(codex_dir=codex_home, prune=True)
         assert not (default_home / ".codex" / "config.toml").exists()
 
     def test_register_codex_mcp_server_uses_direct_executable_for_dev_build(

--- a/tests/unit/cli/test_uninstall.py
+++ b/tests/unit/cli/test_uninstall.py
@@ -400,6 +400,34 @@ class TestUninstallCLI:
         assert result.exit_code == 0
         assert data_dir.exists()
 
+    def test_nested_only_custom_codex_profile_is_discovered_and_removed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        project_dir = tmp_path / "project"
+        codex_home = tmp_path / "active-codex"
+        home_dir.mkdir()
+        project_dir.mkdir()
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(
+            '[profiles.ouroboros-fast.model_provider]\nname = "custom"\n\n[other]\nfoo = 1\n'
+        )
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with (
+            patch("pathlib.Path.home", return_value=home_dir),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("ouroboros.cli.commands.uninstall._find_opencode_config", return_value=None),
+        ):
+            result = runner.invoke(app, ["--keep-data", "-y"])
+
+        assert result.exit_code == 0
+        assert "Ouroboros has been removed." in result.output
+        remaining = config_path.read_text()
+        assert "profiles.ouroboros-fast" not in remaining
+        assert "[other]" in remaining
+
     def test_custom_codex_config_failure_reports_partial_removal(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/unit/cli/test_uninstall.py
+++ b/tests/unit/cli/test_uninstall.py
@@ -112,6 +112,24 @@ class TestRemoveCodexMcp:
         assert "[other]" in content
         assert 'model = "gpt-5"' in content
 
+    def test_removes_mcp_from_literal_custom_codex_home(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CODEX_HOME", "~/custom-codex")
+        codex_config = tmp_path / "~" / "custom-codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n\n'
+            "[profiles.ouroboros-fast]\n"
+            'model_reasoning_effort = "low"\n\n'
+            "[other]\nfoo = 1\n"
+        )
+
+        assert _remove_codex_mcp(dry_run=False) is True
+        assert "[mcp_servers.ouroboros]" not in codex_config.read_text()
+        assert "[profiles.ouroboros-fast]" not in codex_config.read_text()
+        assert "[other]" in codex_config.read_text()
+
     def test_preserves_user_comments_outside_managed_block(self, tmp_path: Path) -> None:
         """User comments outside the ouroboros section are preserved."""
         codex_config = tmp_path / ".codex" / "config.toml"
@@ -221,6 +239,25 @@ class TestRemoveCodexArtifacts:
         assert not (skills_dir / "ouroboros-interview").exists()
         assert not (skills_dir / "ouroboros-run").exists()
         assert (skills_dir / "other").exists()
+
+    def test_removes_artifacts_from_literal_custom_codex_home(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CODEX_HOME", "~/custom-codex")
+        codex_dir = tmp_path / "~" / "custom-codex"
+        rules_path = codex_dir / "rules" / "ouroboros.md"
+        skill_path = codex_dir / "skills" / "ouroboros-status"
+        profile_path = codex_dir / "ouroboros-fast.config.toml"
+        rules_path.parent.mkdir(parents=True)
+        skill_path.mkdir(parents=True)
+        rules_path.write_text("rules", encoding="utf-8")
+        profile_path.write_text('model_reasoning_effort = "low"\n', encoding="utf-8")
+
+        assert _remove_codex_artifacts(dry_run=False) is True
+        assert not rules_path.exists()
+        assert not skill_path.exists()
+        assert not profile_path.exists()
 
 
 # ── _remove_claude_md_block ──────────────────────────────────────

--- a/tests/unit/cli/test_uninstall.py
+++ b/tests/unit/cli/test_uninstall.py
@@ -122,12 +122,15 @@ class TestRemoveCodexMcp:
             'command = "uvx"\n\n'
             "[profiles.ouroboros-fast]\n"
             'model_reasoning_effort = "low"\n\n'
+            "[profiles.ouroboros-fast.model_provider]\n"
+            'name = "custom"\n\n'
             "[other]\nfoo = 1\n"
         )
 
         assert _remove_codex_mcp(dry_run=False) is True
         assert "[mcp_servers.ouroboros]" not in codex_config.read_text()
         assert "[profiles.ouroboros-fast]" not in codex_config.read_text()
+        assert "[profiles.ouroboros-fast.model_provider]" not in codex_config.read_text()
         assert "[other]" in codex_config.read_text()
 
     def test_preserves_user_comments_outside_managed_block(self, tmp_path: Path) -> None:
@@ -396,6 +399,66 @@ class TestUninstallCLI:
 
         assert result.exit_code == 0
         assert data_dir.exists()
+
+    def test_custom_codex_config_failure_reports_partial_removal(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        project_dir = tmp_path / "project"
+        codex_home = tmp_path / "active-codex"
+        home_dir.mkdir()
+        project_dir.mkdir()
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with (
+            patch("pathlib.Path.home", return_value=home_dir),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("ouroboros.cli.commands.uninstall._find_opencode_config", return_value=None),
+            patch(
+                "ouroboros.cli.commands.uninstall._remove_codex_mcp",
+                return_value=False,
+            ) as remove_codex_mcp,
+        ):
+            result = runner.invoke(app, ["--keep-data", "-y"])
+
+        assert result.exit_code == 0
+        remove_codex_mcp.assert_called_once_with(dry_run=False)
+        assert config_path.exists()
+        assert "partially removed" in result.output
+        assert "Ouroboros has been removed." not in result.output
+
+    def test_custom_codex_artifact_failure_reports_partial_removal(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        project_dir = tmp_path / "project"
+        codex_home = tmp_path / "active-codex"
+        rules_path = codex_home / "rules" / "ouroboros.md"
+        home_dir.mkdir()
+        project_dir.mkdir()
+        rules_path.parent.mkdir(parents=True)
+        rules_path.write_text("rules")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with (
+            patch("pathlib.Path.home", return_value=home_dir),
+            patch("pathlib.Path.cwd", return_value=project_dir),
+            patch("ouroboros.cli.commands.uninstall._find_opencode_config", return_value=None),
+            patch(
+                "ouroboros.cli.commands.uninstall._remove_codex_artifacts",
+                return_value=False,
+            ) as remove_codex_artifacts,
+        ):
+            result = runner.invoke(app, ["--keep-data", "-y"])
+
+        assert result.exit_code == 0
+        remove_codex_artifacts.assert_called_once_with(dry_run=False)
+        assert rules_path.exists()
+        assert "partially removed" in result.output
+        assert "Ouroboros has been removed." not in result.output
 
 
 # ── _remove_opencode_bridge_plugin ──────────────────────────────

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -2,8 +2,8 @@
 
 import importlib.util
 import json
-import os
 from pathlib import Path
+import subprocess
 from unittest.mock import patch
 
 # Load keyword-detector.py as a module (it uses hyphens in filename)
@@ -20,99 +20,53 @@ is_mcp_configured = _mod.is_mcp_configured
 
 
 class TestMcpConfiguration:
-    def test_codex_only_registration_is_configured(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
-
-        with patch.object(_mod.Path, "home", return_value=tmp_path):
-            assert is_mcp_configured() is True
-
-    def test_codex_only_registration_uses_python_310_fallback(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text(
-            '[mcp_servers.ouroboros]\ncommand = "uvx"\nargs = ["ouroboros-ai"]\n'
+    @staticmethod
+    def _codex_result(*, enabled=True, transport=None, returncode=0, stdout=None):
+        payload = {
+            "name": "ouroboros",
+            "enabled": enabled,
+            "transport": transport or {"type": "stdio", "command": "uvx", "args": ["ouroboros"]},
+        }
+        return subprocess.CompletedProcess(
+            ["codex", "mcp", "get", "ouroboros", "--json"],
+            returncode,
+            stdout=json.dumps(payload) if stdout is None else stdout,
+            stderr="",
         )
 
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod, "_toml_loads", None),
-        ):
-            assert is_mcp_configured() is True
-
-    def test_python_310_fallback_rejects_header_without_transport(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\nargs = ["broken"]\n')
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod, "_toml_loads", None),
-        ):
-            assert is_mcp_configured() is False
-
-    def test_codex_home_is_authoritative(self, tmp_path):
-        default_home = tmp_path / "home"
-        default_home.mkdir()
-        codex_home = tmp_path / "custom-codex"
-        codex_home.mkdir()
-        (codex_home / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
-
-        with (
-            patch.object(_mod.Path, "home", return_value=default_home),
-            patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=True),
-        ):
+    def test_codex_uses_effective_cli_registration(self):
+        with patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run:
             assert is_mcp_configured("codex") is True
 
-    def test_disabled_or_transportless_codex_registration_is_not_configured(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        config_path = codex_dir / "config.toml"
+        run.assert_called_once_with(
+            ["codex", "mcp", "get", "ouroboros", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
 
-        with patch.object(_mod.Path, "home", return_value=tmp_path):
-            config_path.write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\nenabled = false\n')
+    def test_disabled_or_transportless_codex_registration_is_not_configured(self):
+        disabled = self._codex_result(enabled=False)
+        transportless = self._codex_result(transport={"type": "stdio", "args": ["ouroboros"]})
+
+        with patch.object(_mod.subprocess, "run", return_value=disabled):
+            assert is_mcp_configured("codex") is False
+        with patch.object(_mod.subprocess, "run", return_value=transportless):
             assert is_mcp_configured("codex") is False
 
-            config_path.write_text('[mcp_servers.ouroboros]\nargs = ["ouroboros-ai"]\n')
-            assert is_mcp_configured("codex") is False
-
-    def test_python_310_fallback_accepts_inline_comments(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text(
-            '[mcp_servers.ouroboros]\ncommand = "uvx" # normal comment\nenabled = true # active\n'
-        )
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod, "_toml_loads", None),
+    def test_missing_malformed_or_timed_out_codex_query_is_not_configured(self):
+        for result in (
+            self._codex_result(returncode=1),
+            self._codex_result(stdout="not json"),
         ):
-            assert is_mcp_configured("codex") is True
+            with patch.object(_mod.subprocess, "run", return_value=result):
+                assert is_mcp_configured("codex") is False
 
-    def test_python_310_fallback_ignores_triple_quote_in_comment(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text(
-            '# documentation mentions """ strings\n[mcp_servers.ouroboros]\ncommand = "uvx"\n'
-        )
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod, "_toml_loads", None),
-        ):
-            assert is_mcp_configured("codex") is True
-
-    def test_python_310_fallback_ignores_multiline_string_decoy(self, tmp_path):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text(
-            'notice = """\n[mcp_servers.ouroboros]\ncommand = "uvx"\n"""\n'
-        )
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod, "_toml_loads", None),
+        with patch.object(
+            _mod.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("codex", 3),
         ):
             assert is_mcp_configured("codex") is False
 
@@ -129,6 +83,7 @@ class TestMcpConfiguration:
 
         with (
             patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod.subprocess, "run", return_value=self._codex_result(returncode=1)),
             patch("sys.stdin") as mock_stdin,
         ):
             mock_stdin.read.return_value = json.dumps(payload)
@@ -139,9 +94,6 @@ class TestMcpConfiguration:
         assert "/ouroboros:status" not in context
 
     def test_claude_hook_does_not_use_codex_only_registration(self, tmp_path, capsys):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
         payload = {
             "session_id": "claude-session",
             "prompt": "ooo status",
@@ -150,19 +102,18 @@ class TestMcpConfiguration:
 
         with (
             patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run,
             patch("sys.stdin") as mock_stdin,
         ):
             mock_stdin.read.return_value = json.dumps(payload)
             main()
 
+        run.assert_not_called()
         context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:setup" in context
         assert "/ouroboros:status" not in context
 
     def test_codex_only_registration_routes_status_without_setup(self, tmp_path, capsys):
-        codex_dir = tmp_path / ".codex"
-        codex_dir.mkdir()
-        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
         payload = {
             "session_id": "test-session",
             "turn_id": "test-turn",
@@ -172,6 +123,7 @@ class TestMcpConfiguration:
 
         with (
             patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod.subprocess, "run", return_value=self._codex_result()),
             patch("sys.stdin") as mock_stdin,
         ):
             mock_stdin.read.return_value = json.dumps(payload)
@@ -185,7 +137,14 @@ class TestMcpConfiguration:
 class TestFirstTimePrefs:
     def test_missing_prefs_file_is_first_time(self, tmp_path):
         home = tmp_path
-        with patch.object(_mod.Path, "home", return_value=home):
+        with (
+            patch.object(_mod.Path, "home", return_value=home),
+            patch.object(
+                _mod.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess([], 1, stdout="", stderr=""),
+            ),
+        ):
             assert is_first_time() is True
 
     def test_welcome_completed_marks_not_first_time(self, tmp_path):
@@ -247,7 +206,14 @@ class TestFirstTimePrefs:
         # Regression guard for the discriminator: a truly empty home (no prefs,
         # no install artifacts, no MCP registration) is still a genuine first
         # run and SHOULD surface the welcome experience.
-        with patch.object(_mod.Path, "home", return_value=tmp_path):
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(
+                _mod.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess([], 1, stdout="", stderr=""),
+            ),
+        ):
             assert is_first_time() is True
 
     def test_malformed_prefs_stays_first_time_despite_install_markers(self, tmp_path):

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -2,9 +2,7 @@
 
 import importlib.util
 import json
-import os
 from pathlib import Path
-import subprocess
 from unittest.mock import patch
 
 # Load keyword-detector.py as a module (it uses hyphens in filename)
@@ -21,69 +19,19 @@ is_mcp_configured = _mod.is_mcp_configured
 
 
 class TestMcpConfiguration:
-    @staticmethod
-    def _codex_result(*, enabled=True, transport=None, returncode=0, stdout=None):
-        payload = {
-            "name": "ouroboros",
-            "enabled": enabled,
-            "transport": transport or {"type": "stdio", "command": "uvx", "args": ["ouroboros"]},
-        }
-        return subprocess.CompletedProcess(
-            ["codex", "mcp", "get", "ouroboros", "--json"],
-            returncode,
-            stdout=json.dumps(payload) if stdout is None else stdout,
-            stderr="",
-        )
-
-    def test_codex_uses_effective_cli_registration(self, tmp_path):
-        home = tmp_path / "home"
-        home.mkdir()
-        with (
-            patch.dict(
-                os.environ,
-                {"HOME": str(home), "CODEX_HOME": "~/custom-codex"},
-                clear=True,
-            ),
-            patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run,
-        ):
-            assert is_mcp_configured("codex") is True
-
-        call = run.call_args
-        assert call.args == (["codex", "mcp", "get", "ouroboros", "--json"],)
-        assert call.kwargs["env"]["CODEX_HOME"] == str(home / "custom-codex")
-        assert call.kwargs["capture_output"] is True
-        assert call.kwargs["text"] is True
-        assert call.kwargs["timeout"] == 3
-        assert call.kwargs["check"] is False
-
-    def test_disabled_or_transportless_codex_registration_is_not_configured(self):
-        disabled = self._codex_result(enabled=False)
-        transportless = self._codex_result(transport={"type": "stdio", "args": ["ouroboros"]})
-
-        with patch.object(_mod.subprocess, "run", return_value=disabled):
-            assert is_mcp_configured("codex") is False
-        with patch.object(_mod.subprocess, "run", return_value=transportless):
-            assert is_mcp_configured("codex") is False
-
-    def test_missing_malformed_or_timed_out_codex_query_is_not_configured(self):
-        for result in (
-            self._codex_result(returncode=1),
-            self._codex_result(stdout="not json"),
-        ):
-            with patch.object(_mod.subprocess, "run", return_value=result):
-                assert is_mcp_configured("codex") is False
-
-        with patch.object(
-            _mod.subprocess,
-            "run",
-            side_effect=subprocess.TimeoutExpired("codex", 3),
-        ):
-            assert is_mcp_configured("codex") is False
-
-    def test_codex_hook_does_not_use_claude_only_registration(self, tmp_path, capsys):
+    def test_claude_registration_requires_usable_transport(self, tmp_path):
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
-        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {"command": "uvx"}}}')
+        config_path = claude_dir / "mcp.json"
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            config_path.write_text('{"mcpServers": {"ouroboros": {}}}')
+            assert is_mcp_configured("claude") is False
+            config_path.write_text(
+                '{"mcpServers": {"ouroboros": {"command": "uvx"}}}', encoding="utf-8"
+            )
+            assert is_mcp_configured("claude") is True
+
+    def test_codex_hook_does_not_reconstruct_parent_configuration(self, tmp_path, capsys):
         payload = {
             "session_id": "codex-session",
             "turn_id": "codex-turn",
@@ -93,47 +41,6 @@ class TestMcpConfiguration:
 
         with (
             patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod.subprocess, "run", return_value=self._codex_result(returncode=1)),
-            patch("sys.stdin") as mock_stdin,
-        ):
-            mock_stdin.read.return_value = json.dumps(payload)
-            main()
-
-        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
-        assert "/ouroboros:setup" in context
-        assert "/ouroboros:status" not in context
-
-    def test_claude_hook_does_not_use_codex_only_registration(self, tmp_path, capsys):
-        payload = {
-            "session_id": "claude-session",
-            "prompt": "ooo status",
-            "hook_event_name": "UserPromptSubmit",
-        }
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run,
-            patch("sys.stdin") as mock_stdin,
-        ):
-            mock_stdin.read.return_value = json.dumps(payload)
-            main()
-
-        run.assert_not_called()
-        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
-        assert "/ouroboros:setup" in context
-        assert "/ouroboros:status" not in context
-
-    def test_codex_only_registration_routes_status_without_setup(self, tmp_path, capsys):
-        payload = {
-            "session_id": "test-session",
-            "turn_id": "test-turn",
-            "prompt": "ooo status",
-            "hook_event_name": "UserPromptSubmit",
-        }
-
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(_mod.subprocess, "run", return_value=self._codex_result()),
             patch("sys.stdin") as mock_stdin,
         ):
             mock_stdin.read.return_value = json.dumps(payload)
@@ -143,18 +50,41 @@ class TestMcpConfiguration:
         assert "/ouroboros:status" in context
         assert "/ouroboros:setup" not in context
 
+    def test_claude_hook_without_registration_routes_setup(self, tmp_path, capsys):
+        payload = {
+            "session_id": "claude-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:setup" in context
+        assert "/ouroboros:status" not in context
+
+    def test_raw_input_preserves_legacy_claude_setup_boundary(self, tmp_path, capsys):
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = "ooo status"
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:setup" in context
+        assert "/ouroboros:status" not in context
+
 
 class TestFirstTimePrefs:
     def test_missing_prefs_file_is_first_time(self, tmp_path):
         home = tmp_path
-        with (
-            patch.object(_mod.Path, "home", return_value=home),
-            patch.object(
-                _mod.subprocess,
-                "run",
-                return_value=subprocess.CompletedProcess([], 1, stdout="", stderr=""),
-            ),
-        ):
+        with patch.object(_mod.Path, "home", return_value=home):
             assert is_first_time() is True
 
     def test_welcome_completed_marks_not_first_time(self, tmp_path):
@@ -216,14 +146,7 @@ class TestFirstTimePrefs:
         # Regression guard for the discriminator: a truly empty home (no prefs,
         # no install artifacts, no MCP registration) is still a genuine first
         # run and SHOULD surface the welcome experience.
-        with (
-            patch.object(_mod.Path, "home", return_value=tmp_path),
-            patch.object(
-                _mod.subprocess,
-                "run",
-                return_value=subprocess.CompletedProcess([], 1, stdout="", stderr=""),
-            ),
-        ):
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
             assert is_first_time() is True
 
     def test_malformed_prefs_stays_first_time_despite_install_markers(self, tmp_path):

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -1,6 +1,7 @@
 """Tests for keyword-detector.py — setup gate and routing behavior."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -325,3 +326,56 @@ class TestMainGate:
         out = capsys.readouterr().out
         assert "/ouroboros:setup" not in out
         assert "/ouroboros:resume-session" in out
+
+
+class TestHookProtocol:
+    """UserPromptSubmit input and output follow the shared hook JSON protocol."""
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_json_payload_detection_uses_only_prompt_field(self, _first, capsys):
+        payload = {
+            "session_id": "ooo status",
+            "prompt": "hello world",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        assert capsys.readouterr().out == ""
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_json_payload_match_emits_structured_context(self, _first, _mcp, capsys):
+        payload = {
+            "session_id": "test-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        assert output == {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    "<skill-suggestion>\n🎯 MATCHED SKILLS:\n"
+                    '- /ouroboros:status - Detected "ooo status"\n'
+                    "</skill-suggestion>"
+                ),
+            }
+        }
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_text_fallback_remains_supported(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "ooo qa"
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:qa" in context
+        assert "ooo qa" in context

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -51,12 +52,94 @@ class TestMcpConfiguration:
         ):
             assert is_mcp_configured() is False
 
+    def test_codex_home_is_authoritative(self, tmp_path):
+        default_home = tmp_path / "home"
+        default_home.mkdir()
+        codex_home = tmp_path / "custom-codex"
+        codex_home.mkdir()
+        (codex_home / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
+
+        with (
+            patch.object(_mod.Path, "home", return_value=default_home),
+            patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=True),
+        ):
+            assert is_mcp_configured("codex") is True
+
+    def test_disabled_or_transportless_codex_registration_is_not_configured(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        config_path = codex_dir / "config.toml"
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            config_path.write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\nenabled = false\n')
+            assert is_mcp_configured("codex") is False
+
+            config_path.write_text('[mcp_servers.ouroboros]\nargs = ["ouroboros-ai"]\n')
+            assert is_mcp_configured("codex") is False
+
+    def test_python_310_fallback_ignores_multiline_string_decoy(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            'notice = """\n[mcp_servers.ouroboros]\ncommand = "uvx"\n"""\n'
+        )
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod, "_toml_loads", None),
+        ):
+            assert is_mcp_configured("codex") is False
+
+    def test_codex_hook_does_not_use_claude_only_registration(self, tmp_path, capsys):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {"command": "uvx"}}}')
+        payload = {
+            "session_id": "codex-session",
+            "turn_id": "codex-turn",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:setup" in context
+        assert "/ouroboros:status" not in context
+
+    def test_claude_hook_does_not_use_codex_only_registration(self, tmp_path, capsys):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
+        payload = {
+            "session_id": "claude-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:setup" in context
+        assert "/ouroboros:status" not in context
+
     def test_codex_only_registration_routes_status_without_setup(self, tmp_path, capsys):
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()
         (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
         payload = {
             "session_id": "test-session",
+            "turn_id": "test-turn",
             "prompt": "ooo status",
             "hook_event_name": "UserPromptSubmit",
         }
@@ -129,7 +212,7 @@ class TestFirstTimePrefs:
         # MCP registered in ~/.claude/mcp.json means setup has already run.
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
-        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {}}}')
+        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {"command": "uvx"}}}')
 
         with patch.object(_mod.Path, "home", return_value=tmp_path):
             assert is_first_time() is False

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -408,3 +408,15 @@ class TestHookProtocol:
         output = json.loads(capsys.readouterr().out)
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:status" in context
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_deeply_nested_raw_json_falls_back_without_crashing(self, _first, capsys):
+        raw_prompt = "[" * 10_000 + "]" * 10_000
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch.object(_mod.json, "loads", side_effect=RecursionError),
+        ):
+            mock_stdin.read.return_value = raw_prompt
+            main()
+
+        assert capsys.readouterr().out == ""

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -390,3 +390,21 @@ class TestHookProtocol:
         output = json.loads(capsys.readouterr().out)
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:status" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_hook_shaped_raw_json_without_session_id_remains_prompt(self, _first, _mcp, capsys):
+        raw_prompt = json.dumps(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "explain this payload",
+                "command": "ooo status",
+            }
+        )
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = raw_prompt
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 from unittest.mock import patch
@@ -34,17 +35,26 @@ class TestMcpConfiguration:
             stderr="",
         )
 
-    def test_codex_uses_effective_cli_registration(self):
-        with patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run:
+    def test_codex_uses_effective_cli_registration(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        with (
+            patch.dict(
+                os.environ,
+                {"HOME": str(home), "CODEX_HOME": "~/custom-codex"},
+                clear=True,
+            ),
+            patch.object(_mod.subprocess, "run", return_value=self._codex_result()) as run,
+        ):
             assert is_mcp_configured("codex") is True
 
-        run.assert_called_once_with(
-            ["codex", "mcp", "get", "ouroboros", "--json"],
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
+        call = run.call_args
+        assert call.args == (["codex", "mcp", "get", "ouroboros", "--json"],)
+        assert call.kwargs["env"]["CODEX_HOME"] == str(home / "custom-codex")
+        assert call.kwargs["capture_output"] is True
+        assert call.kwargs["text"] is True
+        assert call.kwargs["timeout"] == 3
+        assert call.kwargs["check"] is False
 
     def test_disabled_or_transportless_codex_registration_is_not_configured(self):
         disabled = self._codex_result(enabled=False)

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -15,6 +15,38 @@ detect_keywords = _mod.detect_keywords
 SETUP_BYPASS_SKILLS = _mod.SETUP_BYPASS_SKILLS
 main = _mod.main
 is_first_time = _mod.is_first_time
+is_mcp_configured = _mod.is_mcp_configured
+
+
+class TestMcpConfiguration:
+    def test_codex_only_registration_is_configured(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_mcp_configured() is True
+
+    def test_codex_only_registration_routes_status_without_setup(self, tmp_path, capsys):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\ncommand = "uvx"\n')
+        payload = {
+            "session_id": "test-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context
+        assert "/ouroboros:setup" not in context
 
 
 class TestFirstTimePrefs:

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -27,6 +27,30 @@ class TestMcpConfiguration:
         with patch.object(_mod.Path, "home", return_value=tmp_path):
             assert is_mcp_configured() is True
 
+    def test_codex_only_registration_uses_python_310_fallback(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\ncommand = "uvx"\nargs = ["ouroboros-ai"]\n'
+        )
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod, "_toml_loads", None),
+        ):
+            assert is_mcp_configured() is True
+
+    def test_python_310_fallback_rejects_header_without_transport(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text('[mcp_servers.ouroboros]\nargs = ["broken"]\n')
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod, "_toml_loads", None),
+        ):
+            assert is_mcp_configured() is False
+
     def test_codex_only_registration_routes_status_without_setup(self, tmp_path, capsys):
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -77,6 +77,32 @@ class TestMcpConfiguration:
             config_path.write_text('[mcp_servers.ouroboros]\nargs = ["ouroboros-ai"]\n')
             assert is_mcp_configured("codex") is False
 
+    def test_python_310_fallback_accepts_inline_comments(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\ncommand = "uvx" # normal comment\nenabled = true # active\n'
+        )
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod, "_toml_loads", None),
+        ):
+            assert is_mcp_configured("codex") is True
+
+    def test_python_310_fallback_ignores_triple_quote_in_comment(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "config.toml").write_text(
+            '# documentation mentions """ strings\n[mcp_servers.ouroboros]\ncommand = "uvx"\n'
+        )
+
+        with (
+            patch.object(_mod.Path, "home", return_value=tmp_path),
+            patch.object(_mod, "_toml_loads", None),
+        ):
+            assert is_mcp_configured("codex") is True
+
     def test_python_310_fallback_ignores_multiline_string_decoy(self, tmp_path):
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -379,3 +379,14 @@ class TestHookProtocol:
         context = output["hookSpecificOutput"]["additionalContext"]
         assert "/ouroboros:qa" in context
         assert "ooo qa" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_json_object_text_without_hook_marker_remains_prompt(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = '{"command": "ooo status"}'
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context


### PR DESCRIPTION
## Summary
- parse Codex and Claude UserPromptSubmit JSON envelopes before keyword matching
- require the genuine envelope shape (`hook_event_name`, string `session_id`, and string `prompt`) so hook-shaped raw JSON remains compatible
- emit schema-valid hookSpecificOutput only for matching prompts and preserve no-match silence

Replaces #1708 after exact-head independent review was unavailable on the reopened PR.

Closes #1694.

## Verification
- exact-head independent review of `37c0b52e218935e2d45d41db31c81f13cd4fff57`: APPROVE
- focused hook tests: 47 passed
- full script suite passed
- Ruff and format checks passed
- full GitHub CI passed on the identical commit tree
- actual Codex plugin paths completed successfully