### PR TITLE
fix(seed): preserve literal pipes in constraints across both seed paths

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -21,8 +21,9 @@ Example: "Build a CLI task management tool in Python"
 
 ### 2. CONSTRAINTS
 Hard limitations or requirements that must be satisfied.
-Format: pipe-separated list
-Example: "Python >= 3.12 | No external database | Must work offline"
+Format: single-line JSON array of strings. Values may contain any characters,
+including literal `|` pipes; never use a bare pipe as the list separator.
+Example: ["Python >= 3.12", "No external database", "Must work offline"]
 
 ### 3. ACCEPTANCE_CRITERIA
 Specific, measurable criteria for success.
@@ -74,7 +75,7 @@ Provide your analysis in this exact structure:
 
 ```
 GOAL: <clear goal statement>
-CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+CONSTRAINTS: ["<constraint 1>", "<constraint 2>", ...]
 ACCEPTANCE_CRITERIA:
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>

--- a/src/ouroboros/bigbang/requirement_distillation.py
+++ b/src/ouroboros/bigbang/requirement_distillation.py
@@ -266,8 +266,8 @@ def apply_requirement_distillation(
     ]
     filtered = {
         "goal": promoted_goals[0] if promoted_goals else "Confirmed interview requirements",
-        "constraints": " | ".join(dict.fromkeys(promoted_constraints)),
-        "acceptance_criteria": " | ".join(promoted_criteria),
+        "constraints": tuple(dict.fromkeys(promoted_constraints)),
+        "acceptance_criteria": tuple(promoted_criteria),
         "ontology_name": "ConfirmedRequirementContract",
         "ontology_description": "Only user-authorized interview requirements.",
         "ontology_fields": "",
@@ -288,6 +288,21 @@ def apply_requirement_distillation(
     )
 
 
+def _normalized_requirement_values(raw_value: object) -> tuple[str, ...]:
+    """Normalize promoted requirement values without splitting literal pipes.
+
+    Promoted candidates carry verbatim user statements, so a delimiter-based
+    round trip would corrupt values that legitimately contain ``|`` (#1696).
+    A plain string therefore stays one value instead of being pipe-split.
+    """
+    if isinstance(raw_value, str):
+        value = raw_value.strip()
+        return (value,) if value else ()
+    if isinstance(raw_value, list | tuple):
+        return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
+    return ()
+
+
 def build_promoted_reference_seed(
     state: InterviewState,
     distillation: RequirementDistillation,
@@ -299,16 +314,8 @@ def build_promoted_reference_seed(
     if applied.promotion.blockers:
         raise ValueError(seed_readiness_details(applied.promotion))
     requirements = applied.requirements
-    constraints = tuple(
-        item.strip()
-        for item in str(requirements.get("constraints") or "").split("|")
-        if item.strip()
-    )
-    criteria = tuple(
-        item.strip()
-        for item in str(requirements.get("acceptance_criteria") or "").split("|")
-        if item.strip()
-    )
+    constraints = _normalized_requirement_values(requirements.get("constraints"))
+    criteria = _normalized_requirement_values(requirements.get("acceptance_criteria"))
     context_references = tuple(
         ContextReference(
             path=entry.get("path", ""),

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -56,6 +56,26 @@ EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
 _LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[\s*[^\s\"'\[\]][^\[\]\r\n]*\]\s+\S")
+
+
+def _is_legacy_bracket_prose(text: str) -> bool:
+    """True for ``[tag] prose`` where the leading group is not itself JSON.
+
+    A leading bracket group that parses as a JSON array on its own (e.g.
+    ``[null]``, ``[123, "x"]``) signals JSON intent with trailing garbage,
+    not a legacy ``[P0]``-style tag, so it must not fall back to pipe
+    splitting.
+    """
+    if not _LEGACY_BRACKET_PREFIX_RE.match(text):
+        return False
+    bracket_group = text[: text.index("]") + 1]
+    try:
+        json.loads(bracket_group)
+    except json.JSONDecodeError:
+        return True
+    return False
+
+
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
@@ -87,7 +107,7 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
         try:
             decoded = json.loads(text)
         except json.JSONDecodeError as e:
-            if not _LEGACY_BRACKET_PREFIX_RE.match(text):
+            if not _is_legacy_bracket_prose(text):
                 raise ValueError(
                     f"CONSTRAINTS looks like a JSON array but is not valid JSON: {e}. "
                     f"Value: {text[:200]}"

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -64,17 +64,19 @@ def _parse_constraint_values(raw_value: object, *, strict: bool = False) -> tupl
     The extraction format requests a single-line JSON array so literal pipe
     characters inside one constraint survive as data (#1696).
 
-    In strict mode (extraction time) any value starting with ``[`` must be a
-    valid JSON array of strings; anything else raises so the extraction retry
-    path can ask the LLM to reformat — the extraction prompt already demands
-    a JSON array. In lenient mode (stored legacy requirements consumed at
-    seed-build time) invalid JSON falls back to the historical pipe split,
-    including bracket-prefixed prose such as ``[P0] Must work offline``, and
-    never raises: stored data has no retry path.
+    In strict mode (extraction time) the value must be a valid JSON array of
+    strings regardless of shape — plain pipe lists, bracket prose, and any
+    other non-array text raise so the extraction retry path can ask the LLM
+    to reformat into the JSON array the extraction prompt already demands.
+    The strict boundary therefore has no fallback surface at all. In lenient
+    mode (stored legacy requirements consumed at seed-build time) invalid
+    JSON falls back to the historical pipe split, including bracket-prefixed
+    prose such as ``[P0] Must work offline``, and never raises: stored data
+    has no retry path.
 
     Raises:
-        ValueError: Only in strict mode, when a ``[``-led value is not a
-            valid JSON array of strings.
+        ValueError: Only in strict mode, when the value is not a valid JSON
+            array of strings.
     """
     if isinstance(raw_value, list | tuple):
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
@@ -83,26 +85,32 @@ def _parse_constraint_values(raw_value: object, *, strict: bool = False) -> tupl
     text = raw_value.strip()
     if not text:
         return ()
-    if text.startswith("["):
+    if strict:
         try:
             decoded = json.loads(text)
         except json.JSONDecodeError as e:
-            if strict:
-                raise ValueError(
-                    f"CONSTRAINTS must be a single-line JSON array of strings: {e}. "
-                    f"Value: {text[:200]}"
-                ) from e
+            raise ValueError(
+                f"CONSTRAINTS must be a single-line JSON array of strings: {e}. Value: {text[:200]}"
+            ) from e
+        if not isinstance(decoded, list):
+            raise ValueError(
+                "CONSTRAINTS must be a JSON array of strings, got "
+                f"{type(decoded).__name__}. Value: {text[:200]}"
+            )
+        non_strings = tuple(type(entry).__name__ for entry in decoded if not isinstance(entry, str))
+        if non_strings:
+            raise ValueError(
+                "CONSTRAINTS JSON array must contain only strings; got "
+                f"{', '.join(non_strings)}. Value: {text[:200]}"
+            )
+        return tuple(item for item in (entry.strip() for entry in decoded) if item)
+    if text.startswith("["):
+        try:
+            decoded = json.loads(text)
+        except json.JSONDecodeError:
+            pass
         else:
             if isinstance(decoded, list):
-                if strict:
-                    non_strings = tuple(
-                        type(entry).__name__ for entry in decoded if not isinstance(entry, str)
-                    )
-                    if non_strings:
-                        raise ValueError(
-                            "CONSTRAINTS JSON array must contain only strings; got "
-                            f"{', '.join(non_strings)}. Value: {text[:200]}"
-                        )
                 return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
     return tuple(item.strip() for item in text.split("|") if item.strip())
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -12,6 +12,7 @@ The SeedGenerator:
 """
 
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 import re
 from typing import Any
@@ -55,6 +56,32 @@ EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
+
+
+def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
+    """Parse constraints from a JSON array, a sequence, or a legacy pipe list.
+
+    The extraction format requests a single-line JSON array so literal pipe
+    characters inside one constraint survive as data (#1696). Legacy
+    pipe-delimited responses keep the historical split, including
+    bracket-prefixed prose such as ``[P0] Must work offline`` that merely
+    starts with ``[`` without being valid JSON.
+    """
+    if isinstance(raw_value, list | tuple):
+        return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
+    if not isinstance(raw_value, str):
+        return ()
+    text = raw_value.strip()
+    if not text:
+        return ()
+    if text.startswith("[") and text.endswith("]"):
+        try:
+            decoded = json.loads(text)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, list):
+            return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
+    return tuple(item.strip() for item in text.split("|") if item.strip())
 
 
 def _parse_acceptance_criteria_contracts(
@@ -574,8 +601,10 @@ ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one indepe
 ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell command. Never use heredoc or multiline syntax (`<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts); use `python -c "..."`, `python3 -c "..."`, or `python -m pytest -q` instead.
 ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
