### PR TITLE
fix(seed): preserve literal pipe characters in constraints

### DIFF
--- a/src/ouroboros/bigbang/requirement_distillation.py
+++ b/src/ouroboros/bigbang/requirement_distillation.py
@@ -50,6 +50,16 @@ _CONSTRAINT_RE = re.compile(
 )
 
 
+def split_escaped_pipe_values(raw_value: object) -> tuple[str, ...]:
+    if isinstance(raw_value, list | tuple):
+        values = (str(item) for item in raw_value)
+    elif isinstance(raw_value, str):
+        values = re.split(r"(?<!\\)\|", raw_value)
+    else:
+        return ()
+    return tuple(value.replace(r"\|", "|").strip() for value in values if value.strip())
+
+
 @dataclass(frozen=True, slots=True)
 class AppliedRequirementDistillation:
     """Requirements after the deterministic reference-aware promotion gate."""
@@ -299,16 +309,8 @@ def build_promoted_reference_seed(
     if applied.promotion.blockers:
         raise ValueError(seed_readiness_details(applied.promotion))
     requirements = applied.requirements
-    constraints = tuple(
-        item.strip()
-        for item in str(requirements.get("constraints") or "").split("|")
-        if item.strip()
-    )
-    criteria = tuple(
-        item.strip()
-        for item in str(requirements.get("acceptance_criteria") or "").split("|")
-        if item.strip()
-    )
+    constraints = split_escaped_pipe_values(requirements.get("constraints"))
+    criteria = split_escaped_pipe_values(requirements.get("acceptance_criteria"))
     context_references = tuple(
         ContextReference(
             path=entry.get("path", ""),

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -32,6 +32,7 @@ from ouroboros.bigbang.requirement_distillation import (
     build_requirement_distillation,
     is_reference_aware_distillation,
     seed_readiness_details,
+    split_escaped_pipe_values,
 )
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
@@ -804,11 +805,7 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
         constraints: tuple[str, ...] = ()
         if "constraints" in requirements and requirements["constraints"]:
             # Keep legacy pipe-delimited extraction while preserving escaped literal pipes.
-            constraints = tuple(
-                c.replace(r"\|", "|").strip()
-                for c in re.split(r"(?<!\\)\|", requirements["constraints"])
-                if c.strip()
-            )
+            constraints = split_escaped_pipe_values(requirements["constraints"])
 
         # Parse acceptance criteria
         acceptance_criteria: tuple[AcceptanceCriterionSpec | str, ...] = ()

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -575,7 +575,7 @@ ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell
 ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
 GOAL: <clear goal statement>
-CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+CONSTRAINTS: <constraint 1> | <constraint 2> | ... (escape literal pipes as \\|)
 ACCEPTANCE_CRITERIA:
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
@@ -674,7 +674,7 @@ ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell
 ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
 GOAL: <clear goal statement>
-CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+CONSTRAINTS: <constraint 1> | <constraint 2> | ... (escape literal pipes as \\|)
 ACCEPTANCE_CRITERIA:
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
@@ -803,8 +803,11 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
         # Parse constraints
         constraints: tuple[str, ...] = ()
         if "constraints" in requirements and requirements["constraints"]:
+            # Keep legacy pipe-delimited extraction while preserving escaped literal pipes.
             constraints = tuple(
-                c.strip() for c in requirements["constraints"].split("|") if c.strip()
+                c.replace(r"\|", "|").strip()
+                for c in re.split(r"(?<!\\)\|", requirements["constraints"])
+                if c.strip()
             )
 
         # Parse acceptance criteria

--- a/tests/unit/bigbang/test_requirement_distillation.py
+++ b/tests/unit/bigbang/test_requirement_distillation.py
@@ -8,6 +8,7 @@ from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBre
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
 from ouroboros.bigbang.requirement_distillation import (
     apply_requirement_distillation,
+    build_promoted_reference_seed,
     build_requirement_distillation,
 )
 from ouroboros.bigbang.seed_generator import SeedGenerator
@@ -307,6 +308,15 @@ async def test_seed_generator_keeps_explicitly_confirmed_reference_ac(tmp_path) 
     assert tuple(str(item) for item in result.value.acceptance_criteria) == (
         "For the Linear-like reference, keyboard-first navigation is required.",
     )
+
+
+def test_reference_seed_preserves_literal_pipe_in_constraint() -> None:
+    state = _reference_state(confirmation="Only --lang ko\\|en is required.")
+    distillation = build_requirement_distillation(state)
+
+    seed = build_promoted_reference_seed(state, distillation, ambiguity_score=0.1)
+
+    assert seed.constraints == ("Only --lang ko|en is required.",)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -477,6 +477,31 @@ class TestSeedGeneratorExtraction:
             assert "No external database" in result.value.constraints
 
     @pytest.mark.asyncio
+    async def test_generate_preserves_literal_pipe_in_constraint_value(self) -> None:
+        """SeedGenerator keeps escaped literal pipes inside a single constraint."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            constraints="--lang ko\\|en | keep exact flag"
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.constraints == ("--lang ko|en", "keep exact flag")
+
+    @pytest.mark.asyncio
     async def test_generate_extracts_acceptance_criteria(self) -> None:
         """SeedGenerator extracts acceptance_criteria as tuple."""
         mock_adapter = AsyncMock()


### PR DESCRIPTION
## Summary
- preserve escaped literal pipes in Seed constraint values
- keep legacy `|`-delimited constraints unchanged for ordinary values
- document `\\|` in both extraction prompt paths
- add a regression test for `--lang ko\\|en`

## Verification
- `uv run pytest tests/unit/bigbang/test_seed_generator.py -q` (44 passed)
- `uv run ruff check src/ouroboros/bigbang/seed_generator.py tests/unit/bigbang/test_seed_generator.py`

Closes #1696