+CONSTRAINTS rule: respond with one single-line JSON array of strings, e.g. ["<constraint 1>", "<constraint 2>"]. Constraint values may contain any characters, including literal | pipes; never use a bare pipe as the list separator.
+
 GOAL: <clear goal statement>
-CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+CONSTRAINTS: ["<constraint 1>", "<constraint 2>", ...]
 ACCEPTANCE_CRITERIA:
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
@@ -673,8 +702,10 @@ ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one indepe
 ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell command. Never use heredoc or multiline syntax (`<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts); use `python -c "..."`, `python3 -c "..."`, or `python -m pytest -q` instead.
 ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
+CONSTRAINTS rule: respond with one single-line JSON array of strings, e.g. ["<constraint 1>", "<constraint 2>"]. Constraint values may contain any characters, including literal | pipes; never use a bare pipe as the list separator.
+
 GOAL: <clear goal statement>
-CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+CONSTRAINTS: ["<constraint 1>", "<constraint 2>", ...]
 ACCEPTANCE_CRITERIA:
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
@@ -800,12 +831,8 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
         Returns:
             Constructed Seed instance.
         """
-        # Parse constraints
-        constraints: tuple[str, ...] = ()
-        if "constraints" in requirements and requirements["constraints"]:
-            constraints = tuple(
-                c.strip() for c in requirements["constraints"].split("|") if c.strip()
-            )
+        # Parse constraints (JSON array preferred; legacy pipe list supported)
+        constraints = _parse_constraint_values(requirements.get("constraints"))
 
         # Parse acceptance criteria
         acceptance_criteria: tuple[AcceptanceCriterionSpec | str, ...] = ()

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -55,16 +55,18 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
-_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[\s*[^\s\"'\[\]][^\[\]\r\n]*\]\s+\S")
+_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[[A-Za-z0-9][\w .:-]{0,31}\]\s+\S")
 
 
 def _is_legacy_bracket_prose(text: str) -> bool:
-    """True for ``[tag] prose`` where the leading group is not itself JSON.
+    """True for ``[tag] prose`` where the leading group is a plain tag token.
 
-    A leading bracket group that parses as a JSON array on its own (e.g.
-    ``[null]``, ``[123, "x"]``) signals JSON intent with trailing garbage,
-    not a legacy ``[P0]``-style tag, so it must not fall back to pipe
-    splitting.
+    Legacy prose tags are short word-like tokens such as ``[P0]``, ``[HIGH]``
+    or ``[v2.1]``. Anything else — commas, pipes, quotes, or other JSON
+    punctuation inside the bracket group — signals JSON-array intent and must
+    not fall back to pipe splitting. A tag-shaped group that nevertheless
+    parses as a JSON array on its own (e.g. ``[null]``, ``[123]``) is also
+    treated as JSON intent with trailing garbage.
     """
     if not _LEGACY_BRACKET_PREFIX_RE.match(text):
         return False

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -55,7 +55,7 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
-_JSON_ARRAY_INTENT_RE = re.compile(r"^\[\s*['\"]")
+_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[[^\[\]\r\n]+\]\s+\S")
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
@@ -69,11 +69,10 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
     starts with ``[`` without signalling JSON intent.
 
     Raises:
-        ValueError: If the value signals JSON-array intent (``[`` followed by
-            a quote) but is not a valid JSON array — e.g. a trailing comma or
-            a truncated array. Raising here lets extraction-time callers route
-            malformed structured output through the existing retry path
-            instead of silently pipe-splitting it.
+        ValueError: If the value starts with ``[`` but is neither a valid JSON
+            array nor legacy bracket-prefixed prose such as ``[P0] ...``.
+            Raising here routes malformed structured output through the
+            existing extraction retry path.
     """
     if isinstance(raw_value, list | tuple):
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
@@ -82,11 +81,11 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
     text = raw_value.strip()
     if not text:
         return ()
-    if text.startswith("[") and text.endswith("]"):
+    if text.startswith("["):
         try:
             decoded = json.loads(text)
         except json.JSONDecodeError as e:
-            if _JSON_ARRAY_INTENT_RE.match(text):
+            if not _LEGACY_BRACKET_PREFIX_RE.match(text):
                 raise ValueError(
                     f"CONSTRAINTS looks like a JSON array but is not valid JSON: {e}. "
                     f"Value: {text[:200]}"
@@ -94,11 +93,6 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
         else:
             if isinstance(decoded, list):
                 return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
-    elif _JSON_ARRAY_INTENT_RE.match(text):
-        raise ValueError(
-            "CONSTRAINTS looks like a truncated JSON array (no closing bracket). "
-            f"Value: {text[:200]}"
-        )
     return tuple(item.strip() for item in text.split("|") if item.strip())
 
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -55,6 +55,7 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
+_JSON_ARRAY_INTENT_RE = re.compile(r"^\[\s*['\"]")
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
@@ -65,7 +66,14 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
     characters inside one constraint survive as data (#1696). Legacy
     pipe-delimited responses keep the historical split, including
     bracket-prefixed prose such as ``[P0] Must work offline`` that merely
-    starts with ``[`` without being valid JSON.
+    starts with ``[`` without signalling JSON intent.
+
+    Raises:
+        ValueError: If the value signals JSON-array intent (``[`` followed by
+            a quote) but is not a valid JSON array — e.g. a trailing comma or
+            a truncated array. Raising here lets extraction-time callers route
+            malformed structured output through the existing retry path
+            instead of silently pipe-splitting it.
     """
     if isinstance(raw_value, list | tuple):
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
@@ -77,10 +85,20 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
     if text.startswith("[") and text.endswith("]"):
         try:
             decoded = json.loads(text)
-        except json.JSONDecodeError:
-            decoded = None
-        if isinstance(decoded, list):
-            return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
+        except json.JSONDecodeError as e:
+            if _JSON_ARRAY_INTENT_RE.match(text):
+                raise ValueError(
+                    f"CONSTRAINTS looks like a JSON array but is not valid JSON: {e}. "
+                    f"Value: {text[:200]}"
+                ) from e
+        else:
+            if isinstance(decoded, list):
+                return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
+    elif _JSON_ARRAY_INTENT_RE.match(text):
+        raise ValueError(
+            "CONSTRAINTS looks like a truncated JSON array (no closing bracket). "
+            f"Value: {text[:200]}"
+        )
     return tuple(item.strip() for item in text.split("|") if item.strip())
 
 
@@ -818,6 +836,12 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
                     f"Found: {list(requirements.keys())}. "
                     f"Response preview: {response[:200]}"
                 )
+
+        # Validate constraints at parse time so malformed JSON-intent output
+        # (e.g. a trailing-comma array) triggers the extraction retry path
+        # instead of being silently pipe-split downstream (#1696).
+        if "constraints" in requirements:
+            requirements["constraints"] = _parse_constraint_values(requirements["constraints"])
 
         return requirements
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -55,7 +55,7 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
-_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[[^\[\]\r\n]+\]\s+\S")
+_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[\s*[^\s\"'\[\]][^\[\]\r\n]*\]\s+\S")
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
@@ -70,9 +70,11 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
 
     Raises:
         ValueError: If the value starts with ``[`` but is neither a valid JSON
-            array nor legacy bracket-prefixed prose such as ``[P0] ...``.
-            Raising here routes malformed structured output through the
-            existing extraction retry path.
+            array of strings nor legacy bracket-prefixed prose such as
+            ``[P0] ...``. Quote-led values are always treated as JSON intent
+            (so ``["a"] stray text`` retries rather than pipe-splitting), and
+            valid arrays containing non-string members (e.g. ``[null]``)
+            violate the array-of-strings contract and retry as well.
     """
     if isinstance(raw_value, list | tuple):
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
@@ -92,7 +94,15 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
                 ) from e
         else:
             if isinstance(decoded, list):
-                return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
+                non_strings = tuple(
+                    type(entry).__name__ for entry in decoded if not isinstance(entry, str)
+                )
+                if non_strings:
+                    raise ValueError(
+                        "CONSTRAINTS JSON array must contain only strings; got "
+                        f"{', '.join(non_strings)}. Value: {text[:200]}"
+                    )
+                return tuple(item for item in (entry.strip() for entry in decoded) if item)
     return tuple(item.strip() for item in text.split("|") if item.strip())
 
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -55,48 +55,26 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
-_LEGACY_BRACKET_PREFIX_RE = re.compile(r"^\[[A-Za-z0-9][\w .:-]{0,31}\]\s+\S")
-
-
-def _is_legacy_bracket_prose(text: str) -> bool:
-    """True for ``[tag] prose`` where the leading group is a plain tag token.
-
-    Legacy prose tags are short word-like tokens such as ``[P0]``, ``[HIGH]``
-    or ``[v2.1]``. Anything else — commas, pipes, quotes, or other JSON
-    punctuation inside the bracket group — signals JSON-array intent and must
-    not fall back to pipe splitting. A tag-shaped group that nevertheless
-    parses as a JSON array on its own (e.g. ``[null]``, ``[123]``) is also
-    treated as JSON intent with trailing garbage.
-    """
-    if not _LEGACY_BRACKET_PREFIX_RE.match(text):
-        return False
-    bracket_group = text[: text.index("]") + 1]
-    try:
-        json.loads(bracket_group)
-    except json.JSONDecodeError:
-        return True
-    return False
-
-
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
-def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
+def _parse_constraint_values(raw_value: object, *, strict: bool = False) -> tuple[str, ...]:
     """Parse constraints from a JSON array, a sequence, or a legacy pipe list.
 
     The extraction format requests a single-line JSON array so literal pipe
-    characters inside one constraint survive as data (#1696). Legacy
-    pipe-delimited responses keep the historical split, including
-    bracket-prefixed prose such as ``[P0] Must work offline`` that merely
-    starts with ``[`` without signalling JSON intent.
+    characters inside one constraint survive as data (#1696).
+
+    In strict mode (extraction time) any value starting with ``[`` must be a
+    valid JSON array of strings; anything else raises so the extraction retry
+    path can ask the LLM to reformat — the extraction prompt already demands
+    a JSON array. In lenient mode (stored legacy requirements consumed at
+    seed-build time) invalid JSON falls back to the historical pipe split,
+    including bracket-prefixed prose such as ``[P0] Must work offline``, and
+    never raises: stored data has no retry path.
 
     Raises:
-        ValueError: If the value starts with ``[`` but is neither a valid JSON
-            array of strings nor legacy bracket-prefixed prose such as
-            ``[P0] ...``. Quote-led values are always treated as JSON intent
-            (so ``["a"] stray text`` retries rather than pipe-splitting), and
-            valid arrays containing non-string members (e.g. ``[null]``)
-            violate the array-of-strings contract and retry as well.
+        ValueError: Only in strict mode, when a ``[``-led value is not a
+            valid JSON array of strings.
     """
     if isinstance(raw_value, list | tuple):
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
@@ -109,22 +87,23 @@ def _parse_constraint_values(raw_value: object) -> tuple[str, ...]:
         try:
             decoded = json.loads(text)
         except json.JSONDecodeError as e:
-            if not _is_legacy_bracket_prose(text):
+            if strict:
                 raise ValueError(
-                    f"CONSTRAINTS looks like a JSON array but is not valid JSON: {e}. "
+                    f"CONSTRAINTS must be a single-line JSON array of strings: {e}. "
                     f"Value: {text[:200]}"
                 ) from e
         else:
             if isinstance(decoded, list):
-                non_strings = tuple(
-                    type(entry).__name__ for entry in decoded if not isinstance(entry, str)
-                )
-                if non_strings:
-                    raise ValueError(
-                        "CONSTRAINTS JSON array must contain only strings; got "
-                        f"{', '.join(non_strings)}. Value: {text[:200]}"
+                if strict:
+                    non_strings = tuple(
+                        type(entry).__name__ for entry in decoded if not isinstance(entry, str)
                     )
-                return tuple(item for item in (entry.strip() for entry in decoded) if item)
+                    if non_strings:
+                        raise ValueError(
+                            "CONSTRAINTS JSON array must contain only strings; got "
+                            f"{', '.join(non_strings)}. Value: {text[:200]}"
+                        )
+                return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
     return tuple(item.strip() for item in text.split("|") if item.strip())
 
 
@@ -867,7 +846,9 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
         # (e.g. a trailing-comma array) triggers the extraction retry path
         # instead of being silently pipe-split downstream (#1696).
         if "constraints" in requirements:
-            requirements["constraints"] = _parse_constraint_values(requirements["constraints"])
+            requirements["constraints"] = _parse_constraint_values(
+                requirements["constraints"], strict=True
+            )
 
         return requirements
 

--- a/tests/unit/bigbang/test_requirement_distillation.py
+++ b/tests/unit/bigbang/test_requirement_distillation.py
@@ -118,7 +118,7 @@ def _low_ambiguity() -> AmbiguityScore:
 def _extraction_response() -> CompletionResponse:
     return CompletionResponse(
         content="""GOAL: Build an issue tool
-CONSTRAINTS: Python
+CONSTRAINTS: ["Python"]
 ACCEPTANCE_CRITERIA:
 AC: Keyboard-first command menu | verify: NONE | artifacts: NONE | expect: NONE
 AC: Queue navigation | verify: NONE | artifacts: NONE | expect: NONE

--- a/tests/unit/bigbang/test_requirement_distillation.py
+++ b/tests/unit/bigbang/test_requirement_distillation.py
@@ -8,6 +8,7 @@ from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBre
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
 from ouroboros.bigbang.requirement_distillation import (
     apply_requirement_distillation,
+    build_promoted_reference_seed,
     build_requirement_distillation,
 )
 from ouroboros.bigbang.seed_generator import SeedGenerator
@@ -139,7 +140,7 @@ def test_reference_contrast_does_not_promote_inferred_acceptance_criteria() -> N
     applied = apply_requirement_distillation(_requirements(), distillation)
 
     assert applied.promotion.is_ready_for_seed
-    assert applied.requirements["acceptance_criteria"] == ""
+    assert applied.requirements["acceptance_criteria"] == ()
 
 
 def test_unresolved_reference_blocks_seed_generation() -> None:
@@ -180,7 +181,7 @@ def test_explicit_reference_confirmation_promotes_exact_user_statement() -> None
 
     assert applied.promotion.is_ready_for_seed
     assert applied.requirements["acceptance_criteria"] == (
-        "For the Linear-like reference, keyboard-first navigation is required."
+        "For the Linear-like reference, keyboard-first navigation is required.",
     )
     promoted = [
         candidate
@@ -206,7 +207,7 @@ def test_non_english_confirmation_after_reference_contrast_is_preserved(
     applied = apply_requirement_distillation(_requirements(), distillation)
 
     assert applied.promotion.is_ready_for_seed
-    assert applied.requirements["acceptance_criteria"] == confirmation
+    assert applied.requirements["acceptance_criteria"] == (confirmation,)
     promoted = [
         candidate
         for candidate in applied.promotion.promoted
@@ -224,7 +225,7 @@ def test_ordinary_follow_up_after_reference_contrast_is_not_promoted() -> None:
     applied = apply_requirement_distillation(_requirements(), distillation)
 
     assert applied.promotion.is_ready_for_seed
-    assert applied.requirements["acceptance_criteria"] == ""
+    assert applied.requirements["acceptance_criteria"] == ()
     assert all(
         candidate.candidate_id != "round-3:requirement" for candidate in distillation.candidates
     )
@@ -250,6 +251,30 @@ def test_non_reference_interview_preserves_legacy_extraction() -> None:
     )
 
     assert applied.requirements == requirements
+
+
+def test_promoted_reference_seed_preserves_literal_pipe_in_constraint() -> None:
+    state = _reference_state(
+        confirmation="The CLI must accept only --lang ko|en as the language flag."
+    )
+    distillation = build_requirement_distillation(state)
+
+    seed = build_promoted_reference_seed(state, distillation, ambiguity_score=0.1)
+
+    assert seed.constraints == ("The CLI must accept only --lang ko|en as the language flag.",)
+
+
+def test_promoted_reference_seed_preserves_literal_pipe_in_acceptance_criterion() -> None:
+    state = _reference_state(
+        confirmation="The confirmed requirement is that output must show ko|en verbatim."
+    )
+    distillation = build_requirement_distillation(state)
+
+    seed = build_promoted_reference_seed(state, distillation, ambiguity_score=0.1)
+
+    assert tuple(str(item) for item in seed.acceptance_criteria) == (
+        "The confirmed requirement is that output must show ko|en verbatim.",
+    )
 
 
 def test_reference_cue_merge_changes_fingerprint_and_revision() -> None:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -21,6 +21,7 @@ from ouroboros.bigbang.interview import (
 )
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
+    _parse_constraint_values,
     load_seed,
     save_seed_sync,
 )
@@ -528,6 +529,52 @@ class TestSeedGeneratorExtraction:
                 "[P0] Must work offline",
                 "[P1] Fast startup",
             )
+
+    def test_parse_constraint_values_rejects_malformed_json_intent(self) -> None:
+        """JSON-looking but invalid CONSTRAINTS raise instead of silently splitting."""
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_constraint_values('["--lang ko|en",]')
+
+    def test_parse_constraint_values_coerces_non_string_json_entries(self) -> None:
+        """Valid JSON arrays with non-string entries are coerced to strings."""
+        assert _parse_constraint_values('[1, "x"]') == ("1", "x")
+
+    def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
+        """A quote-led array missing its closing bracket raises for retry."""
+        with pytest.raises(ValueError, match="truncated JSON array"):
+            _parse_constraint_values('["--lang ko|en"')
+
+    @pytest.mark.asyncio
+    async def test_generate_retries_on_malformed_json_constraints(self) -> None:
+        """Malformed JSON-intent CONSTRAINTS trigger the extraction retry path."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        malformed_response = create_valid_extraction_response(
+            constraints='["--lang ko|en", "keep exact flag",]'
+        )
+        valid_response = create_valid_extraction_response(
+            constraints='["--lang ko|en", "keep exact flag"]'
+        )
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed_response)),
+                Result.ok(create_mock_completion_response(valid_response)),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.constraints == ("--lang ko|en", "keep exact flag")
+            assert mock_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio
     async def test_generate_extracts_acceptance_criteria(self) -> None:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -540,20 +540,25 @@ class TestSeedGeneratorExtraction:
         assert _parse_constraint_values('[1, "x"]') == ("1", "x")
 
     def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
-        """A quote-led array missing its closing bracket raises for retry."""
-        with pytest.raises(ValueError, match="truncated JSON array"):
-            _parse_constraint_values('["--lang ko|en"')
+        """Any malformed array missing its closing bracket raises for retry."""
+        for malformed in ('["--lang ko|en"', "[--lang ko|en"):
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_constraint_values(malformed)
 
     @pytest.mark.asyncio
-    async def test_generate_retries_on_malformed_json_constraints(self) -> None:
+    @pytest.mark.parametrize(
+        "malformed_constraints",
+        ('["--lang ko|en", "keep exact flag",]', "[--lang ko|en | keep exact flag"),
+    )
+    async def test_generate_retries_on_malformed_json_constraints(
+        self, malformed_constraints: str
+    ) -> None:
         """Malformed JSON-intent CONSTRAINTS trigger the extraction retry path."""
         mock_adapter = AsyncMock()
         state = create_interview_state_with_rounds()
         low_ambiguity = create_low_ambiguity_score()
 
-        malformed_response = create_valid_extraction_response(
-            constraints='["--lang ko|en", "keep exact flag",]'
-        )
+        malformed_response = create_valid_extraction_response(constraints=malformed_constraints)
         valid_response = create_valid_extraction_response(
             constraints='["--lang ko|en", "keep exact flag"]'
         )

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -503,17 +503,23 @@ class TestSeedGeneratorExtraction:
             assert result.value.constraints == ("--lang ko|en", "keep exact flag")
 
     @pytest.mark.asyncio
-    async def test_generate_keeps_legacy_bracket_prefixed_constraints(self) -> None:
-        """Legacy bracket-prefixed prose is not mistaken for JSON and still splits."""
+    async def test_generate_retries_bracket_prose_and_accepts_reformatted_json(self) -> None:
+        """At extraction time bracket prose triggers retry; the reformatted array wins."""
         mock_adapter = AsyncMock()
         state = create_interview_state_with_rounds()
         low_ambiguity = create_low_ambiguity_score()
 
-        extraction_response = create_valid_extraction_response(
+        prose_response = create_valid_extraction_response(
             constraints="[P0] Must work offline | [P1] Fast startup"
         )
+        reformatted_response = create_valid_extraction_response(
+            constraints='["[P0] Must work offline", "[P1] Fast startup"]'
+        )
         mock_adapter.complete = AsyncMock(
-            return_value=Result.ok(create_mock_completion_response(extraction_response))
+            side_effect=[
+                Result.ok(create_mock_completion_response(prose_response)),
+                Result.ok(create_mock_completion_response(reformatted_response)),
+            ]
         )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -529,51 +535,48 @@ class TestSeedGeneratorExtraction:
                 "[P0] Must work offline",
                 "[P1] Fast startup",
             )
+            assert mock_adapter.complete.await_count == 2
 
-    def test_parse_constraint_values_rejects_malformed_json_intent(self) -> None:
-        """JSON-looking but invalid CONSTRAINTS raise instead of silently splitting."""
-        with pytest.raises(ValueError, match="JSON array"):
-            _parse_constraint_values('["--lang ko|en",]')
+    def test_strict_rejects_any_bracket_led_value_that_is_not_a_json_string_array(self) -> None:
+        """Strict (extraction-time) mode: [-led values must be JSON string arrays."""
+        malformed_cases = (
+            '["--lang ko|en",]',  # trailing comma
+            '["--lang ko|en"',  # truncated, quote-led
+            "[--lang ko|en",  # truncated, unquoted
+            '["--lang ko|en"] stray text',  # valid array + trailing garbage
+            '[null, "x"] stray text',  # JSON-parseable group + trailing garbage
+            "[--lang ko|en, keep exact flag] trailing note",  # unquoted array shape
+            "[ko] preserve ko|en flag",  # word-tag shape from malformed array output
+            "[P0] Must work offline | [P1] Fast startup",  # prose retries at extraction
+        )
+        for malformed in malformed_cases:
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_constraint_values(malformed, strict=True)
 
-    def test_parse_constraint_values_rejects_non_string_json_entries(self) -> None:
-        """JSON arrays must contain only strings; non-string members retry."""
+    def test_strict_rejects_non_string_json_entries(self) -> None:
+        """Strict mode: JSON arrays must contain only strings."""
         for malformed in ("[null]", '[1, "x"]'):
             with pytest.raises(ValueError, match="only strings"):
-                _parse_constraint_values(malformed)
+                _parse_constraint_values(malformed, strict=True)
 
-    def test_parse_constraint_values_rejects_quote_led_array_with_trailing_text(self) -> None:
-        """A closed quoted array followed by prose is malformed JSON, not legacy prose."""
-        with pytest.raises(ValueError, match="JSON array"):
-            _parse_constraint_values('["--lang ko|en"] stray text')
-
-    def test_parse_constraint_values_rejects_json_parseable_group_with_trailing_text(self) -> None:
-        """A leading bracket group that is itself valid JSON is intent, not a tag."""
-        for malformed in ('[null, "x"] stray text', "[null] stray text", "[123] stray | text"):
-            with pytest.raises(ValueError, match="JSON array"):
-                _parse_constraint_values(malformed)
-
-    def test_parse_constraint_values_rejects_non_tag_bracket_group_with_trailing_text(self) -> None:
-        """Only word-like [tag] tokens are prose; other bracket groups retry."""
-        for malformed in (
-            "[--lang ko|en, keep exact flag] trailing note",
-            "[--lang ko|en] trailing note",
-            "[a, b] trailing note",
-        ):
-            with pytest.raises(ValueError, match="JSON array"):
-                _parse_constraint_values(malformed)
-
-    def test_parse_constraint_values_keeps_word_tag_prose(self) -> None:
-        """Word-like tags including dots and dashes stay on the legacy split."""
+    def test_lenient_keeps_legacy_bracket_prose_split(self) -> None:
+        """Lenient (stored-data) mode: bracket prose keeps the historical split."""
+        assert _parse_constraint_values("[P0] Must work offline | [P1] Fast startup") == (
+            "[P0] Must work offline",
+            "[P1] Fast startup",
+        )
         assert _parse_constraint_values("[v2.1-rc] Must ship | [2026-01] Later") == (
             "[v2.1-rc] Must ship",
             "[2026-01] Later",
         )
 
-    def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
-        """Any malformed array missing its closing bracket raises for retry."""
-        for malformed in ('["--lang ko|en"', "[--lang ko|en"):
-            with pytest.raises(ValueError, match="JSON array"):
-                _parse_constraint_values(malformed)
+    def test_lenient_never_raises_on_malformed_json(self) -> None:
+        """Lenient mode: stored data has no retry path, so it pipe-splits instead."""
+        assert _parse_constraint_values('["--lang ko|en",]') == (
+            '["--lang ko',
+            'en",]',
+        )
+        assert _parse_constraint_values("[null]") == ("None",)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -585,6 +588,7 @@ class TestSeedGeneratorExtraction:
             "[null]",
             '[null, "x"] stray text',
             "[--lang ko|en, keep exact flag] trailing note",
+            "[ko] preserve ko|en flag",
         ),
     )
     async def test_generate_retries_on_malformed_json_constraints(

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -477,6 +477,59 @@ class TestSeedGeneratorExtraction:
             assert "No external database" in result.value.constraints
 
     @pytest.mark.asyncio
+    async def test_generate_preserves_literal_pipe_in_json_array_constraints(self) -> None:
+        """JSON-array CONSTRAINTS keep literal pipes inside one constraint (#1696)."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            constraints='["--lang ko|en", "keep exact flag"]'
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.constraints == ("--lang ko|en", "keep exact flag")
+
+    @pytest.mark.asyncio
+    async def test_generate_keeps_legacy_bracket_prefixed_constraints(self) -> None:
+        """Legacy bracket-prefixed prose is not mistaken for JSON and still splits."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            constraints="[P0] Must work offline | [P1] Fast startup"
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.constraints == (
+                "[P0] Must work offline",
+                "[P1] Fast startup",
+            )
+
+    @pytest.mark.asyncio
     async def test_generate_extracts_acceptance_criteria(self) -> None:
         """SeedGenerator extracts acceptance_criteria as tuple."""
         mock_adapter = AsyncMock()

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -535,9 +535,16 @@ class TestSeedGeneratorExtraction:
         with pytest.raises(ValueError, match="JSON array"):
             _parse_constraint_values('["--lang ko|en",]')
 
-    def test_parse_constraint_values_coerces_non_string_json_entries(self) -> None:
-        """Valid JSON arrays with non-string entries are coerced to strings."""
-        assert _parse_constraint_values('[1, "x"]') == ("1", "x")
+    def test_parse_constraint_values_rejects_non_string_json_entries(self) -> None:
+        """JSON arrays must contain only strings; non-string members retry."""
+        for malformed in ("[null]", '[1, "x"]'):
+            with pytest.raises(ValueError, match="only strings"):
+                _parse_constraint_values(malformed)
+
+    def test_parse_constraint_values_rejects_quote_led_array_with_trailing_text(self) -> None:
+        """A closed quoted array followed by prose is malformed JSON, not legacy prose."""
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_constraint_values('["--lang ko|en"] stray text')
 
     def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
         """Any malformed array missing its closing bracket raises for retry."""
@@ -548,7 +555,12 @@ class TestSeedGeneratorExtraction:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "malformed_constraints",
-        ('["--lang ko|en", "keep exact flag",]', "[--lang ko|en | keep exact flag"),
+        (
+            '["--lang ko|en", "keep exact flag",]',
+            "[--lang ko|en | keep exact flag",
+            '["--lang ko|en"] stray text',
+            "[null]",
+        ),
     )
     async def test_generate_retries_on_malformed_json_constraints(
         self, malformed_constraints: str

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -56,7 +56,7 @@ def create_mock_completion_response(
 
 def create_valid_extraction_response(
     goal: str = "Build a CLI task manager with project grouping",
-    constraints: str = "Python 3.14+ | No external database | Single-file storage",
+    constraints: str = '["Python 3.14+", "No external database", "Single-file storage"]',
     acceptance_criteria: str = "Tasks can be created | Tasks can be listed | Tasks can be deleted",
     ontology_name: str = "TaskManager",
     ontology_description: str = "Task management domain model",
@@ -458,7 +458,7 @@ class TestSeedGeneratorExtraction:
         low_ambiguity = create_low_ambiguity_score()
 
         extraction_response = create_valid_extraction_response(
-            constraints="Python 3.14+ | No external database | Must be cross-platform"
+            constraints='["Python 3.14+", "No external database", "Must be cross-platform"]'
         )
         mock_adapter.complete = AsyncMock(
             return_value=Result.ok(create_mock_completion_response(extraction_response))
@@ -548,6 +548,9 @@ class TestSeedGeneratorExtraction:
             "[--lang ko|en, keep exact flag] trailing note",  # unquoted array shape
             "[ko] preserve ko|en flag",  # word-tag shape from malformed array output
             "[P0] Must work offline | [P1] Fast startup",  # prose retries at extraction
+            "--lang ko|en | keep exact flag",  # plain pipe list, no brackets
+            "Must work offline",  # plain prose, not an array
+            '"just a JSON string"',  # valid JSON but not an array
         )
         for malformed in malformed_cases:
             with pytest.raises(ValueError, match="JSON array"):
@@ -577,6 +580,10 @@ class TestSeedGeneratorExtraction:
             'en",]',
         )
         assert _parse_constraint_values("[null]") == ("None",)
+        assert _parse_constraint_values("Python 3.14+ | No external database") == (
+            "Python 3.14+",
+            "No external database",
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -589,6 +596,7 @@ class TestSeedGeneratorExtraction:
             '[null, "x"] stray text',
             "[--lang ko|en, keep exact flag] trailing note",
             "[ko] preserve ko|en flag",
+            "--lang ko|en | keep exact flag",
         ),
     )
     async def test_generate_retries_on_malformed_json_constraints(

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -552,6 +552,23 @@ class TestSeedGeneratorExtraction:
             with pytest.raises(ValueError, match="JSON array"):
                 _parse_constraint_values(malformed)
 
+    def test_parse_constraint_values_rejects_non_tag_bracket_group_with_trailing_text(self) -> None:
+        """Only word-like [tag] tokens are prose; other bracket groups retry."""
+        for malformed in (
+            "[--lang ko|en, keep exact flag] trailing note",
+            "[--lang ko|en] trailing note",
+            "[a, b] trailing note",
+        ):
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_constraint_values(malformed)
+
+    def test_parse_constraint_values_keeps_word_tag_prose(self) -> None:
+        """Word-like tags including dots and dashes stay on the legacy split."""
+        assert _parse_constraint_values("[v2.1-rc] Must ship | [2026-01] Later") == (
+            "[v2.1-rc] Must ship",
+            "[2026-01] Later",
+        )
+
     def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
         """Any malformed array missing its closing bracket raises for retry."""
         for malformed in ('["--lang ko|en"', "[--lang ko|en"):
@@ -567,6 +584,7 @@ class TestSeedGeneratorExtraction:
             '["--lang ko|en"] stray text',
             "[null]",
             '[null, "x"] stray text',
+            "[--lang ko|en, keep exact flag] trailing note",
         ),
     )
     async def test_generate_retries_on_malformed_json_constraints(

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -546,6 +546,12 @@ class TestSeedGeneratorExtraction:
         with pytest.raises(ValueError, match="JSON array"):
             _parse_constraint_values('["--lang ko|en"] stray text')
 
+    def test_parse_constraint_values_rejects_json_parseable_group_with_trailing_text(self) -> None:
+        """A leading bracket group that is itself valid JSON is intent, not a tag."""
+        for malformed in ('[null, "x"] stray text', "[null] stray text", "[123] stray | text"):
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_constraint_values(malformed)
+
     def test_parse_constraint_values_rejects_truncated_json_intent(self) -> None:
         """Any malformed array missing its closing bracket raises for retry."""
         for malformed in ('["--lang ko|en"', "[--lang ko|en"):
@@ -560,6 +566,7 @@ class TestSeedGeneratorExtraction:
             "[--lang ko|en | keep exact flag",
             '["--lang ko|en"] stray text',
             "[null]",
+            '[null, "x"] stray text',
         ),
     )
     async def test_generate_retries_on_malformed_json_constraints(


### PR DESCRIPTION
## Summary

Literal `|` characters inside a single constraint value are corrupted on both seed-generation paths (#1696):

- `_build_seed` splits extracted CONSTRAINTS on bare `|` (`src/ouroboros/bigbang/seed_generator.py`), so `--lang ko|en` becomes two constraints.
- The promoted-reference path joins confirmed constraints/acceptance criteria with `" | "` and re-splits them in `build_promoted_reference_seed` (`src/ouroboros/bigbang/requirement_distillation.py`) — the blocker called out when #1698 was closed.

Following that close comment's guidance, each path now uses a structured representation with no delimiter round trip:

- **Extraction**: CONSTRAINTS is requested as a single-line JSON array in both prompt templates. `_parse_constraint_values` prefers JSON and falls back to legacy pipe splitting on `JSONDecodeError`, so bracket-prefixed prose like `[P0] Must work offline` keeps its legacy behavior.
- **Promotion**: `apply_requirement_distillation` emits constraints/acceptance criteria as tuples, and `build_promoted_reference_seed` consumes them directly via `_normalized_requirement_values`.

One scope note: this is structured-per-path (JSON array at the LLM text boundary, tuples for in-process promotion) rather than one shared form across both — each boundary uses its natural structure. Happy to adjust if you'd prefer a single shared representation.

Four existing assertions in `tests/unit/bigbang/test_requirement_distillation.py` pinned the pipe-joined string form of applied requirements and were updated to the structured tuples.

Relationship to #1713: that PR takes an escaping approach for the extraction path; this one follows the "one structured representation" direction from the #1698 close and also fixes the reference-aware path. Happy to coordinate whichever direction you prefer.

Closes #1696

## Test plan

- [x] 4 new regression tests: JSON-array pipe preservation, legacy bracket-prefixed fallback, promoted-reference pipe preservation for constraints and for acceptance criteria (3 fail before the fix, all pass after)
- [x] `uv run pytest tests/ -q` passes — 12888 passed, 12 skipped
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/` clean — no issues in 467 source files
