### PR TITLE
feat(orchestrator): establish process-local execution authority

### DIFF
--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -450,6 +450,16 @@ The Foundation A implementation must demonstrate all of the following:
 43. CLI cancellation preserves the typed distinction between a durable
     `CANCELLED` winner and `CANCELLATION_REQUESTED`; single and `--all` output
     and counts never report a live-owner request as completed cancellation.
+44. PAUSED publication is conditional on the absence of an explicit terminal
+    winner in the same persistence transaction; sequential, parallel, and
+    resumed runners reconstruct a losing terminal winner, project it, and
+    retire authority, heartbeat, routing, and workspace ownership.
+45. `UnitOfWork` routes exported terminal session events through the same
+    one-winner EventStore append instead of `append_batch`; both a CAS winner
+    and loser are successful commits and leave no permanently pending event.
+46. `cancel --all` counts marker/session persistence failures separately from
+    skipped or requested sessions, prints retry guidance, and never reports
+    "No running executions" when an active cancellation attempt failed.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -580,6 +580,25 @@ The Foundation A implementation must demonstrate all of the following:
     reconstruction drains the probe, preserves the nonterminal owner's request
     marker, and then re-propagates `CancelledError`; it cannot return the normal
     `cancellation_requested` disposition to a cancelled caller.
+80. a retained process-local resume whose initial durable reconstruction is
+    transiently unreadable returns typed retryable
+    `process_local_reconstruction_pending`; the MCP background wrapper does not
+    append a generic `FAILED` event or close the handler-owned EventStore.
+81. terminal cleanup that cannot retire the exact adapter-bound authority does
+    not unregister another live route or release its heartbeat; a stale local
+    route may be removed without clearing a marker while a same-process owner
+    or foreign heartbeat remains live.
+82. when public cancellation persistence fails and the caller is cancelled
+    during shielded durable reconstruction, reconciliation drains to completion
+    and re-propagates the caller `CancelledError` with the original persistence
+    failure retained as context.
+83. both initial preparation-progress failure forms (raised exception and
+    `Result.err`) route a successfully persisted `FAILED` winner through full
+    terminal cleanup, including authority, heartbeat, workspace, route, and
+    cancellation-marker acknowledgement.
+84. cancellation-marker acknowledgement retries a transient unlink failure up
+    to the bounded retry limit and surfaces the final `OSError`; a terminal
+    caller cannot report successful cleanup while the file-backed marker remains.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -431,6 +431,19 @@ The Foundation A implementation must demonstrate all of the following:
     identity-mismatch response crosses the same durable-publication boundary:
     definite absence retires, a committed start terminalizes, and ambiguous
     persistence retains the exact owner instead of guessing.
+37. a sequential recoverable failure reports `PAUSED` only after
+    `mark_paused()` succeeds; persistence failure returns typed
+    `pause_persistence_pending` while retaining the exact owner and lease.
+38. a parallel recoverable failure applies the same durable pause boundary and
+    cannot emit `execution.terminal(status=paused)` over durable `RUNNING`.
+39. a recoverable failure during resume applies the same durable pause boundary
+    and cannot return a resumable success while pause persistence is pending.
+40. a cross-process cancellation marker arriving during parallel pause
+    publication remains pending after the claim is released, so the next exact
+    owner terminalizes it before effects.
+41. a cross-process cancellation marker arriving during resumed pause
+    publication is likewise preserved; only a terminal lifecycle path may
+    acknowledge and clear it.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -501,6 +501,21 @@ The Foundation A implementation must demonstrate all of the following:
 57. the active-runner cancellation entry point forwards the caller's bounded
     `reason` and `cancelled_by` metadata unchanged to the cooperative request
     consumed by terminal persistence.
+58. active-runner cancellation interrupted immediately after its conditional
+    `CANCELLED` write reconstructs the durable winner under shielding; a
+    committed winner drains authority, heartbeat, routing, and workspace
+    ownership before the original cancellation propagates.
+59. an unreadable public-cancellation result keeps a non-effectful retryable
+    `TERMINALIZING` reservation, and a later cancellation request may reclaim
+    that reservation to retry the terminal CAS when durable state is still
+    `RUNNING` or `PAUSED`.
+60. one session aggregate has exactly one immutable `session.started` identity:
+    concurrent creation and caller-supplied reuse cannot append a second start
+    event, including when the public event factory is committed through
+    `UnitOfWork`.
+61. resume replays pending lifecycle intent and arbitrates persisted
+    process-local authority before evaluating current fat-harness or investment
+    policy; lost or foreign authority cannot be masked by a newer policy gate.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -308,6 +308,8 @@ the durable winner and projects that status instead; it never publishes a
 | A stale paused/running snapshot observes authority retirement after a public terminal write | conditional terminal append finds the existing terminal event and does not append `FAILED` | no generation is recreated or retired a second time | fail-closed resume error while the durable terminal status remains unchanged |
 | A concurrent same-owner resume occurs during a claim or terminalization reservation | no competing terminal write | `claim` fails without releasing the live owner or its worktree state | `process_local_execution_in_progress` |
 | A foreign live process holds the heartbeat lease and public cancel arrives | publish a file-backed nonterminal request; do not write terminal state beneath its effects | no local registration is manufactured or retired; the owner observes the request at its normal checkpoints | successful `cancellation_requested`; an unavailable signal path returns a retryable persistence error |
+| A local or foreign claimed owner receives a public cancellation reason/actor | preserve `reason` and `cancelled_by` in the in-memory or file-backed request metadata | the exact owner consumes the metadata when it wins `CANCELLED`; no controller writes terminal state beneath it | durable session cancellation retains CLI/MCP/JobManager attribution instead of runner defaults |
+| The owning runner commits `CANCELLED` and is repeatedly cancelled during acknowledgement/projection | the durable winner remains `CANCELLED` | marker clearing, execution projection, authority/heartbeat retirement, route removal, and workspace release drain in one shielded child task | no terminal/live-owner coexistence window remains |
 | A terminal record is written through a public paused-owner cancellation | call `retire_after_terminal_persistence` only after the write | registry atomically detaches the opaque binding, then finalizers evict runner/cache/store and lease resources | later resume sees terminal state and cannot leak a retained owner |
 | A raw caller cancellation interrupts pre-effect contract/tool setup after a claim | first drain any published cooperative cancellation in a shielded task | successful cancellation retires normally; failed persistence releases only the claim/route/lock and preserves retryable authority | cancellation result or `cancellation_persistence_pending`, never `PAUSED → FAILED` through lost authority |
 | Setup or execution raises and the `FAILED` transition cannot persist | no false terminal result is reported | release only claim/route/worktree; retain registration and heartbeat for the same owner | typed `terminal_persistence_pending`; wrapper must retain rather than manufacture another failure |
@@ -468,6 +470,17 @@ The Foundation A implementation must demonstrate all of the following:
 48. `UnitOfWork` is not lifecycle authority: it rejects a terminal event for
     any session with a live process-local registry entry, leaving both the
     pending event and resumable owner intact for owner-mediated terminalization.
+49. `UnitOfWork` also rejects terminal events when a different live process
+    holds the session heartbeat lease; a foreign writer cannot bypass the
+    owning process merely because its local registry is empty.
+50. after the owning runner commits `CANCELLED`, cooperative request clearing,
+    execution-terminal projection, authority and heartbeat retirement, active
+    route removal, and workspace release drain under shielding across repeated
+    caller cancellation.
+51. cooperative cancellation preserves the caller's bounded `reason` and
+    `cancelled_by` metadata through both the same-process registry and the
+    atomic file-backed cross-process channel; the owning runner uses that
+    metadata for the durable session cancellation event.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -526,6 +526,14 @@ The Foundation A implementation must demonstrate all of the following:
     process-local contract before attempting durable reconstruction, so an
     unreadable aggregate cannot leave inaccessible authority beside a closed
     store.
+64. an aborted preparation releases the runner-wide workspace lock only when
+    no earlier or concurrently registered process-local owner still depends on
+    it; a rejected session-ID collision cannot remove another live execution's
+    workspace exclusion.
+65. replay-only orphan detection is terminal-absorbing and rechecks the fully
+    reconstructed tracker before classification; late `RUNNING` progress cannot
+    revive or report a durable `COMPLETED`, `FAILED`, or `CANCELLED` session as
+    orphaned.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -238,7 +238,8 @@ stateDiagram-v2
     registered --> claimed: atomically claim effects
     claimed --> registered: pause or retryable cancellation failure\nrelease claim only
     registered --> terminalizing: public terminalization reservation
-    terminalizing --> registered: durable write fails or caller is cancelled
+    terminalizing --> registered: durable write fails or reconciliation proves nonterminal
+    terminalizing --> terminalizing: interrupted outcome unreadable\nretryable reservation
     terminalizing --> retired: durable terminal record + registry finalizer
     claimed --> retired: owner persists terminal record + owner teardown
     registered --> retired: setup abort or proven lost authority
@@ -516,6 +517,15 @@ The Foundation A implementation must demonstrate all of the following:
 61. resume replays pending lifecycle intent and arbitrates persisted
     process-local authority before evaluating current fat-harness or investment
     policy; lost or foreign authority cannot be masked by a newer policy gate.
+62. start publication rejects any pre-existing durable session lifecycle row,
+    including terminal-only legacy aggregates, in the same transaction that
+    claims the immutable start guard; no new runner may execute under a reused
+    session ID whose replay belongs to another lifecycle.
+63. an MCP preparation result that retains `terminal_persistence_pending`
+    records the exact runner and handler-owned EventStore from its live
+    process-local contract before attempting durable reconstruction, so an
+    unreadable aggregate cannot leave inaccessible authority beside a closed
+    store.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -599,6 +599,10 @@ The Foundation A implementation must demonstrate all of the following:
 84. cancellation-marker acknowledgement retries a transient unlink failure up
     to the bounded retry limit and surfaces the final `OSError`; a terminal
     caller cannot report successful cleanup while the file-backed marker remains.
+85. a retained resume restores and reacquires every persisted task-workspace
+    lock before the retained runner can produce an effect, even when the
+    caller passes `use_worktree=false`; that flag cannot bypass authoritative
+    workspace exclusion, and missing restoration fails closed before claim.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -392,6 +392,10 @@ The Foundation A implementation must demonstrate all of the following:
 25. a runner emits `execution.terminal` only after the session terminal CAS has
     selected a durable winner, and a CAS loser projects the winner rather than
     its stale requested status.
+26. replay and pre-aggregated session-activity snapshots both treat an explicit
+    `COMPLETED`, `FAILED`, or `CANCELLED` lifecycle event as absorbing; a late
+    `runtime_status: running` progress checkpoint cannot make orphan detection
+    or another snapshot consumer observe the session as active again.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -415,6 +415,22 @@ The Foundation A implementation must demonstrate all of the following:
 31. an MCP background task cancelled before its first coroutine turn retains
     its exact owner and owned EventStore when lost-authority terminalization
     cannot persist, and reconciles cleanup only after reading a terminal record.
+32. cancellation racing `create_session` reconstructs the allocated durable
+    identity under shielding; a committed `RUNNING` start is terminalized before
+    retirement, while an unreadable publication retains its exact owner/lease.
+33. a caller-supplied terminal tracker is never authority for cleanup; the
+    durable session must independently prove a terminal status before the
+    process-local registration or heartbeat can be retired.
+34. an MCP preparation error that retains `terminal_persistence_pending` also
+    retains its handler-owned EventStore through the enclosing handler cleanup,
+    so the exact owner remains genuinely callable for retry.
+35. post-CAS reconciliation drains under shielding across repeated task
+    cancellation for both owning-runner and public-cancellation paths; only
+    after cleanup completes does the original cancellation propagate.
+36. every failed `create_session` return, raised exception, cancellation, and
+    identity-mismatch response crosses the same durable-publication boundary:
+    definite absence retires, a committed start terminalizes, and ambiguous
+    persistence retains the exact owner instead of guessing.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -444,6 +444,12 @@ The Foundation A implementation must demonstrate all of the following:
 41. a cross-process cancellation marker arriving during resumed pause
     publication is likewise preserved; only a terminal lifecycle path may
     acknowledge and clear it.
+42. once `PAUSED` is durable, failure of the auxiliary execution-terminal
+    projection, frugality proof, or retrospective cannot route through generic
+    `FAILED` cleanup in sequential, parallel, or resumed execution.
+43. CLI cancellation preserves the typed distinction between a durable
+    `CANCELLED` winner and `CANCELLATION_REQUESTED`; single and `--all` output
+    and counts never report a live-owner request as completed cancellation.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -46,12 +46,20 @@ globals, modules, environment maps, handler maps, cache contents, or opaque
 objects. Credential-shaped values are never serialized; they force the owning
 component to process-local.
 
-Every process-local component receives an opaque random nonce once per
-**authority generation**. `ExecutionAuthorityLiveBinding` retains that nonce
-for its same-instance integrity rechecks; a new executor/runtime capture gets a
-new nonce. Two instances may have similar visible configuration, but they
-cannot compare as a portable authority or accidentally authorize cross-process
-reuse.
+Every dynamically or unsafely identified process-local component receives an
+opaque random nonce once per **authority generation**.
+`ExecutionAuthorityLiveBinding` retains that nonce for its same-instance
+integrity rechecks; a new executor/runtime capture gets a new nonce. Two
+instances may have similar visible configuration, but they cannot compare as a
+portable authority or accidentally authorize cross-process reuse.
+
+More precisely, a nonce is attached to each component whose own identity is
+dynamic, unsafe, or otherwise not canonically observable. A valid declarative
+workspace or policy descriptor need not receive a separate nonce merely because
+another component makes the *whole* authority process-local. In Foundation A
+every current runtime is such a component, so its live nonce makes the complete
+authority generation process-local even when the workspace and policy retain
+their finite declarative descriptors.
 
 An authority generation additionally has a non-serializable live capability
 held in the process-local registry by session id. The persisted event contract
@@ -135,6 +143,12 @@ runtime-owned dynamic collaborator. If a `process_local` session has no live
 capability, resume terminates with a typed `process_local_resume_unavailable`
 outcome and an operator must start a new attempt; it must never silently fall
 back to a stale session, a cached pass, or a newly computed runtime descriptor.
+
+This is also a deployment boundary: a one-shot detached worker may retain an
+owner while it remains alive, but its handler-local runner and capability leave
+with that worker. A later request handled by a different worker therefore
+returns `process_local_resume_unavailable`; it is not a durable-resume path and
+must not attempt to recreate the prior owner from its stored correlation data.
 
 For a new process-local session, the runner validates/allocates the session id,
 registers the registry-minted capability, and acquires its PID-and-boot-time

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -180,8 +180,10 @@ Effectful execution atomically claims the live session capability. A second
 same-process caller receives `process_local_execution_in_progress` and must
 not terminalize or retire the original caller. `PAUSED` releases **only** that
 exclusive claim: its registry registration/capability and liveness lease remain
-held by the original owner. Terminal, cancellation, and setup-abort paths retire
-the registration, issuance, claim, and owned lease together.
+held by the original owner. Only a durable terminal winner retires the
+registration, issuance, claim, and owned lease. A raw task cancellation or
+failed terminal write releases the exiting coroutine's claim, active route, and
+worktree lock while preserving the exact owner for retry.
 
 On a valid process-local resume, a foreign runner or observer must treat either
 a live registry registration or a live liveness lease as an active owner and
@@ -305,9 +307,10 @@ the durable winner and projects that status instead; it never publishes a
 | MCP execution wrapper receives `cancellation_persistence_pending` | must not call `mark_failed` | retains the exact owner and its liveness until a successful terminal write | retryable nonterminal error |
 | A stale paused/running snapshot observes authority retirement after a public terminal write | conditional terminal append finds the existing terminal event and does not append `FAILED` | no generation is recreated or retired a second time | fail-closed resume error while the durable terminal status remains unchanged |
 | A concurrent same-owner resume occurs during a claim or terminalization reservation | no competing terminal write | `claim` fails without releasing the live owner or its worktree state | `process_local_execution_in_progress` |
-| A foreign live process holds the heartbeat lease | must not terminalize a process it cannot signal | no local registration is manufactured or retired | retryable `process_local_authority_held_elsewhere` |
+| A foreign live process holds the heartbeat lease and public cancel arrives | publish a file-backed nonterminal request; do not write terminal state beneath its effects | no local registration is manufactured or retired; the owner observes the request at its normal checkpoints | successful `cancellation_requested`; an unavailable signal path returns a retryable persistence error |
 | A terminal record is written through a public paused-owner cancellation | call `retire_after_terminal_persistence` only after the write | registry atomically detaches the opaque binding, then finalizers evict runner/cache/store and lease resources | later resume sees terminal state and cannot leak a retained owner |
 | A raw caller cancellation interrupts pre-effect contract/tool setup after a claim | first drain any published cooperative cancellation in a shielded task | successful cancellation retires normally; failed persistence releases only the claim/route/lock and preserves retryable authority | cancellation result or `cancellation_persistence_pending`, never `PAUSED → FAILED` through lost authority |
+| Setup or execution raises and the `FAILED` transition cannot persist | no false terminal result is reported | release only claim/route/worktree; retain registration and heartbeat for the same owner | typed `terminal_persistence_pending`; wrapper must retain rather than manufacture another failure |
 
 The `claim` and terminalization reservation are intentionally the same mutual
 exclusion boundary. Thus a resume cannot acquire effects between public-cancel
@@ -372,9 +375,10 @@ The Foundation A implementation must demonstrate all of the following:
 18. a failed worker cancellation write releases the departed effect claim,
     active route, and worktree lock while preserving the live registration,
     heartbeat, and cancellation request for an exact-owner retry;
-19. the MCP wrapper preserves that retryable cancellation state rather than
-    manufacturing `FAILED`, and a foreign live heartbeat receives a retryable
-    ownership block rather than an unsafe public terminal write;
+19. the MCP wrapper preserves retryable cancellation/terminal-persistence state
+    rather than manufacturing `FAILED`; a foreign resume receives the typed
+    ownership block, while a foreign public cancel publishes a durable
+    nonterminal request instead of writing terminal state beneath active effects;
 20. an externally persisted terminal record drains the exact retained runner,
     handler cache, heartbeat, worktree ownership, and owned EventStore through
     the registry's one finalizer path; and
@@ -396,6 +400,12 @@ The Foundation A implementation must demonstrate all of the following:
     `COMPLETED`, `FAILED`, or `CANCELLED` lifecycle event as absorbing; a late
     `runtime_status: running` progress checkpoint cannot make orphan detection
     or another snapshot consumer observe the session as active again.
+27. setup and execution exception handlers persist or observe a terminal winner
+    before retiring authority or liveness; if that write fails, they preserve an
+    unclaimed same-process owner and return `terminal_persistence_pending`.
+28. cancellation issued from a separate CLI/MCP process reaches a live owner
+    through a containment-safe file-backed request marker, which is distinct
+    from both the heartbeat lease and terminal session evidence.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -454,12 +454,20 @@ The Foundation A implementation must demonstrate all of the following:
     winner in the same persistence transaction; sequential, parallel, and
     resumed runners reconstruct a losing terminal winner, project it, and
     retire authority, heartbeat, routing, and workspace ownership.
-45. `UnitOfWork` routes exported terminal session events through the same
-    one-winner EventStore append instead of `append_batch`; both a CAS winner
-    and loser are successful commits and leave no permanently pending event.
+45. for sessions without a live process-local owner, `UnitOfWork` routes
+    exported terminal session events through the same one-winner EventStore
+    append instead of `append_batch`; both a CAS winner and loser are
+    successful commits and leave no permanently pending event.
 46. `cancel --all` counts marker/session persistence failures separately from
     skipped or requested sessions, prints retry guidance, and never reports
     "No running executions" when an active cancellation attempt failed.
+47. a retained owner preserves the full pending `COMPLETED`, `FAILED`, or
+    `PAUSED` transition payload in process-local state; the next exact-owner
+    resume retries that transition before runtime arbitration or effects, then
+    reconciles projection and ownership from the durable result.
+48. `UnitOfWork` is not lifecycle authority: it rejects a terminal event for
+    any session with a live process-local registry entry, leaving both the
+    pending event and resumable owner intact for owner-mediated terminalization.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -560,6 +560,26 @@ The Foundation A implementation must demonstrate all of the following:
 73. a retained resume reserves workspace exclusion before restoring the
     worktree and holds it until the resumed identity is claimed or the handoff
     fails, so a sibling session cannot release the shared lock in that window.
+74. cancellation shielding drains the selected lifecycle cleanup but preserves
+    the first caller `CancelledError` and re-raises it after cleanup; shielding
+    cannot turn a cancelled public operation into an ordinary successful return.
+75. public terminalization treats authority retirement, all registered
+    finalizers, and cancellation-marker acknowledgement as one cancellation-
+    resistant boundary; a cancelling finalizer cannot leave a terminal session
+    with a pending cooperative request.
+76. an existing-terminal runner reconciliation retires authority, heartbeat,
+    active routing, and workspace ownership before its final cancellation-marker
+    clear, preventing a concurrent publisher from outliving terminal cleanup.
+77. the owning runner's durable `CANCELLED` path applies the same final-clear
+    ordering and propagates caller cancellation only after every live resource
+    and the request marker have been drained.
+78. resumed terminal completion applies the same final-clear ordering, while a
+    durable `PAUSED` result deliberately preserves a late marker for the next
+    exact-owner resume checkpoint.
+79. cancelling a claimed-owner public cancellation probe during durable
+    reconstruction drains the probe, preserves the nonterminal owner's request
+    marker, and then re-propagates `CancelledError`; it cannot return the normal
+    `cancellation_requested` disposition to a cancelled caller.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -1,0 +1,246 @@
+# AC Runtime Execution Authority Boundary
+
+## Status
+
+Proposed Foundation A replacement for the closed implementation PRs #1682,
+#1704, and #1705. This document deliberately selects the conservative first
+boundary: every currently supported CLI runtime is executable **only within
+its creating process**. No existing CLI runtime can claim portable execution
+identity until it is rebuilt around the sealed kernel described below.
+
+Foundation A is identity-only. It does not authorize result reuse, checkpoint
+reuse, trust reuse, dispatch, routing, acceptance, or cross-run learning.
+
+## Problem
+
+The prior designs tried to promote `CodexCliRuntime` to portable identity by
+binding its public `execute_task` method and an expanding set of configuration
+fields. That is not a finite effect boundary: the unchanged public method
+dynamically resolves `_execute_task_impl`, command builders, event handlers,
+local skill/MCP handlers, process hooks, and caches. Binding each newly found
+helper would turn Foundation A back into an unbounded inspection of a Python
+object graph.
+
+Consequently, an unchanged public `execute_task` could dispatch a changed
+post-construction helper while the contract was still marked portable. A
+portable claim made under those conditions is false and must not be an input to
+later reuse or acceptance decisions.
+
+## Foundation A contract
+
+`ExecutionAuthorityContract` is a canonical, digest-only snapshot with these
+components:
+
+| Component | Portable treatment | Process-local treatment |
+| --- | --- | --- |
+| Executor policy | Closed versioned declarative values owned by the executor | Invalid/unknown values add a live-instance nonce |
+| Workspace | Canonical workspace identity; a future portable kernel must also bind an immutable workspace generation | Missing/unsafe identity or a missing future generation adds a nonce |
+| Built-in verifier | Closed implementation version and declarative configuration | Custom, dynamic, or unsafe verifier adds a nonce |
+| Runtime | **No legacy CLI runtime is portable in Foundation A** | Runtime type and all runtime execution behavior are scoped to one live instance |
+| Prompt, AC, tool list, model override, effort, session/handle, checkpoint | Excluded; attempt input | Excluded; Foundation C owns it |
+| Event store, queues, locks, signal hubs, local handler caches, globals, closures, monkeypatches | Excluded | Live process state |
+
+The canonical JSON contains only safe, finite declarative values or their
+digests. It never recursively hashes callables, closures, descriptors,
+globals, modules, environment maps, handler maps, cache contents, or opaque
+objects. Credential-shaped values are never serialized; they force the owning
+component to process-local.
+
+Every process-local component receives an opaque random nonce once per
+**authority generation**. `ExecutionAuthorityLiveBinding` retains that nonce
+for its same-instance integrity rechecks; a new executor/runtime capture gets a
+new nonce. Two instances may have similar visible configuration, but they
+cannot compare as a portable authority or accidentally authorize cross-process
+reuse.
+
+An authority generation additionally has a non-serializable live capability
+held in the process-local registry by session id. The persisted event contract
+may record `scope: "process_local"` and a correlation id, but never contains
+that capability. Deserializing the correlation id in another process is
+evidence only: it cannot recreate the capability or authorize an effect.
+
+The registry alone mints generations and accepts registrations; it exposes no
+public "register this correlation id" or caller-constructed capability path.
+It records the exact minted object and its creating PID. After `fork`, the
+child replaces the registry state and lock, so inherited memory cannot act as
+a parent capability and cannot deadlock on a lock held by a vanished parent
+thread. A child must create a fresh authority generation for a fresh attempt.
+
+`portable_across_processes` is an identity-stability predicate only. It is
+false for every current CLI runtime. There is no
+`reusable_across_processes` alias: reuse is a later, separately authorized
+decision in Foundation C and the Final Gate.
+
+## Runtime rule
+
+`CodexCliRuntime`, `CopilotCliRuntime`, `ZcodeCLIRuntime`, and every custom or
+subclassed runtime remain fully executable. Their dynamic helpers, local skill
+interception, MCP-handler caches, profile loaders, environment reads, launcher
+chains, and resume recovery hooks are normal live-process behavior, not a
+portable authority declaration.
+
+Foundation A must not call a runtime's dynamic identity provider while
+constructing a portable witness. A runtime may expose a descriptor for logging
+or same-process diagnostics, but that descriptor cannot upgrade its stability.
+
+The supported legacy runtime catalog is the factory's complete set: Codex,
+OpenCode, Hermes, Gemini, Antigravity, Grok, Kiro, Copilot, Goose, Pi, GJC,
+Zcode, and all custom/subclassed adapters. Tests enumerate that catalog rather
+than relying on a prose list.
+
+The executor may still capture its own fixed entry functions to prevent an
+accidental internal dispatch through a replaced executor method. That is a
+local integrity check, not a proof that an arbitrary runtime's whole Python
+implementation is portable.
+
+## Future portable runtime: sealed execution kernel
+
+A future, separate proposal may admit one portable runtime only by introducing
+an explicit `SealedExecutionKernel`. It must not wrap or call the legacy
+runtime's dynamically resolved `self._...` helpers on the portable path.
+
+Its finite data and collaborators must be:
+
+1. an immutable `LaunchSpec` containing the canonical executable chain,
+   working directory, allowed child-environment snapshot, permissions, fixed
+   timeouts, and bounded process policy;
+2. a fixed parser/normalizer implementation table whose functions are captured
+   at kernel construction and invoked directly;
+3. a direct subprocess launcher collaborator captured at construction;
+4. no local skill interception, mutable MCP handler cache, session-signal hub,
+   arbitrary callback, or dynamic profile/config lookup on the portable path;
+5. a versioned closed implementation identifier, with reviewed source changes
+   requiring a version bump; and
+6. an immutable settled-workspace generation/snapshot, rather than a path-only
+   workspace identity; and
+7. a live guard that validates the kernel object and its exact finite
+   collaborators before it produces an executor-owned effect.
+
+Local interception and any unsupported configuration must route to the legacy
+process-local runtime instead. The sealed kernel is deliberately deferred; it
+is not simulated by a long allowlist of legacy helper methods.
+
+## Consumer rules
+
+Foundation B may attach an authority fingerprint to attempt and final-acceptance
+events as diagnostic attribution, but a process-local fingerprint or correlation
+id must never be used as an event-deduplication key, replay/idempotency key,
+trust key, reusable-result key, or final-acceptance key. Foundation B's
+replay-safe final event will have its own authority-generation semantics.
+
+The runner records the authority scope when a new run starts. On resume it must
+check the live generation capability **before** looking up
+`execution_identity_contract`, a resume-selector provider, or any other
+runtime-owned dynamic collaborator. If a `process_local` session has no live
+capability, resume terminates with a typed `process_local_resume_unavailable`
+outcome and an operator must start a new attempt; it must never silently fall
+back to a stale session, a cached pass, or a newly computed runtime descriptor.
+
+For a new process-local session, the runner validates/allocates the session id,
+registers the registry-minted capability, and acquires its PID-and-boot-time
+liveness lease **before** it persists the durable `RUNNING` tracker. If either
+registration or lease acquisition fails, no `RUNNING` tracker is published.
+The lease is liveness evidence only; it never transfers or reconstructs the
+opaque authority capability.
+
+Effectful execution atomically claims the live session capability. A second
+same-process caller receives `process_local_execution_in_progress` and must
+not terminalize or retire the original caller. `PAUSED` releases **only** that
+exclusive claim: its registry registration/capability and liveness lease remain
+held by the original owner. Terminal, cancellation, and setup-abort paths retire
+the registration, issuance, claim, and owned lease together.
+
+On a valid process-local resume, a foreign runner or observer must treat either
+a live registry registration or a live liveness lease as an active owner and
+return the non-terminal typed block
+`process_local_authority_held_elsewhere`. It produces the terminal
+`process_local_resume_unavailable` result only when **both** the matching
+registry registration and liveness lease are absent. This distinguishes an
+active process from a crashed/exited owner without treating a lock as portable
+authority.
+
+The MCP handler retains a paused process-local owner strongly. A same-handler
+resume selects the exact retained runner, adapter, and handler-owned
+`EventStore`; it does not reconstruct a fresh runtime or capability from the
+persisted correlation id. Because pausing releases the task-worktree lock, the
+handler restores that exact workspace and reacquires its lock before the
+retained runner resumes. The retained event store stays open while paused and
+is closed only after that runner reaches a terminal state.
+
+New process-local session ids must pass the canonical safe-id validation before
+registration or lease acquisition. For an old/corrupt persisted id that is not
+safe, heartbeat observers derive a containment-safe hashed lookup filename;
+they do not use the raw value as a path and cannot register it as a new
+authority. Heartbeat observers never delete stale or malformed lease records:
+their read is non-atomic, and removal could race with a new holder. Such a
+record simply cannot prove liveness.
+
+Contracts created before this schema have no Foundation A authority scope. They
+are not migrated into the new authority model: a runner that cannot prove a
+same-process generation rejects their resume explicitly. This is a deliberate
+fail-closed migration rule, not a claim that old persisted runtime descriptors
+were portable.
+
+Foundation C may support same-process capsule continuation for a process-local
+generation. Cross-process fresh-session continuation is locked behind the
+sealed-kernel prerequisite: until that kernel is approved, a process restart
+produces the explicit terminal/new-attempt path above. A later C sub-slice may
+enable cross-process continuation only when every component is portable and its
+capsule contract is independently valid.
+
+## Exit matrix
+
+The Foundation A implementation must demonstrate all of the following:
+
+1. exact current CLI runtimes, their subclasses, custom runtimes, custom
+   verifiers, local skill dispatch, local handler caches, and signal hubs are
+   process-local;
+2. changing `_execute_task_impl`, `_build_command`, a local handler cache, or
+   `execution_identity_contract` after capture never leaves a runtime marked
+   portable;
+3. no runtime descriptor, credential-shaped value, callable closure/global, or
+   cache contents appear in canonical authority JSON;
+4. two process-local runtime captures receive distinct fingerprints even when
+   configured alike, while a live binding retains its captured nonce for a
+   same-instance recheck;
+5. workspace, built-in verifier, and closed executor-policy divergence change
+   the identity; malformed or unsafe values fail closed to process-local;
+6. executor-owned fixed entry-root drift is rejected before its next owned
+   effect, while runtime helper drift is explicitly outside the portable
+   guarantee; and
+7. no public Foundation A API says or implies that a portable identity grants
+   reuse, dispatch, result, checkpoint, trust, routing, or final acceptance.
+8. a new run registers its non-serializable generation capability; same-process
+   resume retains it, while a reconstructed process-local contract without that
+   capability rejects before any dynamic runtime identity or resume-selector
+   provider is invoked;
+9. a correlation id, forged or deserialized generation, or forked child cannot
+   register a live authority; issuance and registration are registry-private
+   and PID-bound;
+10. only one caller may hold an effectful claim for a session, while a second
+    caller fails non-terminally and a live `RUNNING` holder is never
+    terminalized by an observer;
+11. a `RUNNING` tracker whose registry capability and liveness lease have both
+    disappeared takes the explicit terminal/new-attempt path;
+12. process-local authority data is attribution only and cannot be used by an
+    attempt/final-event reducer as a dedupe, replay, trust, or acceptance key;
+    and
+13. every runtime-factory backend and a subclass/custom adapter are classified
+    process-local, the boundary matrix lists `legacy_runtime_descriptor` only
+    under `process_local`, and legacy persisted contracts without the new scope
+    marker take the explicit fail-closed migration path.
+14. registry registration and the held liveness lease precede durable `RUNNING`
+    persistence; a failed lease acquisition rolls the registration back without
+    publishing a recoverable-looking session;
+15. `PAUSED` releases only the effect claim, and the same handler's retained
+    runner/adapter/EventStore resumes only after it has reacquired the paused
+    worktree lock; a concurrent or foreign resume returns a typed non-terminal
+    result without calling `mark_failed`; and
+16. heartbeat lookup is contained for unsafe legacy ids, while observers retain
+    stale/malformed lease files rather than deleting liveness evidence they did
+    not own.
+
+This exit matrix is intentionally narrower than an arbitrary-code sandbox and
+broader than a cosmetic fingerprint: it makes the only cross-process claim
+that Foundation A can currently prove, which is that it makes no such claim
+for legacy dynamic runtimes.

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -481,6 +481,19 @@ The Foundation A implementation must demonstrate all of the following:
     `cancelled_by` metadata through both the same-process registry and the
     atomic file-backed cross-process channel; the owning runner uses that
     metadata for the durable session cancellation event.
+52. retained `COMPLETED` and `FAILED` intent replay reconstructs the durable
+    winner after an interrupted terminal CAS response; a committed winner
+    retires authority, heartbeat, active routing, and workspace ownership
+    instead of preserving a contradictory retry owner.
+53. generic failure cleanup applies the same post-CAS reconstruction before
+    returning persistence-pending or propagating cancellation, so a committed
+    terminal winner cannot coexist with live process-local resources.
+54. lost-authority terminalization reconciles an interrupted conditional
+    `FAILED` write under shielding before deciding whether terminal intent must
+    remain pending.
+55. preparation-failure terminalization uses the same durable-winner boundary;
+    cancellation after a committed `FAILED` append drains the early authority
+    and heartbeat before it propagates.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -406,6 +406,15 @@ The Foundation A implementation must demonstrate all of the following:
 28. cancellation issued from a separate CLI/MCP process reaches a live owner
     through a containment-safe file-backed request marker, which is distinct
     from both the heartbeat lease and terminal session evidence.
+29. a transient or persistent `COMPLETED` write failure retries or preserves
+    the original completion intent; no generic exception funnel may rewrite a
+    successful runtime result as `FAILED`.
+30. cancellation after a durable terminal CAS but before projection/cleanup
+    reconstructs the terminal winner and retires local authority instead of
+    restoring a live owner beside `COMPLETED`, `FAILED`, or `CANCELLED`.
+31. an MCP background task cancelled before its first coroutine turn retains
+    its exact owner and owned EventStore when lost-authority terminalization
+    cannot persist, and reconciles cleanup only after reading a terminal record.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -3,13 +3,32 @@
 ## Status
 
 Proposed Foundation A replacement for the closed implementation PRs #1682,
-#1704, and #1705. This document deliberately selects the conservative first
+#1704, #1705, and #1706. This document deliberately selects the conservative first
 boundary: every currently supported CLI runtime is executable **only within
 its creating process**. No existing CLI runtime can claim portable execution
 identity until it is rebuilt around the sealed kernel described below.
 
-Foundation A is identity-only. It does not authorize result reuse, checkpoint
-reuse, trust reuse, dispatch, routing, acceptance, or cross-run learning.
+Foundation A's persisted authority contract is identity-only. This replacement
+also defines the process-local lifecycle required to keep that identity
+truthful while effects are active. It does not authorize result reuse,
+checkpoint reuse, trust reuse, dispatch, routing, acceptance, or cross-run
+learning.
+
+## Review-derived approval constraints
+
+The four closed implementation PRs are evidence for hard exclusions in this
+replacement, not a backlog of helper names to bind later:
+
+| Review evidence | Rejected assumption | Binding rule in this replacement |
+| --- | --- | --- |
+| #1682 | A growing snapshot of workspace, runtime, verifier, dispatcher, rate gate, and executor objects can prove portable behavior | Never infer portable authority by recursively inspecting live Python objects |
+| #1704 | More callable/global/credential inspection can make that open object graph complete and safe to serialize | Canonical authority contains only finite declarative data; dynamic behavior and credential-shaped values force process-local scope |
+| #1705 | A narrow legacy CLI allowlist can be portable if enough launch and helper fields are enumerated | Every existing CLI runtime is process-local; portability requires a separate sealed execution kernel with a closed effect path |
+| #1706 | Runner, heartbeat, retained MCP owner, and public cancellation may each perform their own terminal cleanup | One registry owns one lifecycle entry per session; other surfaces request transitions and durable terminal state has one CAS winner |
+
+These constraints may not be relaxed by a follow-up patch in Foundation A. A
+future proposal that needs portability, routing, or reuse must introduce its own
+reviewed authority rather than widening this boundary.
 
 ## Problem
 
@@ -205,7 +224,9 @@ capsule contract is independently valid.
 ## Process-local lifecycle ownership
 
 The process-local registry is the sole in-process owner of the authority
-generation's lifecycle.  It has a deliberately small state machine; runner,
+generation's lifecycle. It stores one lifecycle entry per session with one
+explicit, mutually exclusive state; claim and terminalization are not parallel
+maps that can both appear owned. It has a deliberately small state machine; runner,
 MCP execution, and public cancellation surfaces may request a transition, but
 they must not each infer a separate terminal lifecycle.
 
@@ -266,6 +287,12 @@ property on other supported stores. The outcome is either one durable winner or
 a successful no-op because another terminal event already won. A stale
 `PAUSED`/`RUNNING` snapshot therefore cannot append `FAILED` over a concurrent
 `CANCELLED` record after the registry has retired its local generation.
+
+The session terminal CAS is the durable source of truth. A runner persists that
+transition before emitting the `execution.terminal` projection used by
+single-stream consumers. If its requested transition loses, it reconstructs
+the durable winner and projects that status instead; it never publishes a
+`completed` or `failed` execution mirror before the session winner is known.
 
 ### Cancellation and resume race matrix
 
@@ -359,6 +386,12 @@ The Foundation A implementation must demonstrate all of the following:
 23. a raw task cancellation in every claimed-but-pre-effect setup window drains
     a published cooperative cancellation before generic cleanup, or preserves
     the explicit retryable cancellation state for the next exact-owner resume.
+24. every live session is represented by one registry lifecycle entry whose
+    state is exactly one of `registered`, `claimed`, or `terminalizing`; a claim
+    and a terminalization reservation cannot coexist.
+25. a runner emits `execution.terminal` only after the session terminal CAS has
+    selected a durable winner, and a CAS loser projects the winner rather than
+    its stale requested status.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -494,6 +494,13 @@ The Foundation A implementation must demonstrate all of the following:
 55. preparation-failure terminalization uses the same durable-winner boundary;
     cancellation after a committed `FAILED` append drains the early authority
     and heartbeat before it propagates.
+56. an interrupted public cancellation with an unreadable post-CAS winner
+    keeps its exact owner in non-effectful `TERMINALIZING` state; a later
+    cancellation request retries durable reconciliation and retires a proven
+    terminal winner instead of restoring execution authority.
+57. the active-runner cancellation entry point forwards the caller's bounded
+    `reason` and `cancelled_by` metadata unchanged to the cooperative request
+    consumed by terminal persistence.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -534,6 +534,32 @@ The Foundation A implementation must demonstrate all of the following:
     reconstructed tracker before classification; late `RUNNING` progress cannot
     revive or report a durable `COMPLETED`, `FAILED`, or `CANCELLED` session as
     orphaned.
+66. runner-wide workspace exclusion is reference-counted by effectful session
+    identity: completion, failure, cancellation, pause, or persistence-pending
+    cleanup for one session cannot release a lock still used by another session,
+    and the last relinquishing identity releases it exactly once.
+67. snapshot-based orphan detection applies the same reconstructed-status check
+    as replay fallback, so an active-looking snapshot cannot append a durable
+    terminal tracker to the orphan set.
+68. a duplicate preparation using the exact same session and execution IDs on
+    the same runner cannot retire the older registered generation, its liveness
+    lease, or its workspace ownership when the new generation is rejected.
+69. workspace cleanup is idempotent across runner, handler, callback, and outer
+    `finally` layers: after the last identity releases the lock, repeated
+    cleanup for that identity cannot release the same lock again.
+70. direct cancellation that observes an already-terminal durable tracker
+    drains any matching retained authority and its final workspace ownership;
+    the early `already_terminal` return cannot leak live resources.
+71. cooperative cancellation rechecks durable status after publishing to both
+    a claimed local owner and a heartbeat-backed foreign owner; if completion
+    won the race, the late in-memory or file-backed signal is cleared and the
+    caller observes `already_terminal` instead of `cancellation_requested`.
+72. an in-flight preparation reserves runner-wide workspace exclusion before
+    its first await, so another session finishing during contract construction
+    cannot release the lock before the new identity is registered or aborted.
+73. a retained resume reserves workspace exclusion before restoring the
+    worktree and holds it until the resumed identity is claimed or the handoff
+    fails, so a sibling session cannot release the shared lock in that window.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/docs/rfc/ac-runtime-execution-authority-boundary.md
+++ b/docs/rfc/ac-runtime-execution-authority-boundary.md
@@ -202,6 +202,92 @@ produces the explicit terminal/new-attempt path above. A later C sub-slice may
 enable cross-process continuation only when every component is portable and its
 capsule contract is independently valid.
 
+## Process-local lifecycle ownership
+
+The process-local registry is the sole in-process owner of the authority
+generation's lifecycle.  It has a deliberately small state machine; runner,
+MCP execution, and public cancellation surfaces may request a transition, but
+they must not each infer a separate terminal lifecycle.
+
+```mermaid
+stateDiagram-v2
+    [*] --> registered: mint + register + acquire lease
+    registered --> claimed: atomically claim effects
+    claimed --> registered: pause or retryable cancellation failure\nrelease claim only
+    registered --> terminalizing: public terminalization reservation
+    terminalizing --> registered: durable write fails or caller is cancelled
+    terminalizing --> retired: durable terminal record + registry finalizer
+    claimed --> retired: owner persists terminal record + owner teardown
+    registered --> retired: setup abort or proven lost authority
+    retired --> [*]
+```
+
+`registered` holds the opaque generation, registration, heartbeat lease, and
+registered terminal finalizers. `claimed` adds the one exclusive right to
+perform effects. `terminalizing` is not a second effect owner: it is a
+reservation held only while a public terminal surface writes its durable record
+for an otherwise unclaimed paused owner. `retired` contains none of those
+resources. A session must never be both durably terminal and locally
+`registered` after a successful terminalization path completes.
+
+### Terminalization API
+
+The registry exposes four lifecycle operations, all keyed by the exact
+session/execution/correlation tuple:
+
+| Operation | Preconditions | Result |
+| --- | --- | --- |
+| `claim` | `registered`, no effect claim or reservation | moves to `claimed`; a competing caller receives the non-terminal in-progress block |
+| `release` | exact current effect owner | returns `claimed` to `registered`, preserving the registration and lease for a paused/retryable owner |
+| `begin_terminalization` | `registered` and unclaimed | reserves `terminalizing`; an active claim or another reservation is signalled instead of being terminalized underneath |
+| `retire_after_terminal_persistence` | a durable terminal record has already succeeded | atomically removes registration, claim/reservation, issuance, and finalizer set, then drains the captured finalizers |
+
+Only the final operation is allowed to run the retained-owner cleanup callbacks.
+The callbacks close retained `EventStore` instances, evict handler-held runners,
+release heartbeat/worktree state through their exact owner, and are idempotent.
+They are registered against the opaque live binding rather than reconstructed
+from persisted diagnostic data. If cancellation reaches the caller while this
+finalizer set is draining, the drain still completes every callback before that
+caller cancellation is re-raised. A cancelled or failing individual callback is
+logged and cannot prevent subsequent cleanup callbacks from running.
+
+Normal runner-owned completion persists its terminal tracker before performing
+its own teardown. A public terminal surface follows the same order, but first
+takes `begin_terminalization`; it has no authority to mint/reconstruct a
+runner. This gives the paused retained owner and the public MCP surface one
+shared transition instead of two competing cleanup paths.
+
+Authority-loss failure and public cancellation use an additional durable
+transition guard: `append_session_terminal_if_active`. It checks for an
+explicit session terminal event and appends the new terminal event in the same
+database transaction. For SQLite it takes the immediate write transaction;
+the per-session unique terminal-transition guard provides the same one-winner
+property on other supported stores. The outcome is either one durable winner or
+a successful no-op because another terminal event already won. A stale
+`PAUSED`/`RUNNING` snapshot therefore cannot append `FAILED` over a concurrent
+`CANCELLED` record after the registry has retired its local generation.
+
+### Cancellation and resume race matrix
+
+| Situation | Durable action | Local authority result | Caller-visible outcome |
+| --- | --- | --- | --- |
+| A local worker is `claimed`; public cancel arrives | Do not write a terminal record underneath it; publish the cooperative request | claim remains with worker until its orderly cancellation path | successful `cancellation_requested` response; worker performs persistence and teardown |
+| A local paused owner is `registered`; public cancel arrives | reserve first, publish request, then write `CANCELLED` | reservation blocks a concurrent resume claim; successful write retires and drains all finalizers | terminal cancellation response |
+| The paused-owner cancellation write fails or its caller is cancelled | no terminal record is reported | release only the reservation; preserve registration, lease, and published cancellation request | retryable error/caller cancellation; retained owner retries before any next effect |
+| Worker cancellation persistence fails | no false `CANCELLED`/`FAILED` record | release exiting worker's effect claim, active route, and worktree lock; retain registration, heartbeat, and cancellation request | typed `cancellation_persistence_pending`; next same-process resume retries cancellation before executing effects |
+| MCP execution wrapper receives `cancellation_persistence_pending` | must not call `mark_failed` | retains the exact owner and its liveness until a successful terminal write | retryable nonterminal error |
+| A stale paused/running snapshot observes authority retirement after a public terminal write | conditional terminal append finds the existing terminal event and does not append `FAILED` | no generation is recreated or retired a second time | fail-closed resume error while the durable terminal status remains unchanged |
+| A concurrent same-owner resume occurs during a claim or terminalization reservation | no competing terminal write | `claim` fails without releasing the live owner or its worktree state | `process_local_execution_in_progress` |
+| A foreign live process holds the heartbeat lease | must not terminalize a process it cannot signal | no local registration is manufactured or retired | retryable `process_local_authority_held_elsewhere` |
+| A terminal record is written through a public paused-owner cancellation | call `retire_after_terminal_persistence` only after the write | registry atomically detaches the opaque binding, then finalizers evict runner/cache/store and lease resources | later resume sees terminal state and cannot leak a retained owner |
+| A raw caller cancellation interrupts pre-effect contract/tool setup after a claim | first drain any published cooperative cancellation in a shielded task | successful cancellation retires normally; failed persistence releases only the claim/route/lock and preserves retryable authority | cancellation result or `cancellation_persistence_pending`, never `PAUSED → FAILED` through lost authority |
+
+The `claim` and terminalization reservation are intentionally the same mutual
+exclusion boundary. Thus a resume cannot acquire effects between public-cancel
+preflight and persistence. The implementation still treats an observed
+post-write active claim defensively: it republishes cancellation for that owner
+to complete orderly teardown rather than silently deleting its live state.
+
 ## Exit matrix
 
 The Foundation A implementation must demonstrate all of the following:
@@ -253,6 +339,26 @@ The Foundation A implementation must demonstrate all of the following:
 16. heartbeat lookup is contained for unsafe legacy ids, while observers retain
     stale/malformed lease files rather than deleting liveness evidence they did
     not own.
+17. a public terminalization reserves an unclaimed paused generation before its
+    durable write, blocks concurrent effect claims, and releases that reservation
+    without retiring the owner when the write or its caller fails;
+18. a failed worker cancellation write releases the departed effect claim,
+    active route, and worktree lock while preserving the live registration,
+    heartbeat, and cancellation request for an exact-owner retry;
+19. the MCP wrapper preserves that retryable cancellation state rather than
+    manufacturing `FAILED`, and a foreign live heartbeat receives a retryable
+    ownership block rather than an unsafe public terminal write;
+20. an externally persisted terminal record drains the exact retained runner,
+    handler cache, heartbeat, worktree ownership, and owned EventStore through
+    the registry's one finalizer path; and
+21. caller cancellation and a cancelled/failing finalizer cannot skip the
+    remaining registered finalizers or leave the registry reservation behind.
+22. competing `FAILED`/`CANCELLED` session lifecycle writes have exactly one
+    durable winner, and a stale pre-terminal tracker cannot overwrite that
+    terminal status after authority retirement; and
+23. a raw task cancellation in every claimed-but-pre-effect setup window drains
+    a published cooperative cancellation before generic cleanup, or preserves
+    the explicit retryable cancellation state for the next exact-owner resume.
 
 This exit matrix is intentionally narrower than an arbitrary-code sandbox and
 broader than a cosmetic fingerprint: it makes the only cross-process claim

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -231,7 +231,7 @@ async def _list_active_sessions(event_store) -> list:
 async def _cancel_all_running(
     event_store,
     reason: str = "Cancelled all running sessions via CLI",
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
     """Cancel all running/paused sessions.
 
     Args:
@@ -239,7 +239,8 @@ async def _cancel_all_running(
         reason: Reason for cancellation.
 
     Returns:
-        Tuple of (cancelled_count, requested_count, skipped_count).
+        Tuple of (cancelled_count, requested_count,
+        retryable_failed_count, skipped_count).
     """
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
@@ -249,10 +250,11 @@ async def _cancel_all_running(
     session_events = await event_store.get_all_sessions()
 
     if not session_events:
-        return (0, 0, 0)
+        return (0, 0, 0, 0)
 
     cancelled = 0
     requested = 0
+    retryable_failed = 0
     skipped = 0
 
     for event in session_events:
@@ -261,7 +263,8 @@ async def _cancel_all_running(
         # Reconstruct to get current status
         result = await repo.reconstruct_session(session_id)
         if result.is_err:
-            skipped += 1
+            retryable_failed += 1
+            console.print(f"  [yellow]Retry required:[/] {session_id} (session read failed)")
             continue
 
         tracker = result.value
@@ -285,6 +288,13 @@ async def _cancel_all_running(
             ):
                 requested += 1
                 console.print(f"  [dim]Cancellation requested:[/] {session_id}")
+            elif (
+                process_local.disposition == ProcessLocalCancellationDisposition.PERSISTENCE_PENDING
+            ):
+                retryable_failed += 1
+                console.print(
+                    f"  [yellow]Retry required:[/] {session_id} (cancellation persistence pending)"
+                )
             else:
                 skipped += 1
             continue
@@ -299,10 +309,13 @@ async def _cancel_all_running(
         if cancel_result.is_ok and cancel_result.value is not False:
             cancelled += 1
             console.print(f"  [dim]Cancelled:[/] {session_id}")
+        elif cancel_result.is_err:
+            retryable_failed += 1
+            console.print(f"  [yellow]Retry required:[/] {session_id} (terminal write failed)")
         else:
             skipped += 1
 
-    return (cancelled, requested, skipped)
+    return (cancelled, requested, retryable_failed, skipped)
 
 
 def _display_active_sessions(sessions: list) -> None:
@@ -465,15 +478,21 @@ async def _cancel_execution_async(
     try:
         if all_:
             print_info("Cancelling all running executions...")
-            cancelled, requested, skipped = await _cancel_all_running(event_store, reason)
+            cancelled, requested, retryable_failed, skipped = await _cancel_all_running(
+                event_store, reason
+            )
 
-            if cancelled == 0 and requested == 0:
+            if cancelled == 0 and requested == 0 and retryable_failed == 0:
                 print_info("No running executions found to cancel.")
             else:
                 if cancelled:
                     print_success(f"Cancelled {cancelled} execution(s).")
                 if requested:
                     print_info(f"Cancellation requested for {requested} execution(s).")
+                if retryable_failed:
+                    print_warning(
+                        f"Cancellation failed for {retryable_failed} execution(s); retry required."
+                    )
         else:
             assert execution_id is not None
             disposition = await _cancel_session(event_store, execution_id, reason)

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -31,6 +31,10 @@ from ouroboros.events.hitl import (
     create_hitl_cancelled_event,
     create_hitl_requested_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    ProcessLocalCancellationDisposition,
+    request_process_local_cancellation,
+)
 
 app = typer.Typer(
     name="cancel",
@@ -118,7 +122,7 @@ async def _cancel_session(
     event_store,
     session_id: str,
     reason: str = "Cancelled by user via CLI",
-) -> bool:
+) -> ProcessLocalCancellationDisposition | None:
     """Cancel a single session by ID.
 
     Args:
@@ -127,12 +131,9 @@ async def _cancel_session(
         reason: Reason for cancellation.
 
     Returns:
-        True if session was cancelled, False if it was not in a cancellable state.
+        The exact cancellation disposition, or ``None`` when no cancellation
+        action was accepted.
     """
-    from ouroboros.orchestrator.execution_authority import (
-        ProcessLocalCancellationDisposition,
-        request_process_local_cancellation,
-    )
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
     repo = SessionRepository(event_store)
@@ -141,19 +142,19 @@ async def _cancel_session(
     result = await repo.reconstruct_session(session_id)
     if result.is_err:
         print_error(f"Session not found: {session_id}")
-        return False
+        return None
 
     tracker = result.value
     if tracker.status == SessionStatus.CANCELLED:
         print_warning(f"Session {session_id} is already cancelled.")
-        return False
+        return None
 
     if tracker.status in (SessionStatus.COMPLETED, SessionStatus.FAILED):
         print_warning(
             f"Session {session_id} is already {tracker.status.value}. "
             "Only running or paused sessions can be cancelled."
         )
-        return False
+        return None
 
     process_local = await request_process_local_cancellation(
         tracker,
@@ -166,7 +167,7 @@ async def _cancel_session(
             ProcessLocalCancellationDisposition.CANCELLED,
             ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED,
         }:
-            return True
+            return process_local.disposition
         if process_local.disposition == ProcessLocalCancellationDisposition.HELD_ELSEWHERE:
             print_warning(
                 f"Session {session_id} is held by another live process-local owner; "
@@ -178,7 +179,7 @@ async def _cancel_session(
             )
         else:
             print_warning(f"Session {session_id} became terminal before cancellation completed.")
-        return False
+        return None
 
     # Historical sessions have no live Foundation A capability to coordinate.
     cancel_result = await repo.mark_cancelled(
@@ -189,12 +190,12 @@ async def _cancel_session(
 
     if cancel_result.is_err:
         print_error(f"Failed to cancel session {session_id}: {cancel_result.error}")
-        return False
+        return None
     if cancel_result.value is False:
         print_warning(f"Session {session_id} became terminal before cancellation completed.")
-        return False
+        return None
 
-    return True
+    return ProcessLocalCancellationDisposition.CANCELLED
 
 
 async def _list_active_sessions(event_store) -> list:
@@ -230,7 +231,7 @@ async def _list_active_sessions(event_store) -> list:
 async def _cancel_all_running(
     event_store,
     reason: str = "Cancelled all running sessions via CLI",
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """Cancel all running/paused sessions.
 
     Args:
@@ -238,12 +239,8 @@ async def _cancel_all_running(
         reason: Reason for cancellation.
 
     Returns:
-        Tuple of (cancelled_count, skipped_count).
+        Tuple of (cancelled_count, requested_count, skipped_count).
     """
-    from ouroboros.orchestrator.execution_authority import (
-        ProcessLocalCancellationDisposition,
-        request_process_local_cancellation,
-    )
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
     repo = SessionRepository(event_store)
@@ -252,9 +249,10 @@ async def _cancel_all_running(
     session_events = await event_store.get_all_sessions()
 
     if not session_events:
-        return (0, 0)
+        return (0, 0, 0)
 
     cancelled = 0
+    requested = 0
     skipped = 0
 
     for event in session_events:
@@ -278,18 +276,15 @@ async def _cancel_all_running(
             cancelled_by="user",
         )
         if process_local is not None:
-            if process_local.disposition in {
-                ProcessLocalCancellationDisposition.CANCELLED,
-                ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED,
-            }:
+            if process_local.disposition == ProcessLocalCancellationDisposition.CANCELLED:
                 cancelled += 1
-                status = (
-                    "requested"
-                    if process_local.disposition
-                    == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
-                    else "cancelled"
-                )
-                console.print(f"  [dim]Cancellation {status}:[/] {session_id}")
+                console.print(f"  [dim]Cancelled:[/] {session_id}")
+            elif (
+                process_local.disposition
+                == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+            ):
+                requested += 1
+                console.print(f"  [dim]Cancellation requested:[/] {session_id}")
             else:
                 skipped += 1
             continue
@@ -307,7 +302,7 @@ async def _cancel_all_running(
         else:
             skipped += 1
 
-    return (cancelled, skipped)
+    return (cancelled, requested, skipped)
 
 
 def _display_active_sessions(sessions: list) -> None:
@@ -394,9 +389,11 @@ async def _interactive_cancel(reason: str) -> None:
             print_info("Cancelled. No executions were modified.")
             return
 
-        success = await _cancel_session(event_store, session_id, reason)
-        if success:
+        disposition = await _cancel_session(event_store, session_id, reason)
+        if disposition == ProcessLocalCancellationDisposition.CANCELLED:
             print_success(f"Cancelled execution: {session_id}")
+        elif disposition == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED:
+            print_info(f"Cancellation requested for execution: {session_id}")
     finally:
         await event_store.close()
 
@@ -468,17 +465,22 @@ async def _cancel_execution_async(
     try:
         if all_:
             print_info("Cancelling all running executions...")
-            cancelled, skipped = await _cancel_all_running(event_store, reason)
+            cancelled, requested, skipped = await _cancel_all_running(event_store, reason)
 
-            if cancelled == 0:
+            if cancelled == 0 and requested == 0:
                 print_info("No running executions found to cancel.")
             else:
-                print_success(f"Cancelled {cancelled} execution(s).")
+                if cancelled:
+                    print_success(f"Cancelled {cancelled} execution(s).")
+                if requested:
+                    print_info(f"Cancellation requested for {requested} execution(s).")
         else:
             assert execution_id is not None
-            success = await _cancel_session(event_store, execution_id, reason)
-            if success:
+            disposition = await _cancel_session(event_store, execution_id, reason)
+            if disposition == ProcessLocalCancellationDisposition.CANCELLED:
                 print_success(f"Cancelled execution: {execution_id}")
+            elif disposition == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED:
+                print_info(f"Cancellation requested for execution: {execution_id}")
     finally:
         await event_store.close()
 

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -129,6 +129,10 @@ async def _cancel_session(
     Returns:
         True if session was cancelled, False if it was not in a cancellable state.
     """
+    from ouroboros.orchestrator.execution_authority import (
+        ProcessLocalCancellationDisposition,
+        request_process_local_cancellation,
+    )
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
     repo = SessionRepository(event_store)
@@ -151,7 +155,32 @@ async def _cancel_session(
         )
         return False
 
-    # Cancel the session
+    process_local = await request_process_local_cancellation(
+        tracker,
+        repo,
+        reason=reason,
+        cancelled_by="user",
+    )
+    if process_local is not None:
+        if process_local.disposition in {
+            ProcessLocalCancellationDisposition.CANCELLED,
+            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED,
+        }:
+            return True
+        if process_local.disposition == ProcessLocalCancellationDisposition.HELD_ELSEWHERE:
+            print_warning(
+                f"Session {session_id} is held by another live process-local owner; "
+                "cancel it through that owner."
+            )
+        elif process_local.disposition == ProcessLocalCancellationDisposition.PERSISTENCE_PENDING:
+            print_warning(
+                f"Cancellation for session {session_id} is pending durable persistence; retry it."
+            )
+        else:
+            print_warning(f"Session {session_id} became terminal before cancellation completed.")
+        return False
+
+    # Historical sessions have no live Foundation A capability to coordinate.
     cancel_result = await repo.mark_cancelled(
         session_id=session_id,
         reason=reason,
@@ -160,6 +189,9 @@ async def _cancel_session(
 
     if cancel_result.is_err:
         print_error(f"Failed to cancel session {session_id}: {cancel_result.error}")
+        return False
+    if cancel_result.value is False:
+        print_warning(f"Session {session_id} became terminal before cancellation completed.")
         return False
 
     return True
@@ -208,6 +240,10 @@ async def _cancel_all_running(
     Returns:
         Tuple of (cancelled_count, skipped_count).
     """
+    from ouroboros.orchestrator.execution_authority import (
+        ProcessLocalCancellationDisposition,
+        request_process_local_cancellation,
+    )
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
     repo = SessionRepository(event_store)
@@ -235,14 +271,37 @@ async def _cancel_all_running(
             skipped += 1
             continue
 
-        # Cancel this session
+        process_local = await request_process_local_cancellation(
+            tracker,
+            repo,
+            reason=reason,
+            cancelled_by="user",
+        )
+        if process_local is not None:
+            if process_local.disposition in {
+                ProcessLocalCancellationDisposition.CANCELLED,
+                ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED,
+            }:
+                cancelled += 1
+                status = (
+                    "requested"
+                    if process_local.disposition
+                    == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+                    else "cancelled"
+                )
+                console.print(f"  [dim]Cancellation {status}:[/] {session_id}")
+            else:
+                skipped += 1
+            continue
+
+        # Historical sessions have no live Foundation A capability to coordinate.
         cancel_result = await repo.mark_cancelled(
             session_id=session_id,
             reason=reason,
             cancelled_by="user",
         )
 
-        if cancel_result.is_ok:
+        if cancel_result.is_ok and cancel_result.value is not False:
             cancelled += 1
             console.print(f"  [dim]Cancelled:[/] {session_id}")
         else:

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -381,6 +381,7 @@ class JobManager:
         self._backstops: dict[str, asyncio.Task[None]] = {}
         self._started_job_ids: set[str] = set()
         self._monitor_terminalized_jobs: set[str] = set()
+        self._drained_job_ids: set[str] = set()
         self._recovery_locks: dict[str, asyncio.Lock] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
@@ -2320,7 +2321,11 @@ class JobManager:
         Returns the number of jobs whose tasks finished within the grace.
         """
         self._draining = True
-        live_job_ids = [job_id for job_id, task in self._tasks.items() if not task.done()]
+        live_job_ids = [
+            job_id
+            for job_id, task in self._tasks.items()
+            if not task.done() and job_id not in self._drained_job_ids
+        ]
         log.info(
             "mcp.job.drain_start",
             live_job_count=len(live_job_ids),
@@ -2430,6 +2435,11 @@ class JobManager:
                 continue
             if snapshot.is_terminal:
                 drained += 1
+                # The terminal event can become durable just before
+                # ``_run_job`` removes its still-live task from ``_tasks``.
+                # Remember that this invocation already counted the job so a
+                # repeated drain in that scheduling window remains idempotent.
+                self._drained_job_ids.add(job_id)
         log.info(
             "mcp.job.drain_complete",
             drained=drained,
@@ -2486,6 +2496,7 @@ class JobManager:
             self._monitors.pop(job_id, None)
             self._recovery_locks.pop(job_id, None)
             self._monitor_terminalized_jobs.discard(job_id)
+            self._drained_job_ids.discard(job_id)
             self._started_job_ids.discard(job_id)
         return len(expired)
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -19,6 +19,10 @@ from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
+from ouroboros.orchestrator.execution_authority import (
+    ProcessLocalCancellationDisposition,
+    request_process_local_cancellation,
+)
 from ouroboros.orchestrator.heartbeat import (
     current_process_identity,
     is_holder_alive,
@@ -2040,12 +2044,40 @@ class JobManager:
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
         should_persist_linked_cancel = False
+        process_local_cancellation = None
         if snapshot.links.session_id:
             if not linked_session_terminal:
-                await request_cancellation(snapshot.links.session_id)
-                should_persist_linked_cancel = linked_session_reconstructed and (
-                    not linked_session_started or not linked_session_owned_by_current_process
-                )
+                if linked_session_reconstructed:
+                    process_local_cancellation = await request_process_local_cancellation(
+                        session_result.value,
+                        linked_session_repo,
+                        reason="Background job cancelled",
+                        cancelled_by="mcp_job_manager",
+                    )
+                if process_local_cancellation is None:
+                    # Historical sessions retain the established cooperative
+                    # signal/direct-persistence split because they have no
+                    # Foundation A capability to reserve.
+                    await request_cancellation(snapshot.links.session_id)
+                    should_persist_linked_cancel = linked_session_reconstructed and (
+                        not linked_session_started or not linked_session_owned_by_current_process
+                    )
+                elif (
+                    process_local_cancellation.disposition
+                    == ProcessLocalCancellationDisposition.HELD_ELSEWHERE
+                ):
+                    logger.info(
+                        "job_manager.cancel_job: process-local session held elsewhere",
+                        extra={"job_id": job_id, "session_id": snapshot.links.session_id},
+                    )
+                elif (
+                    process_local_cancellation.disposition
+                    == ProcessLocalCancellationDisposition.PERSISTENCE_PENDING
+                ):
+                    logger.warning(
+                        "job_manager.cancel_job: process-local cancellation persistence pending",
+                        extra={"job_id": job_id, "session_id": snapshot.links.session_id},
+                    )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)
@@ -2053,11 +2085,35 @@ class JobManager:
             task.cancel()
             cancelled_tasks.append(task)
         runner_task = self._runner_tasks.get(job_id)
-        if runner_task is not None and not runner_task.done():
+        if (
+            runner_task is not None
+            and not runner_task.done()
+            and (
+                snapshot.links.session_id is None
+                or process_local_cancellation is None
+                or process_local_cancellation.disposition
+                == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+            )
+        ):
             runner_task.cancel()
             cancelled_tasks.append(runner_task)
         if cancelled_tasks:
             await asyncio.wait(cancelled_tasks, timeout=5)
+        if (
+            snapshot.links.session_id
+            and snapshot.links.execution_id
+            and process_local_cancellation is not None
+            and process_local_cancellation.disposition
+            == ProcessLocalCancellationDisposition.CANCELLED
+        ):
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=snapshot.links.execution_id,
+                    session_id=snapshot.links.session_id,
+                    status="cancelled",
+                    error_message="Background job cancelled",
+                )
+            )
         if snapshot.links.session_id and should_persist_linked_cancel:
             repo = linked_session_repo or SessionRepository(self._event_store)
             latest_session = await repo.reconstruct_session(snapshot.links.session_id)
@@ -2081,7 +2137,12 @@ class JobManager:
                     raise ValueError(
                         f"Failed to mark linked session cancelled: {cancel_result.error.message}"
                     )
-                if snapshot.links.execution_id:
+                if cancel_result.value is False:
+                    logger.info(
+                        "job_manager.cancel_job: linked session became terminal before cancellation",
+                        extra={"job_id": job_id, "session_id": snapshot.links.session_id},
+                    )
+                elif snapshot.links.execution_id:
                     await self._event_store.append(
                         create_execution_terminal_event(
                             execution_id=snapshot.links.execution_id,

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -847,9 +847,35 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             result = await session_repo.reconstruct_session(tracker.session_id)
         except Exception:
             result = None
-        if result is not None and result.is_ok and result.value.status == SessionStatus.PAUSED:
-            self._remember_process_local_owner(result.value, runner)
+        terminal_record_observed = False
+        if result is not None and result.is_ok:
+            status = result.value.status
+            if status == SessionStatus.PAUSED:
+                self._remember_process_local_owner(result.value, runner)
+                if self._process_local_resume_owners.get(tracker.session_id) is runner:
+                    return True, None
+            elif status in (
+                SessionStatus.COMPLETED,
+                SessionStatus.CANCELLED,
+                SessionStatus.FAILED,
+            ):
+                # An explicit terminal record is the one durable observation
+                # that may evict a retained owner while its handler unwinds.
+                terminal_record_observed = True
+
+        raw_contract = tracker.progress.get("execution_contract")
+        # Read errors, Result.err, and RUNNING (or a future nonterminal state)
+        # are inconclusive during post-run reconciliation. Preserve the owner
+        # only while its opaque capability still proves it is live. A durable
+        # terminal record is intentionally the one exception.
+        if not terminal_record_observed and runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            self._remember_process_local_owner(tracker, runner)
             return self._process_local_resume_owners.get(tracker.session_id) is runner, None
+
         owned_event_store: EventStore | None = None
         if self._process_local_resume_owners.get(tracker.session_id) is runner:
             self._process_local_resume_owners.pop(tracker.session_id, None)

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -103,6 +103,7 @@ _PROCESS_LOCAL_BACKGROUND_OWNED_BLOCKS = frozenset(
         "typed_evidence_gate_required",
         "investment_authority_required",
         "cancellation_persistence_pending",
+        "pause_persistence_pending",
         "terminal_persistence_pending",
         # This error path already conditionally persisted its own terminal
         # result (or observed a concurrent terminal winner). A background

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -100,7 +100,10 @@ _PROCESS_LOCAL_BACKGROUND_OWNED_BLOCKS = frozenset(
         "process_local_execution_in_progress",
         "process_local_authority_held_elsewhere",
         "session_not_paused",
+        "typed_evidence_gate_required",
+        "investment_authority_required",
         "cancellation_persistence_pending",
+        "terminal_persistence_pending",
         # This error path already conditionally persisted its own terminal
         # result (or observed a concurrent terminal winner). A background
         # wrapper must never append a second FAILED event over that outcome.
@@ -1541,10 +1544,26 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         session_id=session_id,
                     )
                     if prepared.is_err:
+                        prepared_details = prepared.error.details
+                        terminal_persistence_pending = (
+                            prepared_details.get("resume_blocked") == "terminal_persistence_pending"
+                        )
+                        if terminal_persistence_pending:
+                            retained_tracker = await session_repo.reconstruct_session(
+                                prepared_details.get("session_id", session_id or "")
+                            )
+                            if retained_tracker.is_ok:
+                                self._remember_process_local_owner(
+                                    retained_tracker.value,
+                                    runner,
+                                    owned_event_store=(event_store if owns_event_store else None),
+                                )
                         return Result.err(
                             MCPToolError(
                                 f"Execution failed: {prepared.error.message}",
                                 tool_name="ouroboros_execute_seed",
+                                is_retriable=terminal_persistence_pending,
+                                details=dict(prepared_details),
                             )
                         )
                     tracker = prepared.value

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -1593,6 +1593,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                     runner,
                                     owned_event_store=(event_store if owns_event_store else None),
                                 )
+                                retained_after_run = (
+                                    self._process_local_resume_owners.get(
+                                        retained_tracker.value.session_id
+                                    )
+                                    is runner
+                                )
                         return Result.err(
                             MCPToolError(
                                 f"Execution failed: {prepared.error.message}",

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -76,11 +76,17 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.execution_authority import (
     _has_live_process_local_authority_registration,
+    _register_process_local_authority_terminal_finalizer,
+    _retire_process_local_authority_after_terminal_persistence,
     valid_process_local_authority_contract,
 )
 from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.model_routing import tier_from_model_tier_arg
-from ouroboros.orchestrator.runner import OrchestratorRunner
+from ouroboros.orchestrator.runner import (
+    OrchestratorRunner,
+    clear_cancellation,
+    request_cancellation,
+)
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore
@@ -94,6 +100,7 @@ _NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS = frozenset(
         "process_local_execution_in_progress",
         "process_local_authority_held_elsewhere",
         "session_not_paused",
+        "cancellation_persistence_pending",
     }
 )
 
@@ -812,6 +819,71 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         """Release the handler-local pre-resume gate after the runner settles."""
         self._process_local_resume_handoffs.discard(session_id)
 
+    async def _release_terminal_process_local_owner(
+        self,
+        *,
+        session_id: str,
+        runner: OrchestratorRunner,
+    ) -> None:
+        """Drop this handler's retained references after a terminal transition."""
+        if self._process_local_resume_owners.get(session_id) is not runner:
+            return
+        self._process_local_resume_owners.pop(session_id, None)
+        owned_event_store = self._process_local_owned_event_stores.pop(session_id, None)
+        self._process_local_resume_handoffs.discard(session_id)
+        if owned_event_store is not None:
+            try:
+                close_result = owned_event_store.close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+            except Exception:
+                log.exception("mcp.tool.execute_seed.event_store_close_error")
+
+    async def _reconcile_terminal_process_local_owner(self, tracker: SessionTracker) -> None:
+        """Reconcile a terminal record through the registry-owned transition.
+
+        This is a defensive fallback for terminal records written outside this
+        handler.  The registry drains every registered runner/handler finalizer
+        together; a still-active effect claim is only signalled because it owns
+        its orderly terminal cleanup.
+        """
+        raw_contract = tracker.progress.get("execution_contract")
+        authority = (
+            raw_contract.get("foundation_a_authority")
+            if isinstance(raw_contract, Mapping)
+            else None
+        )
+        retired, claimed = await _retire_process_local_authority_after_terminal_persistence(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+        )
+        if claimed:
+            await request_cancellation(tracker.session_id)
+            return
+        if retired:
+            await clear_cancellation(tracker.session_id)
+            return
+
+        owner = self._process_local_resume_owners.get(tracker.session_id)
+        if owner is None:
+            return
+        if owner.active_sessions.get(tracker.execution_id) == tracker.session_id:
+            await request_cancellation(tracker.session_id)
+            return
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        owner._unregister_session(tracker.execution_id, tracker.session_id)
+        if owner._task_workspace is not None:
+            release_lock(owner._task_workspace.lock_path)
+        await clear_cancellation(tracker.session_id)
+        await self._release_terminal_process_local_owner(
+            session_id=tracker.session_id,
+            runner=owner,
+        )
+
     def _remember_process_local_owner(
         self,
         tracker: SessionTracker,
@@ -829,6 +901,18 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             self._process_local_resume_owners[tracker.session_id] = runner
             if owned_event_store is not None:
                 self._process_local_owned_event_stores[tracker.session_id] = owned_event_store
+            if isinstance(raw_contract, Mapping):
+                _register_process_local_authority_terminal_finalizer(
+                    tracker.session_id,
+                    tracker.execution_id,
+                    raw_contract.get("foundation_a_authority"),
+                    runner._adapter,
+                    ("execute-seed-handler", id(self), id(runner)),
+                    lambda: self._release_terminal_process_local_owner(
+                        session_id=tracker.session_id,
+                        runner=runner,
+                    ),
+                )
 
     async def _reconcile_process_local_owner(
         self,
@@ -1240,6 +1324,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         SessionStatus.CANCELLED,
                         SessionStatus.FAILED,
                     ):
+                        await self._reconcile_terminal_process_local_owner(tracker)
                         return Result.err(
                             MCPToolError(
                                 (

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -105,6 +105,10 @@ _PROCESS_LOCAL_BACKGROUND_OWNED_BLOCKS = frozenset(
         "cancellation_persistence_pending",
         "pause_persistence_pending",
         "terminal_persistence_pending",
+        # Durable reconstruction was inconclusive. The retained process-local
+        # owner remains the only safe retry path; the background wrapper must
+        # not manufacture a generic FAILED terminal event.
+        "process_local_reconstruction_pending",
         # This error path already conditionally persisted its own terminal
         # result (or observed a concurrent terminal winner). A background
         # wrapper must never append a second FAILED event over that outcome.

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -74,6 +74,11 @@ from ouroboros.orchestrator.adapter import (
     DELEGATED_PARENT_TRANSCRIPT_PATH_ARG,
     RuntimeHandle,
 )
+from ouroboros.orchestrator.execution_authority import (
+    _has_live_process_local_authority_registration,
+    valid_process_local_authority_contract,
+)
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.model_routing import tier_from_model_tier_arg
 from ouroboros.orchestrator.runner import OrchestratorRunner
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
@@ -82,6 +87,72 @@ from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
+
+
+_NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS = frozenset(
+    {
+        "process_local_execution_in_progress",
+        "process_local_authority_held_elsewhere",
+        "session_not_paused",
+    }
+)
+
+
+def _is_nonterminal_process_local_resume_error(error: object) -> bool:
+    """Return whether a runner error intentionally leaves its session live.
+
+    A process-local owner may be running in another adapter or process.  The
+    runner reports that as a typed non-terminal rejection; the background MCP
+    wrapper must preserve it rather than immediately writing ``mark_failed``
+    and undoing the runner's liveness protection.
+    """
+    details = getattr(error, "details", None)
+    return isinstance(details, Mapping) and (
+        details.get("resume_blocked") in _NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS
+    )
+
+
+def _process_local_authority_is_held_elsewhere(tracker: SessionTracker) -> bool:
+    """Check non-owning handler preflight before it touches a task worktree.
+
+    A handler can only resume a process-local session through its retained exact
+    runner.  If this handler has no such owner but the registry or PID lease is
+    still live, fail with the typed ownership result before a task-worktree lock
+    can obscure the authority outcome with a generic workspace error.
+    """
+    raw_contract = tracker.progress.get("execution_contract")
+    if not isinstance(raw_contract, Mapping):
+        return False
+    authority = raw_contract.get("foundation_a_authority")
+    if not valid_process_local_authority_contract(authority):
+        return False
+    return _has_live_process_local_authority_registration(
+        tracker.session_id,
+        tracker.execution_id,
+        authority,
+    ) or is_holder_alive(tracker.session_id)
+
+
+def _process_local_resume_block_error(
+    tracker: SessionTracker,
+    *,
+    resume_blocked: str,
+) -> MCPToolError:
+    """Build a typed, retryable MCP result for a live process-local owner."""
+    if resume_blocked == "process_local_execution_in_progress":
+        message = "This process-local session is already being resumed"
+    else:
+        message = "This process-local session is held by another live owner"
+    return MCPToolError(
+        message,
+        tool_name="ouroboros_execute_seed",
+        is_retriable=True,
+        details={
+            "session_id": tracker.session_id,
+            "execution_id": tracker.execution_id,
+            "resume_blocked": resume_blocked,
+        },
+    )
 
 
 def _resolve_execution_model(runtime_backend: str | None) -> str | None:
@@ -673,6 +744,120 @@ class ExecuteSeedHandler(BridgeAwareMixin):
     opencode_mode: str | None = field(default=None, repr=False)
     session_signal_hub: Any | None = field(default=None, repr=False)
     _background_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
+    _process_local_resume_owners: dict[str, OrchestratorRunner] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _process_local_owned_event_stores: dict[str, EventStore] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _process_local_resume_handoffs: set[str] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+    )
+
+    async def _retained_process_local_owner(
+        self,
+        tracker: SessionTracker,
+    ) -> OrchestratorRunner | None:
+        """Return the exact in-memory runner that still owns a paused session.
+
+        This is an opaque owner handoff, not authority reconstruction: the
+        original runner retains the registry-minted capability and still has to
+        claim it before doing effects. A fresh MCP request may select that
+        retained object, but can never manufacture a runner, adapter, or
+        capability from durable correlation data.
+        """
+        owner = self._process_local_resume_owners.get(tracker.session_id)
+        if owner is None:
+            return None
+        raw_contract = tracker.progress.get("execution_contract")
+        if owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            return owner
+        owned_event_store: EventStore | None = None
+        if self._process_local_resume_owners.get(tracker.session_id) is owner:
+            self._process_local_resume_owners.pop(tracker.session_id, None)
+            owned_event_store = self._process_local_owned_event_stores.pop(
+                tracker.session_id,
+                None,
+            )
+        if owned_event_store is not None:
+            # The capability is already gone, so no terminal resume path can
+            # reach this handler-owned store. Close it here rather than losing
+            # the only reference while evicting the stale retained owner.
+            try:
+                close_result = owned_event_store.close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+            except Exception:
+                log.exception("mcp.tool.execute_seed.event_store_close_error")
+        return None
+
+    def _begin_process_local_resume_handoff(self, session_id: str) -> bool:
+        """Reserve same-handler worktree restoration for one retained owner."""
+        if session_id in self._process_local_resume_handoffs:
+            return False
+        self._process_local_resume_handoffs.add(session_id)
+        return True
+
+    def _finish_process_local_resume_handoff(self, session_id: str) -> None:
+        """Release the handler-local pre-resume gate after the runner settles."""
+        self._process_local_resume_handoffs.discard(session_id)
+
+    def _remember_process_local_owner(
+        self,
+        tracker: SessionTracker,
+        runner: OrchestratorRunner,
+        *,
+        owned_event_store: EventStore | None = None,
+    ) -> None:
+        """Keep a callable owner alive while its process-local lease is live."""
+        raw_contract = tracker.progress.get("execution_contract")
+        if runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        ):
+            self._process_local_resume_owners[tracker.session_id] = runner
+            if owned_event_store is not None:
+                self._process_local_owned_event_stores[tracker.session_id] = owned_event_store
+
+    async def _reconcile_process_local_owner(
+        self,
+        *,
+        tracker: SessionTracker,
+        runner: OrchestratorRunner,
+        session_repo: SessionRepository,
+    ) -> tuple[bool, EventStore | None]:
+        """Retain a paused owner or release a terminal owner after a run.
+
+        Returns whether the runner remains retained and, only for a terminal
+        result, an internally owned store that can be closed after the caller
+        no longer needs it.
+        """
+        try:
+            result = await session_repo.reconstruct_session(tracker.session_id)
+        except Exception:
+            result = None
+        if result is not None and result.is_ok and result.value.status == SessionStatus.PAUSED:
+            self._remember_process_local_owner(result.value, runner)
+            return self._process_local_resume_owners.get(tracker.session_id) is runner, None
+        owned_event_store: EventStore | None = None
+        if self._process_local_resume_owners.get(tracker.session_id) is runner:
+            self._process_local_resume_owners.pop(tracker.session_id, None)
+            owned_event_store = self._process_local_owned_event_stores.pop(
+                tracker.session_id,
+                None,
+            )
+        return False, owned_event_store
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -1001,7 +1186,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             workspace: TaskWorkspace | None = None
             tracker = None
             launched = False
+            retained_after_run = False
+            retained_event_store_to_close: EventStore | None = None
             use_worktree = bool(arguments.get("use_worktree", True))
+            retained_owner: OrchestratorRunner | None = None
+            retained_resume_handoff = False
 
             try:
                 if is_resume and session_id:
@@ -1034,6 +1223,30 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 tool_name="ouroboros_execute_seed",
                             )
                         )
+                    retained_owner = await self._retained_process_local_owner(tracker)
+                    if retained_owner is not None:
+                        # Reserve this exact handler's pre-resume workspace handoff
+                        # before touching the worktree. Without this gate a second
+                        # same-handler resume can surface a generic lock error ahead
+                        # of the process-local exclusive-claim result.
+                        if not self._begin_process_local_resume_handoff(tracker.session_id):
+                            return Result.err(
+                                _process_local_resume_block_error(
+                                    tracker,
+                                    resume_blocked="process_local_execution_in_progress",
+                                )
+                            )
+                        retained_resume_handoff = True
+                    elif _process_local_authority_is_held_elsewhere(tracker):
+                        # This handler has no exact retained owner. Do not let a
+                        # foreign process-local capability fail later as a generic
+                        # worktree collision or create a fresh runtime first.
+                        return Result.err(
+                            _process_local_resume_block_error(
+                                tracker,
+                                resume_blocked="process_local_authority_held_elsewhere",
+                            )
+                        )
                     if use_worktree:
                         persisted = TaskWorkspace.from_progress_dict(
                             tracker.progress.get("workspace")
@@ -1052,6 +1265,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                     tool_name="ouroboros_execute_seed",
                                 )
                             )
+                        if retained_owner is not None:
+                            # The paused run releases its worktree lock. Restore
+                            # that exact workspace before resuming through the
+                            # retained runner so its resume identity check and
+                            # its next effect use a freshly held task lock.
+                            retained_owner._task_workspace = workspace
                 elif use_worktree:
                     try:
                         workspace = maybe_prepare_task_workspace(
@@ -1067,24 +1286,81 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
 
-                delegated_permission_mode = (
-                    inherited_runtime_handle.approval_mode
-                    if inherited_runtime_handle and inherited_runtime_handle.approval_mode
-                    else None
-                )
-                agent_adapter = create_agent_runtime(
-                    backend=self.agent_runtime_backend,
-                    model=_resolve_execution_model(self.agent_runtime_backend),
-                    cwd=Path(workspace.effective_cwd) if workspace else resolved_cwd,
-                    llm_backend=self.llm_backend,
-                    startup_output_timeout_seconds=0,
-                    stdout_idle_timeout_seconds=0,
-                    **(
-                        {"permission_mode": delegated_permission_mode}
-                        if delegated_permission_mode
-                        else {}
-                    ),
-                )
+                if retained_owner is not None:
+                    # Resume through the exact in-memory runner that owns the
+                    # opaque capability. Do not construct a fresh runtime or
+                    # create a fresh runner: either operation would turn a
+                    # same-process continuation into a foreign-adapter path.
+                    runner = retained_owner
+                    agent_adapter = runner._adapter
+                    if event_store is not runner._event_store:
+                        # A handler without an injected store opened this
+                        # short-lived observer connection solely to reconstruct
+                        # the tracker above. The retained runner's store is the
+                        # one that must survive the paused lifecycle.
+                        if owns_event_store:
+                            close_result = event_store.close()
+                            if inspect.isawaitable(close_result):
+                                await close_result
+                        event_store = runner._event_store
+                        owns_event_store = False
+                    session_repo = runner._session_repo
+                else:
+                    delegated_permission_mode = (
+                        inherited_runtime_handle.approval_mode
+                        if inherited_runtime_handle and inherited_runtime_handle.approval_mode
+                        else None
+                    )
+                    agent_adapter = create_agent_runtime(
+                        backend=self.agent_runtime_backend,
+                        model=_resolve_execution_model(self.agent_runtime_backend),
+                        cwd=Path(workspace.effective_cwd) if workspace else resolved_cwd,
+                        llm_backend=self.llm_backend,
+                        startup_output_timeout_seconds=0,
+                        stdout_idle_timeout_seconds=0,
+                        **(
+                            {"permission_mode": delegated_permission_mode}
+                            if delegated_permission_mode
+                            else {}
+                        ),
+                    )
+
+                    # Create checkpoint store for execution state persistence
+                    checkpoint_store = CheckpointStore()
+                    checkpoint_store.initialize()
+                    fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
+                    if is_resume:
+                        persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
+                        if isinstance(persisted_fat_harness_mode, bool):
+                            fat_harness_mode = persisted_fat_harness_mode
+                        else:
+                            # No persisted contract (historical session): mirror the
+                            # CLI resume semantics — verify-by-default unless the
+                            # seed opts out with execution_mode='legacy'.
+                            fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
+
+                    # Create orchestrator runner
+                    runner = OrchestratorRunner(
+                        adapter=agent_adapter,
+                        event_store=event_store,
+                        console=console,
+                        mcp_manager=self.mcp_manager,
+                        mcp_tool_prefix=self.mcp_tool_prefix,
+                        debug=False,
+                        enable_decomposition=True,
+                        inherited_runtime_handle=inherited_runtime_handle,
+                        inherited_tools=inherited_effective_tools,
+                        task_workspace=workspace,
+                        checkpoint_store=checkpoint_store,
+                        max_parallel_workers=max_parallel_workers,
+                        fat_harness_mode=fat_harness_mode,
+                        # Drive model-tier routing from the MCP model_tier arg
+                        # (small/medium/large → frugal/standard/frontier top-level tier).
+                        base_model_tier=base_model_tier_override,
+                        efficiency_mode=raw_efficiency_mode,
+                        frugality_assurance=raw_frugality_assurance,
+                        session_signal_hub=self.session_signal_hub,
+                    )
                 runtime_backend_attr = getattr(agent_adapter, "runtime_backend", None)
                 if not (isinstance(runtime_backend_attr, str) and runtime_backend_attr):
                     runtime_backend_attr = getattr(agent_adapter, "_runtime_backend", None)
@@ -1092,43 +1368,6 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     runtime_backend_attr
                     if isinstance(runtime_backend_attr, str) and runtime_backend_attr
                     else runtime_backend or "unknown"
-                )
-
-                # Create checkpoint store for execution state persistence
-                checkpoint_store = CheckpointStore()
-                checkpoint_store.initialize()
-                fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
-                if is_resume:
-                    persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
-                    if isinstance(persisted_fat_harness_mode, bool):
-                        fat_harness_mode = persisted_fat_harness_mode
-                    else:
-                        # No persisted contract (historical session): mirror the
-                        # CLI resume semantics — verify-by-default unless the
-                        # seed opts out with execution_mode='legacy'.
-                        fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
-
-                # Create orchestrator runner
-                runner = OrchestratorRunner(
-                    adapter=agent_adapter,
-                    event_store=event_store,
-                    console=console,
-                    mcp_manager=self.mcp_manager,
-                    mcp_tool_prefix=self.mcp_tool_prefix,
-                    debug=False,
-                    enable_decomposition=True,
-                    inherited_runtime_handle=inherited_runtime_handle,
-                    inherited_tools=inherited_effective_tools,
-                    task_workspace=workspace,
-                    checkpoint_store=checkpoint_store,
-                    max_parallel_workers=max_parallel_workers,
-                    fat_harness_mode=fat_harness_mode,
-                    # Drive model-tier routing from the MCP model_tier arg
-                    # (small/medium/large → frugal/standard/frontier top-level tier).
-                    base_model_tier=base_model_tier_override,
-                    efficiency_mode=raw_efficiency_mode,
-                    frugality_assurance=raw_frugality_assurance,
-                    session_signal_hub=self.session_signal_hub,
                 )
 
                 skip_qa = arguments.get("skip_qa", False)
@@ -1146,6 +1385,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
                     tracker = prepared.value
+                    self._remember_process_local_owner(
+                        tracker,
+                        runner,
+                        owned_event_store=event_store if owns_event_store else None,
+                    )
 
                 # Background execution coroutine — either awaited directly
                 # (synchronous=True) or wrapped in create_task (fire-and-forget).
@@ -1160,7 +1404,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     _session_repo: SessionRepository = session_repo,
                     _event_store: EventStore = event_store,
                     _owns_event_store: bool = owns_event_store,
+                    _retained_resume_handoff: bool = retained_resume_handoff,
                 ) -> None:
+                    nonlocal retained_after_run, retained_event_store_to_close
                     try:
                         if _resume_existing:
                             result = await _runner.resume_session(_tracker.session_id, _seed)
@@ -1176,6 +1422,13 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 session_id=_tracker.session_id,
                                 error=str(result.error),
                             )
+                            if _is_nonterminal_process_local_resume_error(result.error):
+                                log.info(
+                                    "mcp.tool.execute_seed.background_nonterminal_resume_block",
+                                    session_id=_tracker.session_id,
+                                    resume_blocked=result.error.details.get("resume_blocked"),
+                                )
+                                return
                             await _session_repo.mark_failed(
                                 _tracker.session_id,
                                 error_message=str(result.error),
@@ -1236,15 +1489,39 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         except Exception:
                             log.exception("mcp.tool.execute_seed.mark_failed_error")
                     finally:
+                        (
+                            retained_after_run,
+                            retained_event_store_to_close,
+                        ) = await self._reconcile_process_local_owner(
+                            tracker=_tracker,
+                            runner=_runner,
+                            session_repo=_session_repo,
+                        )
                         if _workspace is not None:
                             release_lock(_workspace.lock_path)
-                        if _owns_event_store:
+                        if _owns_event_store and not retained_after_run:
                             try:
                                 close_result = _event_store.close()
                                 if inspect.isawaitable(close_result):
                                     await close_result
+                                if retained_event_store_to_close is _event_store:
+                                    retained_event_store_to_close = None
                             except Exception:
                                 log.exception("mcp.tool.execute_seed.event_store_close_error")
+                        if (
+                            retained_event_store_to_close is not None
+                            and not retained_after_run
+                            and not synchronous
+                        ):
+                            try:
+                                close_result = retained_event_store_to_close.close()
+                                if inspect.isawaitable(close_result):
+                                    await close_result
+                                retained_event_store_to_close = None
+                            except Exception:
+                                log.exception("mcp.tool.execute_seed.event_store_close_error")
+                        if _retained_resume_handoff:
+                            self._finish_process_local_resume_handoff(_tracker.session_id)
 
                 session_status: SessionStatus | None = None
                 pause_metadata: dict[str, Any] = {}
@@ -1290,6 +1567,15 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     launched = True
                     self._background_tasks.add(task)
                     task.add_done_callback(self._background_tasks.discard)
+                    if retained_resume_handoff:
+                        # A task cancelled before its coroutine starts will not
+                        # execute the coroutine's ``finally`` block. The discard
+                        # is idempotent and covers that scheduling edge too.
+                        task.add_done_callback(
+                            lambda _task, _session_id=tracker.session_id: (
+                                self._finish_process_local_resume_handoff(_session_id)
+                            )
+                        )
                     status_label = "running"
                     success = None  # unknown yet
                     is_error = False
@@ -1376,13 +1662,24 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # after reconstruct_session has finished using the store.
                 if workspace is not None and (not launched or synchronous):
                     release_lock(workspace.lock_path)
-                if owns_event_store and (not launched or synchronous):
+                if owns_event_store and (not launched or synchronous) and not retained_after_run:
                     try:
                         close_result = event_store.close()
                         if inspect.isawaitable(close_result):
                             await close_result
+                        if retained_event_store_to_close is event_store:
+                            retained_event_store_to_close = None
                     except Exception:
                         log.exception("mcp.tool.execute_seed.event_store_close_error")
+                if retained_event_store_to_close is not None and not retained_after_run:
+                    try:
+                        close_result = retained_event_store_to_close.close()
+                        if inspect.isawaitable(close_result):
+                            await close_result
+                    except Exception:
+                        log.exception("mcp.tool.execute_seed.event_store_close_error")
+                if retained_resume_handoff and (not launched or synchronous):
+                    self._finish_process_local_resume_handoff(tracker.session_id)
         except Exception as e:
             log.error("mcp.tool.execute_seed.error", error=str(e))
             return Result.err(

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -866,33 +866,68 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         discarding the cancelled task reference.
         """
         try:
-            await runner._mark_process_local_resume_unavailable(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
-        except Exception:
-            log.exception(
-                "mcp.tool.execute_seed.unstarted_background_terminalization_failed",
-                session_id=tracker.session_id,
-            )
-        try:
-            await self._reconcile_terminal_process_local_owner(tracker)
-        except Exception:
-            log.exception(
-                "mcp.tool.execute_seed.unstarted_background_owner_cleanup_failed",
-                session_id=tracker.session_id,
-            )
-        if workspace is not None:
-            release_lock(workspace.lock_path)
-        if owned_event_store is not None:
             try:
-                close_result = owned_event_store.close()
-                if inspect.isawaitable(close_result):
-                    await close_result
+                terminalization_error = await runner._mark_process_local_resume_unavailable(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
             except Exception:
-                log.exception("mcp.tool.execute_seed.event_store_close_error")
-        if retained_resume_handoff:
-            self._finish_process_local_resume_handoff(tracker.session_id)
+                log.exception(
+                    "mcp.tool.execute_seed.unstarted_background_terminalization_failed",
+                    session_id=tracker.session_id,
+                )
+                return
+
+            if (
+                terminalization_error.details.get("resume_blocked")
+                == "terminal_persistence_pending"
+            ):
+                log.warning(
+                    "mcp.tool.execute_seed.unstarted_background_terminal_persistence_pending",
+                    session_id=tracker.session_id,
+                )
+                return
+
+            try:
+                reconstructed = await runner.session_repo.reconstruct_session(tracker.session_id)
+            except Exception:
+                log.exception(
+                    "mcp.tool.execute_seed.unstarted_background_terminal_reconstruct_failed",
+                    session_id=tracker.session_id,
+                )
+                return
+            if reconstructed.is_err or reconstructed.value.status not in {
+                SessionStatus.COMPLETED,
+                SessionStatus.FAILED,
+                SessionStatus.CANCELLED,
+            }:
+                log.warning(
+                    "mcp.tool.execute_seed.unstarted_background_terminal_unproven",
+                    session_id=tracker.session_id,
+                )
+                return
+
+            retained_store = self._process_local_owned_event_stores.get(tracker.session_id)
+            try:
+                await self._reconcile_terminal_process_local_owner(reconstructed.value)
+            except Exception:
+                log.exception(
+                    "mcp.tool.execute_seed.unstarted_background_owner_cleanup_failed",
+                    session_id=tracker.session_id,
+                )
+                return
+            if owned_event_store is not None and owned_event_store is not retained_store:
+                try:
+                    close_result = owned_event_store.close()
+                    if inspect.isawaitable(close_result):
+                        await close_result
+                except Exception:
+                    log.exception("mcp.tool.execute_seed.event_store_close_error")
+        finally:
+            if workspace is not None:
+                release_lock(workspace.lock_path)
+            if retained_resume_handoff:
+                self._finish_process_local_resume_handoff(tracker.session_id)
 
     async def _reconcile_terminal_process_local_owner(self, tracker: SessionTracker) -> None:
         """Reconcile a terminal record through the registry-owned transition.

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -95,27 +95,32 @@ from ouroboros.providers.base import LLMAdapter
 log = structlog.get_logger(__name__)
 
 
-_NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS = frozenset(
+_PROCESS_LOCAL_BACKGROUND_OWNED_BLOCKS = frozenset(
     {
         "process_local_execution_in_progress",
         "process_local_authority_held_elsewhere",
         "session_not_paused",
         "cancellation_persistence_pending",
+        # This error path already conditionally persisted its own terminal
+        # result (or observed a concurrent terminal winner). A background
+        # wrapper must never append a second FAILED event over that outcome.
+        "process_local_resume_unavailable",
     }
 )
 
 
-def _is_nonterminal_process_local_resume_error(error: object) -> bool:
-    """Return whether a runner error intentionally leaves its session live.
+def _is_process_local_background_owned_error(error: object) -> bool:
+    """Return whether a runner error already owns its session lifecycle result.
 
-    A process-local owner may be running in another adapter or process.  The
-    runner reports that as a typed non-terminal rejection; the background MCP
-    wrapper must preserve it rather than immediately writing ``mark_failed``
-    and undoing the runner's liveness protection.
+    Most of these typed results intentionally leave a process-local owner live;
+    ``process_local_resume_unavailable`` instead conditionally persists (or
+    observes) a terminal outcome itself.  In both cases the background MCP
+    wrapper must preserve the runner-owned lifecycle rather than append an
+    unconditional ``mark_failed``.
     """
     details = getattr(error, "details", None)
     return isinstance(details, Mapping) and (
-        details.get("resume_blocked") in _NONTERMINAL_PROCESS_LOCAL_RESUME_BLOCKS
+        details.get("resume_blocked") in _PROCESS_LOCAL_BACKGROUND_OWNED_BLOCKS
     )
 
 
@@ -839,6 +844,53 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             except Exception:
                 log.exception("mcp.tool.execute_seed.event_store_close_error")
 
+    async def _cleanup_unstarted_process_local_background_task(
+        self,
+        *,
+        tracker: SessionTracker,
+        runner: OrchestratorRunner,
+        workspace: TaskWorkspace | None,
+        owned_event_store: EventStore | None,
+        retained_resume_handoff: bool,
+    ) -> None:
+        """Close a task cancelled before its coroutine can enter ``finally``.
+
+        ``asyncio`` never executes a coroutine's body when its task is
+        cancelled before the first scheduling turn.  A freshly prepared
+        process-local session has already registered its capability, lease,
+        handler owner, and possibly EventStore by that point, so the done
+        callback must create an explicit terminal cleanup task instead of only
+        discarding the cancelled task reference.
+        """
+        try:
+            await runner._mark_process_local_resume_unavailable(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+        except Exception:
+            log.exception(
+                "mcp.tool.execute_seed.unstarted_background_terminalization_failed",
+                session_id=tracker.session_id,
+            )
+        try:
+            await self._reconcile_terminal_process_local_owner(tracker)
+        except Exception:
+            log.exception(
+                "mcp.tool.execute_seed.unstarted_background_owner_cleanup_failed",
+                session_id=tracker.session_id,
+            )
+        if workspace is not None:
+            release_lock(workspace.lock_path)
+        if owned_event_store is not None:
+            try:
+                close_result = owned_event_store.close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+            except Exception:
+                log.exception("mcp.tool.execute_seed.event_store_close_error")
+        if retained_resume_handoff:
+            self._finish_process_local_resume_handoff(tracker.session_id)
+
     async def _reconcile_terminal_process_local_owner(self, tracker: SessionTracker) -> None:
         """Reconcile a terminal record through the registry-owned transition.
 
@@ -1502,6 +1554,8 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         owned_event_store=event_store if owns_event_store else None,
                     )
 
+                background_started = False
+
                 # Background execution coroutine — either awaited directly
                 # (synchronous=True) or wrapped in create_task (fire-and-forget).
                 async def _run_in_background(
@@ -1517,7 +1571,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     _owns_event_store: bool = owns_event_store,
                     _retained_resume_handoff: bool = retained_resume_handoff,
                 ) -> None:
-                    nonlocal retained_after_run, retained_event_store_to_close
+                    nonlocal background_started, retained_after_run, retained_event_store_to_close
+                    # This must be the first coroutine action. A done callback
+                    # distinguishes cancellation before this first scheduling
+                    # turn (no ``finally`` execution) from ordinary in-body
+                    # cancellation, which reaches the cleanup below.
+                    background_started = True
                     try:
                         if _resume_existing:
                             result = await _runner.resume_session(_tracker.session_id, _seed)
@@ -1533,17 +1592,28 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 session_id=_tracker.session_id,
                                 error=str(result.error),
                             )
-                            if _is_nonterminal_process_local_resume_error(result.error):
+                            if _is_process_local_background_owned_error(result.error):
                                 log.info(
-                                    "mcp.tool.execute_seed.background_nonterminal_resume_block",
+                                    "mcp.tool.execute_seed.background_process_local_lifecycle_owned",
                                     session_id=_tracker.session_id,
                                     resume_blocked=result.error.details.get("resume_blocked"),
                                 )
                                 return
-                            await _session_repo.mark_failed(
+                            mark_result = await _session_repo.mark_failed(
                                 _tracker.session_id,
                                 error_message=str(result.error),
                             )
+                            if mark_result.is_err:
+                                log.error(
+                                    "mcp.tool.execute_seed.background_mark_failed_error",
+                                    session_id=_tracker.session_id,
+                                    error=str(mark_result.error),
+                                )
+                            elif mark_result.value is False:
+                                log.info(
+                                    "mcp.tool.execute_seed.background_terminal_preserved",
+                                    session_id=_tracker.session_id,
+                                )
                             return
                         if not result.value.success:
                             log.warning(
@@ -1593,10 +1663,21 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             session_id=_tracker.session_id,
                         )
                         try:
-                            await _session_repo.mark_failed(
+                            mark_result = await _session_repo.mark_failed(
                                 _tracker.session_id,
                                 error_message="Unexpected error in background execution",
                             )
+                            if mark_result.is_err:
+                                log.error(
+                                    "mcp.tool.execute_seed.mark_failed_error",
+                                    session_id=_tracker.session_id,
+                                    error=str(mark_result.error),
+                                )
+                            elif mark_result.value is False:
+                                log.info(
+                                    "mcp.tool.execute_seed.background_terminal_preserved",
+                                    session_id=_tracker.session_id,
+                                )
                         except Exception:
                             log.exception("mcp.tool.execute_seed.mark_failed_error")
                     finally:
@@ -1677,16 +1758,24 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     )
                     launched = True
                     self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
-                    if retained_resume_handoff:
-                        # A task cancelled before its coroutine starts will not
-                        # execute the coroutine's ``finally`` block. The discard
-                        # is idempotent and covers that scheduling edge too.
-                        task.add_done_callback(
-                            lambda _task, _session_id=tracker.session_id: (
-                                self._finish_process_local_resume_handoff(_session_id)
+
+                    def _background_done(completed: asyncio.Task[None]) -> None:
+                        self._background_tasks.discard(completed)
+                        if not completed.cancelled() or background_started:
+                            return
+                        cleanup = asyncio.create_task(
+                            self._cleanup_unstarted_process_local_background_task(
+                                tracker=tracker,
+                                runner=runner,
+                                workspace=workspace,
+                                owned_event_store=event_store if owns_event_store else None,
+                                retained_resume_handoff=retained_resume_handoff,
                             )
                         )
+                        self._background_tasks.add(cleanup)
+                        cleanup.add_done_callback(self._background_tasks.discard)
+
+                    task.add_done_callback(_background_done)
                     status_label = "running"
                     success = None  # unknown yet
                     is_error = False

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -1524,9 +1524,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     # process-local authority, and only flips its in-memory
                     # ``_task_workspace_lock_held`` bit while the durable lock
                     # remains absent.
-                    persisted = TaskWorkspace.from_progress_dict(
-                        tracker.progress.get("workspace")
-                    )
+                    persisted = TaskWorkspace.from_progress_dict(tracker.progress.get("workspace"))
                     if use_worktree or persisted is not None:
                         if retained_owner is not None:
                             workspace_reservation_runner = retained_owner

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -828,6 +828,30 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         """Release the handler-local pre-resume gate after the runner settles."""
         self._process_local_resume_handoffs.discard(session_id)
 
+    @staticmethod
+    def _release_runner_task_workspace(
+        runner: object,
+        workspace: TaskWorkspace,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Release through the runner lifecycle boundary when it is available.
+
+        Lightweight test/runtime doubles may not implement the private runner
+        boundary.  The fallback preserves the legacy single-owner behavior for
+        those doubles; production runners always take the idempotent,
+        identity-aware path.
+        """
+        release_workspace = getattr(runner, "_release_task_workspace_for_identity", None)
+        if callable(release_workspace):
+            release_workspace(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            return
+        release_lock(workspace.lock_path)
+
     async def _release_terminal_process_local_owner(
         self,
         *,
@@ -856,6 +880,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         workspace: TaskWorkspace | None,
         owned_event_store: EventStore | None,
         retained_resume_handoff: bool,
+        workspace_reservation: object | None = None,
     ) -> None:
         """Close a task cancelled before its coroutine can enter ``finally``.
 
@@ -925,8 +950,14 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 except Exception:
                     log.exception("mcp.tool.execute_seed.event_store_close_error")
         finally:
+            runner._release_task_workspace_reservation(workspace_reservation)
             if workspace is not None:
-                release_lock(workspace.lock_path)
+                self._release_runner_task_workspace(
+                    runner,
+                    workspace,
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
             if retained_resume_handoff:
                 self._finish_process_local_resume_handoff(tracker.session_id)
 
@@ -968,7 +999,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         )
         owner._unregister_session(tracker.execution_id, tracker.session_id)
         if owner._task_workspace is not None:
-            release_lock(owner._task_workspace.lock_path)
+            self._release_runner_task_workspace(
+                owner,
+                owner._task_workspace,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
         await clear_cancellation(tracker.session_id)
         await self._release_terminal_process_local_owner(
             session_id=tracker.session_id,
@@ -1412,6 +1448,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             use_worktree = bool(arguments.get("use_worktree", True))
             retained_owner: OrchestratorRunner | None = None
             retained_resume_handoff = False
+            workspace_runner: OrchestratorRunner | None = None
+            workspace_session_id = session_id
+            workspace_execution_id = execution_id
+            workspace_reservation_runner: OrchestratorRunner | None = None
+            workspace_reservation: object | None = None
 
             try:
                 if is_resume and session_id:
@@ -1424,6 +1465,8 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
                     tracker = tracker_result.value
+                    workspace_session_id = tracker.session_id
+                    workspace_execution_id = tracker.execution_id
                     try:
                         execution_preferences = _persisted_execution_preferences(tracker.progress)
                     except ValueError as exc:
@@ -1470,6 +1513,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
                     if use_worktree:
+                        if retained_owner is not None:
+                            workspace_reservation_runner = retained_owner
+                            workspace_reservation = retained_owner._reserve_task_workspace()
                         persisted = TaskWorkspace.from_progress_dict(
                             tracker.progress.get("workspace")
                         )
@@ -1481,6 +1527,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 allow_dirty=inherited_runtime_handle is not None,
                             )
                         except WorktreeError as e:
+                            if workspace_reservation_runner is not None:
+                                workspace_reservation_runner._release_task_workspace_reservation(
+                                    workspace_reservation
+                                )
+                                workspace_reservation = None
                             return Result.err(
                                 MCPToolError(
                                     f"Task workspace error: {e.message}",
@@ -1583,6 +1634,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         frugality_assurance=raw_frugality_assurance,
                         session_signal_hub=self.session_signal_hub,
                     )
+                workspace_runner = runner
                 runtime_backend_attr = getattr(agent_adapter, "runtime_backend", None)
                 if not (isinstance(runtime_backend_attr, str) and runtime_backend_attr):
                     runtime_backend_attr = getattr(agent_adapter, "_runtime_backend", None)
@@ -1601,6 +1653,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     )
                     if prepared.is_err:
                         prepared_details = prepared.error.details
+                        detail_session_id = prepared_details.get("session_id")
+                        detail_execution_id = prepared_details.get("execution_id")
+                        if isinstance(detail_session_id, str):
+                            workspace_session_id = detail_session_id
+                        if isinstance(detail_execution_id, str):
+                            workspace_execution_id = detail_execution_id
                         terminal_persistence_pending = (
                             prepared_details.get("resume_blocked") == "terminal_persistence_pending"
                         )
@@ -1650,6 +1708,8 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             )
                         )
                     tracker = prepared.value
+                    workspace_session_id = tracker.session_id
+                    workspace_execution_id = tracker.execution_id
                     self._remember_process_local_owner(
                         tracker,
                         runner,
@@ -1672,6 +1732,10 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     _event_store: EventStore = event_store,
                     _owns_event_store: bool = owns_event_store,
                     _retained_resume_handoff: bool = retained_resume_handoff,
+                    _workspace_reservation_runner: OrchestratorRunner | None = (
+                        workspace_reservation_runner
+                    ),
+                    _workspace_reservation: object | None = workspace_reservation,
                 ) -> None:
                     nonlocal background_started, retained_after_run, retained_event_store_to_close
                     # This must be the first coroutine action. A done callback
@@ -1791,8 +1855,17 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             runner=_runner,
                             session_repo=_session_repo,
                         )
+                        if _workspace_reservation_runner is not None:
+                            _workspace_reservation_runner._release_task_workspace_reservation(
+                                _workspace_reservation
+                            )
                         if _workspace is not None:
-                            release_lock(_workspace.lock_path)
+                            self._release_runner_task_workspace(
+                                _runner,
+                                _workspace,
+                                session_id=_tracker.session_id,
+                                execution_id=_tracker.execution_id,
+                            )
                         if _owns_event_store and not retained_after_run:
                             try:
                                 close_result = _event_store.close()
@@ -1870,6 +1943,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 tracker=tracker,
                                 runner=runner,
                                 workspace=workspace,
+                                workspace_reservation=workspace_reservation,
                                 owned_event_store=event_store if owns_event_store else None,
                                 retained_resume_handoff=retained_resume_handoff,
                             )
@@ -1962,8 +2036,21 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # In synchronous mode, _run_in_background was told NOT to own
                 # cleanup (_owns_event_store=False), so the caller cleans up
                 # after reconstruct_session has finished using the store.
+                if not launched or synchronous:
+                    if workspace_reservation_runner is not None:
+                        workspace_reservation_runner._release_task_workspace_reservation(
+                            workspace_reservation
+                        )
                 if workspace is not None and (not launched or synchronous):
-                    release_lock(workspace.lock_path)
+                    if workspace_runner is not None:
+                        self._release_runner_task_workspace(
+                            workspace_runner,
+                            workspace,
+                            session_id=workspace_session_id,
+                            execution_id=workspace_execution_id,
+                        )
+                    else:
+                        release_lock(workspace.lock_path)
                 if owns_event_store and (not launched or synchronous) and not retained_after_run:
                     try:
                         close_result = event_store.close()

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -1516,13 +1516,21 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 resume_blocked="process_local_authority_held_elsewhere",
                             )
                         )
-                    if use_worktree:
+                    # A persisted task workspace is authoritative for resume,
+                    # even when the caller omits ``use_worktree``.  That flag
+                    # controls provisioning of a *new* workspace; it must not
+                    # bypass reacquisition of the lock for a retained runner.
+                    # Otherwise the runner keeps the workspace object, claims
+                    # process-local authority, and only flips its in-memory
+                    # ``_task_workspace_lock_held`` bit while the durable lock
+                    # remains absent.
+                    persisted = TaskWorkspace.from_progress_dict(
+                        tracker.progress.get("workspace")
+                    )
+                    if use_worktree or persisted is not None:
                         if retained_owner is not None:
                             workspace_reservation_runner = retained_owner
                             workspace_reservation = retained_owner._reserve_task_workspace()
-                        persisted = TaskWorkspace.from_progress_dict(
-                            tracker.progress.get("workspace")
-                        )
                         try:
                             workspace = maybe_restore_task_workspace(
                                 session_id,

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -984,26 +984,46 @@ class ExecuteSeedHandler(BridgeAwareMixin):
     ) -> None:
         """Keep a callable owner alive while its process-local lease is live."""
         raw_contract = tracker.progress.get("execution_contract")
+        self._remember_process_local_owner_identity(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+            raw_contract=raw_contract,
+            runner=runner,
+            owned_event_store=owned_event_store,
+        )
+
+    def _remember_process_local_owner_identity(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+        runner: OrchestratorRunner,
+        owned_event_store: EventStore | None = None,
+    ) -> bool:
+        """Retain an exact owner even when durable reconstruction is unavailable."""
         if runner._has_live_process_local_authority(
-            tracker.session_id,
-            tracker.execution_id,
+            session_id,
+            execution_id,
             raw_contract,
         ):
-            self._process_local_resume_owners[tracker.session_id] = runner
+            self._process_local_resume_owners[session_id] = runner
             if owned_event_store is not None:
-                self._process_local_owned_event_stores[tracker.session_id] = owned_event_store
+                self._process_local_owned_event_stores[session_id] = owned_event_store
             if isinstance(raw_contract, Mapping):
                 _register_process_local_authority_terminal_finalizer(
-                    tracker.session_id,
-                    tracker.execution_id,
+                    session_id,
+                    execution_id,
                     raw_contract.get("foundation_a_authority"),
                     runner._adapter,
                     ("execute-seed-handler", id(self), id(runner)),
                     lambda: self._release_terminal_process_local_owner(
-                        session_id=tracker.session_id,
+                        session_id=session_id,
                         runner=runner,
                     ),
                 )
+            return True
+        return False
 
     async def _reconcile_process_local_owner(
         self,
@@ -1585,10 +1605,31 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             prepared_details.get("resume_blocked") == "terminal_persistence_pending"
                         )
                         if terminal_persistence_pending:
-                            retained_tracker = await session_repo.reconstruct_session(
-                                prepared_details.get("session_id", session_id or "")
+                            retained_session_id = prepared_details.get(
+                                "session_id", session_id or ""
                             )
-                            if retained_tracker.is_ok:
+                            retained_execution_id = prepared_details.get(
+                                "execution_id", execution_id or ""
+                            )
+                            if isinstance(retained_session_id, str) and isinstance(
+                                retained_execution_id, str
+                            ):
+                                retained_after_run = self._remember_process_local_owner_identity(
+                                    session_id=retained_session_id,
+                                    execution_id=retained_execution_id,
+                                    raw_contract=runner._execution_contract,
+                                    runner=runner,
+                                    owned_event_store=(event_store if owns_event_store else None),
+                                )
+                            if not retained_after_run:
+                                retained_tracker = await session_repo.reconstruct_session(
+                                    retained_session_id
+                                    if isinstance(retained_session_id, str)
+                                    else ""
+                                )
+                            else:
+                                retained_tracker = None
+                            if retained_tracker is not None and retained_tracker.is_ok:
                                 self._remember_process_local_owner(
                                     retained_tracker.value,
                                     runner,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -40,13 +40,9 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.orchestrator.execution_authority import (
-    _abort_process_local_authority_terminalization,
-    _begin_process_local_authority_terminalization,
-    _retire_process_local_authority_after_terminal_persistence,
-    valid_process_local_authority_contract,
+    ProcessLocalCancellationDisposition,
+    request_process_local_cancellation,
 )
-from ouroboros.orchestrator.heartbeat import is_holder_alive
-from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
@@ -776,26 +772,86 @@ class CancelExecutionHandler:
                     )
                 )
 
-            raw_contract = tracker.progress.get("execution_contract")
-            authority = (
-                raw_contract.get("foundation_a_authority")
-                if isinstance(raw_contract, dict)
-                else None
+            process_local = await request_process_local_cancellation(
+                tracker,
+                self._session_repo,
+                reason=reason,
+                cancelled_by="mcp_tool",
             )
-            terminalization_started, authority_claimed = (
-                _begin_process_local_authority_terminalization(
-                    tracker.session_id,
-                    tracker.execution_id,
-                    authority,
-                )
-            )
-            if authority_claimed:
-                # Do not write a terminal record underneath a live worker. It
-                # will observe this request, persist cancellation, and retire
-                # its exact authority in one lifecycle transition.
-                await request_cancellation(tracker.session_id)
+            if process_local is not None:
+                if (
+                    process_local.disposition
+                    == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+                ):
+                    # Do not write a terminal record underneath a live worker.
+                    # It owns effects and will persist cancellation during its
+                    # orderly cancellation path.
+                    status_text = (
+                        f"Execution {execution_id} cancellation has been requested.\n"
+                        f"Previous status: {tracker.status.value}\n"
+                        f"Reason: {reason}\n"
+                    )
+                    return Result.ok(
+                        MCPToolResult(
+                            content=(MCPContentItem(type=ContentType.TEXT, text=status_text),),
+                            is_error=False,
+                            meta={
+                                "execution_id": execution_id,
+                                "previous_status": tracker.status.value,
+                                "new_status": "cancellation_requested",
+                                "reason": reason,
+                                "cancelled_by": "mcp_tool",
+                                "in_flight": True,
+                            },
+                        )
+                    )
+                if process_local.disposition == ProcessLocalCancellationDisposition.HELD_ELSEWHERE:
+                    return Result.err(
+                        MCPToolError(
+                            "This process-local execution is held by another live owner; "
+                            "cancel it through that owner.",
+                            tool_name="ouroboros_cancel_execution",
+                            is_retriable=True,
+                            details={
+                                "session_id": tracker.session_id,
+                                "execution_id": tracker.execution_id,
+                                "resume_blocked": "process_local_authority_held_elsewhere",
+                            },
+                        )
+                    )
+                if (
+                    process_local.disposition
+                    == ProcessLocalCancellationDisposition.PERSISTENCE_PENDING
+                ):
+                    return Result.err(
+                        MCPToolError(
+                            f"Failed to persist cancellation for execution {execution_id}; retry it "
+                            "through the retained process-local owner.",
+                            tool_name="ouroboros_cancel_execution",
+                            is_retriable=True,
+                            details={
+                                "session_id": tracker.session_id,
+                                "execution_id": tracker.execution_id,
+                                "resume_blocked": "cancellation_persistence_pending",
+                                "cause": str(process_local.error),
+                            },
+                        )
+                    )
+                if (
+                    process_local.disposition
+                    == ProcessLocalCancellationDisposition.ALREADY_TERMINAL
+                ):
+                    return Result.err(
+                        MCPToolError(
+                            f"Execution {execution_id} became terminal before cancellation completed.",
+                            tool_name="ouroboros_cancel_execution",
+                        )
+                    )
+
+                # The helper has persisted one terminal winner and drained the
+                # exact local owner/finalizers before this public success reply.
                 status_text = (
-                    f"Execution {execution_id} cancellation has been requested.\n"
+                    f"Execution {execution_id} has been cancelled.\n"
                     f"Previous status: {tracker.status.value}\n"
                     f"Reason: {reason}\n"
                 )
@@ -806,129 +862,33 @@ class CancelExecutionHandler:
                         meta={
                             "execution_id": execution_id,
                             "previous_status": tracker.status.value,
-                            "new_status": "cancellation_requested",
+                            "new_status": SessionStatus.CANCELLED.value,
                             "reason": reason,
                             "cancelled_by": "mcp_tool",
-                            "in_flight": True,
                         },
                     )
                 )
 
-            if (
-                not terminalization_started
-                and valid_process_local_authority_contract(authority)
-                and is_holder_alive(tracker.session_id)
-            ):
-                # The registry and cancellation signal are process-local. A
-                # different live process cannot receive this request, so
-                # terminalizing its durable session here would split terminal
-                # state from active effects. Fail retryably instead.
-                return Result.err(
-                    MCPToolError(
-                        "This process-local execution is held by another live owner; "
-                        "cancel it through that owner.",
-                        tool_name="ouroboros_cancel_execution",
-                        is_retriable=True,
-                        details={
-                            "session_id": tracker.session_id,
-                            "execution_id": tracker.execution_id,
-                            "resume_blocked": "process_local_authority_held_elsewhere",
-                        },
-                    )
-                )
-
-            # Reserve first, then publish the cooperative request.  A paused
-            # runner cannot claim effects while the durable terminal write is
-            # in flight; if that write fails, it will observe this request on
-            # its next resume and retry cancellation before executing effects.
-            cancellation_request_published = False
-            try:
-                await request_cancellation(tracker.session_id)
-                cancellation_request_published = True
-                cancel_result = await self._session_repo.mark_cancelled_if_active(
-                    session_id=tracker.session_id,
-                    reason=reason,
-                    cancelled_by="mcp_tool",
-                )
-            except BaseException:
-                if terminalization_started:
-                    _abort_process_local_authority_terminalization(
-                        tracker.session_id,
-                        tracker.execution_id,
-                        authority,
-                    )
-                elif cancellation_request_published:
-                    await clear_cancellation(tracker.session_id)
-                raise
-
+            # Historical/non-Foundation-A sessions have no live capability to
+            # protect, so retain their established direct cancellation path.
+            cancel_result = await self._session_repo.mark_cancelled(
+                session_id=tracker.session_id,
+                reason=reason,
+                cancelled_by="mcp_tool",
+            )
             if cancel_result.is_err:
-                if terminalization_started:
-                    _abort_process_local_authority_terminalization(
-                        tracker.session_id,
-                        tracker.execution_id,
-                        authority,
-                    )
-                else:
-                    await clear_cancellation(tracker.session_id)
-                cancel_error = cancel_result.error
                 return Result.err(
                     MCPToolError(
-                        f"Failed to cancel execution: {cancel_error.message}",
+                        f"Failed to cancel execution: {cancel_result.error.message}",
                         tool_name="ouroboros_cancel_execution",
                     )
                 )
-
-            if not cancel_result.value:
-                # A competing terminal writer won after this handler's initial
-                # snapshot.  Preserve that durable result and still drain this
-                # process's exact paused owner when our reservation proves it
-                # belongs to the same lifecycle.
-                (
-                    retired,
-                    claim_became_active,
-                ) = await _retire_process_local_authority_after_terminal_persistence(
-                    tracker.session_id,
-                    tracker.execution_id,
-                    authority,
-                )
-                if claim_became_active:
-                    await request_cancellation(tracker.session_id)
-                else:
-                    await clear_cancellation(tracker.session_id)
-                if retired:
-                    log.info(
-                        "mcp.tool.cancel_execution.preexisting_terminal_owner_retired",
-                        execution_id=tracker.execution_id,
-                        session_id=tracker.session_id,
-                    )
+            if cancel_result.value is False:
                 return Result.err(
                     MCPToolError(
                         f"Execution {execution_id} became terminal before cancellation completed.",
                         tool_name="ouroboros_cancel_execution",
                     )
-                )
-
-            (
-                retired,
-                claim_became_active,
-            ) = await _retire_process_local_authority_after_terminal_persistence(
-                tracker.session_id,
-                tracker.execution_id,
-                authority,
-            )
-            if claim_became_active:
-                # A worker raced from paused/unclaimed to active after the
-                # preflight.  The terminal record is already durable; signal
-                # it so it performs normal orderly cleanup rather than leaving
-                # an owner live indefinitely.
-                await request_cancellation(tracker.session_id)
-            else:
-                await clear_cancellation(tracker.session_id)
-            if retired:
-                log.info(
-                    "mcp.tool.cancel_execution.process_local_owner_retired",
-                    execution_id=tracker.execution_id,
-                    session_id=tracker.session_id,
                 )
 
             status_text = (

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -39,6 +39,14 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.execution_authority import (
+    _abort_process_local_authority_terminalization,
+    _begin_process_local_authority_terminalization,
+    _retire_process_local_authority_after_terminal_persistence,
+    valid_process_local_authority_contract,
+)
+from ouroboros.orchestrator.heartbeat import is_holder_alive
+from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
@@ -768,20 +776,159 @@ class CancelExecutionHandler:
                     )
                 )
 
-            # Perform cancellation
-            cancel_result = await self._session_repo.mark_cancelled(
-                session_id=tracker.session_id,
-                reason=reason,
-                cancelled_by="mcp_tool",
+            raw_contract = tracker.progress.get("execution_contract")
+            authority = (
+                raw_contract.get("foundation_a_authority")
+                if isinstance(raw_contract, dict)
+                else None
             )
+            terminalization_started, authority_claimed = (
+                _begin_process_local_authority_terminalization(
+                    tracker.session_id,
+                    tracker.execution_id,
+                    authority,
+                )
+            )
+            if authority_claimed:
+                # Do not write a terminal record underneath a live worker. It
+                # will observe this request, persist cancellation, and retire
+                # its exact authority in one lifecycle transition.
+                await request_cancellation(tracker.session_id)
+                status_text = (
+                    f"Execution {execution_id} cancellation has been requested.\n"
+                    f"Previous status: {tracker.status.value}\n"
+                    f"Reason: {reason}\n"
+                )
+                return Result.ok(
+                    MCPToolResult(
+                        content=(MCPContentItem(type=ContentType.TEXT, text=status_text),),
+                        is_error=False,
+                        meta={
+                            "execution_id": execution_id,
+                            "previous_status": tracker.status.value,
+                            "new_status": "cancellation_requested",
+                            "reason": reason,
+                            "cancelled_by": "mcp_tool",
+                            "in_flight": True,
+                        },
+                    )
+                )
+
+            if (
+                not terminalization_started
+                and valid_process_local_authority_contract(authority)
+                and is_holder_alive(tracker.session_id)
+            ):
+                # The registry and cancellation signal are process-local. A
+                # different live process cannot receive this request, so
+                # terminalizing its durable session here would split terminal
+                # state from active effects. Fail retryably instead.
+                return Result.err(
+                    MCPToolError(
+                        "This process-local execution is held by another live owner; "
+                        "cancel it through that owner.",
+                        tool_name="ouroboros_cancel_execution",
+                        is_retriable=True,
+                        details={
+                            "session_id": tracker.session_id,
+                            "execution_id": tracker.execution_id,
+                            "resume_blocked": "process_local_authority_held_elsewhere",
+                        },
+                    )
+                )
+
+            # Reserve first, then publish the cooperative request.  A paused
+            # runner cannot claim effects while the durable terminal write is
+            # in flight; if that write fails, it will observe this request on
+            # its next resume and retry cancellation before executing effects.
+            cancellation_request_published = False
+            try:
+                await request_cancellation(tracker.session_id)
+                cancellation_request_published = True
+                cancel_result = await self._session_repo.mark_cancelled_if_active(
+                    session_id=tracker.session_id,
+                    reason=reason,
+                    cancelled_by="mcp_tool",
+                )
+            except BaseException:
+                if terminalization_started:
+                    _abort_process_local_authority_terminalization(
+                        tracker.session_id,
+                        tracker.execution_id,
+                        authority,
+                    )
+                elif cancellation_request_published:
+                    await clear_cancellation(tracker.session_id)
+                raise
 
             if cancel_result.is_err:
+                if terminalization_started:
+                    _abort_process_local_authority_terminalization(
+                        tracker.session_id,
+                        tracker.execution_id,
+                        authority,
+                    )
+                else:
+                    await clear_cancellation(tracker.session_id)
                 cancel_error = cancel_result.error
                 return Result.err(
                     MCPToolError(
                         f"Failed to cancel execution: {cancel_error.message}",
                         tool_name="ouroboros_cancel_execution",
                     )
+                )
+
+            if not cancel_result.value:
+                # A competing terminal writer won after this handler's initial
+                # snapshot.  Preserve that durable result and still drain this
+                # process's exact paused owner when our reservation proves it
+                # belongs to the same lifecycle.
+                (
+                    retired,
+                    claim_became_active,
+                ) = await _retire_process_local_authority_after_terminal_persistence(
+                    tracker.session_id,
+                    tracker.execution_id,
+                    authority,
+                )
+                if claim_became_active:
+                    await request_cancellation(tracker.session_id)
+                else:
+                    await clear_cancellation(tracker.session_id)
+                if retired:
+                    log.info(
+                        "mcp.tool.cancel_execution.preexisting_terminal_owner_retired",
+                        execution_id=tracker.execution_id,
+                        session_id=tracker.session_id,
+                    )
+                return Result.err(
+                    MCPToolError(
+                        f"Execution {execution_id} became terminal before cancellation completed.",
+                        tool_name="ouroboros_cancel_execution",
+                    )
+                )
+
+            (
+                retired,
+                claim_became_active,
+            ) = await _retire_process_local_authority_after_terminal_persistence(
+                tracker.session_id,
+                tracker.execution_id,
+                authority,
+            )
+            if claim_became_active:
+                # A worker raced from paused/unclaimed to active after the
+                # preflight.  The terminal record is already durable; signal
+                # it so it performs normal orderly cleanup rather than leaving
+                # an owner live indefinitely.
+                await request_cancellation(tracker.session_id)
+            else:
+                await clear_cancellation(tracker.session_id)
+            if retired:
+                log.info(
+                    "mcp.tool.cancel_execution.process_local_owner_retired",
+                    execution_id=tracker.execution_id,
+                    session_id=tracker.session_id,
                 )
 
             status_text = (

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -850,6 +850,31 @@ async def request_process_local_cancellation(
         )
         return reconstructed_status, True
 
+    async def _outcome_after_cancellation_publication() -> ProcessLocalCancellationOutcome:
+        """Reconcile a terminal winner that raced cooperative publication.
+
+        A claimed local owner or heartbeat-backed foreign owner can finish
+        between the initial ownership observation and publication of the
+        cancellation signal.  Reconstruct after publication so a late marker
+        cannot outlive an already-terminal aggregate or report a request to an
+        owner that has already retired.
+        """
+        reconstructed_status, terminal_winner = await _await_process_local_cleanup(
+            _reconcile_terminalizing_owner()
+        )
+        if terminal_winner:
+            return ProcessLocalCancellationOutcome(
+                (
+                    ProcessLocalCancellationDisposition.CANCELLED
+                    if reconstructed_status == "cancelled"
+                    else ProcessLocalCancellationDisposition.ALREADY_TERMINAL
+                ),
+                retired=True,
+            )
+        return ProcessLocalCancellationOutcome(
+            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+        )
+
     terminalization_started, authority_claimed = _begin_process_local_authority_terminalization(
         session_id,
         execution_id,
@@ -878,9 +903,7 @@ async def request_process_local_cancellation(
                 reason=reason,
                 cancelled_by=cancelled_by,
             )
-            return ProcessLocalCancellationOutcome(
-                ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
-            )
+            return await _outcome_after_cancellation_publication()
         # A local claimed runner owns the effect boundary.  It observes this
         # signal and persists cancellation before its own teardown.
         await request_cancellation(
@@ -888,9 +911,7 @@ async def request_process_local_cancellation(
             reason=reason,
             cancelled_by=cancelled_by,
         )
-        return ProcessLocalCancellationOutcome(
-            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
-        )
+        return await _outcome_after_cancellation_publication()
 
     if not terminalization_started and is_holder_alive(session_id):
         # Do not terminalize beneath a foreign process's active effects. The
@@ -909,9 +930,7 @@ async def request_process_local_cancellation(
                 ProcessLocalCancellationDisposition.PERSISTENCE_PENDING,
                 error=exc,
             )
-        return ProcessLocalCancellationOutcome(
-            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
-        )
+        return await _outcome_after_cancellation_publication()
 
     cancellation_request_published = False
     try:

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -711,9 +711,21 @@ async def request_process_local_cancellation(
         )
 
     if not terminalization_started and is_holder_alive(session_id):
-        # Registry signals cannot cross processes, so a live foreign holder
-        # must not receive a durable terminal state beneath active effects.
-        return ProcessLocalCancellationOutcome(ProcessLocalCancellationDisposition.HELD_ELSEWHERE)
+        # Do not terminalize beneath a foreign process's active effects. The
+        # request marker is a separate durable nonterminal channel that the
+        # owning runner observes at its normal cancellation checkpoints.
+        from ouroboros.orchestrator.heartbeat import publish_cancellation_request
+
+        try:
+            publish_cancellation_request(session_id)
+        except OSError as exc:
+            return ProcessLocalCancellationOutcome(
+                ProcessLocalCancellationDisposition.PERSISTENCE_PENDING,
+                error=exc,
+            )
+        return ProcessLocalCancellationOutcome(
+            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+        )
 
     cancellation_request_published = False
     try:

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -9,11 +9,13 @@ exact live object for this process; it is never made portable by introspection.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import asyncio
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import hashlib
 import inspect
 import json
+import logging
 import math
 import os
 from pathlib import Path
@@ -65,6 +67,7 @@ _RATE_GATE_BUCKET_HELPER_NAMES = (
 
 _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN = object()
 _SAFE_PROCESS_LOCAL_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
+_LOG = logging.getLogger(__name__)
 
 
 class _ProcessLocalAuthorityGeneration:
@@ -125,6 +128,15 @@ class _ProcessLocalAuthorityRegistry:
         self._issued: dict[int, _ProcessLocalAuthorityIssuance] = {}
         self._registrations: dict[str, _ProcessLocalAuthorityRegistration] = {}
         self._claims: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        # A public terminalization reserves an otherwise-unclaimed owner while
+        # its durable terminal record is being written.  This prevents a
+        # paused runner from acquiring effects between cancellation preflight
+        # and persistence.
+        self._terminalizations: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        # A public terminalization surface may not hold the creating runner.
+        # Keep only local cleanup callbacks alongside the opaque registration,
+        # so a durable terminal record can retire the whole local lifecycle.
+        self._terminal_finalizers: dict[str, dict[object, Callable[[], object]]] = {}
         self._lock = RLock()
 
     @staticmethod
@@ -200,6 +212,88 @@ class _ProcessLocalAuthorityRegistry:
             ):
                 raise ValueError("process-local authority session is already registered")
             self._registrations[session_id] = registration
+            self._terminal_finalizers.setdefault(session_id, {})
+
+    def begin_terminalization(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> tuple[bool, bool]:
+        """Reserve an unclaimed owner while another surface writes terminal state.
+
+        The first result means this caller owns the terminalization reservation.
+        The second means an effectful claim or another terminalization is already
+        live, so the caller must signal it rather than write terminal state
+        underneath it.
+        """
+        if not valid_process_local_authority_contract(value):
+            return False, False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return False, False
+            if (
+                self._claims.get(session_id) is not None
+                or self._terminalizations.get(session_id) is not None
+            ):
+                return False, True
+            self._terminalizations[session_id] = entry
+            return True, False
+
+    def abort_terminalization(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> None:
+        """Release this caller's terminalization reservation after write failure."""
+        if not valid_process_local_authority_contract(value):
+            return
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            reservation = self._terminalizations.get(session_id)
+            if (
+                entry is not None
+                and reservation is entry
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+            ):
+                self._terminalizations.pop(session_id, None)
+
+    def add_terminal_finalizer(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+        adapter: object,
+        finalizer_key: object,
+        finalizer: Callable[[], object],
+    ) -> bool:
+        """Attach idempotent local cleanup to one exact live registration."""
+        if not valid_process_local_authority_contract(value):
+            return False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return False
+            self._terminal_finalizers.setdefault(session_id, {})[finalizer_key] = finalizer
+            return True
 
     def live_generation(
         self,
@@ -275,7 +369,7 @@ class _ProcessLocalAuthorityRegistry:
             ):
                 return None, False
             claim = self._claims.get(session_id)
-            if claim is not None:
+            if claim is not None or self._terminalizations.get(session_id) is not None:
                 return None, True
             self._claims[session_id] = entry
             return entry.generation, False
@@ -292,6 +386,22 @@ class _ProcessLocalAuthorityRegistry:
             ):
                 self._claims.pop(session_id, None)
 
+    def is_claimed(self, session_id: str, execution_id: str, value: object) -> bool:
+        """Report whether the exact durable correlation currently owns effects."""
+        if not valid_process_local_authority_contract(value):
+            return False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            claim = self._claims.get(session_id)
+            return (
+                entry is not None
+                and claim is entry
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+            )
+
     def retire(self, session_id: str, execution_id: str, adapter: object) -> bool:
         """Retire an exact session binding and report whether this owner did it."""
         with self._lock:
@@ -305,10 +415,46 @@ class _ProcessLocalAuthorityRegistry:
                 return False
             self._registrations.pop(session_id, None)
             self._claims.pop(session_id, None)
+            self._terminalizations.pop(session_id, None)
+            self._terminal_finalizers.pop(session_id, None)
             issuance = self._issued.get(id(entry.generation))
             if issuance is not None and issuance.generation is entry.generation:
                 self._issued.pop(id(entry.generation), None)
             return True
+
+    def retire_after_terminal_persistence(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> tuple[bool, bool, tuple[Callable[[], object], ...]]:
+        """Retire an unclaimed binding after a durable terminal transition.
+
+        The first boolean reports whether this call retired the exact binding;
+        the second reports an active effectful claim.  Callers must signal an
+        active worker rather than terminalizing underneath it.
+        """
+        if not valid_process_local_authority_contract(value):
+            return False, False, ()
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return False, False, ()
+            if self._claims.get(session_id) is not None:
+                return False, True, ()
+            self._registrations.pop(session_id, None)
+            self._terminalizations.pop(session_id, None)
+            finalizers = tuple(self._terminal_finalizers.pop(session_id, {}).values())
+            issuance = self._issued.get(id(entry.generation))
+            if issuance is not None and issuance.generation is entry.generation:
+                self._issued.pop(id(entry.generation), None)
+            return True, False, finalizers
 
     def discard(self, generation: _ProcessLocalAuthorityGeneration) -> None:
         """Discard an unregistered generation after failed session preparation."""
@@ -326,6 +472,8 @@ class _ProcessLocalAuthorityRegistry:
         self._issued = {}
         self._registrations = {}
         self._claims = {}
+        self._terminalizations = {}
+        self._terminal_finalizers = {}
         self._lock = RLock()
 
 
@@ -395,6 +543,60 @@ def _has_live_process_local_authority_registration(
     )
 
 
+def _process_local_authority_is_claimed(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> bool:
+    """Return whether this local authority is actively executing effects."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.is_claimed(session_id, execution_id, value)
+
+
+def _begin_process_local_authority_terminalization(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> tuple[bool, bool]:
+    """Reserve a local owner while durable terminalization is in progress."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.begin_terminalization(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
+def _abort_process_local_authority_terminalization(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> None:
+    """Release a failed public terminalization reservation."""
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.abort_terminalization(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
+def _register_process_local_authority_terminal_finalizer(
+    session_id: str,
+    execution_id: str,
+    value: object,
+    adapter: object,
+    finalizer_key: object,
+    finalizer: Callable[[], object],
+) -> bool:
+    """Register local cleanup for a terminal transition observed elsewhere."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.add_terminal_finalizer(
+        session_id,
+        execution_id,
+        value,
+        adapter,
+        finalizer_key,
+        finalizer,
+    )
+
+
 def _claim_process_local_authority_generation(
     session_id: str,
     execution_id: str,
@@ -423,6 +625,71 @@ def _retire_process_local_authority_generation(
     adapter: object,
 ) -> bool:
     return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
+
+
+async def _retire_process_local_authority_after_terminal_persistence(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> tuple[bool, bool]:
+    """Release an unclaimed local owner after a durable terminal transition.
+
+    A public cancellation handler can call this without receiving the opaque
+    generation or adapter.  It succeeds only for the exact correlation and
+    deliberately refuses to race an active effectful claim.
+    """
+    retired, claimed, finalizers = (
+        _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire_after_terminal_persistence(
+            session_id,
+            execution_id,
+            value,
+        )
+    )
+    if not retired:
+        return False, claimed
+
+    cancellation: asyncio.CancelledError | None = None
+    try:
+        for finalizer in finalizers:
+            try:
+                result = finalizer()
+                if inspect.isawaitable(result):
+                    task = asyncio.ensure_future(result)
+                    while not task.done():
+                        try:
+                            await asyncio.shield(task)
+                        except asyncio.CancelledError as exc:
+                            # A terminal transition has already invalidated the
+                            # registry entry.  Finish every registered cleanup
+                            # callback before propagating cancellation so a
+                            # cancelled caller cannot leak a retained store.
+                            cancellation = cancellation or exc
+                    try:
+                        task.result()
+                    except asyncio.CancelledError as exc:
+                        cancellation = cancellation or exc
+                        _LOG.warning(
+                            "process_local_authority.terminal_finalizer_cancelled",
+                            extra={"session_id": session_id, "execution_id": execution_id},
+                        )
+            except asyncio.CancelledError as exc:
+                cancellation = cancellation or exc
+                _LOG.warning(
+                    "process_local_authority.terminal_finalizer_cancelled",
+                    extra={"session_id": session_id, "execution_id": execution_id},
+                )
+            except Exception:
+                _LOG.exception(
+                    "process_local_authority.terminal_finalizer_failed",
+                    extra={"session_id": session_id, "execution_id": execution_id},
+                )
+    finally:
+        from ouroboros.orchestrator.heartbeat import release_if_owned_by_current_process
+
+        release_if_owned_by_current_process(session_id)
+    if cancellation is not None:
+        raise cancellation
+    return True, False
 
 
 def _discard_process_local_authority_generation(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -738,7 +738,11 @@ async def request_process_local_cancellation(
     if authority_claimed:
         # A local claimed runner owns the effect boundary.  It observes this
         # signal and persists cancellation before its own teardown.
-        await request_cancellation(session_id)
+        await request_cancellation(
+            session_id,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
         return ProcessLocalCancellationOutcome(
             ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
         )
@@ -750,7 +754,11 @@ async def request_process_local_cancellation(
         from ouroboros.orchestrator.heartbeat import publish_cancellation_request
 
         try:
-            publish_cancellation_request(session_id)
+            publish_cancellation_request(
+                session_id,
+                reason=reason,
+                cancelled_by=cancelled_by,
+            )
         except OSError as exc:
             return ProcessLocalCancellationOutcome(
                 ProcessLocalCancellationDisposition.PERSISTENCE_PENDING,
@@ -762,7 +770,11 @@ async def request_process_local_cancellation(
 
     cancellation_request_published = False
     try:
-        await request_cancellation(session_id)
+        await request_cancellation(
+            session_id,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
         cancellation_request_published = True
         cancel_result = await session_repo.mark_cancelled_if_active(
             session_id=session_id,
@@ -795,7 +807,11 @@ async def request_process_local_cancellation(
                     authority,
                 )
                 if claim_became_active:
-                    await request_cancellation(session_id)
+                    await request_cancellation(
+                        session_id,
+                        reason=reason,
+                        cancelled_by=cancelled_by,
+                    )
                 else:
                     await clear_cancellation(session_id)
                 _LOG.info(
@@ -847,7 +863,11 @@ async def request_process_local_cancellation(
         authority,
     )
     if claim_became_active:
-        await request_cancellation(session_id)
+        await request_cancellation(
+            session_id,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
     else:
         await clear_cancellation(session_id)
 

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -396,6 +396,17 @@ class _ProcessLocalAuthorityRegistry:
                 and entry.generation.correlation_id == value.get("correlation_id")
             )
 
+    def has_live_session(self, session_id: str) -> bool:
+        """Report whether this PID retains any authority for ``session_id``."""
+        with self._lock:
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
+            return (
+                entry is not None
+                and entry.creator_pid == os.getpid()
+                and self._is_issued_here(entry.generation)
+            )
+
     def claim(
         self,
         session_id: str,
@@ -594,6 +605,11 @@ def _has_live_process_local_authority_registration(
         execution_id,
         value,
     )
+
+
+def _has_live_process_local_authority_session(session_id: str) -> bool:
+    """Report a live local session binding without exposing its capability."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.has_live_session(session_id)
 
 
 def _process_local_authority_is_claimed(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -981,7 +981,9 @@ async def request_process_local_cancellation(
             reason=reason,
             cancelled_by=cancelled_by,
         )
-    except BaseException:
+    except BaseException as operation_error:
+        cleanup_cancellation: asyncio.CancelledError | None = None
+        cleanup_error: BaseException | None = None
         if terminalization_started:
 
             async def _retry_interrupted_terminalization() -> tuple[str | None, bool]:
@@ -1001,7 +1003,14 @@ async def request_process_local_cancellation(
                 interrupted_status, terminal_winner = await _await_process_local_cleanup(
                     _retry_interrupted_terminalization()
                 )
-            except BaseException:
+            except asyncio.CancelledError as exc:
+                cleanup_cancellation = exc
+                _LOG.warning(
+                    "process_local_authority.interrupted_terminal_reconcile_cancelled",
+                    extra={"session_id": session_id, "execution_id": execution_id},
+                )
+            except BaseException as exc:
+                cleanup_error = exc
                 _LOG.warning(
                     "process_local_authority.interrupted_terminal_reconcile_failed",
                     extra={"session_id": session_id, "execution_id": execution_id},
@@ -1023,7 +1032,20 @@ async def request_process_local_cancellation(
                     extra={"session_id": session_id, "execution_id": execution_id},
                 )
         elif cancellation_request_published:
-            await clear_cancellation(session_id)
+            try:
+                await clear_cancellation(session_id)
+            except asyncio.CancelledError as exc:
+                cleanup_cancellation = exc
+            except BaseException as exc:
+                cleanup_error = exc
+        if cleanup_cancellation is not None:
+            # The caller's cancellation is the stronger lifecycle signal. The
+            # reconciliation helper has already drained its shielded task, so
+            # propagate it after preserving the original operation failure as
+            # context instead of silently returning the persistence error.
+            raise cleanup_cancellation from operation_error
+        if cleanup_error is not None:
+            raise operation_error from cleanup_error
         raise
 
     if cancel_result.is_err:

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -320,6 +320,27 @@ class _ProcessLocalAuthorityRegistry:
             ):
                 lifecycle.state = _ProcessLocalAuthorityLifecycleState.REGISTERED
 
+    def is_terminalizing(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> bool:
+        """Report an exact owner's non-effectful terminalization reservation."""
+        if not valid_process_local_authority_contract(value):
+            return False
+        with self._lock:
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
+            return (
+                entry is not None
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+                and lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+            )
+
     def add_terminal_finalizer(
         self,
         session_id: str,
@@ -647,6 +668,19 @@ def _abort_process_local_authority_terminalization(
     )
 
 
+def _process_local_authority_is_terminalizing(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> bool:
+    """Report whether a public terminal writer currently owns the lifecycle."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.is_terminalizing(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
 def _register_process_local_authority_terminal_finalizer(
     session_id: str,
     execution_id: str,
@@ -730,12 +764,79 @@ async def request_process_local_cancellation(
     from ouroboros.orchestrator.heartbeat import is_holder_alive
     from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 
+    async def _reconcile_terminalizing_owner() -> tuple[str | None, bool]:
+        """Reconstruct and retire a terminal winner without restoring effects."""
+        try:
+            reconstructed = await session_repo.reconstruct_session(session_id)
+        except Exception:
+            return None, False
+        if reconstructed.is_err:
+            return None, False
+        reconstructed_status = getattr(
+            reconstructed.value.status,
+            "value",
+            reconstructed.value.status,
+        )
+        if reconstructed_status not in {"completed", "failed", "cancelled"}:
+            return reconstructed_status, False
+        (
+            retired,
+            claim_became_active,
+        ) = await _retire_process_local_authority_after_terminal_persistence(
+            session_id,
+            execution_id,
+            authority,
+        )
+        if claim_became_active:
+            await request_cancellation(
+                session_id,
+                reason=reason,
+                cancelled_by=cancelled_by,
+            )
+        else:
+            await clear_cancellation(session_id)
+        _LOG.info(
+            "process_local_authority.interrupted_terminal_reconciled",
+            extra={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "durable_status": reconstructed_status,
+                "retired": retired,
+            },
+        )
+        return reconstructed_status, True
+
     terminalization_started, authority_claimed = _begin_process_local_authority_terminalization(
         session_id,
         execution_id,
         authority,
     )
     if authority_claimed:
+        if _process_local_authority_is_terminalizing(
+            session_id,
+            execution_id,
+            authority,
+        ):
+            reconstructed_status, terminal_winner = await _await_process_local_cleanup(
+                _reconcile_terminalizing_owner()
+            )
+            if terminal_winner:
+                return ProcessLocalCancellationOutcome(
+                    (
+                        ProcessLocalCancellationDisposition.CANCELLED
+                        if reconstructed_status == "cancelled"
+                        else ProcessLocalCancellationDisposition.ALREADY_TERMINAL
+                    ),
+                    retired=True,
+                )
+            await request_cancellation(
+                session_id,
+                reason=reason,
+                cancelled_by=cancelled_by,
+            )
+            return ProcessLocalCancellationOutcome(
+                ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+            )
         # A local claimed runner owns the effect boundary.  It observes this
         # signal and persists cancellation before its own teardown.
         await request_cancellation(
@@ -784,62 +885,38 @@ async def request_process_local_cancellation(
     except BaseException:
         if terminalization_started:
 
-            async def _reconcile_interrupted_terminalization() -> bool:
-                reconstructed = await session_repo.reconstruct_session(session_id)
-                reconstructed_status = (
-                    getattr(reconstructed.value.status, "value", reconstructed.value.status)
-                    if reconstructed.is_ok
-                    else None
-                )
-                terminal_winner = reconstructed_status in {
-                    "completed",
-                    "failed",
-                    "cancelled",
-                }
-                if not terminal_winner:
-                    return False
-                (
-                    retired,
-                    claim_became_active,
-                ) = await _retire_process_local_authority_after_terminal_persistence(
-                    session_id,
-                    execution_id,
-                    authority,
-                )
-                if claim_became_active:
-                    await request_cancellation(
-                        session_id,
-                        reason=reason,
-                        cancelled_by=cancelled_by,
-                    )
-                else:
-                    await clear_cancellation(session_id)
-                _LOG.info(
-                    "process_local_authority.interrupted_terminal_reconciled",
-                    extra={
-                        "session_id": session_id,
-                        "execution_id": execution_id,
-                        "durable_status": reconstructed_status,
-                        "retired": retired,
-                    },
-                )
-                return True
+            async def _retry_interrupted_terminalization() -> tuple[str | None, bool]:
+                reconstructed_status: str | None = None
+                terminal_winner = False
+                for attempt in range(3):
+                    reconstructed_status, terminal_winner = await _reconcile_terminalizing_owner()
+                    if terminal_winner or reconstructed_status is not None:
+                        break
+                    if attempt < 2:
+                        await asyncio.sleep(0.05 * (2**attempt))
+                return reconstructed_status, terminal_winner
 
+            interrupted_status: str | None = None
             terminal_winner = False
             try:
-                terminal_winner = await _await_process_local_cleanup(
-                    _reconcile_interrupted_terminalization()
+                interrupted_status, terminal_winner = await _await_process_local_cleanup(
+                    _retry_interrupted_terminalization()
                 )
             except BaseException:
                 _LOG.warning(
                     "process_local_authority.interrupted_terminal_reconcile_failed",
                     extra={"session_id": session_id, "execution_id": execution_id},
                 )
-            if not terminal_winner:
+            if not terminal_winner and interrupted_status is not None:
                 _abort_process_local_authority_terminalization(
                     session_id,
                     execution_id,
                     authority,
+                )
+            elif not terminal_winner:
+                _LOG.warning(
+                    "process_local_authority.interrupted_terminal_reconcile_pending",
+                    extra={"session_id": session_id, "execution_id": execution_id},
                 )
         elif cancellation_request_published:
             await clear_cancellation(session_id)

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,0 +1,2074 @@
+"""Finite execution-authority identity for the AC runtime.
+
+Foundation A deliberately identifies a small, explicit component boundary. It
+does not attempt to derive authority from an arbitrary Python callable graph:
+closures, globals, descriptors, module monkeypatches, caches, and runtime
+handles are volatile. A custom verifier can therefore be bound only to its
+exact live object for this process; it is never made portable by introspection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import inspect
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+from threading import RLock
+from typing import Any
+import uuid
+
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
+from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+EXECUTION_AUTHORITY_VERSION = 6
+EXECUTION_AUTHORITY_BOUNDARY_VERSION = 6
+
+_MAX_IDENTITY_DEPTH = 8
+_MAX_IDENTITY_ITEMS = 256
+_MAX_IDENTITY_SCALAR_CHARS = 8_192
+_MAX_IDENTITY_JSON_CHARS = 64_000
+_MAX_RUNTIME_EXECUTABLE_BYTES = 64 * 1024 * 1024
+
+# No legacy runtime is a portable implementation in Foundation A.  In
+# particular, a public CLI entry point that dynamically resolves ``self._...``
+# helpers cannot be promoted by adding an ever-growing helper manifest.  A
+# future sealed execution kernel may populate a separate reviewed table, but
+# the current table is intentionally empty.
+_CLOSED_RUNTIME_IMPLEMENTATIONS: dict[type[object], tuple[str, object, object]] = {}
+
+_EXECUTOR_COMPONENT_VERSIONS = {
+    "parallel_ac_executor": "parallel-ac-executor/v2",
+    "leaf_dispatcher": "leaf-dispatcher/v1",
+    "level_coordinator": "level-coordinator/v1",
+    "rate_limit_gate": "rate-limit-gate/v1",
+}
+_BUILTIN_TRANSCRIPT_VERIFIER = "runtime-transcript-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER = "structural-atomic-verifier/v1"
+_BUILTIN_STRUCTURAL_VERIFIER_CODE = structural_atomic_verifier.__code__
+_RATE_GATE_BUCKET_HELPER_NAMES = (
+    "_prune",
+    "_tokens_in_window",
+    "_snapshot",
+    "_request_wait_seconds",
+    "_token_wait_seconds",
+)
+
+
+_PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN = object()
+_SAFE_PROCESS_LOCAL_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
+
+
+class _ProcessLocalAuthorityGeneration:
+    """An opaque, unpickleable capability minted only by the local registry.
+
+    The correlation id is diagnostic data.  It is deliberately insufficient to
+    construct a usable generation: the registry records the exact object that
+    it minted and the PID that minted it.  This is a process-local lifecycle
+    primitive, not a boundary against code that can monkeypatch this module.
+    """
+
+    __slots__ = ("_correlation_id",)
+
+    def __init__(self, construction_token: object, correlation_id: str) -> None:
+        if construction_token is not _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN:
+            raise TypeError("process-local authority generations are registry-minted")
+        self._correlation_id = correlation_id
+
+    @property
+    def correlation_id(self) -> str:
+        """Return a diagnostics-only correlation id."""
+        return self._correlation_id
+
+    def __reduce__(self) -> object:
+        raise TypeError("process-local authority generations cannot be serialized")
+
+    def __copy__(self) -> object:
+        raise TypeError("process-local authority generations cannot be copied")
+
+    def __deepcopy__(self, memo: object) -> object:
+        del memo
+        raise TypeError("process-local authority generations cannot be copied")
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessLocalAuthorityIssuance:
+    """The registry-private mint record used to reject reconstructed objects."""
+
+    generation: _ProcessLocalAuthorityGeneration
+    correlation_id: str
+    creator_pid: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessLocalAuthorityRegistration:
+    """One exact live binding for a process-local session."""
+
+    execution_id: str
+    generation: _ProcessLocalAuthorityGeneration
+    adapter: object
+    creator_pid: int
+
+
+class _ProcessLocalAuthorityRegistry:
+    """Keep opaque Foundation A capabilities in one process and PID epoch."""
+
+    def __init__(self) -> None:
+        self._issued: dict[int, _ProcessLocalAuthorityIssuance] = {}
+        self._registrations: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        self._claims: dict[str, _ProcessLocalAuthorityRegistration] = {}
+        self._lock = RLock()
+
+    @staticmethod
+    def _valid_session_or_execution_id(value: object, *, label: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"process-local authority requires a {label}")
+        if label == "session id" and _SAFE_PROCESS_LOCAL_SESSION_ID.fullmatch(value) is None:
+            raise ValueError("process-local authority requires a canonical safe session id")
+        return value
+
+    def mint(self) -> _ProcessLocalAuthorityGeneration:
+        """Mint an unforgeable-in-this-registry generation for one new run."""
+        generation = _ProcessLocalAuthorityGeneration(
+            _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN,
+            uuid.uuid4().hex,
+        )
+        issuance = _ProcessLocalAuthorityIssuance(
+            generation=generation,
+            correlation_id=generation.correlation_id,
+            creator_pid=os.getpid(),
+        )
+        with self._lock:
+            self._issued[id(generation)] = issuance
+        return generation
+
+    def _is_issued_here(self, generation: object) -> bool:
+        if not isinstance(generation, _ProcessLocalAuthorityGeneration):
+            return False
+        issuance = self._issued.get(id(generation))
+        return (
+            issuance is not None
+            and issuance.generation is generation
+            and issuance.correlation_id == generation.correlation_id
+            and issuance.creator_pid == os.getpid()
+        )
+
+    def contract(self, generation: _ProcessLocalAuthorityGeneration) -> dict[str, object]:
+        """Return persisted correlation data for an issued live generation."""
+        with self._lock:
+            if not self._is_issued_here(generation):
+                raise ValueError("process-local authority generation is not live in this process")
+            return {
+                "version": 1,
+                "scope": "process_local",
+                "correlation_id": generation.correlation_id,
+            }
+
+    def register(
+        self,
+        session_id: str,
+        execution_id: str,
+        generation: _ProcessLocalAuthorityGeneration,
+        adapter: object,
+    ) -> None:
+        """Bind an issued generation to exactly one session and adapter."""
+        session_id = self._valid_session_or_execution_id(session_id, label="session id")
+        execution_id = self._valid_session_or_execution_id(execution_id, label="execution id")
+        with self._lock:
+            if not self._is_issued_here(generation):
+                raise ValueError("process-local authority requires a registry-issued generation")
+            current = self._registrations.get(session_id)
+            registration = _ProcessLocalAuthorityRegistration(
+                execution_id=execution_id,
+                generation=generation,
+                adapter=adapter,
+                creator_pid=os.getpid(),
+            )
+            if current is not None and not (
+                current.execution_id == registration.execution_id
+                and current.generation is registration.generation
+                and current.adapter is registration.adapter
+                and current.creator_pid == registration.creator_pid
+            ):
+                raise ValueError("process-local authority session is already registered")
+            self._registrations[session_id] = registration
+
+    def live_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+        adapter: object,
+    ) -> _ProcessLocalAuthorityGeneration | None:
+        """Return the exact live generation only for this creating process."""
+        if not valid_process_local_authority_contract(value):
+            return None
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return None
+            return entry.generation
+
+    def has_live_registration(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> bool:
+        """Report a live local binding without making it transferable.
+
+        A different adapter in the same PID must not receive the capability,
+        but it also must not mistake the original adapter's live binding for a
+        crashed process and terminalize the persisted session.
+        """
+        if not valid_process_local_authority_contract(value):
+            return False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            return (
+                entry is not None
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+            )
+
+    def claim(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+        adapter: object,
+    ) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+        """Atomically claim one live session for effectful execution.
+
+        The bool reports an already-live authority that is currently claimed.
+        It is intentionally distinct from a missing capability: a concurrent
+        caller must not terminally invalidate the original active session.
+        """
+        if not valid_process_local_authority_contract(value):
+            return None, False
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+                or not self._is_issued_here(entry.generation)
+                or entry.generation.correlation_id != value.get("correlation_id")
+            ):
+                return None, False
+            claim = self._claims.get(session_id)
+            if claim is not None:
+                return None, True
+            self._claims[session_id] = entry
+            return entry.generation, False
+
+    def release(self, session_id: str, execution_id: str, adapter: object) -> None:
+        """Release a paused session's exclusive execution claim."""
+        with self._lock:
+            claim = self._claims.get(session_id)
+            if (
+                claim is not None
+                and claim.creator_pid == os.getpid()
+                and claim.execution_id == execution_id
+                and claim.adapter is adapter
+            ):
+                self._claims.pop(session_id, None)
+
+    def retire(self, session_id: str, execution_id: str, adapter: object) -> bool:
+        """Retire an exact session binding and report whether this owner did it."""
+        with self._lock:
+            entry = self._registrations.get(session_id)
+            if (
+                entry is None
+                or entry.creator_pid != os.getpid()
+                or entry.execution_id != execution_id
+                or entry.adapter is not adapter
+            ):
+                return False
+            self._registrations.pop(session_id, None)
+            self._claims.pop(session_id, None)
+            issuance = self._issued.get(id(entry.generation))
+            if issuance is not None and issuance.generation is entry.generation:
+                self._issued.pop(id(entry.generation), None)
+            return True
+
+    def discard(self, generation: _ProcessLocalAuthorityGeneration) -> None:
+        """Discard an unregistered generation after failed session preparation."""
+        with self._lock:
+            issuance = self._issued.get(id(generation))
+            if issuance is not None and issuance.generation is generation:
+                if not any(item.generation is generation for item in self._registrations.values()):
+                    self._issued.pop(id(generation), None)
+
+    def clear_after_fork(self) -> None:
+        """Do not let a fork inherit the parent process's capabilities."""
+        # This hook runs in a post-fork child.  A parent thread may have held
+        # the inherited lock at fork time, so acquiring it here can deadlock
+        # forever because that owner no longer exists in the child.
+        self._issued = {}
+        self._registrations = {}
+        self._claims = {}
+        self._lock = RLock()
+
+
+_PROCESS_LOCAL_AUTHORITY_REGISTRY = _ProcessLocalAuthorityRegistry()
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_PROCESS_LOCAL_AUTHORITY_REGISTRY.clear_after_fork)
+
+
+def _mint_process_local_authority_generation() -> _ProcessLocalAuthorityGeneration:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.mint()
+
+
+def _process_local_authority_contract(
+    generation: _ProcessLocalAuthorityGeneration,
+) -> dict[str, object]:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.contract(generation)
+
+
+def valid_process_local_authority_contract(value: object) -> bool:
+    """Return whether a persisted process-local correlation record is canonical."""
+    return (
+        isinstance(value, Mapping)
+        and set(value) == {"version", "scope", "correlation_id"}
+        and isinstance(value.get("version"), int)
+        and not isinstance(value.get("version"), bool)
+        and value.get("version") == 1
+        and value.get("scope") == "process_local"
+        and isinstance(value.get("correlation_id"), str)
+        and len(value["correlation_id"]) == 32
+        and all(character in "0123456789abcdef" for character in value["correlation_id"])
+    )
+
+
+def _register_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    generation: _ProcessLocalAuthorityGeneration,
+    adapter: object,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.register(session_id, execution_id, generation, adapter)
+
+
+def _live_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    value: object,
+    adapter: object,
+) -> _ProcessLocalAuthorityGeneration | None:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.live_generation(
+        session_id,
+        execution_id,
+        value,
+        adapter,
+    )
+
+
+def _has_live_process_local_authority_registration(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> bool:
+    """Report an in-process binding without exposing its capability object."""
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.has_live_registration(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
+def _claim_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    value: object,
+    adapter: object,
+) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.claim(
+        session_id,
+        execution_id,
+        value,
+        adapter,
+    )
+
+
+def _release_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    adapter: object,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.release(session_id, execution_id, adapter)
+
+
+def _retire_process_local_authority_generation(
+    session_id: str,
+    execution_id: str,
+    adapter: object,
+) -> bool:
+    return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
+
+
+def _discard_process_local_authority_generation(
+    generation: _ProcessLocalAuthorityGeneration,
+) -> None:
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.discard(generation)
+
+
+def _canonical_json(value: object, *, field: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} is not canonical JSON") from exc
+
+
+def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
+    normalized = json.loads(_canonical_json(value, field=field))
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{field} is not an object")
+    return normalized
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalized_identity_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _is_sensitive_identity_key(value: str) -> bool:
+    """Return whether an explicit identity key can carry a credential value."""
+    compact = _normalized_identity_key(value)
+    return (
+        any(
+            marker in compact
+            for marker in (
+                "apikey",
+                "credential",
+                "password",
+                "authorization",
+                "bearer",
+                "privatekey",
+                "clientsecret",
+                "secretkey",
+                "accesskey",
+                "authkey",
+                "signingkey",
+                "encryptionkey",
+                "accountkey",
+                "masterkey",
+                "connectionstring",
+                "accesstoken",
+                "refreshtoken",
+                "sessiontoken",
+            )
+        )
+        or compact.startswith("secret")
+        or compact.endswith(("token", "tokenvalue", "keyvalue", "secret", "secretvalue"))
+    )
+
+
+def _looks_like_credential(value: str) -> bool:
+    """Recognize opaque credential shapes without redacting ordinary prose."""
+    normalized = value.strip()
+    lowered = normalized.lower()
+    if normalized.startswith("AIza") and len(normalized) >= 35:
+        return True
+    if lowered.startswith(
+        (
+            "sk-",
+            "sk_live_",
+            "sk_test_",
+            "ghp_",
+            "github_pat_",
+            "rk_live_",
+            "rk_test_",
+            "xoxb-",
+            "xoxp-",
+        )
+    ):
+        return len(normalized) >= 16
+    if lowered.startswith("bearer "):
+        return len(normalized.split(maxsplit=1)[-1]) >= 16
+    return False
+
+
+def _project_explicit_identity(
+    value: object,
+    *,
+    field: str,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> object:
+    """Accept only bounded JSON data that is safe to digest.
+
+    This validates an *explicit descriptor*, not object implementation state.
+    Unsupported values make the corresponding component process-local.
+    """
+    if depth > _MAX_IDENTITY_DEPTH:
+        raise ValueError(f"{field} exceeds identity depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{field} contains a non-finite float")
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_IDENTITY_SCALAR_CHARS:
+            raise ValueError(f"{field} contains oversized text")
+        if _looks_like_credential(value):
+            raise ValueError(f"{field} contains credential-shaped text")
+        return value
+
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        raise ValueError(f"{field} contains cyclic state")
+    seen.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many mapping items")
+            projected: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{field} contains a non-string or empty key")
+                if len(key) > _MAX_IDENTITY_SCALAR_CHARS:
+                    raise ValueError(f"{field} contains an oversized key")
+                if _is_sensitive_identity_key(key):
+                    raise ValueError(f"{field} contains a credential-bearing key")
+                projected[key] = _project_explicit_identity(
+                    item,
+                    field=f"{field}.{key}",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return projected
+        if isinstance(value, (list, tuple)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many sequence items")
+            return [
+                _project_explicit_identity(
+                    item,
+                    field=f"{field}[{index}]",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+                for index, item in enumerate(value)
+            ]
+        raise ValueError(f"{field} is not canonical JSON data")
+    finally:
+        seen.remove(value_id)
+
+
+def _safe_identity_digest(value: object, *, field: str) -> str | None:
+    try:
+        projected = _project_explicit_identity(value, field=field)
+        encoded = _canonical_json(projected, field=field)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return None
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        return None
+    return _sha256(encoded)
+
+
+def _digest_descriptor(value: object, *, field: str) -> dict[str, object]:
+    digest = _safe_identity_digest(value, field=field)
+    if digest is None:
+        return {"observed": False}
+    return {"observed": True, "digest": digest}
+
+
+def _valid_digest_descriptor(value: object) -> bool:
+    if not isinstance(value, Mapping) or not isinstance(value.get("observed"), bool):
+        return False
+    if value.get("observed") is False:
+        return set(value) == {"observed"}
+    digest = value.get("digest")
+    return (
+        set(value) == {"observed", "digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def execution_authority_boundary_contract() -> dict[str, object]:
+    """Return the finite ownership matrix embedded in every baseline."""
+    return {
+        "version": EXECUTION_AUTHORITY_BOUNDARY_VERSION,
+        "portable": [
+            "executor_components",
+            "workspace_descriptor",
+            "static_execution_policy",
+            "built_in_verifier",
+        ],
+        "per_attempt": [
+            "ac",
+            "prompt",
+            "tool_catalog",
+            "selected_route",
+            "selected_effort",
+            "runtime_handle",
+            "checkpoint",
+            "session_state",
+        ],
+        "process_local": [
+            "legacy_runtime_descriptor",
+        ],
+        "volatile": [
+            "custom_callable_graph",
+            "event_store",
+            "event_emitter",
+            "cache",
+            "queue",
+            "lock",
+            "signal_hub",
+            "module_monkeypatch",
+        ],
+    }
+
+
+def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
+    """Return a digest-only identity for the effect-owning workspace."""
+    if not isinstance(workspace, str) or not workspace.strip():
+        return {"version": 1, "stability": "process_local", "observed": False}
+    try:
+        canonical = str(Path(workspace).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"version": 1, "stability": "process_local", "observed": False}
+    descriptor = _digest_descriptor(canonical, field="workspace identity")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_workspace_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    observed = value.get("observed")
+    stability = value.get("stability")
+    if observed is False:
+        return stability == "process_local" and set(value) == {"version", "stability", "observed"}
+    digest = value.get("identity_digest")
+    return (
+        observed is True
+        and stability == "durable"
+        and set(value) == {"version", "stability", "observed", "identity_digest"}
+        and isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and len(digest) == 71
+    )
+
+
+def constructor_model_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized constructor-level model pin, when observable."""
+    try:
+        raw_model = inspect.getattr_static(adapter, "_model")
+    except AttributeError:
+        return {"observed": False}
+    if raw_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(raw_model, str):
+        return {"observed": False}
+
+    normalized_model: object = raw_model.strip() or None
+    normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
+    if normalizer_descriptor is not None:
+        try:
+            normalizer = object.__getattribute__(adapter, "_normalize_model")
+            normalized_model = normalizer(raw_model)
+        except Exception:
+            return {"observed": False}
+    if normalized_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(normalized_model, str) or not normalized_model.strip():
+        return {"observed": False}
+    return {"observed": True, "model": normalized_model.strip()}
+
+
+def valid_constructor_model_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    model = value.get("model")
+    return set(value) == {"observed", "model"} and (
+        model is None or isinstance(model, str) and bool(model.strip())
+    )
+
+
+def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
+    """Return the adapter's explicit execution identity for runner resume."""
+    provider_descriptor = inspect.getattr_static(type(adapter), "execution_identity_contract", None)
+    if provider_descriptor is None:
+        return {"version": 1, "observed": False}
+
+    provider = object.__getattribute__(adapter, "execution_identity_contract")
+    identity = provider()
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime execution identity contract is not a mapping")
+    normalized = _canonical_object(
+        dict(identity),
+        field="runtime execution identity contract",
+    )
+    # An empty object carries no execution identity. Treat it like a missing
+    # provider declaration instead of allowing a digest of ``{}`` to witness
+    # portability.
+    if not normalized:
+        return {"version": 1, "observed": False}
+    return {"version": 1, "observed": True, "identity": normalized}
+
+
+def valid_runtime_execution_identity_contract(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    version = value.get("version")
+    observed = value.get("observed")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != 1
+        or not isinstance(observed, bool)
+    ):
+        return False
+    if not observed:
+        return set(value) == {"version", "observed"}
+    identity = value.get("identity")
+    if set(value) != {"version", "observed", "identity"} or not isinstance(identity, Mapping):
+        return False
+    try:
+        _canonical_json(dict(identity), field="runtime execution identity contract")
+    except ValueError:
+        return False
+    return bool(identity)
+
+
+def runtime_execution_proves_effective_model(value: object) -> bool:
+    if not valid_runtime_execution_identity_contract(value):
+        return False
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    identity = value.get("identity")
+    return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+
+
+def _runtime_capabilities_descriptor(adapter: object) -> dict[str, object]:
+    try:
+        capabilities = runtime_capabilities_for(adapter)
+        value = {
+            "skill_dispatch": capabilities.skill_dispatch,
+            "targeted_resume": capabilities.targeted_resume,
+            "structured_output": capabilities.structured_output,
+            "system_prompt_support": capabilities.system_prompt_support.value,
+            "tool_restriction_support": capabilities.tool_restriction_support.value,
+            "permission_mode_support": capabilities.permission_mode_support.value,
+            "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+            "enforceable_reasoning_efforts": (
+                sorted(capabilities.enforceable_reasoning_efforts)
+                if capabilities.enforceable_reasoning_efforts is not None
+                else None
+            ),
+            "model_override_support": capabilities.model_override_support.value,
+            "subagent_orchestration": capabilities.subagent_orchestration.value,
+            "session_signals": capabilities.session_signals.to_event_data(),
+        }
+    except Exception:
+        return {"observed": False}
+    return _digest_descriptor(value, field="runtime capabilities")
+
+
+def _runtime_label_descriptor(adapter: object, name: str) -> dict[str, object]:
+    try:
+        value = object.__getattribute__(adapter, name)
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(value, str) or not value.strip():
+        return {"observed": False}
+    return _digest_descriptor(value.strip(), field=f"runtime {name}")
+
+
+def _runtime_implementation_descriptor(adapter: object) -> dict[str, object]:
+    """Return a reviewed identity for one exact built-in runtime type."""
+    runtime_type = type(adapter)
+    implementation = _CLOSED_RUNTIME_IMPLEMENTATIONS.get(runtime_type)
+    if implementation is None:
+        return {"observed": False}
+    version, expected_dispatch_root, expected_dispatch_code = implementation
+    dispatch_root = _static_callable_root(adapter, "execute_task")
+    if (
+        dispatch_root is not expected_dispatch_root
+        or _callable_code_identity(dispatch_root) is not expected_dispatch_code
+    ):
+        return {"observed": False}
+    return _digest_descriptor(
+        {
+            "type": f"{runtime_type.__module__}.{runtime_type.__qualname__}",
+            "version": version,
+        },
+        field="runtime implementation",
+    )
+
+
+def _runtime_executable_descriptor(adapter: object) -> dict[str, object]:
+    """Digest one bounded, resolved CLI executable without serializing its path."""
+    try:
+        configured_path = object.__getattribute__(adapter, "_cli_path")
+    except (AttributeError, TypeError):
+        return {"observed": False}
+    if not isinstance(configured_path, str) or not configured_path.strip():
+        return {"observed": False}
+
+    try:
+        candidate = Path(configured_path).expanduser()
+        if not candidate.is_absolute():
+            resolved_from_path = shutil.which(configured_path)
+            if resolved_from_path is None:
+                return {"observed": False}
+            candidate = Path(resolved_from_path)
+        executable_path = candidate.resolve(strict=True)
+        executable_stat = executable_path.stat()
+        executable_mode = stat.S_IMODE(executable_stat.st_mode)
+        if (
+            not stat.S_ISREG(executable_stat.st_mode)
+            or not executable_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            or executable_stat.st_size > _MAX_RUNTIME_EXECUTABLE_BYTES
+        ):
+            return {"observed": False}
+        digest = hashlib.sha256()
+        with executable_path.open("rb") as executable_file:
+            while chunk := executable_file.read(1024 * 1024):
+                digest.update(chunk)
+    except (OSError, ValueError):
+        return {"observed": False}
+
+    return _digest_descriptor(
+        {
+            "path": str(executable_path),
+            "generation": {
+                "device": executable_stat.st_dev,
+                "inode": executable_stat.st_ino,
+                "size": executable_stat.st_size,
+                "mtime_ns": executable_stat.st_mtime_ns,
+                "mode": executable_mode,
+            },
+            "content_digest": "sha256:" + digest.hexdigest(),
+        },
+        field="runtime executable",
+    )
+
+
+def _runtime_configuration_descriptor(adapter: object) -> dict[str, object]:
+    """Digest the finite mutable execution settings of the CLI runtime family."""
+    runtime_type = type(adapter)
+    if runtime_type is ZcodeCLIRuntime:
+        # Zcode can launch an app-bundle Electron executable or a PATH-resolved
+        # Node executable before its configured script. That external launcher
+        # chain is not a finite portable descriptor in Foundation A.
+        return {"observed": False}
+
+    try:
+        skills_dir = object.__getattribute__(adapter, "_skills_dir")
+        skill_dispatcher = object.__getattribute__(adapter, "_skill_dispatcher")
+        if skills_dir is not None or skill_dispatcher is not None:
+            # User-provided skill directories and dispatchers are live behavior,
+            # not a closed portable component in Foundation A.
+            return {"observed": False}
+        cwd = object.__getattribute__(adapter, "_cwd")
+        startup_timeout = object.__getattribute__(adapter, "_startup_output_timeout_seconds")
+        stdout_timeout = object.__getattribute__(adapter, "_stdout_idle_timeout_seconds")
+        process_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_process_shutdown_timeout_seconds",
+        )
+        completed_shutdown_timeout = object.__getattribute__(
+            adapter,
+            "_completed_process_group_shutdown_timeout_seconds",
+        )
+        max_resume_retries = object.__getattribute__(adapter, "_max_resume_retries")
+        max_depth = object.__getattribute__(adapter, "_max_ouroboros_depth")
+        max_stderr_lines = object.__getattribute__(adapter, "_max_stderr_lines")
+        use_process_group = object.__getattribute__(adapter, "_use_process_group")
+        child_session_env_keys = object.__getattribute__(adapter, "_child_session_env_keys")
+        copilot_runtime_profile = (
+            object.__getattribute__(adapter, "_runtime_profile")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
+        copilot_agent = (
+            object.__getattribute__(adapter, "_copilot_agent")
+            if runtime_type is CopilotCliRuntime
+            else None
+        )
+    except (AttributeError, TypeError):
+        return {"observed": False}
+
+    timeouts = (
+        startup_timeout,
+        stdout_timeout,
+        process_shutdown_timeout,
+        completed_shutdown_timeout,
+    )
+    if (
+        not isinstance(cwd, str)
+        or not cwd.strip()
+        or not all(value is None or _is_finite_number(value) for value in timeouts)
+        or any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in (max_resume_retries, max_depth, max_stderr_lines)
+        )
+        or not isinstance(use_process_group, bool)
+        or not isinstance(child_session_env_keys, (tuple, list, frozenset))
+        or not all(isinstance(value, str) for value in child_session_env_keys)
+        or (
+            runtime_type is CopilotCliRuntime
+            and (
+                copilot_runtime_profile is not None
+                and (
+                    not isinstance(copilot_runtime_profile, str)
+                    or not copilot_runtime_profile.strip()
+                )
+                or copilot_agent is not None
+                and (not isinstance(copilot_agent, str) or not copilot_agent.strip())
+            )
+        )
+    ):
+        return {"observed": False}
+    try:
+        canonical_cwd = str(Path(cwd).expanduser().resolve(strict=False))
+    except (OSError, ValueError):
+        return {"observed": False}
+    configuration: dict[str, object] = {
+        "working_directory": canonical_cwd,
+        "startup_output_timeout_seconds": startup_timeout,
+        "stdout_idle_timeout_seconds": stdout_timeout,
+        "process_shutdown_timeout_seconds": process_shutdown_timeout,
+        "completed_process_group_shutdown_timeout_seconds": completed_shutdown_timeout,
+        "max_resume_retries": max_resume_retries,
+        "max_ouroboros_depth": max_depth,
+        "max_stderr_lines": max_stderr_lines,
+        "use_process_group": use_process_group,
+        "child_session_env_keys": sorted(child_session_env_keys),
+    }
+    if runtime_type is CopilotCliRuntime:
+        # Copilot translates the resolved runtime profile to an --agent flag.
+        # Bind the exact stored value that command construction consumes.
+        configuration["copilot"] = {
+            "runtime_profile": copilot_runtime_profile,
+            "resolved_agent": copilot_agent,
+        }
+    return _digest_descriptor(configuration, field="runtime execution configuration")
+
+
+def runtime_authority_contract(
+    adapter: object,
+    *,
+    force_process_local: bool = False,
+    instance_nonce: str | None = None,
+) -> dict[str, object]:
+    """Return a process-local descriptor without invoking runtime behavior.
+
+    Current CLI runtimes use dynamic instance helpers, handler caches,
+    configuration readers, and launcher chains.  Calling their identity or
+    capability providers while constructing an authority would itself re-open
+    an unbounded behavior surface.  They remain executable, but a fresh nonce
+    confines every capture to one live process until a separate sealed kernel
+    supplies a reviewed finite execution path.
+    """
+    del adapter, force_process_local
+    return {
+        "version": 5,
+        "stability": "process_local",
+        "portable_identity_observed": False,
+        "runtime_backend": {"observed": False},
+        "llm_backend": {"observed": False},
+        "permission_mode": {"observed": False},
+        "execution_identity": {"observed": False},
+        "capabilities": {"observed": False},
+        "implementation": {"observed": False},
+        "executable": {"observed": False},
+        "configuration": {"observed": False},
+        "self_governs_rate_limit": None,
+        "instance_nonce": instance_nonce or uuid.uuid4().hex,
+    }
+
+
+def _valid_runtime_authority(value: object) -> bool:
+    required = {
+        "version",
+        "stability",
+        "runtime_backend",
+        "llm_backend",
+        "permission_mode",
+        "execution_identity",
+        "capabilities",
+        "implementation",
+        "executable",
+        "configuration",
+        "self_governs_rate_limit",
+        "portable_identity_observed",
+        "instance_nonce",
+    }
+    if not isinstance(value, Mapping) or set(value) != required or value.get("version") != 5:
+        return False
+    if value.get("stability") not in {"durable", "process_local"}:
+        return False
+    if not all(
+        _valid_digest_descriptor(value.get(name))
+        for name in (
+            "runtime_backend",
+            "llm_backend",
+            "permission_mode",
+            "execution_identity",
+            "capabilities",
+            "implementation",
+            "executable",
+            "configuration",
+        )
+    ):
+        return False
+    self_governs_rate_limit = value.get("self_governs_rate_limit")
+    portable_identity_observed = value.get("portable_identity_observed")
+    if not isinstance(portable_identity_observed, bool):
+        return False
+    nonce = value.get("instance_nonce")
+    return (
+        value.get("stability") == "process_local"
+        and not portable_identity_observed
+        and self_governs_rate_limit is None
+        and isinstance(nonce, str)
+        and len(nonce) == 32
+    )
+
+
+def execution_policy_authority_contract(policy: Mapping[str, object]) -> dict[str, object]:
+    """Represent the explicit static policy by a safe digest only."""
+    descriptor = _digest_descriptor(dict(policy), field="execution policy")
+    if descriptor["observed"] is not True:
+        return {"version": 1, "stability": "process_local", "observed": False}
+    return {
+        "version": 1,
+        "stability": "durable",
+        "observed": True,
+        "identity_digest": descriptor["digest"],
+    }
+
+
+def _valid_execution_policy_authority(value: object) -> bool:
+    return _valid_workspace_authority(value)
+
+
+def executor_authority_contract() -> dict[str, object]:
+    """Return the closed Foundation A implementation component registry."""
+    return {
+        "version": 1,
+        "stability": "durable",
+        "components": dict(_EXECUTOR_COMPONENT_VERSIONS),
+    }
+
+
+def verifier_authority_contract(
+    verifier: Verifier | None,
+    *,
+    instance_nonce: str | None = None,
+) -> dict[str, object]:
+    """Describe a verifier without inspecting arbitrary Python behavior."""
+    if verifier is None:
+        return {
+            "version": 1,
+            "mode": "runtime_transcript",
+            "stability": "durable",
+            "implementation": _BUILTIN_TRANSCRIPT_VERIFIER,
+        }
+    if (
+        verifier is structural_atomic_verifier
+        and getattr(verifier, "__code__", None) is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+    ):
+        return {
+            "version": 1,
+            "mode": "structural_atomic",
+            "stability": "durable",
+            "implementation": _BUILTIN_STRUCTURAL_VERIFIER,
+        }
+
+    return {
+        "version": 1,
+        "mode": "custom",
+        "stability": "process_local",
+        "instance_nonce": instance_nonce or uuid.uuid4().hex,
+        # A custom verifier can expose arbitrary dynamic behavior through a
+        # descriptor method.  Do not execute that method merely to describe it.
+        "configuration": {"observed": False},
+    }
+
+
+def _valid_verifier_authority(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("version") != 1:
+        return False
+    mode = value.get("mode")
+    if mode in {"runtime_transcript", "structural_atomic"}:
+        return (
+            value.get("stability") == "durable"
+            and set(value) == {"version", "mode", "stability", "implementation"}
+            and isinstance(value.get("implementation"), str)
+        )
+    if mode != "custom":
+        return False
+    nonce = value.get("instance_nonce")
+    return (
+        value.get("stability") == "process_local"
+        and set(value) == {"version", "mode", "stability", "instance_nonce", "configuration"}
+        and isinstance(nonce, str)
+        and len(nonce) == 32
+        and _valid_digest_descriptor(value.get("configuration"))
+    )
+
+
+def _contains_sensitive_authority_data(value: object) -> bool:
+    if isinstance(value, str):
+        return _looks_like_credential(value)
+    if isinstance(value, Mapping):
+        return any(
+            _is_sensitive_identity_key(key) or _contains_sensitive_authority_data(item)
+            for key, item in value.items()
+            if isinstance(key, str)
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_sensitive_authority_data(item) for item in value)
+    return False
+
+
+def _unwrap_static_callable(value: object) -> object | None:
+    if isinstance(value, (staticmethod, classmethod)):
+        value = value.__func__
+    return value if callable(value) else None
+
+
+def _static_callable_root(value: object | None, member_name: str | None) -> object | None:
+    """Return one direct callable root without traversing its behavior graph."""
+    if value is None:
+        return None
+    try:
+        if member_name is not None:
+            return _unwrap_static_callable(inspect.getattr_static(value, member_name))
+        if inspect.isfunction(value) or inspect.isbuiltin(value) or inspect.ismethod(value):
+            return value
+        return _unwrap_static_callable(inspect.getattr_static(type(value), "__call__"))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _class_callable_root(value: object, member_name: str) -> object | None:
+    """Return a callable declared on an instance type, never its instance dict."""
+    try:
+        return _unwrap_static_callable(inspect.getattr_static(type(value), member_name))
+    except (AttributeError, TypeError):
+        return None
+
+
+def _callable_code_identity(value: object | None) -> object | None:
+    """Return a direct Python-code root without traversing callable state."""
+    if not inspect.isfunction(value):
+        return None
+    try:
+        return value.__code__
+    except AttributeError:
+        return None
+
+
+def _static_property_getter_root(value: object | None, member_name: str) -> object | None:
+    """Return a direct property getter without invoking dynamic lookup."""
+    if value is None:
+        return None
+    try:
+        descriptor = inspect.getattr_static(type(value), member_name)
+    except (AttributeError, TypeError):
+        return None
+    if not isinstance(descriptor, property):
+        return None
+    getter = descriptor.fget
+    return getter if callable(getter) else None
+
+
+def _is_finite_number(value: object) -> bool:
+    """Accept the finite scalar knobs owned by the rate-gate algorithm."""
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _has_observable_runtime_dispatch_root(adapter: object) -> bool:
+    """Return whether a runtime exposes one direct, non-dynamic dispatch root."""
+    try:
+        dispatch_root = _static_callable_root(adapter, "execute_task")
+        return (
+            dispatch_root is not None
+            and dispatch_root is _class_callable_root(adapter, "execute_task")
+            and _callable_code_identity(dispatch_root) is not None
+            and _uses_default_instance_attribute_resolution(adapter)
+        )
+    except TypeError:
+        return False
+
+
+def _uses_default_instance_attribute_resolution(value: object) -> bool:
+    """Return whether instances have the closed default attribute lookup root.
+
+    A static method root alone is not sufficient when a class can redirect an
+    instance attribute through ``__getattribute__``. This is intentionally a
+    finite check of the direct effect-owner type, not inspection of arbitrary
+    instance state or callable graphs.
+    """
+    target_type = value if isinstance(value, type) else type(value)
+    try:
+        return target_type.__getattribute__ is object.__getattribute__
+    except (AttributeError, TypeError):
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityContract:
+    """Immutable, versioned Foundation A baseline and fingerprint."""
+
+    canonical_json: str
+
+    def __post_init__(self) -> None:
+        try:
+            decoded = json.loads(self.canonical_json)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("execution authority contract is invalid JSON") from exc
+        data = _canonical_object(decoded, field="execution authority contract")
+        required = {
+            "version",
+            "boundary",
+            "executor",
+            "workspace",
+            "runtime",
+            "verifier",
+            "execution_policy",
+        }
+        if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != required:
+            raise ValueError("execution authority contract has an invalid shape")
+        if data.get("boundary") != execution_authority_boundary_contract():
+            raise ValueError("execution authority contract has an invalid boundary")
+        if not executor_authority_contract() == data.get("executor"):
+            raise ValueError("execution authority contract has an invalid executor")
+        if not _valid_workspace_authority(data.get("workspace")):
+            raise ValueError("execution authority contract has an invalid workspace")
+        if not _valid_runtime_authority(data.get("runtime")):
+            raise ValueError("execution authority contract has an invalid runtime")
+        if not _valid_verifier_authority(data.get("verifier")):
+            raise ValueError("execution authority contract has an invalid verifier")
+        if not _valid_execution_policy_authority(data.get("execution_policy")):
+            raise ValueError("execution authority contract has an invalid execution policy")
+        if _contains_sensitive_authority_data(data):
+            raise ValueError("execution authority contract contains sensitive data")
+        if _canonical_json(data, field="execution authority contract") != self.canonical_json:
+            raise ValueError("execution authority contract is not canonical")
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        verifier_instance_nonce: str | None = None,
+        runtime_instance_nonce: str | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityContract:
+        data = {
+            "version": EXECUTION_AUTHORITY_VERSION,
+            "boundary": execution_authority_boundary_contract(),
+            "executor": executor_authority_contract(),
+            "workspace": canonical_workspace_authority(workspace),
+            "runtime": runtime_authority_contract(
+                adapter,
+                force_process_local=force_runtime_process_local,
+                instance_nonce=runtime_instance_nonce,
+            ),
+            "verifier": verifier_authority_contract(
+                verifier,
+                instance_nonce=verifier_instance_nonce,
+            ),
+            "execution_policy": execution_policy_authority_contract(execution_policy),
+        }
+        return cls(_canonical_json(data, field="execution authority contract"))
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256(self.canonical_json)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        value = json.loads(self.canonical_json)
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise ValueError("execution authority contract is not an object")
+        return value
+
+    @property
+    def portable_across_processes(self) -> bool:
+        """Return only an identity-stability property, never reuse authority."""
+        data = self.data
+        runtime = data.get("runtime")
+        return (
+            all(
+                isinstance(component, Mapping) and component.get("stability") == "durable"
+                for component in (
+                    data.get("executor"),
+                    data.get("workspace"),
+                    data.get("runtime"),
+                    data.get("verifier"),
+                    data.get("execution_policy"),
+                )
+            )
+            and isinstance(runtime, Mapping)
+            and runtime.get("portable_identity_observed") is True
+            and data.get("workspace", {}).get("observed") is True
+            and data.get("execution_policy", {}).get("observed") is True
+        )
+
+
+@dataclass(frozen=True, slots=True, weakref_slot=True)
+class ExecutionAuthorityLiveBinding:
+    """The finite live roots that must remain identical before an effect."""
+
+    contract: ExecutionAuthorityContract
+    executor: object | None
+    executor_attribute_resolution_observable: bool
+    adapter: object
+    runtime_instance_nonce: str | None
+    verifier: Verifier | None
+    session_signal_hub: object | None
+    dispatcher_type: object
+    dispatcher: object | None
+    dispatcher_executor: object | None
+    transcript_verifier: object
+    adapter_dispatch_root: object | None
+    adapter_dispatch_code: object | None
+    adapter_attribute_resolution_observable: bool
+    verifier_root: object | None
+    verifier_code: object | None
+    dispatcher_stream_root: object | None
+    dispatcher_stream_code: object | None
+    dispatcher_stream_callable: object | None
+    dispatcher_attribute_resolution_observable: bool
+    dispatcher_binding_observable: bool
+    transcript_verifier_root: object | None
+    transcript_verifier_code: object | None
+    coordinator: object | None
+    coordinator_review_callable: object | None
+    coordinator_review_root: object | None
+    coordinator_review_code: object | None
+    coordinator_adapter: object | None
+    coordinator_task_cwd: object | None
+    coordinator_reasoning_effort: object | None
+    coordinator_attribute_resolution_observable: bool
+    coordinator_binding_observable: bool
+    rate_gate: object
+    rate_gate_acquire_root: object | None
+    rate_gate_acquire_code: object | None
+    rate_gate_acquire_callable: object | None
+    rate_gate_attribute_resolution_observable: bool
+    rate_gate_max_wait_seconds: object | None
+    rate_gate_heartbeat_seconds: object | None
+    rate_gate_sleep: object | None
+    rate_gate_sleep_root: object | None
+    rate_gate_sleep_code: object | None
+    rate_gate_semantics_observable: bool
+    rate_gate_bucket: object | None
+    rate_gate_bucket_config: tuple[object, object, object, object] | None
+    rate_gate_bucket_attribute_resolution_observable: bool
+    rate_gate_bucket_time: object | None
+    rate_gate_bucket_time_root: object | None
+    rate_gate_bucket_time_code: object | None
+    rate_gate_bucket_enabled_root: object | None
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object | None
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object | None
+    rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
+    rate_gate_bucket_binding_observable: bool
+    verifier_instance_nonce: str | None
+    force_runtime_process_local: bool
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        executor: object | None = None,
+        session_signal_hub: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        expected_dispatcher_type: object | None = None,
+        expected_dispatcher_stream_root: object | None = None,
+        expected_dispatcher_stream_code: object | None = None,
+        expected_transcript_verifier: object | None = None,
+        expected_transcript_verifier_code: object | None = None,
+        expected_rate_gate_acquire_root: object | None = None,
+        expected_rate_gate_acquire_code: object | None = None,
+        expected_rate_gate_type: type[object] | None = None,
+        expected_rate_gate_sleep: object | None = None,
+        expected_rate_gate_sleep_code: object | None = None,
+        expected_rate_gate_bucket_type: type[object] | None = None,
+        expected_rate_gate_bucket_time: object | None = None,
+        expected_rate_gate_bucket_enabled_root: object | None = None,
+        expected_rate_gate_bucket_enabled_code: object | None = None,
+        expected_rate_gate_bucket_acquire_root: object | None = None,
+        expected_rate_gate_bucket_acquire_code: object | None = None,
+        expected_rate_gate_bucket_force_reserve_root: object | None = None,
+        expected_rate_gate_bucket_force_reserve_code: object | None = None,
+        expected_rate_gate_bucket_helper_roots: (
+            tuple[tuple[str, object | None, object | None], ...] | None
+        ) = None,
+        expected_coordinator_type: type[object] | None = None,
+        expected_coordinator_review_root: object | None = None,
+        expected_coordinator_review_code: object | None = None,
+        force_runtime_process_local: bool = False,
+    ) -> ExecutionAuthorityLiveBinding:
+        executor_attribute_resolution_observable = (
+            executor is None or _uses_default_instance_attribute_resolution(executor)
+        )
+        adapter_dispatch_root = _static_callable_root(adapter, "execute_task")
+        adapter_dispatch_code = _callable_code_identity(adapter_dispatch_root)
+        adapter_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            adapter
+        )
+        verifier_root = _static_callable_root(verifier, None)
+        verifier_code = _callable_code_identity(verifier_root)
+        dispatcher_stream_root = _static_callable_root(dispatcher_type, "stream")
+        dispatcher_stream_code = _callable_code_identity(dispatcher_stream_root)
+        dispatcher_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            dispatcher_type
+        )
+        captured_dispatcher_executor: object | None = None
+        dispatcher_binding_observable = dispatcher is None
+        if dispatcher is not None:
+            try:
+                captured_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+                dispatcher_binding_observable = (
+                    type(dispatcher) is dispatcher_type
+                    and captured_dispatcher_executor is dispatcher_executor
+                )
+            except (AttributeError, TypeError):
+                dispatcher_binding_observable = False
+        transcript_verifier_root = _static_callable_root(transcript_verifier, None)
+        transcript_verifier_code = _callable_code_identity(transcript_verifier_root)
+        if coordinator_review_callable is None:
+            try:
+                candidate = coordinator.run_review if coordinator is not None else None
+                coordinator_review_callable = candidate if callable(candidate) else None
+            except (AttributeError, TypeError):
+                coordinator_review_callable = None
+        coordinator_review_root = _static_callable_root(coordinator, "run_review")
+        coordinator_review_code = _callable_code_identity(coordinator_review_root)
+        coordinator_adapter: object | None = None
+        coordinator_task_cwd: object | None = None
+        coordinator_reasoning_effort: object | None = None
+        coordinator_attribute_resolution_observable = (
+            coordinator is None or _uses_default_instance_attribute_resolution(coordinator)
+        )
+        coordinator_binding_observable = coordinator is None
+        if coordinator is not None:
+            try:
+                coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+                coordinator_binding_observable = (
+                    coordinator_adapter is adapter
+                    and (coordinator_task_cwd is None or isinstance(coordinator_task_cwd, str))
+                    and (
+                        coordinator_reasoning_effort is None
+                        or isinstance(coordinator_reasoning_effort, str)
+                    )
+                )
+            except (AttributeError, TypeError):
+                coordinator_binding_observable = False
+        rate_gate_acquire_root = _static_callable_root(rate_gate, "acquire")
+        rate_gate_acquire_code = _callable_code_identity(rate_gate_acquire_root)
+        rate_gate_attribute_resolution_observable = _uses_default_instance_attribute_resolution(
+            rate_gate
+        )
+        rate_gate_max_wait_seconds: object | None = None
+        rate_gate_heartbeat_seconds: object | None = None
+        rate_gate_sleep: object | None = None
+        rate_gate_sleep_root: object | None = None
+        rate_gate_sleep_code: object | None = None
+        rate_gate_semantics_observable = False
+        rate_gate_bucket: object | None = None
+        rate_gate_bucket_config: tuple[object, object, object, object] | None = None
+        rate_gate_bucket_attribute_resolution_observable = False
+        rate_gate_bucket_time: object | None = None
+        rate_gate_bucket_time_root: object | None = None
+        rate_gate_bucket_time_code: object | None = None
+        rate_gate_bucket_enabled_root: object | None = None
+        rate_gate_bucket_enabled_code: object | None = None
+        rate_gate_bucket_acquire_root: object | None = None
+        rate_gate_bucket_acquire_code: object | None = None
+        rate_gate_bucket_force_reserve_root: object | None = None
+        rate_gate_bucket_force_reserve_code: object | None = None
+        rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...] = ()
+        rate_gate_bucket_binding_observable = False
+        try:
+            rate_gate_max_wait_seconds = object.__getattribute__(rate_gate, "_max_wait_seconds")
+            rate_gate_heartbeat_seconds = object.__getattribute__(rate_gate, "_heartbeat_seconds")
+            rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
+            rate_gate_sleep_root = _static_callable_root(rate_gate_sleep, None)
+            rate_gate_sleep_code = _callable_code_identity(rate_gate_sleep_root)
+            rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+            rate_gate_bucket_config = (
+                object.__getattribute__(rate_gate_bucket, "_runtime_backend"),
+                object.__getattribute__(rate_gate_bucket, "_request_limit"),
+                object.__getattribute__(rate_gate_bucket, "_token_limit"),
+                object.__getattribute__(rate_gate_bucket, "_window_seconds"),
+            )
+            rate_gate_bucket_attribute_resolution_observable = (
+                _uses_default_instance_attribute_resolution(rate_gate_bucket)
+            )
+            rate_gate_bucket_time = object.__getattribute__(rate_gate_bucket, "_time")
+            rate_gate_bucket_time_root = _static_callable_root(rate_gate_bucket_time, None)
+            rate_gate_bucket_time_code = _callable_code_identity(rate_gate_bucket_time_root)
+            rate_gate_bucket_enabled_root = _static_property_getter_root(
+                rate_gate_bucket,
+                "enabled",
+            )
+            rate_gate_bucket_enabled_code = _callable_code_identity(rate_gate_bucket_enabled_root)
+            rate_gate_bucket_acquire_root = _static_callable_root(rate_gate_bucket, "acquire")
+            rate_gate_bucket_acquire_code = _callable_code_identity(rate_gate_bucket_acquire_root)
+            rate_gate_bucket_force_reserve_root = _static_callable_root(
+                rate_gate_bucket,
+                "force_reserve",
+            )
+            rate_gate_bucket_force_reserve_code = _callable_code_identity(
+                rate_gate_bucket_force_reserve_root
+            )
+            bucket_helper_roots: list[tuple[str, object | None, object | None]] = []
+            for name in _RATE_GATE_BUCKET_HELPER_NAMES:
+                helper_root = _static_callable_root(rate_gate_bucket, name)
+                bucket_helper_roots.append(
+                    (name, helper_root, _callable_code_identity(helper_root))
+                )
+            rate_gate_bucket_helper_roots = tuple(bucket_helper_roots)
+            rate_gate_bucket_binding_observable = (
+                isinstance(rate_gate_bucket_config[0], str)
+                and (
+                    rate_gate_bucket_config[1] is None
+                    or isinstance(rate_gate_bucket_config[1], int)
+                    and not isinstance(rate_gate_bucket_config[1], bool)
+                )
+                and (
+                    rate_gate_bucket_config[2] is None
+                    or isinstance(rate_gate_bucket_config[2], int)
+                    and not isinstance(rate_gate_bucket_config[2], bool)
+                )
+                and _is_finite_number(rate_gate_bucket_config[3])
+            )
+            rate_gate_semantics_observable = (
+                _is_finite_number(rate_gate_max_wait_seconds)
+                and _is_finite_number(rate_gate_heartbeat_seconds)
+                and rate_gate_sleep_root is not None
+                and rate_gate_sleep_code is not None
+                and rate_gate_bucket_attribute_resolution_observable
+                and rate_gate_bucket_time_root is not None
+                and rate_gate_bucket_enabled_root is not None
+                and rate_gate_bucket_enabled_code is not None
+                and rate_gate_bucket_acquire_root is not None
+                and rate_gate_bucket_acquire_code is not None
+                and rate_gate_bucket_force_reserve_root is not None
+                and rate_gate_bucket_force_reserve_code is not None
+                and all(
+                    helper_root is not None and helper_code is not None
+                    for _, helper_root, helper_code in rate_gate_bucket_helper_roots
+                )
+            )
+        except (AttributeError, TypeError):
+            rate_gate_bucket = None
+            rate_gate_bucket_config = None
+        dispatcher_is_closed = (
+            expected_dispatcher_type is not None
+            and dispatcher_type is expected_dispatcher_type
+            and expected_dispatcher_stream_root is not None
+            and dispatcher_stream_root is expected_dispatcher_stream_root
+            and expected_dispatcher_stream_code is not None
+            and dispatcher_stream_code is expected_dispatcher_stream_code
+            and dispatcher_stream_callable is dispatcher_stream_root
+        )
+        transcript_is_closed = (
+            expected_transcript_verifier is not None
+            and transcript_verifier is expected_transcript_verifier
+            and transcript_verifier_root is expected_transcript_verifier
+            and expected_transcript_verifier_code is not None
+            and transcript_verifier_code is expected_transcript_verifier_code
+        )
+        rate_gate_is_closed = (
+            expected_rate_gate_type is not None
+            and type(rate_gate) is expected_rate_gate_type
+            and expected_rate_gate_acquire_root is not None
+            and rate_gate_acquire_root is expected_rate_gate_acquire_root
+            and expected_rate_gate_acquire_code is not None
+            and rate_gate_acquire_code is expected_rate_gate_acquire_code
+            and rate_gate_acquire_callable is rate_gate_acquire_root
+            and rate_gate_semantics_observable
+            and expected_rate_gate_sleep is not None
+            and rate_gate_sleep is expected_rate_gate_sleep
+            and expected_rate_gate_sleep_code is not None
+            and rate_gate_sleep_code is expected_rate_gate_sleep_code
+            and expected_rate_gate_bucket_type is not None
+            and type(rate_gate_bucket) is expected_rate_gate_bucket_type
+            and expected_rate_gate_bucket_time is not None
+            and rate_gate_bucket_time is expected_rate_gate_bucket_time
+            and expected_rate_gate_bucket_enabled_root is not None
+            and rate_gate_bucket_enabled_root is expected_rate_gate_bucket_enabled_root
+            and expected_rate_gate_bucket_enabled_code is not None
+            and rate_gate_bucket_enabled_code is expected_rate_gate_bucket_enabled_code
+            and expected_rate_gate_bucket_acquire_root is not None
+            and rate_gate_bucket_acquire_root is expected_rate_gate_bucket_acquire_root
+            and expected_rate_gate_bucket_acquire_code is not None
+            and rate_gate_bucket_acquire_code is expected_rate_gate_bucket_acquire_code
+            and expected_rate_gate_bucket_force_reserve_root is not None
+            and rate_gate_bucket_force_reserve_root is expected_rate_gate_bucket_force_reserve_root
+            and expected_rate_gate_bucket_force_reserve_code is not None
+            and rate_gate_bucket_force_reserve_code is expected_rate_gate_bucket_force_reserve_code
+            and expected_rate_gate_bucket_helper_roots is not None
+            and len(rate_gate_bucket_helper_roots) == len(expected_rate_gate_bucket_helper_roots)
+            and all(
+                name == expected_name and root is expected_root and code is expected_code
+                for (name, root, code), (
+                    expected_name,
+                    expected_root,
+                    expected_code,
+                ) in zip(
+                    rate_gate_bucket_helper_roots,
+                    expected_rate_gate_bucket_helper_roots,
+                    strict=True,
+                )
+            )
+        )
+        coordinator_is_closed = coordinator is None or (
+            expected_coordinator_type is not None
+            and type(coordinator) is expected_coordinator_type
+            and expected_coordinator_review_root is not None
+            and coordinator_review_root is expected_coordinator_review_root
+            and expected_coordinator_review_code is not None
+            and coordinator_review_code is expected_coordinator_review_code
+        )
+        # A dynamic attribute hook or a missing direct callable root has no
+        # finite implementation identity. Keep execution working, but do not
+        # upgrade that adapter to a portable authority claim.
+        force_runtime_process_local = force_runtime_process_local or (
+            session_signal_hub is not None
+            or not executor_attribute_resolution_observable
+            or adapter_dispatch_root is None
+            or adapter_dispatch_code is None
+            or not adapter_attribute_resolution_observable
+            or not dispatcher_is_closed
+            or not dispatcher_attribute_resolution_observable
+            or not dispatcher_binding_observable
+            or not transcript_is_closed
+            or (
+                coordinator is not None
+                and (
+                    coordinator_review_callable is None
+                    or not coordinator_is_closed
+                    or not coordinator_binding_observable
+                    or not coordinator_attribute_resolution_observable
+                )
+            )
+            or not rate_gate_is_closed
+            or not rate_gate_attribute_resolution_observable
+            or not rate_gate_semantics_observable
+            or not rate_gate_bucket_binding_observable
+        )
+        # A pristine structural verifier is the one built-in verifier with a
+        # durable implementation descriptor. If its code was already changed
+        # before construction, keep it executable as a custom, process-local
+        # verifier with one stable live-instance nonce instead of generating a
+        # new nonce on every guard check.
+        nonce = (
+            None
+            if verifier is None
+            or (
+                verifier is structural_atomic_verifier
+                and verifier_code is _BUILTIN_STRUCTURAL_VERIFIER_CODE
+            )
+            else uuid.uuid4().hex
+        )
+        runtime_instance_nonce = uuid.uuid4().hex
+        contract = ExecutionAuthorityContract.build(
+            adapter=adapter,
+            verifier=verifier,
+            workspace=workspace,
+            execution_policy=execution_policy,
+            verifier_instance_nonce=nonce,
+            runtime_instance_nonce=runtime_instance_nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+        return cls(
+            contract=contract,
+            executor=executor,
+            executor_attribute_resolution_observable=executor_attribute_resolution_observable,
+            adapter=adapter,
+            runtime_instance_nonce=runtime_instance_nonce,
+            verifier=verifier,
+            session_signal_hub=session_signal_hub,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=captured_dispatcher_executor,
+            transcript_verifier=transcript_verifier,
+            adapter_dispatch_root=adapter_dispatch_root,
+            adapter_dispatch_code=adapter_dispatch_code,
+            adapter_attribute_resolution_observable=adapter_attribute_resolution_observable,
+            verifier_root=verifier_root,
+            verifier_code=verifier_code,
+            dispatcher_stream_root=dispatcher_stream_root,
+            dispatcher_stream_code=dispatcher_stream_code,
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            dispatcher_attribute_resolution_observable=(dispatcher_attribute_resolution_observable),
+            dispatcher_binding_observable=dispatcher_binding_observable,
+            transcript_verifier_root=transcript_verifier_root,
+            transcript_verifier_code=transcript_verifier_code,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+            coordinator_review_root=coordinator_review_root,
+            coordinator_review_code=coordinator_review_code,
+            coordinator_adapter=coordinator_adapter,
+            coordinator_task_cwd=coordinator_task_cwd,
+            coordinator_reasoning_effort=coordinator_reasoning_effort,
+            coordinator_attribute_resolution_observable=(
+                coordinator_attribute_resolution_observable
+            ),
+            coordinator_binding_observable=coordinator_binding_observable,
+            rate_gate=rate_gate,
+            rate_gate_acquire_root=rate_gate_acquire_root,
+            rate_gate_acquire_code=rate_gate_acquire_code,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            rate_gate_attribute_resolution_observable=rate_gate_attribute_resolution_observable,
+            rate_gate_max_wait_seconds=rate_gate_max_wait_seconds,
+            rate_gate_heartbeat_seconds=rate_gate_heartbeat_seconds,
+            rate_gate_sleep=rate_gate_sleep,
+            rate_gate_sleep_root=rate_gate_sleep_root,
+            rate_gate_sleep_code=rate_gate_sleep_code,
+            rate_gate_semantics_observable=rate_gate_semantics_observable,
+            rate_gate_bucket=rate_gate_bucket,
+            rate_gate_bucket_config=rate_gate_bucket_config,
+            rate_gate_bucket_attribute_resolution_observable=(
+                rate_gate_bucket_attribute_resolution_observable
+            ),
+            rate_gate_bucket_time=rate_gate_bucket_time,
+            rate_gate_bucket_time_root=rate_gate_bucket_time_root,
+            rate_gate_bucket_time_code=rate_gate_bucket_time_code,
+            rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+            rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+            rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+            rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+            rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+            rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+            rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
+            rate_gate_bucket_binding_observable=rate_gate_bucket_binding_observable,
+            verifier_instance_nonce=nonce,
+            force_runtime_process_local=force_runtime_process_local,
+        )
+
+    def is_intact(
+        self,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        dispatcher_type: object,
+        transcript_verifier: object,
+        rate_gate: object,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+        session_signal_hub: object | None = None,
+        executor: object | None = None,
+        coordinator: object | None = None,
+        coordinator_review_callable: object | None = None,
+        dispatcher: object | None = None,
+        dispatcher_executor: object | None = None,
+        dispatcher_stream_callable: object | None = None,
+        rate_gate_acquire_callable: object | None = None,
+    ) -> bool:
+        if executor is not self.executor:
+            return False
+        if adapter is not self.adapter or verifier is not self.verifier:
+            return False
+        if session_signal_hub is not self.session_signal_hub:
+            return False
+        if dispatcher_type is not self.dispatcher_type:
+            return False
+        if dispatcher is not self.dispatcher or dispatcher_executor is not self.dispatcher_executor:
+            return False
+        if dispatcher_stream_callable is not self.dispatcher_stream_callable:
+            return False
+        if transcript_verifier is not self.transcript_verifier:
+            return False
+        if coordinator is not self.coordinator:
+            return False
+        if coordinator_review_callable is not self.coordinator_review_callable:
+            return False
+        if rate_gate is not self.rate_gate:
+            return False
+        if rate_gate_acquire_callable is not self.rate_gate_acquire_callable:
+            return False
+        if (
+            self.executor_attribute_resolution_observable
+            and executor is not None
+            and not _uses_default_instance_attribute_resolution(executor)
+        ):
+            return False
+        if (
+            self.adapter_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(adapter)
+        ):
+            return False
+        if (
+            self.dispatcher_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(dispatcher_type)
+        ):
+            return False
+        if (
+            self.coordinator_attribute_resolution_observable
+            and coordinator is not None
+            and not _uses_default_instance_attribute_resolution(coordinator)
+        ):
+            return False
+        if (
+            self.rate_gate_attribute_resolution_observable
+            and not _uses_default_instance_attribute_resolution(rate_gate)
+        ):
+            return False
+        if (
+            self.rate_gate_bucket_attribute_resolution_observable
+            and self.rate_gate_bucket is not None
+            and not _uses_default_instance_attribute_resolution(self.rate_gate_bucket)
+        ):
+            return False
+        if self.rate_gate_semantics_observable:
+            try:
+                current_rate_gate_max_wait_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_max_wait_seconds",
+                )
+                current_rate_gate_heartbeat_seconds = object.__getattribute__(
+                    rate_gate,
+                    "_heartbeat_seconds",
+                )
+                current_rate_gate_sleep = object.__getattribute__(rate_gate, "_sleep")
+                current_rate_gate_bucket = object.__getattribute__(rate_gate, "_bucket")
+                current_rate_gate_bucket_config = (
+                    object.__getattribute__(current_rate_gate_bucket, "_runtime_backend"),
+                    object.__getattribute__(current_rate_gate_bucket, "_request_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_token_limit"),
+                    object.__getattribute__(current_rate_gate_bucket, "_window_seconds"),
+                )
+                current_rate_gate_bucket_time = object.__getattribute__(
+                    current_rate_gate_bucket,
+                    "_time",
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                not _is_finite_number(current_rate_gate_max_wait_seconds)
+                or not _is_finite_number(current_rate_gate_heartbeat_seconds)
+                or current_rate_gate_max_wait_seconds != self.rate_gate_max_wait_seconds
+                or current_rate_gate_heartbeat_seconds != self.rate_gate_heartbeat_seconds
+                or current_rate_gate_sleep is not self.rate_gate_sleep
+                or _static_callable_root(current_rate_gate_sleep, None)
+                is not self.rate_gate_sleep_root
+                or _callable_code_identity(_static_callable_root(current_rate_gate_sleep, None))
+                is not self.rate_gate_sleep_code
+                or current_rate_gate_bucket is not self.rate_gate_bucket
+                or current_rate_gate_bucket_config != self.rate_gate_bucket_config
+                or current_rate_gate_bucket_time is not self.rate_gate_bucket_time
+                or _static_callable_root(current_rate_gate_bucket_time, None)
+                is not self.rate_gate_bucket_time_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket_time, None)
+                )
+                is not self.rate_gate_bucket_time_code
+                or _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                is not self.rate_gate_bucket_enabled_root
+                or _callable_code_identity(
+                    _static_property_getter_root(current_rate_gate_bucket, "enabled")
+                )
+                is not self.rate_gate_bucket_enabled_code
+                or _static_callable_root(current_rate_gate_bucket, "acquire")
+                is not self.rate_gate_bucket_acquire_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "acquire")
+                )
+                is not self.rate_gate_bucket_acquire_code
+                or _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                is not self.rate_gate_bucket_force_reserve_root
+                or _callable_code_identity(
+                    _static_callable_root(current_rate_gate_bucket, "force_reserve")
+                )
+                is not self.rate_gate_bucket_force_reserve_code
+            ):
+                return False
+            for name, root, code in self.rate_gate_bucket_helper_roots:
+                current_root = _static_callable_root(current_rate_gate_bucket, name)
+                if current_root is not root or _callable_code_identity(current_root) is not code:
+                    return False
+        if (
+            self.adapter_dispatch_root is not None
+            and _static_callable_root(adapter, "execute_task") is not self.adapter_dispatch_root
+        ):
+            return False
+        if (
+            self.adapter_dispatch_code is not None
+            and _callable_code_identity(_static_callable_root(adapter, "execute_task"))
+            is not self.adapter_dispatch_code
+        ):
+            return False
+        if (
+            self.verifier_root is not None
+            and _static_callable_root(verifier, None) is not self.verifier_root
+        ):
+            return False
+        if (
+            self.verifier_code is not None
+            and _callable_code_identity(_static_callable_root(verifier, None))
+            is not self.verifier_code
+        ):
+            return False
+        if (
+            self.dispatcher_stream_root is not None
+            and _static_callable_root(dispatcher_type, "stream") is not self.dispatcher_stream_root
+        ):
+            return False
+        if (
+            self.dispatcher_stream_code is not None
+            and _callable_code_identity(_static_callable_root(dispatcher_type, "stream"))
+            is not self.dispatcher_stream_code
+        ):
+            return False
+        if self.dispatcher_binding_observable and dispatcher is not None:
+            try:
+                current_dispatcher_executor = object.__getattribute__(dispatcher, "_executor")
+            except (AttributeError, TypeError):
+                return False
+            if current_dispatcher_executor is not self.dispatcher_executor:
+                return False
+        if (
+            self.transcript_verifier_root is not None
+            and _static_callable_root(transcript_verifier, None)
+            is not self.transcript_verifier_root
+        ):
+            return False
+        if (
+            self.transcript_verifier_code is not None
+            and _callable_code_identity(_static_callable_root(transcript_verifier, None))
+            is not self.transcript_verifier_code
+        ):
+            return False
+        if (
+            self.coordinator_review_root is not None
+            and _static_callable_root(coordinator, "run_review") is not self.coordinator_review_root
+        ):
+            return False
+        if (
+            self.coordinator_review_code is not None
+            and _callable_code_identity(_static_callable_root(coordinator, "run_review"))
+            is not self.coordinator_review_code
+        ):
+            return False
+        if self.coordinator_binding_observable and coordinator is not None:
+            try:
+                current_coordinator_adapter = object.__getattribute__(coordinator, "_adapter")
+                current_coordinator_task_cwd = object.__getattribute__(coordinator, "_task_cwd")
+                current_coordinator_reasoning_effort = object.__getattribute__(
+                    coordinator,
+                    "_reasoning_effort",
+                )
+            except (AttributeError, TypeError):
+                return False
+            if (
+                current_coordinator_adapter is not self.coordinator_adapter
+                or current_coordinator_task_cwd != self.coordinator_task_cwd
+                or current_coordinator_reasoning_effort != self.coordinator_reasoning_effort
+            ):
+                return False
+        if (
+            self.rate_gate_acquire_root is not None
+            and _static_callable_root(rate_gate, "acquire") is not self.rate_gate_acquire_root
+        ):
+            return False
+        if (
+            self.rate_gate_acquire_code is not None
+            and _callable_code_identity(_static_callable_root(rate_gate, "acquire"))
+            is not self.rate_gate_acquire_code
+        ):
+            return False
+        try:
+            current = ExecutionAuthorityContract.build(
+                adapter=adapter,
+                verifier=verifier,
+                workspace=workspace,
+                execution_policy=execution_policy,
+                verifier_instance_nonce=self.verifier_instance_nonce,
+                runtime_instance_nonce=self.runtime_instance_nonce,
+                force_runtime_process_local=self.force_runtime_process_local,
+            )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return False
+        return current.canonical_json == self.contract.canonical_json
+
+
+__all__ = [
+    "EXECUTION_AUTHORITY_VERSION",
+    "ExecutionAuthorityContract",
+    "ExecutionAuthorityLiveBinding",
+    "canonical_workspace_authority",
+    "constructor_model_contract",
+    "execution_authority_boundary_contract",
+    "execution_policy_authority_contract",
+    "executor_authority_contract",
+    "runtime_authority_contract",
+    "runtime_execution_identity_contract",
+    "runtime_execution_proves_effective_model",
+    "valid_constructor_model_contract",
+    "valid_process_local_authority_contract",
+    "valid_runtime_execution_identity_contract",
+    "verifier_authority_contract",
+]

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -159,6 +159,7 @@ class _ProcessLocalAuthorityLifecycle:
     registration: _ProcessLocalAuthorityRegistration
     state: _ProcessLocalAuthorityLifecycleState
     terminal_finalizers: dict[object, Callable[[], object]]
+    terminalization_retryable: bool = False
 
 
 class ProcessLocalCancellationDisposition(StrEnum):
@@ -293,9 +294,16 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.generation.correlation_id != value.get("correlation_id")
             ):
                 return False, False
+            if (
+                lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+                and lifecycle.terminalization_retryable
+            ):
+                lifecycle.terminalization_retryable = False
+                return True, False
             if lifecycle.state is not _ProcessLocalAuthorityLifecycleState.REGISTERED:
                 return False, True
             lifecycle.state = _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+            lifecycle.terminalization_retryable = False
             return True, False
 
     def abort_terminalization(
@@ -319,6 +327,29 @@ class _ProcessLocalAuthorityRegistry:
                 and lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
             ):
                 lifecycle.state = _ProcessLocalAuthorityLifecycleState.REGISTERED
+                lifecycle.terminalization_retryable = False
+
+    def retain_terminalization_for_retry(
+        self,
+        session_id: str,
+        execution_id: str,
+        value: object,
+    ) -> None:
+        """Keep an ambiguous terminal writer non-effectful but reclaimable."""
+        if not valid_process_local_authority_contract(value):
+            return
+        with self._lock:
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
+            if (
+                entry is not None
+                and entry.creator_pid == os.getpid()
+                and entry.execution_id == execution_id
+                and self._is_issued_here(entry.generation)
+                and entry.generation.correlation_id == value.get("correlation_id")
+                and lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+            ):
+                lifecycle.terminalization_retryable = True
 
     def is_terminalizing(
         self,
@@ -681,6 +712,19 @@ def _process_local_authority_is_terminalizing(
     )
 
 
+def _retain_process_local_authority_terminalization_for_retry(
+    session_id: str,
+    execution_id: str,
+    value: object,
+) -> None:
+    """Leave an ambiguous public terminalization reserved for exact retry."""
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY.retain_terminalization_for_retry(
+        session_id,
+        execution_id,
+        value,
+    )
+
+
 def _register_process_local_authority_terminal_finalizer(
     session_id: str,
     execution_id: str,
@@ -914,6 +958,11 @@ async def request_process_local_cancellation(
                     authority,
                 )
             elif not terminal_winner:
+                _retain_process_local_authority_terminalization_for_retry(
+                    session_id,
+                    execution_id,
+                    authority,
+                )
                 _LOG.warning(
                     "process_local_authority.interrupted_terminal_reconcile_pending",
                     extra={"session_id": session_id, "execution_id": execution_id},

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 import hashlib
 import inspect
 import json
@@ -121,22 +122,53 @@ class _ProcessLocalAuthorityRegistration:
     creator_pid: int
 
 
+class _ProcessLocalAuthorityLifecycleState(StrEnum):
+    """The only live states of one process-local authority generation."""
+
+    REGISTERED = "registered"
+    CLAIMED = "claimed"
+    TERMINALIZING = "terminalizing"
+
+
+@dataclass(slots=True)
+class _ProcessLocalAuthorityLifecycle:
+    """One registry-owned lifecycle entry for a process-local session.
+
+    Keeping the state and finalizers on the same entry makes it impossible for
+    a session to be represented as both claimed and terminalizing.  Callers may
+    request transitions, but only the registry mutates this object.
+    """
+
+    registration: _ProcessLocalAuthorityRegistration
+    state: _ProcessLocalAuthorityLifecycleState
+    terminal_finalizers: dict[object, Callable[[], object]]
+
+
+class ProcessLocalCancellationDisposition(StrEnum):
+    """Outcome of one public cancellation request for a live authority."""
+
+    CANCELLED = "cancelled"
+    ALREADY_TERMINAL = "already_terminal"
+    CANCELLATION_REQUESTED = "cancellation_requested"
+    HELD_ELSEWHERE = "process_local_authority_held_elsewhere"
+    PERSISTENCE_PENDING = "cancellation_persistence_pending"
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessLocalCancellationOutcome:
+    """Typed result shared by every public process-local cancellation surface."""
+
+    disposition: ProcessLocalCancellationDisposition
+    retired: bool = False
+    error: object | None = None
+
+
 class _ProcessLocalAuthorityRegistry:
     """Keep opaque Foundation A capabilities in one process and PID epoch."""
 
     def __init__(self) -> None:
         self._issued: dict[int, _ProcessLocalAuthorityIssuance] = {}
-        self._registrations: dict[str, _ProcessLocalAuthorityRegistration] = {}
-        self._claims: dict[str, _ProcessLocalAuthorityRegistration] = {}
-        # A public terminalization reserves an otherwise-unclaimed owner while
-        # its durable terminal record is being written.  This prevents a
-        # paused runner from acquiring effects between cancellation preflight
-        # and persistence.
-        self._terminalizations: dict[str, _ProcessLocalAuthorityRegistration] = {}
-        # A public terminalization surface may not hold the creating runner.
-        # Keep only local cleanup callbacks alongside the opaque registration,
-        # so a durable terminal record can retire the whole local lifecycle.
-        self._terminal_finalizers: dict[str, dict[object, Callable[[], object]]] = {}
+        self._lifecycles: dict[str, _ProcessLocalAuthorityLifecycle] = {}
         self._lock = RLock()
 
     @staticmethod
@@ -197,7 +229,7 @@ class _ProcessLocalAuthorityRegistry:
         with self._lock:
             if not self._is_issued_here(generation):
                 raise ValueError("process-local authority requires a registry-issued generation")
-            current = self._registrations.get(session_id)
+            current = self._lifecycles.get(session_id)
             registration = _ProcessLocalAuthorityRegistration(
                 execution_id=execution_id,
                 generation=generation,
@@ -205,14 +237,18 @@ class _ProcessLocalAuthorityRegistry:
                 creator_pid=os.getpid(),
             )
             if current is not None and not (
-                current.execution_id == registration.execution_id
-                and current.generation is registration.generation
-                and current.adapter is registration.adapter
-                and current.creator_pid == registration.creator_pid
+                current.registration.execution_id == registration.execution_id
+                and current.registration.generation is registration.generation
+                and current.registration.adapter is registration.adapter
+                and current.registration.creator_pid == registration.creator_pid
             ):
                 raise ValueError("process-local authority session is already registered")
-            self._registrations[session_id] = registration
-            self._terminal_finalizers.setdefault(session_id, {})
+            if current is None:
+                self._lifecycles[session_id] = _ProcessLocalAuthorityLifecycle(
+                    registration=registration,
+                    state=_ProcessLocalAuthorityLifecycleState.REGISTERED,
+                    terminal_finalizers={},
+                )
 
     def begin_terminalization(
         self,
@@ -230,7 +266,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return False, False
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -239,12 +276,9 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.generation.correlation_id != value.get("correlation_id")
             ):
                 return False, False
-            if (
-                self._claims.get(session_id) is not None
-                or self._terminalizations.get(session_id) is not None
-            ):
+            if lifecycle.state is not _ProcessLocalAuthorityLifecycleState.REGISTERED:
                 return False, True
-            self._terminalizations[session_id] = entry
+            lifecycle.state = _ProcessLocalAuthorityLifecycleState.TERMINALIZING
             return True, False
 
     def abort_terminalization(
@@ -257,17 +291,17 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return
         with self._lock:
-            entry = self._registrations.get(session_id)
-            reservation = self._terminalizations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is not None
-                and reservation is entry
                 and entry.creator_pid == os.getpid()
                 and entry.execution_id == execution_id
                 and self._is_issued_here(entry.generation)
                 and entry.generation.correlation_id == value.get("correlation_id")
+                and lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
             ):
-                self._terminalizations.pop(session_id, None)
+                lifecycle.state = _ProcessLocalAuthorityLifecycleState.REGISTERED
 
     def add_terminal_finalizer(
         self,
@@ -282,7 +316,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return False
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -292,7 +327,7 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.generation.correlation_id != value.get("correlation_id")
             ):
                 return False
-            self._terminal_finalizers.setdefault(session_id, {})[finalizer_key] = finalizer
+            lifecycle.terminal_finalizers[finalizer_key] = finalizer
             return True
 
     def live_generation(
@@ -306,7 +341,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return None
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -333,7 +369,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return False
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             return (
                 entry is not None
                 and entry.creator_pid == os.getpid()
@@ -358,7 +395,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return None, False
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -368,34 +406,35 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.generation.correlation_id != value.get("correlation_id")
             ):
                 return None, False
-            claim = self._claims.get(session_id)
-            if claim is not None or self._terminalizations.get(session_id) is not None:
+            if lifecycle.state is not _ProcessLocalAuthorityLifecycleState.REGISTERED:
                 return None, True
-            self._claims[session_id] = entry
+            lifecycle.state = _ProcessLocalAuthorityLifecycleState.CLAIMED
             return entry.generation, False
 
     def release(self, session_id: str, execution_id: str, adapter: object) -> None:
         """Release a paused session's exclusive execution claim."""
         with self._lock:
-            claim = self._claims.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            claim = lifecycle.registration if lifecycle is not None else None
             if (
                 claim is not None
                 and claim.creator_pid == os.getpid()
                 and claim.execution_id == execution_id
                 and claim.adapter is adapter
+                and lifecycle.state is _ProcessLocalAuthorityLifecycleState.CLAIMED
             ):
-                self._claims.pop(session_id, None)
+                lifecycle.state = _ProcessLocalAuthorityLifecycleState.REGISTERED
 
     def is_claimed(self, session_id: str, execution_id: str, value: object) -> bool:
         """Report whether the exact durable correlation currently owns effects."""
         if not valid_process_local_authority_contract(value):
             return False
         with self._lock:
-            entry = self._registrations.get(session_id)
-            claim = self._claims.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             return (
                 entry is not None
-                and claim is entry
+                and lifecycle.state is _ProcessLocalAuthorityLifecycleState.CLAIMED
                 and entry.creator_pid == os.getpid()
                 and entry.execution_id == execution_id
                 and self._is_issued_here(entry.generation)
@@ -405,7 +444,8 @@ class _ProcessLocalAuthorityRegistry:
     def retire(self, session_id: str, execution_id: str, adapter: object) -> bool:
         """Retire an exact session binding and report whether this owner did it."""
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -413,10 +453,7 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.adapter is not adapter
             ):
                 return False
-            self._registrations.pop(session_id, None)
-            self._claims.pop(session_id, None)
-            self._terminalizations.pop(session_id, None)
-            self._terminal_finalizers.pop(session_id, None)
+            self._lifecycles.pop(session_id, None)
             issuance = self._issued.get(id(entry.generation))
             if issuance is not None and issuance.generation is entry.generation:
                 self._issued.pop(id(entry.generation), None)
@@ -437,7 +474,8 @@ class _ProcessLocalAuthorityRegistry:
         if not valid_process_local_authority_contract(value):
             return False, False, ()
         with self._lock:
-            entry = self._registrations.get(session_id)
+            lifecycle = self._lifecycles.get(session_id)
+            entry = lifecycle.registration if lifecycle is not None else None
             if (
                 entry is None
                 or entry.creator_pid != os.getpid()
@@ -446,11 +484,10 @@ class _ProcessLocalAuthorityRegistry:
                 or entry.generation.correlation_id != value.get("correlation_id")
             ):
                 return False, False, ()
-            if self._claims.get(session_id) is not None:
+            if lifecycle.state is _ProcessLocalAuthorityLifecycleState.CLAIMED:
                 return False, True, ()
-            self._registrations.pop(session_id, None)
-            self._terminalizations.pop(session_id, None)
-            finalizers = tuple(self._terminal_finalizers.pop(session_id, {}).values())
+            self._lifecycles.pop(session_id, None)
+            finalizers = tuple(lifecycle.terminal_finalizers.values())
             issuance = self._issued.get(id(entry.generation))
             if issuance is not None and issuance.generation is entry.generation:
                 self._issued.pop(id(entry.generation), None)
@@ -461,7 +498,9 @@ class _ProcessLocalAuthorityRegistry:
         with self._lock:
             issuance = self._issued.get(id(generation))
             if issuance is not None and issuance.generation is generation:
-                if not any(item.generation is generation for item in self._registrations.values()):
+                if not any(
+                    item.registration.generation is generation for item in self._lifecycles.values()
+                ):
                     self._issued.pop(id(generation), None)
 
     def clear_after_fork(self) -> None:
@@ -470,10 +509,7 @@ class _ProcessLocalAuthorityRegistry:
         # the inherited lock at fork time, so acquiring it here can deadlock
         # forever because that owner no longer exists in the child.
         self._issued = {}
-        self._registrations = {}
-        self._claims = {}
-        self._terminalizations = {}
-        self._terminal_finalizers = {}
+        self._lifecycles = {}
         self._lock = RLock()
 
 
@@ -625,6 +661,107 @@ def _retire_process_local_authority_generation(
     adapter: object,
 ) -> bool:
     return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
+
+
+async def request_process_local_cancellation(
+    tracker: object,
+    session_repo: Any,
+    *,
+    reason: str,
+    cancelled_by: str,
+) -> ProcessLocalCancellationOutcome | None:
+    """Apply the one public cancellation protocol to a process-local session.
+
+    Returns ``None`` when ``tracker`` is not a Foundation A process-local
+    session, leaving legacy callers to use their existing cancellation path.
+    A live claim is signalled rather than terminalized underneath its effects;
+    an unclaimed retained owner is reserved until the conditional terminal
+    write finishes.  This lives beside the registry so CLI, MCP, and job
+    surfaces cannot each invent a different terminalization sequence.
+    """
+    session_id = getattr(tracker, "session_id", None)
+    execution_id = getattr(tracker, "execution_id", None)
+    progress = getattr(tracker, "progress", None)
+    authority = (
+        progress.get("execution_contract", {}).get("foundation_a_authority")
+        if isinstance(progress, Mapping) and isinstance(progress.get("execution_contract"), Mapping)
+        else None
+    )
+    if (
+        not isinstance(session_id, str)
+        or not isinstance(execution_id, str)
+        or not valid_process_local_authority_contract(authority)
+    ):
+        return None
+
+    from ouroboros.orchestrator.heartbeat import is_holder_alive
+    from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
+
+    terminalization_started, authority_claimed = _begin_process_local_authority_terminalization(
+        session_id,
+        execution_id,
+        authority,
+    )
+    if authority_claimed:
+        # A local claimed runner owns the effect boundary.  It observes this
+        # signal and persists cancellation before its own teardown.
+        await request_cancellation(session_id)
+        return ProcessLocalCancellationOutcome(
+            ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+        )
+
+    if not terminalization_started and is_holder_alive(session_id):
+        # Registry signals cannot cross processes, so a live foreign holder
+        # must not receive a durable terminal state beneath active effects.
+        return ProcessLocalCancellationOutcome(ProcessLocalCancellationDisposition.HELD_ELSEWHERE)
+
+    cancellation_request_published = False
+    try:
+        await request_cancellation(session_id)
+        cancellation_request_published = True
+        cancel_result = await session_repo.mark_cancelled_if_active(
+            session_id=session_id,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
+    except BaseException:
+        if terminalization_started:
+            _abort_process_local_authority_terminalization(session_id, execution_id, authority)
+        elif cancellation_request_published:
+            await clear_cancellation(session_id)
+        raise
+
+    if cancel_result.is_err:
+        if terminalization_started:
+            # Keep the cooperative request after a failed durable write.  The
+            # retained same-process owner must retry it before future effects.
+            _abort_process_local_authority_terminalization(session_id, execution_id, authority)
+        else:
+            await clear_cancellation(session_id)
+        return ProcessLocalCancellationOutcome(
+            ProcessLocalCancellationDisposition.PERSISTENCE_PENDING,
+            error=cancel_result.error,
+        )
+
+    retired, claim_became_active = await _retire_process_local_authority_after_terminal_persistence(
+        session_id,
+        execution_id,
+        authority,
+    )
+    if claim_became_active:
+        await request_cancellation(session_id)
+    else:
+        await clear_cancellation(session_id)
+
+    if cancel_result.value:
+        return ProcessLocalCancellationOutcome(
+            ProcessLocalCancellationDisposition.CANCELLED,
+            retired=retired,
+        )
+    return ProcessLocalCancellationOutcome(
+        ProcessLocalCancellationDisposition.ALREADY_TERMINAL,
+        retired=retired,
+    )
 
 
 async def _retire_process_local_authority_after_terminal_persistence(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -738,7 +738,52 @@ async def request_process_local_cancellation(
         )
     except BaseException:
         if terminalization_started:
-            _abort_process_local_authority_terminalization(session_id, execution_id, authority)
+            terminal_winner = False
+            try:
+                reconstructed = await session_repo.reconstruct_session(session_id)
+                reconstructed_status = (
+                    getattr(reconstructed.value.status, "value", reconstructed.value.status)
+                    if reconstructed.is_ok
+                    else None
+                )
+                terminal_winner = reconstructed_status in {
+                    "completed",
+                    "failed",
+                    "cancelled",
+                }
+                if terminal_winner:
+                    (
+                        retired,
+                        claim_became_active,
+                    ) = await _retire_process_local_authority_after_terminal_persistence(
+                        session_id,
+                        execution_id,
+                        authority,
+                    )
+                    if claim_became_active:
+                        await request_cancellation(session_id)
+                    else:
+                        await clear_cancellation(session_id)
+                    _LOG.info(
+                        "process_local_authority.interrupted_terminal_reconciled",
+                        extra={
+                            "session_id": session_id,
+                            "execution_id": execution_id,
+                            "durable_status": reconstructed_status,
+                            "retired": retired,
+                        },
+                    )
+            except BaseException:
+                _LOG.warning(
+                    "process_local_authority.interrupted_terminal_reconcile_failed",
+                    extra={"session_id": session_id, "execution_id": execution_id},
+                )
+            if not terminal_winner:
+                _abort_process_local_authority_terminalization(
+                    session_id,
+                    execution_id,
+                    authority,
+                )
         elif cancellation_request_published:
             await clear_cancellation(session_id)
         raise

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -80,12 +80,22 @@ async def _await_process_local_cleanup(awaitable: Awaitable[Any]) -> Any:
     returns; only cleanup receives shielding.
     """
     task = asyncio.ensure_future(awaitable)
+    cancellation: asyncio.CancelledError | None = None
     while not task.done():
         try:
             await asyncio.shield(task)
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
+            cancellation = cancellation or exc
             continue
-    return task.result()
+    try:
+        result = task.result()
+    except BaseException as child_error:
+        if cancellation is not None:
+            raise cancellation from child_error
+        raise
+    if cancellation is not None:
+        raise cancellation
+    return result
 
 
 class _ProcessLocalAuthorityGeneration:
@@ -808,6 +818,45 @@ async def request_process_local_cancellation(
     from ouroboros.orchestrator.heartbeat import is_holder_alive
     from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 
+    async def _retire_and_acknowledge_terminal_owner() -> tuple[bool, bool]:
+        """Retire live state and reconcile its marker as one cleanup boundary."""
+        cancellation: asyncio.CancelledError | None = None
+        try:
+            (
+                retired,
+                claim_became_active,
+            ) = await _retire_process_local_authority_after_terminal_persistence(
+                session_id,
+                execution_id,
+                authority,
+            )
+        except asyncio.CancelledError as exc:
+            # ``_retire_process_local_authority_after_terminal_persistence``
+            # raises only after a successful retirement has drained all of its
+            # finalizers.  Marker acknowledgement must still happen before the
+            # cancellation is propagated to the public caller.
+            cancellation = exc
+            retired = True
+            claim_became_active = False
+
+        async def _acknowledge() -> None:
+            if claim_became_active:
+                await request_cancellation(
+                    session_id,
+                    reason=reason,
+                    cancelled_by=cancelled_by,
+                )
+            else:
+                await clear_cancellation(session_id)
+
+        try:
+            await _await_process_local_cleanup(_acknowledge())
+        except asyncio.CancelledError as exc:
+            cancellation = cancellation or exc
+        if cancellation is not None:
+            raise cancellation
+        return retired, claim_became_active
+
     async def _reconcile_terminalizing_owner() -> tuple[str | None, bool]:
         """Reconstruct and retire a terminal winner without restoring effects."""
         try:
@@ -823,22 +872,9 @@ async def request_process_local_cancellation(
         )
         if reconstructed_status not in {"completed", "failed", "cancelled"}:
             return reconstructed_status, False
-        (
-            retired,
-            claim_became_active,
-        ) = await _retire_process_local_authority_after_terminal_persistence(
-            session_id,
-            execution_id,
-            authority,
+        retired, claim_became_active = await _await_process_local_cleanup(
+            _retire_and_acknowledge_terminal_owner()
         )
-        if claim_became_active:
-            await request_cancellation(
-                session_id,
-                reason=reason,
-                cancelled_by=cancelled_by,
-            )
-        else:
-            await clear_cancellation(session_id)
         _LOG.info(
             "process_local_authority.interrupted_terminal_reconciled",
             extra={
@@ -1002,19 +1038,9 @@ async def request_process_local_cancellation(
             error=cancel_result.error,
         )
 
-    retired, claim_became_active = await _retire_process_local_authority_after_terminal_persistence(
-        session_id,
-        execution_id,
-        authority,
+    retired, claim_became_active = await _await_process_local_cleanup(
+        _retire_and_acknowledge_terminal_owner()
     )
-    if claim_became_active:
-        await request_cancellation(
-            session_id,
-            reason=reason,
-            cancelled_by=cancelled_by,
-        )
-    else:
-        await clear_cancellation(session_id)
 
     if cancel_result.value:
         return ProcessLocalCancellationOutcome(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -10,7 +10,7 @@ exact live object for this process; it is never made portable by introspection.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 import hashlib
@@ -69,6 +69,23 @@ _RATE_GATE_BUCKET_HELPER_NAMES = (
 _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN = object()
 _SAFE_PROCESS_LOCAL_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 _LOG = logging.getLogger(__name__)
+
+
+async def _await_process_local_cleanup(awaitable: Awaitable[Any]) -> Any:
+    """Drain lifecycle reconciliation despite repeated caller cancellation.
+
+    Once durable terminal persistence may have committed, cancellation is no
+    longer allowed to interrupt the read/retire reconciliation window.  The
+    caller still propagates its original cancellation after this helper
+    returns; only cleanup receives shielding.
+    """
+    task = asyncio.ensure_future(awaitable)
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    return task.result()
 
 
 class _ProcessLocalAuthorityGeneration:
@@ -738,8 +755,8 @@ async def request_process_local_cancellation(
         )
     except BaseException:
         if terminalization_started:
-            terminal_winner = False
-            try:
+
+            async def _reconcile_interrupted_terminalization() -> bool:
                 reconstructed = await session_repo.reconstruct_session(session_id)
                 reconstructed_status = (
                     getattr(reconstructed.value.status, "value", reconstructed.value.status)
@@ -751,28 +768,36 @@ async def request_process_local_cancellation(
                     "failed",
                     "cancelled",
                 }
-                if terminal_winner:
-                    (
-                        retired,
-                        claim_became_active,
-                    ) = await _retire_process_local_authority_after_terminal_persistence(
-                        session_id,
-                        execution_id,
-                        authority,
-                    )
-                    if claim_became_active:
-                        await request_cancellation(session_id)
-                    else:
-                        await clear_cancellation(session_id)
-                    _LOG.info(
-                        "process_local_authority.interrupted_terminal_reconciled",
-                        extra={
-                            "session_id": session_id,
-                            "execution_id": execution_id,
-                            "durable_status": reconstructed_status,
-                            "retired": retired,
-                        },
-                    )
+                if not terminal_winner:
+                    return False
+                (
+                    retired,
+                    claim_became_active,
+                ) = await _retire_process_local_authority_after_terminal_persistence(
+                    session_id,
+                    execution_id,
+                    authority,
+                )
+                if claim_became_active:
+                    await request_cancellation(session_id)
+                else:
+                    await clear_cancellation(session_id)
+                _LOG.info(
+                    "process_local_authority.interrupted_terminal_reconciled",
+                    extra={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "durable_status": reconstructed_status,
+                        "retired": retired,
+                    },
+                )
+                return True
+
+            terminal_winner = False
+            try:
+                terminal_winner = await _await_process_local_cleanup(
+                    _reconcile_interrupted_terminalization()
+                )
             except BaseException:
                 _LOG.warning(
                     "process_local_authority.interrupted_terminal_reconcile_failed",

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import re
 from threading import RLock
+from uuid import uuid4
 
 try:  # pragma: no cover - exercised on Unix CI; fallback supports Windows imports
     import fcntl
@@ -30,6 +31,7 @@ except ImportError:  # pragma: no cover - Windows fallback
 log = logging.getLogger(__name__)
 
 LOCK_DIR = Path.home() / ".ouroboros" / "locks"
+CANCELLATION_DIR = Path.home() / ".ouroboros" / "cancellations"
 _LEASE_OPERATION_LOCK = RLock()
 _HELD_LEASE_FDS: dict[str, int] = {}
 _SAFE_LOCK_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
@@ -38,6 +40,11 @@ _SAFE_LOCK_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 def _ensure_dir() -> Path:
     LOCK_DIR.mkdir(parents=True, exist_ok=True)
     return LOCK_DIR
+
+
+def _ensure_cancellation_dir() -> Path:
+    CANCELLATION_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return CANCELLATION_DIR
 
 
 def _clear_held_leases_after_fork() -> None:
@@ -115,6 +122,53 @@ def lock_path(session_id: str) -> Path:
     # created, while this digest prevents a legacy value from escaping LOCK_DIR.
     raw = str(session_id).encode("utf-8", "surrogatepass")
     return _ensure_dir() / f"__invalid_session_id__{hashlib.sha256(raw).hexdigest()}"
+
+
+def cancellation_path(session_id: str) -> Path:
+    """Return a containment-safe cooperative cancellation signal path."""
+    if isinstance(session_id, str) and _SAFE_LOCK_SESSION_ID.fullmatch(session_id) is not None:
+        return _ensure_cancellation_dir() / session_id
+    raw = str(session_id).encode("utf-8", "surrogatepass")
+    return _ensure_cancellation_dir() / (f"__invalid_session_id__{hashlib.sha256(raw).hexdigest()}")
+
+
+def publish_cancellation_request(session_id: str) -> None:
+    """Publish a durable nonterminal cancellation signal across processes.
+
+    The liveness lease intentionally cannot be used as a signal channel: an
+    observer must never replace or remove another process's lease.  This
+    separate existence-only marker lets CLI/MCP processes request cooperative
+    cancellation while the owning runner keeps sole authority to persist the
+    terminal session result.
+    """
+    path = cancellation_path(session_id)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, f"{os.getpid()}\n".encode("ascii"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def has_cancellation_request(session_id: str) -> bool:
+    """Return whether any process published a cooperative cancellation request."""
+    return cancellation_path(session_id).is_file()
+
+
+def clear_cancellation_request(session_id: str) -> None:
+    """Remove a cooperative request after the owning lifecycle acknowledges it."""
+    try:
+        cancellation_path(session_id).unlink(missing_ok=True)
+    except OSError:
+        log.warning(
+            "session_cancellation.clear_failed",
+            extra={"session_id": session_id},
+        )
 
 
 def acquire(session_id: str) -> None:

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -15,18 +15,53 @@ Any runtime can participate — just call acquire/release.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
+import re
+from threading import RLock
+
+try:  # pragma: no cover - exercised on Unix CI; fallback supports Windows imports
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None  # type: ignore[assignment]
 
 log = logging.getLogger(__name__)
 
 LOCK_DIR = Path.home() / ".ouroboros" / "locks"
+_LEASE_OPERATION_LOCK = RLock()
+_HELD_LEASE_FDS: dict[str, int] = {}
+_SAFE_LOCK_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 
 
 def _ensure_dir() -> Path:
     LOCK_DIR.mkdir(parents=True, exist_ok=True)
     return LOCK_DIR
+
+
+def _clear_held_leases_after_fork() -> None:
+    """Drop inherited lease descriptors in a post-fork child.
+
+    Advisory-lock state is tied to an open file description. If a child
+    retained a copied descriptor, a dead parent could leave its liveness lease
+    locked until the unrelated child exits. Do not acquire the inherited
+    RLock here: a vanished parent thread may have owned it at fork time.
+    """
+    global _HELD_LEASE_FDS, _LEASE_OPERATION_LOCK
+
+    inherited_fds = tuple(_HELD_LEASE_FDS.values())
+    _HELD_LEASE_FDS = {}
+    _LEASE_OPERATION_LOCK = RLock()
+    for fd in inherited_fds:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_clear_held_leases_after_fork)
 
 
 def _get_process_start_time(pid: int) -> float | None:
@@ -72,8 +107,14 @@ def _get_process_start_time(pid: int) -> float | None:
 
 
 def lock_path(session_id: str) -> Path:
-    """Return the lock file path for a given session."""
-    return _ensure_dir() / session_id
+    """Return a containment-safe lock path for a given session identifier."""
+    if isinstance(session_id, str) and _SAFE_LOCK_SESSION_ID.fullmatch(session_id) is not None:
+        return _ensure_dir() / session_id
+    # Old/corrupt persisted session ids still need an observer-safe lookup.
+    # New process-local registrations reject them before any effect or lease is
+    # created, while this digest prevents a legacy value from escaping LOCK_DIR.
+    raw = str(session_id).encode("utf-8", "surrogatepass")
+    return _ensure_dir() / f"__invalid_session_id__{hashlib.sha256(raw).hexdigest()}"
 
 
 def acquire(session_id: str) -> None:
@@ -87,7 +128,57 @@ def acquire(session_id: str) -> None:
     payload = f"{pid}:{start_time}" if start_time else str(pid)
 
     path = lock_path(session_id)
-    path.write_text(payload)
+    # Keep an advisory exclusive lock open for the holder's lifetime. This
+    # lets a later process safely distinguish a stale file (lock obtainable)
+    # from a live lease (lock busy) without overwriting or deleting the latter.
+    # The file payload remains human-readable diagnostic evidence; the held FD
+    # is the race-free ownership primitive.
+    with _LEASE_OPERATION_LOCK:
+        if session_id in _HELD_LEASE_FDS and is_owned_by_current_process(session_id):
+            return
+
+        path_existed = path.exists()
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+        lock_acquired = False
+        try:
+            if fcntl is not None:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    lock_acquired = True
+                except BlockingIOError as exc:
+                    raise OSError(f"session liveness lease is held: {session_id}") from exc
+            elif path_existed and not is_owned_by_current_process(session_id):
+                # On platforms without ``fcntl`` preserve safety by refusing
+                # to replace any extant lease rather than guessing it is stale.
+                raise OSError(f"session liveness lease is already held: {session_id}")
+
+            if (
+                path_existed
+                and is_holder_alive(session_id)
+                and not is_owned_by_current_process(session_id)
+            ):
+                raise OSError(f"session liveness lease is held: {session_id}")
+
+            if is_owned_by_current_process(session_id):
+                _HELD_LEASE_FDS[session_id] = fd
+                fd = -1  # ownership transferred to the process-lifetime registry
+                return
+
+            os.ftruncate(fd, 0)
+            os.write(fd, payload.encode("utf-8"))
+            os.fsync(fd)
+            _HELD_LEASE_FDS[session_id] = fd
+            fd = -1  # ownership transferred to the process-lifetime registry
+        except Exception:
+            if lock_acquired and fcntl is not None:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            raise
+        finally:
+            if fd >= 0:
+                os.close(fd)
     log.info(
         "session_lock.acquired",
         extra={"session_id": session_id, "pid": pid},
@@ -97,23 +188,40 @@ def acquire(session_id: str) -> None:
 def release(session_id: str) -> None:
     """Release a session lock when execution completes or is cancelled."""
     path = lock_path(session_id)
-    try:
-        path.unlink(missing_ok=True)
-        log.info(
-            "session_lock.released",
-            extra={"session_id": session_id},
-        )
-    except OSError:
-        pass
+    with _LEASE_OPERATION_LOCK:
+        fd = _HELD_LEASE_FDS.pop(session_id, None)
+        try:
+            path.unlink(missing_ok=True)
+            log.info(
+                "session_lock.released",
+                extra={"session_id": session_id},
+            )
+        except OSError:
+            pass
+        finally:
+            if fd is not None:
+                if fcntl is not None:
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
 
 def release_if_owned_by_current_process(session_id: str) -> bool:
     """Release a session lock only when the current process owns it."""
-    if not is_owned_by_current_process(session_id):
-        return False
+    # ``acquire`` cannot replace an extant lease, and this lock serializes two
+    # local cleanup paths. Once ownership has been checked, no other normal
+    # owner can create a replacement until this unlink has completed.
+    with _LEASE_OPERATION_LOCK:
+        if not is_owned_by_current_process(session_id):
+            return False
 
-    release(session_id)
-    return True
+        release(session_id)
+        return True
 
 
 def is_owned_by_current_process(session_id: str) -> bool:
@@ -182,7 +290,12 @@ def is_holder_alive(session_id: str) -> bool:
     2. The recorded PID is running
     3. The process start time matches (guards against PID recycling)
 
-    Returns False if no lock exists or the holder is confirmed dead.
+    Returns False if no lock exists or the holder is confirmed dead. This
+    observer never unlinks malformed or stale records: deleting after a
+    non-atomic read could remove a newly acquired lease from another process.
+    Stale filenames are harmless because session ids are unique; a caller that
+    deliberately reuses one must resolve it explicitly rather than overwrite
+    liveness evidence.
     """
     path = lock_path(session_id)
     if not path.exists():
@@ -200,19 +313,22 @@ def is_holder_alive(session_id: str) -> bool:
     except ValueError:
         return False
 
-    recorded_start = float(parts[1]) if len(parts) > 1 and parts[1] != "None" else None
-
-    if not is_process_identity_alive(pid, recorded_start):
-        release(session_id)  # Clean up stale lock
+    try:
+        recorded_start = float(parts[1]) if len(parts) > 1 and parts[1] != "None" else None
+    except ValueError:
+        # A malformed lease cannot prove that a compatible process owns this
+        # session. Treat it as unheld without deleting it: a fresh owner may
+        # have atomically replaced the observation between read and cleanup.
         return False
 
-    return True
+    return is_process_identity_alive(pid, recorded_start)
 
 
 def get_alive_sessions() -> set[str]:
     """Return session IDs with live lock holders.
 
-    Scans the lock directory, verifies each, and cleans up stale entries.
+    Scans the lock directory and verifies each entry without deleting stale
+    paths from an observer race.
     """
     alive: set[str] = set()
     lock_dir = _ensure_dir()

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -15,7 +15,9 @@ Any runtime can participate — just call acquire/release.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import hashlib
+import json
 import logging
 import os
 from pathlib import Path
@@ -35,6 +37,44 @@ CANCELLATION_DIR = Path.home() / ".ouroboros" / "cancellations"
 _LEASE_OPERATION_LOCK = RLock()
 _HELD_LEASE_FDS: dict[str, int] = {}
 _SAFE_LOCK_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
+_DEFAULT_CANCELLATION_REASON = "Cancellation detected during execution"
+_DEFAULT_CANCELLED_BY = "runner"
+_MAX_CANCELLATION_REASON_CHARS = 4096
+_MAX_CANCELLED_BY_CHARS = 256
+
+
+@dataclass(frozen=True, slots=True)
+class CancellationRequest:
+    """Metadata carried by the cooperative cross-process cancel channel."""
+
+    reason: str
+    cancelled_by: str
+
+
+def _bounded_cancellation_text(value: object, *, default: str, limit: int) -> str:
+    if not isinstance(value, str) or not value:
+        return default
+    return value[:limit]
+
+
+def normalize_cancellation_request(
+    *,
+    reason: object,
+    cancelled_by: object,
+) -> CancellationRequest:
+    """Create bounded metadata shared by local and cross-process channels."""
+    return CancellationRequest(
+        reason=_bounded_cancellation_text(
+            reason,
+            default=_DEFAULT_CANCELLATION_REASON,
+            limit=_MAX_CANCELLATION_REASON_CHARS,
+        ),
+        cancelled_by=_bounded_cancellation_text(
+            cancelled_by,
+            default=_DEFAULT_CANCELLED_BY,
+            limit=_MAX_CANCELLED_BY_CHARS,
+        ),
+    )
 
 
 def _ensure_dir() -> Path:
@@ -132,20 +172,40 @@ def cancellation_path(session_id: str) -> Path:
     return _ensure_cancellation_dir() / (f"__invalid_session_id__{hashlib.sha256(raw).hexdigest()}")
 
 
-def publish_cancellation_request(session_id: str) -> None:
+def publish_cancellation_request(
+    session_id: str,
+    *,
+    reason: str = _DEFAULT_CANCELLATION_REASON,
+    cancelled_by: str = _DEFAULT_CANCELLED_BY,
+) -> None:
     """Publish a durable nonterminal cancellation signal across processes.
 
     The liveness lease intentionally cannot be used as a signal channel: an
     observer must never replace or remove another process's lease.  This
-    separate existence-only marker lets CLI/MCP processes request cooperative
-    cancellation while the owning runner keeps sole authority to persist the
-    terminal session result.
+    separate marker lets CLI/MCP processes request cooperative cancellation
+    while the owning runner keeps sole authority to persist the terminal
+    session result. The public request metadata travels with the marker so the
+    owner does not replace CLI/MCP attribution with runner defaults.
     """
     path = cancellation_path(session_id)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
     fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        os.write(fd, f"{os.getpid()}\n".encode("ascii"))
+        request = normalize_cancellation_request(
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
+        payload = json.dumps(
+            {
+                "version": 1,
+                "requesting_pid": os.getpid(),
+                "reason": request.reason,
+                "cancelled_by": request.cancelled_by,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        os.write(fd, payload)
         os.fsync(fd)
     finally:
         os.close(fd)
@@ -158,6 +218,27 @@ def publish_cancellation_request(session_id: str) -> None:
 def has_cancellation_request(session_id: str) -> bool:
     """Return whether any process published a cooperative cancellation request."""
     return cancellation_path(session_id).is_file()
+
+
+def read_cancellation_request(session_id: str) -> CancellationRequest | None:
+    """Read bounded request metadata, accepting legacy existence-only markers."""
+    path = cancellation_path(session_id)
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except OSError:
+        if path.is_file():
+            return normalize_cancellation_request(reason=None, cancelled_by=None)
+        return None
+    try:
+        parsed = json.loads(payload)
+    except (json.JSONDecodeError, UnicodeError):
+        parsed = None
+    if not isinstance(parsed, dict):
+        return normalize_cancellation_request(reason=None, cancelled_by=None)
+    return normalize_cancellation_request(
+        reason=parsed.get("reason"),
+        cancelled_by=parsed.get("cancelled_by"),
+    )
 
 
 def clear_cancellation_request(session_id: str) -> None:

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -243,13 +243,19 @@ def read_cancellation_request(session_id: str) -> CancellationRequest | None:
 
 def clear_cancellation_request(session_id: str) -> None:
     """Remove a cooperative request after the owning lifecycle acknowledges it."""
-    try:
-        cancellation_path(session_id).unlink(missing_ok=True)
-    except OSError:
-        log.warning(
-            "session_cancellation.clear_failed",
-            extra={"session_id": session_id},
-        )
+    last_error: OSError | None = None
+    for attempt in range(3):
+        try:
+            cancellation_path(session_id).unlink(missing_ok=True)
+            return
+        except OSError as exc:
+            last_error = exc
+            log.warning(
+                "session_cancellation.clear_failed",
+                extra={"session_id": session_id, "attempt": attempt + 1},
+            )
+    assert last_error is not None
+    raise last_error
 
 
 def acquire(session_id: str) -> None:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -28,16 +28,19 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
+from functools import wraps
 import json
 import math
 import os
 from pathlib import Path
 import re
-from typing import TYPE_CHECKING, Any, Literal
+import time
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from weakref import ref
 
 import anyio
 from rich.console import Console
@@ -254,6 +257,10 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ExecutionAuthorityLiveBinding,
+)
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -273,6 +280,7 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
+    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -286,6 +294,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedMod
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
     RateLimitGate,
+    SharedRateLimitBucket,
     build_rate_limit_gate,
     estimate_runtime_request_tokens,
 )
@@ -318,6 +327,583 @@ if TYPE_CHECKING:
     from ouroboros.persistence.event_store import EventStore
 
 log = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _FoundationAClosedRoots:
+    """Original direct roots held by the executor constructor default."""
+
+    leaf_dispatcher_type: type[LeafDispatcher]
+    leaf_dispatcher_stream_root: Callable[..., Awaitable[None]]
+    leaf_dispatcher_stream_code: object
+    level_coordinator_type: type[LevelCoordinator]
+    level_coordinator_review_root: object
+    level_coordinator_review_code: object
+    rate_gate_factory: Callable[..., RateLimitGate]
+    rate_gate_type: type[RateLimitGate]
+    rate_gate_acquire_root: Callable[..., Awaitable[None]]
+    rate_gate_acquire_code: object
+    rate_gate_sleep: object
+    rate_gate_sleep_code: object | None
+    rate_gate_bucket_type: type[SharedRateLimitBucket]
+    rate_gate_bucket_time: object
+    rate_gate_bucket_enabled_root: object
+    rate_gate_bucket_enabled_code: object | None
+    rate_gate_bucket_acquire_root: object
+    rate_gate_bucket_acquire_code: object | None
+    rate_gate_bucket_force_reserve_root: object
+    rate_gate_bucket_force_reserve_code: object | None
+    rate_gate_bucket_helper_roots: tuple[tuple[str, object | None, object | None], ...]
+    transcript_verifier: Callable[..., VerifierVerdict]
+    transcript_verifier_code: object
+
+
+class _FoundationAInternalEntryRoots(NamedTuple):
+    """Closed entry functions used by the executor's own orchestration path."""
+
+    executor_type: type[object]
+    execute_single_ac_root: Callable[..., Any]
+    execute_single_ac_code: object
+    execute_atomic_ac_root: Callable[..., Any]
+    execute_atomic_ac_code: object
+    await_dispatch_rate_budget_root: Callable[..., Any]
+    await_dispatch_rate_budget_code: object
+    dispatch_decomposition_prompt_root: Callable[..., Any]
+    dispatch_decomposition_prompt_code: object
+    run_atomic_verifier_pass_root: Callable[..., Any]
+    run_atomic_verifier_pass_code: object
+    run_ac_verify_gate_root: Callable[..., Any]
+    run_ac_verify_gate_code: object
+
+
+# These names document the closed components. ``ParallelACExecutor.__init__``
+# receives a value-based default built from them below, so changing a mutable
+# module global after import cannot replace the roots it binds.
+_FOUNDATION_A_LEAF_DISPATCHER_TYPE = LeafDispatcher
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT = LeafDispatcher.stream
+_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE = LeafDispatcher.stream.__code__
+_FOUNDATION_A_LEVEL_COORDINATOR_TYPE = LevelCoordinator
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT = LevelCoordinator.run_review
+_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE = LevelCoordinator.run_review.__code__
+_FOUNDATION_A_RATE_GATE_FACTORY = build_rate_limit_gate
+_FOUNDATION_A_RATE_GATE_TYPE = RateLimitGate
+_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT = RateLimitGate.acquire
+_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE = RateLimitGate.acquire.__code__
+_FOUNDATION_A_RATE_GATE_SLEEP = asyncio.sleep
+_FOUNDATION_A_RATE_GATE_SLEEP_CODE = asyncio.sleep.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_TYPE = SharedRateLimitBucket
+_FOUNDATION_A_RATE_GATE_BUCKET_TIME = time.monotonic
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT = SharedRateLimitBucket.enabled.fget
+_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE = (
+    _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT.__code__
+    if _FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT is not None
+    else None
+)
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT = SharedRateLimitBucket.acquire
+_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE = SharedRateLimitBucket.acquire.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT = SharedRateLimitBucket.force_reserve
+_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE = SharedRateLimitBucket.force_reserve.__code__
+_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS = (
+    ("_prune", SharedRateLimitBucket._prune, SharedRateLimitBucket._prune.__code__),
+    (
+        "_tokens_in_window",
+        SharedRateLimitBucket._tokens_in_window,
+        SharedRateLimitBucket._tokens_in_window.__code__,
+    ),
+    ("_snapshot", SharedRateLimitBucket._snapshot, SharedRateLimitBucket._snapshot.__code__),
+    (
+        "_request_wait_seconds",
+        SharedRateLimitBucket._request_wait_seconds,
+        SharedRateLimitBucket._request_wait_seconds.__code__,
+    ),
+    (
+        "_token_wait_seconds",
+        SharedRateLimitBucket._token_wait_seconds,
+        SharedRateLimitBucket._token_wait_seconds.__code__,
+    ),
+)
+_FOUNDATION_A_TRANSCRIPT_VERIFIER = _verify_atomic_evidence_against_runtime_messages
+_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE = _verify_atomic_evidence_against_runtime_messages.__code__
+_FOUNDATION_A_CLOSED_ROOTS = _FoundationAClosedRoots(
+    leaf_dispatcher_type=_FOUNDATION_A_LEAF_DISPATCHER_TYPE,
+    leaf_dispatcher_stream_root=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_ROOT,
+    leaf_dispatcher_stream_code=_FOUNDATION_A_LEAF_DISPATCHER_STREAM_CODE,
+    level_coordinator_type=_FOUNDATION_A_LEVEL_COORDINATOR_TYPE,
+    level_coordinator_review_root=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_ROOT,
+    level_coordinator_review_code=_FOUNDATION_A_LEVEL_COORDINATOR_REVIEW_CODE,
+    rate_gate_factory=_FOUNDATION_A_RATE_GATE_FACTORY,
+    rate_gate_type=_FOUNDATION_A_RATE_GATE_TYPE,
+    rate_gate_acquire_root=_FOUNDATION_A_RATE_GATE_ACQUIRE_ROOT,
+    rate_gate_acquire_code=_FOUNDATION_A_RATE_GATE_ACQUIRE_CODE,
+    rate_gate_sleep=_FOUNDATION_A_RATE_GATE_SLEEP,
+    rate_gate_sleep_code=_FOUNDATION_A_RATE_GATE_SLEEP_CODE,
+    rate_gate_bucket_type=_FOUNDATION_A_RATE_GATE_BUCKET_TYPE,
+    rate_gate_bucket_time=_FOUNDATION_A_RATE_GATE_BUCKET_TIME,
+    rate_gate_bucket_enabled_root=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_ROOT,
+    rate_gate_bucket_enabled_code=_FOUNDATION_A_RATE_GATE_BUCKET_ENABLED_CODE,
+    rate_gate_bucket_acquire_root=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_ROOT,
+    rate_gate_bucket_acquire_code=_FOUNDATION_A_RATE_GATE_BUCKET_ACQUIRE_CODE,
+    rate_gate_bucket_force_reserve_root=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_ROOT,
+    rate_gate_bucket_force_reserve_code=_FOUNDATION_A_RATE_GATE_BUCKET_FORCE_RESERVE_CODE,
+    rate_gate_bucket_helper_roots=_FOUNDATION_A_RATE_GATE_BUCKET_HELPER_ROOTS,
+    transcript_verifier=_FOUNDATION_A_TRANSCRIPT_VERIFIER,
+    transcript_verifier_code=_FOUNDATION_A_TRANSCRIPT_VERIFIER_CODE,
+)
+
+
+def _bind_foundation_a_roots(
+    roots: _FoundationAClosedRoots,
+) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """Bind closed roots in a closure instead of a caller-controlled kwarg."""
+
+    # Extract every root while this decorator is applied at module import. Do
+    # not retain the dataclass bundle itself: ``frozen=True`` is not a Python
+    # memory-integrity boundary and ``object.__setattr__`` could otherwise
+    # poison the bundle before a later executor is constructed.
+    leaf_dispatcher_type = roots.leaf_dispatcher_type
+    leaf_dispatcher_stream_root = roots.leaf_dispatcher_stream_root
+    leaf_dispatcher_stream_code = roots.leaf_dispatcher_stream_code
+    level_coordinator_type = roots.level_coordinator_type
+    level_coordinator_review_root = roots.level_coordinator_review_root
+    level_coordinator_review_code = roots.level_coordinator_review_code
+    rate_gate_factory = roots.rate_gate_factory
+    rate_gate_type = roots.rate_gate_type
+    rate_gate_acquire_root = roots.rate_gate_acquire_root
+    rate_gate_acquire_code = roots.rate_gate_acquire_code
+    rate_gate_sleep = roots.rate_gate_sleep
+    rate_gate_sleep_code = roots.rate_gate_sleep_code
+    rate_gate_bucket_type = roots.rate_gate_bucket_type
+    rate_gate_bucket_time = roots.rate_gate_bucket_time
+    rate_gate_bucket_enabled_root = roots.rate_gate_bucket_enabled_root
+    rate_gate_bucket_enabled_code = roots.rate_gate_bucket_enabled_code
+    rate_gate_bucket_acquire_root = roots.rate_gate_bucket_acquire_root
+    rate_gate_bucket_acquire_code = roots.rate_gate_bucket_acquire_code
+    rate_gate_bucket_force_reserve_root = roots.rate_gate_bucket_force_reserve_root
+    rate_gate_bucket_force_reserve_code = roots.rate_gate_bucket_force_reserve_code
+    rate_gate_bucket_helper_roots = roots.rate_gate_bucket_helper_roots
+    transcript_verifier = roots.transcript_verifier
+    transcript_verifier_code = roots.transcript_verifier_code
+
+    def decorate(initializer: Callable[..., None]) -> Callable[..., None]:
+        @wraps(initializer)
+        def bound(self: object, *args: object, **kwargs: object) -> None:
+            initializer(
+                self,
+                *args,
+                **kwargs,
+                _foundation_a_roots=_FoundationAClosedRoots(
+                    leaf_dispatcher_type=leaf_dispatcher_type,
+                    leaf_dispatcher_stream_root=leaf_dispatcher_stream_root,
+                    leaf_dispatcher_stream_code=leaf_dispatcher_stream_code,
+                    level_coordinator_type=level_coordinator_type,
+                    level_coordinator_review_root=level_coordinator_review_root,
+                    level_coordinator_review_code=level_coordinator_review_code,
+                    rate_gate_factory=rate_gate_factory,
+                    rate_gate_type=rate_gate_type,
+                    rate_gate_acquire_root=rate_gate_acquire_root,
+                    rate_gate_acquire_code=rate_gate_acquire_code,
+                    rate_gate_sleep=rate_gate_sleep,
+                    rate_gate_sleep_code=rate_gate_sleep_code,
+                    rate_gate_bucket_type=rate_gate_bucket_type,
+                    rate_gate_bucket_time=rate_gate_bucket_time,
+                    rate_gate_bucket_enabled_root=rate_gate_bucket_enabled_root,
+                    rate_gate_bucket_enabled_code=rate_gate_bucket_enabled_code,
+                    rate_gate_bucket_acquire_root=rate_gate_bucket_acquire_root,
+                    rate_gate_bucket_acquire_code=rate_gate_bucket_acquire_code,
+                    rate_gate_bucket_force_reserve_root=rate_gate_bucket_force_reserve_root,
+                    rate_gate_bucket_force_reserve_code=rate_gate_bucket_force_reserve_code,
+                    rate_gate_bucket_helper_roots=rate_gate_bucket_helper_roots,
+                    transcript_verifier=transcript_verifier,
+                    transcript_verifier_code=transcript_verifier_code,
+                ),
+            )
+
+        return bound
+
+    return decorate
+
+
+_FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC = 0
+_FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC = 1
+_FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET = 2
+_FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT = 3
+_FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS = 4
+_FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE = 5
+
+
+def _foundation_a_internal_entry_root_specs(
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[tuple[str, Callable[..., Any], object], ...]:
+    """Return the small, versioned set of internal effect-entry roots."""
+
+    return (
+        ("_execute_single_ac", roots.execute_single_ac_root, roots.execute_single_ac_code),
+        ("_execute_atomic_ac", roots.execute_atomic_ac_root, roots.execute_atomic_ac_code),
+        (
+            "_await_dispatch_rate_budget",
+            roots.await_dispatch_rate_budget_root,
+            roots.await_dispatch_rate_budget_code,
+        ),
+        (
+            "_dispatch_decomposition_prompt",
+            roots.dispatch_decomposition_prompt_root,
+            roots.dispatch_decomposition_prompt_code,
+        ),
+        (
+            "_run_atomic_verifier_pass",
+            roots.run_atomic_verifier_pass_root,
+            roots.run_atomic_verifier_pass_code,
+        ),
+        (
+            "_run_ac_verify_gate",
+            roots.run_ac_verify_gate_root,
+            roots.run_ac_verify_gate_code,
+        ),
+    )
+
+
+def _capture_foundation_a_internal_entry_roots(
+    executor_type: type[object],
+) -> _FoundationAInternalEntryRoots:
+    """Capture finite direct entry functions from one concrete executor type."""
+
+    try:
+        execute_single_ac_root = type.__getattribute__(executor_type, "_execute_single_ac")
+        execute_atomic_ac_root = type.__getattribute__(executor_type, "_execute_atomic_ac")
+        await_dispatch_rate_budget_root = type.__getattribute__(
+            executor_type,
+            "_await_dispatch_rate_budget",
+        )
+        dispatch_decomposition_prompt_root = type.__getattribute__(
+            executor_type,
+            "_dispatch_decomposition_prompt",
+        )
+        run_atomic_verifier_pass_root = type.__getattribute__(
+            executor_type,
+            "_run_atomic_verifier_pass",
+        )
+        run_ac_verify_gate_root = type.__getattribute__(executor_type, "_run_ac_verify_gate")
+        return _FoundationAInternalEntryRoots(
+            executor_type=executor_type,
+            execute_single_ac_root=execute_single_ac_root,
+            execute_single_ac_code=object.__getattribute__(execute_single_ac_root, "__code__"),
+            execute_atomic_ac_root=execute_atomic_ac_root,
+            execute_atomic_ac_code=object.__getattribute__(execute_atomic_ac_root, "__code__"),
+            await_dispatch_rate_budget_root=await_dispatch_rate_budget_root,
+            await_dispatch_rate_budget_code=object.__getattribute__(
+                await_dispatch_rate_budget_root,
+                "__code__",
+            ),
+            dispatch_decomposition_prompt_root=dispatch_decomposition_prompt_root,
+            dispatch_decomposition_prompt_code=object.__getattribute__(
+                dispatch_decomposition_prompt_root,
+                "__code__",
+            ),
+            run_atomic_verifier_pass_root=run_atomic_verifier_pass_root,
+            run_atomic_verifier_pass_code=object.__getattribute__(
+                run_atomic_verifier_pass_root,
+                "__code__",
+            ),
+            run_ac_verify_gate_root=run_ac_verify_gate_root,
+            run_ac_verify_gate_code=object.__getattribute__(run_ac_verify_gate_root, "__code__"),
+        )
+    except (AttributeError, TypeError) as exc:
+        raise ValueError("execution authority internal entry roots are not bindable") from exc
+
+
+def _foundation_a_internal_entry_roots_are_closed(
+    roots: _FoundationAInternalEntryRoots,
+    expected_roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Return whether construction found the import-time executor entry set."""
+
+    return roots.executor_type is expected_roots.executor_type and all(
+        root is expected_root and code is expected_code
+        for (_, root, code), (_, expected_root, expected_code) in zip(
+            _foundation_a_internal_entry_root_specs(roots),
+            _foundation_a_internal_entry_root_specs(expected_roots),
+            strict=True,
+        )
+    )
+
+
+def _foundation_a_internal_entry_roots_are_current(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> bool:
+    """Check only direct implementation roots, never arbitrary callable state."""
+
+    try:
+        if type(executor) is not roots.executor_type:
+            return False
+        instance_values = object.__getattribute__(executor, "__dict__")
+        executor_type = type(executor)
+        for name, expected_root, expected_code in _foundation_a_internal_entry_root_specs(roots):
+            if name in instance_values:
+                return False
+            current_root = type.__getattribute__(executor_type, name)
+            if current_root is not expected_root:
+                return False
+            if object.__getattribute__(current_root, "__code__") is not expected_code:
+                return False
+    except (AttributeError, KeyError, TypeError):
+        return False
+    return True
+
+
+def _make_foundation_a_internal_entry_invokers(
+    executor: object,
+    roots: _FoundationAInternalEntryRoots,
+) -> tuple[Callable[..., Any], ...]:
+    """Close direct function calls over the constructor's finite root snapshot."""
+
+    executor_ref = ref(executor)
+    execute_single_ac_root = roots.execute_single_ac_root
+    execute_atomic_ac_root = roots.execute_atomic_ac_root
+    await_dispatch_rate_budget_root = roots.await_dispatch_rate_budget_root
+    dispatch_decomposition_prompt_root = roots.dispatch_decomposition_prompt_root
+    run_atomic_verifier_pass_root = roots.run_atomic_verifier_pass_root
+    run_ac_verify_gate_root = roots.run_ac_verify_gate_root
+
+    def _require_captured_executor(current_executor: object) -> None:
+        if executor_ref() is not current_executor:
+            raise ValueError("execution authority entry root is unavailable")
+
+    def execute_single_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_single_ac_root(current_executor, **kwargs)
+
+    def execute_atomic_ac(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return execute_atomic_ac_root(current_executor, **kwargs)
+
+    def await_dispatch_rate_budget(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return await_dispatch_rate_budget_root(current_executor, **kwargs)
+
+    def dispatch_decomposition_prompt(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return dispatch_decomposition_prompt_root(current_executor, **kwargs)
+
+    def run_atomic_verifier_pass(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_atomic_verifier_pass_root(current_executor, **kwargs)
+
+    def run_ac_verify_gate(current_executor: object, **kwargs: object) -> Any:
+        _require_captured_executor(current_executor)
+        return run_ac_verify_gate_root(current_executor, **kwargs)
+
+    return (
+        execute_single_ac,
+        execute_atomic_ac,
+        await_dispatch_rate_budget,
+        dispatch_decomposition_prompt,
+        run_atomic_verifier_pass,
+        run_ac_verify_gate,
+    )
+
+
+def _bind_foundation_a_internal_entry_roots(executor_type: type[Any]) -> type[Any]:
+    """Capture original internal entry functions after the class body is complete."""
+
+    expected_roots = _capture_foundation_a_internal_entry_roots(executor_type)
+    initializer = executor_type.__init__
+
+    @wraps(initializer)
+    def bound(self: object, *args: object, **kwargs: object) -> None:
+        if (
+            "_foundation_a_internal_entry_roots" in kwargs
+            or "_foundation_a_internal_entry_roots_are_closed" in kwargs
+        ):
+            raise TypeError("_foundation_a_internal_entry_roots is constructor-bound")
+        roots = _capture_foundation_a_internal_entry_roots(type(self))
+        initializer(
+            self,
+            *args,
+            **kwargs,
+            _foundation_a_internal_entry_roots=roots,
+            _foundation_a_internal_entry_roots_are_closed=(
+                _foundation_a_internal_entry_roots_are_closed(roots, expected_roots)
+            ),
+        )
+
+    executor_type.__init__ = bound
+    return executor_type
+
+
+def _make_execution_authority_guard(
+    executor: object,
+    *,
+    binding: ExecutionAuthorityLiveBinding,
+    workspace_builder: Callable[[], str | None],
+    policy_builder: Callable[[], dict[str, object]],
+    internal_entry_roots: _FoundationAInternalEntryRoots,
+) -> Callable[[object], None]:
+    """Capture Foundation A roots outside mutable executor instance fields."""
+
+    executor_ref = ref(executor)
+    binding_ref = ref(binding)
+    binding_is_intact = ExecutionAuthorityLiveBinding.is_intact
+    binding_is_intact_code = binding_is_intact.__code__
+    workspace_builder_root = workspace_builder.__func__
+    workspace_builder_code = workspace_builder_root.__code__
+    policy_builder_root = policy_builder.__func__
+    policy_builder_code = policy_builder_root.__code__
+    internal_entry_roots_are_current = _foundation_a_internal_entry_roots_are_current
+    internal_entry_roots_are_current_code = internal_entry_roots_are_current.__code__
+
+    def guard(current_executor: object) -> None:
+        captured_executor = executor_ref()
+        captured_binding = binding_ref()
+        if captured_executor is not current_executor or captured_binding is None:
+            raise ValueError("execution authority guard is unavailable")
+        authority_verifier = captured_binding.verifier
+        adapter = captured_binding.adapter
+        dispatcher_type = captured_binding.dispatcher_type
+        dispatcher = captured_binding.dispatcher
+        transcript_verifier = captured_binding.transcript_verifier
+        rate_gate = captured_binding.rate_gate
+        dispatcher_stream_callable = captured_binding.dispatcher_stream_callable
+        rate_gate_acquire_callable = captured_binding.rate_gate_acquire_callable
+        coordinator = captured_binding.coordinator
+        coordinator_review_callable = captured_binding.coordinator_review_callable
+        session_signal_hub = captured_binding.session_signal_hub
+        get_attribute = object.__getattribute__
+        if (
+            get_attribute(current_executor, "_execution_authority_live_binding")
+            is not captured_binding
+            or get_attribute(current_executor, "_authority_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_atomic_verifier") is not authority_verifier
+            or get_attribute(current_executor, "_adapter") is not adapter
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_type")
+            is not dispatcher_type
+            or get_attribute(current_executor, "_authority_leaf_dispatcher") is not dispatcher
+            or get_attribute(current_executor, "_authority_transcript_verifier")
+            is not transcript_verifier
+            or get_attribute(current_executor, "_dispatch_rate_gate") is not rate_gate
+            or get_attribute(current_executor, "_authority_leaf_dispatcher_stream")
+            is not dispatcher_stream_callable
+            or get_attribute(current_executor, "_authority_rate_gate_acquire_root")
+            is not rate_gate_acquire_callable
+            or get_attribute(current_executor, "_coordinator") is not coordinator
+            or get_attribute(current_executor, "_authority_coordinator_review")
+            is not coordinator_review_callable
+            or get_attribute(current_executor, "_session_signal_hub") is not session_signal_hub
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if (
+            binding_is_intact.__code__ is not binding_is_intact_code
+            or workspace_builder_root.__code__ is not workspace_builder_code
+            or policy_builder_root.__code__ is not policy_builder_code
+            or internal_entry_roots_are_current.__code__
+            is not internal_entry_roots_are_current_code
+        ):
+            raise ValueError("execution authority drifted before effect")
+        if not internal_entry_roots_are_current(current_executor, internal_entry_roots):
+            raise ValueError("execution authority drifted before effect")
+        if not binding_is_intact(
+            captured_binding,
+            executor=current_executor,
+            adapter=adapter,
+            verifier=authority_verifier,
+            dispatcher_type=dispatcher_type,
+            dispatcher=dispatcher,
+            dispatcher_executor=current_executor,
+            transcript_verifier=transcript_verifier,
+            rate_gate=rate_gate,
+            workspace=workspace_builder_root(current_executor),
+            execution_policy=policy_builder_root(current_executor),
+            session_signal_hub=session_signal_hub,
+            dispatcher_stream_callable=dispatcher_stream_callable,
+            rate_gate_acquire_callable=rate_gate_acquire_callable,
+            coordinator=coordinator,
+            coordinator_review_callable=coordinator_review_callable,
+        ):
+            raise ValueError("execution authority drifted before effect")
+
+    return guard
+
+
+def _make_execution_authority_registry() -> tuple[
+    Callable[[object, Callable[[object], None], tuple[Callable[..., Any], ...]], None],
+    Callable[[object], None],
+    Callable[..., Any],
+]:
+    """Keep guards and direct invokers in closure-only process state.
+
+    This is an integrity boundary for normal collaborators, not a Python
+    sandbox against code that deliberately introspects and mutates private
+    module closures in its own process.
+    """
+
+    # ``WeakKeyDictionary`` delegates identity to user-defined ``__hash__`` and
+    # ``__eq__``. Foundation A deliberately supports process-local executor
+    # subclasses, including unhashable and equality-overriding ones, so keep a
+    # private identity-keyed table instead. Every lookup verifies the weak
+    # referent before use, which also makes delayed cleanup and ``id`` reuse
+    # safe. Values retain only the guard/invokers; those retain weak executor
+    # references and therefore cannot keep an executor alive.
+    states: dict[
+        int,
+        tuple[
+            ref[object],
+            Callable[[object], None],
+            tuple[Callable[..., Any], ...],
+        ],
+    ] = {}
+
+    def _lookup(
+        executor: object,
+    ) -> tuple[Callable[[object], None], tuple[Callable[..., Any], ...]]:
+        executor_id = id(executor)
+        state = states.get(executor_id)
+        if state is None:
+            raise ValueError("execution authority guard is unavailable")
+        executor_ref, guard, invokers = state
+        if executor_ref() is not executor:
+            # The stale entry may await a weakref callback, or its integer key
+            # may have been reused. Never dispatch through either case.
+            if executor_ref() is None:
+                states.pop(executor_id, None)
+            raise ValueError("execution authority guard is unavailable")
+        return guard, invokers
+
+    def register(
+        executor: object,
+        guard: Callable[[object], None],
+        invokers: tuple[Callable[..., Any], ...],
+    ) -> None:
+        executor_id = id(executor)
+
+        def cleanup(executor_ref: ref[object]) -> None:
+            state = states.get(executor_id)
+            if state is not None and state[0] is executor_ref:
+                states.pop(executor_id, None)
+
+        executor_ref = ref(executor, cleanup)
+        states[executor_id] = (executor_ref, guard, invokers)
+
+    def invoke_guard(executor: object) -> None:
+        guard, _ = _lookup(executor)
+        guard(executor)
+
+    def invoke_entry(executor: object, entry_index: int, **kwargs: object) -> Any:
+        try:
+            guard, invokers = _lookup(executor)
+            invoker = invokers[entry_index]
+        except IndexError as exc:
+            raise ValueError("execution authority entry root is unavailable") from exc
+        guard(executor)
+        return invoker(executor, **kwargs)
+
+    return register, invoke_guard, invoke_entry
+
+
+(
+    _register_execution_authority_state,
+    _invoke_execution_authority_guard,
+    _invoke_execution_authority_entry,
+) = _make_execution_authority_registry()
 
 
 def _is_session_signal_application_acknowledgement(message: AgentMessage) -> bool:
@@ -874,9 +1460,11 @@ def render_parallel_completion_message(
 # =============================================================================
 
 
+@_bind_foundation_a_internal_entry_roots
 class ParallelACExecutor:
     """Executes ACs in parallel based on dependency graph."""
 
+    @_bind_foundation_a_roots(_FOUNDATION_A_CLOSED_ROOTS)
     def __init__(
         self,
         adapter: AgentRuntime,
@@ -900,6 +1488,9 @@ class ParallelACExecutor:
         cross_harness_redispatch: bool | None = None,
         shadow_replay_enabled: bool = False,
         session_signal_hub: SessionSignalHub | None = None,
+        _foundation_a_roots: _FoundationAClosedRoots = _FOUNDATION_A_CLOSED_ROOTS,
+        _foundation_a_internal_entry_roots: _FoundationAInternalEntryRoots | None = None,
+        _foundation_a_internal_entry_roots_are_closed: bool = False,
     ):
         """Initialize executor.
 
@@ -935,6 +1526,10 @@ class ParallelACExecutor:
                 today's single-dispatch behavior; real run paths (CLI `ooo run`
                 via the runner) pass the config value (default 2).
         """
+        if _foundation_a_internal_entry_roots is None:
+            raise ValueError("execution authority internal entry roots are unavailable")
+        internal_entry_roots = _foundation_a_internal_entry_roots
+
         self._adapter = adapter
         self._event_store = event_store
         self._console = console or Console()
@@ -946,6 +1541,7 @@ class ParallelACExecutor:
         )
         self._enable_decomposition = self._decomposition_mode != "off"
         self._max_decomposition_depth = max(0, max_decomposition_depth)
+        self._max_concurrent = max_concurrent
         approval_mode = getattr(adapter, "permission_mode", None)
         self._inherited_runtime_handle = (
             replace(inherited_runtime_handle, approval_mode=approval_mode.strip())
@@ -978,11 +1574,26 @@ class ParallelACExecutor:
         self._shadow_replay_enabled = shadow_replay_enabled
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
-        self._coordinator = LevelCoordinator(
+        # These exact objects are the finite effect-owner roots Foundation A
+        # can bind at runtime. Callable internals remain explicitly volatile;
+        # custom verifiers never become portable through graph inspection.
+        self._authority_verifier = atomic_verifier
+        self._authority_leaf_dispatcher_type = _foundation_a_roots.leaf_dispatcher_type
+        # Construct the leaf once through closed primitive roots, then call the
+        # captured stream implementation directly. A later class ``__init__``
+        # or instance ``stream`` hook cannot replace the immediate dispatcher
+        # effect after the authority check.
+        self._authority_leaf_dispatcher = object.__new__(self._authority_leaf_dispatcher_type)
+        object.__setattr__(self._authority_leaf_dispatcher, "_executor", self)
+        self._authority_leaf_dispatcher_stream = _foundation_a_roots.leaf_dispatcher_stream_root
+        self._authority_transcript_verifier = _foundation_a_roots.transcript_verifier
+        self._coordinator = _foundation_a_roots.level_coordinator_type(
             adapter,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=task_cwd,
         )
+        self._authority_coordinator = self._coordinator
+        self._authority_coordinator_review = self._coordinator.run_review
         self._semaphore = anyio.Semaphore(max_concurrent)
         self._ac_runtime_handle_manager = ACRuntimeHandleManager(
             adapter,
@@ -997,7 +1608,11 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
         self._execution_counters_lock = asyncio.Lock()
-        self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        self._dispatch_rate_gate = self._build_dispatch_rate_gate(
+            adapter,
+            rate_gate_factory=_foundation_a_roots.rate_gate_factory,
+        )
+        self._authority_rate_gate_acquire_root = _foundation_a_roots.rate_gate_acquire_root
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1015,9 +1630,161 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
+        workspace_builder = object.__getattribute__(
+            self,
+            "_execution_authority_workspace",
+        )
+        policy_builder = object.__getattribute__(
+            self,
+            "_execution_authority_policy",
+        )
+        binding = ExecutionAuthorityLiveBinding.capture(
+            executor=self,
+            adapter=adapter,
+            verifier=atomic_verifier,
+            dispatcher_type=self._authority_leaf_dispatcher_type,
+            dispatcher=self._authority_leaf_dispatcher,
+            dispatcher_executor=self,
+            transcript_verifier=self._authority_transcript_verifier,
+            rate_gate=self._dispatch_rate_gate,
+            workspace=workspace_builder(),
+            execution_policy=policy_builder(),
+            session_signal_hub=self._session_signal_hub,
+            dispatcher_stream_callable=self._authority_leaf_dispatcher_stream,
+            rate_gate_acquire_callable=self._authority_rate_gate_acquire_root,
+            coordinator=self._authority_coordinator,
+            coordinator_review_callable=self._authority_coordinator_review,
+            expected_dispatcher_type=_foundation_a_roots.leaf_dispatcher_type,
+            expected_dispatcher_stream_root=_foundation_a_roots.leaf_dispatcher_stream_root,
+            expected_dispatcher_stream_code=_foundation_a_roots.leaf_dispatcher_stream_code,
+            expected_transcript_verifier=_foundation_a_roots.transcript_verifier,
+            expected_transcript_verifier_code=_foundation_a_roots.transcript_verifier_code,
+            expected_rate_gate_acquire_root=_foundation_a_roots.rate_gate_acquire_root,
+            expected_rate_gate_acquire_code=_foundation_a_roots.rate_gate_acquire_code,
+            expected_rate_gate_type=_foundation_a_roots.rate_gate_type,
+            expected_rate_gate_sleep=_foundation_a_roots.rate_gate_sleep,
+            expected_rate_gate_sleep_code=_foundation_a_roots.rate_gate_sleep_code,
+            expected_rate_gate_bucket_type=_foundation_a_roots.rate_gate_bucket_type,
+            expected_rate_gate_bucket_time=_foundation_a_roots.rate_gate_bucket_time,
+            expected_rate_gate_bucket_enabled_root=(
+                _foundation_a_roots.rate_gate_bucket_enabled_root
+            ),
+            expected_rate_gate_bucket_enabled_code=(
+                _foundation_a_roots.rate_gate_bucket_enabled_code
+            ),
+            expected_rate_gate_bucket_acquire_root=(
+                _foundation_a_roots.rate_gate_bucket_acquire_root
+            ),
+            expected_rate_gate_bucket_acquire_code=(
+                _foundation_a_roots.rate_gate_bucket_acquire_code
+            ),
+            expected_rate_gate_bucket_force_reserve_root=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_root
+            ),
+            expected_rate_gate_bucket_force_reserve_code=(
+                _foundation_a_roots.rate_gate_bucket_force_reserve_code
+            ),
+            expected_rate_gate_bucket_helper_roots=(
+                _foundation_a_roots.rate_gate_bucket_helper_roots
+            ),
+            expected_coordinator_type=_foundation_a_roots.level_coordinator_type,
+            expected_coordinator_review_root=_foundation_a_roots.level_coordinator_review_root,
+            expected_coordinator_review_code=_foundation_a_roots.level_coordinator_review_code,
+            force_runtime_process_local=(
+                not _foundation_a_internal_entry_roots_are_closed
+                or self._session_signal_hub is not None
+            ),
+        )
+        self._execution_authority_live_binding = binding
+        self._execution_authority = binding.contract
+        internal_entry_invokers = _make_foundation_a_internal_entry_invokers(
+            self,
+            internal_entry_roots,
+        )
+        _register_execution_authority_state(
+            self,
+            _make_execution_authority_guard(
+                self,
+                binding=binding,
+                workspace_builder=workspace_builder,
+                policy_builder=policy_builder,
+                internal_entry_roots=internal_entry_roots,
+            ),
+            internal_entry_invokers,
+        )
+
+    @property
+    def execution_authority(self) -> ExecutionAuthorityContract:
+        """Return the immutable authority snapshot used by this executor."""
+        return self._execution_authority
+
+    def _execution_authority_workspace(self) -> str | None:
+        """Return the finite effect-workspace root for Foundation A."""
+        get_attribute = object.__getattribute__
+        task_cwd = get_attribute(self, "_task_cwd")
+        adapter = get_attribute(self, "_adapter")
+        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        return workspace if isinstance(workspace, str) else None
+
+    def _execution_authority_policy(self) -> dict[str, object]:
+        """Return only static executor policy; attempt inputs stay excluded."""
+        get_attribute = object.__getattribute__
+        adapter = get_attribute(self, "_adapter")
+        coordinator = get_attribute(self, "_coordinator")
+        backend = getattr(adapter, "runtime_backend", None)
+        limits = resolve_backend_limits(backend if isinstance(backend, str) else None)
+        coordinator_effort = getattr(coordinator, "_reasoning_effort", None)
+        return {
+            "version": 1,
+            "decomposition_mode": get_attribute(self, "_decomposition_mode"),
+            "max_decomposition_depth": get_attribute(self, "_max_decomposition_depth"),
+            "max_concurrent": get_attribute(self, "_max_concurrent"),
+            "execution_profile": (
+                get_attribute(self, "_execution_profile").model_dump(mode="json")
+                if get_attribute(self, "_execution_profile") is not None
+                else None
+            ),
+            "fat_harness_mode": get_attribute(self, "_fat_harness_mode"),
+            "run_verify_commands": get_attribute(self, "_run_verify_commands"),
+            "verify_command_timeout_seconds": get_attribute(
+                self,
+                "_verify_command_timeout_seconds",
+            ),
+            "ac_retry_attempts": get_attribute(self, "_ac_retry_attempts"),
+            "reasoning_effort": get_attribute(self, "_reasoning_effort"),
+            "coordinator_reasoning_effort": coordinator_effort,
+            "model_routing": serialize_model_router(get_attribute(self, "_model_router")),
+            "cross_harness_redispatch": get_attribute(
+                self,
+                "_cross_harness_redispatch_enabled",
+            ),
+            "shadow_replay_enabled": get_attribute(self, "_shadow_replay_enabled"),
+            "session_signal_hub_enabled": get_attribute(self, "_session_signal_hub") is not None,
+            "dispatch_rate": {
+                "algorithm": "rate-limit-gate/v1",
+                "backend": backend if isinstance(backend, str) else None,
+                "self_governs_rate_limit": getattr(
+                    adapter,
+                    "self_governs_rate_limit",
+                    False,
+                ),
+                "requests_per_minute": limits.requests_per_minute,
+                "tokens_per_minute": limits.tokens_per_minute,
+            },
+        }
+
+    def _require_execution_authority_intact(self) -> None:
+        """Fail closed when an enumerated live effect-owner root drifts."""
+        _invoke_execution_authority_guard(self)
 
     @staticmethod
-    def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
+    def _build_dispatch_rate_gate(
+        adapter: AgentRuntime,
+        *,
+        rate_gate_factory: Callable[
+            ..., RateLimitGate
+        ] = _FOUNDATION_A_CLOSED_ROOTS.rate_gate_factory,
+    ) -> RateLimitGate:
         """Build the shared dispatch rate gate for non-self-governing backends.
 
         Ouroboros — not the runtime — paces delivery within the backend's
@@ -1032,10 +1799,14 @@ class ParallelACExecutor:
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
 
         if getattr(adapter, "self_governs_rate_limit", False):
-            return build_rate_limit_gate(backend, request_limit=None, token_limit=None)
+            return rate_gate_factory(
+                backend,
+                request_limit=None,
+                token_limit=None,
+            )
 
         limits = resolve_backend_limits(backend)
-        return build_rate_limit_gate(
+        return rate_gate_factory(
             backend,
             request_limit=limits.requests_per_minute,
             token_limit=limits.tokens_per_minute,
@@ -1054,9 +1825,7 @@ class ParallelACExecutor:
         workers (they share this executor's single gate instance) and logs each
         backoff for observability.
         """
-        if not self._dispatch_rate_gate.enabled:
-            return
-
+        _invoke_execution_authority_guard(self)
         estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
 
         def _log_backoff(backoff: RateLimitBackoff) -> None:
@@ -1072,7 +1841,14 @@ class ParallelACExecutor:
                 token_limit=backoff.snapshot.token_limit,
             )
 
-        await self._dispatch_rate_gate.acquire(estimated_tokens, on_backoff=_log_backoff)
+        await self._authority_rate_gate_acquire_root(
+            self._dispatch_rate_gate,
+            estimated_tokens,
+            on_backoff=_log_backoff,
+        )
+        # Rate admission can suspend. Revalidate before returning to a caller
+        # that will dispatch to the runtime immediately afterwards.
+        _invoke_execution_authority_guard(self)
 
     def _announce_param_degradations(
         self,
@@ -1564,7 +2340,9 @@ class ParallelACExecutor:
             async with self._semaphore:
                 try:
                     ac_criterion = seed.acceptance_criteria[ac_idx]
-                    batch_results[idx] = await self._execute_single_ac(
+                    batch_results[idx] = await _invoke_execution_authority_entry(
+                        self,
+                        _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                         ac_index=ac_idx,
                         ac_content=ac_text(ac_criterion),
                         session_id=session_id,
@@ -1893,7 +2671,12 @@ class ParallelACExecutor:
                         and (spec.verify_command or spec.expected_artifacts)
                     ):
                         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                        gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                        gate = await _invoke_execution_authority_entry(
+                            self,
+                            _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                            spec=spec,
+                            cwd=cwd,
+                        )
                         if not gate.passed:
                             executable.append(ac_idx)
                             log.info(
@@ -2211,7 +2994,8 @@ class ParallelACExecutor:
                             level=level_num,
                             conflicts=conflicts,
                         )
-                        review = await self._coordinator.run_review(
+                        _invoke_execution_authority_guard(self)
+                        review = await self._authority_coordinator_review(
                             execution_id=execution_id,
                             conflicts=conflicts,
                             level_context=level_ctx,
@@ -2488,7 +3272,9 @@ class ParallelACExecutor:
                     status="executing",
                     node_identity=child_node_identity,
                 )
-                sub_results[idx] = await self._execute_single_ac(
+                sub_results[idx] = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
                     ac_index=ac_index * 100 + idx,
                     ac_content=sub_ac,
                     session_id=session_id,
@@ -2651,7 +3437,17 @@ class ParallelACExecutor:
         parent executor inherited a resumable handle.
         """
         self._announce_param_degradations(system_prompt=system_prompt, tools=[])
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        _invoke_execution_authority_guard(self)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
+        # Acquiring rate budget can suspend, so validate once more at the
+        # immediate effect boundary rather than assuming the pre-wait snapshot
+        # still applies.
+        _invoke_execution_authority_guard(self)
         response_text = ""
         async with asyncio.timeout(DECOMPOSITION_TIMEOUT_SECONDS):
             async for message in self._adapter.execute_task(
@@ -2689,7 +3485,9 @@ class ParallelACExecutor:
             f"## Bounded Attempt Trace\n{trace.summary}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt="You are a conservative execution-recovery classifier.",
             )
@@ -3115,7 +3913,9 @@ class ParallelACExecutor:
             "semantic_ac_key": semantic_ac_key,
         }
         while True:
-            atomic_result = await self._execute_atomic_ac(
+            atomic_result = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_EXECUTE_ATOMIC_AC,
                 ac_index=ac_index,
                 ac_content=ac_content,
                 session_id=session_id,
@@ -3469,7 +4269,7 @@ class ParallelACExecutor:
             task_cwd=self._task_cwd,
             execution_profile=self._execution_profile,
             fat_harness_mode=self._fat_harness_mode,
-            atomic_verifier=self._atomic_verifier,
+            atomic_verifier=self._authority_verifier,
             reasoning_effort=self._reasoning_effort,
             # The router's backend-mismatch guard makes it inert on a different
             # backend, so passing it to the alt-harness executor is safe.
@@ -3481,7 +4281,12 @@ class ParallelACExecutor:
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
         )
-        return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
+        return await _invoke_execution_authority_entry(
+            alt_executor,
+            _FOUNDATION_A_ENTRY_EXECUTE_SINGLE_AC,
+            **rerun_kwargs,
+            retry_attempt=retry_attempt,
+        )
 
     @staticmethod
     def _parse_legacy_decomposition(
@@ -3568,7 +4373,9 @@ class ParallelACExecutor:
             f"{json.dumps(proposal.to_dict(), sort_keys=True)}"
         )
         try:
-            response = await self._dispatch_decomposition_prompt(
+            response = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt=system_prompt,
                 independent_session=True,
@@ -3747,7 +4554,9 @@ Respond with either ATOMIC or the structured JSON object only.
             decompose_prompt += f"\n\n## Bounded Attempt Trace\n{bounded_trace}"
 
         try:
-            response_text = await self._dispatch_decomposition_prompt(
+            response_text = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=decompose_prompt,
                 system_prompt=decomposition_system_prompt,
             )
@@ -3805,7 +4614,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     min_sub_acs=min_sub_acs,
                     max_sub_acs=max_sub_acs,
                 )
-                repaired_text = await self._dispatch_decomposition_prompt(
+                repaired_text = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                     prompt=repair_prompt,
                     system_prompt=decomposition_system_prompt,
                 )
@@ -4286,7 +5097,12 @@ Respond with either ATOMIC or the structured JSON object only.
         self._announce_param_degradations(system_prompt=system_prompt, tools=tools)
         # Pace delivery within the backend's shared rate budget (dormant unless
         # an RPM/TPM is configured for this backend) before the stall-scoped run.
-        await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
+        await _invoke_execution_authority_entry(
+            self,
+            _FOUNDATION_A_ENTRY_AWAIT_DISPATCH_RATE_BUDGET,
+            prompt=prompt,
+            system_prompt=system_prompt,
+        )
 
         investment_assessment = assess_investment(investment_spec)
         await self._event_emitter.emit_investment_assessed(
@@ -4484,7 +5300,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
-            await LeafDispatcher(self).stream(
+            _invoke_execution_authority_guard(self)
+            await self._authority_leaf_dispatcher_stream(
+                self._authority_leaf_dispatcher,
                 state=dispatch_state,
                 prompt=prompt,
                 tools=tools,
@@ -4586,7 +5404,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
-                        await LeafDispatcher(self).stream(
+                        _invoke_execution_authority_guard(self)
+                        await self._authority_leaf_dispatcher_stream(
+                            self._authority_leaf_dispatcher,
                             state=dispatch_state,
                             prompt=(
                                 render_inform_signal_prompt(queued_signal.signal)
@@ -4745,7 +5565,12 @@ Respond with either ATOMIC or the structured JSON object only.
             verify_gate_outcome: _VerifyGateOutcome | None = None
             if success and verify_gate_active and has_success_contract:
                 cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                verify_gate_outcome = await self._run_ac_verify_gate(spec=ac_spec, cwd=cwd)
+                verify_gate_outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=ac_spec,
+                    cwd=cwd,
+                )
 
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
@@ -4755,7 +5580,9 @@ Respond with either ATOMIC or the structured JSON object only.
                 has_expected_artifacts=has_expected_artifacts,
                 verify_gate_active=verify_gate_active,
             )
-            verifier_verdict = self._run_atomic_verifier_pass(
+            verifier_verdict = _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
                 ac_content=ac_content,
                 final_message=final_message,
                 success=success,
@@ -5350,7 +6177,12 @@ Respond with either ATOMIC or the structured JSON object only.
                 outcome=cached_outcome,
             )
         else:
-            outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+            outcome = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                spec=spec,
+                cwd=cwd,
+            )
         if outcome.passed:
             if not result.success and not result.is_blocked and not result.is_invalid:
                 from ouroboros.events.base import BaseEvent
@@ -5564,7 +6396,12 @@ Respond with either ATOMIC or the structured JSON object only.
                     outcome=cached_outcome,
                 )
             else:
-                outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                outcome = await _invoke_execution_authority_entry(
+                    self,
+                    _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                    spec=spec,
+                    cwd=cwd,
+                )
             if not outcome.passed:
                 gated_out.add(ac_idx)
         return frozenset(gated_out)
@@ -6050,7 +6887,8 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return None
 
-        verifier = self._atomic_verifier
+        _invoke_execution_authority_guard(self)
+        verifier = self._authority_verifier
         try:
             effective_schema = _effective_evidence_schema_for_ac(
                 self._execution_profile,
@@ -6078,14 +6916,21 @@ Respond with either ATOMIC or the structured JSON object only.
                     record=scoped_evidence,
                 )
                 if verifier is not None and not force_runtime_transcript
-                else self._verify_atomic_evidence_against_runtime_messages(
+                # Do not route acceptance through the mutable executor wrapper.
+                # Foundation A captured this closed transcript verifier at
+                # construction and has just checked that binding above.
+                else self._authority_transcript_verifier(
                     messages=messages,
                     typed_evidence=scoped_evidence,
                     ac_content=ac_content,
+                    execution_profile=self._execution_profile,
+                    task_cwd=task_cwd_override or self._task_cwd,
+                    adapter_working_directory=(
+                        task_cwd_override or self._adapter.working_directory
+                    ),
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
                     verify_gate_active=verify_gate_active,
-                    task_cwd_override=task_cwd_override,
                 )
             )
         except VerifierContractError:
@@ -6108,7 +6953,7 @@ Respond with either ATOMIC or the structured JSON object only.
         verify_gate_active: bool = False,
         task_cwd_override: str | None = None,
     ) -> VerifierVerdict:
-        return _verify_atomic_evidence_against_runtime_messages(
+        return self._authority_transcript_verifier(
             messages=messages,
             typed_evidence=typed_evidence,
             ac_content=ac_content,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -97,6 +97,7 @@ from ouroboros.orchestrator.execution_authority import (
     _process_local_authority_contract,
     _ProcessLocalAuthorityGeneration,
     _register_process_local_authority_generation,
+    _register_process_local_authority_terminal_finalizer,
     _release_process_local_authority_generation,
     _retire_process_local_authority_generation,
     constructor_model_contract,
@@ -1787,6 +1788,23 @@ class OrchestratorRunner:
             self._adapter,
         )
 
+    def _cleanup_process_local_authority_after_external_terminal(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Drop runner-local references after another surface wrote terminal state.
+
+        The registry has already invalidated the opaque capability.  This
+        callback intentionally cleans only runner-local bookkeeping; the
+        registry owns the liveness-lease release so it remains one operation.
+        """
+        self._process_local_authorities.pop((session_id, execution_id), None)
+        self._active_sessions.pop(execution_id, None)
+        if self._task_workspace is not None:
+            release_lock(self._task_workspace.lock_path)
+
     def _register_process_local_authority(
         self,
         *,
@@ -1828,6 +1846,28 @@ class OrchestratorRunner:
                 },
             ) from exc
         self._process_local_authorities[(session_id, execution_id)] = generation
+        if not _register_process_local_authority_terminal_finalizer(
+            session_id,
+            execution_id,
+            authority,
+            self._adapter,
+            ("runner", id(self)),
+            lambda: self._cleanup_process_local_authority_after_external_terminal(
+                session_id=session_id,
+                execution_id=execution_id,
+            ),
+        ):
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            raise OrchestratorError(
+                message="Cannot register process-local terminal cleanup",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                },
+            )
         # Establish the cross-process liveness record as soon as a session owns
         # a live capability, before a detached caller can observe its persisted
         # RUNNING tracker.  It is a lease/liveness marker, never authority.
@@ -1938,7 +1978,7 @@ class OrchestratorRunner:
         """Terminally record a lost local capability without trying a fallback."""
         error = self._process_local_resume_unavailable_error(session_id, execution_id)
         try:
-            result = await self._session_repo.mark_failed(
+            result = await self._session_repo.mark_failed_if_active(
                 session_id,
                 error.message,
                 error.details,
@@ -1949,6 +1989,12 @@ class OrchestratorRunner:
                     session_id=session_id,
                     execution_id=execution_id,
                     error=str(result.error),
+                )
+            elif not result.value:
+                log.info(
+                    "orchestrator.runner.process_local_resume_terminal_already_persisted",
+                    session_id=session_id,
+                    execution_id=execution_id,
                 )
         except Exception as exc:  # pragma: no cover - best-effort terminal record
             log.warning(
@@ -4007,6 +4053,110 @@ class OrchestratorRunner:
             )
             return False
 
+    def _cancellation_persistence_pending_result(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        cause: object,
+    ) -> Result[OrchestratorResult, OrchestratorError]:
+        """Leave a failed cancellation write retryable without stranding a claim.
+
+        The live registration and heartbeat remain as a truthful same-process
+        owner, and the cancellation request remains set.  The effectful claim,
+        active route, and worktree lock belong to the coroutine that is now
+        exiting, so they must be released for a retained owner to retry the
+        durable terminal write on a later resume request.
+        """
+        self._release_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        self._unregister_session(
+            execution_id,
+            session_id,
+            release_liveness_lease=False,
+        )
+        if self._task_workspace is not None:
+            release_lock(self._task_workspace.lock_path)
+        return Result.err(
+            OrchestratorError(
+                message="Failed to persist cancellation; process-local authority remains live",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "cause": str(cause),
+                    "resume_blocked": "cancellation_persistence_pending",
+                    "cancellation_persistence_pending": True,
+                },
+            )
+        )
+
+    async def _drain_requested_cancellation_before_pre_execution_cleanup(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        messages_processed: int,
+        start_time: datetime,
+    ) -> Result[OrchestratorResult, OrchestratorError] | None:
+        """Persist a published cancellation before abandoning a claimed setup.
+
+        A public cancellation can arrive after a resume/new-run claims the
+        generation but before the runner has registered its normal active
+        route.  Raw task cancellation in that window must not retire the
+        capability and leave a durable ``PAUSED`` tracker that a later resume
+        reclassifies as lost authority.  Run the normal cancellation lifecycle
+        in a shielded child task so a repeat caller cancellation cannot skip
+        the durable write or its retryable-pending cleanup.
+
+        Returns ``None`` when no cooperative cancellation is pending; otherwise
+        it returns the normal cancellation result.  A second raw cancellation
+        is re-raised after the child has drained its lifecycle work.
+        """
+        if not await is_cancellation_requested(session_id):
+            return None
+
+        task = asyncio.create_task(
+            self._handle_cancellation(
+                session_id=session_id,
+                execution_id=execution_id,
+                messages_processed=messages_processed,
+                start_time=start_time,
+            )
+        )
+        repeated_cancellation: asyncio.CancelledError | None = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as exc:
+                repeated_cancellation = repeated_cancellation or exc
+
+        try:
+            result = task.result()
+        except asyncio.CancelledError as exc:
+            repeated_cancellation = repeated_cancellation or exc
+            result = self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause="cancellation lifecycle task cancelled",
+            )
+        except Exception as exc:  # pragma: no cover - defensive task boundary
+            log.exception(
+                "orchestrator.runner.pre_execution_cancellation_drain_failed",
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            result = self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=exc,
+            )
+
+        if repeated_cancellation is not None:
+            raise repeated_cancellation
+        return result
+
     async def _handle_cancellation(
         self,
         session_id: str,
@@ -4118,15 +4268,10 @@ class OrchestratorRunner:
                 session_id=session_id,
                 error=str(exc),
             )
-            return Result.err(
-                OrchestratorError(
-                    message="Failed to persist cancellation; process-local authority remains live",
-                    details={
-                        "session_id": session_id,
-                        "execution_id": execution_id,
-                        "cause": str(exc),
-                    },
-                )
+            return self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=exc,
             )
         if cancel_result is not None and cancel_result.is_err:
             log.warning(
@@ -4134,15 +4279,10 @@ class OrchestratorRunner:
                 session_id=session_id,
                 error=str(cancel_result.error),
             )
-            return Result.err(
-                OrchestratorError(
-                    message="Failed to persist cancellation; process-local authority remains live",
-                    details={
-                        "session_id": session_id,
-                        "execution_id": execution_id,
-                        "cause": str(cancel_result.error),
-                    },
-                )
+            return self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=cancel_result.error,
             )
 
         # The session is now terminal.  It is safe to clear the request and
@@ -4552,10 +4692,16 @@ class OrchestratorRunner:
             await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
             self._execution_guidance_delivery_mode()
         except asyncio.CancelledError:
-            # The exclusive generation was claimed before contract restoration.
-            # A raw task cancellation must release that claim (and its lease)
-            # even though it intentionally does not write a terminal session
-            # record; callers still receive the original cancellation.
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=0,
+                    start_time=start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 tracker.session_id,
@@ -4563,6 +4709,16 @@ class OrchestratorRunner:
             )
             raise
         except OrchestratorError as exc:
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=0,
+                    start_time=start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 tracker.session_id,
@@ -4686,13 +4842,16 @@ class OrchestratorRunner:
                 execution_plan=direct_graph.to_execution_plan(),
             )
         except asyncio.CancelledError:
-            if session_registered and await is_cancellation_requested(tracker.session_id):
-                return await self._handle_cancellation(
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
                 )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 exec_id,
                 tracker.session_id,
@@ -4700,6 +4859,16 @@ class OrchestratorRunner:
             )
             raise
         except Exception as e:
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=0,
+                    start_time=start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 exec_id,
                 tracker.session_id,
@@ -5740,6 +5909,59 @@ class OrchestratorRunner:
                     )
                 )
             if authority_generation is not None:
+                # A previous cancellation attempt may have failed its durable
+                # write after the worker stopped.  Its request remains live
+                # precisely so this retained owner can claim the generation
+                # and retry terminalization instead of stranding a claim or
+                # turning a RUNNING tracker into a normal resume.
+                # Register a route before the await so cancellation cleanup
+                # has one owner.  This probe is cancellation-safe: on raw task
+                # cancellation it releases only its claim/route and preserves
+                # the live registration and lease of the original owner.
+                try:
+                    self._register_session(tracker.execution_id, session_id)
+                    if await self._check_startup_cancellation(session_id):
+                        return await self._handle_cancellation(
+                            session_id=session_id,
+                            execution_id=tracker.execution_id,
+                            messages_processed=tracker.messages_processed,
+                            start_time=datetime.now(UTC),
+                        )
+                except asyncio.CancelledError:
+                    self._release_process_local_authority(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                    self._unregister_session(
+                        tracker.execution_id,
+                        session_id,
+                        release_liveness_lease=False,
+                    )
+                    if self._task_workspace is not None:
+                        release_lock(self._task_workspace.lock_path)
+                    raise
+                except Exception as exc:
+                    self._release_process_local_authority(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                    self._unregister_session(
+                        tracker.execution_id,
+                        session_id,
+                        release_liveness_lease=False,
+                    )
+                    if self._task_workspace is not None:
+                        release_lock(self._task_workspace.lock_path)
+                    return Result.err(
+                        OrchestratorError(
+                            message=f"Failed to inspect live process-local session: {exc}",
+                            details={
+                                "session_id": session_id,
+                                "execution_id": tracker.execution_id,
+                            },
+                        )
+                    )
+
                 # This runner still owns the live generation but the durable
                 # status is non-resumable. The probe claim was only for
                 # arbitration, so restore the pre-existing unclaimed state
@@ -5747,6 +5969,11 @@ class OrchestratorRunner:
                 self._release_process_local_authority(
                     session_id=session_id,
                     execution_id=tracker.execution_id,
+                )
+                self._unregister_session(
+                    tracker.execution_id,
+                    session_id,
+                    release_liveness_lease=False,
                 )
                 return Result.err(
                     OrchestratorError(
@@ -5829,9 +6056,16 @@ class OrchestratorRunner:
             )
             self._execution_guidance_delivery_mode()
         except asyncio.CancelledError:
-            # Resume claims the exact live generation before restoration. Do
-            # not leave it permanently claimed if the caller cancels during
-            # this otherwise pre-effect setup window.
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=tracker.messages_processed,
+                    start_time=tracker.start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
@@ -5839,6 +6073,16 @@ class OrchestratorRunner:
             )
             raise
         except OrchestratorError as exc:
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=tracker.messages_processed,
+                    start_time=tracker.start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
@@ -5851,6 +6095,18 @@ class OrchestratorRunner:
             # Register session for cancellation tracking
             self._register_session(tracker.execution_id, session_id)
             session_registered = True
+
+            # A public cancellation may have reserved this previously-paused
+            # owner between resume arbitration and registration.  Honor that
+            # request before restoring handles, assembling tools, or invoking
+            # any runtime effect.
+            if await self._check_startup_cancellation(session_id):
+                return await self._handle_cancellation(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=tracker.messages_processed,
+                    start_time=datetime.now(UTC),
+                )
 
             if execution_contract_changed and self._execution_contract is not None:
                 contract_progress = {
@@ -5930,6 +6186,16 @@ Note: This is a resumed session. Please continue from where execution was interr
             )
             await self._replay_workflow_state(session_id, state_tracker)
         except asyncio.CancelledError:
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=tracker.messages_processed,
+                    start_time=tracker.start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
@@ -5937,6 +6203,16 @@ Note: This is a resumed session. Please continue from where execution was interr
             )
             raise
         except Exception as e:
+            cancellation_result = (
+                await self._drain_requested_cancellation_before_pre_execution_cleanup(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=tracker.messages_processed,
+                    start_time=tracker.start_time,
+                )
+            )
+            if cancellation_result is not None:
+                return cancellation_result
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4211,6 +4211,23 @@ class OrchestratorRunner:
         # in a runner-wide mutable slot: concurrent preparations must not share
         # a capability or correlation id.
         authority_generation = self._begin_process_local_authority_generation()
+
+        def abort_process_local_preparation() -> None:
+            """Dispose every authority state reachable from an aborted prepare.
+
+            The registration may have completed before a later setup step
+            raises, while an earlier failure has only an unregistered issuance.
+            Both cleanup operations are idempotent and together leave no
+            capability or lease behind.
+            """
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            self._discard_process_local_authority(authority_generation)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+
         try:
             execution_contract = await asyncio.to_thread(
                 self._build_execution_contract,
@@ -4218,18 +4235,10 @@ class OrchestratorRunner:
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
-        except OrchestratorError as exc:
-            self._discard_process_local_authority(authority_generation)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
-            return Result.err(exc)
-        self._execution_contract = execution_contract
-
-        # Establish the exact capability and PID liveness lease before any
-        # durable RUNNING tracker can be reconstructed by an observer.  The
-        # resolved session id is allocated locally for that purpose rather
-        # than delegated to SessionRepository after its start event is written.
-        try:
+            # Establish the exact capability and PID liveness lease before any
+            # durable RUNNING tracker can be reconstructed by an observer. The
+            # resolved session id is allocated locally for that purpose rather
+            # than delegated to SessionRepository after its start event is written.
             self._register_process_local_authority(
                 session_id=resolved_session_id,
                 execution_id=exec_id,
@@ -4237,10 +4246,32 @@ class OrchestratorRunner:
                 generation=authority_generation,
             )
         except OrchestratorError as exc:
-            self._discard_process_local_authority(authority_generation)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            abort_process_local_preparation()
             return Result.err(exc)
+        except asyncio.CancelledError:
+            abort_process_local_preparation()
+            raise
+        except Exception as exc:
+            abort_process_local_preparation()
+            log.exception(
+                "orchestrator.runner.prepare_authority_failed",
+                execution_id=exec_id,
+                session_id=resolved_session_id,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to prepare process-local execution authority",
+                    details={
+                        "execution_id": exec_id,
+                        "session_id": resolved_session_id,
+                        "cause": type(exc).__name__,
+                    },
+                )
+            )
+        except BaseException:
+            abort_process_local_preparation()
+            raise
+        self._execution_contract = execution_contract
 
         try:
             session_result = await self._session_repo.create_session(
@@ -5611,53 +5642,65 @@ class OrchestratorRunner:
         # owner has crashed or exited and Foundation A must terminally reject it
         # rather than leave a restartable-looking RUNNING session stranded.
         if tracker.status != SessionStatus.PAUSED:
-            own_live_authority = self._has_live_process_local_authority(
-                session_id,
-                tracker.execution_id,
-                raw_contract,
-            )
-            held_elsewhere = (
-                not own_live_authority
-                and self._process_local_authority_held_elsewhere(
+            authority_generation, authority_claimed = (
+                self._claim_process_local_authority_generation(
                     session_id,
                     tracker.execution_id,
                     raw_contract,
                 )
             )
-            if not own_live_authority and not held_elsewhere:
-                error = await self._mark_process_local_resume_unavailable(
+            if authority_claimed:
+                # The current runner is already performing effects. Do not
+                # release its worktree or downgrade the typed nonterminal
+                # ownership result to a generic state error.
+                return Result.err(
+                    self._process_local_execution_in_progress_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            if authority_generation is not None:
+                # This runner still owns the live generation but the durable
+                # status is non-resumable. The probe claim was only for
+                # arbitration, so restore the pre-existing unclaimed state
+                # without touching its workspace or lease.
+                self._release_process_local_authority(
                     session_id=session_id,
                     execution_id=tracker.execution_id,
                 )
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
-                    session_id,
-                    session_registered=False,
+                return Result.err(
+                    OrchestratorError(
+                        message=(
+                            f"Session is not paused and cannot resume ({tracker.status.value})"
+                        ),
+                        details={
+                            "session_id": session_id,
+                            "status": tracker.status.value,
+                            "resume_blocked": "session_not_paused",
+                        },
+                    )
                 )
-                return Result.err(error)
-            if held_elsewhere:
+            if self._process_local_authority_held_elsewhere(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
                 return Result.err(
                     self._process_local_authority_held_elsewhere_error(
                         session_id,
                         tracker.execution_id,
                     )
                 )
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
-                retire_authority=False,
             )
-            return Result.err(
-                OrchestratorError(
-                    message=f"Session is not paused and cannot resume ({tracker.status.value})",
-                    details={
-                        "session_id": session_id,
-                        "status": tracker.status.value,
-                        "resume_blocked": "session_not_paused",
-                    },
-                )
-            )
+            return Result.err(error)
 
         # This is intentionally before Foundation A contract restoration,
         # resume-handle selection, and every runtime-owned identity provider.

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1439,6 +1439,61 @@ class OrchestratorRunner:
             )
         )
 
+    async def _resolve_pause_publication(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        pause_result: Result[bool, PersistenceError],
+    ) -> tuple[
+        SessionStatus | None,
+        Result[OrchestratorResult, OrchestratorError] | None,
+    ]:
+        """Resolve conditional PAUSED publication against a terminal winner.
+
+        ``PAUSED`` means the pause append won. An explicit terminal status
+        means the pause lost and callers must project/clean up that durable
+        winner. An unreadable winner is retryable and preserves the exact
+        process-local owner rather than guessing at lifecycle state.
+        """
+        if pause_result.is_err:
+            return None, self._pause_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=pause_result.error,
+            )
+        if pause_result.value:
+            return SessionStatus.PAUSED, None
+
+        try:
+            reconstructed = await self._session_repo.reconstruct_session(session_id)
+        except Exception as exc:
+            return None, self._pause_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=exc,
+            )
+        if reconstructed.is_ok and reconstructed.value.status in {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.CANCELLED,
+        }:
+            return reconstructed.value.status, None
+
+        cause: object = (
+            reconstructed.error
+            if reconstructed.is_err
+            else PersistenceError(
+                "Conditional pause lost but no durable terminal winner could be reconstructed",
+                details={"session_id": session_id},
+            )
+        )
+        return None, self._pause_persistence_pending_result(
+            session_id=session_id,
+            execution_id=execution_id,
+            cause=cause,
+        )
+
     async def _project_execution_outcome(
         self,
         *,
@@ -5805,20 +5860,30 @@ class OrchestratorRunner:
                     resume_after=recoverable_failure_pause.resume_after,
                     pause_kind=recoverable_failure_pause.pause_kind,
                 )
-                if pause_result.is_err:
-                    return self._pause_persistence_pending_result(
-                        session_id=tracker.session_id,
-                        execution_id=exec_id,
-                        cause=pause_result.error,
-                    )
-
-                self._console.print(
-                    Panel(
-                        Text(final_message[:1000], style="yellow"),
-                        title="[yellow]Execution Paused[/yellow]",
-                        border_style="yellow",
-                    )
+                pause_status, pause_pending = await self._resolve_pause_publication(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    pause_result=pause_result,
                 )
+                if pause_pending is not None:
+                    return pause_pending
+                assert pause_status is not None
+                if pause_status is SessionStatus.PAUSED:
+                    self._console.print(
+                        Panel(
+                            Text(final_message[:1000], style="yellow"),
+                            title="[yellow]Execution Paused[/yellow]",
+                            border_style="yellow",
+                        )
+                    )
+                else:
+                    durable_terminal_status = pause_status
+                    recoverable_failure_pause = None
+                    success = pause_status is SessionStatus.COMPLETED
+                    final_message = (
+                        "Execution pause was not persisted because the session was already "
+                        f"{pause_status.value}."
+                    )
             else:
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
@@ -6277,20 +6342,30 @@ class OrchestratorRunner:
                 resume_after=recoverable_failure_pause.resume_after,
                 pause_kind=recoverable_failure_pause.pause_kind,
             )
-            if pause_result.is_err:
-                return self._pause_persistence_pending_result(
-                    session_id=tracker.session_id,
-                    execution_id=exec_id,
-                    cause=pause_result.error,
-                )
-
-            self._console.print(
-                Panel(
-                    Text(final_message, style="yellow"),
-                    title="[yellow]Parallel Execution Paused[/yellow]",
-                    border_style="yellow",
-                )
+            pause_status, pause_pending = await self._resolve_pause_publication(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                pause_result=pause_result,
             )
+            if pause_pending is not None:
+                return pause_pending
+            assert pause_status is not None
+            if pause_status is SessionStatus.PAUSED:
+                self._console.print(
+                    Panel(
+                        Text(final_message, style="yellow"),
+                        title="[yellow]Parallel Execution Paused[/yellow]",
+                        border_style="yellow",
+                    )
+                )
+            else:
+                durable_terminal_status = pause_status
+                recoverable_failure_pause = None
+                success = pause_status is SessionStatus.COMPLETED
+                final_message = (
+                    "Parallel pause was not persisted because the session was already "
+                    f"{pause_status.value}."
+                )
         else:
             durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
@@ -7078,19 +7153,30 @@ Note: This is a resumed session. Please continue from where execution was interr
                     resume_after=recoverable_resume_failure.resume_after,
                     pause_kind=recoverable_resume_failure.pause_kind,
                 )
-                if pause_result.is_err:
-                    return self._pause_persistence_pending_result(
-                        session_id=session_id,
-                        execution_id=tracker.execution_id,
-                        cause=pause_result.error,
-                    )
-                self._console.print(
-                    Panel(
-                        Text(final_message[:1000], style="yellow"),
-                        title="[yellow]Resumed Execution Paused[/yellow]",
-                        border_style="yellow",
-                    )
+                pause_status, pause_pending = await self._resolve_pause_publication(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    pause_result=pause_result,
                 )
+                if pause_pending is not None:
+                    return pause_pending
+                assert pause_status is not None
+                if pause_status is SessionStatus.PAUSED:
+                    self._console.print(
+                        Panel(
+                            Text(final_message[:1000], style="yellow"),
+                            title="[yellow]Resumed Execution Paused[/yellow]",
+                            border_style="yellow",
+                        )
+                    )
+                else:
+                    durable_terminal_status = pause_status
+                    recoverable_resume_failure = None
+                    success = pause_status is SessionStatus.COMPLETED
+                    final_message = (
+                        "Resumed execution pause was not persisted because the session was already "
+                        f"{pause_status.value}."
+                    )
             else:
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=session_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4592,7 +4592,11 @@ class OrchestratorRunner:
 
         if session_id is not None:
             # In-flight cancellation: signal via the cancellation registry
-            await request_cancellation(session_id)
+            await request_cancellation(
+                session_id,
+                reason=reason,
+                cancelled_by=cancelled_by,
+            )
             log.info(
                 "orchestrator.runner.cancellation_requested",
                 execution_id=execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -92,6 +92,7 @@ from ouroboros.orchestrator.execution_authority import (
     _claim_process_local_authority_generation,
     _discard_process_local_authority_generation,
     _has_live_process_local_authority_registration,
+    _has_live_process_local_authority_session,
     _live_process_local_authority_generation,
     _mint_process_local_authority_generation,
     _process_local_authority_contract,
@@ -5437,6 +5438,7 @@ class OrchestratorRunner:
         # in a runner-wide mutable slot: concurrent preparations must not share
         # a capability or correlation id.
         authority_generation = self._begin_process_local_authority_generation()
+        workspace_had_existing_owner = bool(self._process_local_authorities)
 
         def abort_process_local_preparation() -> None:
             """Dispose every authority state reachable from an aborted prepare.
@@ -5451,7 +5453,24 @@ class OrchestratorRunner:
                 execution_id=exec_id,
             )
             self._discard_process_local_authority(authority_generation)
-            if self._task_workspace is not None:
+            # The workspace lock is runner-wide, while this authority
+            # generation belongs only to the current preparation. A rejected
+            # second preparation must not release exclusion still owned by an
+            # earlier live session. The dynamic check also covers concurrent
+            # preparations that both began before either registered.
+            workspace_has_other_owner = any(
+                identity != (resolved_session_id, exec_id)
+                for identity in self._process_local_authorities
+            )
+            workspace_has_live_session_owner = _has_live_process_local_authority_session(
+                resolved_session_id
+            )
+            if (
+                self._task_workspace is not None
+                and not workspace_had_existing_owner
+                and not workspace_has_other_owner
+                and not workspace_has_live_session_owner
+            ):
                 release_lock(self._task_workspace.lock_path)
 
         try:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1408,6 +1408,28 @@ class OrchestratorRunner:
             execution_id=execution_id,
         )
 
+    async def _cleanup_terminal_process_local_state(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Retire all live state, then acknowledge cancellation last."""
+
+        async def _cleanup() -> None:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            self._unregister_session(execution_id, session_id)
+            self._release_task_workspace_for_identity(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            await clear_cancellation(session_id)
+
+        await _await_process_local_cleanup(_cleanup())
+
     def _release_task_workspace_for_identity(
         self,
         *,
@@ -1719,13 +1741,7 @@ class OrchestratorRunner:
                 return None
             durable_status = reconstructed.value.status
             self._pending_lifecycle_intents.pop(session_id, None)
-            self._retire_process_local_authority(
-                session_id=session_id,
-                execution_id=execution_id,
-            )
-            self._unregister_session(execution_id, session_id)
-            await clear_cancellation(session_id)
-            self._release_task_workspace_for_identity(
+            await self._cleanup_terminal_process_local_state(
                 session_id=session_id,
                 execution_id=execution_id,
             )
@@ -1806,13 +1822,7 @@ class OrchestratorRunner:
             )
 
         if not reconciled_during_exception:
-            self._retire_process_local_authority(
-                session_id=session_id,
-                execution_id=execution_id,
-            )
-            self._unregister_session(execution_id, session_id)
-            await clear_cancellation(session_id)
-            self._release_task_workspace_for_identity(
+            await self._cleanup_terminal_process_local_state(
                 session_id=session_id,
                 execution_id=execution_id,
             )
@@ -2519,7 +2529,6 @@ class OrchestratorRunner:
                         session_id=session_id,
                         execution_id=execution_id,
                     )
-                    await clear_cancellation(session_id)
                     return error
                 last_error = result.error
             log.warning(
@@ -2634,6 +2643,7 @@ class OrchestratorRunner:
         """
 
         async def _reconcile() -> bool:
+            terminal_cleanup_completed = False
             try:
                 reconstructed = await self._session_repo.reconstruct_session(session_id)
             except Exception:
@@ -2658,11 +2668,11 @@ class OrchestratorRunner:
                         SessionStatus.FAILED,
                         SessionStatus.CANCELLED,
                     }:
-                        self._retire_process_local_authority(
+                        await self._cleanup_terminal_process_local_state(
                             session_id=session_id,
                             execution_id=execution_id,
                         )
-                        await clear_cancellation(session_id)
+                        terminal_cleanup_completed = True
                     else:
                         terminal_mark_error = await self._mark_preparation_failed_best_effort(
                             tracker=tracker,
@@ -2674,11 +2684,11 @@ class OrchestratorRunner:
                             },
                         )
                         if terminal_mark_error is None:
-                            self._retire_process_local_authority(
+                            await self._cleanup_terminal_process_local_state(
                                 session_id=session_id,
                                 execution_id=execution_id,
                             )
-                            await clear_cancellation(session_id)
+                            terminal_cleanup_completed = True
                         else:
                             log.warning(
                                 "orchestrator.runner.create_session_cancel_terminal_pending",
@@ -2686,10 +2696,11 @@ class OrchestratorRunner:
                                 execution_id=execution_id,
                                 error=terminal_mark_error,
                             )
-            self._release_task_workspace_for_identity(
-                session_id=session_id,
-                execution_id=execution_id,
-            )
+            if not terminal_cleanup_completed:
+                self._release_task_workspace_for_identity(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
             return (session_id, execution_id) in self._process_local_authorities
 
         return bool(await _await_process_local_cleanup(_reconcile()))
@@ -3033,17 +3044,15 @@ class OrchestratorRunner:
                     tracker.session_id,
                     release_liveness_lease=False,
                 )
-            else:
-                self._retire_process_local_authority(
+                self._release_task_workspace_for_identity(
                     session_id=tracker.session_id,
                     execution_id=tracker.execution_id,
                 )
-                self._unregister_session(tracker.execution_id, tracker.session_id)
-                await clear_cancellation(tracker.session_id)
-            self._release_task_workspace_for_identity(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+            else:
+                await self._cleanup_terminal_process_local_state(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
 
         self._pending_lifecycle_intents.pop(tracker.session_id, None)
         return Result.ok(
@@ -4785,15 +4794,10 @@ class OrchestratorRunner:
             SessionStatus.FAILED,
             SessionStatus.CANCELLED,
         }:
-            self._retire_process_local_authority(
+            await self._cleanup_terminal_process_local_state(
                 session_id=session_id,
                 execution_id=execution_id,
             )
-            self._release_task_workspace_for_identity(
-                session_id=session_id,
-                execution_id=execution_id,
-            )
-            await clear_cancellation(session_id)
             return Result.ok(
                 {
                     "execution_id": execution_id,
@@ -5305,7 +5309,6 @@ class OrchestratorRunner:
 
             async def _reconcile_existing_terminal_owner() -> None:
                 try:
-                    await clear_cancellation(session_id)
                     if not execution_terminal_events:
                         await self._event_store.append(
                             create_execution_terminal_event(
@@ -5324,12 +5327,7 @@ class OrchestratorRunner:
                             )
                         )
                 finally:
-                    self._retire_process_local_authority(
-                        session_id=session_id,
-                        execution_id=execution_id,
-                    )
-                    self._unregister_session(execution_id, session_id)
-                    self._release_task_workspace_for_identity(
+                    await self._cleanup_terminal_process_local_state(
                         session_id=session_id,
                         execution_id=execution_id,
                     )
@@ -5431,7 +5429,6 @@ class OrchestratorRunner:
         # durable CAS has committed.
         async def _reconcile_cancelled_owner() -> None:
             try:
-                await clear_cancellation(session_id)
                 await self._event_store.append(
                     create_execution_terminal_event(
                         execution_id=execution_id,
@@ -5442,12 +5439,7 @@ class OrchestratorRunner:
                     )
                 )
             finally:
-                self._retire_process_local_authority(
-                    session_id=session_id,
-                    execution_id=execution_id,
-                )
-                self._unregister_session(execution_id, session_id)
-                self._release_task_workspace_for_identity(
+                await self._cleanup_terminal_process_local_state(
                     session_id=session_id,
                     execution_id=execution_id,
                 )
@@ -5881,12 +5873,10 @@ class OrchestratorRunner:
                 SessionStatus.CANCELLED,
                 SessionStatus.FAILED,
             }:
-                self._cleanup_pre_execution_state(
-                    durable_tracker.execution_id,
-                    durable_tracker.session_id,
-                    session_registered=False,
+                await self._cleanup_terminal_process_local_state(
+                    session_id=durable_tracker.session_id,
+                    execution_id=durable_tracker.execution_id,
                 )
-                await clear_cancellation(durable_tracker.session_id)
                 return Result.err(
                     OrchestratorError(
                         message=(
@@ -6579,9 +6569,8 @@ class OrchestratorRunner:
                 duration_seconds=duration,
             )
 
-            # Clean up session tracking
             if terminal_status != "paused":
-                self._retire_process_local_authority(
+                await self._cleanup_terminal_process_local_state(
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                 )
@@ -6590,17 +6579,15 @@ class OrchestratorRunner:
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                 )
-            self._unregister_session(
-                exec_id,
-                tracker.session_id,
-                release_liveness_lease=terminal_status != "paused",
-            )
-            if terminal_status != "paused":
-                await clear_cancellation(tracker.session_id)
-            self._release_task_workspace_for_identity(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+                self._unregister_session(
+                    exec_id,
+                    tracker.session_id,
+                    release_liveness_lease=False,
+                )
+                self._release_task_workspace_for_identity(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
 
             return Result.ok(
                 OrchestratorResult(
@@ -7073,9 +7060,8 @@ class OrchestratorRunner:
             duration_seconds=duration,
         )
 
-        # Clean up session tracking
         if terminal_status != "paused":
-            self._retire_process_local_authority(
+            await self._cleanup_terminal_process_local_state(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
             )
@@ -7084,17 +7070,15 @@ class OrchestratorRunner:
                 session_id=tracker.session_id,
                 execution_id=exec_id,
             )
-        self._unregister_session(
-            exec_id,
-            tracker.session_id,
-            release_liveness_lease=terminal_status != "paused",
-        )
-        if terminal_status != "paused":
-            await clear_cancellation(tracker.session_id)
-        self._release_task_workspace_for_identity(
-            session_id=tracker.session_id,
-            execution_id=tracker.execution_id,
-        )
+            self._unregister_session(
+                exec_id,
+                tracker.session_id,
+                release_liveness_lease=False,
+            )
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
         return Result.ok(
             OrchestratorResult(
@@ -7154,12 +7138,10 @@ class OrchestratorRunner:
             SessionStatus.FAILED,
         ):
             self._pending_lifecycle_intents.pop(session_id, None)
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
+            await self._cleanup_terminal_process_local_state(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
             )
-            await clear_cancellation(session_id)
             return Result.err(
                 OrchestratorError(
                     message=f"Session is in terminal state {tracker.status.value}, cannot resume",
@@ -7183,6 +7165,8 @@ class OrchestratorRunner:
                 session_registered=False,
                 retire_authority=False,
             )
+            if error.details.get("terminal_persistence_pending") is not True:
+                await clear_cancellation(session_id)
             return Result.err(error)
 
         # Persisted process-local authority is arbitrated before any policy
@@ -7222,6 +7206,8 @@ class OrchestratorRunner:
                 session_registered=False,
                 retire_authority=False,
             )
+            if error.details.get("terminal_persistence_pending") is not True:
+                await clear_cancellation(session_id)
             return Result.err(error)
 
         # A RUNNING tracker with a current Foundation A contract belongs to an
@@ -7827,32 +7813,31 @@ Note: This is a resumed session. Please continue from where execution was interr
                 duration_seconds=duration,
             )
 
-            # A paused owner has not acknowledged a cancellation that may have
-            # arrived after its final execution checkpoint. Preserve that
-            # marker so the next resume entry point terminalizes before effects.
-            if terminal_status != "paused":
-                await clear_cancellation(session_id)
+            async def _cleanup_resumed_owner() -> None:
+                # A paused owner has not acknowledged a cancellation that may
+                # have arrived after its final execution checkpoint. Preserve
+                # that marker so the next resume terminalizes before effects.
+                if terminal_status != "paused":
+                    await self._cleanup_terminal_process_local_state(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                else:
+                    self._release_process_local_authority(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                    self._unregister_session(
+                        tracker.execution_id,
+                        session_id,
+                        release_liveness_lease=False,
+                    )
+                    self._release_task_workspace_for_identity(
+                        session_id=tracker.session_id,
+                        execution_id=tracker.execution_id,
+                    )
 
-            # Clean up session tracking
-            if terminal_status != "paused":
-                self._retire_process_local_authority(
-                    session_id=session_id,
-                    execution_id=tracker.execution_id,
-                )
-            else:
-                self._release_process_local_authority(
-                    session_id=session_id,
-                    execution_id=tracker.execution_id,
-                )
-            self._unregister_session(
-                tracker.execution_id,
-                session_id,
-                release_liveness_lease=terminal_status != "paused",
-            )
-            self._release_task_workspace_for_identity(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+            await _await_process_local_cleanup(_cleanup_resumed_owner())
 
             return Result.ok(
                 OrchestratorResult(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1287,8 +1287,11 @@ class OrchestratorRunner:
         """
         from ouroboros.orchestrator.heartbeat import acquire as acquire_lock
 
-        self._active_sessions[execution_id] = session_id
         acquire_lock(session_id)
+        # Do not publish an in-memory cancellation route before its liveness
+        # lease exists. A failed claim must not leave a routable, unowned
+        # session behind.
+        self._active_sessions[execution_id] = session_id
 
     def _unregister_session(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -168,6 +168,7 @@ if TYPE_CHECKING:
     from ouroboros.events.base import BaseEvent
     from ouroboros.mcp.client.manager import MCPClientManager
     from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
+    from ouroboros.orchestrator.heartbeat import CancellationRequest
     from ouroboros.orchestrator.model_routing import ModelRouter
     from ouroboros.orchestrator.synapse import SessionSignalHub
     from ouroboros.persistence.event_store import EventStore
@@ -267,15 +268,20 @@ class ExecutionCancelledError(OuroborosError):
 # In-memory Cancellation Registry
 # =============================================================================
 
-# Module-level set of session IDs marked for cancellation.
-# The MCP cancel tool adds IDs here; the runner's execution loop checks it.
+# Module-level requests keyed by session ID.
+# The MCP cancel tool adds metadata here; the runner's execution loop checks it.
 # Guarded by _cancellation_lock to prevent races between MCP cancel calls
-# and the runner's message loop reading the set concurrently.
-_cancellation_registry: set[str] = set()
+# and the runner's message loop reading the mapping concurrently.
+_cancellation_registry: dict[str, CancellationRequest] = {}
 _cancellation_lock: asyncio.Lock = asyncio.Lock()
 
 
-async def request_cancellation(session_id: str) -> None:
+async def request_cancellation(
+    session_id: str,
+    *,
+    reason: str = "Cancellation detected during execution",
+    cancelled_by: str = "runner",
+) -> None:
     """Mark a session for cancellation.
 
     Called by the MCP cancel tool to signal that the runner should
@@ -284,8 +290,24 @@ async def request_cancellation(session_id: str) -> None:
     Args:
         session_id: Session to cancel.
     """
+    from ouroboros.orchestrator.heartbeat import normalize_cancellation_request
+
     async with _cancellation_lock:
-        _cancellation_registry.add(session_id)
+        _cancellation_registry[session_id] = normalize_cancellation_request(
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
+
+
+async def get_cancellation_request(session_id: str) -> CancellationRequest | None:
+    """Return local or cross-process metadata for a pending cancellation."""
+    async with _cancellation_lock:
+        request = _cancellation_registry.get(session_id)
+    if request is not None:
+        return request
+    from ouroboros.orchestrator.heartbeat import read_cancellation_request
+
+    return read_cancellation_request(session_id)
 
 
 async def is_cancellation_requested(session_id: str) -> bool:
@@ -297,12 +319,7 @@ async def is_cancellation_requested(session_id: str) -> bool:
     Returns:
         True if cancellation was requested.
     """
-    async with _cancellation_lock:
-        if session_id in _cancellation_registry:
-            return True
-    from ouroboros.orchestrator.heartbeat import has_cancellation_request
-
-    return has_cancellation_request(session_id)
+    return await get_cancellation_request(session_id) is not None
 
 
 async def clear_cancellation(session_id: str) -> None:
@@ -315,7 +332,7 @@ async def clear_cancellation(session_id: str) -> None:
         session_id: Session to clear.
     """
     async with _cancellation_lock:
-        _cancellation_registry.discard(session_id)
+        _cancellation_registry.pop(session_id, None)
     from ouroboros.orchestrator.heartbeat import clear_cancellation_request
 
     clear_cancellation_request(session_id)
@@ -5039,6 +5056,15 @@ class OrchestratorRunner:
             messages_processed=messages_processed,
             duration_seconds=duration,
         )
+        cancellation_request = await get_cancellation_request(session_id)
+        cancellation_reason = (
+            cancellation_request.reason
+            if cancellation_request is not None
+            else "Cancellation detected during execution"
+        )
+        cancelled_by = (
+            cancellation_request.cancelled_by if cancellation_request is not None else "runner"
+        )
 
         # Determine and durably publish the terminal state *before* withdrawing
         # the process-local capability or its heartbeat.  A RUNNING tracker
@@ -5069,31 +5095,37 @@ class OrchestratorRunner:
                 )
             except Exception:
                 execution_terminal_events = []
-            await clear_cancellation(session_id)
-            try:
-                if not execution_terminal_events:
-                    await self._event_store.append(
-                        create_execution_terminal_event(
-                            execution_id=execution_id,
-                            session_id=session_id,
-                            status=terminal_status.value,
-                            summary=summary if terminal_status == SessionStatus.COMPLETED else None,
-                            error_message=(
-                                final_message
-                                if terminal_status != SessionStatus.COMPLETED
-                                else None
-                            ),
-                            messages_processed=messages_processed,
+
+            async def _reconcile_existing_terminal_owner() -> None:
+                try:
+                    await clear_cancellation(session_id)
+                    if not execution_terminal_events:
+                        await self._event_store.append(
+                            create_execution_terminal_event(
+                                execution_id=execution_id,
+                                session_id=session_id,
+                                status=terminal_status.value,
+                                summary=(
+                                    summary if terminal_status == SessionStatus.COMPLETED else None
+                                ),
+                                error_message=(
+                                    final_message
+                                    if terminal_status != SessionStatus.COMPLETED
+                                    else None
+                                ),
+                                messages_processed=messages_processed,
+                            )
                         )
+                finally:
+                    self._retire_process_local_authority(
+                        session_id=session_id,
+                        execution_id=execution_id,
                     )
-            finally:
-                self._retire_process_local_authority(
-                    session_id=session_id,
-                    execution_id=execution_id,
-                )
-                self._unregister_session(execution_id, session_id)
-                if self._task_workspace is not None:
-                    release_lock(self._task_workspace.lock_path)
+                    self._unregister_session(execution_id, session_id)
+                    if self._task_workspace is not None:
+                        release_lock(self._task_workspace.lock_path)
+
+            await _await_process_local_cleanup(_reconcile_existing_terminal_owner())
             await self._report_frugality_retrospective(
                 execution_id=execution_id,
                 session_id=session_id,
@@ -5114,8 +5146,8 @@ class OrchestratorRunner:
         try:
             cancel_result = await self._session_repo.mark_cancelled(
                 session_id,
-                reason="Cancellation detected during execution",
-                cancelled_by="runner",
+                reason=cancellation_reason,
+                cancelled_by=cancelled_by,
             )
         except Exception as exc:
             log.warning(
@@ -5160,28 +5192,32 @@ class OrchestratorRunner:
                 ),
             )
 
-        # The session is now terminal.  It is safe to clear the request and
-        # retire the live capability; the execution-stream mirror is useful to
-        # projections but no longer determines whether cleanup is safe.
-        await clear_cancellation(session_id)
-        try:
-            await self._event_store.append(
-                create_execution_terminal_event(
-                    execution_id=execution_id,
-                    session_id=session_id,
-                    status="cancelled",
-                    error_message="Execution cancelled by external request",
-                    messages_processed=messages_processed,
+        # The session is now terminal. Drain the complete reconciliation in a
+        # shielded child task: repeated caller cancellation may not interrupt
+        # marker acknowledgement, projection, or live-owner teardown after the
+        # durable CAS has committed.
+        async def _reconcile_cancelled_owner() -> None:
+            try:
+                await clear_cancellation(session_id)
+                await self._event_store.append(
+                    create_execution_terminal_event(
+                        execution_id=execution_id,
+                        session_id=session_id,
+                        status="cancelled",
+                        error_message=cancellation_reason,
+                        messages_processed=messages_processed,
+                    )
                 )
-            )
-        finally:
-            self._retire_process_local_authority(
-                session_id=session_id,
-                execution_id=execution_id,
-            )
-            self._unregister_session(execution_id, session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            finally:
+                self._retire_process_local_authority(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                self._unregister_session(execution_id, session_id)
+                if self._task_workspace is not None:
+                    release_lock(self._task_workspace.lock_path)
+
+        await _await_process_local_cleanup(_reconcile_cancelled_owner())
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -7669,6 +7705,7 @@ __all__ = [
     "build_system_prompt",
     "build_task_prompt",
     "clear_cancellation",
+    "get_cancellation_request",
     "get_pending_cancellations",
     "is_cancellation_requested",
     "request_cancellation",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1411,6 +1411,78 @@ class OrchestratorRunner:
             )
         )
 
+    @staticmethod
+    def _requested_terminal_status_from_error(error: BaseException) -> SessionStatus | None:
+        """Recover the original terminal intent from a typed persistence error."""
+        if not isinstance(error, OrchestratorError):
+            return None
+        details = error.details
+        if details.get("terminal_persistence_pending") is not True:
+            return None
+        requested_status = details.get("requested_status")
+        try:
+            status = SessionStatus(requested_status)
+        except (TypeError, ValueError):
+            return None
+        if status not in {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.CANCELLED,
+        }:
+            return None
+        return status
+
+    def _terminal_persistence_pending_from_error(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        error: BaseException,
+    ) -> Result[OrchestratorResult, OrchestratorError] | None:
+        """Preserve ownership instead of changing a failed terminal intent."""
+        requested_status = self._requested_terminal_status_from_error(error)
+        if requested_status is None:
+            return None
+        return self._terminal_persistence_pending_result(
+            session_id=session_id,
+            execution_id=execution_id,
+            requested_status=requested_status,
+            cause=error,
+        )
+
+    async def _cleanup_if_durable_terminal(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> bool:
+        """Retire a claimed owner only after reconstructing a terminal winner.
+
+        Cancellation can arrive after the session CAS commits but before the
+        execution-stream projection or ordinary cleanup finishes.  In that
+        window preserving the live generation would contradict the durable
+        terminal source of truth, so interruption paths reconcile first.
+        """
+        try:
+            reconstructed = await self._session_repo.reconstruct_session(session_id)
+        except Exception:
+            return False
+        if reconstructed.is_err or reconstructed.value.status not in {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.CANCELLED,
+        }:
+            return False
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        self._unregister_session(execution_id, session_id)
+        await clear_cancellation(session_id)
+        if self._task_workspace is not None:
+            release_lock(self._task_workspace.lock_path)
+        return True
+
     async def _persist_failure_and_cleanup(
         self,
         *,
@@ -2200,42 +2272,77 @@ class OrchestratorRunner:
         winner, otherwise completion and public cancellation can produce
         contradictory terminal streams.
         """
-        if requested_status is SessionStatus.COMPLETED:
-            result = await self._session_repo.mark_completed(
-                session_id,
-                summary,
-                messages_processed=messages_processed,
+        result: Any = None
+        last_error: object | None = None
+        for attempt in range(3):
+            try:
+                if requested_status is SessionStatus.COMPLETED:
+                    result = await self._session_repo.mark_completed(
+                        session_id,
+                        summary,
+                        messages_processed=messages_processed,
+                    )
+                elif requested_status is SessionStatus.FAILED:
+                    result = await self._session_repo.mark_failed(
+                        session_id,
+                        error_message or "Execution failed",
+                        error_details,
+                        error_type=error_type,
+                        messages_processed=messages_processed,
+                    )
+                elif requested_status is SessionStatus.CANCELLED:
+                    result = await self._session_repo.mark_cancelled(
+                        session_id,
+                        reason=error_message or "Execution cancelled",
+                        cancelled_by=cancelled_by,
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported terminal session status: {requested_status.value}"
+                    )
+            except Exception as exc:
+                last_error = exc
+            else:
+                if result.is_ok:
+                    break
+                last_error = result.error
+            log.warning(
+                "orchestrator.runner.terminal_persistence_retry",
+                session_id=session_id,
+                requested_status=requested_status.value,
+                attempt=attempt + 1,
+                error=str(last_error),
             )
-        elif requested_status is SessionStatus.FAILED:
-            result = await self._session_repo.mark_failed(
-                session_id,
-                error_message or "Execution failed",
-                error_details,
-                error_type=error_type,
-                messages_processed=messages_processed,
-            )
-        elif requested_status is SessionStatus.CANCELLED:
-            result = await self._session_repo.mark_cancelled(
-                session_id,
-                reason=error_message or "Execution cancelled",
-                cancelled_by=cancelled_by,
-            )
+            if attempt < 2:
+                await asyncio.sleep(0.05 * (2**attempt))
         else:
-            raise ValueError(f"Unsupported terminal session status: {requested_status.value}")
-
-        if result.is_err:
             raise OrchestratorError(
                 message=f"Failed to persist terminal session status: {requested_status.value}",
                 details={
                     "session_id": session_id,
                     "requested_status": requested_status.value,
-                    "cause": str(result.error),
+                    "cause": str(last_error),
+                    "resume_blocked": "terminal_persistence_pending",
+                    "terminal_persistence_pending": True,
                 },
             )
+
         if result.value is not False:
             return requested_status
 
-        winner = await self._session_repo.reconstruct_session(session_id)
+        try:
+            winner = await self._session_repo.reconstruct_session(session_id)
+        except Exception as exc:
+            raise OrchestratorError(
+                message="Terminal session transition lost its CAS without a readable winner",
+                details={
+                    "session_id": session_id,
+                    "requested_status": requested_status.value,
+                    "cause": str(exc),
+                    "resume_blocked": "terminal_persistence_pending",
+                    "terminal_persistence_pending": True,
+                },
+            ) from exc
         terminal_statuses = {
             SessionStatus.COMPLETED,
             SessionStatus.FAILED,
@@ -2255,6 +2362,8 @@ class OrchestratorRunner:
                 "session_id": session_id,
                 "requested_status": requested_status.value,
                 **({"cause": str(winner.error)} if winner.is_err else {}),
+                "resume_blocked": "terminal_persistence_pending",
+                "terminal_persistence_pending": True,
             },
         )
 
@@ -5146,6 +5255,11 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
+            if await self._cleanup_if_durable_terminal(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            ):
+                raise
             self._preserve_process_local_owner_for_retry(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
@@ -5162,6 +5276,13 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
+            terminal_persistence_pending = self._terminal_persistence_pending_from_error(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                error=e,
+            )
+            if terminal_persistence_pending is not None:
+                return terminal_persistence_pending
             log.exception(
                 "orchestrator.runner.execute_setup_failed",
                 execution_id=exec_id,
@@ -5639,6 +5760,11 @@ class OrchestratorRunner:
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
+            if await self._cleanup_if_durable_terminal(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            ):
+                raise
             self._preserve_process_local_owner_for_retry(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
@@ -5651,6 +5777,13 @@ class OrchestratorRunner:
                 error=str(e),
             )
 
+            terminal_persistence_pending = self._terminal_persistence_pending_from_error(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                error=e,
+            )
+            if terminal_persistence_pending is not None:
+                return terminal_persistence_pending
             durable_terminal_status, persistence_pending = await self._persist_failure_and_cleanup(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
@@ -6394,6 +6527,11 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
+            if await self._cleanup_if_durable_terminal(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            ):
+                raise
             self._preserve_process_local_owner_for_retry(
                 execution_id=tracker.execution_id,
                 session_id=session_id,
@@ -6538,6 +6676,13 @@ Note: This is a resumed session. Please continue from where execution was interr
             )
             if cancellation_result is not None:
                 return cancellation_result
+            terminal_persistence_pending = self._terminal_persistence_pending_from_error(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+                error=e,
+            )
+            if terminal_persistence_pending is not None:
+                return terminal_persistence_pending
             log.exception(
                 "orchestrator.runner.resume_setup_failed",
                 session_id=session_id,
@@ -6876,6 +7021,11 @@ Note: This is a resumed session. Please continue from where execution was interr
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
+            if await self._cleanup_if_durable_terminal(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            ):
+                raise
             self._preserve_process_local_owner_for_retry(
                 session_id=session_id,
                 execution_id=tracker.execution_id,
@@ -6888,6 +7038,13 @@ Note: This is a resumed session. Please continue from where execution was interr
                 error=str(e),
             )
 
+            terminal_persistence_pending = self._terminal_persistence_pending_from_error(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+                error=e,
+            )
+            if terminal_persistence_pending is not None:
+                return terminal_persistence_pending
             durable_terminal_status, persistence_pending = await self._persist_failure_and_cleanup(
                 session_id=session_id,
                 execution_id=tracker.execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,23 @@ from ouroboros.orchestrator.events import (
     create_tool_called_event,
     create_workflow_progress_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    _claim_process_local_authority_generation,
+    _discard_process_local_authority_generation,
+    _has_live_process_local_authority_registration,
+    _live_process_local_authority_generation,
+    _mint_process_local_authority_generation,
+    _process_local_authority_contract,
+    _ProcessLocalAuthorityGeneration,
+    _register_process_local_authority_generation,
+    _release_process_local_authority_generation,
+    _retire_process_local_authority_generation,
+    constructor_model_contract,
+    runtime_execution_proves_effective_model,
+    valid_constructor_model_contract,
+    valid_process_local_authority_contract,
+    valid_runtime_execution_identity_contract,
+)
 from ouroboros.orchestrator.execution_guidance import (
     ExecutionGuidanceBundle,
     resolve_execution_guidance,
@@ -543,7 +560,7 @@ CANCELLATION_CHECK_INTERVAL = 5
 # most this many same-seed executions.
 FRUGALITY_PROOF_SESSION_LOOKBACK = 1000
 FRUGALITY_PROOF_MAX_COHORT_RUNS = 50
-EXECUTION_CONTRACT_VERSION = 1
+EXECUTION_CONTRACT_VERSION = 2
 FRUGALITY_PROOF_PROTOCOL_VERSION = 1
 EXECUTION_CONTRACT_PROGRESS_KEY = "execution_contract"
 FORCED_EXECUTION_PERMISSION_MODE = "bypassPermissions"
@@ -784,6 +801,9 @@ class OrchestratorRunner:
             )
         self._apply_efficiency_mode_to_router()
         self._execution_contract: dict[str, Any] | None = None
+        self._process_local_authorities: dict[
+            tuple[str, str], _ProcessLocalAuthorityGeneration
+        ] = {}
         self._execution_guidance: ExecutionGuidanceBundle | None = None
         # Opt-in shadow-replay baseline harness (frugality-proof AC5). Read ONCE
         # here next to the router build and threaded to the parallel executor.
@@ -1270,22 +1290,34 @@ class OrchestratorRunner:
         self._active_sessions[execution_id] = session_id
         acquire_lock(session_id)
 
-    def _unregister_session(self, execution_id: str, session_id: str) -> None:
+    def _unregister_session(
+        self,
+        execution_id: str,
+        session_id: str,
+        *,
+        release_liveness_lease: bool = True,
+    ) -> None:
         """Unregister a session after execution completes.
 
         Called at the end of execution (success, failure, or cancellation)
-        to clean up tracking state and remove the heartbeat file.
+        to clean up tracking state and normally remove the heartbeat file. A
+        deliberately paused process-local session keeps its liveness lease:
+        the claim is released so its original owner can resume it, while other
+        runners must still recognize that the live capability has not crashed.
 
         Args:
             execution_id: Execution ID to remove.
             session_id: Session ID to remove.
+            release_liveness_lease: Whether this lifecycle path is terminal and
+                may remove the PID liveness lease.
         """
         from ouroboros.orchestrator.heartbeat import (
             release_if_owned_by_current_process as release_lock,
         )
 
         self._active_sessions.pop(execution_id, None)
-        release_lock(session_id)
+        if release_liveness_lease:
+            release_lock(session_id)
 
     def _cleanup_pre_execution_state(
         self,
@@ -1293,8 +1325,19 @@ class OrchestratorRunner:
         session_id: str | None,
         *,
         session_registered: bool,
+        retire_authority: bool = True,
     ) -> None:
-        """Release pre-loop runner state after setup fails."""
+        """Release pre-loop runner state after an aborted execution path.
+
+        A setup failure or externally cancelled task does not leave a valid
+        same-process continuation.  Retire its live capability before releasing
+        bookkeeping so a stale tracker cannot become an alternate resume path.
+        """
+        if retire_authority and execution_id is not None and session_id is not None:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
         if session_registered and execution_id is not None and session_id is not None:
             self._unregister_session(execution_id, session_id)
         if self._task_workspace is not None:
@@ -1584,145 +1627,378 @@ class OrchestratorRunner:
         runtimes that expose no constructor model at all; current-format resume
         then fails closed because the effective pin cannot be verified.
         """
-        try:
-            raw_model = inspect.getattr_static(self._adapter, "_model")
-        except AttributeError:
-            return {"observed": False}
-        if raw_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(raw_model, str):
-            return {"observed": False}
-
-        normalized_model: object = raw_model.strip() or None
-        normalizer_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "_normalize_model",
-            None,
-        )
-        if normalizer_descriptor is not None:
-            try:
-                normalizer = object.__getattribute__(self._adapter, "_normalize_model")
-                normalized_model = normalizer(raw_model)
-            except Exception:
-                return {"observed": False}
-        if normalized_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(normalized_model, str) or not normalized_model.strip():
-            return {"observed": False}
-        return {"observed": True, "model": normalized_model.strip()}
+        return constructor_model_contract(self._adapter)
 
     @staticmethod
     def _valid_constructor_model_contract(value: object) -> bool:
         """Return whether a persisted constructor-model contract is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        observed = value.get("observed")
-        if observed is not True:
-            return False
-        model = value.get("model")
-        return set(value) == {"observed", "model"} and (
-            model is None or isinstance(model, str) and bool(model.strip())
-        )
+        return valid_constructor_model_contract(value)
 
     def _runtime_execution_identity_contract(self) -> dict[str, Any]:
-        """Return backend-specific resolved execution inputs, when observable.
+        """Return no cross-process identity for a legacy dynamic runtime.
 
-        The generic constructor-model pin is sufficient for runtimes whose
-        model is fully selected by ``_model``. Some runtimes have an additional
-        resolved execution profile, though: Codex can choose a provider/model
-        through ``runtime_profile`` / ``--profile`` while ``_model`` remains
-        ``None``. Bundled runtimes may expose ``execution_identity_contract`` to
-        persist those command-relevant inputs without teaching the runner every
-        backend's private configuration model.
+        Foundation A intentionally does not execute a runtime-owned identity
+        provider here.  That provider may itself resolve mutable helpers,
+        profile files, handler caches, or launcher state.  A live
+        process-local generation below controls same-process resume instead.
         """
-
-        provider_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "execution_identity_contract",
-            None,
-        )
-        if provider_descriptor is None:
-            return {"version": 1, "observed": False}
-
-        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
-        identity = provider()
-        if not isinstance(identity, Mapping):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        try:
-            encoded = json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-            normalized_identity = json.loads(encoded)
-        except (TypeError, ValueError) as exc:
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={
-                    "adapter_type": type(self._adapter).__name__,
-                    "cause": str(exc),
-                },
-            ) from exc
-        if not isinstance(normalized_identity, dict):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        return {
-            "version": 1,
-            "observed": True,
-            "identity": normalized_identity,
-        }
+        return {"version": 1, "observed": False}
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
         """Return whether a persisted backend execution identity is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        version = value.get("version")
-        observed = value.get("observed")
-        if (
-            isinstance(version, bool)
-            or not isinstance(version, int)
-            or version != 1
-            or not isinstance(observed, bool)
-        ):
-            return False
-        if not observed:
-            return set(value) == {"version", "observed"}
-        identity = value.get("identity")
-        if (
-            set(value) != {"version", "observed", "identity"}
-            or not isinstance(identity, Mapping)
-            or not identity
-        ):
-            return False
-        try:
-            json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError):
-            return False
-        return True
+        return valid_runtime_execution_identity_contract(value)
 
     @staticmethod
     def _runtime_execution_proves_effective_model(value: object) -> bool:
         """Return whether a backend identity observed a concrete model/profile."""
-        if not OrchestratorRunner._valid_runtime_execution_identity_contract(value):
+        return runtime_execution_proves_effective_model(value)
+
+    @staticmethod
+    def _begin_process_local_authority_generation() -> _ProcessLocalAuthorityGeneration:
+        """Mint one fresh live-only authority generation for a new session.
+
+        The generation is deliberately returned to the caller rather than kept
+        in a mutable runner-wide slot.  A single runner can prepare several
+        sessions concurrently, and each preparation must retain its exact
+        generation through contract creation and registry binding.
+        """
+        return _mint_process_local_authority_generation()
+
+    @staticmethod
+    def _process_local_authority_contract(
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> dict[str, object]:
+        """Build evidence-only scope data for one issued live generation."""
+        return _process_local_authority_contract(generation)
+
+    def _has_live_process_local_authority(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """Check live authority before restoring runtime-controlled state."""
+        if not isinstance(raw_contract, Mapping):
             return False
-        if not isinstance(value, Mapping) or value.get("observed") is not True:
+        authority = raw_contract.get("foundation_a_authority")
+        return (
+            _live_process_local_authority_generation(
+                session_id,
+                execution_id,
+                authority,
+                self._adapter,
+            )
+            is not None
+        )
+
+    def _has_live_process_local_authority_registration(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """See a local capability without granting another adapter its use.
+
+        This distinction lets an observer reject safely when another live
+        adapter owns the generation, instead of turning a valid paused or
+        transitioning session into a false crash recovery.
+        """
+        if not isinstance(raw_contract, Mapping):
             return False
-        identity = value.get("identity")
-        return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+        return _has_live_process_local_authority_registration(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+        )
+
+    def _process_local_authority_held_elsewhere(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> bool:
+        """Return whether another live owner retains this process-local session.
+
+        A different adapter must never receive the opaque capability, but it
+        must also never turn a valid owner into a false crash-recovery path.
+        The in-process registration covers a foreign adapter in this PID; the
+        PID lease covers a holder in another process.  The exact adapter's own
+        capability is intentionally excluded so normal non-paused validation
+        continues to report the session state rather than an ownership error.
+        """
+        if self._has_live_process_local_authority(session_id, execution_id, raw_contract):
+            return False
+        if self._has_live_process_local_authority_registration(
+            session_id,
+            execution_id,
+            raw_contract,
+        ):
+            return True
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+
+        return is_holder_alive(session_id)
+
+    def _live_process_local_authority_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> _ProcessLocalAuthorityGeneration | None:
+        """Return the registry-issued generation for an already-live session."""
+        if not isinstance(raw_contract, Mapping):
+            return None
+        return _live_process_local_authority_generation(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+            self._adapter,
+        )
+
+    def _claim_process_local_authority_generation(
+        self,
+        session_id: str,
+        execution_id: str,
+        raw_contract: object,
+    ) -> tuple[_ProcessLocalAuthorityGeneration | None, bool]:
+        """Claim a live capability before any effectful session work begins."""
+        if not isinstance(raw_contract, Mapping):
+            return None, False
+        return _claim_process_local_authority_generation(
+            session_id,
+            execution_id,
+            raw_contract.get("foundation_a_authority"),
+            self._adapter,
+        )
+
+    def _release_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Make a deliberately paused session resumable in this process again."""
+        _release_process_local_authority_generation(
+            session_id,
+            execution_id,
+            self._adapter,
+        )
+
+    def _register_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        execution_contract: Mapping[str, object],
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> None:
+        """Bind the persisted correlation record to its live process capability."""
+        authority = execution_contract.get("foundation_a_authority")
+        if (
+            not valid_process_local_authority_contract(authority)
+            or authority.get("correlation_id") != generation.correlation_id
+        ):
+            raise OrchestratorError(
+                message="Cannot create an invalid process-local execution authority",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "invalid": "foundation_a_authority",
+                },
+            )
+        from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+
+        try:
+            _register_process_local_authority_generation(
+                session_id,
+                execution_id,
+                generation,
+                self._adapter,
+            )
+        except ValueError as exc:
+            raise OrchestratorError(
+                message="Cannot register process-local execution authority",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "cause": str(exc),
+                },
+            ) from exc
+        self._process_local_authorities[(session_id, execution_id)] = generation
+        # Establish the cross-process liveness record as soon as a session owns
+        # a live capability, before a detached caller can observe its persisted
+        # RUNNING tracker.  It is a lease/liveness marker, never authority.
+        try:
+            acquire_session_lock(session_id)
+        except OSError as exc:
+            # A registry entry without its liveness lease would let another
+            # process misclassify a durable RUNNING tracker as crashed. Undo
+            # the exact binding before returning the setup failure.
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            raise OrchestratorError(
+                message="Cannot establish process-local execution liveness lease",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "cause": str(exc),
+                },
+            ) from exc
+
+    def _retire_process_local_authority(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> bool:
+        """Discard a terminal session's capability only when this adapter owns it."""
+        retired = _retire_process_local_authority_generation(
+            session_id,
+            execution_id,
+            self._adapter,
+        )
+        if retired:
+            from ouroboros.orchestrator.heartbeat import (
+                release_if_owned_by_current_process as release_session_lock,
+            )
+
+            release_session_lock(session_id)
+        self._process_local_authorities.pop((session_id, execution_id), None)
+        return retired
+
+    def _discard_process_local_authority(
+        self,
+        generation: _ProcessLocalAuthorityGeneration,
+    ) -> None:
+        """Discard an unregistered capability after failed preparation."""
+        _discard_process_local_authority_generation(generation)
+
+    @staticmethod
+    def _process_local_resume_unavailable_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Return the explicit non-fallback outcome for a lost live generation."""
+        return OrchestratorError(
+            message=(
+                "Cannot resume this process-local execution after its live authority "
+                "generation is unavailable; start a new attempt."
+            ),
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_resume_unavailable",
+            },
+        )
+
+    @staticmethod
+    def _process_local_execution_in_progress_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Return the non-terminal outcome for a concurrent same-process claim."""
+        return OrchestratorError(
+            message="This process-local execution is already active in this process.",
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_execution_in_progress",
+            },
+        )
+
+    @staticmethod
+    def _process_local_authority_held_elsewhere_error(
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Reject an observer without revoking another adapter's live binding."""
+        return OrchestratorError(
+            message=(
+                "This process-local execution is retained by another live runtime "
+                "adapter or process."
+            ),
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "resume_blocked": "process_local_authority_held_elsewhere",
+            },
+        )
+
+    async def _mark_process_local_resume_unavailable(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> OrchestratorError:
+        """Terminally record a lost local capability without trying a fallback."""
+        error = self._process_local_resume_unavailable_error(session_id, execution_id)
+        try:
+            result = await self._session_repo.mark_failed(
+                session_id,
+                error.message,
+                error.details,
+            )
+            if result.is_err:
+                log.warning(
+                    "orchestrator.runner.process_local_resume_terminal_mark_failed",
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    error=str(result.error),
+                )
+        except Exception as exc:  # pragma: no cover - best-effort terminal record
+            log.warning(
+                "orchestrator.runner.process_local_resume_terminal_mark_raised",
+                session_id=session_id,
+                execution_id=execution_id,
+                error=str(exc),
+            )
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        return error
+
+    async def _mark_preparation_failed_best_effort(
+        self,
+        *,
+        tracker: SessionTracker,
+        message: str,
+        details: Mapping[str, Any],
+    ) -> str | None:
+        """Record a post-start preparation failure without masking cleanup.
+
+        ``create_session`` has already written a RUNNING durable tracker by
+        the time initial progress is persisted.  If that second write fails,
+        leave neither an apparently resumable RUNNING session nor a live
+        process-local capability behind.  A persistence failure while writing
+        this terminal state is reported as diagnostics, never allowed to skip
+        authority retirement.
+        """
+        try:
+            result = await self._session_repo.mark_failed(
+                tracker.session_id,
+                message,
+                dict(details),
+            )
+        except Exception as exc:  # pragma: no cover - defensive persistence boundary
+            log.warning(
+                "orchestrator.runner.prepare_terminal_mark_raised",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=str(exc),
+            )
+            return str(exc)
+        if result.is_err:
+            log.warning(
+                "orchestrator.runner.prepare_terminal_mark_failed",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=str(result.error),
+            )
+            return str(result.error)
+        return None
 
     def _validate_resume_handle_execution_identity(
         self,
@@ -2003,6 +2279,7 @@ class OrchestratorRunner:
         *,
         seed: Seed | None = None,
         seed_fingerprint: str | None = None,
+        authority_generation: _ProcessLocalAuthorityGeneration | None = None,
     ) -> dict[str, Any]:
         """Build the durable resolved inputs shared by resume and proof cohorting."""
         from ouroboros.orchestrator.model_routing import serialize_model_router
@@ -2026,8 +2303,22 @@ class OrchestratorRunner:
             resolved_seed_fingerprint = self._seed_semantics_fingerprint(seed)
         if resolved_seed_fingerprint is not None:
             proof_contract["seed_fingerprint"] = resolved_seed_fingerprint
+        if authority_generation is None:
+            # Diagnostics and contract-validation callers need attribution
+            # shape, not a live capability. Do not mint a registry issuance
+            # here: there is no session lifecycle that could register and
+            # retire it. The random correlation remains evidence-only, and
+            # cannot be claimed or registered without an explicit generation.
+            authority_contract: dict[str, object] = {
+                "version": 1,
+                "scope": "process_local",
+                "correlation_id": uuid4().hex,
+            }
+        else:
+            authority_contract = self._process_local_authority_contract(authority_generation)
         return {
             "version": EXECUTION_CONTRACT_VERSION,
+            "foundation_a_authority": authority_contract,
             "execution_preferences": self._execution_preferences.to_contract_data(),
             "model_routing": routing_contract,
             "frugality_proof": proof_contract,
@@ -2274,6 +2565,7 @@ class OrchestratorRunner:
         progress: Mapping[str, Any],
         *,
         seed: Seed | None = None,
+        authority_generation: _ProcessLocalAuthorityGeneration | None = None,
     ) -> bool:
         """Restore the persisted router unless this invocation explicitly overrides it.
 
@@ -2285,7 +2577,10 @@ class OrchestratorRunner:
         if EXECUTION_CONTRACT_PROGRESS_KEY not in progress:
             self._validate_legacy_resume_identity(progress, seed=seed)
             self._execution_guidance = self._resolve_guidance_bundle(())
-            self._execution_contract = self._build_execution_contract(seed=seed)
+            self._execution_contract = self._build_execution_contract(
+                seed=seed,
+                authority_generation=authority_generation,
+            )
             # One unavoidable recomputation migrates a legacy session. Persist the
             # resolved contract now so every later resume restores this exact policy
             # instead of drifting again with each environment/config change.
@@ -2308,14 +2603,18 @@ class OrchestratorRunner:
         raw_routing = raw_contract.get("model_routing")
         raw_resume = raw_contract.get("resume")
         raw_preferences = raw_contract.get("execution_preferences")
+        raw_authority = raw_contract.get("foundation_a_authority")
         if (
             not isinstance(raw_proof, Mapping)
             or not isinstance(raw_routing, Mapping)
             or not isinstance(raw_resume, Mapping)
+            or not valid_process_local_authority_contract(raw_authority)
         ):
             raise OrchestratorError(
                 message="Cannot resume with an invalid execution contract",
-                details={"missing": "frugality_proof, model_routing, or resume"},
+                details={
+                    "missing": "frugality_proof, model_routing, resume, or foundation_a_authority"
+                },
             )
 
         self._restore_guidance_contract(raw_contract)
@@ -2504,6 +2803,9 @@ class OrchestratorRunner:
         effective_model_observed = self._runtime_execution_proves_effective_model(
             persisted_runtime_execution
         )
+        process_local_authority = valid_process_local_authority_contract(
+            raw_contract.get("foundation_a_authority")
+        )
         model_override_support = getattr(
             getattr(self._adapter, "capabilities", None),
             "model_override_support",
@@ -2513,6 +2815,7 @@ class OrchestratorRunner:
             constructor_model_value is None
             and not effective_model_observed
             and not (restored_router is not None and model_override_support is ParamSupport.NATIVE)
+            and not process_local_authority
         ):
             raise OrchestratorError(
                 message="Cannot resume because the effective runtime model is unverifiable",
@@ -2530,10 +2833,18 @@ class OrchestratorRunner:
         self._execution_preferences = persisted_preferences
         self._shadow_replay_enabled = self._resolved_shadow_replay_enabled()
         if self._model_routing_override_explicit:
-            self._execution_contract = self._build_execution_contract(
+            replacement = self._build_execution_contract(
                 seed=seed,
                 seed_fingerprint=(persisted_seed_fingerprint if valid_seed_fingerprint else None),
+                authority_generation=authority_generation,
             )
+            # Only the public resume path reaches this branch with a live,
+            # registry-issued generation.  Preserve the persisted diagnostics
+            # in direct contract-validation calls so those calls cannot mint a
+            # replacement correlation id by accident.
+            if authority_generation is None:
+                replacement["foundation_a_authority"] = dict(raw_contract["foundation_a_authority"])
+            self._execution_contract = replacement
             return self._execution_contract != raw_contract
 
         self._model_router = restored_router
@@ -2552,11 +2863,8 @@ class OrchestratorRunner:
     def _proof_cohort_identity(
         event_data: Mapping[str, Any],
     ) -> tuple[str, str, str, int, str, str, str] | None:
-        """Extract the exact fail-closed identity tuple from a session start."""
-        raw_seed_id = event_data.get("seed_id")
+        """Reject cross-run proof cohorts for Foundation A process-local runs."""
         raw_contract = event_data.get(EXECUTION_CONTRACT_PROGRESS_KEY)
-        if not isinstance(raw_seed_id, str) or not raw_seed_id.strip():
-            return None
         if not isinstance(raw_contract, Mapping):
             return None
         raw_version = raw_contract.get("version")
@@ -2566,79 +2874,11 @@ class OrchestratorRunner:
             or raw_version != EXECUTION_CONTRACT_VERSION
         ):
             return None
-        proof_contract = raw_contract.get("frugality_proof")
-        if not isinstance(proof_contract, Mapping):
-            return None
-        routing_contract = raw_contract.get("model_routing")
-        if not isinstance(routing_contract, Mapping):
-            return None
-        guidance_contract = raw_contract.get("guidance")
-        if guidance_contract is None:
-            guidance_fingerprint = "legacy:no-declared-guidance"
-        elif isinstance(guidance_contract, Mapping):
-            guidance_fingerprint = guidance_contract.get("rendered_fragment_hash")
-            if (
-                guidance_contract.get("provenance_scope") != "ouroboros_declared_guidance_only"
-                or not isinstance(guidance_fingerprint, str)
-                or not guidance_fingerprint.startswith("sha256:")
-                or len(guidance_fingerprint) != 71
-            ):
-                return None
-        else:
-            return None
-        runtime_backend = routing_contract.get("runtime_backend")
-        llm_backend = routing_contract.get("llm_backend")
-        permission_mode = routing_contract.get("permission_mode")
-        constructor_model = routing_contract.get("constructor_model")
-        runtime_execution = routing_contract.get("runtime_execution")
-        if (
-            not isinstance(runtime_backend, str)
-            or not runtime_backend.strip()
-            or not isinstance(llm_backend, str)
-            or not llm_backend.strip()
-            or not OrchestratorRunner._valid_permission_mode_contract(permission_mode)
-            or not OrchestratorRunner._valid_constructor_model_contract(constructor_model)
-            or not OrchestratorRunner._valid_runtime_execution_identity_contract(runtime_execution)
-        ):
-            return None
-        protocol_version = proof_contract.get("protocol_version")
-        project_root = proof_contract.get("project_root")
-        workspace_path = proof_contract.get("workspace_path")
-        routing_fingerprint = proof_contract.get("routing_fingerprint")
-        seed_fingerprint = proof_contract.get("seed_fingerprint")
-        if (
-            isinstance(protocol_version, bool)
-            or not isinstance(protocol_version, int)
-            or protocol_version < 1
-        ):
-            return None
-        if not isinstance(project_root, str) or not project_root.strip():
-            return None
-        if not isinstance(workspace_path, str) or not workspace_path.strip():
-            return None
-        if (
-            not isinstance(routing_fingerprint, str)
-            or len(routing_fingerprint) != 64
-            or any(char not in "0123456789abcdef" for char in routing_fingerprint)
-        ):
-            return None
-        if routing_fingerprint != OrchestratorRunner._routing_fingerprint(routing_contract):
-            return None
-        if (
-            not isinstance(seed_fingerprint, str)
-            or len(seed_fingerprint) != 64
-            or any(char not in "0123456789abcdef" for char in seed_fingerprint)
-        ):
-            return None
-        return (
-            raw_seed_id.strip(),
-            project_root.strip(),
-            workspace_path.strip(),
-            protocol_version,
-            routing_fingerprint,
-            seed_fingerprint,
-            guidance_fingerprint,
-        )
+        # Foundation A's current correlation record is diagnostic attribution
+        # only.  It must not form a replay, idempotency, trust, or cross-run
+        # proof cohort key.  A future portable authority needs its own reviewed
+        # consumer rule rather than falling through this legacy proof path.
+        return None
 
     def _build_dependency_analyzer(self) -> DependencyAnalyzer:
         """Create a dependency analyzer wired to the active LLM backend when available.
@@ -3481,6 +3721,10 @@ class OrchestratorRunner:
             )
             for ev in session_events:
                 if ev.type in _terminal_event_types:
+                    self._retire_process_local_authority(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
                     log.info(
                         "orchestrator.runner.cancel_skipped_terminal",
                         execution_id=execution_id,
@@ -3522,6 +3766,10 @@ class OrchestratorRunner:
                 )
             )
 
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -3789,6 +4037,10 @@ class OrchestratorRunner:
 
         # Clean up session tracking
         self._unregister_session(execution_id, session_id)
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
 
@@ -3918,7 +4170,11 @@ class OrchestratorRunner:
         Returns:
             Result containing OrchestratorResult on success.
         """
-        session_result = await self.prepare_session(seed, execution_id=execution_id)
+        session_result = await self.prepare_session(
+            seed,
+            execution_id=execution_id,
+            session_id=session_id,
+        )
         if session_result.is_err:
             return Result.err(session_result.error)
 
@@ -3946,39 +4202,107 @@ class OrchestratorRunner:
         immediately and then start the actual runtime work asynchronously.
         """
         exec_id = execution_id or f"exec_{uuid4().hex[:12]}"
+        resolved_session_id = session_id or f"orch_{uuid4().hex[:12]}"
         self._execution_guidance = None
+        # A generation belongs to this one preparation call.  Do not store it
+        # in a runner-wide mutable slot: concurrent preparations must not share
+        # a capability or correlation id.
+        authority_generation = self._begin_process_local_authority_generation()
         try:
             execution_contract = await asyncio.to_thread(
                 self._build_execution_contract,
                 seed=seed,
+                authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
         except OrchestratorError as exc:
+            self._discard_process_local_authority(authority_generation)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
             return Result.err(exc)
         self._execution_contract = execution_contract
-        session_result = await self._session_repo.create_session(
-            execution_id=exec_id,
-            seed_id=seed.metadata.seed_id,
-            session_id=session_id,
-            seed_goal=seed.goal,
-            runtime_backend=getattr(self._adapter, "runtime_backend", None),
-            llm_backend=getattr(self._adapter, "llm_backend", None),
-            execution_contract=execution_contract,
-        )
+
+        # Establish the exact capability and PID liveness lease before any
+        # durable RUNNING tracker can be reconstructed by an observer.  The
+        # resolved session id is allocated locally for that purpose rather
+        # than delegated to SessionRepository after its start event is written.
+        try:
+            self._register_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+                execution_contract=execution_contract,
+                generation=authority_generation,
+            )
+        except OrchestratorError as exc:
+            self._discard_process_local_authority(authority_generation)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(exc)
+
+        try:
+            session_result = await self._session_repo.create_session(
+                execution_id=exec_id,
+                seed_id=seed.metadata.seed_id,
+                session_id=resolved_session_id,
+                seed_goal=seed.goal,
+                runtime_backend=getattr(self._adapter, "runtime_backend", None),
+                llm_backend=getattr(self._adapter, "llm_backend", None),
+                execution_contract=execution_contract,
+            )
+        except Exception as exc:
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(
+                OrchestratorError(
+                    message=f"Failed to create session: {exc}",
+                    details={"execution_id": exec_id, "session_id": resolved_session_id},
+                )
+            )
 
         if session_result.is_err:
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {session_result.error}",
-                    details={"execution_id": exec_id, "session_id": session_id},
+                    details={"execution_id": exec_id, "session_id": resolved_session_id},
                 )
             )
 
         tracker = session_result.value
+        if tracker.session_id != resolved_session_id or tracker.execution_id != exec_id:
+            # The registration and its early lease were established for the
+            # caller-supplied durable identity before ``create_session`` wrote
+            # ``session.started``.  Accepting a repository response for a
+            # different identity would attach that capability to a tracker that
+            # was never protected during publication.  This is a repository
+            # contract violation, not a reason to mutate or terminalize the
+            # unrelated returned tracker.
+            self._retire_process_local_authority(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(
+                OrchestratorError(
+                    message="Session repository returned an unexpected session identity",
+                    details={
+                        "expected_session_id": resolved_session_id,
+                        "expected_execution_id": exec_id,
+                        "returned_session_id": tracker.session_id,
+                        "returned_execution_id": tracker.execution_id,
+                    },
+                )
+            )
         initial_progress: dict[str, Any] = {
             "fat_harness_mode": self._fat_harness_mode,
             "messages_processed": 0,
@@ -3986,35 +4310,62 @@ class OrchestratorRunner:
         }
         if self._task_workspace is not None:
             initial_progress["workspace"] = self._task_workspace.to_progress_dict()
-        progress_result = await self._session_repo.track_progress(
-            tracker.session_id,
-            initial_progress,
-        )
-        if progress_result.is_err:
-            fail_result = await self._session_repo.mark_failed(
+        try:
+            progress_result = await self._session_repo.track_progress(
                 tracker.session_id,
-                "Failed to persist initial session contract",
-                {
-                    "execution_id": tracker.execution_id,
-                    "fat_harness_mode": self._fat_harness_mode,
-                    "cause": str(progress_result.error),
-                },
+                initial_progress,
+            )
+        except Exception as exc:
+            progress_exception_details: dict[str, Any] = {
+                "session_id": tracker.session_id,
+                "execution_id": tracker.execution_id,
+                "fat_harness_mode": self._fat_harness_mode,
+                "cause": str(exc),
+            }
+            terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                tracker=tracker,
+                message="Failed to persist initial session contract",
+                details=progress_exception_details,
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
             )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
-
-            details: dict[str, Any] = {
+            if terminal_mark_error is not None:
+                progress_exception_details["terminal_mark_error"] = terminal_mark_error
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist initial session contract",
+                    details=progress_exception_details,
+                )
+            )
+        if progress_result.is_err:
+            progress_result_details: dict[str, Any] = {
                 "session_id": tracker.session_id,
                 "execution_id": tracker.execution_id,
                 "fat_harness_mode": self._fat_harness_mode,
                 "cause": str(progress_result.error),
             }
-            if fail_result.is_err:
-                details["terminal_mark_error"] = str(fail_result.error)
+            terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                tracker=tracker,
+                message="Failed to persist initial session contract",
+                details=progress_result_details,
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+
+            if terminal_mark_error is not None:
+                progress_result_details["terminal_mark_error"] = terminal_mark_error
             return Result.err(
                 OrchestratorError(
                     message="Failed to persist initial session contract",
-                    details=details,
+                    details=progress_result_details,
                 )
             )
 
@@ -4038,30 +4389,73 @@ class OrchestratorRunner:
         set_console_logging(self._debug)
 
         raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
-        if raw_contract is not None:
-            if not isinstance(raw_contract, Mapping):
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
-                    tracker.session_id,
-                    session_registered=False,
+        if tracker.status in (
+            SessionStatus.COMPLETED,
+            SessionStatus.CANCELLED,
+            SessionStatus.FAILED,
+        ):
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=f"Session is in terminal state {tracker.status.value}, cannot execute",
+                    details={"session_id": tracker.session_id, "status": tracker.status.value},
                 )
+            )
+
+        # This API may execute only the tracker returned by ``prepare_session``.
+        # A legacy/reconstructed tracker with no contract is not a new-session
+        # shortcut: it has no Foundation A generation and must fail closed before
+        # prompts, tool setup, or any runtime-owned provider are consulted.
+        authority_generation, authority_claimed = self._claim_process_local_authority_generation(
+            tracker.session_id,
+            exec_id,
+            raw_contract,
+        )
+        if authority_claimed:
+            return Result.err(
+                self._process_local_execution_in_progress_error(
+                    tracker.session_id,
+                    tracker.execution_id,
+                )
+            )
+        if authority_generation is None:
+            if self._process_local_authority_held_elsewhere(
+                tracker.session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
                 return Result.err(
-                    OrchestratorError(
-                        message="Cannot execute with an invalid execution contract",
-                        details={"invalid": "execution_contract"},
+                    self._process_local_authority_held_elsewhere_error(
+                        tracker.session_id,
+                        tracker.execution_id,
                     )
                 )
-            try:
-                await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
-                self._execution_guidance_delivery_mode()
-            except OrchestratorError as exc:
-                self._cleanup_pre_execution_state(
-                    tracker.execution_id,
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(
+                self._process_local_resume_unavailable_error(
                     tracker.session_id,
-                    session_registered=False,
+                    tracker.execution_id,
                 )
-                return Result.err(exc)
-            self._execution_contract = dict(raw_contract)
+            )
+        try:
+            await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
+            self._execution_guidance_delivery_mode()
+        except OrchestratorError as exc:
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            return Result.err(exc)
+        self._execution_contract = dict(raw_contract)
 
         log.info(
             "orchestrator.runner.execute_started",
@@ -4599,7 +4993,21 @@ class OrchestratorRunner:
             )
 
             # Clean up session tracking
-            self._unregister_session(exec_id, tracker.session_id)
+            if terminal_status != "paused":
+                self._retire_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                )
+            else:
+                self._release_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                )
+            self._unregister_session(
+                exec_id,
+                tracker.session_id,
+                release_liveness_lease=terminal_status != "paused",
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
@@ -4627,6 +5035,10 @@ class OrchestratorRunner:
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
             self._unregister_session(exec_id, tracker.session_id)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
@@ -4654,6 +5066,10 @@ class OrchestratorRunner:
             await self._session_repo.mark_failed(
                 tracker.session_id,
                 str(e),
+            )
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
             )
             await self._event_store.append(
                 create_execution_terminal_event(
@@ -5041,7 +5457,21 @@ class OrchestratorRunner:
         )
 
         # Clean up session tracking
-        self._unregister_session(exec_id, tracker.session_id)
+        if terminal_status != "paused":
+            self._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
+        else:
+            self._release_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+            )
+        self._unregister_session(
+            exec_id,
+            tracker.session_id,
+            release_liveness_lease=terminal_status != "paused",
+        )
         await clear_cancellation(tracker.session_id)
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
@@ -5159,11 +5589,117 @@ class OrchestratorRunner:
                 )
             )
 
+        raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
+        if not isinstance(raw_contract, Mapping):
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            return Result.err(error)
+
+        # A RUNNING tracker with a current Foundation A contract belongs to an
+        # active process while its early liveness lease is held.  If the lease
+        # is gone and this process has no live registry capability, the prior
+        # owner has crashed or exited and Foundation A must terminally reject it
+        # rather than leave a restartable-looking RUNNING session stranded.
+        if tracker.status != SessionStatus.PAUSED:
+            own_live_authority = self._has_live_process_local_authority(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            )
+            held_elsewhere = (
+                not own_live_authority
+                and self._process_local_authority_held_elsewhere(
+                    session_id,
+                    tracker.execution_id,
+                    raw_contract,
+                )
+            )
+            if not own_live_authority and not held_elsewhere:
+                error = await self._mark_process_local_resume_unavailable(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._cleanup_pre_execution_state(
+                    tracker.execution_id,
+                    session_id,
+                    session_registered=False,
+                )
+                return Result.err(error)
+            if held_elsewhere:
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+                retire_authority=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=f"Session is not paused and cannot resume ({tracker.status.value})",
+                    details={
+                        "session_id": session_id,
+                        "status": tracker.status.value,
+                        "resume_blocked": "session_not_paused",
+                    },
+                )
+            )
+
+        # This is intentionally before Foundation A contract restoration,
+        # resume-handle selection, and every runtime-owned identity provider.
+        # The durable correlation id cannot recreate this process's capability.
+        authority_generation, authority_claimed = self._claim_process_local_authority_generation(
+            session_id,
+            tracker.execution_id,
+            raw_contract,
+        )
+        if authority_claimed:
+            return Result.err(
+                self._process_local_execution_in_progress_error(
+                    session_id,
+                    tracker.execution_id,
+                )
+            )
+        if authority_generation is None:
+            if self._process_local_authority_held_elsewhere(
+                session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(
+                        session_id,
+                        tracker.execution_id,
+                    )
+                )
+            error = await self._mark_process_local_resume_unavailable(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            return Result.err(error)
+
         try:
             execution_contract_changed = await asyncio.to_thread(
                 self._restore_execution_contract,
                 tracker.progress,
                 seed=seed,
+                authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
         except OrchestratorError as exc:
@@ -5257,6 +5793,13 @@ Note: This is a resumed session. Please continue from where execution was interr
                 activity_map=resume_strategy.get_activity_map(),
             )
             await self._replay_workflow_state(session_id, state_tracker)
+        except asyncio.CancelledError:
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=session_registered,
+            )
+            raise
         except Exception as e:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
@@ -5516,7 +6059,21 @@ Note: This is a resumed session. Please continue from where execution was interr
             await clear_cancellation(session_id)
 
             # Clean up session tracking
-            self._unregister_session(tracker.execution_id, session_id)
+            if terminal_status != "paused":
+                self._retire_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+            else:
+                self._release_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+            self._unregister_session(
+                tracker.execution_id,
+                session_id,
+                release_liveness_lease=terminal_status != "paused",
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
@@ -5532,6 +6089,22 @@ Note: This is a resumed session. Please continue from where execution was interr
                 )
             )
 
+        except asyncio.CancelledError:
+            if await is_cancellation_requested(session_id):
+                return await self._handle_cancellation(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=messages_processed,
+                    start_time=start_time,
+                )
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._unregister_session(tracker.execution_id, session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            raise
         except Exception as e:
             log.exception(
                 "orchestrator.runner.resume_failed",
@@ -5550,6 +6123,11 @@ Note: This is a resumed session. Please continue from where execution was interr
                     status="failed",
                     error_message=str(e),
                 )
+            )
+            await self._session_repo.mark_failed(session_id, str(e))
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
             )
             await self._report_frugality_retrospective(
                 execution_id=tracker.execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1417,10 +1417,41 @@ class OrchestratorRunner:
         """Retire all live state, then acknowledge cancellation last."""
 
         async def _cleanup() -> None:
-            self._retire_process_local_authority(
+            retired = self._retire_process_local_authority(
                 session_id=session_id,
                 execution_id=execution_id,
             )
+            if not retired:
+                # A different live adapter/runner may still own this exact
+                # session. Never unregister its route or release its PID
+                # heartbeat merely because this cleanup observer saw a
+                # terminal record. If this runner has a stale local route,
+                # remove only that route while preserving the shared lease.
+                if self._active_sessions.get(execution_id) == session_id:
+                    self._unregister_session(
+                        execution_id,
+                        session_id,
+                        release_liveness_lease=False,
+                    )
+                self._release_task_workspace_for_identity(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                from ouroboros.orchestrator.heartbeat import (
+                    is_holder_alive,
+                    is_owned_by_current_process,
+                )
+
+                if not _has_live_process_local_authority_session(session_id) and not (
+                    is_holder_alive(session_id) and not is_owned_by_current_process(session_id)
+                ):
+                    await clear_cancellation(session_id)
+                log.warning(
+                    "orchestrator.runner.terminal_cleanup_authority_not_retired",
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                return
             self._unregister_session(execution_id, session_id)
             self._release_task_workspace_for_identity(
                 session_id=session_id,
@@ -5764,14 +5795,10 @@ class OrchestratorRunner:
                 details=progress_exception_details,
             )
             if terminal_mark_error is None:
-                self._retire_process_local_authority(
+                await self._cleanup_terminal_process_local_state(
                     session_id=tracker.session_id,
                     execution_id=tracker.execution_id,
                 )
-            self._release_task_workspace_for_identity(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
             if terminal_mark_error is not None:
                 progress_exception_details["terminal_mark_error"] = terminal_mark_error
                 progress_exception_details["resume_blocked"] = "terminal_persistence_pending"
@@ -5795,14 +5822,10 @@ class OrchestratorRunner:
                 details=progress_result_details,
             )
             if terminal_mark_error is None:
-                self._retire_process_local_authority(
+                await self._cleanup_terminal_process_local_state(
                     session_id=tracker.session_id,
                     execution_id=tracker.execution_id,
                 )
-            self._release_task_workspace_for_identity(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
 
             if terminal_mark_error is not None:
                 progress_result_details["terminal_mark_error"] = terminal_mark_error
@@ -7118,14 +7141,37 @@ class OrchestratorRunner:
             session_id=session_id,
         )
 
-        # Reconstruct session
-        session_result = await self._session_repo.reconstruct_session(session_id)
+        # Reconstruct session. A transient read failure is not evidence that
+        # the retained process-local owner is lost; preserve it as a typed,
+        # retryable lifecycle result so a background wrapper cannot append a
+        # generic FAILED event or evict the owner/store.
+        try:
+            session_result = await self._session_repo.reconstruct_session(session_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return Result.err(
+                OrchestratorError(
+                    message=f"Failed to reconstruct session: {exc}",
+                    details={
+                        "session_id": session_id,
+                        "cause": str(exc),
+                        "resume_blocked": "process_local_reconstruction_pending",
+                        "retryable": True,
+                    },
+                )
+            )
 
         if session_result.is_err:
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to reconstruct session: {session_result.error}",
-                    details={"session_id": session_id},
+                    details={
+                        "session_id": session_id,
+                        "cause": str(session_result.error),
+                        "resume_blocked": "process_local_reconstruction_pending",
+                        "retryable": True,
+                    },
                 )
             )
 

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -41,7 +41,7 @@ from rich.text import Text
 from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.conductor import ConductorDirective
-from ouroboros.core.errors import ConfigError, OuroborosError
+from ouroboros.core.errors import ConfigError, OuroborosError, PersistenceError
 from ouroboros.core.execution_preferences import (
     execution_preferences_from_contract,
     resolve_execution_preferences,
@@ -83,12 +83,11 @@ from ouroboros.orchestrator.events import (
     create_mcp_tools_loaded_event,
     create_policy_capabilities_evaluated_event,
     create_progress_event,
-    create_session_completed_event,
-    create_session_failed_event,
     create_tool_called_event,
     create_workflow_progress_event,
 )
 from ouroboros.orchestrator.execution_authority import (
+    ProcessLocalCancellationDisposition,
     _claim_process_local_authority_generation,
     _discard_process_local_authority_generation,
     _has_live_process_local_authority_registration,
@@ -101,6 +100,7 @@ from ouroboros.orchestrator.execution_authority import (
     _release_process_local_authority_generation,
     _retire_process_local_authority_generation,
     constructor_model_contract,
+    request_process_local_cancellation,
     runtime_execution_proves_effective_model,
     valid_constructor_model_contract,
     valid_process_local_authority_contract,
@@ -2049,6 +2049,83 @@ class OrchestratorRunner:
             return str(result.error)
         return None
 
+    async def _persist_session_terminal_status(
+        self,
+        *,
+        session_id: str,
+        requested_status: SessionStatus,
+        summary: dict[str, Any] | None = None,
+        error_message: str | None = None,
+        error_details: dict[str, Any] | None = None,
+        error_type: str | None = None,
+        messages_processed: int = 0,
+        cancelled_by: str = "runner",
+    ) -> SessionStatus:
+        """Persist one terminal winner and return the authoritative status.
+
+        Session lifecycle is the durable source of truth. Execution-terminal
+        events are projections and must be emitted only after this CAS has a
+        winner, otherwise completion and public cancellation can produce
+        contradictory terminal streams.
+        """
+        if requested_status is SessionStatus.COMPLETED:
+            result = await self._session_repo.mark_completed(
+                session_id,
+                summary,
+                messages_processed=messages_processed,
+            )
+        elif requested_status is SessionStatus.FAILED:
+            result = await self._session_repo.mark_failed(
+                session_id,
+                error_message or "Execution failed",
+                error_details,
+                error_type=error_type,
+                messages_processed=messages_processed,
+            )
+        elif requested_status is SessionStatus.CANCELLED:
+            result = await self._session_repo.mark_cancelled(
+                session_id,
+                reason=error_message or "Execution cancelled",
+                cancelled_by=cancelled_by,
+            )
+        else:
+            raise ValueError(f"Unsupported terminal session status: {requested_status.value}")
+
+        if result.is_err:
+            raise OrchestratorError(
+                message=f"Failed to persist terminal session status: {requested_status.value}",
+                details={
+                    "session_id": session_id,
+                    "requested_status": requested_status.value,
+                    "cause": str(result.error),
+                },
+            )
+        if result.value is not False:
+            return requested_status
+
+        winner = await self._session_repo.reconstruct_session(session_id)
+        terminal_statuses = {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.CANCELLED,
+        }
+        if winner.is_ok and winner.value.status in terminal_statuses:
+            log.info(
+                "orchestrator.runner.terminal_transition_preserved",
+                session_id=session_id,
+                requested_status=requested_status.value,
+                durable_status=winner.value.status.value,
+            )
+            return winner.value.status
+        raise OrchestratorError(
+            message="Terminal session transition lost its CAS without a readable winner",
+            details={
+                "session_id": session_id,
+                "requested_status": requested_status.value,
+                **({"cause": str(winner.error)} if winner.is_err else {}),
+            },
+        )
+
     def _validate_resume_handle_execution_identity(
         self,
         runtime_handle: RuntimeHandle | None,
@@ -3755,49 +3832,96 @@ class OrchestratorRunner:
                 )
             )
 
-        # Guard: do not overwrite a terminal state (completed/failed/cancelled)
-        _terminal_event_types = frozenset(
-            {
-                "orchestrator.session.completed",
-                "orchestrator.session.failed",
-                "orchestrator.session.cancelled",
-            }
-        )
-        try:
-            session_events = await self._event_store.query_events(
-                aggregate_id=session_id,
-                limit=100,
+        tracker_result = await self._session_repo.reconstruct_session(session_id)
+        if tracker_result.is_err:
+            return Result.err(
+                OrchestratorError(
+                    message=f"Failed to reconstruct session for cancellation: {tracker_result.error}",
+                    details={"execution_id": execution_id, "session_id": session_id},
+                )
             )
-            for ev in session_events:
-                if ev.type in _terminal_event_types:
-                    self._retire_process_local_authority(
-                        session_id=session_id,
-                        execution_id=execution_id,
-                    )
-                    log.info(
-                        "orchestrator.runner.cancel_skipped_terminal",
-                        execution_id=execution_id,
-                        session_id=session_id,
-                        terminal_event=ev.type,
-                    )
-                    return Result.ok(
-                        {
-                            "execution_id": execution_id,
-                            "session_id": session_id,
-                            "status": "already_terminal",
-                            "terminal_event": ev.type,
-                            "reason": reason,
-                        }
-                    )
-        except Exception as e:
-            log.warning(
-                "orchestrator.runner.terminal_check_failed",
-                execution_id=execution_id,
+        tracker = tracker_result.value
+        if tracker.status in {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.CANCELLED,
+        }:
+            self._retire_process_local_authority(
                 session_id=session_id,
-                error=str(e),
+                execution_id=execution_id,
+            )
+            return Result.ok(
+                {
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "status": "already_terminal",
+                    "terminal_status": tracker.status.value,
+                    "reason": reason,
+                }
             )
 
-        # Mark as cancelled via repository
+        process_local = await request_process_local_cancellation(
+            tracker,
+            self._session_repo,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
+        if process_local is not None:
+            if (
+                process_local.disposition
+                == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+            ):
+                return Result.ok(
+                    {
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "status": "cancellation_requested",
+                        "in_flight": True,
+                        "reason": reason,
+                    }
+                )
+            if process_local.disposition == ProcessLocalCancellationDisposition.HELD_ELSEWHERE:
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(session_id, execution_id)
+                )
+            if process_local.disposition == ProcessLocalCancellationDisposition.PERSISTENCE_PENDING:
+                return Result.err(
+                    OrchestratorError(
+                        message="Failed to persist cancellation; retained process-local owner must retry",
+                        details={
+                            "execution_id": execution_id,
+                            "session_id": session_id,
+                            "resume_blocked": "cancellation_persistence_pending",
+                            "cause": str(process_local.error),
+                        },
+                    )
+                )
+            if process_local.disposition == ProcessLocalCancellationDisposition.ALREADY_TERMINAL:
+                return Result.ok(
+                    {
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "status": "already_terminal",
+                        "reason": reason,
+                    }
+                )
+
+            await self._report_frugality_retrospective(
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status="cancelled",
+            )
+            return Result.ok(
+                {
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "status": "cancelled",
+                    "in_flight": False,
+                    "reason": reason,
+                }
+            )
+
+        # Historical sessions have no live Foundation A capability to coordinate.
         cancel_result = await self._session_repo.mark_cancelled(
             session_id=session_id,
             reason=reason,
@@ -3814,11 +3938,29 @@ class OrchestratorRunner:
                     },
                 )
             )
+        if cancel_result.value is False:
+            terminal_result = await self._session_repo.reconstruct_session(session_id)
+            terminal_status = (
+                terminal_result.value.status
+                if terminal_result.is_ok
+                and terminal_result.value.status
+                in {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
+                else None
+            )
+            return Result.ok(
+                {
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "status": "already_terminal",
+                    **(
+                        {"terminal_status": terminal_status.value}
+                        if terminal_status is not None
+                        else {}
+                    ),
+                    "reason": reason,
+                }
+            )
 
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
-        )
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -4283,6 +4425,26 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
                 cause=cancel_result.error,
+            )
+        if cancel_result is not None and cancel_result.value is False:
+            # The session became terminal after the initial reconstruction but
+            # before this owner won its cancellation transition. Re-enter once
+            # so the authoritative terminal branch mirrors the real winner and
+            # tears down this process-local owner without reporting cancellation.
+            winner = await self._session_repo.reconstruct_session(session_id)
+            if winner.is_ok and winner.value.status in _terminal:
+                return await self._handle_cancellation(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    messages_processed=messages_processed,
+                    start_time=start_time,
+                )
+            return self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=PersistenceError(
+                    "Terminal cancellation lost its CAS but the durable winner could not be read"
+                ),
             )
 
         # The session is now terminal.  It is safe to clear the request and
@@ -5156,30 +5318,36 @@ class OrchestratorRunner:
             # Calculate duration
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
-            # Emit completion event
+            durable_terminal_status: SessionStatus | None = None
+            completion_summary: dict[str, Any] | None = None
             if success:
                 completion_summary = {
                     "final_message": final_message[:500],
                     "messages_processed": messages_processed,
                     **self._task_summary(),
                 }
-                completed_event = create_session_completed_event(
+                durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
+                    requested_status=SessionStatus.COMPLETED,
                     summary=completion_summary,
                     messages_processed=messages_processed,
                 )
-                await self._event_store.append(completed_event)
-                await self._session_repo.mark_completed(
-                    tracker.session_id,
-                    completion_summary,
-                )
+                success = durable_terminal_status is SessionStatus.COMPLETED
+                if not success:
+                    final_message = (
+                        "Execution result was not persisted because the session was already "
+                        f"{durable_terminal_status.value}."
+                    )
 
-                # Display success
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="green"),
-                        title="[green]Execution Completed[/green]",
-                        border_style="green",
+                        Text(final_message[:1000], style="green" if success else "yellow"),
+                        title=(
+                            "[green]Execution Completed[/green]"
+                            if success
+                            else f"[yellow]Execution {durable_terminal_status.value.title()}[/yellow]"
+                        ),
+                        border_style="green" if success else "yellow",
                     )
                 )
             elif recoverable_failure_pause is not None:
@@ -5200,23 +5368,28 @@ class OrchestratorRunner:
                     )
                 )
             else:
-                failed_event = create_session_failed_event(
+                durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
+                    requested_status=SessionStatus.FAILED,
                     error_message=final_message,
                     messages_processed=messages_processed,
                 )
-                await self._event_store.append(failed_event)
-                await self._session_repo.mark_failed(
-                    tracker.session_id,
-                    final_message,
-                )
+                success = durable_terminal_status is SessionStatus.COMPLETED
+                if durable_terminal_status is not SessionStatus.FAILED:
+                    final_message = (
+                        "Execution failure was not persisted because the session was already "
+                        f"{durable_terminal_status.value}."
+                    )
 
-                # Display failure
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="red"),
-                        title="[red]Execution Failed[/red]",
-                        border_style="red",
+                        Text(final_message[:1000], style="green" if success else "red"),
+                        title=(
+                            "[green]Execution Completed[/green]"
+                            if success
+                            else f"[red]Execution {durable_terminal_status.value.title()}[/red]"
+                        ),
+                        border_style="green" if success else "red",
                     )
                 )
 
@@ -5224,14 +5397,27 @@ class OrchestratorRunner:
             # single-stream consumers (TUI) detect completion without
             # polling the separate session aggregate.
             terminal_status = (
-                "completed" if success else ("paused" if recoverable_failure_pause else "failed")
+                "paused"
+                if recoverable_failure_pause is not None
+                else (
+                    durable_terminal_status.value
+                    if durable_terminal_status is not None
+                    else SessionStatus.FAILED.value
+                )
             )
             terminal_event = create_execution_terminal_event(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
                 status=terminal_status,
-                summary=completion_summary if success else None,
-                error_message=final_message if not success else None,
+                summary=completion_summary
+                if terminal_status == SessionStatus.COMPLETED.value
+                else None,
+                error_message=(
+                    final_message
+                    if terminal_status
+                    not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
+                    else None
+                ),
                 messages_processed=messages_processed,
                 pause_seconds=(
                     recoverable_failure_pause.pause_seconds
@@ -5338,17 +5524,12 @@ class OrchestratorRunner:
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
-            # Emit failure event
-            failed_event = create_session_failed_event(
+            durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
+                requested_status=SessionStatus.FAILED,
                 error_message=str(e),
                 error_type=type(e).__name__,
                 messages_processed=messages_processed,
-            )
-            await self._event_store.append(failed_event)
-            await self._session_repo.mark_failed(
-                tracker.session_id,
-                str(e),
             )
             self._retire_process_local_authority(
                 session_id=tracker.session_id,
@@ -5358,15 +5539,17 @@ class OrchestratorRunner:
                 create_execution_terminal_event(
                     execution_id=exec_id,
                     session_id=tracker.session_id,
-                    status="failed",
-                    error_message=str(e),
+                    status=durable_terminal_status.value,
+                    error_message=(
+                        str(e) if durable_terminal_status is not SessionStatus.COMPLETED else None
+                    ),
                     messages_processed=messages_processed,
                 )
             )
             await self._report_frugality_retrospective(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
-                terminal_status="failed",
+                terminal_status=durable_terminal_status.value,
             )
 
             return Result.err(
@@ -5619,24 +5802,30 @@ class OrchestratorRunner:
             **self._task_summary(),
         }
 
-        # Emit completion event
+        durable_terminal_status: SessionStatus | None = None
         if success:
-            completed_event = create_session_completed_event(
+            durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
+                requested_status=SessionStatus.COMPLETED,
                 summary=execution_summary,
                 messages_processed=parallel_result.total_messages,
             )
-            await self._event_store.append(completed_event)
-            await self._session_repo.mark_completed(
-                tracker.session_id,
-                execution_summary,
-            )
+            success = durable_terminal_status is SessionStatus.COMPLETED
+            if not success:
+                final_message = (
+                    "Parallel result was not persisted because the session was already "
+                    f"{durable_terminal_status.value}."
+                )
 
             self._console.print(
                 Panel(
-                    Text(final_message, style="green"),
-                    title="[green]Parallel Execution Completed[/green]",
-                    border_style="green",
+                    Text(final_message, style="green" if success else "yellow"),
+                    title=(
+                        "[green]Parallel Execution Completed[/green]"
+                        if success
+                        else f"[yellow]Parallel Execution {durable_terminal_status.value.title()}[/yellow]"
+                    ),
+                    border_style="green" if success else "yellow",
                 )
             )
         elif recoverable_failure_pause is not None:
@@ -5657,8 +5846,9 @@ class OrchestratorRunner:
                 )
             )
         else:
-            failed_event = create_session_failed_event(
+            durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
+                requested_status=SessionStatus.FAILED,
                 error_message=(
                     "Partial failure: "
                     f"{parallel_result.failure_count} failed, "
@@ -5667,30 +5857,48 @@ class OrchestratorRunner:
                 ),
                 messages_processed=parallel_result.total_messages,
             )
-            await self._event_store.append(failed_event)
-            await self._session_repo.mark_failed(
-                tracker.session_id,
-                final_message,
-            )
+            success = durable_terminal_status is SessionStatus.COMPLETED
+            if durable_terminal_status is not SessionStatus.FAILED:
+                final_message = (
+                    "Parallel failure was not persisted because the session was already "
+                    f"{durable_terminal_status.value}."
+                )
 
             self._console.print(
                 Panel(
-                    Text(final_message, style="yellow"),
-                    title="[yellow]Partial Success[/yellow]",
-                    border_style="yellow",
+                    Text(final_message, style="green" if success else "yellow"),
+                    title=(
+                        "[green]Parallel Execution Completed[/green]"
+                        if success
+                        else f"[yellow]Parallel Execution {durable_terminal_status.value.title()}[/yellow]"
+                    ),
+                    border_style="green" if success else "yellow",
                 )
             )
 
         terminal_status = (
-            "completed" if success else ("paused" if recoverable_failure_pause else "failed")
+            "paused"
+            if recoverable_failure_pause is not None
+            else (
+                durable_terminal_status.value
+                if durable_terminal_status is not None
+                else SessionStatus.FAILED.value
+            )
         )
         await self._event_store.append(
             create_execution_terminal_event(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
                 status=terminal_status,
-                summary=execution_summary if success else None,
-                error_message=final_message if not success else None,
+                summary=(
+                    execution_summary if terminal_status == SessionStatus.COMPLETED.value else None
+                ),
+                error_message=(
+                    final_message
+                    if terminal_status
+                    not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
+                    else None
+                ),
                 messages_processed=parallel_result.total_messages,
                 pause_seconds=(
                     recoverable_failure_pause.pause_seconds
@@ -6374,19 +6582,32 @@ Note: This is a resumed session. Please continue from where execution was interr
 
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
+            durable_terminal_status: SessionStatus | None = None
             if success:
-                await self._session_repo.mark_completed(
-                    session_id,
-                    {
+                durable_terminal_status = await self._persist_session_terminal_status(
+                    session_id=session_id,
+                    requested_status=SessionStatus.COMPLETED,
+                    summary={
                         "messages_processed": messages_processed,
                         **self._task_summary(),
                     },
+                    messages_processed=messages_processed,
                 )
+                success = durable_terminal_status is SessionStatus.COMPLETED
+                if not success:
+                    final_message = (
+                        "Resumed execution result was not persisted because the session was already "
+                        f"{durable_terminal_status.value}."
+                    )
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="green"),
-                        title="[green]Resumed Execution Completed[/green]",
-                        border_style="green",
+                        Text(final_message[:1000], style="green" if success else "yellow"),
+                        title=(
+                            "[green]Resumed Execution Completed[/green]"
+                            if success
+                            else f"[yellow]Resumed Execution {durable_terminal_status.value.title()}[/yellow]"
+                        ),
+                        border_style="green" if success else "yellow",
                     )
                 )
             elif recoverable_resume_failure is not None:
@@ -6406,25 +6627,51 @@ Note: This is a resumed session. Please continue from where execution was interr
                     )
                 )
             else:
-                await self._session_repo.mark_failed(session_id, final_message)
+                durable_terminal_status = await self._persist_session_terminal_status(
+                    session_id=session_id,
+                    requested_status=SessionStatus.FAILED,
+                    error_message=final_message,
+                    messages_processed=messages_processed,
+                )
+                success = durable_terminal_status is SessionStatus.COMPLETED
+                if durable_terminal_status is not SessionStatus.FAILED:
+                    final_message = (
+                        "Resumed execution failure was not persisted because the session was already "
+                        f"{durable_terminal_status.value}."
+                    )
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="red"),
-                        title="[red]Resumed Execution Failed[/red]",
-                        border_style="red",
+                        Text(final_message[:1000], style="green" if success else "red"),
+                        title=(
+                            "[green]Resumed Execution Completed[/green]"
+                            if success
+                            else f"[red]Resumed Execution {durable_terminal_status.value.title()}[/red]"
+                        ),
+                        border_style="green" if success else "red",
                     )
                 )
 
             # Mirror terminal state into execution stream for TUI.
             terminal_status = (
-                "completed" if success else ("paused" if recoverable_resume_failure else "failed")
+                "paused"
+                if recoverable_resume_failure is not None
+                else (
+                    durable_terminal_status.value
+                    if durable_terminal_status is not None
+                    else SessionStatus.FAILED.value
+                )
             )
             await self._event_store.append(
                 create_execution_terminal_event(
                     execution_id=tracker.execution_id,
                     session_id=session_id,
                     status=terminal_status,
-                    error_message=final_message if not success else None,
+                    error_message=(
+                        final_message
+                        if terminal_status
+                        not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
+                        else None
+                    ),
                     messages_processed=messages_processed,
                     pause_seconds=(
                         recoverable_resume_failure.pause_seconds
@@ -6528,23 +6775,30 @@ Note: This is a resumed session. Please continue from where execution was interr
             self._unregister_session(tracker.execution_id, session_id)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
-            await self._event_store.append(
-                create_execution_terminal_event(
-                    execution_id=tracker.execution_id,
-                    session_id=session_id,
-                    status="failed",
-                    error_message=str(e),
-                )
+            durable_terminal_status = await self._persist_session_terminal_status(
+                session_id=session_id,
+                requested_status=SessionStatus.FAILED,
+                error_message=str(e),
+                error_type=type(e).__name__,
             )
-            await self._session_repo.mark_failed(session_id, str(e))
             self._retire_process_local_authority(
                 session_id=session_id,
                 execution_id=tracker.execution_id,
             )
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=tracker.execution_id,
+                    session_id=session_id,
+                    status=durable_terminal_status.value,
+                    error_message=(
+                        str(e) if durable_terminal_status is not SessionStatus.COMPLETED else None
+                    ),
+                )
+            )
             await self._report_frugality_retrospective(
                 execution_id=tracker.execution_id,
                 session_id=session_id,
-                terminal_status="failed",
+                terminal_status=durable_terminal_status.value,
             )
 
             return Result.err(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1608,13 +1608,13 @@ class OrchestratorRunner:
             cause=error,
         )
 
-    async def _cleanup_if_durable_terminal(
+    async def _reconcile_durable_terminal_and_cleanup(
         self,
         *,
         session_id: str,
         execution_id: str,
-    ) -> bool:
-        """Retire a claimed owner only after reconstructing a terminal winner.
+    ) -> SessionStatus | None:
+        """Return and fully reconcile a reconstructed durable terminal winner.
 
         Cancellation can arrive after the session CAS commits but before the
         execution-stream projection or ordinary cleanup finishes.  In that
@@ -1622,17 +1622,19 @@ class OrchestratorRunner:
         terminal source of truth, so interruption paths reconcile first.
         """
 
-        async def _reconcile() -> bool:
+        async def _reconcile() -> SessionStatus | None:
             try:
                 reconstructed = await self._session_repo.reconstruct_session(session_id)
             except Exception:
-                return False
+                return None
             if reconstructed.is_err or reconstructed.value.status not in {
                 SessionStatus.COMPLETED,
                 SessionStatus.FAILED,
                 SessionStatus.CANCELLED,
             }:
-                return False
+                return None
+            durable_status = reconstructed.value.status
+            self._pending_lifecycle_intents.pop(session_id, None)
             self._retire_process_local_authority(
                 session_id=session_id,
                 execution_id=execution_id,
@@ -1641,9 +1643,24 @@ class OrchestratorRunner:
             await clear_cancellation(session_id)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
-            return True
+            return durable_status
 
-        return bool(await _await_process_local_cleanup(_reconcile()))
+        return await _await_process_local_cleanup(_reconcile())
+
+    async def _cleanup_if_durable_terminal(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> bool:
+        """Retire a claimed owner only after reconstructing a terminal winner."""
+        return (
+            await self._reconcile_durable_terminal_and_cleanup(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            is not None
+        )
 
     async def _persist_failure_and_cleanup(
         self,
@@ -1654,6 +1671,7 @@ class OrchestratorRunner:
         messages_processed: int = 0,
     ) -> tuple[SessionStatus | None, Result[OrchestratorResult, OrchestratorError] | None]:
         """Persist one durable failure winner before withdrawing ownership."""
+        reconciled_during_exception = False
         try:
             durable_status = await self._persist_session_terminal_status(
                 session_id=session_id,
@@ -1663,22 +1681,53 @@ class OrchestratorRunner:
                 error_type=type(error).__name__,
                 messages_processed=messages_processed,
             )
-        except BaseException as persistence_error:
+        except (Exception, asyncio.CancelledError) as persistence_error:
+            durable_status = await self._reconcile_durable_terminal_and_cleanup(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            if durable_status is not None:
+                reconciled_during_exception = True
+                if isinstance(persistence_error, asyncio.CancelledError):
+                    raise
+            else:
+                self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                    execution_id=execution_id,
+                    status=SessionStatus.FAILED,
+                    error_message=str(error),
+                    error_type=type(error).__name__,
+                    messages_processed=messages_processed,
+                )
+                if isinstance(persistence_error, asyncio.CancelledError):
+                    self._preserve_process_local_owner_for_retry(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                    raise
+                return None, self._terminal_persistence_pending_result(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    requested_status=SessionStatus.FAILED,
+                    cause=persistence_error,
+                )
+
+        if durable_status is None:
             return None, self._terminal_persistence_pending_result(
                 session_id=session_id,
                 execution_id=execution_id,
                 requested_status=SessionStatus.FAILED,
-                cause=persistence_error,
+                cause=error,
             )
 
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
-        )
-        self._unregister_session(execution_id, session_id)
-        await clear_cancellation(session_id)
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
+        if not reconciled_during_exception:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            self._unregister_session(execution_id, session_id)
+            await clear_cancellation(session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
         try:
             await self._event_store.append(
                 create_execution_terminal_event(
@@ -2338,7 +2387,27 @@ class OrchestratorRunner:
                     error.message,
                     error.details,
                 )
-            except Exception as exc:  # pragma: no cover - defensive persistence boundary
+            except (Exception, asyncio.CancelledError) as exc:
+                durable_status = await self._reconcile_durable_terminal_and_cleanup(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                if durable_status is not None:
+                    if isinstance(exc, asyncio.CancelledError):
+                        raise
+                    return error
+                if isinstance(exc, asyncio.CancelledError):
+                    self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                        execution_id=execution_id,
+                        status=SessionStatus.FAILED,
+                        error_message=error.message,
+                        error_details=dict(error.details),
+                    )
+                    self._preserve_process_local_owner_for_retry(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                    raise
                 last_error = exc
             else:
                 if result.is_ok:
@@ -2405,7 +2474,28 @@ class OrchestratorRunner:
                     message,
                     dict(details),
                 )
-            except Exception as exc:  # pragma: no cover - defensive persistence boundary
+            except (Exception, asyncio.CancelledError) as exc:
+                durable_status = await self._reconcile_durable_terminal_and_cleanup(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                if durable_status is not None:
+                    if isinstance(exc, asyncio.CancelledError):
+                        raise
+                    return None
+                if isinstance(exc, asyncio.CancelledError):
+                    self._pending_lifecycle_intents[tracker.session_id] = _PendingLifecycleIntent(
+                        execution_id=tracker.execution_id,
+                        status=SessionStatus.FAILED,
+                        error_message=message,
+                        error_details=dict(details),
+                        messages_processed=tracker.messages_processed,
+                    )
+                    self._preserve_process_local_owner_for_retry(
+                        session_id=tracker.session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                    raise
                 last_error = exc
             else:
                 if result.is_ok:
@@ -2760,10 +2850,17 @@ class OrchestratorRunner:
                     cancelled_by=intent.cancelled_by,
                 )
         except asyncio.CancelledError:
-            self._preserve_process_local_owner_for_retry(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+            if (
+                await self._reconcile_durable_terminal_and_cleanup(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                is None
+            ):
+                self._preserve_process_local_owner_for_retry(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
             raise
         except BaseException as exc:
             pending = self._terminal_persistence_pending_from_error(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -165,6 +165,7 @@ from ouroboros.resilience.recovery import (
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
+    from ouroboros.events.base import BaseEvent
     from ouroboros.mcp.client.manager import MCPClientManager
     from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
     from ouroboros.orchestrator.model_routing import ModelRouter
@@ -1437,6 +1438,33 @@ class OrchestratorRunner:
                 },
             )
         )
+
+    async def _project_execution_outcome(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+        terminal_status: str,
+        terminal_event: BaseEvent,
+    ) -> None:
+        """Run auxiliary outcome projections without invalidating durable PAUSED."""
+        try:
+            await self._event_store.append(terminal_event)
+            await self._evaluate_frugality_proof(execution_id)
+            if terminal_status in {"completed", "failed", "cancelled"}:
+                await self._report_frugality_retrospective(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    terminal_status=terminal_status,
+                )
+        except Exception:
+            if terminal_status != SessionStatus.PAUSED.value:
+                raise
+            log.exception(
+                "orchestrator.runner.paused_auxiliary_projection_failed",
+                execution_id=execution_id,
+                session_id=session_id,
+            )
 
     @staticmethod
     def _requested_terminal_status_from_error(error: BaseException) -> SessionStatus | None:
@@ -5864,17 +5892,12 @@ class OrchestratorRunner:
                     else None
                 ),
             )
-            await self._event_store.append(terminal_event)
-
-            # Deterministic frugality proof over this execution's per-AC triads.
-            # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
-            await self._evaluate_frugality_proof(exec_id)
-            if terminal_status in {"completed", "failed", "cancelled"}:
-                await self._report_frugality_retrospective(
-                    execution_id=exec_id,
-                    session_id=tracker.session_id,
-                    terminal_status=terminal_status,
-                )
+            await self._project_execution_outcome(
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status=terminal_status,
+                terminal_event=terminal_event,
+            )
 
             log.info(
                 "orchestrator.runner.execute_completed",
@@ -6308,53 +6331,47 @@ class OrchestratorRunner:
                 else SessionStatus.FAILED.value
             )
         )
-        await self._event_store.append(
-            create_execution_terminal_event(
-                execution_id=exec_id,
-                session_id=tracker.session_id,
-                status=terminal_status,
-                summary=(
-                    execution_summary if terminal_status == SessionStatus.COMPLETED.value else None
-                ),
-                error_message=(
-                    final_message
-                    if terminal_status
-                    not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
-                    else None
-                ),
-                messages_processed=parallel_result.total_messages,
-                pause_seconds=(
-                    recoverable_failure_pause.pause_seconds
-                    if recoverable_failure_pause is not None
-                    else None
-                ),
-                resume_after=(
-                    recoverable_failure_pause.resume_after
-                    if recoverable_failure_pause is not None
-                    else None
-                ),
-                pause_kind=(
-                    recoverable_failure_pause.pause_kind
-                    if recoverable_failure_pause is not None
-                    else None
-                ),
-                resume_hint=(
-                    recoverable_failure_pause.resume_hint
-                    if recoverable_failure_pause is not None
-                    else None
-                ),
-            )
+        terminal_event = create_execution_terminal_event(
+            execution_id=exec_id,
+            session_id=tracker.session_id,
+            status=terminal_status,
+            summary=(
+                execution_summary if terminal_status == SessionStatus.COMPLETED.value else None
+            ),
+            error_message=(
+                final_message
+                if terminal_status
+                not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
+                else None
+            ),
+            messages_processed=parallel_result.total_messages,
+            pause_seconds=(
+                recoverable_failure_pause.pause_seconds
+                if recoverable_failure_pause is not None
+                else None
+            ),
+            resume_after=(
+                recoverable_failure_pause.resume_after
+                if recoverable_failure_pause is not None
+                else None
+            ),
+            pause_kind=(
+                recoverable_failure_pause.pause_kind
+                if recoverable_failure_pause is not None
+                else None
+            ),
+            resume_hint=(
+                recoverable_failure_pause.resume_hint
+                if recoverable_failure_pause is not None
+                else None
+            ),
         )
-
-        # Deterministic frugality proof over this execution's per-AC triads.
-        # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
-        await self._evaluate_frugality_proof(exec_id)
-        if terminal_status in {"completed", "failed", "cancelled"}:
-            await self._report_frugality_retrospective(
-                execution_id=exec_id,
-                session_id=tracker.session_id,
-                terminal_status=terminal_status,
-            )
+        await self._project_execution_outcome(
+            execution_id=exec_id,
+            session_id=tracker.session_id,
+            terminal_status=terminal_status,
+            terminal_event=terminal_event,
+        )
 
         log.info(
             "orchestrator.runner.parallel_completed",
@@ -7109,50 +7126,44 @@ Note: This is a resumed session. Please continue from where execution was interr
                     else SessionStatus.FAILED.value
                 )
             )
-            await self._event_store.append(
-                create_execution_terminal_event(
-                    execution_id=tracker.execution_id,
-                    session_id=session_id,
-                    status=terminal_status,
-                    error_message=(
-                        final_message
-                        if terminal_status
-                        not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
-                        else None
-                    ),
-                    messages_processed=messages_processed,
-                    pause_seconds=(
-                        recoverable_resume_failure.pause_seconds
-                        if recoverable_resume_failure is not None
-                        else None
-                    ),
-                    resume_after=(
-                        recoverable_resume_failure.resume_after
-                        if recoverable_resume_failure is not None
-                        else None
-                    ),
-                    pause_kind=(
-                        recoverable_resume_failure.pause_kind
-                        if recoverable_resume_failure is not None
-                        else None
-                    ),
-                    resume_hint=(
-                        recoverable_resume_failure.resume_hint
-                        if recoverable_resume_failure is not None
-                        else None
-                    ),
-                )
+            terminal_event = create_execution_terminal_event(
+                execution_id=tracker.execution_id,
+                session_id=session_id,
+                status=terminal_status,
+                error_message=(
+                    final_message
+                    if terminal_status
+                    not in {SessionStatus.COMPLETED.value, SessionStatus.PAUSED.value}
+                    else None
+                ),
+                messages_processed=messages_processed,
+                pause_seconds=(
+                    recoverable_resume_failure.pause_seconds
+                    if recoverable_resume_failure is not None
+                    else None
+                ),
+                resume_after=(
+                    recoverable_resume_failure.resume_after
+                    if recoverable_resume_failure is not None
+                    else None
+                ),
+                pause_kind=(
+                    recoverable_resume_failure.pause_kind
+                    if recoverable_resume_failure is not None
+                    else None
+                ),
+                resume_hint=(
+                    recoverable_resume_failure.resume_hint
+                    if recoverable_resume_failure is not None
+                    else None
+                ),
             )
-
-            # Deterministic frugality proof over this execution's per-AC triads.
-            # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
-            await self._evaluate_frugality_proof(tracker.execution_id)
-            if terminal_status in {"completed", "failed", "cancelled"}:
-                await self._report_frugality_retrospective(
-                    execution_id=tracker.execution_id,
-                    session_id=session_id,
-                    terminal_status=terminal_status,
-                )
+            await self._project_execution_outcome(
+                execution_id=tracker.execution_id,
+                session_id=session_id,
+                terminal_status=terminal_status,
+                terminal_event=terminal_event,
+            )
 
             log.info(
                 "orchestrator.runner.resume_completed",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -228,6 +228,21 @@ class RecoverableFailurePause:
     resume_after: datetime | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _PendingLifecycleIntent:
+    """Process-local lifecycle transition retained for exact-owner replay."""
+
+    execution_id: str
+    status: SessionStatus
+    summary: dict[str, Any] | None = None
+    error_message: str | None = None
+    error_details: dict[str, Any] | None = None
+    error_type: str | None = None
+    messages_processed: int = 0
+    cancelled_by: str = "runner"
+    pause: RecoverableFailurePause | None = None
+
+
 # =============================================================================
 # Errors
 # =============================================================================
@@ -814,6 +829,7 @@ class OrchestratorRunner:
         self._process_local_authorities: dict[
             tuple[str, str], _ProcessLocalAuthorityGeneration
         ] = {}
+        self._pending_lifecycle_intents: dict[str, _PendingLifecycleIntent] = {}
         self._execution_guidance: ExecutionGuidanceBundle | None = None
         # Opt-in shadow-replay baseline harness (frugality-proof AC5). Read ONCE
         # here next to the router build and threaded to the parallel executor.
@@ -1445,6 +1461,7 @@ class OrchestratorRunner:
         session_id: str,
         execution_id: str,
         pause_result: Result[bool, PersistenceError],
+        pause: RecoverableFailurePause,
     ) -> tuple[
         SessionStatus | None,
         Result[OrchestratorResult, OrchestratorError] | None,
@@ -1457,12 +1474,19 @@ class OrchestratorRunner:
         process-local owner rather than guessing at lifecycle state.
         """
         if pause_result.is_err:
+            self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                execution_id=execution_id,
+                status=SessionStatus.PAUSED,
+                error_message=pause.reason,
+                pause=pause,
+            )
             return None, self._pause_persistence_pending_result(
                 session_id=session_id,
                 execution_id=execution_id,
                 cause=pause_result.error,
             )
         if pause_result.value:
+            self._pending_lifecycle_intents.pop(session_id, None)
             return SessionStatus.PAUSED, None
 
         try:
@@ -1478,6 +1502,7 @@ class OrchestratorRunner:
             SessionStatus.FAILED,
             SessionStatus.CANCELLED,
         }:
+            self._pending_lifecycle_intents.pop(session_id, None)
             return reconstructed.value.status, None
 
         cause: object = (
@@ -1487,6 +1512,12 @@ class OrchestratorRunner:
                 "Conditional pause lost but no durable terminal winner could be reconstructed",
                 details={"session_id": session_id},
             )
+        )
+        self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+            execution_id=execution_id,
+            status=SessionStatus.PAUSED,
+            error_message=pause.reason,
+            pause=pause,
         )
         return None, self._pause_persistence_pending_result(
             session_id=session_id,
@@ -1609,6 +1640,7 @@ class OrchestratorRunner:
         try:
             durable_status = await self._persist_session_terminal_status(
                 session_id=session_id,
+                execution_id=execution_id,
                 requested_status=SessionStatus.FAILED,
                 error_message=str(error),
                 error_type=type(error).__name__,
@@ -2315,6 +2347,12 @@ class OrchestratorRunner:
             )
             if attempt < 2:
                 await asyncio.sleep(0.05 * (2**attempt))
+        self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+            execution_id=execution_id,
+            status=SessionStatus.FAILED,
+            error_message=error.message,
+            error_details=dict(error.details),
+        )
         return OrchestratorError(
             message="Failed to persist lost process-local authority terminal state",
             details={
@@ -2354,6 +2392,7 @@ class OrchestratorRunner:
                 last_error = exc
             else:
                 if result.is_ok:
+                    self._pending_lifecycle_intents.pop(tracker.session_id, None)
                     return None
                 last_error = result.error
             log.warning(
@@ -2365,6 +2404,13 @@ class OrchestratorRunner:
             )
             if attempt < 2:
                 await asyncio.sleep(0.05 * (2**attempt))
+        self._pending_lifecycle_intents[tracker.session_id] = _PendingLifecycleIntent(
+            execution_id=tracker.execution_id,
+            status=SessionStatus.FAILED,
+            error_message=message,
+            error_details=dict(details),
+            messages_processed=tracker.messages_processed,
+        )
         return str(last_error)
 
     async def _reconcile_session_publication_interruption(
@@ -2445,6 +2491,7 @@ class OrchestratorRunner:
         self,
         *,
         session_id: str,
+        execution_id: str,
         requested_status: SessionStatus,
         summary: dict[str, Any] | None = None,
         error_message: str | None = None,
@@ -2460,6 +2507,16 @@ class OrchestratorRunner:
         winner, otherwise completion and public cancellation can produce
         contradictory terminal streams.
         """
+        intent = _PendingLifecycleIntent(
+            execution_id=execution_id,
+            status=requested_status,
+            summary=summary,
+            error_message=error_message,
+            error_details=error_details,
+            error_type=error_type,
+            messages_processed=messages_processed,
+            cancelled_by=cancelled_by,
+        )
         result: Any = None
         last_error: object | None = None
         for attempt in range(3):
@@ -2504,6 +2561,7 @@ class OrchestratorRunner:
             if attempt < 2:
                 await asyncio.sleep(0.05 * (2**attempt))
         else:
+            self._pending_lifecycle_intents[session_id] = intent
             raise OrchestratorError(
                 message=f"Failed to persist terminal session status: {requested_status.value}",
                 details={
@@ -2516,11 +2574,13 @@ class OrchestratorRunner:
             )
 
         if result.value is not False:
+            self._pending_lifecycle_intents.pop(session_id, None)
             return requested_status
 
         try:
             winner = await self._session_repo.reconstruct_session(session_id)
         except Exception as exc:
+            self._pending_lifecycle_intents[session_id] = intent
             raise OrchestratorError(
                 message="Terminal session transition lost its CAS without a readable winner",
                 details={
@@ -2537,6 +2597,7 @@ class OrchestratorRunner:
             SessionStatus.CANCELLED,
         }
         if winner.is_ok and winner.value.status in terminal_statuses:
+            self._pending_lifecycle_intents.pop(session_id, None)
             log.info(
                 "orchestrator.runner.terminal_transition_preserved",
                 session_id=session_id,
@@ -2544,6 +2605,7 @@ class OrchestratorRunner:
                 durable_status=winner.value.status.value,
             )
             return winner.value.status
+        self._pending_lifecycle_intents[session_id] = intent
         raise OrchestratorError(
             message="Terminal session transition lost its CAS without a readable winner",
             details={
@@ -2553,6 +2615,234 @@ class OrchestratorRunner:
                 "resume_blocked": "terminal_persistence_pending",
                 "terminal_persistence_pending": True,
             },
+        )
+
+    async def _retry_pending_lifecycle_intent(
+        self,
+        tracker: SessionTracker,
+    ) -> Result[OrchestratorResult, OrchestratorError] | None:
+        """Replay an exact owner's retained terminal or pause transition.
+
+        Persistence-pending is not a normal RUNNING resume. The retained
+        process-local runner must first reclaim its generation and retry the
+        original transition with its original payload. Only after that intent
+        is durably resolved may ownership be released or retired.
+        """
+        intent = self._pending_lifecycle_intents.get(tracker.session_id)
+        if intent is None:
+            return None
+        if intent.execution_id != tracker.execution_id:
+            return Result.err(
+                OrchestratorError(
+                    message="Pending lifecycle intent does not match the durable execution",
+                    details={
+                        "session_id": tracker.session_id,
+                        "execution_id": tracker.execution_id,
+                        "pending_execution_id": intent.execution_id,
+                        "resume_blocked": "pending_lifecycle_identity_mismatch",
+                    },
+                )
+            )
+
+        raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
+        if not isinstance(raw_contract, Mapping):
+            return Result.err(
+                self._process_local_resume_unavailable_error(
+                    tracker.session_id,
+                    tracker.execution_id,
+                )
+            )
+        generation, already_claimed = self._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            raw_contract,
+        )
+        if already_claimed:
+            return Result.err(
+                self._process_local_execution_in_progress_error(
+                    tracker.session_id,
+                    tracker.execution_id,
+                )
+            )
+        if generation is None:
+            if self._process_local_authority_held_elsewhere(
+                tracker.session_id,
+                tracker.execution_id,
+                raw_contract,
+            ):
+                return Result.err(
+                    self._process_local_authority_held_elsewhere_error(
+                        tracker.session_id,
+                        tracker.execution_id,
+                    )
+                )
+            return Result.err(
+                self._process_local_resume_unavailable_error(
+                    tracker.session_id,
+                    tracker.execution_id,
+                )
+            )
+
+        try:
+            self._register_session(tracker.execution_id, tracker.session_id)
+        except Exception as exc:
+            if intent.status is SessionStatus.PAUSED:
+                return self._pause_persistence_pending_result(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    cause=exc,
+                )
+            return self._terminal_persistence_pending_result(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                requested_status=intent.status,
+                cause=exc,
+            )
+
+        resolved_status: SessionStatus
+        try:
+            if intent.status is SessionStatus.PAUSED:
+                pause = intent.pause
+                if pause is None:
+                    raise OrchestratorError(
+                        message="Pending PAUSED intent is missing its replay payload",
+                        details={
+                            "session_id": tracker.session_id,
+                            "execution_id": tracker.execution_id,
+                            "resume_blocked": "pending_lifecycle_payload_missing",
+                        },
+                    )
+                pause_result = await self._session_repo.mark_paused(
+                    tracker.session_id,
+                    reason=pause.reason,
+                    resume_hint=pause.resume_hint,
+                    pause_seconds=pause.pause_seconds,
+                    resume_after=pause.resume_after,
+                    pause_kind=pause.pause_kind,
+                )
+                resolved, pending = await self._resolve_pause_publication(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    pause_result=pause_result,
+                    pause=pause,
+                )
+                if pending is not None:
+                    return pending
+                assert resolved is not None
+                resolved_status = resolved
+            else:
+                resolved_status = await self._persist_session_terminal_status(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    requested_status=intent.status,
+                    summary=intent.summary,
+                    error_message=intent.error_message,
+                    error_details=intent.error_details,
+                    error_type=intent.error_type,
+                    messages_processed=intent.messages_processed,
+                    cancelled_by=intent.cancelled_by,
+                )
+        except asyncio.CancelledError:
+            self._preserve_process_local_owner_for_retry(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            raise
+        except BaseException as exc:
+            pending = self._terminal_persistence_pending_from_error(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=exc,
+            )
+            if pending is not None:
+                return pending
+            if intent.status is SessionStatus.PAUSED:
+                return self._pause_persistence_pending_result(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    cause=exc,
+                )
+            return self._terminal_persistence_pending_result(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                requested_status=intent.status,
+                cause=exc,
+            )
+
+        pause = intent.pause if resolved_status is SessionStatus.PAUSED else None
+        final_message = (
+            pause.reason
+            if pause is not None
+            else (
+                intent.error_message
+                or f"Pending {resolved_status.value} lifecycle transition persisted"
+            )
+        )
+        terminal_event = create_execution_terminal_event(
+            execution_id=tracker.execution_id,
+            session_id=tracker.session_id,
+            status=resolved_status.value,
+            summary=intent.summary if resolved_status is SessionStatus.COMPLETED else None,
+            error_message=(
+                final_message
+                if resolved_status not in {SessionStatus.COMPLETED, SessionStatus.PAUSED}
+                else None
+            ),
+            messages_processed=intent.messages_processed,
+            pause_seconds=pause.pause_seconds if pause is not None else None,
+            resume_after=pause.resume_after if pause is not None else None,
+            pause_kind=pause.pause_kind if pause is not None else None,
+            resume_hint=pause.resume_hint if pause is not None else None,
+        )
+        try:
+            await self._project_execution_outcome(
+                execution_id=tracker.execution_id,
+                session_id=tracker.session_id,
+                terminal_status=resolved_status.value,
+                terminal_event=terminal_event,
+            )
+        except Exception:
+            log.exception(
+                "orchestrator.runner.pending_lifecycle_projection_failed",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                durable_status=resolved_status.value,
+            )
+        finally:
+            if resolved_status is SessionStatus.PAUSED:
+                self._release_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._unregister_session(
+                    tracker.execution_id,
+                    tracker.session_id,
+                    release_liveness_lease=False,
+                )
+            else:
+                self._retire_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._unregister_session(tracker.execution_id, tracker.session_id)
+                await clear_cancellation(tracker.session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+
+        self._pending_lifecycle_intents.pop(tracker.session_id, None)
+        return Result.ok(
+            OrchestratorResult(
+                success=resolved_status is SessionStatus.COMPLETED,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                summary={
+                    **(intent.summary or {}),
+                    "replayed_pending_lifecycle": resolved_status.value,
+                },
+                messages_processed=intent.messages_processed,
+                final_message=final_message,
+                duration_seconds=0.0,
+            )
         )
 
     def _validate_resume_handle_execution_identity(
@@ -5829,6 +6119,7 @@ class OrchestratorRunner:
                 }
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
+                    execution_id=exec_id,
                     requested_status=SessionStatus.COMPLETED,
                     summary=completion_summary,
                     messages_processed=messages_processed,
@@ -5864,6 +6155,7 @@ class OrchestratorRunner:
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                     pause_result=pause_result,
+                    pause=recoverable_failure_pause,
                 )
                 if pause_pending is not None:
                     return pause_pending
@@ -5887,6 +6179,7 @@ class OrchestratorRunner:
             else:
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
+                    execution_id=exec_id,
                     requested_status=SessionStatus.FAILED,
                     error_message=final_message,
                     messages_processed=messages_processed,
@@ -6311,6 +6604,7 @@ class OrchestratorRunner:
         if success:
             durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
+                execution_id=exec_id,
                 requested_status=SessionStatus.COMPLETED,
                 summary=execution_summary,
                 messages_processed=parallel_result.total_messages,
@@ -6346,6 +6640,7 @@ class OrchestratorRunner:
                 session_id=tracker.session_id,
                 execution_id=exec_id,
                 pause_result=pause_result,
+                pause=recoverable_failure_pause,
             )
             if pause_pending is not None:
                 return pause_pending
@@ -6369,6 +6664,7 @@ class OrchestratorRunner:
         else:
             durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
+                execution_id=exec_id,
                 requested_status=SessionStatus.FAILED,
                 error_message=(
                     "Partial failure: "
@@ -6540,6 +6836,7 @@ class OrchestratorRunner:
             SessionStatus.CANCELLED,
             SessionStatus.FAILED,
         ):
+            self._pending_lifecycle_intents.pop(session_id, None)
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
                 session_id,
@@ -6552,6 +6849,10 @@ class OrchestratorRunner:
                     details={"session_id": session_id, "status": tracker.status.value},
                 )
             )
+
+        pending_lifecycle = await self._retry_pending_lifecycle_intent(tracker)
+        if pending_lifecycle is not None:
+            return pending_lifecycle
 
         if self._fat_harness_mode:
             self._cleanup_pre_execution_state(
@@ -7120,6 +7421,7 @@ Note: This is a resumed session. Please continue from where execution was interr
             if success:
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=session_id,
+                    execution_id=tracker.execution_id,
                     requested_status=SessionStatus.COMPLETED,
                     summary={
                         "messages_processed": messages_processed,
@@ -7157,6 +7459,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     session_id=session_id,
                     execution_id=tracker.execution_id,
                     pause_result=pause_result,
+                    pause=recoverable_resume_failure,
                 )
                 if pause_pending is not None:
                     return pause_pending
@@ -7180,6 +7483,7 @@ Note: This is a resumed session. Please continue from where execution was interr
             else:
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=session_id,
+                    execution_id=tracker.execution_id,
                     requested_status=SessionStatus.FAILED,
                     error_message=final_message,
                     messages_processed=messages_processed,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,7 @@ from ouroboros.orchestrator.events import (
 )
 from ouroboros.orchestrator.execution_authority import (
     ProcessLocalCancellationDisposition,
+    _await_process_local_cleanup,
     _claim_process_local_authority_generation,
     _discard_process_local_authority_generation,
     _has_live_process_local_authority_registration,
@@ -1463,25 +1464,29 @@ class OrchestratorRunner:
         window preserving the live generation would contradict the durable
         terminal source of truth, so interruption paths reconcile first.
         """
-        try:
-            reconstructed = await self._session_repo.reconstruct_session(session_id)
-        except Exception:
-            return False
-        if reconstructed.is_err or reconstructed.value.status not in {
-            SessionStatus.COMPLETED,
-            SessionStatus.FAILED,
-            SessionStatus.CANCELLED,
-        }:
-            return False
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
-        )
-        self._unregister_session(execution_id, session_id)
-        await clear_cancellation(session_id)
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
-        return True
+
+        async def _reconcile() -> bool:
+            try:
+                reconstructed = await self._session_repo.reconstruct_session(session_id)
+            except Exception:
+                return False
+            if reconstructed.is_err or reconstructed.value.status not in {
+                SessionStatus.COMPLETED,
+                SessionStatus.FAILED,
+                SessionStatus.CANCELLED,
+            }:
+                return False
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            self._unregister_session(execution_id, session_id)
+            await clear_cancellation(session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return True
+
+        return bool(await _await_process_local_cleanup(_reconcile()))
 
     async def _persist_failure_and_cleanup(
         self,
@@ -2252,6 +2257,80 @@ class OrchestratorRunner:
             if attempt < 2:
                 await asyncio.sleep(0.05 * (2**attempt))
         return str(last_error)
+
+    async def _reconcile_session_publication_interruption(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> bool:
+        """Resolve an interrupted or failed durable session-start append.
+
+        ``create_session`` may commit ``session.started`` and still be
+        interrupted before returning its tracker.  Never retire the early
+        process-local owner from the exception alone: reconstruct under
+        shielding, terminalize a proven active publication, or retain the
+        exact owner when persistence cannot be established.
+        """
+
+        async def _reconcile() -> bool:
+            try:
+                reconstructed = await self._session_repo.reconstruct_session(session_id)
+            except Exception:
+                reconstructed = None
+
+            if reconstructed is not None and reconstructed.is_err:
+                reconstruction_message = getattr(
+                    reconstructed.error,
+                    "message",
+                    str(reconstructed.error),
+                )
+                if reconstruction_message.startswith(("No events found", "No start event found")):
+                    self._retire_process_local_authority(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+            elif reconstructed is not None and reconstructed.is_ok:
+                tracker = reconstructed.value
+                if tracker.session_id == session_id and tracker.execution_id == execution_id:
+                    if tracker.status in {
+                        SessionStatus.COMPLETED,
+                        SessionStatus.FAILED,
+                        SessionStatus.CANCELLED,
+                    }:
+                        self._retire_process_local_authority(
+                            session_id=session_id,
+                            execution_id=execution_id,
+                        )
+                        await clear_cancellation(session_id)
+                    else:
+                        terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                            tracker=tracker,
+                            message="Session preparation was cancelled after durable publication",
+                            details={
+                                "session_id": session_id,
+                                "execution_id": execution_id,
+                                "cause": "CancelledError",
+                            },
+                        )
+                        if terminal_mark_error is None:
+                            self._retire_process_local_authority(
+                                session_id=session_id,
+                                execution_id=execution_id,
+                            )
+                            await clear_cancellation(session_id)
+                        else:
+                            log.warning(
+                                "orchestrator.runner.create_session_cancel_terminal_pending",
+                                session_id=session_id,
+                                execution_id=execution_id,
+                                error=terminal_mark_error,
+                            )
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return (session_id, execution_id) in self._process_local_authorities
+
+        return bool(await _await_process_local_cleanup(_reconcile()))
 
     async def _persist_session_terminal_status(
         self,
@@ -4871,31 +4950,54 @@ class OrchestratorRunner:
                 execution_contract=execution_contract,
             )
         except asyncio.CancelledError:
-            # Registration and its liveness lease precede durable publication.
-            # A caller cancelling this await must not strand that live
-            # generation even when the repository did not return a tracker.
-            abort_process_local_preparation()
+            await self._reconcile_session_publication_interruption(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
             raise
         except Exception as exc:
-            abort_process_local_preparation()
+            retained_owner = await self._reconcile_session_publication_interruption(
+                session_id=resolved_session_id,
+                execution_id=exec_id,
+            )
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {exc}",
-                    details={"execution_id": exec_id, "session_id": resolved_session_id},
+                    details={
+                        "execution_id": exec_id,
+                        "session_id": resolved_session_id,
+                        **(
+                            {
+                                "resume_blocked": "terminal_persistence_pending",
+                                "terminal_persistence_pending": True,
+                            }
+                            if retained_owner
+                            else {}
+                        ),
+                    },
                 )
             )
 
         if session_result.is_err:
-            self._retire_process_local_authority(
+            retained_owner = await self._reconcile_session_publication_interruption(
                 session_id=resolved_session_id,
                 execution_id=exec_id,
             )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {session_result.error}",
-                    details={"execution_id": exec_id, "session_id": resolved_session_id},
+                    details={
+                        "execution_id": exec_id,
+                        "session_id": resolved_session_id,
+                        **(
+                            {
+                                "resume_blocked": "terminal_persistence_pending",
+                                "terminal_persistence_pending": True,
+                            }
+                            if retained_owner
+                            else {}
+                        ),
+                    },
                 )
             )
 
@@ -4908,12 +5010,10 @@ class OrchestratorRunner:
             # was never protected during publication.  This is a repository
             # contract violation, not a reason to mutate or terminalize the
             # unrelated returned tracker.
-            self._retire_process_local_authority(
+            retained_owner = await self._reconcile_session_publication_interruption(
                 session_id=resolved_session_id,
                 execution_id=exec_id,
             )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
             return Result.err(
                 OrchestratorError(
                     message="Session repository returned an unexpected session identity",
@@ -4922,6 +5022,14 @@ class OrchestratorRunner:
                         "expected_execution_id": exec_id,
                         "returned_session_id": tracker.session_id,
                         "returned_execution_id": tracker.execution_id,
+                        **(
+                            {
+                                "resume_blocked": "terminal_persistence_pending",
+                                "terminal_persistence_pending": True,
+                            }
+                            if retained_owner
+                            else {}
+                        ),
                     },
                 )
             )
@@ -4938,23 +5046,10 @@ class OrchestratorRunner:
                 initial_progress,
             )
         except asyncio.CancelledError:
-            # ``create_session`` has already made a RUNNING tracker durable.
-            # Record its terminal preparation failure before withdrawing the
-            # process-local lease, then re-raise the caller's cancellation.
-            terminal_mark_error = await self._mark_preparation_failed_best_effort(
-                tracker=tracker,
-                message="Session preparation cancelled before initial contract was persisted",
-                details={
-                    "session_id": tracker.session_id,
-                    "execution_id": tracker.execution_id,
-                    "fat_harness_mode": self._fat_harness_mode,
-                    "cause": "CancelledError",
-                },
+            await self._reconcile_session_publication_interruption(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
             )
-            if terminal_mark_error is None:
-                abort_process_local_preparation()
-            elif self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
             raise
         except Exception as exc:
             progress_exception_details: dict[str, Any] = {
@@ -5035,24 +5130,67 @@ class OrchestratorRunner:
 
         set_console_logging(self._debug)
 
-        raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
         if tracker.status in (
             SessionStatus.COMPLETED,
             SessionStatus.CANCELLED,
             SessionStatus.FAILED,
         ):
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                tracker.session_id,
-                session_registered=False,
+            durable_tracker_result = await self._session_repo.reconstruct_session(
+                tracker.session_id
             )
-            await clear_cancellation(tracker.session_id)
-            return Result.err(
-                OrchestratorError(
-                    message=f"Session is in terminal state {tracker.status.value}, cannot execute",
-                    details={"session_id": tracker.session_id, "status": tracker.status.value},
+            if durable_tracker_result.is_err:
+                return Result.err(
+                    OrchestratorError(
+                        message="Cannot verify caller-supplied terminal session state",
+                        details={
+                            "session_id": tracker.session_id,
+                            "execution_id": tracker.execution_id,
+                            "cause": str(durable_tracker_result.error),
+                            "resume_blocked": "terminal_state_unverified",
+                        },
+                    )
                 )
-            )
+            durable_tracker = durable_tracker_result.value
+            if (
+                durable_tracker.session_id != tracker.session_id
+                or durable_tracker.execution_id != tracker.execution_id
+            ):
+                return Result.err(
+                    OrchestratorError(
+                        message="Durable session identity does not match the supplied tracker",
+                        details={
+                            "session_id": tracker.session_id,
+                            "execution_id": tracker.execution_id,
+                        },
+                    )
+                )
+            if durable_tracker.status in {
+                SessionStatus.COMPLETED,
+                SessionStatus.CANCELLED,
+                SessionStatus.FAILED,
+            }:
+                self._cleanup_pre_execution_state(
+                    durable_tracker.execution_id,
+                    durable_tracker.session_id,
+                    session_registered=False,
+                )
+                await clear_cancellation(durable_tracker.session_id)
+                return Result.err(
+                    OrchestratorError(
+                        message=(
+                            "Session is in terminal state "
+                            f"{durable_tracker.status.value}, cannot execute"
+                        ),
+                        details={
+                            "session_id": durable_tracker.session_id,
+                            "status": durable_tracker.status.value,
+                        },
+                    )
+                )
+            tracker = durable_tracker
+            exec_id = tracker.execution_id
+
+        raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
 
         # This API may execute only the tracker returned by ``prepare_session``.
         # A legacy/reconstructed tracker with no contract is not a new-session

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1412,6 +1412,32 @@ class OrchestratorRunner:
             )
         )
 
+    def _pause_persistence_pending_result(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        cause: object,
+    ) -> Result[OrchestratorResult, OrchestratorError]:
+        """Return a typed pause failure without publishing a false PAUSED state."""
+        self._preserve_process_local_owner_for_retry(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        return Result.err(
+            OrchestratorError(
+                message="Failed to persist paused session state; process-local authority remains live",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "requested_status": SessionStatus.PAUSED.value,
+                    "cause": str(cause),
+                    "resume_blocked": "pause_persistence_pending",
+                    "pause_persistence_pending": True,
+                },
+            )
+        )
+
     @staticmethod
     def _requested_terminal_status_from_error(error: BaseException) -> SessionStatus | None:
         """Recover the original terminal intent from a typed persistence error."""
@@ -5743,7 +5769,7 @@ class OrchestratorRunner:
                     )
                 )
             elif recoverable_failure_pause is not None:
-                await self._session_repo.mark_paused(
+                pause_result = await self._session_repo.mark_paused(
                     tracker.session_id,
                     reason=recoverable_failure_pause.reason,
                     resume_hint=recoverable_failure_pause.resume_hint,
@@ -5751,6 +5777,12 @@ class OrchestratorRunner:
                     resume_after=recoverable_failure_pause.resume_after,
                     pause_kind=recoverable_failure_pause.pause_kind,
                 )
+                if pause_result.is_err:
+                    return self._pause_persistence_pending_result(
+                        session_id=tracker.session_id,
+                        execution_id=exec_id,
+                        cause=pause_result.error,
+                    )
 
                 self._console.print(
                     Panel(
@@ -6214,7 +6246,7 @@ class OrchestratorRunner:
                 )
             )
         elif recoverable_failure_pause is not None:
-            await self._session_repo.mark_paused(
+            pause_result = await self._session_repo.mark_paused(
                 tracker.session_id,
                 reason=recoverable_failure_pause.reason,
                 resume_hint=recoverable_failure_pause.resume_hint,
@@ -6222,6 +6254,12 @@ class OrchestratorRunner:
                 resume_after=recoverable_failure_pause.resume_after,
                 pause_kind=recoverable_failure_pause.pause_kind,
             )
+            if pause_result.is_err:
+                return self._pause_persistence_pending_result(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    cause=pause_result.error,
+                )
 
             self._console.print(
                 Panel(
@@ -6348,7 +6386,8 @@ class OrchestratorRunner:
             tracker.session_id,
             release_liveness_lease=terminal_status != "paused",
         )
-        await clear_cancellation(tracker.session_id)
+        if terminal_status != "paused":
+            await clear_cancellation(tracker.session_id)
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
 
@@ -7014,7 +7053,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     )
                 )
             elif recoverable_resume_failure is not None:
-                await self._session_repo.mark_paused(
+                pause_result = await self._session_repo.mark_paused(
                     session_id,
                     reason=recoverable_resume_failure.reason,
                     resume_hint=recoverable_resume_failure.resume_hint,
@@ -7022,6 +7061,12 @@ Note: This is a resumed session. Please continue from where execution was interr
                     resume_after=recoverable_resume_failure.resume_after,
                     pause_kind=recoverable_resume_failure.pause_kind,
                 )
+                if pause_result.is_err:
+                    return self._pause_persistence_pending_result(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                        cause=pause_result.error,
+                    )
                 self._console.print(
                     Panel(
                         Text(final_message[:1000], style="yellow"),
@@ -7117,8 +7162,11 @@ Note: This is a resumed session. Please continue from where execution was interr
                 duration_seconds=duration,
             )
 
-            # Clear the in-memory cancellation flag so it doesn't linger
-            await clear_cancellation(session_id)
+            # A paused owner has not acknowledged a cancellation that may have
+            # arrived after its final execution checkpoint. Preserve that
+            # marker so the next resume entry point terminalizes before effects.
+            if terminal_status != "paused":
+                await clear_cancellation(session_id)
 
             # Clean up session tracking
             if terminal_status != "paused":

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -281,7 +281,11 @@ async def is_cancellation_requested(session_id: str) -> bool:
         True if cancellation was requested.
     """
     async with _cancellation_lock:
-        return session_id in _cancellation_registry
+        if session_id in _cancellation_registry:
+            return True
+    from ouroboros.orchestrator.heartbeat import has_cancellation_request
+
+    return has_cancellation_request(session_id)
 
 
 async def clear_cancellation(session_id: str) -> None:
@@ -295,6 +299,9 @@ async def clear_cancellation(session_id: str) -> None:
     """
     async with _cancellation_lock:
         _cancellation_registry.discard(session_id)
+    from ouroboros.orchestrator.heartbeat import clear_cancellation_request
+
+    clear_cancellation_request(session_id)
 
 
 async def get_pending_cancellations() -> frozenset[str]:
@@ -1333,9 +1340,10 @@ class OrchestratorRunner:
     ) -> None:
         """Release pre-loop runner state after an aborted execution path.
 
-        A setup failure or externally cancelled task does not leave a valid
-        same-process continuation.  Retire its live capability before releasing
-        bookkeeping so a stale tracker cannot become an alternate resume path.
+        Use this only when the caller has either observed a durable terminal
+        result or proved that no usable authority exists. Retryable persistence
+        and raw-cancellation paths use
+        :meth:`_preserve_process_local_owner_for_retry` instead.
         """
         if retire_authority and execution_id is not None and session_id is not None:
             self._retire_process_local_authority(
@@ -1346,6 +1354,116 @@ class OrchestratorRunner:
             self._unregister_session(execution_id, session_id)
         if self._task_workspace is not None:
             release_lock(self._task_workspace.lock_path)
+
+    def _preserve_process_local_owner_for_retry(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+    ) -> None:
+        """Release an exiting coroutine's effects without retiring authority.
+
+        A durable RUNNING session remains truthful only while its exact local
+        generation and liveness lease remain available.  Persistence failures
+        and raw task cancellation therefore release the exclusive claim,
+        active route, and worktree lock, but keep the registration resumable by
+        the same retained owner.
+        """
+        self._release_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        self._unregister_session(
+            execution_id,
+            session_id,
+            release_liveness_lease=False,
+        )
+        if self._task_workspace is not None:
+            release_lock(self._task_workspace.lock_path)
+
+    def _terminal_persistence_pending_result(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        requested_status: SessionStatus,
+        cause: object,
+    ) -> Result[OrchestratorResult, OrchestratorError]:
+        """Return a typed retryable result while preserving the live owner."""
+        self._preserve_process_local_owner_for_retry(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        return Result.err(
+            OrchestratorError(
+                message=(
+                    f"Failed to persist terminal status {requested_status.value}; "
+                    "process-local authority remains live"
+                ),
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "requested_status": requested_status.value,
+                    "cause": str(cause),
+                    "resume_blocked": "terminal_persistence_pending",
+                    "terminal_persistence_pending": True,
+                },
+            )
+        )
+
+    async def _persist_failure_and_cleanup(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        error: BaseException,
+        messages_processed: int = 0,
+    ) -> tuple[SessionStatus | None, Result[OrchestratorResult, OrchestratorError] | None]:
+        """Persist one durable failure winner before withdrawing ownership."""
+        try:
+            durable_status = await self._persist_session_terminal_status(
+                session_id=session_id,
+                requested_status=SessionStatus.FAILED,
+                error_message=str(error),
+                error_type=type(error).__name__,
+                messages_processed=messages_processed,
+            )
+        except BaseException as persistence_error:
+            return None, self._terminal_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                requested_status=SessionStatus.FAILED,
+                cause=persistence_error,
+            )
+
+        self._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        self._unregister_session(execution_id, session_id)
+        await clear_cancellation(session_id)
+        if self._task_workspace is not None:
+            release_lock(self._task_workspace.lock_path)
+        try:
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    status=durable_status.value,
+                    error_message=(
+                        str(error) if durable_status is not SessionStatus.COMPLETED else None
+                    ),
+                    messages_processed=messages_processed,
+                )
+            )
+        except Exception:
+            log.warning(
+                "orchestrator.runner.failure_projection_failed",
+                session_id=session_id,
+                execution_id=execution_id,
+                durable_status=durable_status.value,
+            )
+        return durable_status, None
 
     def _deserialize_runtime_handle(self, progress: dict[str, Any]) -> RuntimeHandle | None:
         """Deserialize runtime resume state from session progress."""
@@ -1977,37 +2095,51 @@ class OrchestratorRunner:
     ) -> OrchestratorError:
         """Terminally record a lost local capability without trying a fallback."""
         error = self._process_local_resume_unavailable_error(session_id, execution_id)
-        try:
-            result = await self._session_repo.mark_failed_if_active(
-                session_id,
-                error.message,
-                error.details,
-            )
-            if result.is_err:
-                log.warning(
-                    "orchestrator.runner.process_local_resume_terminal_mark_failed",
-                    session_id=session_id,
-                    execution_id=execution_id,
-                    error=str(result.error),
+        last_error: object | None = None
+        for attempt in range(3):
+            try:
+                result = await self._session_repo.mark_failed_if_active(
+                    session_id,
+                    error.message,
+                    error.details,
                 )
-            elif not result.value:
-                log.info(
-                    "orchestrator.runner.process_local_resume_terminal_already_persisted",
-                    session_id=session_id,
-                    execution_id=execution_id,
-                )
-        except Exception as exc:  # pragma: no cover - best-effort terminal record
+            except Exception as exc:  # pragma: no cover - defensive persistence boundary
+                last_error = exc
+            else:
+                if result.is_ok:
+                    if not result.value:
+                        log.info(
+                            "orchestrator.runner.process_local_resume_terminal_already_persisted",
+                            session_id=session_id,
+                            execution_id=execution_id,
+                        )
+                    self._retire_process_local_authority(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                    await clear_cancellation(session_id)
+                    return error
+                last_error = result.error
             log.warning(
-                "orchestrator.runner.process_local_resume_terminal_mark_raised",
+                "orchestrator.runner.process_local_resume_terminal_mark_retry",
                 session_id=session_id,
                 execution_id=execution_id,
-                error=str(exc),
+                attempt=attempt + 1,
+                error=str(last_error),
             )
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
+            if attempt < 2:
+                await asyncio.sleep(0.05 * (2**attempt))
+        return OrchestratorError(
+            message="Failed to persist lost process-local authority terminal state",
+            details={
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "requested_status": SessionStatus.FAILED.value,
+                "cause": str(last_error),
+                "resume_blocked": "terminal_persistence_pending",
+                "terminal_persistence_pending": True,
+            },
         )
-        return error
 
     async def _mark_preparation_failed_best_effort(
         self,
@@ -2020,34 +2152,34 @@ class OrchestratorRunner:
 
         ``create_session`` has already written a RUNNING durable tracker by
         the time initial progress is persisted.  If that second write fails,
-        leave neither an apparently resumable RUNNING session nor a live
-        process-local capability behind.  A persistence failure while writing
-        this terminal state is reported as diagnostics, never allowed to skip
-        authority retirement.
+        retry the terminal write briefly. If persistence remains unavailable,
+        the caller preserves the process-local capability and lease instead of
+        manufacturing an unowned durable RUNNING session.
         """
-        try:
-            result = await self._session_repo.mark_failed(
-                tracker.session_id,
-                message,
-                dict(details),
-            )
-        except Exception as exc:  # pragma: no cover - defensive persistence boundary
+        last_error: object | None = None
+        for attempt in range(3):
+            try:
+                result = await self._session_repo.mark_failed(
+                    tracker.session_id,
+                    message,
+                    dict(details),
+                )
+            except Exception as exc:  # pragma: no cover - defensive persistence boundary
+                last_error = exc
+            else:
+                if result.is_ok:
+                    return None
+                last_error = result.error
             log.warning(
-                "orchestrator.runner.prepare_terminal_mark_raised",
+                "orchestrator.runner.prepare_terminal_mark_retry",
                 session_id=tracker.session_id,
                 execution_id=tracker.execution_id,
-                error=str(exc),
+                attempt=attempt + 1,
+                error=str(last_error),
             )
-            return str(exc)
-        if result.is_err:
-            log.warning(
-                "orchestrator.runner.prepare_terminal_mark_failed",
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-                error=str(result.error),
-            )
-            return str(result.error)
-        return None
+            if attempt < 2:
+                await asyncio.sleep(0.05 * (2**attempt))
+        return str(last_error)
 
     async def _persist_session_terminal_status(
         self,
@@ -3850,6 +3982,7 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
             )
+            await clear_cancellation(session_id)
             return Result.ok(
                 {
                     "execution_id": execution_id,
@@ -4210,17 +4343,10 @@ class OrchestratorRunner:
         exiting, so they must be released for a retained owner to retry the
         durable terminal write on a later resume request.
         """
-        self._release_process_local_authority(
+        self._preserve_process_local_owner_for_retry(
             session_id=session_id,
             execution_id=execution_id,
         )
-        self._unregister_session(
-            execution_id,
-            session_id,
-            release_liveness_lease=False,
-        )
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
         return Result.err(
             OrchestratorError(
                 message="Failed to persist cancellation; process-local authority remains live",
@@ -4706,19 +4832,20 @@ class OrchestratorRunner:
             # ``create_session`` has already made a RUNNING tracker durable.
             # Record its terminal preparation failure before withdrawing the
             # process-local lease, then re-raise the caller's cancellation.
-            try:
-                await self._mark_preparation_failed_best_effort(
-                    tracker=tracker,
-                    message="Session preparation cancelled before initial contract was persisted",
-                    details={
-                        "session_id": tracker.session_id,
-                        "execution_id": tracker.execution_id,
-                        "fat_harness_mode": self._fat_harness_mode,
-                        "cause": "CancelledError",
-                    },
-                )
-            finally:
+            terminal_mark_error = await self._mark_preparation_failed_best_effort(
+                tracker=tracker,
+                message="Session preparation cancelled before initial contract was persisted",
+                details={
+                    "session_id": tracker.session_id,
+                    "execution_id": tracker.execution_id,
+                    "fat_harness_mode": self._fat_harness_mode,
+                    "cause": "CancelledError",
+                },
+            )
+            if terminal_mark_error is None:
                 abort_process_local_preparation()
+            elif self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
             raise
         except Exception as exc:
             progress_exception_details: dict[str, Any] = {
@@ -4732,14 +4859,17 @@ class OrchestratorRunner:
                 message="Failed to persist initial session contract",
                 details=progress_exception_details,
             )
-            self._retire_process_local_authority(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+            if terminal_mark_error is None:
+                self._retire_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
             if terminal_mark_error is not None:
                 progress_exception_details["terminal_mark_error"] = terminal_mark_error
+                progress_exception_details["resume_blocked"] = "terminal_persistence_pending"
+                progress_exception_details["terminal_persistence_pending"] = True
             return Result.err(
                 OrchestratorError(
                     message="Failed to persist initial session contract",
@@ -4758,15 +4888,18 @@ class OrchestratorRunner:
                 message="Failed to persist initial session contract",
                 details=progress_result_details,
             )
-            self._retire_process_local_authority(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-            )
+            if terminal_mark_error is None:
+                self._retire_process_local_authority(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
             if terminal_mark_error is not None:
                 progress_result_details["terminal_mark_error"] = terminal_mark_error
+                progress_result_details["resume_blocked"] = "terminal_persistence_pending"
+                progress_result_details["terminal_persistence_pending"] = True
             return Result.err(
                 OrchestratorError(
                     message="Failed to persist initial session contract",
@@ -4804,6 +4937,7 @@ class OrchestratorRunner:
                 tracker.session_id,
                 session_registered=False,
             )
+            await clear_cancellation(tracker.session_id)
             return Result.err(
                 OrchestratorError(
                     message=f"Session is in terminal state {tracker.status.value}, cannot execute",
@@ -4864,10 +4998,9 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                tracker.session_id,
-                session_registered=False,
+            self._preserve_process_local_owner_for_retry(
+                execution_id=tracker.execution_id,
+                session_id=tracker.session_id,
             )
             raise
         except OrchestratorError as exc:
@@ -4881,11 +5014,13 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                tracker.session_id,
-                session_registered=False,
+            _, persistence_pending = await self._persist_failure_and_cleanup(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=exc,
             )
+            if persistence_pending is not None:
+                return persistence_pending
             return Result.err(exc)
         self._execution_contract = dict(raw_contract)
 
@@ -4896,12 +5031,9 @@ class OrchestratorRunner:
             seed_id=seed.metadata.seed_id,
             goal=seed.goal[:100],
         )
-        session_registered = False
-
         try:
             # Register session for cancellation tracking
             self._register_session(exec_id, tracker.session_id)
-            session_registered = True
             if await self._check_startup_cancellation(tracker.session_id):
                 return await self._handle_cancellation(
                     session_id=tracker.session_id,
@@ -5014,10 +5146,9 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                exec_id,
-                tracker.session_id,
-                session_registered=session_registered,
+            self._preserve_process_local_owner_for_retry(
+                execution_id=exec_id,
+                session_id=tracker.session_id,
             )
             raise
         except Exception as e:
@@ -5031,16 +5162,18 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                exec_id,
-                tracker.session_id,
-                session_registered=session_registered,
-            )
             log.exception(
                 "orchestrator.runner.execute_setup_failed",
                 execution_id=exec_id,
                 error=str(e),
             )
+            _, persistence_pending = await self._persist_failure_and_cleanup(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                error=e,
+            )
+            if persistence_pending is not None:
+                return persistence_pending
             return Result.err(
                 OrchestratorError(
                     message=f"Orchestrator execution failed: {e}",
@@ -5477,6 +5610,8 @@ class OrchestratorRunner:
                 tracker.session_id,
                 release_liveness_lease=terminal_status != "paused",
             )
+            if terminal_status != "paused":
+                await clear_cancellation(tracker.session_id)
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
 
@@ -5504,13 +5639,10 @@ class OrchestratorRunner:
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
-            self._retire_process_local_authority(
+            self._preserve_process_local_owner_for_retry(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
             )
-            self._unregister_session(exec_id, tracker.session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
             raise
         except Exception as e:
             log.exception(
@@ -5519,33 +5651,15 @@ class OrchestratorRunner:
                 error=str(e),
             )
 
-            # Clean up session tracking
-            self._unregister_session(exec_id, tracker.session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
-
-            durable_terminal_status = await self._persist_session_terminal_status(
-                session_id=tracker.session_id,
-                requested_status=SessionStatus.FAILED,
-                error_message=str(e),
-                error_type=type(e).__name__,
-                messages_processed=messages_processed,
-            )
-            self._retire_process_local_authority(
+            durable_terminal_status, persistence_pending = await self._persist_failure_and_cleanup(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
+                error=e,
+                messages_processed=messages_processed,
             )
-            await self._event_store.append(
-                create_execution_terminal_event(
-                    execution_id=exec_id,
-                    session_id=tracker.session_id,
-                    status=durable_terminal_status.value,
-                    error_message=(
-                        str(e) if durable_terminal_status is not SessionStatus.COMPLETED else None
-                    ),
-                    messages_processed=messages_processed,
-                )
-            )
+            if persistence_pending is not None:
+                return persistence_pending
+            assert durable_terminal_status is not None
             await self._report_frugality_retrospective(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
@@ -6029,6 +6143,7 @@ class OrchestratorRunner:
                 session_id,
                 session_registered=False,
             )
+            await clear_cancellation(session_id)
             return Result.err(
                 OrchestratorError(
                     message=f"Session is in terminal state {tracker.status.value}, cannot resume",
@@ -6041,6 +6156,7 @@ class OrchestratorRunner:
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
+                retire_authority=False,
             )
             return Result.err(
                 OrchestratorError(
@@ -6063,6 +6179,7 @@ class OrchestratorRunner:
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
+                retire_authority=False,
             )
             return Result.err(
                 OrchestratorError(
@@ -6090,6 +6207,7 @@ class OrchestratorRunner:
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
+                retire_authority=False,
             )
             return Result.err(error)
 
@@ -6214,6 +6332,7 @@ class OrchestratorRunner:
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
+                retire_authority=False,
             )
             return Result.err(error)
 
@@ -6252,6 +6371,7 @@ class OrchestratorRunner:
                 tracker.execution_id,
                 session_id,
                 session_registered=False,
+                retire_authority=False,
             )
             return Result.err(error)
 
@@ -6274,10 +6394,9 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
+            self._preserve_process_local_owner_for_retry(
+                execution_id=tracker.execution_id,
+                session_id=session_id,
             )
             raise
         except OrchestratorError as exc:
@@ -6291,18 +6410,17 @@ class OrchestratorRunner:
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
+            _, persistence_pending = await self._persist_failure_and_cleanup(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+                error=exc,
             )
+            if persistence_pending is not None:
+                return persistence_pending
             return Result.err(exc)
-        session_registered = False
-
         try:
             # Register session for cancellation tracking
             self._register_session(tracker.execution_id, session_id)
-            session_registered = True
 
             # A public cancellation may have reserved this previously-paused
             # owner between resume arbitration and registration.  Honor that
@@ -6404,10 +6522,9 @@ Note: This is a resumed session. Please continue from where execution was interr
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=session_registered,
+            self._preserve_process_local_owner_for_retry(
+                execution_id=tracker.execution_id,
+                session_id=session_id,
             )
             raise
         except Exception as e:
@@ -6421,16 +6538,19 @@ Note: This is a resumed session. Please continue from where execution was interr
             )
             if cancellation_result is not None:
                 return cancellation_result
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=session_registered,
-            )
             log.exception(
                 "orchestrator.runner.resume_setup_failed",
                 session_id=session_id,
                 error=str(e),
             )
+            _, persistence_pending = await self._persist_failure_and_cleanup(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+                error=e,
+                messages_processed=tracker.messages_processed,
+            )
+            if persistence_pending is not None:
+                return persistence_pending
             return Result.err(
                 OrchestratorError(
                     message=f"Session resume failed: {e}",
@@ -6756,13 +6876,10 @@ Note: This is a resumed session. Please continue from where execution was interr
                     messages_processed=messages_processed,
                     start_time=start_time,
                 )
-            self._retire_process_local_authority(
+            self._preserve_process_local_owner_for_retry(
                 session_id=session_id,
                 execution_id=tracker.execution_id,
             )
-            self._unregister_session(tracker.execution_id, session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
             raise
         except Exception as e:
             log.exception(
@@ -6771,30 +6888,15 @@ Note: This is a resumed session. Please continue from where execution was interr
                 error=str(e),
             )
 
-            # Clean up session tracking
-            self._unregister_session(tracker.execution_id, session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
-            durable_terminal_status = await self._persist_session_terminal_status(
-                session_id=session_id,
-                requested_status=SessionStatus.FAILED,
-                error_message=str(e),
-                error_type=type(e).__name__,
-            )
-            self._retire_process_local_authority(
+            durable_terminal_status, persistence_pending = await self._persist_failure_and_cleanup(
                 session_id=session_id,
                 execution_id=tracker.execution_id,
+                error=e,
+                messages_processed=messages_processed,
             )
-            await self._event_store.append(
-                create_execution_terminal_event(
-                    execution_id=tracker.execution_id,
-                    session_id=session_id,
-                    status=durable_terminal_status.value,
-                    error_message=(
-                        str(e) if durable_terminal_status is not SessionStatus.COMPLETED else None
-                    ),
-                )
-            )
+            if persistence_pending is not None:
+                return persistence_pending
+            assert durable_terminal_status is not None
             await self._report_frugality_retrospective(
                 execution_id=tracker.execution_id,
                 session_id=session_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4035,21 +4035,20 @@ class OrchestratorRunner:
             duration_seconds=duration,
         )
 
-        # Clear the in-memory cancellation flag so it doesn't linger
-        await clear_cancellation(session_id)
-
-        # Clean up session tracking
-        self._unregister_session(execution_id, session_id)
-        self._retire_process_local_authority(
-            session_id=session_id,
-            execution_id=execution_id,
-        )
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
-
-        # Only mark cancelled if not already in a terminal state
+        # Determine and durably publish the terminal state *before* withdrawing
+        # the process-local capability or its heartbeat.  A RUNNING tracker
+        # with neither liveness signal is indistinguishable from a crashed
+        # owner to another process, so releasing first can cause a concurrent
+        # observer to terminalize this deliberate cancellation as lost
+        # authority.  It would also make a persistence failure report a
+        # cancellation that the durable session never recorded.
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
+        # An unreadable snapshot cannot prove that a terminal state already
+        # exists.  Continue through ``mark_cancelled`` while retaining the live
+        # owner; that append is the authoritative terminal write and preserves
+        # the legacy best-effort reconstruction posture without ever releasing
+        # a RUNNING session first.
         session_already_terminal = session_result.is_ok and session_result.value.status in _terminal
         if session_already_terminal:
             terminal_status = session_result.value.status
@@ -4065,19 +4064,31 @@ class OrchestratorRunner:
                 )
             except Exception:
                 execution_terminal_events = []
-            if not execution_terminal_events:
-                await self._event_store.append(
-                    create_execution_terminal_event(
-                        execution_id=execution_id,
-                        session_id=session_id,
-                        status=terminal_status.value,
-                        summary=summary if terminal_status == SessionStatus.COMPLETED else None,
-                        error_message=(
-                            final_message if terminal_status != SessionStatus.COMPLETED else None
-                        ),
-                        messages_processed=messages_processed,
+            await clear_cancellation(session_id)
+            try:
+                if not execution_terminal_events:
+                    await self._event_store.append(
+                        create_execution_terminal_event(
+                            execution_id=execution_id,
+                            session_id=session_id,
+                            status=terminal_status.value,
+                            summary=summary if terminal_status == SessionStatus.COMPLETED else None,
+                            error_message=(
+                                final_message
+                                if terminal_status != SessionStatus.COMPLETED
+                                else None
+                            ),
+                            messages_processed=messages_processed,
+                        )
                     )
+            finally:
+                self._retire_process_local_authority(
+                    session_id=session_id,
+                    execution_id=execution_id,
                 )
+                self._unregister_session(execution_id, session_id)
+                if self._task_workspace is not None:
+                    release_lock(self._task_workspace.lock_path)
             await self._report_frugality_retrospective(
                 execution_id=execution_id,
                 session_id=session_id,
@@ -4095,28 +4106,67 @@ class OrchestratorRunner:
                 )
             )
 
-        cancel_result = await self._session_repo.mark_cancelled(
-            session_id,
-            reason="Cancellation detected during execution",
-            cancelled_by="runner",
-        )
+        try:
+            cancel_result = await self._session_repo.mark_cancelled(
+                session_id,
+                reason="Cancellation detected during execution",
+                cancelled_by="runner",
+            )
+        except Exception as exc:
+            log.warning(
+                "orchestrator.runner.mark_cancelled_raised",
+                session_id=session_id,
+                error=str(exc),
+            )
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist cancellation; process-local authority remains live",
+                    details={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "cause": str(exc),
+                    },
+                )
+            )
         if cancel_result is not None and cancel_result.is_err:
             log.warning(
                 "orchestrator.runner.mark_cancelled_failed",
                 session_id=session_id,
                 error=str(cancel_result.error),
             )
-
-        # Mirror cancellation into execution stream for TUI.
-        await self._event_store.append(
-            create_execution_terminal_event(
-                execution_id=execution_id,
-                session_id=session_id,
-                status="cancelled",
-                error_message="Execution cancelled by external request",
-                messages_processed=messages_processed,
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist cancellation; process-local authority remains live",
+                    details={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "cause": str(cancel_result.error),
+                    },
+                )
             )
-        )
+
+        # The session is now terminal.  It is safe to clear the request and
+        # retire the live capability; the execution-stream mirror is useful to
+        # projections but no longer determines whether cleanup is safe.
+        await clear_cancellation(session_id)
+        try:
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    status="cancelled",
+                    error_message="Execution cancelled by external request",
+                    messages_processed=messages_processed,
+                )
+            )
+        finally:
+            self._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            self._unregister_session(execution_id, session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
         await self._report_frugality_retrospective(
             execution_id=execution_id,
             session_id=session_id,
@@ -4283,13 +4333,14 @@ class OrchestratorRunner:
                 llm_backend=getattr(self._adapter, "llm_backend", None),
                 execution_contract=execution_contract,
             )
+        except asyncio.CancelledError:
+            # Registration and its liveness lease precede durable publication.
+            # A caller cancelling this await must not strand that live
+            # generation even when the repository did not return a tracker.
+            abort_process_local_preparation()
+            raise
         except Exception as exc:
-            self._retire_process_local_authority(
-                session_id=resolved_session_id,
-                execution_id=exec_id,
-            )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            abort_process_local_preparation()
             return Result.err(
                 OrchestratorError(
                     message=f"Failed to create session: {exc}",
@@ -4349,6 +4400,24 @@ class OrchestratorRunner:
                 tracker.session_id,
                 initial_progress,
             )
+        except asyncio.CancelledError:
+            # ``create_session`` has already made a RUNNING tracker durable.
+            # Record its terminal preparation failure before withdrawing the
+            # process-local lease, then re-raise the caller's cancellation.
+            try:
+                await self._mark_preparation_failed_best_effort(
+                    tracker=tracker,
+                    message="Session preparation cancelled before initial contract was persisted",
+                    details={
+                        "session_id": tracker.session_id,
+                        "execution_id": tracker.execution_id,
+                        "fat_harness_mode": self._fat_harness_mode,
+                        "cause": "CancelledError",
+                    },
+                )
+            finally:
+                abort_process_local_preparation()
+            raise
         except Exception as exc:
             progress_exception_details: dict[str, Any] = {
                 "session_id": tracker.session_id,
@@ -4482,6 +4551,17 @@ class OrchestratorRunner:
         try:
             await asyncio.to_thread(self._restore_guidance_contract, raw_contract)
             self._execution_guidance_delivery_mode()
+        except asyncio.CancelledError:
+            # The exclusive generation was claimed before contract restoration.
+            # A raw task cancellation must release that claim (and its lease)
+            # even though it intentionally does not write a terminal session
+            # record; callers still receive the original cancellation.
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                tracker.session_id,
+                session_registered=False,
+            )
+            raise
         except OrchestratorError as exc:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,
@@ -5748,6 +5828,16 @@ class OrchestratorRunner:
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
+        except asyncio.CancelledError:
+            # Resume claims the exact live generation before restoration. Do
+            # not leave it permanently claimed if the caller cancels during
+            # this otherwise pre-effect setup window.
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            raise
         except OrchestratorError as exc:
             self._cleanup_pre_execution_state(
                 tracker.execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -5250,7 +5250,31 @@ class OrchestratorRunner:
                 reason=cancellation_reason,
                 cancelled_by=cancelled_by,
             )
+        except asyncio.CancelledError:
+            if (
+                await self._reconcile_durable_terminal_and_cleanup(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                is None
+            ):
+                self._preserve_process_local_owner_for_retry(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+            raise
         except Exception as exc:
+            durable_status = await self._reconcile_durable_terminal_and_cleanup(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            if durable_status is not None:
+                return await self._handle_cancellation(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    messages_processed=messages_processed,
+                    start_time=start_time,
+                )
             log.warning(
                 "orchestrator.runner.mark_cancelled_raised",
                 session_id=session_id,
@@ -5515,6 +5539,23 @@ class OrchestratorRunner:
             )
 
         if session_result.is_err:
+            persistence_details = getattr(session_result.error, "details", {})
+            if (
+                isinstance(persistence_details, Mapping)
+                and persistence_details.get("session_start_conflict") is True
+            ):
+                abort_process_local_preparation()
+                return Result.err(
+                    OrchestratorError(
+                        message="Session ID already belongs to an immutable execution",
+                        details={
+                            "execution_id": exec_id,
+                            "session_id": resolved_session_id,
+                            "resume_blocked": "session_id_conflict",
+                            "session_id_conflict": True,
+                        },
+                    )
+                )
             retained_owner = await self._reconcile_session_publication_interruption(
                 session_id=resolved_session_id,
                 execution_id=exec_id,
@@ -6991,52 +7032,6 @@ class OrchestratorRunner:
         if pending_lifecycle is not None:
             return pending_lifecycle
 
-        if self._fat_harness_mode:
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
-                retire_authority=False,
-            )
-            return Result.err(
-                OrchestratorError(
-                    message=(
-                        "Resume is blocked because this resume path cannot enforce "
-                        "typed evidence plus verifier PASS; restart the "
-                        "run so each AC goes through the fat-harness acceptance gate."
-                    ),
-                    details={
-                        "session_id": session_id,
-                        "execution_id": tracker.execution_id,
-                        "fat_harness_mode": True,
-                        "resume_blocked": "typed_evidence_gate_required",
-                    },
-                )
-            )
-
-        if _seed_has_investment_metadata(seed):
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
-                retire_authority=False,
-            )
-            return Result.err(
-                OrchestratorError(
-                    message=(
-                        "Resume is blocked because this resume path cannot preserve "
-                        "per-AC investment authority; restart the run so each AC goes "
-                        "through the investment-aware AC executor."
-                    ),
-                    details={
-                        "session_id": session_id,
-                        "execution_id": tracker.execution_id,
-                        "investment_metadata_present": True,
-                        "resume_blocked": "investment_authority_required",
-                    },
-                )
-            )
-
         raw_contract = tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
         if not isinstance(raw_contract, Mapping):
             error = await self._mark_process_local_resume_unavailable(
@@ -7051,134 +7046,9 @@ class OrchestratorRunner:
             )
             return Result.err(error)
 
-        # A RUNNING tracker with a current Foundation A contract belongs to an
-        # active process while its early liveness lease is held.  If the lease
-        # is gone and this process has no live registry capability, the prior
-        # owner has crashed or exited and Foundation A must terminally reject it
-        # rather than leave a restartable-looking RUNNING session stranded.
-        if tracker.status != SessionStatus.PAUSED:
-            authority_generation, authority_claimed = (
-                self._claim_process_local_authority_generation(
-                    session_id,
-                    tracker.execution_id,
-                    raw_contract,
-                )
-            )
-            if authority_claimed:
-                # The current runner is already performing effects. Do not
-                # release its worktree or downgrade the typed nonterminal
-                # ownership result to a generic state error.
-                return Result.err(
-                    self._process_local_execution_in_progress_error(
-                        session_id,
-                        tracker.execution_id,
-                    )
-                )
-            if authority_generation is not None:
-                # A previous cancellation attempt may have failed its durable
-                # write after the worker stopped.  Its request remains live
-                # precisely so this retained owner can claim the generation
-                # and retry terminalization instead of stranding a claim or
-                # turning a RUNNING tracker into a normal resume.
-                # Register a route before the await so cancellation cleanup
-                # has one owner.  This probe is cancellation-safe: on raw task
-                # cancellation it releases only its claim/route and preserves
-                # the live registration and lease of the original owner.
-                try:
-                    self._register_session(tracker.execution_id, session_id)
-                    if await self._check_startup_cancellation(session_id):
-                        return await self._handle_cancellation(
-                            session_id=session_id,
-                            execution_id=tracker.execution_id,
-                            messages_processed=tracker.messages_processed,
-                            start_time=datetime.now(UTC),
-                        )
-                except asyncio.CancelledError:
-                    self._release_process_local_authority(
-                        session_id=session_id,
-                        execution_id=tracker.execution_id,
-                    )
-                    self._unregister_session(
-                        tracker.execution_id,
-                        session_id,
-                        release_liveness_lease=False,
-                    )
-                    if self._task_workspace is not None:
-                        release_lock(self._task_workspace.lock_path)
-                    raise
-                except Exception as exc:
-                    self._release_process_local_authority(
-                        session_id=session_id,
-                        execution_id=tracker.execution_id,
-                    )
-                    self._unregister_session(
-                        tracker.execution_id,
-                        session_id,
-                        release_liveness_lease=False,
-                    )
-                    if self._task_workspace is not None:
-                        release_lock(self._task_workspace.lock_path)
-                    return Result.err(
-                        OrchestratorError(
-                            message=f"Failed to inspect live process-local session: {exc}",
-                            details={
-                                "session_id": session_id,
-                                "execution_id": tracker.execution_id,
-                            },
-                        )
-                    )
-
-                # This runner still owns the live generation but the durable
-                # status is non-resumable. The probe claim was only for
-                # arbitration, so restore the pre-existing unclaimed state
-                # without touching its workspace or lease.
-                self._release_process_local_authority(
-                    session_id=session_id,
-                    execution_id=tracker.execution_id,
-                )
-                self._unregister_session(
-                    tracker.execution_id,
-                    session_id,
-                    release_liveness_lease=False,
-                )
-                return Result.err(
-                    OrchestratorError(
-                        message=(
-                            f"Session is not paused and cannot resume ({tracker.status.value})"
-                        ),
-                        details={
-                            "session_id": session_id,
-                            "status": tracker.status.value,
-                            "resume_blocked": "session_not_paused",
-                        },
-                    )
-                )
-            if self._process_local_authority_held_elsewhere(
-                session_id,
-                tracker.execution_id,
-                raw_contract,
-            ):
-                return Result.err(
-                    self._process_local_authority_held_elsewhere_error(
-                        session_id,
-                        tracker.execution_id,
-                    )
-                )
-            error = await self._mark_process_local_resume_unavailable(
-                session_id=session_id,
-                execution_id=tracker.execution_id,
-            )
-            self._cleanup_pre_execution_state(
-                tracker.execution_id,
-                session_id,
-                session_registered=False,
-                retire_authority=False,
-            )
-            return Result.err(error)
-
-        # This is intentionally before Foundation A contract restoration,
-        # resume-handle selection, and every runtime-owned identity provider.
-        # The durable correlation id cannot recreate this process's capability.
+        # Persisted process-local authority is arbitrated before any policy
+        # derived from the current runner or seed. A current policy gate must
+        # never mask that the exact paused owner has disappeared.
         authority_generation, authority_claimed = self._claim_process_local_authority_generation(
             session_id,
             tracker.execution_id,
@@ -7214,6 +7084,120 @@ class OrchestratorRunner:
                 retire_authority=False,
             )
             return Result.err(error)
+
+        # A RUNNING tracker with a current Foundation A contract belongs to an
+        # active process while its early liveness lease is held.  If the lease
+        # is gone and this process has no live registry capability, the prior
+        # owner has crashed or exited and Foundation A must terminally reject it
+        # rather than leave a restartable-looking RUNNING session stranded.
+        if tracker.status != SessionStatus.PAUSED:
+            # A previous cancellation attempt may have failed its durable
+            # write after the worker stopped. Its request remains live so this
+            # exact owner can retry terminalization before rejecting RUNNING.
+            try:
+                self._register_session(tracker.execution_id, session_id)
+                if await self._check_startup_cancellation(session_id):
+                    return await self._handle_cancellation(
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                        messages_processed=tracker.messages_processed,
+                        start_time=datetime.now(UTC),
+                    )
+            except asyncio.CancelledError:
+                self._release_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._unregister_session(
+                    tracker.execution_id,
+                    session_id,
+                    release_liveness_lease=False,
+                )
+                if self._task_workspace is not None:
+                    release_lock(self._task_workspace.lock_path)
+                raise
+            except Exception as exc:
+                self._release_process_local_authority(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
+                self._unregister_session(
+                    tracker.execution_id,
+                    session_id,
+                    release_liveness_lease=False,
+                )
+                if self._task_workspace is not None:
+                    release_lock(self._task_workspace.lock_path)
+                return Result.err(
+                    OrchestratorError(
+                        message=f"Failed to inspect live process-local session: {exc}",
+                        details={
+                            "session_id": session_id,
+                            "execution_id": tracker.execution_id,
+                        },
+                    )
+                )
+            self._release_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            self._unregister_session(
+                tracker.execution_id,
+                session_id,
+                release_liveness_lease=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=f"Session is not paused and cannot resume ({tracker.status.value})",
+                    details={
+                        "session_id": session_id,
+                        "status": tracker.status.value,
+                        "resume_blocked": "session_not_paused",
+                    },
+                )
+            )
+
+        if self._fat_harness_mode:
+            self._release_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=(
+                        "Resume is blocked because this resume path cannot enforce "
+                        "typed evidence plus verifier PASS; restart the "
+                        "run so each AC goes through the fat-harness acceptance gate."
+                    ),
+                    details={
+                        "session_id": session_id,
+                        "execution_id": tracker.execution_id,
+                        "fat_harness_mode": True,
+                        "resume_blocked": "typed_evidence_gate_required",
+                    },
+                )
+            )
+
+        if _seed_has_investment_metadata(seed):
+            self._release_process_local_authority(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=(
+                        "Resume is blocked because this resume path cannot preserve "
+                        "per-AC investment authority; restart the run so each AC goes "
+                        "through the investment-aware AC executor."
+                    ),
+                    details={
+                        "session_id": session_id,
+                        "execution_id": tracker.execution_id,
+                        "investment_metadata_present": True,
+                        "resume_blocked": "investment_authority_required",
+                    },
+                )
+            )
 
         try:
             execution_contract_changed = await asyncio.to_thread(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -753,6 +753,8 @@ class OrchestratorRunner:
         )
         self._inherited_tools = list(inherited_tools) if inherited_tools else None
         self._task_cwd = task_cwd
+        self._task_workspace_value: TaskWorkspace | None = None
+        self._task_workspace_lock_held = False
         self._task_workspace = task_workspace
         self._max_decomposition_depth = max(0, max_decomposition_depth)
         self._max_parallel_workers = max(1, max_parallel_workers)
@@ -847,6 +849,8 @@ class OrchestratorRunner:
         self._process_local_authorities: dict[
             tuple[str, str], _ProcessLocalAuthorityGeneration
         ] = {}
+        self._task_workspace_users: set[tuple[str, str]] = set()
+        self._task_workspace_reservations: set[object] = set()
         self._pending_lifecycle_intents: dict[str, _PendingLifecycleIntent] = {}
         self._execution_guidance: ExecutionGuidanceBundle | None = None
         # Opt-in shadow-replay baseline harness (frugality-proof AC5). Read ONCE
@@ -1318,6 +1322,17 @@ class OrchestratorRunner:
         """
         return dict(self._active_sessions)
 
+    @property
+    def _task_workspace(self) -> TaskWorkspace | None:
+        """Return the workspace whose lock backs this runner's current effects."""
+        return self._task_workspace_value
+
+    @_task_workspace.setter
+    def _task_workspace(self, workspace: TaskWorkspace | None) -> None:
+        """Bind a freshly acquired workspace and reset release idempotence."""
+        self._task_workspace_value = workspace
+        self._task_workspace_lock_held = workspace is not None
+
     def _register_session(self, execution_id: str, session_id: str) -> None:
         """Register an active session for cancellation tracking.
 
@@ -1388,8 +1403,74 @@ class OrchestratorRunner:
             )
         if session_registered and execution_id is not None and session_id is not None:
             self._unregister_session(execution_id, session_id)
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
+        self._release_task_workspace_for_identity(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+
+    def _release_task_workspace_for_identity(
+        self,
+        *,
+        session_id: str | None,
+        execution_id: str | None,
+    ) -> bool:
+        """Release the shared workspace lock only after its last local owner exits.
+
+        A runner may prepare more than one process-local session, while the
+        managed workspace lock is runner-wide.  The lifecycle path named by
+        ``session_id``/``execution_id`` is relinquishing its workspace use even
+        when its authority remains registered for retry.  Any other live
+        runner-local authority keeps the lock.  If the named identity was never
+        registered here, a global live registration for the same session means
+        this is a collision cleanup and must not release the real owner's lock.
+        """
+        identity = (
+            (session_id, execution_id)
+            if session_id is not None and execution_id is not None
+            else None
+        )
+        owns_named_workspace = identity in self._task_workspace_users
+        if identity is not None:
+            self._task_workspace_users.discard(identity)
+        if self._task_workspace is None or not self._task_workspace_lock_held:
+            return False
+        if self._task_workspace_users or self._task_workspace_reservations:
+            return False
+        if (
+            identity is not None
+            and not owns_named_workspace
+            and session_id is not None
+            and _has_live_process_local_authority_session(session_id)
+        ):
+            return False
+
+        release_lock(self._task_workspace.lock_path)
+        self._task_workspace_lock_held = False
+        return True
+
+    def _reserve_task_workspace(self, token: object | None = None) -> object | None:
+        """Keep a held runner workspace alive across a pre-identity handoff."""
+        if self._task_workspace is None:
+            return None
+        reservation = token if token is not None else object()
+        self._task_workspace_reservations.add(reservation)
+        return reservation
+
+    def _release_task_workspace_reservation(self, token: object | None) -> bool:
+        """Release one pre-identity reservation and the lock if it was last."""
+        if token is None:
+            return False
+        self._task_workspace_reservations.discard(token)
+        if (
+            self._task_workspace is None
+            or not self._task_workspace_lock_held
+            or self._task_workspace_users
+            or self._task_workspace_reservations
+        ):
+            return False
+        release_lock(self._task_workspace.lock_path)
+        self._task_workspace_lock_held = False
+        return True
 
     def _preserve_process_local_owner_for_retry(
         self,
@@ -1414,8 +1495,10 @@ class OrchestratorRunner:
             session_id,
             release_liveness_lease=False,
         )
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
+        self._release_task_workspace_for_identity(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
 
     def _terminal_persistence_pending_result(
         self,
@@ -1642,8 +1725,10 @@ class OrchestratorRunner:
             )
             self._unregister_session(execution_id, session_id)
             await clear_cancellation(session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
             return durable_status
 
         return await _await_process_local_cleanup(_reconcile())
@@ -1727,8 +1812,10 @@ class OrchestratorRunner:
             )
             self._unregister_session(execution_id, session_id)
             await clear_cancellation(session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
         try:
             await self._event_store.append(
                 create_execution_terminal_event(
@@ -2171,12 +2258,16 @@ class OrchestratorRunner:
         """Claim a live capability before any effectful session work begins."""
         if not isinstance(raw_contract, Mapping):
             return None, False
-        return _claim_process_local_authority_generation(
+        generation, already_claimed = _claim_process_local_authority_generation(
             session_id,
             execution_id,
             raw_contract.get("foundation_a_authority"),
             self._adapter,
         )
+        if generation is not None and self._task_workspace is not None:
+            self._task_workspace_users.add((session_id, execution_id))
+            self._task_workspace_lock_held = True
+        return generation, already_claimed
 
     def _release_process_local_authority(
         self,
@@ -2205,8 +2296,10 @@ class OrchestratorRunner:
         """
         self._process_local_authorities.pop((session_id, execution_id), None)
         self._active_sessions.pop(execution_id, None)
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
+        self._release_task_workspace_for_identity(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
 
     def _register_process_local_authority(
         self,
@@ -2292,6 +2385,9 @@ class OrchestratorRunner:
                     "cause": str(exc),
                 },
             ) from exc
+        if self._task_workspace is not None:
+            self._task_workspace_users.add((session_id, execution_id))
+            self._task_workspace_lock_held = True
 
     def _retire_process_local_authority(
         self,
@@ -2312,6 +2408,7 @@ class OrchestratorRunner:
 
             release_session_lock(session_id)
         self._process_local_authorities.pop((session_id, execution_id), None)
+        self._task_workspace_users.discard((session_id, execution_id))
         return retired
 
     def _discard_process_local_authority(
@@ -2589,8 +2686,10 @@ class OrchestratorRunner:
                                 execution_id=execution_id,
                                 error=terminal_mark_error,
                             )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
             return (session_id, execution_id) in self._process_local_authorities
 
         return bool(await _await_process_local_cleanup(_reconcile()))
@@ -2941,8 +3040,10 @@ class OrchestratorRunner:
                 )
                 self._unregister_session(tracker.execution_id, tracker.session_id)
                 await clear_cancellation(tracker.session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
         self._pending_lifecycle_intents.pop(tracker.session_id, None)
         return Result.ok(
@@ -4688,6 +4789,10 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
             )
+            self._release_task_workspace_for_identity(
+                session_id=session_id,
+                execution_id=execution_id,
+            )
             await clear_cancellation(session_id)
             return Result.ok(
                 {
@@ -5224,8 +5329,10 @@ class OrchestratorRunner:
                         execution_id=execution_id,
                     )
                     self._unregister_session(execution_id, session_id)
-                    if self._task_workspace is not None:
-                        release_lock(self._task_workspace.lock_path)
+                    self._release_task_workspace_for_identity(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
 
             await _await_process_local_cleanup(_reconcile_existing_terminal_owner())
             await self._report_frugality_retrospective(
@@ -5340,8 +5447,10 @@ class OrchestratorRunner:
                     execution_id=execution_id,
                 )
                 self._unregister_session(execution_id, session_id)
-                if self._task_workspace is not None:
-                    release_lock(self._task_workspace.lock_path)
+                self._release_task_workspace_for_identity(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
 
         await _await_process_local_cleanup(_reconcile_cancelled_owner())
         await self._report_frugality_retrospective(
@@ -5438,7 +5547,13 @@ class OrchestratorRunner:
         # in a runner-wide mutable slot: concurrent preparations must not share
         # a capability or correlation id.
         authority_generation = self._begin_process_local_authority_generation()
-        workspace_had_existing_owner = bool(self._process_local_authorities)
+        if self._task_workspace is not None:
+            # Reserve the runner-wide lock before the first await.  Otherwise a
+            # different session can finish while contract construction is in a
+            # worker thread and release the lock before this preparation has a
+            # registered identity.
+            self._reserve_task_workspace(authority_generation)
+            self._task_workspace_lock_held = True
 
         def abort_process_local_preparation() -> None:
             """Dispose every authority state reachable from an aborted prepare.
@@ -5448,30 +5563,26 @@ class OrchestratorRunner:
             Both cleanup operations are idempotent and together leave no
             capability or lease behind.
             """
-            self._retire_process_local_authority(
-                session_id=resolved_session_id,
-                execution_id=exec_id,
+            identity = (resolved_session_id, exec_id)
+            owns_registered_generation = (
+                self._process_local_authorities.get(identity) is authority_generation
             )
+            if owns_registered_generation:
+                self._retire_process_local_authority(
+                    session_id=resolved_session_id,
+                    execution_id=exec_id,
+                )
             self._discard_process_local_authority(authority_generation)
-            # The workspace lock is runner-wide, while this authority
-            # generation belongs only to the current preparation. A rejected
-            # second preparation must not release exclusion still owned by an
-            # earlier live session. The dynamic check also covers concurrent
-            # preparations that both began before either registered.
-            workspace_has_other_owner = any(
-                identity != (resolved_session_id, exec_id)
-                for identity in self._process_local_authorities
-            )
-            workspace_has_live_session_owner = _has_live_process_local_authority_session(
-                resolved_session_id
-            )
-            if (
-                self._task_workspace is not None
-                and not workspace_had_existing_owner
-                and not workspace_has_other_owner
-                and not workspace_has_live_session_owner
-            ):
-                release_lock(self._task_workspace.lock_path)
+            self._task_workspace_reservations.discard(authority_generation)
+            # A duplicate exact identity can fail registration while an older
+            # generation still owns the same runner slot.  That failed
+            # preparation acquired no authority or workspace ownership of its
+            # own, so it must not retire or release the existing generation.
+            if owns_registered_generation or identity not in self._task_workspace_users:
+                self._release_task_workspace_for_identity(
+                    session_id=resolved_session_id,
+                    execution_id=exec_id,
+                )
 
         try:
             execution_contract = await asyncio.to_thread(
@@ -5516,6 +5627,7 @@ class OrchestratorRunner:
         except BaseException:
             abort_process_local_preparation()
             raise
+        self._task_workspace_reservations.discard(authority_generation)
         self._execution_contract = execution_contract
 
         try:
@@ -5664,8 +5776,10 @@ class OrchestratorRunner:
                     session_id=tracker.session_id,
                     execution_id=tracker.execution_id,
                 )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
             if terminal_mark_error is not None:
                 progress_exception_details["terminal_mark_error"] = terminal_mark_error
                 progress_exception_details["resume_blocked"] = "terminal_persistence_pending"
@@ -5693,8 +5807,10 @@ class OrchestratorRunner:
                     session_id=tracker.session_id,
                     execution_id=tracker.execution_id,
                 )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
             if terminal_mark_error is not None:
                 progress_result_details["terminal_mark_error"] = terminal_mark_error
@@ -6481,8 +6597,10 @@ class OrchestratorRunner:
             )
             if terminal_status != "paused":
                 await clear_cancellation(tracker.session_id)
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
             return Result.ok(
                 OrchestratorResult(
@@ -6973,8 +7091,10 @@ class OrchestratorRunner:
         )
         if terminal_status != "paused":
             await clear_cancellation(tracker.session_id)
-        if self._task_workspace is not None:
-            release_lock(self._task_workspace.lock_path)
+        self._release_task_workspace_for_identity(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
         return Result.ok(
             OrchestratorResult(
@@ -7132,8 +7252,10 @@ class OrchestratorRunner:
                     session_id,
                     release_liveness_lease=False,
                 )
-                if self._task_workspace is not None:
-                    release_lock(self._task_workspace.lock_path)
+                self._release_task_workspace_for_identity(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
                 raise
             except Exception as exc:
                 self._release_process_local_authority(
@@ -7145,8 +7267,10 @@ class OrchestratorRunner:
                     session_id,
                     release_liveness_lease=False,
                 )
-                if self._task_workspace is not None:
-                    release_lock(self._task_workspace.lock_path)
+                self._release_task_workspace_for_identity(
+                    session_id=session_id,
+                    execution_id=tracker.execution_id,
+                )
                 return Result.err(
                     OrchestratorError(
                         message=f"Failed to inspect live process-local session: {exc}",
@@ -7725,8 +7849,10 @@ Note: This is a resumed session. Please continue from where execution was interr
                 session_id,
                 release_liveness_lease=terminal_status != "paused",
             )
-            if self._task_workspace is not None:
-                release_lock(self._task_workspace.lock_path)
+            self._release_task_workspace_for_identity(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
             return Result.ok(
                 OrchestratorResult(

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -753,15 +753,19 @@ class SessionRepository:
         self,
         session_id: str,
         summary: dict[str, Any] | None = None,
-    ) -> Result[None, PersistenceError]:
+        *,
+        messages_processed: int = 0,
+    ) -> Result[bool, PersistenceError]:
         """Mark session as completed.
 
         Args:
             session_id: Session to complete.
             summary: Optional completion summary.
+            messages_processed: Total runtime messages observed before completion.
 
         Returns:
-            Result indicating success or failure.
+            Result whose value is ``True`` when this completion became durable,
+            or ``False`` when another terminal transition already won.
         """
         event = BaseEvent(
             type="orchestrator.session.completed",
@@ -769,17 +773,25 @@ class SessionRepository:
             aggregate_id=session_id,
             data={
                 "summary": summary or {},
+                "messages_processed": max(messages_processed, 0),
                 "completed_at": datetime.now(UTC).isoformat(),
             },
         )
 
         try:
-            await self._event_store.append(event)
-            log.info(
-                "orchestrator.session.completed",
-                session_id=session_id,
-            )
-            return Result.ok(None)
+            persisted = await self._event_store.append(event)
+            if persisted is False:
+                log.info(
+                    "orchestrator.session.terminal_transition_preserved",
+                    session_id=session_id,
+                    requested_status=SessionStatus.COMPLETED.value,
+                )
+            else:
+                log.info(
+                    "orchestrator.session.completed",
+                    session_id=session_id,
+                )
+            return Result.ok(persisted is not False)
         except Exception as e:
             log.exception(
                 "orchestrator.session.complete_failed",
@@ -798,16 +810,22 @@ class SessionRepository:
         session_id: str,
         error_message: str,
         error_details: dict[str, Any] | None = None,
-    ) -> Result[None, PersistenceError]:
+        *,
+        error_type: str | None = None,
+        messages_processed: int = 0,
+    ) -> Result[bool, PersistenceError]:
         """Mark session as failed.
 
         Args:
             session_id: Session that failed.
             error_message: Error description.
             error_details: Optional error details.
+            error_type: Optional stable failure class.
+            messages_processed: Total runtime messages observed before failure.
 
         Returns:
-            Result indicating success or failure.
+            Result whose value is ``True`` when this failure became durable,
+            or ``False`` when another terminal transition already won.
         """
         event = BaseEvent(
             type="orchestrator.session.failed",
@@ -816,18 +834,27 @@ class SessionRepository:
             data={
                 "error": error_message,
                 "error_details": error_details or {},
+                "error_type": error_type,
+                "messages_processed": max(messages_processed, 0),
                 "failed_at": datetime.now(UTC).isoformat(),
             },
         )
 
         try:
-            await self._event_store.append(event)
-            log.error(
-                "orchestrator.session.failed",
-                session_id=session_id,
-                error=error_message,
-            )
-            return Result.ok(None)
+            persisted = await self._event_store.append(event)
+            if persisted is False:
+                log.info(
+                    "orchestrator.session.terminal_transition_preserved",
+                    session_id=session_id,
+                    requested_status=SessionStatus.FAILED.value,
+                )
+            else:
+                log.error(
+                    "orchestrator.session.failed",
+                    session_id=session_id,
+                    error=error_message,
+                )
+            return Result.ok(persisted is not False)
         except Exception as e:
             log.exception(
                 "orchestrator.session.fail_failed",
@@ -850,48 +877,10 @@ class SessionRepository:
         """Fail an active session without overwriting an existing terminal result.
 
         ``False`` is a successful no-op: another terminal lifecycle event was
-        already durable.  The conditional append is used by process-local
-        authority recovery, where a stale in-memory snapshot must never turn a
-        user cancellation into a later failure.
+        already durable. All terminal writers now use the same CAS boundary;
+        this compatibility name delegates to the canonical method.
         """
-        event = BaseEvent(
-            type="orchestrator.session.failed",
-            aggregate_type="session",
-            aggregate_id=session_id,
-            data={
-                "error": error_message,
-                "error_details": error_details or {},
-                "failed_at": datetime.now(UTC).isoformat(),
-            },
-        )
-
-        try:
-            persisted = await self._event_store.append_session_terminal_if_active(event)
-            if persisted:
-                log.error(
-                    "orchestrator.session.failed",
-                    session_id=session_id,
-                    error=error_message,
-                )
-            else:
-                log.info(
-                    "orchestrator.session.terminal_transition_preserved",
-                    session_id=session_id,
-                    requested_status=SessionStatus.FAILED.value,
-                )
-            return Result.ok(persisted)
-        except Exception as e:
-            log.exception(
-                "orchestrator.session.conditional_fail_failed",
-                session_id=session_id,
-                error=str(e),
-            )
-            return Result.err(
-                PersistenceError(
-                    message=f"Failed to conditionally mark session failed: {e}",
-                    details={"session_id": session_id},
-                )
-            )
+        return await self.mark_failed(session_id, error_message, error_details)
 
     async def mark_paused(
         self,
@@ -958,7 +947,7 @@ class SessionRepository:
         session_id: str,
         reason: str,
         cancelled_by: str = "user",
-    ) -> Result[None, PersistenceError]:
+    ) -> Result[bool, PersistenceError]:
         """Mark session as cancelled.
 
         Args:
@@ -967,7 +956,8 @@ class SessionRepository:
             cancelled_by: Who/what initiated cancellation ("user", "auto_cleanup").
 
         Returns:
-            Result indicating success or failure.
+            Result whose value is ``True`` when this cancellation became
+            durable, or ``False`` when another terminal transition already won.
         """
         event = BaseEvent(
             type="orchestrator.session.cancelled",
@@ -981,14 +971,21 @@ class SessionRepository:
         )
 
         try:
-            await self._event_store.append(event)
-            log.info(
-                "orchestrator.session.cancelled",
-                session_id=session_id,
-                reason=reason,
-                cancelled_by=cancelled_by,
-            )
-            return Result.ok(None)
+            persisted = await self._event_store.append(event)
+            if persisted is False:
+                log.info(
+                    "orchestrator.session.terminal_transition_preserved",
+                    session_id=session_id,
+                    requested_status=SessionStatus.CANCELLED.value,
+                )
+            else:
+                log.info(
+                    "orchestrator.session.cancelled",
+                    session_id=session_id,
+                    reason=reason,
+                    cancelled_by=cancelled_by,
+                )
+            return Result.ok(persisted is not False)
         except Exception as e:
             log.exception(
                 "orchestrator.session.cancel_failed",
@@ -1011,49 +1008,10 @@ class SessionRepository:
         """Cancel an active session without overwriting another terminal result.
 
         ``False`` means the durable session was already terminal.  It is not a
-        persistence failure, and lets a public cancellation surface reconcile a
-        retained process-local owner without appending contradictory terminal
-        events.
+        persistence failure. All terminal writers now use the same CAS boundary;
+        this compatibility name delegates to the canonical method.
         """
-        event = BaseEvent(
-            type="orchestrator.session.cancelled",
-            aggregate_type="session",
-            aggregate_id=session_id,
-            data={
-                "reason": reason,
-                "cancelled_by": cancelled_by,
-                "cancelled_at": datetime.now(UTC).isoformat(),
-            },
-        )
-
-        try:
-            persisted = await self._event_store.append_session_terminal_if_active(event)
-            if persisted:
-                log.info(
-                    "orchestrator.session.cancelled",
-                    session_id=session_id,
-                    reason=reason,
-                    cancelled_by=cancelled_by,
-                )
-            else:
-                log.info(
-                    "orchestrator.session.terminal_transition_preserved",
-                    session_id=session_id,
-                    requested_status=SessionStatus.CANCELLED.value,
-                )
-            return Result.ok(persisted)
-        except Exception as e:
-            log.exception(
-                "orchestrator.session.conditional_cancel_failed",
-                session_id=session_id,
-                error=str(e),
-            )
-            return Result.err(
-                PersistenceError(
-                    message=f"Failed to conditionally mark session cancelled: {e}",
-                    details={"session_id": session_id},
-                )
-            )
+        return await self.mark_cancelled(session_id, reason, cancelled_by)
 
     async def reconstruct_session(
         self,
@@ -1215,6 +1173,17 @@ class SessionRepository:
                     messages_processed += 1
                 status_update = self._status_from_event(event.type, event.data)
                 if status_update is not None:
+                    # A durable terminal lifecycle event is authoritative. A
+                    # delayed runtime/progress observation must not revive a
+                    # cancelled, failed, or completed session during replay.
+                    # ``PAUSED`` deliberately remains resumable: a subsequent
+                    # running progress checkpoint is the existing resume signal.
+                    if explicit_terminal_status in {
+                        SessionStatus.COMPLETED,
+                        SessionStatus.FAILED,
+                        SessionStatus.CANCELLED,
+                    }:
+                        continue
                     tracker = tracker.with_status(status_update)
                     if status_update == SessionStatus.RUNNING:
                         explicit_terminal_status = None
@@ -1464,7 +1433,7 @@ class SessionRepository:
                 cancelled_by="auto_cleanup",
             )
 
-            if result.is_ok:
+            if result.is_ok and result.value is not False:
                 cancelled.append(tracker)
                 # Log to stderr so it's visible in MCP stdio mode
                 print(
@@ -1472,6 +1441,11 @@ class SessionRepository:
                     f"{tracker.session_id} (execution={tracker.execution_id}, "
                     f"previous_status={tracker.status.value})",
                     file=sys.stderr,
+                )
+            elif result.is_ok:
+                log.info(
+                    "orchestrator.auto_cleanup.terminal_transition_preserved",
+                    session_id=tracker.session_id,
                 )
                 log.info(
                     "orchestrator.auto_cleanup.cancelled",

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -553,6 +553,11 @@ class SessionRepository:
 
             result = await self.reconstruct_session(snapshot.session_id)
             if result.is_ok:
+                if result.value.status not in (
+                    SessionStatus.RUNNING,
+                    SessionStatus.PAUSED,
+                ):
+                    continue
                 if self._usage_limit_pause_cleanup_deferred(
                     result.value,
                     now=now,

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -891,7 +891,7 @@ class SessionRepository:
         pause_seconds: int | None = None,
         resume_after: datetime | None = None,
         pause_kind: str | None = None,
-    ) -> Result[None, PersistenceError]:
+    ) -> Result[bool, PersistenceError]:
         """Mark session as paused and resumable.
 
         Args:
@@ -900,7 +900,8 @@ class SessionRepository:
             resume_hint: Optional retry guidance.
 
         Returns:
-            Result indicating success or failure.
+            Result whose value is ``True`` when PAUSED became durable, or
+            ``False`` when an explicit terminal session event already won.
         """
         data: dict[str, Any] = {
             "reason": reason,
@@ -922,13 +923,19 @@ class SessionRepository:
         )
 
         try:
-            await self._event_store.append(event)
-            log.info(
-                "orchestrator.session.paused",
-                session_id=session_id,
-                reason=reason,
-            )
-            return Result.ok(None)
+            persisted = await self._event_store.append_session_pause_if_active(event)
+            if persisted:
+                log.info(
+                    "orchestrator.session.paused",
+                    session_id=session_id,
+                    reason=reason,
+                )
+            else:
+                log.info(
+                    "orchestrator.session.pause_terminal_preserved",
+                    session_id=session_id,
+                )
+            return Result.ok(persisted)
         except Exception as e:
             log.exception(
                 "orchestrator.session.pause_failed",

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -841,6 +841,58 @@ class SessionRepository:
                 )
             )
 
+    async def mark_failed_if_active(
+        self,
+        session_id: str,
+        error_message: str,
+        error_details: dict[str, Any] | None = None,
+    ) -> Result[bool, PersistenceError]:
+        """Fail an active session without overwriting an existing terminal result.
+
+        ``False`` is a successful no-op: another terminal lifecycle event was
+        already durable.  The conditional append is used by process-local
+        authority recovery, where a stale in-memory snapshot must never turn a
+        user cancellation into a later failure.
+        """
+        event = BaseEvent(
+            type="orchestrator.session.failed",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={
+                "error": error_message,
+                "error_details": error_details or {},
+                "failed_at": datetime.now(UTC).isoformat(),
+            },
+        )
+
+        try:
+            persisted = await self._event_store.append_session_terminal_if_active(event)
+            if persisted:
+                log.error(
+                    "orchestrator.session.failed",
+                    session_id=session_id,
+                    error=error_message,
+                )
+            else:
+                log.info(
+                    "orchestrator.session.terminal_transition_preserved",
+                    session_id=session_id,
+                    requested_status=SessionStatus.FAILED.value,
+                )
+            return Result.ok(persisted)
+        except Exception as e:
+            log.exception(
+                "orchestrator.session.conditional_fail_failed",
+                session_id=session_id,
+                error=str(e),
+            )
+            return Result.err(
+                PersistenceError(
+                    message=f"Failed to conditionally mark session failed: {e}",
+                    details={"session_id": session_id},
+                )
+            )
+
     async def mark_paused(
         self,
         session_id: str,
@@ -946,6 +998,59 @@ class SessionRepository:
             return Result.err(
                 PersistenceError(
                     message=f"Failed to mark session cancelled: {e}",
+                    details={"session_id": session_id},
+                )
+            )
+
+    async def mark_cancelled_if_active(
+        self,
+        session_id: str,
+        reason: str,
+        cancelled_by: str = "user",
+    ) -> Result[bool, PersistenceError]:
+        """Cancel an active session without overwriting another terminal result.
+
+        ``False`` means the durable session was already terminal.  It is not a
+        persistence failure, and lets a public cancellation surface reconcile a
+        retained process-local owner without appending contradictory terminal
+        events.
+        """
+        event = BaseEvent(
+            type="orchestrator.session.cancelled",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={
+                "reason": reason,
+                "cancelled_by": cancelled_by,
+                "cancelled_at": datetime.now(UTC).isoformat(),
+            },
+        )
+
+        try:
+            persisted = await self._event_store.append_session_terminal_if_active(event)
+            if persisted:
+                log.info(
+                    "orchestrator.session.cancelled",
+                    session_id=session_id,
+                    reason=reason,
+                    cancelled_by=cancelled_by,
+                )
+            else:
+                log.info(
+                    "orchestrator.session.terminal_transition_preserved",
+                    session_id=session_id,
+                    requested_status=SessionStatus.CANCELLED.value,
+                )
+            return Result.ok(persisted)
+        except Exception as e:
+            log.exception(
+                "orchestrator.session.conditional_cancel_failed",
+                session_id=session_id,
+                error=str(e),
+            )
+            return Result.err(
+                PersistenceError(
+                    message=f"Failed to conditionally mark session cancelled: {e}",
                     details={"session_id": session_id},
                 )
             )

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -1346,6 +1346,12 @@ class SessionRepository:
                 for event in events:
                     status_update = self._status_from_event(event.type, event.data)
                     if status_update is not None:
+                        if status in {
+                            SessionStatus.COMPLETED,
+                            SessionStatus.FAILED,
+                            SessionStatus.CANCELLED,
+                        }:
+                            continue
                         status = status_update
 
                 # Only consider active sessions (RUNNING or PAUSED)
@@ -1381,6 +1387,11 @@ class SessionRepository:
                     # Reconstruct full tracker for the orphaned session
                     result = await self.reconstruct_session(session_id)
                     if result.is_ok:
+                        if result.value.status not in (
+                            SessionStatus.RUNNING,
+                            SessionStatus.PAUSED,
+                        ):
+                            continue
                         if self._usage_limit_pause_cleanup_deferred(
                             result.value,
                             now=now,

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -701,6 +701,8 @@ class SessionRepository:
                 session_id=tracker.session_id,
                 error=str(e),
             )
+            if isinstance(e, PersistenceError):
+                return Result.err(e)
             return Result.err(
                 PersistenceError(
                     message=f"Failed to create session: {e}",

--- a/src/ouroboros/orchestrator/shadow_replay.py
+++ b/src/ouroboros/orchestrator/shadow_replay.py
@@ -313,6 +313,14 @@ async def _run_shadow_replay_inner(
         )
         return
 
+    # This experiment has its own ephemeral workspace and never decides the
+    # live AC's acceptance, but it still must not sidestep the executor's six
+    # captured entry roots. Import lazily to avoid the module cycle: the
+    # executor imports this harness at module load time.
+    from ouroboros.orchestrator.parallel_executor import _invoke_execution_authority_guard
+
+    _invoke_execution_authority_guard(executor)
+
     router = executor._model_router
     if router is None:
         # Model routing dormant → no parent tier to price the baseline at.
@@ -619,7 +627,17 @@ async def _baseline_semantically_accepted(
         has_expected_artifacts=has_expected_artifacts,
         verify_gate_active=verify_gate_active,
     )
-    verifier_verdict = executor._run_atomic_verifier_pass(
+    # Do not look up ``executor._run_atomic_verifier_pass`` dynamically here.
+    # The live executor registered a constructor-captured root, and the registry
+    # both revalidates that root and invokes it directly.
+    from ouroboros.orchestrator.parallel_executor import (
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
+        _invoke_execution_authority_entry,
+    )
+
+    verifier_verdict = _invoke_execution_authority_entry(
+        executor,
+        _FOUNDATION_A_ENTRY_RUN_ATOMIC_VERIFIER_PASS,
         ac_content=ac_content,
         final_message=terminal.content,
         success=True,

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -470,25 +470,27 @@ class EventStore:
                     else:
                         transaction = await conn.begin()
                     try:
-                        existing_start = await conn.scalar(
-                            select(events_table.c.id)
+                        existing_lifecycle = await conn.execute(
+                            select(events_table.c.id, events_table.c.event_type)
                             .where(
                                 events_table.c.aggregate_type == "session",
                                 events_table.c.aggregate_id == event.aggregate_id,
-                                events_table.c.event_type == "orchestrator.session.started",
                             )
                             .limit(1)
                         )
-                        if existing_start is not None:
+                        existing_row = existing_lifecycle.first()
+                        if existing_row is not None:
                             if conn.in_transaction():
                                 await conn.rollback()
                             raise PersistenceError(
-                                "Session ID already has an immutable start identity.",
+                                "Session ID already has durable lifecycle history.",
                                 operation="append_session_start_if_absent",
                                 table="events",
                                 details={
                                     "session_id": event.aggregate_id,
                                     "execution_id": execution_id,
+                                    "existing_event_id": existing_row.id,
+                                    "existing_event_type": existing_row.event_type,
                                     "session_start_conflict": True,
                                 },
                             )

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -26,7 +26,12 @@ from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
-from ouroboros.persistence.schema import events_table, metadata, session_terminal_guards_table
+from ouroboros.persistence.schema import (
+    events_table,
+    metadata,
+    session_start_guards_table,
+    session_terminal_guards_table,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +77,15 @@ def _is_session_terminal_event(event: object) -> bool:
         isinstance(event, BaseEvent)
         and event.aggregate_type == "session"
         and event.type in _SESSION_TERMINAL_EVENT_TYPES
+    )
+
+
+def _is_session_start_event(event: object) -> bool:
+    """Return whether one event publishes immutable session identity."""
+    return (
+        isinstance(event, BaseEvent)
+        and event.aggregate_type == "session"
+        and event.type == "orchestrator.session.started"
     )
 
 
@@ -414,6 +428,9 @@ class EventStore:
         Raises:
             PersistenceError: If the append operation fails.
         """
+        if _is_session_start_event(event):
+            await self.append_session_start_if_absent(event)
+            return None
         # Terminal session lifecycle is a one-winner transition, not a generic
         # append-only observation.  Keep this guard at the public EventStore
         # boundary so event factories and older SessionRepository callers
@@ -422,6 +439,113 @@ class EventStore:
             return await self.append_session_terminal_if_active(event)
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
         return None
+
+    async def append_session_start_if_absent(self, event: BaseEvent) -> None:
+        """Publish exactly one immutable start identity for a session ID."""
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="append_session_start_if_absent",
+            )
+        if not _is_session_start_event(event):
+            raise PersistenceError(
+                "Conditional session start append requires an explicit started event.",
+                operation="append_session_start_if_absent",
+                table="events",
+                details={
+                    "aggregate_type": getattr(event, "aggregate_type", None),
+                    "event_type": getattr(event, "type", None),
+                },
+            )
+        raw_execution_id = event.data.get("execution_id")
+        execution_id = raw_execution_id.strip() if isinstance(raw_execution_id, str) else ""
+
+        for attempt in range(3):
+            try:
+                async with self._engine.connect() as conn:
+                    sqlite = conn.dialect.name == "sqlite"
+                    if sqlite:
+                        await conn.exec_driver_sql("BEGIN IMMEDIATE")
+                        transaction = None
+                    else:
+                        transaction = await conn.begin()
+                    try:
+                        existing_start = await conn.scalar(
+                            select(events_table.c.id)
+                            .where(
+                                events_table.c.aggregate_type == "session",
+                                events_table.c.aggregate_id == event.aggregate_id,
+                                events_table.c.event_type == "orchestrator.session.started",
+                            )
+                            .limit(1)
+                        )
+                        if existing_start is not None:
+                            if conn.in_transaction():
+                                await conn.rollback()
+                            raise PersistenceError(
+                                "Session ID already has an immutable start identity.",
+                                operation="append_session_start_if_absent",
+                                table="events",
+                                details={
+                                    "session_id": event.aggregate_id,
+                                    "execution_id": execution_id,
+                                    "session_start_conflict": True,
+                                },
+                            )
+                        try:
+                            async with conn.begin_nested():
+                                await conn.execute(
+                                    session_start_guards_table.insert().values(
+                                        session_id=event.aggregate_id,
+                                        start_event_id=event.id,
+                                        execution_id=execution_id,
+                                    )
+                                )
+                        except IntegrityError as exc:
+                            if conn.in_transaction():
+                                await conn.rollback()
+                            raise PersistenceError(
+                                "Session ID already has an immutable start identity.",
+                                operation="append_session_start_if_absent",
+                                table="events",
+                                details={
+                                    "session_id": event.aggregate_id,
+                                    "execution_id": execution_id,
+                                    "session_start_conflict": True,
+                                },
+                            ) from exc
+                        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+                        if sqlite:
+                            await conn.commit()
+                        elif transaction is not None:
+                            await transaction.commit()
+                        return
+                    except BaseException:
+                        if conn.in_transaction():
+                            await conn.rollback()
+                        raise
+            except PersistenceError:
+                raise
+            except Exception as exc:
+                if "database is locked" in str(exc) and attempt < 2:
+                    logger.warning(
+                        "event_store.append_session_start_if_absent.retry",
+                        extra={"attempt": attempt + 1, "event_id": event.id},
+                    )
+                    await asyncio.sleep(0.1 * (2**attempt))
+                    continue
+                raise PersistenceError(
+                    f"Failed to conditionally append session start event: {exc}",
+                    operation="append_session_start_if_absent",
+                    table="events",
+                    details={"event_id": event.id, "event_type": event.type},
+                ) from exc
+        raise PersistenceError(
+            "Failed to conditionally append session start event after retries.",
+            operation="append_session_start_if_absent",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        )
 
     async def append_session_terminal_if_active(self, event: BaseEvent) -> bool:
         """Append one terminal session event only while no terminal event exists.
@@ -631,6 +755,11 @@ class EventStore:
         """Return whether ``event`` requires the terminal one-winner append."""
         return _is_session_terminal_event(event)
 
+    @staticmethod
+    def is_session_start_event(event: object) -> bool:
+        """Return whether ``event`` publishes immutable session identity."""
+        return _is_session_start_event(event)
+
     async def append_with_rowid(
         self,
         event: BaseEvent,
@@ -649,6 +778,13 @@ class EventStore:
             raise PersistenceError(
                 "Terminal session lifecycle events must be persisted via append() "
                 "or append_session_terminal_if_active() to preserve the one-winner guard.",
+                operation="append_with_rowid",
+                details={"event_type": event.type, "aggregate_id": event.aggregate_id},
+            )
+        if _is_session_start_event(event):
+            raise PersistenceError(
+                "Session start lifecycle events must be persisted via append() "
+                "or append_session_start_if_absent() to preserve immutable identity.",
                 operation="append_with_rowid",
                 details={"event_type": event.type, "aggregate_id": event.aggregate_id},
             )
@@ -744,6 +880,17 @@ class EventStore:
                 invalid_event,
                 operation="append_batch",
                 index=invalid_index,
+            )
+
+        session_start_events = [event for event in events if _is_session_start_event(event)]
+        if session_start_events:
+            raise PersistenceError(
+                "Session start lifecycle events cannot use append_batch; persist each "
+                "through append() to preserve immutable session identity.",
+                operation="append_batch",
+                details={
+                    "session_ids": sorted({event.aggregate_id for event in session_start_events})
+                },
             )
 
         # Mirror the ``append()`` workflow_ir guard so callers cannot bypass

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 from uuid import uuid4
 
-from sqlalchemy import and_, event, func, or_, select, text
+from sqlalchemy import and_, case, event, func, or_, select, text
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 if TYPE_CHECKING:
@@ -1085,7 +1085,21 @@ class EventStore:
                 func.row_number()
                 .over(
                     partition_by=events_table.c.aggregate_id,
-                    order_by=(events_table.c.timestamp.desc(), events_table.c.id.desc()),
+                    order_by=(
+                        # Explicit terminal lifecycle is absorbing. A delayed
+                        # progress checkpoint may be newer in wall-clock order,
+                        # but it cannot revive a completed/failed/cancelled
+                        # session in the snapshot path used for orphan cleanup.
+                        case(
+                            (
+                                events_table.c.event_type.in_(_SESSION_TERMINAL_EVENT_TYPES),
+                                0,
+                            ),
+                            else_=1,
+                        ),
+                        events_table.c.timestamp.desc(),
+                        events_table.c.id.desc(),
+                    ),
                 )
                 .label("rn"),
             )

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -17,7 +17,7 @@ from urllib.parse import unquote
 from uuid import uuid4
 
 from sqlalchemy import and_, event, func, or_, select, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.workflow_lifecycle import WorkflowLifecycleEvent
@@ -26,7 +26,7 @@ from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
-from ouroboros.persistence.schema import events_table, metadata
+from ouroboros.persistence.schema import events_table, metadata, session_terminal_guards_table
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,13 @@ _RAW_SUBSCRIBED_EVENT_SIGNAL_KEYS = frozenset(
         "thread_id",
         "tool",
         "tool_name",
+    }
+)
+_SESSION_TERMINAL_EVENT_TYPES = frozenset(
+    {
+        "orchestrator.session.completed",
+        "orchestrator.session.failed",
+        "orchestrator.session.cancelled",
     }
 )
 
@@ -394,6 +401,122 @@ class EventStore:
             PersistenceError: If the append operation fails.
         """
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
+
+    async def append_session_terminal_if_active(self, event: BaseEvent) -> bool:
+        """Append one terminal session event only while no terminal event exists.
+
+        Returns ``True`` when ``event`` was inserted and ``False`` when another
+        terminal session event already won.  The check and append share one
+        transaction so a stale in-memory ``PAUSED`` tracker cannot overwrite a
+        concurrent durable cancellation with a later ``FAILED`` event.
+
+        This intentionally protects only the explicit session lifecycle event
+        family.  Callers that need a terminal transition must use a matching
+        ``orchestrator.session.*`` event; ordinary progress events remain
+        append-only observations.
+        """
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="append_session_terminal_if_active",
+            )
+        if not isinstance(event, BaseEvent):
+            self._raise_invalid_append_input(
+                event,
+                operation="append_session_terminal_if_active",
+            )
+        if event.aggregate_type != "session" or event.type not in _SESSION_TERMINAL_EVENT_TYPES:
+            raise PersistenceError(
+                "Conditional session terminal append requires an explicit terminal session event.",
+                operation="append_session_terminal_if_active",
+                table="events",
+                details={
+                    "aggregate_type": event.aggregate_type,
+                    "event_type": event.type,
+                },
+            )
+
+        for attempt in range(3):
+            try:
+                async with self._engine.connect() as conn:
+                    # SQLite needs an immediate write transaction here. A
+                    # deferred SELECT followed by INSERT leaves a gap in which
+                    # another connection can commit the competing terminal
+                    # event. The unique guard below closes the same absent-row
+                    # race on every supported database backend.
+                    sqlite = conn.dialect.name == "sqlite"
+                    if sqlite:
+                        await conn.exec_driver_sql("BEGIN IMMEDIATE")
+                        transaction = None
+                    else:
+                        transaction = await conn.begin()
+
+                    try:
+                        terminal_query = (
+                            select(events_table.c.id)
+                            .where(
+                                events_table.c.aggregate_type == "session",
+                                events_table.c.aggregate_id == event.aggregate_id,
+                                events_table.c.event_type.in_(_SESSION_TERMINAL_EVENT_TYPES),
+                            )
+                            .limit(1)
+                        )
+                        existing_terminal = await conn.scalar(terminal_query)
+                        if existing_terminal is not None:
+                            if sqlite:
+                                await conn.rollback()
+                            elif transaction is not None:
+                                await transaction.rollback()
+                            return False
+
+                        try:
+                            async with conn.begin_nested():
+                                await conn.execute(
+                                    session_terminal_guards_table.insert().values(
+                                        session_id=event.aggregate_id,
+                                        terminal_event_id=event.id,
+                                        terminal_event_type=event.type,
+                                    )
+                                )
+                        except IntegrityError:
+                            # A concurrent conditional terminal transition won
+                            # the per-session unique guard. Roll back this
+                            # outer transaction before returning the successful
+                            # no-op result; the winner's event remains durable.
+                            if conn.in_transaction():
+                                await conn.rollback()
+                            return False
+
+                        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+                        if sqlite:
+                            await conn.commit()
+                        elif transaction is not None:
+                            await transaction.commit()
+                        return True
+                    except BaseException:
+                        if conn.in_transaction():
+                            await conn.rollback()
+                        raise
+            except Exception as e:
+                if "database is locked" in str(e) and attempt < 2:
+                    logger.warning(
+                        "event_store.append_session_terminal_if_active.retry",
+                        extra={"attempt": attempt + 1, "event_id": event.id},
+                    )
+                    await asyncio.sleep(0.1 * (2**attempt))
+                    continue
+                raise PersistenceError(
+                    f"Failed to conditionally append terminal session event: {e}",
+                    operation="append_session_terminal_if_active",
+                    table="events",
+                    details={"event_id": event.id, "event_type": event.type},
+                ) from e
+        raise PersistenceError(
+            "Failed to conditionally append terminal session event after retries.",
+            operation="append_session_terminal_if_active",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        )
 
     async def append_with_rowid(
         self,

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -66,6 +66,15 @@ _SESSION_TERMINAL_EVENT_TYPES = frozenset(
 )
 
 
+def _is_session_terminal_event(event: object) -> bool:
+    """Return whether one event must use the durable terminal transition CAS."""
+    return (
+        isinstance(event, BaseEvent)
+        and event.aggregate_type == "session"
+        and event.type in _SESSION_TERMINAL_EVENT_TYPES
+    )
+
+
 def _normalized_mapping_keys(value: Mapping[object, object]) -> set[str]:
     """Return normalized string keys for mapping inspection."""
     return {str(key).strip().lower().replace("-", "_") for key in value}
@@ -388,11 +397,16 @@ class EventStore:
         event: BaseEvent,
         *,
         _skip_workflow_ir_guard: bool = False,
-    ) -> None:
+    ) -> bool | None:
         """Append an event to the store.
 
         The operation is wrapped in a transaction for atomicity.
         If the insert fails, the transaction is rolled back.
+
+        Returns:
+            ``True`` when a terminal session event wins its conditional
+            transition, ``False`` when an existing terminal event already won,
+            and ``None`` for ordinary append-only events.
 
         Args:
             event: The event to append.
@@ -400,7 +414,14 @@ class EventStore:
         Raises:
             PersistenceError: If the append operation fails.
         """
+        # Terminal session lifecycle is a one-winner transition, not a generic
+        # append-only observation.  Keep this guard at the public EventStore
+        # boundary so event factories and older SessionRepository callers
+        # cannot accidentally bypass the conditional terminal CAS.
+        if _is_session_terminal_event(event):
+            return await self.append_session_terminal_if_active(event)
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
+        return None
 
     async def append_session_terminal_if_active(self, event: BaseEvent) -> bool:
         """Append one terminal session event only while no terminal event exists.
@@ -532,6 +553,13 @@ class EventStore:
             )
         if not isinstance(event, BaseEvent):
             self._raise_invalid_append_input(event, operation="append_with_rowid")
+        if _is_session_terminal_event(event):
+            raise PersistenceError(
+                "Terminal session lifecycle events must be persisted via append() "
+                "or append_session_terminal_if_active() to preserve the one-winner guard.",
+                operation="append_with_rowid",
+                details={"event_type": event.type, "aggregate_id": event.aggregate_id},
+            )
 
         # Guard the workflow IR lifecycle family from direct raw appends:
         # ``WorkflowLifecycleEvent`` enforces the replay-unsafe key blocklist
@@ -646,6 +674,15 @@ class EventStore:
                 "append_workflow_lifecycle_event() and cannot be batched.",
                 operation="append_batch",
                 details={"count": len(workflow_ir_events)},
+            )
+
+        terminal_session_events = [event for event in events if _is_session_terminal_event(event)]
+        if terminal_session_events:
+            raise PersistenceError(
+                "Terminal session lifecycle events cannot be appended in a batch; "
+                "use append() so each session transition takes the one-winner guard.",
+                operation="append_batch",
+                details={"count": len(terminal_session_events)},
             )
 
         for attempt in range(3):

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -539,6 +539,98 @@ class EventStore:
             details={"event_id": event.id, "event_type": event.type},
         )
 
+    async def append_session_pause_if_active(self, event: BaseEvent) -> bool:
+        """Append PAUSED only while no explicit terminal session event exists.
+
+        Returns ``True`` when the pause event was inserted and ``False`` when
+        a completed, failed, or cancelled event already won.  The terminal
+        check and pause append share one write transaction so a runner cannot
+        preserve live resumable authority beside an already-terminal session.
+        """
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="append_session_pause_if_active",
+            )
+        if not isinstance(event, BaseEvent):
+            self._raise_invalid_append_input(
+                event,
+                operation="append_session_pause_if_active",
+            )
+        if event.aggregate_type != "session" or event.type != "orchestrator.session.paused":
+            raise PersistenceError(
+                "Conditional session pause append requires an explicit paused session event.",
+                operation="append_session_pause_if_active",
+                table="events",
+                details={
+                    "aggregate_type": event.aggregate_type,
+                    "event_type": event.type,
+                },
+            )
+
+        for attempt in range(3):
+            try:
+                async with self._engine.connect() as conn:
+                    sqlite = conn.dialect.name == "sqlite"
+                    if sqlite:
+                        await conn.exec_driver_sql("BEGIN IMMEDIATE")
+                        transaction = None
+                    else:
+                        transaction = await conn.begin()
+
+                    try:
+                        terminal_query = (
+                            select(events_table.c.id)
+                            .where(
+                                events_table.c.aggregate_type == "session",
+                                events_table.c.aggregate_id == event.aggregate_id,
+                                events_table.c.event_type.in_(_SESSION_TERMINAL_EVENT_TYPES),
+                            )
+                            .limit(1)
+                        )
+                        if await conn.scalar(terminal_query) is not None:
+                            if sqlite:
+                                await conn.rollback()
+                            elif transaction is not None:
+                                await transaction.rollback()
+                            return False
+
+                        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+                        if sqlite:
+                            await conn.commit()
+                        elif transaction is not None:
+                            await transaction.commit()
+                        return True
+                    except BaseException:
+                        if conn.in_transaction():
+                            await conn.rollback()
+                        raise
+            except Exception as e:
+                if "database is locked" in str(e) and attempt < 2:
+                    logger.warning(
+                        "event_store.append_session_pause_if_active.retry",
+                        extra={"attempt": attempt + 1, "event_id": event.id},
+                    )
+                    await asyncio.sleep(0.1 * (2**attempt))
+                    continue
+                raise PersistenceError(
+                    f"Failed to conditionally append paused session event: {e}",
+                    operation="append_session_pause_if_active",
+                    table="events",
+                    details={"event_id": event.id, "event_type": event.type},
+                ) from e
+        raise PersistenceError(
+            "Failed to conditionally append paused session event after retries.",
+            operation="append_session_pause_if_active",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        )
+
+    @staticmethod
+    def is_session_terminal_event(event: object) -> bool:
+        """Return whether ``event`` requires the terminal one-winner append."""
+        return _is_session_terminal_event(event)
+
     async def append_with_rowid(
         self,
         event: BaseEvent,

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -61,6 +61,24 @@ events_table = Table(
     Index("ix_events_agg_type_id_timestamp", "aggregate_type", "aggregate_id", "timestamp"),
 )
 
+# One durable compare-and-set guard for explicit terminal session lifecycle
+# events. The event stream remains append-only; this table only prevents two
+# concurrent terminal writers from both claiming the same session transition.
+session_terminal_guards_table = Table(
+    "session_terminal_guards",
+    metadata,
+    Column("session_id", String(128), primary_key=True),
+    Column("terminal_event_id", String(36), nullable=False),
+    Column("terminal_event_type", String(200), nullable=False),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+)
+
 # Brownfield repos table - registered repositories/worktrees from brownfield scan.
 # Filesystem discovery is bounded to the scan root. Normal repo roots can add
 # Git-reported linked worktrees outside that root, but linked worktree seeds are

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -79,6 +79,25 @@ session_terminal_guards_table = Table(
     ),
 )
 
+# One immutable start identity per session aggregate. The append-only event
+# stream cannot express a uniqueness constraint over a conditional event type,
+# so this guard closes the absent-row race for caller-supplied session IDs on
+# every supported database backend.
+session_start_guards_table = Table(
+    "session_start_guards",
+    metadata,
+    Column("session_id", String(128), primary_key=True),
+    Column("start_event_id", String(36), nullable=False),
+    Column("execution_id", String(128), nullable=False),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+)
+
 # Brownfield repos table - registered repositories/worktrees from brownfield scan.
 # Filesystem discovery is bounded to the scan root. Normal repo roots can add
 # Git-reported linked worktrees outside that root, but linked worktree seeds are

--- a/src/ouroboros/persistence/uow.py
+++ b/src/ouroboros/persistence/uow.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 
@@ -112,7 +113,11 @@ class UnitOfWork:
                     _has_live_process_local_authority_session,
                 )
 
-                if _has_live_process_local_authority_session(terminal_event.aggregate_id):
+                local_authority_live = _has_live_process_local_authority_session(
+                    terminal_event.aggregate_id
+                )
+                heartbeat_owner_live = is_holder_alive(terminal_event.aggregate_id)
+                if local_authority_live or heartbeat_owner_live:
                     raise PersistenceError(
                         "UnitOfWork cannot terminalize a live process-local session; "
                         "delegate the transition to its retained lifecycle owner.",
@@ -120,7 +125,8 @@ class UnitOfWork:
                         details={
                             "session_id": terminal_event.aggregate_id,
                             "event_type": terminal_event.type,
-                            "process_local_authority_live": True,
+                            "process_local_authority_live": local_authority_live,
+                            "heartbeat_owner_live": heartbeat_owner_live,
                         },
                     )
                 await self._event_store.append(self._pending_events[0])

--- a/src/ouroboros/persistence/uow.py
+++ b/src/ouroboros/persistence/uow.py
@@ -107,6 +107,22 @@ class UnitOfWork:
                     del self._pending_events[:terminal_index]
                     continue
 
+                terminal_event = self._pending_events[0]
+                from ouroboros.orchestrator.execution_authority import (
+                    _has_live_process_local_authority_session,
+                )
+
+                if _has_live_process_local_authority_session(terminal_event.aggregate_id):
+                    raise PersistenceError(
+                        "UnitOfWork cannot terminalize a live process-local session; "
+                        "delegate the transition to its retained lifecycle owner.",
+                        operation="commit",
+                        details={
+                            "session_id": terminal_event.aggregate_id,
+                            "event_type": terminal_event.type,
+                            "process_local_authority_live": True,
+                        },
+                    )
                 await self._event_store.append(self._pending_events[0])
                 del self._pending_events[0]
 

--- a/src/ouroboros/persistence/uow.py
+++ b/src/ouroboros/persistence/uow.py
@@ -95,20 +95,27 @@ class UnitOfWork:
             # one-winner CAS cannot be bypassed. A CAS loser is a successful
             # no-op and is removed from pending just like a winning append.
             while self._pending_events:
-                terminal_index = next(
+                lifecycle_index = next(
                     (
                         index
                         for index, event in enumerate(self._pending_events)
                         if self._event_store.is_session_terminal_event(event)
+                        or self._event_store.is_session_start_event(event)
                     ),
                     len(self._pending_events),
                 )
-                if terminal_index:
-                    await self._event_store.append_batch(self._pending_events[:terminal_index])
-                    del self._pending_events[:terminal_index]
+                if lifecycle_index:
+                    await self._event_store.append_batch(self._pending_events[:lifecycle_index])
+                    del self._pending_events[:lifecycle_index]
                     continue
 
-                terminal_event = self._pending_events[0]
+                lifecycle_event = self._pending_events[0]
+                if self._event_store.is_session_start_event(lifecycle_event):
+                    await self._event_store.append(lifecycle_event)
+                    del self._pending_events[0]
+                    continue
+
+                terminal_event = lifecycle_event
                 from ouroboros.orchestrator.execution_authority import (
                     _has_live_process_local_authority_session,
                 )

--- a/src/ouroboros/persistence/uow.py
+++ b/src/ouroboros/persistence/uow.py
@@ -89,18 +89,32 @@ class UnitOfWork:
             Result.err(PersistenceError) on failure.
         """
         try:
-            # Persist all pending events atomically in a single batch
-            if self._pending_events:
-                await self._event_store.append_batch(self._pending_events)
+            # Ordinary events retain atomic batch persistence. Terminal
+            # session events must pass through EventStore.append() so the
+            # one-winner CAS cannot be bypassed. A CAS loser is a successful
+            # no-op and is removed from pending just like a winning append.
+            while self._pending_events:
+                terminal_index = next(
+                    (
+                        index
+                        for index, event in enumerate(self._pending_events)
+                        if self._event_store.is_session_terminal_event(event)
+                    ),
+                    len(self._pending_events),
+                )
+                if terminal_index:
+                    await self._event_store.append_batch(self._pending_events[:terminal_index])
+                    del self._pending_events[:terminal_index]
+                    continue
+
+                await self._event_store.append(self._pending_events[0])
+                del self._pending_events[0]
 
             # Save checkpoint if provided
             if checkpoint is not None:
                 checkpoint_result = self._checkpoint_store.save(checkpoint)
                 if checkpoint_result.is_err:
                     return checkpoint_result
-
-            # Clear pending events after successful commit
-            self._pending_events.clear()
 
             return Result.ok(None)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,30 @@ os.environ["_TYPER_FORCE_DISABLE_TERMINAL"] = "1"
 os.environ["OUROBOROS_DASHBOARD"] = "0"
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_heartbeat_locks_per_test_worker(tmp_path_factory):
+    """Keep xdist workers from competing over illustrative session IDs.
+
+    Unit tests intentionally use short deterministic IDs (for example
+    ``sess_1``). Production's liveness lease correctly rejects those IDs when
+    two independent processes own them concurrently, but xdist workers are
+    independent processes too. Give each worker a private lock directory while
+    preserving real lease semantics within that worker.
+    """
+    from ouroboros.orchestrator import heartbeat
+
+    previous_lock_dir = heartbeat.LOCK_DIR
+    heartbeat.LOCK_DIR = tmp_path_factory.mktemp("heartbeat-locks")
+    try:
+        yield
+    finally:
+        # A cancellation-focused test may deliberately leave a session alive.
+        # Close those descriptors before pytest tears down the worker.
+        for session_id in tuple(heartbeat._HELD_LEASE_FDS):
+            heartbeat.release(session_id)
+        heartbeat.LOCK_DIR = previous_lock_dir
+
+
 @pytest.fixture(autouse=True)
 def block_runner_real_llm_adapter(monkeypatch):
     """Block execute_seed's dependency analysis from spawning real agent CLIs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,9 @@ def isolate_heartbeat_locks_per_test_worker(tmp_path_factory):
     from ouroboros.orchestrator import heartbeat
 
     previous_lock_dir = heartbeat.LOCK_DIR
+    previous_cancellation_dir = heartbeat.CANCELLATION_DIR
     heartbeat.LOCK_DIR = tmp_path_factory.mktemp("heartbeat-locks")
+    heartbeat.CANCELLATION_DIR = tmp_path_factory.mktemp("cancellation-signals")
     try:
         yield
     finally:
@@ -44,6 +46,7 @@ def isolate_heartbeat_locks_per_test_worker(tmp_path_factory):
         for session_id in tuple(heartbeat._HELD_LEASE_FDS):
             heartbeat.release(session_id)
         heartbeat.LOCK_DIR = previous_lock_dir
+        heartbeat.CANCELLATION_DIR = previous_cancellation_dir
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -513,15 +513,30 @@ def mock_execution_id() -> str:
 
 @pytest.fixture
 async def persisted_session(
-    event_store: Any, mock_session_id: str, mock_execution_id: str, sample_seed: Seed
+    event_store: Any,
+    mock_claude_agent_adapter: MockClaudeAgentAdapter,
+    mock_session_id: str,
+    mock_execution_id: str,
+    sample_seed: Seed,
+    temp_dir: Path,
 ) -> dict[str, Any]:
-    """Create a persisted session in the event store for resumption testing."""
+    """Create a paused session that retains its creating-process capability."""
+    from ouroboros.orchestrator.runner import OrchestratorRunner
     from ouroboros.orchestrator.session import SessionRepository
 
+    # Resume validation requires a concrete constructor-level model pin. The
+    # real CLI adapters expose ``_model``; this minimal E2E adapter does not.
+    mock_claude_agent_adapter._model = "test-model"
+    runner = OrchestratorRunner(
+        adapter=mock_claude_agent_adapter,
+        event_store=event_store,
+        console=MagicMock(),
+        task_cwd=str(temp_dir),
+    )
     repo = SessionRepository(event_store)
-    result = await repo.create_session(
+    result = await runner.prepare_session(
+        sample_seed,
         execution_id=mock_execution_id,
-        seed_id=sample_seed.metadata.seed_id,
         session_id=mock_session_id,
     )
 
@@ -533,10 +548,14 @@ async def persisted_session(
     # Track some progress
     await repo.track_progress(mock_session_id, {"step": 1, "message": "Started"})
     await repo.track_progress(mock_session_id, {"step": 2, "message": "In progress"})
+    pause_result = await repo.mark_paused(mock_session_id, reason="Test interruption")
+    if pause_result.is_err:
+        raise RuntimeError(f"Failed to pause test session: {pause_result.error}")
 
     return {
         "session_id": mock_session_id,
         "execution_id": mock_execution_id,
         "seed_id": sample_seed.metadata.seed_id,
         "tracker": tracker,
+        "runner": runner,
     }

--- a/tests/e2e/test_session_persistence.py
+++ b/tests/e2e/test_session_persistence.py
@@ -9,16 +9,17 @@ This module tests the complete session lifecycle:
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.runner import OrchestratorRunner
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.persistence.event_store import EventStore
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
-    from ouroboros.persistence.event_store import EventStore
     from tests.e2e.conftest import MockClaudeAgentAdapter
 
 
@@ -71,6 +72,47 @@ class TestSessionCreation:
 
         assert result1.is_ok and result2.is_ok
         assert result1.value.session_id != result2.value.session_id
+
+    async def test_concurrent_custom_session_id_has_one_start_identity(
+        self,
+        tmp_path,
+        sample_seed: Seed,
+    ) -> None:
+        """Concurrent publishers cannot create two executions for one session ID."""
+        database_url = f"sqlite+aiosqlite:///{tmp_path / 'start-identity-cas.db'}"
+        first_store = EventStore(database_url)
+        second_store = EventStore(database_url)
+        await first_store.initialize()
+        await second_store.initialize()
+        session_id = "session-concurrent-start-identity"
+        try:
+            first, second = await asyncio.gather(
+                SessionRepository(first_store).create_session(
+                    execution_id="exec-concurrent-start-a",
+                    seed_id=sample_seed.metadata.seed_id,
+                    session_id=session_id,
+                ),
+                SessionRepository(second_store).create_session(
+                    execution_id="exec-concurrent-start-b",
+                    seed_id=sample_seed.metadata.seed_id,
+                    session_id=session_id,
+                ),
+            )
+
+            assert int(first.is_ok) + int(second.is_ok) == 1
+            loser = second if first.is_ok else first
+            assert loser.is_err
+            assert loser.error.details["session_start_conflict"] is True
+            events = await first_store.replay("session", session_id)
+            starts = [event for event in events if event.type == "orchestrator.session.started"]
+            assert len(starts) == 1
+            assert starts[0].data["execution_id"] in {
+                "exec-concurrent-start-a",
+                "exec-concurrent-start-b",
+            }
+        finally:
+            await second_store.close()
+            await first_store.close()
 
     async def test_session_tracks_execution_id(
         self,

--- a/tests/e2e/test_session_persistence.py
+++ b/tests/e2e/test_session_persistence.py
@@ -314,21 +314,17 @@ class TestSessionReconstruction:
 class TestSessionResumption:
     """Test session resumption functionality."""
 
-    async def test_resume_running_session(
+    async def test_same_process_paused_session_resumes(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test resuming a running session."""
+        """A paused session resumes only through its creating process."""
         mock_claude_agent_adapter.add_successful_execution(final_message="Resumed and completed")
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],
@@ -338,21 +334,17 @@ class TestSessionResumption:
         assert result.is_ok
         assert result.value.success
 
-    async def test_resume_preserves_session_id(
+    async def test_same_process_resume_preserves_session_id(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test that resuming preserves the original session ID."""
+        """Same-process resume preserves the original session ID."""
         mock_claude_agent_adapter.add_successful_execution()
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],
@@ -407,14 +399,43 @@ class TestSessionResumption:
 
         assert result.is_err
 
-    async def test_resume_accumulates_messages(
+    async def test_legacy_running_session_is_terminally_rejected(
+        self,
+        event_store: EventStore,
+        sample_seed: Seed,
+        mock_claude_agent_adapter: MockClaudeAgentAdapter,
+    ) -> None:
+        """A persisted legacy RUNNING tracker cannot recreate local authority."""
+        repo = SessionRepository(event_store)
+        session_id = "legacy_running_session"
+        create_result = await repo.create_session(
+            execution_id="exec_legacy_running",
+            seed_id=sample_seed.metadata.seed_id,
+            session_id=session_id,
+        )
+        assert create_result.is_ok
+
+        runner = OrchestratorRunner(
+            adapter=mock_claude_agent_adapter,
+            event_store=event_store,
+            console=MagicMock(),
+        )
+        result = await runner.resume_session(session_id, sample_seed)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+        reconstructed = await repo.reconstruct_session(session_id)
+        assert reconstructed.is_ok
+        assert reconstructed.value.status == SessionStatus.FAILED
+
+    async def test_same_process_resume_accumulates_messages(
         self,
         persisted_session: dict[str, Any],
         event_store: EventStore,
         sample_seed: Seed,
         mock_claude_agent_adapter: MockClaudeAgentAdapter,
     ) -> None:
-        """Test that resuming accumulates message count correctly."""
+        """Same-process resume accumulates its persisted message count."""
         # The persisted_session fixture tracks 2 progress events
         initial_messages = 2
 
@@ -432,11 +453,7 @@ class TestSessionResumption:
         ]
         mock_claude_agent_adapter.add_execution_sequence(messages)
 
-        runner = OrchestratorRunner(
-            adapter=mock_claude_agent_adapter,
-            event_store=event_store,
-            console=MagicMock(),
-        )
+        runner = persisted_session["runner"]
 
         result = await runner.resume_session(
             persisted_session["session_id"],

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from ouroboros.cli.main import app
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.types import Result
 from ouroboros.orchestrator import heartbeat
+from ouroboros.orchestrator.execution_authority import ProcessLocalCancellationDisposition
 from ouroboros.orchestrator.runner import clear_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 
@@ -99,11 +101,51 @@ class TestCancelExecutionValidation:
                     "cross-process CLI cancellation",
                 )
 
-            assert cancelled is True
+            assert cancelled == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
             assert heartbeat.has_cancellation_request(tracker.session_id)
             mark_cancelled.assert_not_awaited()
         finally:
             await clear_cancellation(tracker.session_id)
+
+    @patch("ouroboros.cli.commands.cancel._get_event_store")
+    def test_specific_cli_reports_live_owner_request_without_terminal_claim(
+        self,
+        mock_get_es: AsyncMock,
+    ) -> None:
+        """A nonterminal foreign-owner request is not printed as cancelled."""
+        tracker = _make_tracker(session_id="orch_foreign_cli_output").with_progress(
+            {
+                "execution_contract": {
+                    "foundation_a_authority": {
+                        "version": 1,
+                        "scope": "process_local",
+                        "correlation_id": "b" * 32,
+                    }
+                }
+            }
+        )
+        mock_es = AsyncMock()
+        mock_get_es.return_value = mock_es
+
+        try:
+            with (
+                patch.object(
+                    SessionRepository,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch("ouroboros.orchestrator.heartbeat.is_holder_alive", return_value=True),
+            ):
+                result = runner.invoke(
+                    app,
+                    ["cancel", "execution", tracker.session_id],
+                )
+
+            assert result.exit_code == 0
+            assert f"Cancellation requested for execution: {tracker.session_id}" in result.output
+            assert f"Cancelled execution: {tracker.session_id}" not in result.output
+        finally:
+            asyncio.run(clear_cancellation(tracker.session_id))
 
 
 class TestBareMode:
@@ -631,6 +673,55 @@ class TestCancelAllExecutions:
         assert "No running executions" in result.output
 
     @patch("ouroboros.cli.commands.cancel._get_event_store")
+    def test_cancel_all_counts_live_owner_requests_separately(
+        self,
+        mock_get_es: AsyncMock,
+    ) -> None:
+        """--all reports requested delivery separately from durable cancellation."""
+        from ouroboros.events.base import BaseEvent
+
+        tracker = _make_tracker(session_id="orch_foreign_all").with_progress(
+            {
+                "execution_contract": {
+                    "foundation_a_authority": {
+                        "version": 1,
+                        "scope": "process_local",
+                        "correlation_id": "c" * 32,
+                    }
+                }
+            }
+        )
+        mock_es = AsyncMock()
+        mock_es.get_all_sessions = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id=tracker.session_id,
+                    data={},
+                )
+            ]
+        )
+        mock_get_es.return_value = mock_es
+
+        try:
+            with (
+                patch.object(
+                    SessionRepository,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch("ouroboros.orchestrator.heartbeat.is_holder_alive", return_value=True),
+            ):
+                result = runner.invoke(app, ["cancel", "execution", "--all"])
+
+            assert result.exit_code == 0
+            assert "Cancellation requested for 1 execution(s)." in result.output
+            assert "Cancelled 1 execution(s)." not in result.output
+        finally:
+            asyncio.run(clear_cancellation(tracker.session_id))
+
+    @patch("ouroboros.cli.commands.cancel._get_event_store")
     def test_cancel_all_multiple_running(self, mock_get_es: AsyncMock) -> None:
         """Test --all cancels multiple running sessions."""
         from ouroboros.events.base import BaseEvent
@@ -745,8 +836,8 @@ class TestCancelHelperFunctions:
     """Tests for internal helper functions."""
 
     @pytest.mark.asyncio
-    async def test_cancel_session_returns_false_on_not_found(self) -> None:
-        """Test _cancel_session returns False when session doesn't exist."""
+    async def test_cancel_session_returns_none_on_not_found(self) -> None:
+        """Test _cancel_session returns no disposition when the session does not exist."""
         from ouroboros.cli.commands.cancel import _cancel_session
 
         mock_es = AsyncMock()
@@ -759,11 +850,11 @@ class TestCancelHelperFunctions:
 
             result = await _cancel_session(mock_es, "orch_missing")
 
-        assert result is False
+        assert result is None
 
     @pytest.mark.asyncio
-    async def test_cancel_session_returns_true_on_success(self) -> None:
-        """Test _cancel_session returns True when cancellation succeeds."""
+    async def test_cancel_session_returns_cancelled_on_success(self) -> None:
+        """Test _cancel_session preserves the terminal cancellation disposition."""
         from ouroboros.cli.commands.cancel import _cancel_session
 
         mock_es = AsyncMock()
@@ -776,7 +867,7 @@ class TestCancelHelperFunctions:
 
             result = await _cancel_session(mock_es, "orch_test123")
 
-        assert result is True
+        assert result == ProcessLocalCancellationDisposition.CANCELLED
 
     @pytest.mark.asyncio
     async def test_cancel_all_running_returns_counts(self) -> None:
@@ -815,9 +906,10 @@ class TestCancelHelperFunctions:
             )
             mock_repo.mark_cancelled = AsyncMock(return_value=Result.ok(None))
 
-            cancelled, skipped = await _cancel_all_running(mock_es)
+            cancelled, requested, skipped = await _cancel_all_running(mock_es)
 
         assert cancelled == 1
+        assert requested == 0
         assert skipped == 1
 
     @pytest.mark.asyncio
@@ -828,9 +920,10 @@ class TestCancelHelperFunctions:
         mock_es = AsyncMock()
         mock_es.get_all_sessions = AsyncMock(return_value=[])
 
-        cancelled, skipped = await _cancel_all_running(mock_es)
+        cancelled, requested, skipped = await _cancel_all_running(mock_es)
 
         assert cancelled == 0
+        assert requested == 0
         assert skipped == 0
 
     @pytest.mark.asyncio
@@ -850,7 +943,7 @@ class TestCancelHelperFunctions:
 
             result = await _cancel_session(mock_es, "orch_test123")
 
-        assert result is False
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_cancel_session_returns_false_when_terminal_cas_loses(self) -> None:
@@ -867,4 +960,4 @@ class TestCancelHelperFunctions:
 
             result = await _cancel_session(mock_es, "orch_test123")
 
-        assert result is False
+        assert result is None

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -906,10 +906,11 @@ class TestCancelHelperFunctions:
             )
             mock_repo.mark_cancelled = AsyncMock(return_value=Result.ok(None))
 
-            cancelled, requested, skipped = await _cancel_all_running(mock_es)
+            cancelled, requested, retryable_failed, skipped = await _cancel_all_running(mock_es)
 
         assert cancelled == 1
         assert requested == 0
+        assert retryable_failed == 0
         assert skipped == 1
 
     @pytest.mark.asyncio
@@ -920,11 +921,88 @@ class TestCancelHelperFunctions:
         mock_es = AsyncMock()
         mock_es.get_all_sessions = AsyncMock(return_value=[])
 
-        cancelled, requested, skipped = await _cancel_all_running(mock_es)
+        cancelled, requested, retryable_failed, skipped = await _cancel_all_running(mock_es)
 
         assert cancelled == 0
         assert requested == 0
+        assert retryable_failed == 0
         assert skipped == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_counts_process_local_persistence_pending_as_retryable(self) -> None:
+        """Marker/terminal persistence failure must not disappear into skipped."""
+        from ouroboros.cli.commands.cancel import _cancel_all_running
+        from ouroboros.events.base import BaseEvent
+        from ouroboros.orchestrator.execution_authority import (
+            ProcessLocalCancellationOutcome,
+        )
+
+        mock_es = AsyncMock()
+        mock_es.get_all_sessions = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id="orch_pending",
+                    data={},
+                )
+            ]
+        )
+        tracker = _make_tracker(session_id="orch_pending", status=SessionStatus.RUNNING)
+
+        with (
+            patch("ouroboros.orchestrator.session.SessionRepository") as MockRepo,
+            patch(
+                "ouroboros.cli.commands.cancel.request_process_local_cancellation",
+                AsyncMock(
+                    return_value=ProcessLocalCancellationOutcome(
+                        ProcessLocalCancellationDisposition.PERSISTENCE_PENDING,
+                        error=PersistenceError("marker unavailable"),
+                    )
+                ),
+            ),
+        ):
+            MockRepo.return_value.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+            cancelled, requested, retryable_failed, skipped = await _cancel_all_running(mock_es)
+
+        assert (cancelled, requested, retryable_failed, skipped) == (0, 0, 1, 0)
+
+    @patch("ouroboros.cli.commands.cancel._get_event_store")
+    def test_cancel_all_reports_retryable_terminal_write_failure(
+        self,
+        mock_get_es: AsyncMock,
+    ) -> None:
+        """An all-failed batch prints retry guidance, never 'no running'."""
+        from ouroboros.events.base import BaseEvent
+
+        mock_es = AsyncMock()
+        mock_es.get_all_sessions = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id="orch_write_failure",
+                    data={},
+                )
+            ]
+        )
+        mock_get_es.return_value = mock_es
+        tracker = _make_tracker(
+            session_id="orch_write_failure",
+            status=SessionStatus.RUNNING,
+        )
+
+        with patch("ouroboros.orchestrator.session.SessionRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+            mock_repo.mark_cancelled = AsyncMock(
+                return_value=Result.err(PersistenceError("terminal write failed"))
+            )
+            result = runner.invoke(app, ["cancel", "execution", "--all"])
+
+        assert result.exit_code == 0
+        assert "retry required" in result.output.lower()
+        assert "No running executions" not in result.output
 
     @pytest.mark.asyncio
     async def test_cancel_session_handles_mark_cancelled_error(self) -> None:

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -803,3 +803,20 @@ class TestCancelHelperFunctions:
             result = await _cancel_session(mock_es, "orch_test123")
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_session_returns_false_when_terminal_cas_loses(self) -> None:
+        """A race winner must not be reported as a successful CLI cancellation."""
+        from ouroboros.cli.commands.cancel import _cancel_session
+
+        mock_es = AsyncMock()
+        tracker = _make_tracker(status=SessionStatus.RUNNING)
+
+        with patch("ouroboros.orchestrator.session.SessionRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+            mock_repo.mark_cancelled = AsyncMock(return_value=Result.ok(False))
+
+            result = await _cancel_session(mock_es, "orch_test123")
+
+        assert result is False

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -8,10 +8,13 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
+from ouroboros.cli.commands.cancel import _cancel_session
 from ouroboros.cli.main import app
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.types import Result
-from ouroboros.orchestrator.session import SessionStatus, SessionTracker
+from ouroboros.orchestrator import heartbeat
+from ouroboros.orchestrator.runner import clear_cancellation
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 
 runner = CliRunner()
 
@@ -56,6 +59,51 @@ class TestCancelExecutionValidation:
         result = runner.invoke(app, ["cancel", "execution", "orch_test123", "--all"])
         assert result.exit_code == 1
         assert "Cannot specify both" in result.output
+
+    @pytest.mark.asyncio
+    async def test_cli_process_publishes_request_for_live_foreign_owner(self) -> None:
+        """A separate CLI process can signal without writing terminal state."""
+        tracker = _make_tracker(session_id="orch_foreign_cli").with_progress(
+            {
+                "execution_contract": {
+                    "foundation_a_authority": {
+                        "version": 1,
+                        "scope": "process_local",
+                        "correlation_id": "a" * 32,
+                    }
+                }
+            }
+        )
+        event_store = AsyncMock()
+        mark_cancelled = AsyncMock(return_value=Result.ok(True))
+        try:
+            with (
+                patch.object(
+                    SessionRepository,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch.object(
+                    SessionRepository,
+                    "mark_cancelled_if_active",
+                    mark_cancelled,
+                ),
+                patch(
+                    "ouroboros.orchestrator.heartbeat.is_holder_alive",
+                    return_value=True,
+                ),
+            ):
+                cancelled = await _cancel_session(
+                    event_store,
+                    tracker.session_id,
+                    "cross-process CLI cancellation",
+                )
+
+            assert cancelled is True
+            assert heartbeat.has_cancellation_request(tracker.session_id)
+            mark_cancelled.assert_not_awaited()
+        finally:
+            await clear_cancellation(tracker.session_id)
 
 
 class TestBareMode:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -30,7 +30,7 @@ from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
 from ouroboros.orchestrator.heartbeat import lock_path
 from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
-from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore, PersistenceError
 
@@ -2978,6 +2978,75 @@ class TestJobManager:
             assert await is_cancellation_requested(session_id) is False
             assert not session_cancelled
             assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
+        finally:
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_does_not_mirror_cancel_when_terminal_cas_loses(
+        self, tmp_path
+    ) -> None:
+        """A linked-session race winner must not gain a cancelled execution mirror."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_terminal_cas_loser_123"
+        execution_id = "exec_terminal_cas_loser_123"
+        runner_cancelled = asyncio.Event()
+
+        try:
+            await store.initialize()
+            repository = SessionRepository(store)
+            created = await repository.create_session(
+                execution_id=execution_id,
+                seed_id="seed_terminal_cas_loser_123",
+                session_id=session_id,
+            )
+            assert created.is_ok
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="terminal-cas-loser",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            async def _lose_terminal_race(
+                _repository: SessionRepository,
+                _session_id: str,
+                reason: str,
+                cancelled_by: str = "user",
+            ) -> Result[bool, PersistenceError]:
+                await store.append(
+                    BaseEvent(
+                        type="orchestrator.session.completed",
+                        aggregate_type="session",
+                        aggregate_id=_session_id,
+                        data={"summary": {"won": "completion"}},
+                    )
+                )
+                return Result.ok(False)
+
+            with patch.object(SessionRepository, "mark_cancelled", new=_lose_terminal_race):
+                snapshot = await manager.cancel_job(started.job_id)
+
+            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
+            session = await repository.reconstruct_session(session_id)
+            execution_events = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+            assert session.is_ok and session.value.status is SessionStatus.COMPLETED
+            assert not any(event.data.get("status") == "cancelled" for event in execution_events)
         finally:
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -6011,7 +6011,13 @@ class TestJobManager:
             ) is None
 
             gate.set()
-            await asyncio.sleep(0.05)
+            completed = await _wait_for_job_status(
+                manager,
+                started.job_id,
+                JobStatus.COMPLETED,
+                timeout=2.0,
+            )
+            assert completed.job_id == started.job_id
 
             assert (await manager.find_active_job_by_lineage("lin_recovery")) is None
             terminal_recovered = await manager.find_active_job_by_lineage(

--- a/tests/unit/mcp/test_job_manager_drain.py
+++ b/tests/unit/mcp/test_job_manager_drain.py
@@ -103,6 +103,46 @@ class TestJobManagerDrain:
         finally:
             await store.close()
 
+    async def test_drain_does_not_recount_terminal_job_while_task_unwinds(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        release_terminal_append = asyncio.Event()
+        terminal_persisted = asyncio.Event()
+        original_append = manager._append_terminal_event_with_fallback
+
+        async def _append_then_hold(*args, **kwargs) -> None:
+            await original_append(*args, **kwargs)
+            terminal_persisted.set()
+            release_wait = asyncio.create_task(release_terminal_append.wait())
+            while not release_wait.done():
+                try:
+                    await asyncio.shield(release_wait)
+                except asyncio.CancelledError:
+                    continue
+
+        monkeypatch.setattr(manager, "_append_terminal_event_with_fallback", _append_then_hold)
+        try:
+            snapshot = await _start_blocked_job(manager)
+
+            first_drain = asyncio.create_task(manager.drain(grace_seconds=0.05))
+            await asyncio.wait_for(terminal_persisted.wait(), timeout=2.0)
+            first = await asyncio.wait_for(first_drain, timeout=2.0)
+
+            job_task = manager._tasks[snapshot.job_id]
+            assert not job_task.done()
+            second = await manager.drain(grace_seconds=0.05)
+
+            assert first == 1
+            assert second == 0
+            assert (await manager.get_snapshot(snapshot.job_id)).status is JobStatus.INTERRUPTED
+        finally:
+            release_terminal_append.set()
+            await asyncio.gather(*manager._tasks.values(), return_exceptions=True)
+            await store.close()
+
     async def test_repeated_drain_does_not_double_terminalize_mixed_jobs(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -12,6 +12,7 @@ from ouroboros.bigbang.interview import InterviewRound, InterviewState, Intervie
 from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.errors import ConfigError
 from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.authoring_handlers import _is_interview_completion_signal
 from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
 from ouroboros.mcp.tools.definitions import (
@@ -57,6 +58,7 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.session import SessionStatus, SessionTracker
 from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.schema import events_table
 from ouroboros.resilience.lateral import ThinkingPersona
 
 
@@ -69,6 +71,13 @@ async def memory_event_store() -> AsyncIterator[EventStore]:
         yield store
     finally:
         await store.close()
+
+
+async def _append_legacy_event_unchecked(store: EventStore, event: BaseEvent) -> None:
+    """Seed malformed legacy history that current public append guards reject."""
+    assert store._engine is not None
+    async with store._engine.begin() as conn:
+        await conn.execute(events_table.insert().values(**event.to_db_dict()))
 
 
 class TestExecuteSeedHandler:
@@ -1408,7 +1417,8 @@ class TestProjectionQueryHandler:
                 },
             )
         )
-        await memory_event_store.append(
+        await _append_legacy_event_unchecked(
+            memory_event_store,
             BaseEvent(
                 id="evt_session_exec_b",
                 type="orchestrator.session.started",
@@ -1419,7 +1429,7 @@ class TestProjectionQueryHandler:
                     "seed_id": "seed_projection_b",
                     "seed_goal": "Requested execution",
                 },
-            )
+            ),
         )
         await memory_event_store.append(
             BaseEvent(
@@ -1493,14 +1503,15 @@ class TestProjectionQueryHandler:
                 data={"execution_id": "exec_reused_a", "seed_id": "seed_reused_a"},
             )
         )
-        await memory_event_store.append(
+        await _append_legacy_event_unchecked(
+            memory_event_store,
             BaseEvent(
                 id="evt_reused_session_b",
                 type="orchestrator.session.started",
                 aggregate_type="session",
                 aggregate_id="orch_projection_reused",
                 data={"execution_id": "exec_reused_b", "seed_id": "seed_reused_b"},
-            )
+            ),
         )
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -168,6 +168,9 @@ class TestExecuteSeedHandler:
             def __init__(self, *args: object, fat_harness_mode: bool, **kwargs: object) -> None:
                 captured_modes.append(fat_harness_mode)
 
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
+
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(fresh_tracker)
 
@@ -295,6 +298,9 @@ class TestExecuteSeedHandler:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
+
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(tracker)
 
@@ -379,6 +385,9 @@ class TestExecuteSeedHandler:
         class FakeRunner:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
+
+            def _has_live_process_local_authority(self, *args: object, **kwargs: object) -> bool:
+                return False
 
             async def prepare_session(self, *args: object, **kwargs: object) -> Result:
                 return Result.ok(running_tracker)

--- a/tests/unit/orchestrator/parallel_executor_test_support.py
+++ b/tests/unit/orchestrator/parallel_executor_test_support.py
@@ -1,0 +1,50 @@
+"""Test-only seams for exercising captured parallel-executor entry roots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+
+
+class ProcessLocalTestExecutor(ParallelACExecutor):
+    """Constructor-time test double whose entry roots stay process-local.
+
+    Production execution captures its finite internal entry roots when the
+    executor is constructed. Tests that need controllable leaf behavior use
+    this explicit subclass instead of mutating a production executor's roots
+    after construction.
+    """
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", value)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", value)
+            return
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        if name == "_execute_single_ac":
+            object.__setattr__(self, "_test_single_ac_runner", None)
+            return
+        if name == "_execute_atomic_ac":
+            object.__setattr__(self, "_test_atomic_ac_runner", None)
+            return
+        object.__delattr__(self, name)
+
+    async def _execute_single_ac(self, *args: Any, **kwargs: Any) -> Any:
+        calls = getattr(self, "_test_single_ac_calls", None)
+        if isinstance(calls, list):
+            calls.append(dict(kwargs))
+        runner = getattr(self, "_test_single_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_single_ac(*args, **kwargs)
+
+    async def _execute_atomic_ac(self, *args: Any, **kwargs: Any) -> Any:
+        runner = getattr(self, "_test_atomic_ac_runner", None)
+        if runner is not None:
+            return await runner(*args, **kwargs)
+        return await super()._execute_atomic_ac(*args, **kwargs)

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -409,12 +409,12 @@ def test_credential_alias_in_runtime_identity_becomes_process_local_without_egre
 def test_secret_key_alias_in_runtime_identity_becomes_process_local(
     key_name: str,
 ) -> None:
-    secret = "opaque-provider-credential"
+    credential_value = "opaque-provider-credential"
 
     class CredentialRuntime(_Runtime):
         def execution_identity_contract(self) -> dict[str, object]:
             return {
-                key_name: secret,
+                key_name: credential_value,
                 "effective_model_observed": True,
             }
 
@@ -423,7 +423,7 @@ def test_secret_key_alias_in_runtime_identity_becomes_process_local(
     assert authority.portable_across_processes is False
     assert authority.data["runtime"]["stability"] == "process_local"
     assert authority.data["runtime"]["execution_identity"] == {"observed": False}
-    assert secret not in authority.canonical_json
+    assert credential_value not in authority.canonical_json
 
 
 def test_custom_verifier_credential_alias_never_enters_authority_json() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,0 +1,1748 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+import gc
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock
+import weakref
+
+import pytest
+
+from ouroboros.backends import runtime_backend_choices
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    execution_authority_boundary_contract,
+)
+import ouroboros.orchestrator.parallel_executor as parallel_executor_module
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
+from ouroboros.orchestrator.runtime_factory import create_agent_runtime
+from ouroboros.orchestrator.verifier import VerifierVerdict, structural_atomic_verifier
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+
+class _Runtime:
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory: str | None = None
+    _model = None
+
+    def __init__(self, *, profile: str = "profile-a") -> None:
+        self.profile = profile
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {
+            "profile": self.profile,
+            "effective_model_observed": True,
+        }
+
+    async def execute_task(self, **_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+
+class _DynamicDispatchRuntime:
+    """A runtime whose dispatch entrypoint cannot be statically bound."""
+
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "dynamic-runtime"
+    llm_backend = "dynamic-llm"
+    permission_mode = "bypassPermissions"
+    self_governs_rate_limit = False
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"kind": "dynamic-runtime/v1", "effective_model_observed": True}
+
+    def __getattr__(self, name: str) -> object:
+        if name == "execute_task":
+
+            async def dispatch(**_: object) -> AsyncIterator[object]:
+                if False:  # pragma: no cover - identity-only stand-in
+                    yield None
+
+            return dispatch
+        raise AttributeError(name)
+
+
+class _Verifier:
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": self.identity}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
+def _contract(
+    *,
+    runtime: object | None = None,
+    verifier: object | None = None,
+    workspace: str = "/tmp/workspace-a",
+    policy: dict[str, object] | None = None,
+) -> ExecutionAuthorityContract:
+    return ExecutionAuthorityContract.build(
+        adapter=runtime or _Runtime(),
+        verifier=verifier,  # type: ignore[arg-type]
+        workspace=workspace,
+        execution_policy=policy or {"retry_attempts": 2},
+    )
+
+
+def test_legacy_runtime_authority_never_invokes_dynamic_identity_provider() -> None:
+    class ExplodingRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            raise AssertionError("Foundation A must not execute legacy runtime providers")
+
+    authority = _contract(runtime=ExplodingRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+
+
+def test_legacy_runtime_captures_are_process_local_and_unique() -> None:
+    first = _contract(runtime=_Runtime(profile="a"))
+    second = _contract(runtime=_Runtime(profile="b"))
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_custom_verifier_is_never_promoted_to_portable_authority() -> None:
+    first = _contract(verifier=_Verifier("judge-a"))
+    same = _contract(verifier=_Verifier("judge-a"))
+    changed = _contract(verifier=_Verifier("judge-b"))
+
+    assert first.fingerprint != same.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert first.portable_across_processes is False
+    assert "judge-a" not in first.canonical_json
+
+
+def test_undeclared_custom_verifier_is_process_local() -> None:
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    first = _contract(verifier=verifier)
+    second = _contract(verifier=verifier)
+
+    assert first.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_workspace_and_policy_drift_change_authority() -> None:
+    baseline = _contract()
+    assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
+    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_builtin_verifier_does_not_make_legacy_runtime_portable() -> None:
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+    assert authority.data["verifier"] == {
+        "implementation": "structural-atomic-verifier/v1",
+        "mode": "structural_atomic",
+        "stability": "durable",
+        "version": 1,
+    }
+
+
+def test_complete_runtime_factory_catalog_is_process_local() -> None:
+    """Every shipped runtime backend stays below Foundation A portability."""
+    expected_backends = {
+        "claude",
+        "claude_mcp",
+        "codex",
+        "codex_mcp",
+        "copilot",
+        "gemini",
+        "zcode",
+        "hermes",
+        "kiro",
+        "opencode",
+        "goose",
+        "pi",
+        "gjc",
+        "antigravity",
+        "grok",
+    }
+    assert set(runtime_backend_choices()) == expected_backends
+
+    for backend in sorted(expected_backends):
+        runtime = create_agent_runtime(
+            backend=backend,
+            cli_path=sys.executable,
+            cwd="/tmp",
+            permission_mode="bypassPermissions",
+            model="test-model",
+            llm_backend="test-llm",
+        )
+        authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+        assert authority.portable_across_processes is False, backend
+        assert authority.data["runtime"]["stability"] == "process_local", backend
+
+
+def test_boundary_contract_marks_legacy_runtime_descriptor_process_local() -> None:
+    boundary = execution_authority_boundary_contract()
+
+    assert "legacy_runtime_descriptor" in boundary["process_local"]
+    assert "legacy_runtime_descriptor" not in boundary["portable"]
+    assert "runtime_descriptor" not in boundary["portable"]
+
+
+def test_unknown_runtime_implementation_stays_process_local_and_unique() -> None:
+    class AlternateRuntime(_Runtime):
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            if False:  # pragma: no cover - implementation identity only
+                yield None
+
+    first = _contract(runtime=_Runtime())
+    second = _contract(runtime=AlternateRuntime())
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_runtime_type_name_spoof_cannot_claim_closed_implementation() -> None:
+    class SpoofedCodexRuntime(CodexCliRuntime):
+        pass
+
+    SpoofedCodexRuntime.__module__ = CodexCliRuntime.__module__
+    SpoofedCodexRuntime.__qualname__ = CodexCliRuntime.__qualname__
+    runtime = SpoofedCodexRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_preconstruction_builtin_dispatch_patch_stays_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def altered_execute_task(*_: object, **__: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(CodexCliRuntime, "execute_task", altered_execute_task)
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+
+
+def test_legacy_codex_runtime_never_serializes_runtime_configuration() -> None:
+    baseline = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            stdout_idle_timeout_seconds=30,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    assert baseline.portable_across_processes is False
+    assert baseline.data["runtime"]["configuration"] == {"observed": False}
+    assert "/tmp" not in baseline.canonical_json
+
+
+def test_closed_codex_runtime_custom_skill_configuration_stays_process_local(
+    tmp_path,
+) -> None:
+    custom_skills = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skills_dir=tmp_path,
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    custom_dispatcher = _contract(
+        runtime=CodexCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+            skill_dispatcher=MagicMock(),
+        ),
+        verifier=structural_atomic_verifier,
+    )
+
+    assert custom_skills.portable_across_processes is False
+    assert custom_dispatcher.portable_across_processes is False
+
+
+def test_legacy_codex_dynamic_helpers_and_cache_cannot_gain_portability() -> None:
+    runtime = CodexCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+    )
+    before = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    async def injected_impl(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - must never be invoked during capture
+            yield None
+
+    def exploding_provider() -> dict[str, object]:
+        raise AssertionError("legacy identity provider must not run")
+
+    runtime._execute_task_impl = injected_impl  # type: ignore[method-assign]
+    runtime._build_command = lambda **_: ["injected"]  # type: ignore[method-assign]
+    runtime._builtin_mcp_handlers = {"injected": object()}
+    runtime.execution_identity_contract = exploding_provider  # type: ignore[method-assign]
+    after = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    for authority in (before, after):
+        assert authority.portable_across_processes is False
+        assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+        assert authority.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_copilot_runtime_is_process_local_even_when_profile_changes() -> None:
+    plain = _contract(
+        runtime=CopilotCliRuntime(
+            cli_path=sys.executable,
+            model="test-model",
+            cwd="/tmp",
+        ),
+        verifier=structural_atomic_verifier,
+    )
+    worker_runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd="/tmp",
+        runtime_profile="worker",
+    )
+    worker = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+
+    assert plain.portable_across_processes is False
+    assert worker.portable_across_processes is False
+    assert plain.data["runtime"]["configuration"] == {"observed": False}
+    assert worker.data["runtime"]["configuration"] == {"observed": False}
+
+    worker_runtime._copilot_agent = "different-agent"
+    changed = _contract(runtime=worker_runtime, verifier=structural_atomic_verifier)
+    assert changed.portable_across_processes is False
+    assert changed.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_zcode_runtime_with_external_launcher_chain_stays_process_local() -> None:
+    runtime = ZcodeCLIRuntime(cli_path=sys.executable, cwd="/tmp")
+
+    authority = _contract(runtime=runtime, verifier=structural_atomic_verifier)
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["configuration"] == {"observed": False}
+
+
+def test_credential_shaped_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert secret not in authority.canonical_json
+
+
+def test_stripe_credential_shaped_runtime_identity_becomes_process_local() -> None:
+    secret = "sk_" + "live_abcdefghijklmnopqrstuvwxyz123456"
+    authority = _contract(runtime=_Runtime(profile=secret))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_credential_alias_in_runtime_identity_becomes_process_local_without_egress() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "apiKeyValue": secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+@pytest.mark.parametrize(
+    "key_name",
+    (
+        "secretKey",
+        "secret_access_key",
+        "awsSecretAccessKey",
+        "accountKey",
+        "connectionString",
+        "masterKey",
+    ),
+)
+def test_secret_key_alias_in_runtime_identity_becomes_process_local(
+    key_name: str,
+) -> None:
+    secret = "opaque-provider-credential"
+
+    class CredentialRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                key_name: secret,
+                "effective_model_observed": True,
+            }
+
+    authority = _contract(runtime=CredentialRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_custom_verifier_credential_alias_never_enters_authority_json() -> None:
+    secret = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    class CredentialVerifier(_Verifier):
+        def verification_identity_contract(self) -> dict[str, object]:
+            return {"apiKeyValue": secret}
+
+    authority = _contract(verifier=CredentialVerifier("ignored"))
+
+    assert authority.portable_across_processes is False
+    assert authority.data["verifier"]["configuration"] == {"observed": False}
+    assert secret not in authority.canonical_json
+
+
+def test_contract_deserialization_rejects_credential_shaped_member() -> None:
+    authority = _contract(verifier=structural_atomic_verifier)
+    data = authority.data
+    data["verifier"]["implementation"] = "gh" + "p_abcdefghijklmnopqrstuvwxyz1234567890"
+
+    with pytest.raises(ValueError, match="sensitive"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_contract_deserialization_rejects_promoted_process_local_runtime() -> None:
+    authority = _contract(runtime=_DynamicDispatchRuntime())
+    data = authority.data
+    assert data["runtime"]["portable_identity_observed"] is False
+    data["runtime"]["stability"] = "durable"
+
+    with pytest.raises(ValueError, match="invalid runtime"):
+        ExecutionAuthorityContract(json.dumps(data, sort_keys=True, separators=(",", ":")))
+
+
+def test_empty_runtime_identity_stays_process_local() -> None:
+    class EmptyIdentityRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {}
+
+    authority = _contract(runtime=EmptyIdentityRuntime())
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+
+
+def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=load_profile("code"),
+        atomic_verifier=_Verifier("judge-a"),
+        ac_retry_attempts=2,
+    )
+
+    authority = executor.execution_authority
+    assert authority.fingerprint.startswith("sha256:")
+    assert authority.data["workspace"]["identity_digest"].startswith("sha256:")
+    assert authority.data["runtime"]["execution_identity"] == {"observed": False}
+    assert authority.data["runtime"]["stability"] == "process_local"
+    assert authority.data["execution_policy"]["identity_digest"].startswith("sha256:")
+
+
+def test_session_signal_hub_is_process_local_and_cannot_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    hub = MagicMock()
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        session_signal_hub=hub,
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    assert executor._execution_authority_policy()["session_signal_hub_enabled"] is True
+    executor._require_execution_authority_intact()
+
+    executor._session_signal_hub = MagicMock()
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_keeps_copilot_agent_drift_process_local(tmp_path) -> None:
+    runtime = CopilotCliRuntime(
+        cli_path=sys.executable,
+        model="test-model",
+        cwd=tmp_path,
+        runtime_profile="worker",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+    runtime._copilot_agent = "different-agent"
+    executor._require_execution_authority_intact()
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_execution_authority_registry_does_not_keep_executor_alive(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor_ref = weakref.ref(executor)
+
+    del executor
+    gc.collect()
+    gc.collect()
+
+    assert executor_ref() is None
+
+
+def test_public_constructor_rejects_caller_supplied_closed_roots(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    with pytest.raises(TypeError, match="multiple values"):
+        ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type, call-arg]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            _foundation_a_roots=object(),  # type: ignore[call-arg]
+        )
+
+
+def test_constructor_closure_ignores_a_poisoned_global_roots_bundle(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    roots = parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS
+    original_verifier = roots.transcript_verifier
+    original_verifier_code = roots.transcript_verifier_code
+
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=False, reasons=("poisoned root",))
+
+    object.__setattr__(roots, "transcript_verifier", injected_verifier)
+    object.__setattr__(roots, "transcript_verifier_code", injected_verifier.__code__)
+    try:
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+        )
+    finally:
+        object.__setattr__(roots, "transcript_verifier", original_verifier)
+        object.__setattr__(roots, "transcript_verifier_code", original_verifier_code)
+
+    assert executor._authority_transcript_verifier is original_verifier
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    base_profile = load_profile("code")
+    changed_profile = base_profile.model_copy(update={"profile": "code-v2"})
+
+    def build(profile: ExecutionProfile) -> str:
+        return ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            execution_profile=profile,
+        ).execution_authority.fingerprint
+
+    assert build(base_profile) != build(changed_profile)
+
+
+def test_runtime_mutation_cannot_promote_process_local_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    runtime.profile = "changed"
+
+    # A legacy runtime's dynamic profile is intentionally outside the finite
+    # portable descriptor.  It remains executable in this process, but cannot
+    # become portable merely because the visible value changed or remained
+    # stable.  Executor-owned root drift is covered separately below.
+    executor._require_execution_authority_intact()
+    assert executor.execution_authority.portable_across_processes is False
+    assert _contract(runtime=runtime).portable_across_processes is False
+
+
+def test_executor_rejects_replaced_verifier_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=_Verifier("first"),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._atomic_verifier = _Verifier("replacement")
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_root_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    executor._authority_leaf_dispatcher_type = object
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_runtime_dispatch_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_execute_task(self: _Runtime, **_: object) -> AsyncIterator[object]:
+        del self
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    monkeypatch.setattr(_Runtime, "execute_task", replacement_execute_task)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_dispatcher_method_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        executor._authority_leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_coordinator_review_root_before_effect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    async def replacement_review(**_: object) -> object:
+        return object()
+
+    monkeypatch.setattr(executor._coordinator, "run_review", replacement_review)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_coordinator_adapter_drift_before_effect(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    executor._require_execution_authority_intact()
+
+    replacement = _Runtime(profile="replacement")
+    replacement.working_directory = str(tmp_path)
+    executor._coordinator._adapter = replacement  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_its_own_attribute_resolution_drift_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class EvilRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    evil_runtime = EvilRuntime()
+    evil_runtime.working_directory = str(tmp_path)
+    original_getattribute = ParallelACExecutor.__getattribute__
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_require_execution_authority_intact":
+            return lambda: None
+        if name == "_adapter":
+            return evil_runtime
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "__getattribute__",
+        redirected_getattribute,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._dispatch_decomposition_prompt(
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert evil_runtime.dispatched is False
+
+
+def test_executor_rejects_postconstruction_runtime_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    original_getattribute = _Runtime.__getattribute__
+
+    async def injected_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - must remain unreachable
+            yield None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "execute_task":
+            return injected_dispatch
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(_Runtime, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_dispatcher_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_getattribute = dispatcher_type.__getattribute__
+
+    async def injected_stream(**_: object) -> None:
+        return None
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "stream":
+            return injected_stream
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(dispatcher_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_postconstruction_coordinator_attribute_resolution_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    coordinator_type = type(executor._coordinator)
+    original_getattribute = coordinator_type.__getattribute__
+    replacement_adapter = object()
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "_adapter":
+            return replacement_adapter
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(coordinator_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_rate_gate_attribute_resolution_drift_before_admission(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+
+    gate_type = type(executor._dispatch_rate_gate)
+    original_getattribute = gate_type.__getattribute__
+    injected_calls: list[int] = []
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        injected_calls.append(1)
+
+    def redirected_getattribute(self: object, name: str) -> object:
+        if name == "acquire":
+            return injected_acquire
+        return original_getattribute(self, name)
+
+    monkeypatch.setattr(gate_type, "__getattribute__", redirected_getattribute)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert injected_calls == []
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_replaced_rate_gate_bucket_before_admission(tmp_path) -> None:
+    class EvilBucket:
+        def __init__(self, original: object) -> None:
+            self._runtime_backend = object.__getattribute__(original, "_runtime_backend")
+            self._request_limit = object.__getattribute__(original, "_request_limit")
+            self._token_limit = object.__getattribute__(original, "_token_limit")
+            self._window_seconds = object.__getattribute__(original, "_window_seconds")
+            self.called = False
+
+        async def acquire(self, _: int) -> object:
+            self.called = True
+            return (0.0, object())
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    original_bucket = object.__getattribute__(executor._dispatch_rate_gate, "_bucket")
+    evil_bucket = EvilBucket(original_bucket)
+    object.__setattr__(executor._dispatch_rate_gate, "_bucket", evil_bucket)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await executor._await_dispatch_rate_budget(prompt="test", system_prompt=None)
+
+    assert evil_bucket.called is False
+
+
+@pytest.mark.parametrize(
+    ("attribute", "replacement"),
+    (("_max_wait_seconds", 0.0), ("_heartbeat_seconds", 0.0)),
+)
+def test_executor_rejects_rate_gate_scalar_semantic_drift(
+    tmp_path,
+    attribute: str,
+    replacement: float,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    object.__setattr__(executor._dispatch_rate_gate, attribute, replacement)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_wait_collaborator_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_sleep(_: float) -> None:
+        return None
+
+    object.__setattr__(executor._dispatch_rate_gate, "_sleep", injected_sleep)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_bucket_time_and_method_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    bucket = executor._dispatch_rate_gate._bucket
+
+    object.__setattr__(bucket, "_time", lambda: 0.0)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+    object.__setattr__(bucket, "_time", parallel_executor_module.time.monotonic)
+
+    async def injected_force_reserve(*_: object, **__: object) -> object:
+        return object()
+
+    monkeypatch.setattr(type(bucket), "force_reserve", injected_force_reserve)
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_rate_gate_bucket_helper_code_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    def injected_prune(self: object, now: float) -> None:
+        del self, now
+
+    bucket_type = type(executor._dispatch_rate_gate._bucket)
+    monkeypatch.setattr(bucket_type._prune, "__code__", injected_prune.__code__)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_captured_leaf_dispatch_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_stream(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_leaf_dispatcher_stream = injected_stream
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_replaced_captured_rate_gate_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_acquire(*_: object, **__: object) -> None:
+        return None
+
+    executor._authority_rate_gate_acquire_root = injected_acquire
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_reuses_closed_leaf_dispatcher_after_late_init_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    captured_dispatcher = executor._authority_leaf_dispatcher
+
+    def injected_init(self: object, _: object) -> None:
+        object.__setattr__(self, "_executor", object())
+
+    monkeypatch.setattr(executor._authority_leaf_dispatcher_type, "__init__", injected_init)
+
+    executor._require_execution_authority_intact()
+    assert executor._authority_leaf_dispatcher is captured_dispatcher
+    assert object.__getattribute__(captured_dispatcher, "_executor") is executor
+
+
+def test_executor_uses_closed_import_time_dispatcher_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementDispatcher:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LeafDispatcher", ReplacementDispatcher)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_leaf_dispatcher_type is not ReplacementDispatcher
+    executor._require_execution_authority_intact()
+
+
+def test_executor_uses_closed_import_time_coordinator_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class ReplacementCoordinator:
+        pass
+
+    monkeypatch.setattr(parallel_executor_module, "LevelCoordinator", ReplacementCoordinator)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert type(executor._coordinator) is not ReplacementCoordinator
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_dispatcher_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_stream(self: object, **_: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.leaf_dispatcher_type,
+        "stream",
+        replacement_stream,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_rate_gate_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_acquire(self: object, *_: object, **__: object) -> None:
+        del self
+
+    monkeypatch.setattr(
+        parallel_executor_module.RateLimitGate,
+        "acquire",
+        replacement_acquire,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_coordinator_member_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def replacement_review(self: object, **_: object) -> object:
+        del self
+        return object()
+
+    monkeypatch.setattr(
+        parallel_executor_module._FOUNDATION_A_CLOSED_ROOTS.level_coordinator_type,
+        "run_review",
+        replacement_review,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_preconstruction_transcript_alias_patch_uses_closed_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    def injected_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("injected verifier must not become the closed root",),
+        )
+
+    monkeypatch.setattr(
+        parallel_executor_module,
+        "_FOUNDATION_A_TRANSCRIPT_VERIFIER",
+        injected_verifier,
+    )
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor._authority_transcript_verifier is not injected_verifier
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_reflective_custom_verifier_remains_process_local_without_graph_introspection() -> None:
+    mutable_state = {"passed": True}
+
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=mutable_state["passed"])
+
+    authority = _contract(verifier=verifier)
+
+    assert authority.portable_across_processes is False
+    assert "mutable_state" not in authority.canonical_json
+    assert "passed" not in authority.canonical_json
+
+
+def test_uninspectable_runtime_dispatch_root_stays_process_local() -> None:
+    class Dispatcher:
+        async def stream(self, **_: object) -> None:
+            return None
+
+    class RateGate:
+        async def acquire(self, *_: object, **__: object) -> None:
+            return None
+
+    def transcript_verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    from ouroboros.orchestrator.execution_authority import ExecutionAuthorityLiveBinding
+
+    binding = ExecutionAuthorityLiveBinding.capture(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        dispatcher_type=Dispatcher,
+        transcript_verifier=transcript_verifier,
+        rate_gate=RateGate(),
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert binding.adapter_dispatch_root is None
+    assert binding.contract.portable_across_processes is False
+    assert binding.contract.data["runtime"]["stability"] == "process_local"
+
+
+def test_instance_level_runtime_dispatch_callable_stays_process_local() -> None:
+    class InstanceDispatchRuntime(_Runtime):
+        def __init__(self, dispatch: object) -> None:
+            super().__init__()
+            self.execute_task = dispatch  # type: ignore[method-assign]
+
+    async def first_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    async def second_dispatch(**_: object) -> AsyncIterator[object]:
+        if False:  # pragma: no cover - identity-only stand-in
+            yield None
+
+    first = _contract(runtime=InstanceDispatchRuntime(first_dispatch))
+    second = _contract(runtime=InstanceDispatchRuntime(second_dispatch))
+
+    assert first.portable_across_processes is False
+    assert second.portable_across_processes is False
+    assert first.data["runtime"]["stability"] == "process_local"
+    assert second.data["runtime"]["stability"] == "process_local"
+
+
+def test_direct_contract_with_uninspectable_runtime_stays_process_local() -> None:
+    authority = ExecutionAuthorityContract.build(
+        adapter=_DynamicDispatchRuntime(),
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        execution_policy={"retry_attempts": 2},
+    )
+
+    assert authority.portable_across_processes is False
+    assert authority.data["runtime"]["stability"] == "process_local"
+
+
+def test_captured_transcript_verifier_ignores_replaced_executor_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    profile = load_profile("code").model_copy(
+        update={"evidence_schema": EvidenceSchema(required=())}
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=profile,
+        fat_harness_mode=True,
+    )
+
+    def replaced_wrapper(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("replacement wrapper must not decide acceptance",),
+        )
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "_verify_atomic_evidence_against_runtime_messages",
+        replaced_wrapper,
+    )
+
+    verdict = executor._run_atomic_verifier_pass(
+        ac_content="No transcript proof is required.",
+        final_message="done",
+        success=True,
+        messages=(),
+        typed_evidence=parallel_executor_module.EvidenceRecord(data={}),
+        typed_validation=parallel_executor_module.ValidationResult(ok=True),
+    )
+
+    assert verdict is not None
+    assert verdict.passed is True
+
+
+def test_executor_rejects_in_place_dispatcher_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    dispatcher_type = executor._authority_leaf_dispatcher_type
+    original_code = dispatcher_type.stream.__code__
+
+    async def injected_stream(self: object, **_: object) -> None:
+        del self
+
+    dispatcher_type.stream.__code__ = injected_stream.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        dispatcher_type.stream.__code__ = original_code
+
+
+def test_executor_rejects_in_place_structural_verifier_code_drift(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        atomic_verifier=structural_atomic_verifier,
+    )
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            executor._require_execution_authority_intact()
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
+def test_preconstruction_structural_verifier_code_drift_is_process_local() -> None:
+    original_code = structural_atomic_verifier.__code__
+
+    def injected_structural_verifier(
+        *,
+        profile: object,
+        ac: str,
+        leaf_output: str,
+        record: object,
+    ) -> VerifierVerdict:
+        del profile, ac, leaf_output, record
+        return VerifierVerdict(passed=True)
+
+    structural_atomic_verifier.__code__ = injected_structural_verifier.__code__
+    try:
+        authority = _contract(verifier=structural_atomic_verifier)
+        assert authority.portable_across_processes is False
+        assert authority.data["verifier"]["stability"] == "process_local"
+
+        runtime = _Runtime()
+        executor = ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd="/tmp/workspace-a",
+            atomic_verifier=structural_atomic_verifier,
+        )
+        assert executor.execution_authority.portable_across_processes is False
+        executor._require_execution_authority_intact()
+    finally:
+        structural_atomic_verifier.__code__ = original_code
+
+
+@pytest.mark.parametrize(
+    "entry_name",
+    (
+        "_execute_single_ac",
+        "_execute_atomic_ac",
+        "_await_dispatch_rate_budget",
+        "_dispatch_decomposition_prompt",
+        "_run_atomic_verifier_pass",
+        "_run_ac_verify_gate",
+    ),
+)
+def test_executor_rejects_postconstruction_internal_entry_root_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    entry_name: str,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, entry_name, injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_executor_rejects_instance_shadow_of_internal_entry_root(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(**_: object) -> object:
+        return None
+
+    object.__setattr__(executor, "_execute_single_ac", injected_entry)
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        executor._require_execution_authority_intact()
+
+
+def test_preconstruction_internal_entry_root_patch_is_process_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    async def injected_entry(*_: object, **__: object) -> object:
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_executor_subclass_is_process_local_even_when_it_inherits_entry_roots(tmp_path) -> None:
+    class SubclassedExecutor(ParallelACExecutor):
+        pass
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = SubclassedExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_unhashable_executor_subclass_remains_executable_and_process_local(tmp_path) -> None:
+    class UnhashableExecutor(ParallelACExecutor):
+        __hash__ = None  # type: ignore[assignment]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = UnhashableExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert executor.execution_authority.portable_across_processes is False
+    executor._require_execution_authority_intact()
+
+
+def test_equality_overriding_executor_subclasses_keep_distinct_registry_entries(tmp_path) -> None:
+    class EqualExecutor(ParallelACExecutor):
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, EqualExecutor)
+
+        __hash__ = object.__hash__
+
+    first_runtime = _Runtime(profile="first")
+    first_runtime.working_directory = str(tmp_path)
+    second_runtime = _Runtime(profile="second")
+    second_runtime.working_directory = str(tmp_path)
+    first = EqualExecutor(
+        adapter=first_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    second = EqualExecutor(
+        adapter=second_runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    assert first == second
+    first._require_execution_authority_intact()
+    second._require_execution_authority_intact()
+
+
+@pytest.mark.asyncio
+async def test_dynamic_runtime_does_not_reopen_captured_executor_entry_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _DynamicDispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+    assert executor.execution_authority.portable_across_processes is False
+    injected = False
+
+    async def injected_entry(*_: object, **__: object) -> str:
+        nonlocal injected
+        injected = True
+        return '{"cause":"TOO_BIG","reason":"injected","evidence_refs":[]}'
+
+    monkeypatch.setattr(ParallelACExecutor, "_dispatch_decomposition_prompt", injected_entry)
+
+    result = await executor._request_bounce_classification(
+        trace=parallel_executor_module.DecompositionTraceSummary(summary="bounded evidence"),
+    )
+
+    assert result == (
+        parallel_executor_module.BounceCause.UNKNOWN,
+        "Bounce classifier returned no admissible cause.",
+        (),
+        False,
+    )
+    assert injected is False
+
+
+@pytest.mark.asyncio
+async def test_internal_execution_path_rejects_entry_replacement_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - must remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_entry(*_: object, **__: object) -> object:
+        runtime.dispatched = True
+        return None
+
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", injected_entry)
+    seed = MagicMock()
+    seed.acceptance_criteria = ("Do not dispatch",)
+    seed.goal = "Keep the runtime closed"
+
+    results = await executor._execute_ac_batch(
+        seed=seed,
+        batch_indices=[0],
+        session_id="session",
+        execution_id="execution",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        level_contexts=[],
+        ac_retry_attempts={0: 0},
+    )
+
+    assert isinstance(results[0], ValueError)
+    assert runtime.dispatched is False
+
+
+@pytest.mark.asyncio
+async def test_executor_root_drift_rejects_before_decomposition_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class DispatchRuntime(_Runtime):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dispatched = False
+
+        async def execute_task(self, **_: object) -> AsyncIterator[object]:
+            self.dispatched = True
+            if False:  # pragma: no cover - should remain unreachable
+                yield None
+
+    runtime = DispatchRuntime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    async def injected_decomposition_entry(*_: object, **__: object) -> object:
+        runtime.dispatched = True
+        return None
+
+    monkeypatch.setattr(
+        ParallelACExecutor,
+        "_dispatch_decomposition_prompt",
+        injected_decomposition_entry,
+    )
+
+    with pytest.raises(ValueError, match="execution authority drifted"):
+        await parallel_executor_module._invoke_execution_authority_entry(
+            executor,
+            parallel_executor_module._FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
+            prompt="classify this failure",
+            system_prompt="Be conservative.",
+        )
+
+    assert runtime.dispatched is False

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -1129,7 +1129,7 @@ def _consumer_runner(fabricated: list) -> tuple[OrchestratorRunner, list, MagicM
 
 class TestFrugalityProofConsumer:
     @pytest.mark.asyncio
-    async def test_same_seed_recent_runs_form_cohort_without_mixing_other_seed(self) -> None:
+    async def test_process_local_authority_never_pools_runs_into_a_proof_cohort(self) -> None:
         runner, appended, _console = _consumer_runner([])
         store = runner._event_store
         cohort_seed = Seed(
@@ -1254,8 +1254,9 @@ class TestFrugalityProofConsumer:
                     baseline=100,
                 )
             ]
-        # If this different seed leaked into the cohort it would change both the
-        # row count and aggregate reduction.
+        # A process-local Foundation A contract must not become a cross-run proof
+        # key, even when another run has the same Seed and identical visible
+        # durable fields.
         events_by_execution["run-other"] = [
             event
             for ac in range(20)
@@ -1278,23 +1279,14 @@ class TestFrugalityProofConsumer:
         emitted = [e for e in appended if e.type == "execution.frugality_proof.evaluated"]
         assert len(emitted) == 1
         data = emitted[0].data
-        assert data["seed_id"] == "seed-proof"
-        assert data["cohort_execution_ids"] == ["run-2", "run-1", "run-0"]
-        assert data["status"] == ProofStatus.PASS.value
-        assert data["counted_rows"] == 21
-        assert data["runs"] == 3
-        assert data["token_reduction_pct"] == pytest.approx(50.0)
-        assert all(
-            call.args[0]
-            not in {
-                "run-other",
-                "run-other-project",
-                "run-other-routing",
-                "run-edited-seed",
-                "run-legacy",
-            }
-            for call in store.query_execution_related_events.await_args_list
-        )
+        assert data["seed_id"] is None
+        assert data["cohort_execution_ids"] == ["run-2"]
+        assert data["status"] == ProofStatus.INSUFFICIENT_SAMPLE.value
+        assert data["counted_rows"] == 7
+        assert data["runs"] == 1
+        assert [call.args[0] for call in store.query_execution_related_events.await_args_list] == [
+            "run-2"
+        ]
 
     @pytest.mark.asyncio
     async def test_missing_current_proof_identity_is_current_only(self) -> None:

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -443,16 +443,12 @@ class TestCancellationErrorScenarios:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_failed_still_returns_result(
+    async def test_handle_cancellation_mark_failed_retains_live_owner(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """If mark_cancelled fails during handling, the result is still returned.
-
-        The _handle_cancellation method logs a warning but still returns an
-        OrchestratorResult. This ensures the execution stops even if persistence fails.
-        """
+        """A failed terminal write must not release a still-RUNNING owner."""
         runner._register_session("exec_fail", "sess_fail")
         await request_cancellation("sess_fail")
         self._mock_running_session(runner, "sess_fail")
@@ -479,26 +475,25 @@ class TestCancellationErrorScenarios:
                 error=str(PersistenceError("DB write failed")),
             )
 
-        # Should still return a valid cancellation result
-        assert result.is_ok
-        assert result.value.success is False
-        assert result.value.messages_processed == 7
-        # Cleanup should still happen even if persistence failed
-        assert not await is_cancellation_requested("sess_fail")
-        assert "exec_fail" not in runner.active_sessions
+        # Reporting cancellation while the durable tracker is still RUNNING
+        # would let another process misclassify it as a crashed owner. Keep the
+        # in-memory route, heartbeat, and request live for a retry instead.
+        assert result.is_err
+        assert result.error.message == (
+            "Failed to persist cancellation; process-local authority remains live"
+        )
+        assert await is_cancellation_requested("sess_fail")
+        assert runner.active_sessions["exec_fail"] == "sess_fail"
+        await clear_cancellation("sess_fail")
+        runner._unregister_session("exec_fail", "sess_fail")
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_raises_still_propagates(
+    async def test_handle_cancellation_mark_raises_retains_live_owner(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """If mark_cancelled raises an exception, it propagates (not swallowed).
-
-        Unlike _check_cancellation which degrades gracefully, _handle_cancellation
-        does NOT catch exceptions from mark_cancelled because the execution is
-        already stopping.
-        """
+        """An exception during terminal persistence retains the retryable owner."""
         runner._register_session("exec_raise", "sess_raise")
         self._mock_running_session(runner, "sess_raise")
 
@@ -507,18 +502,17 @@ class TestCancellationErrorScenarios:
             "mark_cancelled",
             side_effect=RuntimeError("Unexpected DB crash"),
         ):
-            with pytest.raises(RuntimeError, match="Unexpected DB crash"):
-                await runner._handle_cancellation(
-                    session_id="sess_raise",
-                    execution_id="exec_raise",
-                    messages_processed=3,
-                    start_time=datetime.now(UTC),
-                )
+            result = await runner._handle_cancellation(
+                session_id="sess_raise",
+                execution_id="exec_raise",
+                messages_processed=3,
+                start_time=datetime.now(UTC),
+            )
 
-        # Despite the exception, registry and session should have been
-        # cleaned up before mark_cancelled was called
-        assert not await is_cancellation_requested("sess_raise")
-        assert "exec_raise" not in runner.active_sessions
+        assert result.is_err
+        assert result.error.details["cause"] == "Unexpected DB crash"
+        assert runner.active_sessions["exec_raise"] == "sess_raise"
+        runner._unregister_session("exec_raise", "sess_raise")
 
     @pytest.mark.asyncio
     async def test_cancel_session_directly_event_store_replay_error(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -443,12 +443,12 @@ class TestCancellationErrorScenarios:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_failed_retains_live_owner(
+    async def test_handle_cancellation_mark_failed_keeps_retryable_owner_without_route(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """A failed terminal write must not release a still-RUNNING owner."""
+        """A failed terminal write keeps liveness but releases the exiting worker route."""
         runner._register_session("exec_fail", "sess_fail")
         await request_cancellation("sess_fail")
         self._mock_running_session(runner, "sess_fail")
@@ -476,24 +476,26 @@ class TestCancellationErrorScenarios:
             )
 
         # Reporting cancellation while the durable tracker is still RUNNING
-        # would let another process misclassify it as a crashed owner. Keep the
-        # in-memory route, heartbeat, and request live for a retry instead.
+        # would let another process misclassify it as a crashed owner. Keep
+        # liveness and the request for retry, but the exiting coroutine must
+        # not leave a routable active-session entry behind.
         assert result.is_err
         assert result.error.message == (
             "Failed to persist cancellation; process-local authority remains live"
         )
         assert await is_cancellation_requested("sess_fail")
-        assert runner.active_sessions["exec_fail"] == "sess_fail"
+        assert "exec_fail" not in runner.active_sessions
+        assert result.error.details["resume_blocked"] == "cancellation_persistence_pending"
         await clear_cancellation("sess_fail")
         runner._unregister_session("exec_fail", "sess_fail")
 
     @pytest.mark.asyncio
-    async def test_handle_cancellation_mark_raises_retains_live_owner(
+    async def test_handle_cancellation_mark_raises_keeps_retryable_owner_without_route(
         self,
         runner: OrchestratorRunner,
         mock_event_store: AsyncMock,
     ) -> None:
-        """An exception during terminal persistence retains the retryable owner."""
+        """An exception during terminal persistence releases the dead active route."""
         runner._register_session("exec_raise", "sess_raise")
         self._mock_running_session(runner, "sess_raise")
 
@@ -511,7 +513,8 @@ class TestCancellationErrorScenarios:
 
         assert result.is_err
         assert result.error.details["cause"] == "Unexpected DB crash"
-        assert runner.active_sessions["exec_raise"] == "sess_raise"
+        assert "exec_raise" not in runner.active_sessions
+        assert result.error.details["resume_blocked"] == "cancellation_persistence_pending"
         runner._unregister_session("exec_raise", "sess_raise")
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -547,11 +547,23 @@ class TestCancellationErrorScenarios:
                 )
             ]
         )
+        legacy_tracker = SessionTracker.create(
+            "exec_dfail",
+            "seed_dfail",
+            session_id="sess_dfail",
+        )
 
-        with patch.object(
-            runner._session_repo,
-            "mark_cancelled",
-            return_value=Result.err(PersistenceError("Write failed")),
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                return_value=Result.ok(legacy_tracker),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                return_value=Result.err(PersistenceError("Write failed")),
+            ),
         ):
             result = await runner.cancel_execution("exec_dfail")
 

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -23,6 +23,7 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.runner import (
     CANCELLATION_CHECK_INTERVAL,
+    EXECUTION_CONTRACT_PROGRESS_KEY,
     ExecutionCancelledError,
     OrchestratorRunner,
     clear_cancellation,
@@ -100,6 +101,27 @@ def sample_seed():
         ontology_schema=OntologySchema(name="Test", description="Test"),
         metadata=SeedMetadata(ambiguity_score=0.1),
     )
+
+
+def _attach_live_process_local_contract(
+    runner: OrchestratorRunner,
+    tracker: SessionTracker,
+    seed: Any,
+) -> SessionTracker:
+    """Give direct precreated-session tests their creating-process capability."""
+    if not isinstance(getattr(runner._adapter, "llm_backend", None), str):
+        runner._adapter.llm_backend = "test-llm"
+    if not isinstance(getattr(runner._adapter, "_model", None), str):
+        runner._adapter._model = "test-model"
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    return tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
 
 
 # =============================================================================
@@ -565,7 +587,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_boundary", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         call_count = 0
 
@@ -605,7 +633,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_full", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             with patch.object(runner._session_repo, "mark_completed", return_value=Result.ok(None)):
@@ -637,7 +671,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_int", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def tracking_check(session_id):
             check_points.append(len(check_points) + 1)
@@ -670,7 +710,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_unreg", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_check(session_id):
             return True  # Always cancel
@@ -699,6 +745,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_task_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
             stream_started.set()
@@ -777,6 +824,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_terminal_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
         completed_tracker = tracker.with_status(SessionStatus.COMPLETED)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -839,6 +887,7 @@ class TestInFlightCancellationGraceful:
             sample_seed.metadata.seed_id,
             session_id="sess_unrequested_cancel",
         )
+        tracker = _attach_live_process_local_contract(runner, tracker, sample_seed)
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
             stream_started.set()
@@ -898,7 +947,13 @@ class TestInFlightCancellationGraceful:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_partial", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         call_count = 0
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,7 +28,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
+from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict, LevelCoordinator
 from ouroboros.orchestrator.decomposition_policy import DecompositionDisposition
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
@@ -56,8 +56,8 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
-from ouroboros.orchestrator.rate_limit import RateLimitGate, SharedRateLimitBucket
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def test_stall_timeout_default_allows_realistic_test_suites() -> None:
@@ -134,15 +134,18 @@ class TestDispatchRateGate:
         await executor._await_dispatch_rate_budget(prompt="hello", system_prompt=None)
 
     @pytest.mark.asyncio
-    async def test_await_dispatch_rate_budget_paces_through_active_gate(
+    async def test_await_dispatch_rate_budget_rejects_postconstruction_gate_semantic_drift(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         monkeypatch.setenv("OUROBOROS_BACKEND_LIMITS", str(tmp_path / "absent.yaml"))
+        monkeypatch.setenv("OUROBOROS_OPENCODE_RPM", "1")
         adapter = _RateGateStubAdapter(runtime_backend="opencode", self_governs=False)
         executor = _make_rate_gate_executor(adapter)
 
-        # Swap in a deterministic gate (rpm=1, fake clock + sleep) to prove the
-        # executor's dispatch hook actually waits on the shared budget.
+        # Replacing behavior-changing collaborators after construction is no
+        # longer a valid deterministic-test seam: the authority guard must
+        # reject it before rate admission. RateLimitGate itself owns separate
+        # deterministic timing tests with injected collaborators at creation.
         clock = {"now": 0.0}
         slept: list[float] = []
 
@@ -150,20 +153,14 @@ class TestDispatchRateGate:
             slept.append(seconds)
             clock["now"] += seconds
 
-        bucket = SharedRateLimitBucket(
-            runtime_backend="opencode",
-            request_limit=1,
-            token_limit=None,
-            time_provider=lambda: clock["now"],
-        )
-        executor._dispatch_rate_gate = RateLimitGate(
-            bucket, heartbeat_seconds=120.0, sleep=fake_sleep
-        )
+        executor._dispatch_rate_gate._bucket._time = lambda: clock["now"]
+        executor._dispatch_rate_gate._sleep = fake_sleep
+        executor._dispatch_rate_gate._heartbeat_seconds = 120.0
 
-        await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
-        await executor._await_dispatch_rate_budget(prompt="b", system_prompt=None)
+        with pytest.raises(ValueError, match="execution authority drifted"):
+            await executor._await_dispatch_rate_budget(prompt="a", system_prompt=None)
 
-        assert slept == [60.0]  # second dispatch waited a full window
+        assert slept == []
 
 
 def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:
@@ -182,7 +179,7 @@ def _make_seed(*acceptance_criteria: str | AcceptanceCriterionSpec) -> Seed:
 
 def _make_executor() -> ParallelACExecutor:
     """Create an executor with mocked dependencies and muted event emitters."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -8371,7 +8368,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_decomposed_ac_inlines_sub_ac_dispatch_into_single_ac(self) -> None:
         """Decomposed execution should recurse through _execute_single_ac without a helper path."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8391,24 +8388,21 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
-        with patch.object(
-            executor,
-            "_execute_single_ac",
-            wraps=executor._execute_single_ac,
-        ) as execute_single_ac_spy:
-            result = await executor._execute_single_ac(
-                ac_index=1,
-                ac_content="Implement parser workflow",
-                session_id="sess_decompose",
-                tools=["Read", "Edit"],
-                tool_catalog=None,
-                system_prompt="system",
-                seed_goal="Ship parser workflow",
-                depth=0,
-                execution_id="exec_decompose",
-            )
+        executor._test_single_ac_calls = []
+        result = await executor._execute_single_ac(
+            ac_index=1,
+            ac_content="Implement parser workflow",
+            session_id="sess_decompose",
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship parser workflow",
+            depth=0,
+            execution_id="exec_decompose",
+        )
 
         assert hasattr(executor, "_execute_sub_acs") is False
         assert result.success is True
@@ -8420,23 +8414,23 @@ class TestParallelACExecutor:
         assert [sub_result.depth for sub_result in result.sub_results] == [1, 1]
         assert [
             (
-                int(call.kwargs["ac_index"]),
-                str(call.kwargs["ac_content"]),
-                int(call.kwargs["depth"]),
+                int(call["ac_index"]),
+                str(call["ac_content"]),
+                int(call["depth"]),
             )
-            for call in execute_single_ac_spy.await_args_list
+            for call in executor._test_single_ac_calls
         ] == [
             (1, "Implement parser workflow", 0),
             (100, "Extract parser", 1),
             (101, "Wire parser", 1),
         ]
         assert executor._try_decompose_ac.await_count == 3
-        assert executor._execute_atomic_ac.await_count == 2
+        assert execute_atomic_ac.await_count == 2
 
     @pytest.mark.asyncio
     async def test_top_level_decomposition_preserves_sub_ac_runtime_identity(self) -> None:
         """First-level decomposed children should still execute with sub-AC runtime metadata."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8456,7 +8450,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         await executor._execute_single_ac(
             ac_index=1,
@@ -8477,7 +8472,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["parent_ac_index"]),
                 int(call.kwargs["sub_ac_index"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, True, 1, 0),
             (101, True, 1, 1),
@@ -8486,7 +8481,7 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_depth_three_forces_atomic_without_further_decomposition(self) -> None:
         """Depth 2 may still recurse, but depth 3 must execute atomically."""
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=AsyncMock(),
             console=MagicMock(),
@@ -8509,7 +8504,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=0,
@@ -8535,8 +8531,8 @@ class TestParallelACExecutor:
             True,
         ]
         executor._try_decompose_ac.assert_awaited_once()
-        assert executor._execute_atomic_ac.await_count == 2
-        assert [call.kwargs["depth"] for call in executor._execute_atomic_ac.await_args_list] == [
+        assert execute_atomic_ac.await_count == 2
+        assert [call.kwargs["depth"] for call in execute_atomic_ac.await_args_list] == [
             3,
             3,
         ]
@@ -8732,7 +8728,7 @@ class TestParallelACExecutor:
         """Leaf retries should not re-run composite decomposition or sibling dispatch."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8765,7 +8761,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=1,
@@ -8789,7 +8786,7 @@ class TestParallelACExecutor:
                 int(call.kwargs["depth"]),
                 int(call.kwargs["retry_attempt"]),
             )
-            for call in executor._execute_atomic_ac.await_args_list
+            for call in execute_atomic_ac.await_args_list
         ] == [
             (100, 1, 0),
             (100, 1, 1),
@@ -8802,7 +8799,7 @@ class TestParallelACExecutor:
             if call.args and call.args[0].type == "execution.ac.stall_detected"
         ]
         assert len(stall_events) == 1
-        first_leaf_identity = executor._execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
+        first_leaf_identity = execute_atomic_ac.await_args_list[0].kwargs["node_identity"]
         assert (
             stall_events[0].aggregate_id == f"exec_atomic_retry_scope_{first_leaf_identity.node_id}"
         )
@@ -8819,7 +8816,7 @@ class TestParallelACExecutor:
         """Single-AC execution should convert an unrecoverable stall into a normal failure."""
         event_store = AsyncMock()
         event_store.append = AsyncMock()
-        executor = ParallelACExecutor(
+        executor = ProcessLocalTestExecutor(
             adapter=MagicMock(),
             event_store=event_store,
             console=MagicMock(),
@@ -8840,7 +8837,8 @@ class TestParallelACExecutor:
                 depth=int(kwargs["depth"]),
             )
 
-        executor._execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        execute_atomic_ac = AsyncMock(side_effect=always_stall)
+        executor._execute_atomic_ac = execute_atomic_ac
 
         result = await executor._execute_single_ac(
             ac_index=2,
@@ -8857,10 +8855,9 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error == f"Stalled (no activity for {STALL_TIMEOUT_SECONDS:.0f}s)"
         assert result.retry_attempt == MAX_STALL_RETRIES
-        assert executor._execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
+        assert execute_atomic_ac.await_count == MAX_STALL_RETRIES + 1
         assert [
-            int(call.kwargs["retry_attempt"])
-            for call in executor._execute_atomic_ac.await_args_list
+            int(call.kwargs["retry_attempt"]) for call in execute_atomic_ac.await_args_list
         ] == list(range(MAX_STALL_RETRIES + 1))
 
         stall_events = [
@@ -10853,7 +10850,10 @@ class TestParallelACExecutor:
         assert result.stages[1].outcome == StageExecutionOutcome.PARTIAL
 
     @pytest.mark.asyncio
-    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(self) -> None:
+    async def test_records_coordinator_results_at_level_scope_without_ac_attribution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Coordinator reconciliation should persist level-scoped events and artifacts only."""
         seed = _make_seed(
             "Update the shared module imports",
@@ -10866,48 +10866,51 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            conflicts_detected=(
+                FileConflict(
+                    file_path="src/shared.py",
+                    ac_indices=(0, 1),
+                    resolved=True,
+                    resolution_description="Merged by coordinator",
+                ),
+            ),
+            review_summary="Resolved shared.py conflict",
+            fixes_applied=("Merged overlapping import edits",),
+            warnings_for_next_level=("Verify shared.py integration paths",),
+            duration_seconds=1.5,
+            session_id="coord-session-1",
+            session_scope_id="level_1_coordinator",
+            session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
+            final_output=(
+                '{"review_summary":"Resolved shared.py conflict",'
+                '"fixes_applied":["Merged overlapping import edits"],'
+                '"warnings_for_next_level":["Verify shared.py integration paths"],'
+                '"conflicts_resolved":["src/shared.py"]}'
+            ),
+            messages=(
+                AgentMessage(
+                    type="assistant",
+                    content="Inspecting shared file",
+                    tool_name="Read",
+                    data={"tool_input": {"file_path": "src/shared.py"}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Reconciling overlap",
+                    data={"thinking": "Merge the import changes without changing behavior."},
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                conflicts_detected=(
-                    FileConflict(
-                        file_path="src/shared.py",
-                        ac_indices=(0, 1),
-                        resolved=True,
-                        resolution_description="Merged by coordinator",
-                    ),
-                ),
-                review_summary="Resolved shared.py conflict",
-                fixes_applied=("Merged overlapping import edits",),
-                warnings_for_next_level=("Verify shared.py integration paths",),
-                duration_seconds=1.5,
-                session_id="coord-session-1",
-                session_scope_id="level_1_coordinator",
-                session_state_path=".ouroboros/execution_runtime/level_1_coordinator/session.json",
-                final_output=(
-                    '{"review_summary":"Resolved shared.py conflict",'
-                    '"fixes_applied":["Merged overlapping import edits"],'
-                    '"warnings_for_next_level":["Verify shared.py integration paths"],'
-                    '"conflicts_resolved":["src/shared.py"]}'
-                ),
-                messages=(
-                    AgentMessage(
-                        type="assistant",
-                        content="Inspecting shared file",
-                        tool_name="Read",
-                        data={"tool_input": {"file_path": "src/shared.py"}},
-                    ),
-                    AgentMessage(
-                        type="assistant",
-                        content="Reconciling overlap",
-                        data={"thinking": "Merge the import changes without changing behavior."},
-                    ),
-                ),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
@@ -10982,7 +10985,10 @@ class TestParallelACExecutor:
         )
 
     @pytest.mark.asyncio
-    async def test_returns_reconciled_level_contexts_for_retry_handoff(self) -> None:
+    async def test_returns_reconciled_level_contexts_for_retry_handoff(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Completed stage contexts should be returned for retry workspace handoff."""
         seed = _make_seed(
             "Land the shared runtime update",
@@ -10995,17 +11001,20 @@ class TestParallelACExecutor:
             ),
             execution_levels=((0, 1),),
         )
+        coordinator_review = CoordinatorReview(
+            level_number=1,
+            review_summary="Reconciled shared workspace",
+            fixes_applied=("Merged shared.py edits",),
+            warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
+        )
+        monkeypatch.setattr(
+            LevelCoordinator,
+            "run_review",
+            AsyncMock(return_value=coordinator_review),
+        )
         executor = _make_executor()
         executor._coordinator.detect_file_conflicts = MagicMock(
             return_value=[FileConflict(file_path="src/shared.py", ac_indices=(0, 1))]
-        )
-        executor._coordinator.run_review = AsyncMock(
-            return_value=CoordinatorReview(
-                level_number=1,
-                review_summary="Reconciled shared workspace",
-                fixes_applied=("Merged shared.py edits",),
-                warnings_for_next_level=("Retry AC 2 against the merged shared.py state",),
-            )
         )
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ACExecutionResult,
     ParallelACExecutor,
 )
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 class _AtomicDecompositionRuntime:
@@ -66,7 +67,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
     depth: int,
 ) -> None:
     """Nested AC execution should stop recursing once decomposition returns ATOMIC."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -81,7 +82,7 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             reasons=("explicit_atomic",),
         )
     )
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         return_value=ACExecutionResult(
             ac_index=depth + 1,
             ac_content=f"Atomic at depth {depth}",
@@ -90,31 +91,27 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
             depth=depth,
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=depth + 1,
-            ac_content=f"Atomic at depth {depth}",
-            session_id=f"sess_atomic_depth_{depth}",
-            tools=["Read"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Preserve ATOMIC termination",
-            depth=depth,
-            execution_id=f"exec_atomic_depth_{depth}",
-        )
+    result = await executor._execute_single_ac(
+        ac_index=depth + 1,
+        ac_content=f"Atomic at depth {depth}",
+        session_id=f"sess_atomic_depth_{depth}",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Preserve ATOMIC termination",
+        depth=depth,
+        execution_id=f"exec_atomic_depth_{depth}",
+    )
 
     assert result.success is True
     assert result.is_decomposed is False
     assert result.depth == depth
     executor._try_decompose_ac.assert_awaited_once()
-    executor._execute_atomic_ac.assert_awaited_once()
-    assert len(execute_single_ac_spy.await_args_list) == 1
-    assert execute_single_ac_spy.await_args.kwargs["depth"] == depth
+    execute_atomic_ac.assert_awaited_once()
+    assert [call["depth"] for call in executor._test_single_ac_calls] == [depth]
 
 
 class _CapturingDecompositionRuntime:

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, ExecutionStage, S
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
 from ouroboros.orchestrator.verifier import RetryAdmission, VerifierVerdict
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 def _failed_result(*, failure_class: str = "SCOPE_CREEP") -> ACExecutionResult:
@@ -65,8 +66,8 @@ def _trusted_split(node_id: str) -> DecompositionDecisionRecord:
     )
 
 
-def _executor(*, max_depth: int = 3) -> ParallelACExecutor:
-    return ParallelACExecutor(
+def _executor(*, max_depth: int = 3) -> ProcessLocalTestExecutor:
+    return ProcessLocalTestExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -263,7 +264,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-restored", ac_index=0)
     executor._decomposition_decisions[node.node_id] = _trusted_split(node.node_id)
-    executor._execute_atomic_ac = AsyncMock(
+    execute_atomic_ac = AsyncMock(
         side_effect=lambda **kwargs: ACExecutionResult(
             ac_index=kwargs["ac_index"],
             ac_content=kwargs["ac_content"],
@@ -271,6 +272,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
             depth=kwargs["depth"],
         )
     )
+    executor._execute_atomic_ac = execute_atomic_ac
     executor._try_decompose_ac = AsyncMock()
     executor._request_bounce_classification = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
@@ -288,7 +290,7 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
     )
 
     assert result.is_decomposed is True
-    assert executor._execute_atomic_ac.await_count == 2
+    assert execute_atomic_ac.await_count == 2
     executor._try_decompose_ac.assert_not_awaited()
     executor._request_bounce_classification.assert_not_awaited()
 

--- a/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
+++ b/tests/unit/orchestrator/test_parallel_executor_recursive_depth.py
@@ -3,18 +3,19 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ouroboros.core.seed import AcceptanceCriterionSpec, InvestmentSpec
-from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult
+from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
 @pytest.mark.asyncio
 async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic() -> None:
     """Composite ACs should keep recursing until the soft depth safety net is reached."""
-    executor = ParallelACExecutor(
+    executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
         console=MagicMock(),
@@ -41,7 +42,9 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             depth=int(kwargs["depth"]),
         )
 
-    executor._execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    execute_atomic_ac = AsyncMock(side_effect=fake_execute_atomic_ac)
+    executor._execute_atomic_ac = execute_atomic_ac
+    executor._test_single_ac_calls = []
     investment = InvestmentSpec(
         difficulty="high",
         stakes="high",
@@ -54,24 +57,19 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         investment=investment,
     )
 
-    with patch.object(
-        executor,
-        "_execute_single_ac",
-        wraps=executor._execute_single_ac,
-    ) as execute_single_ac_spy:
-        result = await executor._execute_single_ac(
-            ac_index=1,
-            ac_content="Root composite AC",
-            session_id="sess_recursive_depth",
-            tools=["Read", "Edit"],
-            tool_catalog=None,
-            system_prompt="system",
-            seed_goal="Support recursive decomposition",
-            depth=0,
-            execution_id="exec_recursive_depth",
-            ac_spec=parent_spec,
-            investment_spec=investment,
-        )
+    result = await executor._execute_single_ac(
+        ac_index=1,
+        ac_content="Root composite AC",
+        session_id="sess_recursive_depth",
+        tools=["Read", "Edit"],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="Support recursive decomposition",
+        depth=0,
+        execution_id="exec_recursive_depth",
+        ac_spec=parent_spec,
+        investment_spec=investment,
+    )
 
     assert result.success is True
     assert result.is_decomposed is True
@@ -95,11 +93,11 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
 
     assert [
         (
-            int(call.kwargs["ac_index"]),
-            str(call.kwargs["ac_content"]),
-            int(call.kwargs["depth"]),
+            int(call["ac_index"]),
+            str(call["ac_content"]),
+            int(call["depth"]),
         )
-        for call in execute_single_ac_spy.await_args_list
+        for call in executor._test_single_ac_calls
     ] == [
         (1, "Root composite AC", 0),
         (100, "Composite depth 1", 1),
@@ -112,7 +110,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
     assert executor._try_decompose_ac.await_count == 5
     assert [
         (int(call.kwargs["ac_index"]), int(call.kwargs["depth"]))
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (1000000, 3),
         (1000001, 3),
@@ -120,8 +118,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (101, 1),
     ]
     assert [
-        call.kwargs["node_identity"].display_path
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["node_identity"].display_path for call in execute_atomic_ac.await_args_list
     ] == [
         "2.1.1.1",
         "2.1.1.2",
@@ -133,7 +130,7 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
             call.kwargs["parent_ac_index"],
             call.kwargs["sub_ac_index"],
         )
-        for call in executor._execute_atomic_ac.await_args_list
+        for call in execute_atomic_ac.await_args_list
     ] == [
         (None, None),
         (None, None),
@@ -141,9 +138,6 @@ async def test_recursive_decomposition_reaches_depth_limit_before_forcing_atomic
         (1, 1),
     ]
     assert all(
-        call.kwargs["investment_spec"] is investment
-        for call in executor._execute_atomic_ac.await_args_list
+        call.kwargs["investment_spec"] is investment for call in execute_atomic_ac.await_args_list
     )
-    assert all(
-        call.kwargs["ac_spec"] is None for call in executor._execute_atomic_ac.await_args_list
-    )
+    assert all(call.kwargs["ac_spec"] is None for call in execute_atomic_ac.await_args_list)

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -4456,6 +4456,208 @@ async def test_public_terminal_finalizer_cancellation_acknowledges_marker() -> N
         )
 
 
+@pytest.mark.asyncio
+async def test_resume_reconstruction_failure_is_typed_and_retains_handler_owner() -> None:
+    """A transient resume read failure cannot become a generic FAILED result."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-resume-reconstruction-pending",
+        execution_id="exec-resume-reconstruction-pending",
+    )
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    session_repo = runner._session_repo
+    session_repo.reconstruct_session = AsyncMock(side_effect=OSError("temporary read failure"))
+
+    try:
+        result = await runner.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details == {
+            "session_id": tracker.session_id,
+            "cause": "temporary read failure",
+            "resume_blocked": "process_local_reconstruction_pending",
+            "retryable": True,
+        }
+        retained, event_store_to_close = await handler._reconcile_process_local_owner(
+            tracker=tracker,
+            runner=runner,
+            session_repo=session_repo,
+        )
+        assert retained is True
+        assert event_store_to_close is None
+        assert handler._process_local_resume_owners[tracker.session_id] is runner
+        assert handler._process_local_owned_event_stores[tracker.session_id] is runner._event_store
+        runner._event_store.close.assert_not_awaited()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_cleanup_does_not_release_foreign_adapter_heartbeat() -> None:
+    """An observer that cannot retire the owner must preserve its lease."""
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-foreign-terminal-cleanup",
+        execution_id="exec-foreign-terminal-cleanup",
+    )
+    observer = _runner()
+
+    try:
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        await observer._cleanup_terminal_process_local_state(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_public_cancel_repropagates_caller_cancellation_after_reconcile() -> None:
+    """Cancellation during shielded recovery wins over the original write error."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-reconcile-cancelled",
+        execution_id="exec-cancel-reconcile-cancelled",
+    )
+    terminal_tracker = tracker.with_status(SessionStatus.COMPLETED)
+    reconstruct_entered = asyncio.Event()
+    release_reconstruct = asyncio.Event()
+
+    async def _blocked_reconstruct(_: str) -> Result[SessionTracker, PersistenceError]:
+        reconstruct_entered.set()
+        await release_reconstruct.wait()
+        return Result.ok(terminal_tracker)
+
+    session_repo = MagicMock()
+    session_repo.mark_cancelled_if_active = AsyncMock(side_effect=RuntimeError("write failed"))
+    session_repo.reconstruct_session = _blocked_reconstruct
+    task = asyncio.create_task(
+        request_process_local_cancellation(
+            tracker,
+            session_repo,
+            reason="cancel during recovery",
+            cancelled_by="test",
+        )
+    )
+
+    try:
+        await reconstruct_entered.wait()
+        task.cancel()
+        release_reconstruct.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not ownerless_cancellation_marker(tracker.session_id)
+    finally:
+        release_reconstruct.set()
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_mode", ("raises", "result"))
+async def test_preparation_terminal_failure_clears_cancellation_marker(
+    failure_mode: str,
+) -> None:
+    """Both initial-progress failure branches use complete terminal cleanup."""
+    runner = _runner()
+    session_id = f"session-prepare-marker-{failure_mode}"
+    execution_id = f"exec-prepare-marker-{failure_mode}"
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    track_progress = (
+        AsyncMock(side_effect=OSError("progress unavailable"))
+        if failure_mode == "raises"
+        else AsyncMock(return_value=Result.err(PersistenceError("progress unavailable")))
+    )
+
+    await request_cancellation(session_id, reason="preparation marker", cancelled_by="test")
+    try:
+        with (
+            patch.object(
+                runner._session_repo, "create_session", AsyncMock(return_value=Result.ok(tracker))
+            ),
+            patch.object(runner._session_repo, "track_progress", track_progress),
+            patch.object(
+                runner._session_repo, "mark_failed", AsyncMock(return_value=Result.ok(None))
+            ),
+        ):
+            result = await runner.prepare_session(
+                _seed(),
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+
+        assert result.is_err
+        assert not await is_cancellation_requested(session_id)
+        assert not heartbeat.is_holder_alive(session_id)
+        assert (session_id, execution_id) not in runner._process_local_authorities
+    finally:
+        await clear_cancellation(session_id)
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+
+
+def ownerless_cancellation_marker(session_id: str) -> bool:
+    """Return whether the file-backed request marker remains after cleanup."""
+    return heartbeat.cancellation_path(session_id).exists()
+
+
+@pytest.mark.parametrize("unlink_failures", (1, 3))
+def test_clear_cancellation_request_retries_and_surfaces_final_failure(
+    unlink_failures: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transient unlink errors retry; a persistent error is visible to callers."""
+    path = MagicMock()
+    outcomes: list[object] = [OSError("unlink failed") for _ in range(unlink_failures)]
+    if unlink_failures < 3:
+        outcomes.append(None)
+    path.unlink.side_effect = outcomes
+    monkeypatch.setattr(heartbeat, "cancellation_path", lambda _: path)
+
+    if unlink_failures == 3:
+        with pytest.raises(OSError, match="unlink failed"):
+            heartbeat.clear_cancellation_request("session-marker-retry")
+    else:
+        heartbeat.clear_cancellation_request("session-marker-retry")
+    assert path.unlink.call_count == min(unlink_failures + 1, 3)
+
+
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
     runner = _runner()
     contract = runner._build_execution_contract(seed=_seed())

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -12,15 +12,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+from ouroboros.cli.commands.cancel import _cancel_session
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
+from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
 from ouroboros.mcp.tools.job_handlers import CancelExecutionHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
 from ouroboros.orchestrator.execution_authority import (
     _PROCESS_LOCAL_AUTHORITY_REGISTRY,
+    _ProcessLocalAuthorityLifecycleState,
     _register_process_local_authority_terminal_finalizer,
     _retire_process_local_authority_after_terminal_persistence,
 )
@@ -158,6 +162,77 @@ async def test_prepare_session_registers_an_opaque_live_generation() -> None:
         tracker.execution_id,
         contract,
     )
+
+
+@pytest.mark.asyncio
+async def test_registry_encodes_claim_and_terminalization_as_one_state() -> None:
+    """One lifecycle entry cannot be claimed and terminalizing simultaneously."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-one-lifecycle-state",
+        execution_id="exec-one-lifecycle-state",
+    )
+    authority = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]["foundation_a_authority"]
+    lifecycle = _PROCESS_LOCAL_AUTHORITY_REGISTRY._lifecycles[tracker.session_id]
+
+    try:
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.REGISTERED
+
+        generation, already_owned = _PROCESS_LOCAL_AUTHORITY_REGISTRY.claim(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+            runner._adapter,
+        )
+        assert generation is not None
+        assert already_owned is False
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.CLAIMED
+
+        reserved, active_owner = _PROCESS_LOCAL_AUTHORITY_REGISTRY.begin_terminalization(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+        )
+        assert reserved is False
+        assert active_owner is True
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.CLAIMED
+
+        _PROCESS_LOCAL_AUTHORITY_REGISTRY.release(
+            tracker.session_id,
+            tracker.execution_id,
+            runner._adapter,
+        )
+        reserved, active_owner = _PROCESS_LOCAL_AUTHORITY_REGISTRY.begin_terminalization(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+        )
+        assert reserved is True
+        assert active_owner is False
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+
+        generation, already_owned = _PROCESS_LOCAL_AUTHORITY_REGISTRY.claim(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+            runner._adapter,
+        )
+        assert generation is None
+        assert already_owned is True
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.TERMINALIZING
+
+        _PROCESS_LOCAL_AUTHORITY_REGISTRY.abort_terminalization(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+        )
+        assert lifecycle.state is _ProcessLocalAuthorityLifecycleState.REGISTERED
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 @pytest.mark.asyncio
@@ -525,7 +600,7 @@ async def test_precreated_setup_cancellation_releases_its_authority_claim() -> N
 
 @pytest.mark.asyncio
 async def test_resume_setup_cancellation_releases_its_authority_claim() -> None:
-    """A raw cancellation during resume restoration cannot leave ``_claims`` set."""
+    """A raw cancellation during resume restoration cannot leave a claimed lifecycle."""
     runner = _runner()
     tracker = await _prepare(
         runner,
@@ -704,6 +779,126 @@ async def test_external_terminalization_retires_retained_owner_and_store() -> No
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,
         )
+
+
+@pytest.mark.asyncio
+async def test_unstarted_background_cleanup_terminalizes_and_drains_process_local_owner(
+    tmp_path,
+) -> None:
+    """The done-callback cleanup leaves no live owner when a task never starts."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'unstarted-background.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-unstarted-background",
+        session_id="session-unstarted-background",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    handler = ExecuteSeedHandler(event_store=event_store)
+    handler._remember_process_local_owner(tracker, runner)
+
+    try:
+        await handler._cleanup_unstarted_process_local_background_task(
+            tracker=tracker,
+            runner=runner,
+            workspace=None,
+            owned_event_store=None,
+            retained_resume_handoff=False,
+        )
+
+        terminal = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert terminal.is_ok
+        assert terminal.value.status == SessionStatus.FAILED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.session_id not in handler._process_local_resume_owners
+        assert tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_before_first_background_turn_runs_process_local_cleanup(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The direct execute-seed done callback covers a never-entered coroutine."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cancel-before-start.db'}")
+    await event_store.initialize()
+    handler = ExecuteSeedHandler(
+        event_store=event_store,
+        agent_runtime_backend="process-local-test",
+    )
+    original_create_task = asyncio.create_task
+    scheduled_tasks: list[asyncio.Task[object]] = []
+
+    class _ExecuteHandlerAsyncio:
+        def __getattr__(self, name: str) -> object:
+            return getattr(asyncio, name)
+
+        def create_task(
+            self,
+            coroutine: object,
+            *args: object,
+            **kwargs: object,
+        ) -> asyncio.Task[object]:
+            task = original_create_task(coroutine, *args, **kwargs)  # type: ignore[arg-type]
+            scheduled_tasks.append(task)
+            if len(scheduled_tasks) == 1:
+                task.cancel()
+            return task
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+        lambda **_kwargs: _CountingRuntime(),
+    )
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.asyncio",
+        _ExecuteHandlerAsyncio(),
+    )
+
+    try:
+        launched = await handler.handle(
+            {
+                "seed_content": yaml.safe_dump(_seed().to_dict()),
+                "skip_qa": True,
+                "use_worktree": False,
+            }
+        )
+        assert launched.is_ok
+        session_id = launched.value.meta["session_id"]
+
+        for _ in range(20):
+            if not handler._background_tasks:
+                break
+            await asyncio.sleep(0)
+
+        terminal = await SessionRepository(event_store).reconstruct_session(session_id)
+        assert terminal.is_ok
+        assert terminal.value.status == SessionStatus.FAILED
+        assert not heartbeat.is_holder_alive(session_id)
+        assert session_id not in handler._process_local_resume_owners
+        assert session_id not in handler._process_local_owned_event_stores
+    finally:
+        for task in tuple(handler._background_tasks):
+            task.cancel()
+        if handler._background_tasks:
+            await asyncio.gather(*handler._background_tasks, return_exceptions=True)
+        await event_store.close()
 
 
 @pytest.mark.asyncio
@@ -1031,6 +1226,192 @@ async def test_public_running_cancellation_signals_claimed_process_local_owner(t
 
 
 @pytest.mark.asyncio
+async def test_job_manager_cancel_does_not_terminalize_a_claimed_process_local_owner(
+    tmp_path,
+) -> None:
+    """The job surface uses the same signal-only path below live effects."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'job-manager-running-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-job-manager-running-cancel",
+        session_id="session-job-manager-running-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    manager = JobManager(event_store)
+    started = asyncio.Event()
+    runner_cancelled = asyncio.Event()
+
+    async def _job_runner() -> MCPToolResult:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            runner_cancelled.set()
+            raise
+        return MCPToolResult(content=(MCPContentItem(type=ContentType.TEXT, text="late"),))
+
+    try:
+        job = await manager.start_job(
+            job_type="process-local-cancel",
+            initial_message="running",
+            runner=_job_runner(),
+            links=JobLinks(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            ),
+        )
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        await manager.cancel_job(job.job_id)
+        await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert await is_cancellation_requested(tracker.session_id)
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert not await event_store.query_events(
+            aggregate_id=tracker.execution_id,
+            event_type="execution.terminal",
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        tasks = [
+            *manager._tasks.values(),
+            *manager._runner_tasks.values(),
+            *manager._monitors.values(),
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_direct_runner_cancel_does_not_terminalize_a_claimed_process_local_owner(
+    tmp_path,
+) -> None:
+    """The direct runner fallback cannot write beneath its own effect claim."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'direct-running-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-direct-running-cancel",
+        session_id="session-direct-running-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+
+    try:
+        result = await runner.cancel_execution(tracker.execution_id)
+
+        assert result.is_ok
+        assert result.value["status"] == "cancellation_requested"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert await is_cancellation_requested(tracker.session_id)
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_cli_cancel_does_not_terminalize_a_claimed_process_local_owner(tmp_path) -> None:
+    """The CLI cancellation surface delegates live ownership to the runner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cli-running-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-cli-running-cancel",
+        session_id="session-cli-running-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+
+    try:
+        assert await _cancel_session(event_store, tracker.session_id) is True
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert await is_cancellation_requested(tracker.session_id)
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_public_cancellation_reservation_blocks_an_interleaved_resume_claim(tmp_path) -> None:
     """A paused owner cannot claim effects while public cancellation persists terminal state."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cancel-race.db'}")
@@ -1183,7 +1564,7 @@ async def test_public_cancel_refuses_a_live_foreign_process_owner(tmp_path) -> N
     try:
         with (
             patch(
-                "ouroboros.mcp.tools.job_handlers.is_holder_alive",
+                "ouroboros.orchestrator.heartbeat.is_holder_alive",
                 return_value=True,
             ),
             patch.object(cancel_handler._session_repo, "mark_cancelled_if_active", mark_cancelled),

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1515,9 +1515,14 @@ async def test_cancelled_before_first_background_turn_runs_process_local_cleanup
         assert launched.is_ok
         session_id = launched.value.meta["session_id"]
 
-        for _ in range(100):
-            if not handler._background_tasks:
+        for _ in range(5):
+            pending = tuple(handler._background_tasks)
+            if not pending:
                 break
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=2,
+            )
             await asyncio.sleep(0)
 
         terminal = await SessionRepository(event_store).reconstruct_session(session_id)

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -3056,6 +3056,90 @@ async def test_public_cancel_interruption_reconciles_committed_terminal_state() 
 
 
 @pytest.mark.asyncio
+async def test_public_cancel_unreadable_post_cas_stays_non_effectful_until_retry(
+    tmp_path,
+) -> None:
+    """An ambiguous post-CAS read cannot restore terminalizing authority."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'public-cancel-retry.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-public-cancel-retry",
+        session_id="session-public-cancel-retry",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    public_repo = SessionRepository(event_store)
+    original_mark_cancelled = public_repo.mark_cancelled_if_active
+    original_reconstruct = public_repo.reconstruct_session
+
+    async def _commit_then_cancel(*args: object, **kwargs: object):
+        committed = await original_mark_cancelled(*args, **kwargs)
+        assert committed.is_ok and committed.value is True
+        raise asyncio.CancelledError
+
+    try:
+        with (
+            patch.object(
+                public_repo,
+                "mark_cancelled_if_active",
+                AsyncMock(side_effect=_commit_then_cancel),
+            ),
+            patch.object(
+                public_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.err(PersistenceError("winner unreadable"))),
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await request_process_local_cancellation(
+                tracker,
+                public_repo,
+                reason="cancel with unreadable winner",
+                cancelled_by="mcp_tool",
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.CANCELLED
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is None
+        assert already_claimed is True
+        assert heartbeat.is_holder_alive(tracker.session_id)
+
+        public_repo.reconstruct_session = original_reconstruct
+        retried = await request_process_local_cancellation(
+            tracker,
+            public_repo,
+            reason="retry terminal reconciliation",
+            cancelled_by="mcp_tool",
+        )
+
+        assert retried is not None
+        assert retried.disposition is ProcessLocalCancellationDisposition.CANCELLED
+        assert retried.retired is True
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_repeated_public_cancel_interruption_drains_terminal_cleanup() -> None:
     """A second cancellation cannot restore a committed public reservation."""
     runner = _runner()

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -22,6 +22,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.core.types import Result
+from ouroboros.core.worktree import TaskWorkspace
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
 from ouroboros.mcp.tools.job_handlers import CancelExecutionHandler
@@ -1794,6 +1795,62 @@ async def test_prepare_rejects_reused_terminal_session_id(tmp_path) -> None:
             colliding_runner._process_local_authorities
         )
         assert not heartbeat.is_holder_alive(session_id)
+    finally:
+        original_runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=original_execution_id,
+        )
+        colliding_runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=collision_execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_collision_preserves_existing_owner_workspace_lock(tmp_path) -> None:
+    """A rejected preparation cannot release another live owner's workspace."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'live-owner-collision.db'}")
+    await event_store.initialize()
+    original_runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    colliding_runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    workspace = TaskWorkspace(
+        durable_id="live-owner-collision",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/live-owner-collision",
+        lock_path="/tmp/live-owner-collision.lock",
+    )
+    original_runner._task_workspace = workspace
+    colliding_runner._task_workspace = workspace
+    session_id = "session-live-owner-collision"
+    original_execution_id = "exec-live-owner-original"
+    collision_execution_id = "exec-live-owner-collision"
+    original = await original_runner.prepare_session(
+        _seed(),
+        execution_id=original_execution_id,
+        session_id=session_id,
+    )
+    assert original.is_ok
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            collision = await colliding_runner.prepare_session(
+                _seed(),
+                execution_id=collision_execution_id,
+                session_id=session_id,
+            )
+
+        assert collision.is_err
+        assert (session_id, original_execution_id) in original_runner._process_local_authorities
+        assert (session_id, collision_execution_id) not in (
+            colliding_runner._process_local_authorities
+        )
+        assert heartbeat.is_holder_alive(session_id)
+        release_lock_mock.assert_not_called()
     finally:
         original_runner._retire_process_local_authority(
             session_id=session_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1864,6 +1864,319 @@ async def test_prepare_collision_preserves_existing_owner_workspace_lock(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_exact_identity_prepare_collision_preserves_original_generation(tmp_path) -> None:
+    """A failed duplicate generation cannot retire the existing exact owner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'exact-owner-collision.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    runner._task_workspace = TaskWorkspace(
+        durable_id="exact-owner-collision",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/exact-owner-collision",
+        lock_path="/tmp/exact-owner-collision.lock",
+    )
+    session_id = "session-exact-owner-collision"
+    execution_id = "exec-exact-owner-collision"
+    original = await runner.prepare_session(
+        _seed(),
+        execution_id=execution_id,
+        session_id=session_id,
+    )
+    assert original.is_ok
+    original_generation = runner._process_local_authorities[(session_id, execution_id)]
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            collision = await runner.prepare_session(
+                _seed(),
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+
+        assert collision.is_err
+        assert runner._process_local_authorities[(session_id, execution_id)] is original_generation
+        assert runner._task_workspace_users == {(session_id, execution_id)}
+        assert runner._task_workspace_lock_held is True
+        assert heartbeat.is_holder_alive(session_id)
+        release_lock_mock.assert_not_called()
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_workspace_lock_releases_after_last_runner_session_owner(tmp_path) -> None:
+    """One terminal session cannot release a workspace used by another session."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'workspace-users.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    runner._task_workspace = TaskWorkspace(
+        durable_id="workspace-users",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/workspace-users",
+        lock_path="/tmp/workspace-users.lock",
+    )
+    first = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-workspace-first",
+        session_id="session-workspace-first",
+    )
+    second = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-workspace-second",
+        session_id="session-workspace-second",
+    )
+    assert first.is_ok
+    assert second.is_ok
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            runner._cleanup_pre_execution_state(
+                "exec-workspace-first",
+                "session-workspace-first",
+                session_registered=False,
+            )
+            release_lock_mock.assert_not_called()
+            assert runner._task_workspace_users == {
+                ("session-workspace-second", "exec-workspace-second")
+            }
+
+            runner._cleanup_pre_execution_state(
+                "exec-workspace-second",
+                "session-workspace-second",
+                session_registered=False,
+            )
+            release_lock_mock.assert_called_once_with("/tmp/workspace-users.lock")
+            assert not runner._task_workspace_users
+
+            runner._cleanup_pre_execution_state(
+                "exec-workspace-second",
+                "session-workspace-second",
+                session_registered=False,
+            )
+            release_lock_mock.assert_called_once_with("/tmp/workspace-users.lock")
+    finally:
+        runner._retire_process_local_authority(
+            session_id="session-workspace-first",
+            execution_id="exec-workspace-first",
+        )
+        runner._retire_process_local_authority(
+            session_id="session-workspace-second",
+            execution_id="exec-workspace-second",
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_inflight_preparation_reserves_workspace_before_registration(tmp_path) -> None:
+    """A session finishing during another contract build cannot release its lock."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'workspace-prepare-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    runner._task_workspace = TaskWorkspace(
+        durable_id="workspace-prepare-race",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/workspace-prepare-race",
+        lock_path="/tmp/workspace-prepare-race.lock",
+    )
+    first = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-workspace-prepare-first",
+        session_id="session-workspace-prepare-first",
+    )
+    assert first.is_ok
+    entered_build = Event()
+    release_build = Event()
+    original_build = runner._build_execution_contract
+
+    def _blocked_build(**kwargs: object) -> dict[str, object]:
+        entered_build.set()
+        assert release_build.wait(timeout=2)
+        return original_build(**kwargs)
+
+    try:
+        with (
+            patch.object(runner, "_build_execution_contract", _blocked_build),
+            patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+        ):
+            second_task = asyncio.create_task(
+                runner.prepare_session(
+                    _seed(),
+                    execution_id="exec-workspace-prepare-second",
+                    session_id="session-workspace-prepare-second",
+                )
+            )
+            assert await asyncio.to_thread(entered_build.wait, 1)
+
+            runner._cleanup_pre_execution_state(
+                "exec-workspace-prepare-first",
+                "session-workspace-prepare-first",
+                session_registered=False,
+            )
+            release_lock_mock.assert_not_called()
+            assert runner._task_workspace_reservations
+
+            release_build.set()
+            second = await asyncio.wait_for(second_task, timeout=2)
+            assert second.is_ok
+            assert not runner._task_workspace_reservations
+
+            runner._cleanup_pre_execution_state(
+                "exec-workspace-prepare-second",
+                "session-workspace-prepare-second",
+                session_registered=False,
+            )
+            release_lock_mock.assert_called_once_with("/tmp/workspace-prepare-race.lock")
+    finally:
+        release_build.set()
+        runner._retire_process_local_authority(
+            session_id="session-workspace-prepare-first",
+            execution_id="exec-workspace-prepare-first",
+        )
+        runner._retire_process_local_authority(
+            session_id="session-workspace-prepare-second",
+            execution_id="exec-workspace-prepare-second",
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_handoff_reserves_workspace_before_reclaim(tmp_path) -> None:
+    """Another session cannot release the lock during retained-workspace restore."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'workspace-resume-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    workspace = TaskWorkspace(
+        durable_id="workspace-resume-race",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/workspace-resume-race",
+        lock_path="/tmp/workspace-resume-race.lock",
+    )
+    runner._task_workspace = workspace
+    first = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-workspace-resume-first",
+        session_id="session-workspace-resume-first",
+    )
+    second = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-workspace-resume-second",
+        session_id="session-workspace-resume-second",
+    )
+    assert first.is_ok
+    assert second.is_ok
+    runner._release_task_workspace_for_identity(
+        session_id=first.value.session_id,
+        execution_id=first.value.execution_id,
+    )
+    reservation = runner._reserve_task_workspace()
+    assert reservation is not None
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            runner._cleanup_pre_execution_state(
+                second.value.execution_id,
+                second.value.session_id,
+                session_registered=False,
+            )
+            release_lock_mock.assert_not_called()
+
+            runner._task_workspace = workspace
+            contract = first.value.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+            generation, already_claimed = runner._claim_process_local_authority_generation(
+                first.value.session_id,
+                first.value.execution_id,
+                contract,
+            )
+            assert generation is not None
+            assert already_claimed is False
+            runner._release_task_workspace_reservation(reservation)
+            release_lock_mock.assert_not_called()
+
+            runner._cleanup_pre_execution_state(
+                first.value.execution_id,
+                first.value.session_id,
+                session_registered=False,
+            )
+            release_lock_mock.assert_called_once_with("/tmp/workspace-resume-race.lock")
+    finally:
+        runner._release_task_workspace_reservation(reservation)
+        runner._retire_process_local_authority(
+            session_id=first.value.session_id,
+            execution_id=first.value.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=second.value.session_id,
+            execution_id=second.value.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_direct_cancel_of_already_terminal_owner_releases_workspace(tmp_path) -> None:
+    """Terminal reconciliation through direct cancellation drains workspace use."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'terminal-cancel-workspace.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    runner._task_workspace = TaskWorkspace(
+        durable_id="terminal-cancel-workspace",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/repo",
+        worktree_path="/tmp/repo",
+        branch="test/terminal-cancel-workspace",
+        lock_path="/tmp/terminal-cancel-workspace.lock",
+    )
+    execution_id = "exec-terminal-cancel-workspace"
+    session_id = "session-terminal-cancel-workspace"
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id=execution_id,
+        session_id=session_id,
+    )
+    assert prepared.is_ok
+    terminal = await runner._session_repo.mark_completed(session_id, {"done": True})
+    assert terminal.is_ok
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            cancelled = await runner.cancel_execution(execution_id)
+
+        assert cancelled.is_ok
+        assert cancelled.value["status"] == "already_terminal"
+        assert (session_id, execution_id) not in runner._process_local_authorities
+        assert not runner._task_workspace_users
+        assert runner._task_workspace_lock_held is False
+        release_lock_mock.assert_called_once_with("/tmp/terminal-cancel-workspace.lock")
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_prepare_rejects_terminal_only_session_id(tmp_path) -> None:
     """Terminal-only legacy history cannot acquire a new live execution owner."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'terminal-only-conflict.db'}")
@@ -2990,6 +3303,79 @@ async def test_public_running_cancellation_signals_claimed_process_local_owner(t
 
 
 @pytest.mark.asyncio
+async def test_claimed_owner_completion_racing_cancel_publication_clears_signal(
+    tmp_path,
+) -> None:
+    """A late local signal cannot survive the owner's terminal winner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'local-cancel-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-local-cancel-race",
+        session_id="session-local-cancel-race",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    original_request_cancellation = request_cancellation
+
+    async def _publish_after_completion(
+        session_id: str,
+        *,
+        reason: str,
+        cancelled_by: str,
+    ) -> None:
+        completed = await runner._session_repo.mark_completed(session_id, {"done": True})
+        assert completed.is_ok
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=tracker.execution_id,
+        )
+        await original_request_cancellation(
+            session_id,
+            reason=reason,
+            cancelled_by=cancelled_by,
+        )
+
+    try:
+        with patch(
+            "ouroboros.orchestrator.runner.request_cancellation",
+            _publish_after_completion,
+        ):
+            outcome = await request_process_local_cancellation(
+                tracker,
+                runner._session_repo,
+                reason="racing local cancellation",
+                cancelled_by="test",
+            )
+
+        assert outcome is not None
+        assert outcome.disposition == ProcessLocalCancellationDisposition.ALREADY_TERMINAL
+        assert not await is_cancellation_requested(tracker.session_id)
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_job_manager_cancel_does_not_terminalize_a_claimed_process_local_owner(
     tmp_path,
 ) -> None:
@@ -3357,6 +3743,54 @@ async def test_public_cancel_signals_a_live_foreign_process_owner(tmp_path) -> N
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_foreign_owner_terminal_racing_cancel_publication_clears_signal(tmp_path) -> None:
+    """A stale foreign liveness observation cannot leave a late file marker."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'foreign-cancel-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-foreign-cancel-race",
+        session_id="session-foreign-cancel-race",
+    )
+    assert prepared.is_ok
+    stale_tracker = prepared.value
+    runner._retire_process_local_authority(
+        session_id=stale_tracker.session_id,
+        execution_id=stale_tracker.execution_id,
+    )
+    completed = await runner._session_repo.mark_completed(
+        stale_tracker.session_id,
+        {"done": True},
+    )
+    assert completed.is_ok
+
+    try:
+        with patch(
+            "ouroboros.orchestrator.heartbeat.is_holder_alive",
+            return_value=True,
+        ):
+            outcome = await request_process_local_cancellation(
+                stale_tracker,
+                runner._session_repo,
+                reason="racing foreign cancellation",
+                cancelled_by="test",
+            )
+
+        assert outcome is not None
+        assert outcome.disposition == ProcessLocalCancellationDisposition.ALREADY_TERMINAL
+        assert not heartbeat.has_cancellation_request(stale_tracker.session_id)
+        assert not await is_cancellation_requested(stale_tracker.session_id)
+    finally:
+        await clear_cancellation(stale_tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=stale_tracker.session_id,
+            execution_id=stale_tracker.execution_id,
         )
         await event_store.close()
 

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -24,6 +24,7 @@ from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
 from ouroboros.orchestrator.execution_authority import (
     _PROCESS_LOCAL_AUTHORITY_REGISTRY,
+    ProcessLocalCancellationDisposition,
     _ProcessLocalAuthorityLifecycleState,
     _register_process_local_authority_terminal_finalizer,
     _retire_process_local_authority_after_terminal_persistence,
@@ -231,6 +232,59 @@ async def test_pause_persistence_failure_keeps_durable_running_owner(tmp_path) -
         assert tracker.execution_id not in runner.active_sessions
         session_events = await event_store.replay("session", tracker.session_id)
         assert "orchestrator.session.paused" not in [event.type for event in session_events]
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_paused_projection_failure_keeps_durable_paused_owner(tmp_path) -> None:
+    """Auxiliary projection failure cannot convert durable PAUSED into FAILED."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'paused-projection.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_RecoverablePauseRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-paused-projection",
+        session_id="session-paused-projection",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    append = event_store.append
+
+    async def fail_execution_projection(event, **kwargs):
+        if event.type == "execution.terminal":
+            raise PersistenceError("execution projection unavailable")
+        return await append(event, **kwargs)
+
+    try:
+        with patch.object(event_store, "append", fail_execution_projection):
+            result = await runner.execute_precreated_session(
+                seed=_seed(),
+                tracker=tracker,
+                parallel=False,
+            )
+
+        assert result.is_ok
+        assert result.value.success is False
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.PAUSED
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        session_events = await event_store.replay("session", tracker.session_id)
+        event_types = [event.type for event in session_events]
+        assert event_types.count("orchestrator.session.paused") == 1
+        assert "orchestrator.session.failed" not in event_types
     finally:
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
@@ -2089,7 +2143,10 @@ async def test_cli_cancel_does_not_terminalize_a_claimed_process_local_owner(tmp
     assert already_claimed is False
 
     try:
-        assert await _cancel_session(event_store, tracker.session_id) is True
+        assert (
+            await _cancel_session(event_store, tracker.session_id)
+            == ProcessLocalCancellationDisposition.CANCELLATION_REQUESTED
+        )
 
         durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
         assert durable.is_ok

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pickle
+from threading import Event
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,9 +16,14 @@ from ouroboros.core.errors import PersistenceError
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+from ouroboros.mcp.tools.job_handlers import CancelExecutionHandler
 from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
-from ouroboros.orchestrator.execution_authority import _PROCESS_LOCAL_AUTHORITY_REGISTRY
+from ouroboros.orchestrator.execution_authority import (
+    _PROCESS_LOCAL_AUTHORITY_REGISTRY,
+    _register_process_local_authority_terminal_finalizer,
+    _retire_process_local_authority_after_terminal_persistence,
+)
 from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 from ouroboros.orchestrator.runner import (
     EXECUTION_CONTRACT_PROGRESS_KEY,
@@ -28,7 +34,8 @@ from ouroboros.orchestrator.runner import (
     is_cancellation_requested,
     request_cancellation,
 )
-from ouroboros.orchestrator.session import SessionStatus, SessionTracker
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
+from ouroboros.persistence.event_store import EventStore
 
 
 class _CountingRuntime:
@@ -343,7 +350,7 @@ async def test_stale_running_tracker_after_process_loss_terminally_fails_closed(
     )
     restarted = _runner(_CountingRuntime())
     restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
-    restarted._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+    restarted._session_repo.mark_failed_if_active = AsyncMock(return_value=Result.ok(True))
 
     # Simulate the creating process exiting: both its registry entry and its
     # early liveness lease disappear before another process observes RUNNING.
@@ -355,7 +362,7 @@ async def test_stale_running_tracker_after_process_loss_terminally_fails_closed(
 
     assert result.is_err
     assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
-    restarted._session_repo.mark_failed.assert_awaited_once()
+    restarted._session_repo.mark_failed_if_active.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -589,7 +596,7 @@ async def test_cooperative_cancellation_persists_terminal_before_retiring_author
 
 @pytest.mark.asyncio
 async def test_cooperative_cancellation_retains_authority_when_terminal_write_fails() -> None:
-    """A failed durable cancellation cannot be reported after liveness is withdrawn."""
+    """A failed durable cancellation keeps authority but releases its dead route."""
     runner = _runner()
     tracker = await _prepare(
         runner,
@@ -602,6 +609,13 @@ async def test_cooperative_cancellation_retains_authority_when_terminal_write_fa
     runner._session_repo.mark_cancelled = AsyncMock(
         return_value=Result.err(PersistenceError("durable cancellation unavailable"))
     )
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
     await request_cancellation(tracker.session_id)
 
     try:
@@ -622,8 +636,20 @@ async def test_cooperative_cancellation_retains_authority_when_terminal_write_fa
             contract,
         )
         assert heartbeat.is_holder_alive(tracker.session_id)
-        assert tracker.execution_id in runner.active_sessions
+        assert tracker.execution_id not in runner.active_sessions
         assert await is_cancellation_requested(tracker.session_id)
+        assert result.error.details["resume_blocked"] == "cancellation_persistence_pending"
+        retry_generation, retry_already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert retry_generation is not None
+        assert retry_already_claimed is False
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
     finally:
         await clear_cancellation(tracker.session_id)
         runner._retire_process_local_authority(
@@ -631,6 +657,700 @@ async def test_cooperative_cancellation_retains_authority_when_terminal_write_fa
             execution_id=tracker.execution_id,
         )
         runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_external_terminalization_retires_retained_owner_and_store() -> None:
+    """A terminal record from another MCP surface drains the local owner atomically."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-external-terminal-cleanup",
+        execution_id="exec-external-terminal-cleanup",
+    )
+    paused_tracker = _paused(tracker)
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+
+    try:
+        retired, claimed = await _retire_process_local_authority_after_terminal_persistence(
+            tracker.session_id,
+            tracker.execution_id,
+            contract["foundation_a_authority"],
+        )
+
+        assert retired is True
+        assert claimed is False
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert (tracker.session_id, tracker.execution_id) not in runner._process_local_authorities
+        assert tracker.session_id not in handler._process_local_resume_owners
+        assert tracker.session_id not in handler._process_local_owned_event_stores
+        runner._event_store.close.assert_awaited_once()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pending_cancellation_retries_before_resuming_effects() -> None:
+    """A retained runner retries the durable cancellation instead of resuming RUNNING work."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancellation-retry",
+        execution_id="exec-cancellation-retry",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._session_repo.mark_cancelled = AsyncMock(
+        side_effect=[
+            Result.err(PersistenceError("first cancellation write fails")),
+            Result.ok(None),
+        ]
+    )
+    runner._report_frugality_retrospective = AsyncMock()
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    await request_cancellation(tracker.session_id)
+
+    try:
+        first = await runner._handle_cancellation(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+            messages_processed=0,
+            start_time=tracker.start_time,
+        )
+        assert first.is_err
+
+        retried = await runner.resume_session(tracker.session_id, _seed())
+
+        assert retried.is_ok
+        assert runner._session_repo.mark_cancelled.await_count == 2
+        assert runner._adapter.execute_calls == 0
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_public_paused_cancellation_retires_retained_process_local_owner(
+    tmp_path,
+) -> None:
+    """Public cancellation must not leave a paused retained runner live forever."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'paused-terminal.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-public-paused-terminal",
+        session_id="session-public-paused-terminal",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    paused = await runner._session_repo.mark_paused(tracker.session_id, reason="test pause")
+    assert paused.is_ok
+    paused_tracker = (await runner._session_repo.reconstruct_session(tracker.session_id)).value
+    handler = ExecuteSeedHandler(event_store=event_store)
+    handler._remember_process_local_owner(paused_tracker, runner)
+
+    try:
+        result = await CancelExecutionHandler(event_store=event_store).handle(
+            {
+                "execution_id": tracker.execution_id,
+                "reason": "public paused cancellation",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["new_status"] == SessionStatus.CANCELLED.value
+        terminal = await runner._session_repo.reconstruct_session(tracker.session_id)
+        assert terminal.is_ok
+        assert terminal.value.status == SessionStatus.CANCELLED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.session_id not in handler._process_local_resume_owners
+        assert tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_paused_resume_cannot_overwrite_public_cancellation_terminal(tmp_path) -> None:
+    """A stale PAUSED snapshot must not turn a durable cancellation into FAILED."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'stale-terminal-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-stale-paused-terminal",
+        session_id="session-stale-paused-terminal",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    paused = await runner._session_repo.mark_paused(tracker.session_id, reason="test pause")
+    assert paused.is_ok
+    stale_paused = (
+        await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+    ).value
+
+    try:
+        cancellation = await CancelExecutionHandler(event_store=event_store).handle(
+            {
+                "execution_id": tracker.execution_id,
+                "reason": "public cancellation wins the terminal race",
+            }
+        )
+        assert cancellation.is_ok
+
+        # Model a resume caller that reconstructed PAUSED before public
+        # cancellation committed, then reaches authority recovery only after
+        # the registry has retired the local generation.
+        runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(stale_paused))
+        resumed = await runner.resume_session(tracker.session_id, _seed())
+
+        assert resumed.is_err
+        assert resumed.error.details["resume_blocked"] == "process_local_resume_unavailable"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.CANCELLED
+        session_events = await event_store.replay("session", tracker.session_id)
+        assert [event.type for event in session_events].count("orchestrator.session.cancelled") == 1
+        assert "orchestrator.session.failed" not in [event.type for event in session_events]
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_conditional_terminal_writes_have_one_durable_winner(tmp_path) -> None:
+    """The EventStore serializes competing terminal lifecycle transitions."""
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'terminal-cas-race.db'}"
+    first_store = EventStore(database_url)
+    second_store = EventStore(database_url)
+    await first_store.initialize()
+    await second_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), first_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-terminal-cas-race",
+        session_id="session-terminal-cas-race",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+
+    try:
+        failed, cancelled = await asyncio.gather(
+            SessionRepository(first_store).mark_failed_if_active(
+                tracker.session_id,
+                "concurrent failure",
+            ),
+            SessionRepository(second_store).mark_cancelled_if_active(
+                tracker.session_id,
+                "concurrent cancellation",
+            ),
+        )
+
+        assert failed.is_ok
+        assert cancelled.is_ok
+        assert int(failed.value) + int(cancelled.value) == 1
+        terminal_events = [
+            event
+            for event in await first_store.replay("session", tracker.session_id)
+            if event.type
+            in {
+                "orchestrator.session.completed",
+                "orchestrator.session.failed",
+                "orchestrator.session.cancelled",
+            }
+        ]
+        assert len(terminal_events) == 1
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await second_store.close()
+        await first_store.close()
+
+
+@pytest.mark.asyncio
+async def test_raw_pre_effect_resume_cancellation_persists_before_authority_cleanup(
+    tmp_path,
+) -> None:
+    """A raw task cancellation cannot convert a pending public cancel to FAILED."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'raw-pre-effect-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-raw-pre-effect-cancel",
+        session_id="session-raw-pre-effect-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    paused = await runner._session_repo.mark_paused(tracker.session_id, reason="test pause")
+    assert paused.is_ok
+    entered_restore = Event()
+    release_restore = Event()
+
+    def _blocked_restore(*_: object, **__: object) -> bool:
+        entered_restore.set()
+        assert release_restore.wait(timeout=2)
+        return False
+
+    try:
+        with patch.object(runner, "_restore_execution_contract", _blocked_restore):
+            resume = asyncio.create_task(runner.resume_session(tracker.session_id, _seed()))
+            assert await asyncio.to_thread(entered_restore.wait, 1)
+            await request_cancellation(tracker.session_id)
+            resume.cancel()
+            result = await asyncio.wait_for(resume, timeout=2)
+
+        assert result.is_ok
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.CANCELLED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+    finally:
+        release_restore.set()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_public_running_cancellation_signals_claimed_process_local_owner(tmp_path) -> None:
+    """A public cancel cannot terminalize underneath a worker with the effect claim."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'running-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-public-running-cancel",
+        session_id="session-public-running-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+
+    try:
+        result = await CancelExecutionHandler(event_store=event_store).handle(
+            {
+                "execution_id": tracker.execution_id,
+                "reason": "public running cancellation",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["new_status"] == "cancellation_requested"
+        assert result.value.meta["in_flight"] is True
+        current = await runner._session_repo.reconstruct_session(tracker.session_id)
+        assert current.is_ok
+        assert current.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_public_cancellation_reservation_blocks_an_interleaved_resume_claim(tmp_path) -> None:
+    """A paused owner cannot claim effects while public cancellation persists terminal state."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cancel-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-cancel-reservation-race",
+        session_id="session-cancel-reservation-race",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    paused = await runner._session_repo.mark_paused(tracker.session_id, reason="test pause")
+    assert paused.is_ok
+    cancel_handler = CancelExecutionHandler(event_store=event_store)
+    original_mark_cancelled = cancel_handler._session_repo.mark_cancelled_if_active
+    persistence_started = asyncio.Event()
+    allow_persistence = asyncio.Event()
+
+    async def _blocked_mark_cancelled(*args: object, **kwargs: object):
+        persistence_started.set()
+        await allow_persistence.wait()
+        return await original_mark_cancelled(*args, **kwargs)
+
+    try:
+        with patch.object(
+            cancel_handler._session_repo,
+            "mark_cancelled_if_active",
+            _blocked_mark_cancelled,
+        ):
+            cancellation = asyncio.create_task(
+                cancel_handler.handle(
+                    {
+                        "execution_id": tracker.execution_id,
+                        "reason": "reservation race regression",
+                    }
+                )
+            )
+            await persistence_started.wait()
+
+            generation, already_claimed = runner._claim_process_local_authority_generation(
+                tracker.session_id,
+                tracker.execution_id,
+                contract,
+            )
+            assert generation is None
+            assert already_claimed is True
+
+            allow_persistence.set()
+            result = await cancellation
+
+        assert result.is_ok
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_public_terminalization_releases_its_reservation(tmp_path) -> None:
+    """Cancelling the cancel request cannot leave a paused owner permanently claimed."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cancel-task-race.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-cancelled-public-terminalization",
+        session_id="session-cancelled-public-terminalization",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    cancel_handler = CancelExecutionHandler(event_store=event_store)
+    persistence_started = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def _never_return(*_: object, **__: object) -> Result[None, PersistenceError]:
+        persistence_started.set()
+        await never_finish.wait()
+        return Result.ok(None)
+
+    try:
+        with patch.object(
+            cancel_handler._session_repo,
+            "mark_cancelled_if_active",
+            _never_return,
+        ):
+            cancellation = asyncio.create_task(
+                cancel_handler.handle(
+                    {
+                        "execution_id": tracker.execution_id,
+                        "reason": "cancel the canceller",
+                    }
+                )
+            )
+            await persistence_started.wait()
+            cancellation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await cancellation
+
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_public_cancel_refuses_a_live_foreign_process_owner(tmp_path) -> None:
+    """A non-owning MCP process cannot write terminal state under a live lease."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'foreign-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-foreign-public-cancel",
+        session_id="session-foreign-public-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    cancel_handler = CancelExecutionHandler(event_store=event_store)
+    runner._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    mark_cancelled = AsyncMock(return_value=Result.ok(True))
+
+    try:
+        with (
+            patch(
+                "ouroboros.mcp.tools.job_handlers.is_holder_alive",
+                return_value=True,
+            ),
+            patch.object(cancel_handler._session_repo, "mark_cancelled_if_active", mark_cancelled),
+        ):
+            result = await cancel_handler.handle(
+                {
+                    "execution_id": tracker.execution_id,
+                    "reason": "foreign owner safety",
+                }
+            )
+
+        assert result.is_err
+        assert result.error.is_retriable is True
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        mark_cancelled.assert_not_awaited()
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_reconcile_does_not_retire_claimed_pre_route_owner() -> None:
+    """Terminal observation must respect a claim acquired before route registration."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-terminal-reconcile-claimed",
+        execution_id="exec-terminal-reconcile-claimed",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(_paused(tracker), runner)
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+
+    try:
+        await handler._reconcile_terminal_process_local_owner(
+            tracker.with_status(SessionStatus.CANCELLED)
+        )
+
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert await is_cancellation_requested(tracker.session_id)
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_running_cancellation_retry_claim_is_released_if_probe_task_is_cancelled() -> None:
+    """Cancelling a retry probe cannot strand its claimed live generation."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancelled-retry-probe",
+        execution_id="exec-cancelled-retry-probe",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._task_workspace = SimpleNamespace(lock_path="/tmp/cancelled-retry-probe.lock")
+    entered_check = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def _blocked_cancellation_check(_: str) -> bool:
+        entered_check.set()
+        await never_finish.wait()
+        return False
+
+    runner._check_startup_cancellation = _blocked_cancellation_check
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            retry = asyncio.create_task(runner.resume_session(tracker.session_id, _seed()))
+            await entered_check.wait()
+            retry.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await retry
+
+        release_lock_mock.assert_called_once_with("/tmp/cancelled-retry-probe.lock")
+
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_terminal_finalizers_drain_before_propagating_cancellation() -> None:
+    """One cancelled finalizer cannot skip later local resource cleanup."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-terminal-finalizer-cancellation",
+        execution_id="exec-terminal-finalizer-cancellation",
+    )
+    authority = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]["foundation_a_authority"]
+    calls: list[str] = []
+
+    async def _self_cancelling_finalizer() -> None:
+        calls.append("first")
+        asyncio.current_task().cancel()
+        await asyncio.sleep(0)
+
+    async def _later_finalizer() -> None:
+        calls.append("second")
+
+    assert _register_process_local_authority_terminal_finalizer(
+        tracker.session_id,
+        tracker.execution_id,
+        authority,
+        runner._adapter,
+        ("test", "self-cancelling"),
+        _self_cancelling_finalizer,
+    )
+    assert _register_process_local_authority_terminal_finalizer(
+        tracker.session_id,
+        tracker.execution_id,
+        authority,
+        runner._adapter,
+        ("test", "later"),
+        _later_finalizer,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await _retire_process_local_authority_after_terminal_persistence(
+            tracker.session_id,
+            tracker.execution_id,
+            authority,
+        )
+
+    assert calls == ["first", "second"]
+    assert not heartbeat.is_holder_alive(tracker.session_id)
 
 
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
@@ -1268,6 +1988,77 @@ async def test_retained_handler_keeps_concurrent_resume_nonterminal(tmp_path) ->
     finally:
         handler._process_local_resume_owners.clear()
         handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_preserves_cancellation_persistence_retry(tmp_path) -> None:
+    """The MCP wrapper must not overwrite a retryable cancellation failure."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-cancellation-pending",
+        execution_id="exec-handler-cancellation-pending",
+    )
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(tracker, runner)
+    pending = OrchestratorError(
+        "cancellation terminal write unavailable",
+        details={"resume_blocked": "cancellation_persistence_pending"},
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    mark_failed = AsyncMock()
+
+    try:
+        with (
+            patch.object(
+                runner,
+                "resume_session",
+                AsyncMock(return_value=Result.err(pending)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(tracker)),
+            ),
+            patch.object(runner._session_repo, "mark_failed", mark_failed),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "unknown"
+        create_runtime.assert_not_called()
+        mark_failed.assert_not_awaited()
+        assert handler._process_local_resume_owners[tracker.session_id] is runner
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -33,6 +33,7 @@ from ouroboros.orchestrator.events import create_session_completed_event
 from ouroboros.orchestrator.execution_authority import (
     _PROCESS_LOCAL_AUTHORITY_REGISTRY,
     ProcessLocalCancellationDisposition,
+    _await_process_local_cleanup,
     _ProcessLocalAuthorityLifecycleState,
     _register_process_local_authority_terminal_finalizer,
     _retire_process_local_authority_after_terminal_persistence,
@@ -171,6 +172,31 @@ async def _prepare(
 
 def _paused(tracker: SessionTracker) -> SessionTracker:
     return tracker.with_status(SessionStatus.PAUSED)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_shield_repropagates_caller_cancellation_after_drain() -> None:
+    """Lifecycle cleanup finishes, but the caller still observes cancellation."""
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+    cleanup_finished = False
+
+    async def _cleanup() -> str:
+        nonlocal cleanup_finished
+        cleanup_started.set()
+        await allow_cleanup.wait()
+        cleanup_finished = True
+        return "clean"
+
+    task = asyncio.create_task(_await_process_local_cleanup(_cleanup()))
+    await cleanup_started.wait()
+    task.cancel()
+    allow_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_finished is True
 
 
 class _HandlerEventStore:
@@ -506,8 +532,28 @@ async def test_resume_pause_reconciles_preexisting_terminal_winner(tmp_path) -> 
         assert cancelled.is_ok and cancelled.value is True
         return await original_mark_paused(*args, **kwargs)
 
+    original_clear = clear_cancellation
+
+    async def clear_after_owner_cleanup(session_id: str) -> None:
+        assert session_id == tracker.session_id
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        assert (tracker.session_id, tracker.execution_id) not in runner._task_workspace_users
+        await original_clear(session_id)
+
     try:
-        with patch.object(runner._session_repo, "mark_paused", terminal_then_pause):
+        with (
+            patch.object(runner._session_repo, "mark_paused", terminal_then_pause),
+            patch(
+                "ouroboros.orchestrator.runner.clear_cancellation",
+                clear_after_owner_cleanup,
+            ),
+        ):
             result = await runner.resume_session(tracker.session_id, _seed())
 
         assert result.is_ok
@@ -2423,6 +2469,14 @@ async def test_repeated_cancellation_after_cancel_cas_drains_owner_cleanup() -> 
     original_clear = clear_cancellation
 
     async def _blocked_clear(session_id: str) -> None:
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        assert (tracker.session_id, tracker.execution_id) not in runner._task_workspace_users
         clear_started.set()
         await allow_clear.wait()
         await original_clear(session_id)
@@ -2442,9 +2496,9 @@ async def test_repeated_cancellation_after_cancel_cas_drains_owner_cleanup() -> 
             cancellation.cancel()
             cancellation.cancel()
             allow_clear.set()
-            result = await asyncio.wait_for(cancellation, timeout=2)
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(cancellation, timeout=2)
 
-        assert result.is_ok
         assert not runner._has_live_process_local_authority(
             tracker.session_id,
             tracker.execution_id,
@@ -2455,6 +2509,59 @@ async def test_repeated_cancellation_after_cancel_cas_drains_owner_cleanup() -> 
         assert not await is_cancellation_requested(tracker.session_id)
     finally:
         allow_clear.set()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_existing_terminal_marker_clears_only_after_owner_cleanup() -> None:
+    """The already-terminal cancellation path acknowledges its marker last."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-existing-terminal-marker-last",
+        execution_id="exec-existing-terminal-marker-last",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    terminal_tracker = tracker.with_status(SessionStatus.COMPLETED)
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(terminal_tracker))
+    runner._event_store.query_events = AsyncMock(return_value=[])
+    runner._event_store.append = AsyncMock()
+    runner._report_frugality_retrospective = AsyncMock()
+    original_clear = clear_cancellation
+
+    async def clear_after_owner_cleanup(session_id: str) -> None:
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        assert (tracker.session_id, tracker.execution_id) not in runner._task_workspace_users
+        await original_clear(session_id)
+
+    await request_cancellation(tracker.session_id)
+    try:
+        with patch(
+            "ouroboros.orchestrator.runner.clear_cancellation",
+            clear_after_owner_cleanup,
+        ):
+            result = await runner._handle_cancellation(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                messages_processed=0,
+                start_time=tracker.start_time,
+            )
+
+        assert result.is_ok
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
         await clear_cancellation(tracker.session_id)
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
@@ -3300,6 +3407,69 @@ async def test_public_running_cancellation_signals_claimed_process_local_owner(t
         )
         runner._unregister_session(tracker.execution_id, tracker.session_id)
         await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_claimed_public_cancel_repropagates_caller_cancellation_after_probe() -> None:
+    """Cancelling the public probe cannot become a normal requested outcome."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-claimed-cancelled-probe",
+        execution_id="exec-claimed-cancelled-probe",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None and already_claimed is False
+    reconstruction_started = asyncio.Event()
+    allow_reconstruction = asyncio.Event()
+    session_repo = MagicMock()
+
+    async def _blocked_reconstruct(_: str):
+        reconstruction_started.set()
+        await allow_reconstruction.wait()
+        return Result.ok(tracker)
+
+    session_repo.reconstruct_session = AsyncMock(side_effect=_blocked_reconstruct)
+
+    try:
+        cancellation = asyncio.create_task(
+            request_process_local_cancellation(
+                tracker,
+                session_repo,
+                reason="cancel the public probe",
+                cancelled_by="test",
+            )
+        )
+        await reconstruction_started.wait()
+        cancellation.cancel()
+        allow_reconstruction.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await cancellation
+
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert await is_cancellation_requested(tracker.session_id)
+    finally:
+        allow_reconstruction.set()
+        await clear_cancellation(tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 @pytest.mark.asyncio
@@ -4238,6 +4408,52 @@ async def test_terminal_finalizers_drain_before_propagating_cancellation() -> No
 
     assert calls == ["first", "second"]
     assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_public_terminal_finalizer_cancellation_acknowledges_marker() -> None:
+    """A cancelled terminal finalizer cannot leave a durable request marker."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-public-finalizer-marker",
+        execution_id="exec-public-finalizer-marker",
+    )
+    authority = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]["foundation_a_authority"]
+    session_repo = MagicMock()
+    session_repo.mark_cancelled_if_active = AsyncMock(return_value=Result.ok(True))
+
+    async def _self_cancelling_finalizer() -> None:
+        asyncio.current_task().cancel()
+        await asyncio.sleep(0)
+
+    assert _register_process_local_authority_terminal_finalizer(
+        tracker.session_id,
+        tracker.execution_id,
+        authority,
+        runner._adapter,
+        ("test", "public-self-cancelling"),
+        _self_cancelling_finalizer,
+    )
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_process_local_cancellation(
+                tracker,
+                session_repo,
+                reason="terminal finalizer interrupted",
+                cancelled_by="test",
+            )
+
+        assert not await is_cancellation_requested(tracker.session_id)
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert (tracker.session_id, tracker.execution_id) not in runner._process_local_authorities
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1,0 +1,1243 @@
+"""Foundation A process-local authority lifecycle regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pickle
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+from ouroboros.orchestrator import heartbeat
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
+from ouroboros.orchestrator.execution_authority import _PROCESS_LOCAL_AUTHORITY_REGISTRY
+from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+from ouroboros.orchestrator.runner import (
+    EXECUTION_CONTRACT_PROGRESS_KEY,
+    OrchestratorError,
+    OrchestratorResult,
+    OrchestratorRunner,
+)
+from ouroboros.orchestrator.session import SessionStatus, SessionTracker
+
+
+class _CountingRuntime:
+    """Runtime double that records forbidden resume-provider lookups."""
+
+    runtime_backend = "process-local-test"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    capabilities = FULL_CAPABILITIES
+    working_directory = "/tmp"
+    _model = "test-model"
+
+    def __init__(self) -> None:
+        self.identity_provider_calls = 0
+        self.resume_selector_calls = 0
+        self.execute_calls = 0
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        self.identity_provider_calls += 1
+        raise AssertionError("process-local resume must not ask a runtime identity provider")
+
+    def resume_handle_execution_identity_contract(self, _: object) -> dict[str, object]:
+        self.resume_selector_calls += 1
+        raise AssertionError("process-local resume must not ask a resume selector provider")
+
+    async def execute_task(self, **_: object):
+        self.execute_calls += 1
+        if False:  # pragma: no cover - process-local guard must stop first
+            yield AgentMessage(type="result", content="unreachable")
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Keep authority process-local",
+        acceptance_criteria=("Do not reuse a lost runtime capability",),
+        ontology_schema=OntologySchema(name="Authority", description="Process-local authority"),
+        metadata=SeedMetadata(seed_id="seed-process-local-authority"),
+    )
+
+
+def _runner(runtime: _CountingRuntime | None = None) -> OrchestratorRunner:
+    return OrchestratorRunner(runtime or _CountingRuntime(), AsyncMock(), MagicMock())
+
+
+async def _prepare(
+    runner: OrchestratorRunner,
+    *,
+    session_id: str,
+    execution_id: str,
+) -> SessionTracker:
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(return_value=Result.ok(tracker)),
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        prepared = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+    assert prepared.is_ok
+    return prepared.value
+
+
+def _paused(tracker: SessionTracker) -> SessionTracker:
+    return tracker.with_status(SessionStatus.PAUSED)
+
+
+class _HandlerEventStore:
+    """Minimal handler store double for process-local resume routing."""
+
+    async def initialize(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_registers_an_opaque_live_generation() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-prepared-local",
+        execution_id="exec-prepared-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation = runner._process_local_authorities[(tracker.session_id, tracker.execution_id)]
+
+    try:
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        with pytest.raises(TypeError, match="cannot be serialized"):
+            pickle.dumps(generation)
+        with pytest.raises(TypeError, match="registry-minted"):
+            type(generation)(object(), generation.correlation_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+
+
+@pytest.mark.asyncio
+async def test_forged_correlation_cannot_register_or_resume_in_a_fresh_runner() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-forged-local",
+        execution_id="exec-forged-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    restarted_runtime = _CountingRuntime()
+    restarted = _runner(restarted_runtime)
+    forged = restarted._begin_process_local_authority_generation()
+    # Simulate a caller that has persisted diagnostics and tampers with a new
+    # locally minted object.  The registry's mint record still retains the
+    # original random correlation, so this cannot become a live authority.
+    object.__setattr__(
+        forged,
+        "_correlation_id",
+        contract["foundation_a_authority"]["correlation_id"],
+    )
+
+    try:
+        with pytest.raises(OrchestratorError, match="Cannot register"):
+            restarted._register_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                execution_contract=contract,
+                generation=forged,
+            )
+
+        paused = _paused(tracker)
+        restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
+        restarted._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+        restore = MagicMock(side_effect=AssertionError("restore must not run"))
+        restarted._restore_execution_contract = restore
+
+        result = await restarted.resume_session(paused.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        assert restarted_runtime.identity_provider_calls == 0
+        assert restarted_runtime.resume_selector_calls == 0
+        assert restarted_runtime.execute_calls == 0
+        restore.assert_not_called()
+    finally:
+        restarted._discard_process_local_authority(forged)
+        original._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_forked_child_cannot_use_parent_process_local_authority() -> None:
+    if not hasattr(os, "fork"):
+        pytest.skip("fork is unavailable on this platform")
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-fork-local",
+        execution_id="exec-fork-local",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    read_fd, write_fd = os.pipe()
+
+    try:
+        child_pid = os.fork()
+        if child_pid == 0:  # pragma: no cover - executed in an isolated child
+            try:
+                os.close(read_fd)
+                live = runner._has_live_process_local_authority(
+                    tracker.session_id,
+                    tracker.execution_id,
+                    contract,
+                )
+                os.write(write_fd, b"1" if live else b"0")
+            finally:
+                os.close(write_fd)
+                os._exit(0)
+        os.close(write_fd)
+        observed = os.read(read_fd, 1)
+        _, status = os.waitpid(child_pid, 0)
+        assert os.WIFEXITED(status)
+        assert observed == b"0"
+    finally:
+        try:
+            os.close(read_fd)
+        except OSError:
+            pass
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_preparations_get_distinct_live_generations() -> None:
+    runner = _runner()
+
+    async def create_session(**kwargs: object) -> Result[SessionTracker, object]:
+        return Result.ok(
+            SessionTracker.create(
+                str(kwargs["execution_id"]),
+                str(kwargs["seed_id"]),
+                session_id=str(kwargs["session_id"]),
+            )
+        )
+
+    with (
+        patch.object(runner._session_repo, "create_session", create_session),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        first_result, second_result = await asyncio.gather(
+            runner.prepare_session(
+                _seed(),
+                session_id="session-concurrent-one",
+                execution_id="exec-concurrent-one",
+            ),
+            runner.prepare_session(
+                _seed(),
+                session_id="session-concurrent-two",
+                execution_id="exec-concurrent-two",
+            ),
+        )
+    assert first_result.is_ok
+    assert second_result.is_ok
+    first = first_result.value
+    second = second_result.value
+    first_contract = first.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    second_contract = second.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+
+    try:
+        assert (
+            first_contract["foundation_a_authority"]["correlation_id"]
+            != second_contract["foundation_a_authority"]["correlation_id"]
+        )
+        assert runner._has_live_process_local_authority(
+            first.session_id,
+            first.execution_id,
+            first_contract,
+        )
+        assert runner._has_live_process_local_authority(
+            second.session_id,
+            second.execution_id,
+            second_contract,
+        )
+    finally:
+        for tracker in (first, second):
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+
+
+@pytest.mark.asyncio
+async def test_legacy_precreated_tracker_fails_before_tool_setup() -> None:
+    runtime = _CountingRuntime()
+    runner = _runner(runtime)
+    tracker = SessionTracker.create(
+        "exec-legacy-local",
+        _seed().metadata.seed_id,
+        session_id="session-legacy-local",
+    )
+    get_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+    runner._get_merged_tools = get_tools
+
+    result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+    assert runtime.identity_provider_calls == 0
+    assert runtime.resume_selector_calls == 0
+    assert runtime.execute_calls == 0
+    get_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stale_running_tracker_after_process_loss_terminally_fails_closed() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-stale-running-local",
+        execution_id="exec-stale-running-local",
+    )
+    restarted = _runner(_CountingRuntime())
+    restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    restarted._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    # Simulate the creating process exiting: both its registry entry and its
+    # early liveness lease disappear before another process observes RUNNING.
+    original._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    result = await restarted.resume_session(tracker.session_id, _seed())
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+    restarted._session_repo.mark_failed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_running_tracker_is_not_terminalized_by_another_runner() -> None:
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id="session-live-running-local",
+        execution_id="exec-live-running-local",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+    finally:
+        original._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+    observer._session_repo.mark_failed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminal_precreated_tracker_retires_a_stale_live_authority() -> None:
+    runner = _runner()
+    prepared = await _prepare(
+        runner,
+        session_id="session-terminal-local",
+        execution_id="exec-terminal-local",
+    )
+    contract = prepared.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    terminal = prepared.with_status(SessionStatus.COMPLETED)
+    get_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+    runner._get_merged_tools = get_tools
+
+    result = await runner.execute_precreated_session(_seed(), terminal, parallel=False)
+
+    assert result.is_err
+    assert not runner._has_live_process_local_authority(
+        prepared.session_id,
+        prepared.execution_id,
+        contract,
+    )
+    get_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_precreated_execution_claim_allows_only_one_effectful_caller() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-exclusive-local",
+        execution_id="exec-exclusive-local",
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    tool_catalog = assemble_session_tool_catalog(["Read"])
+
+    async def block_tool_setup(**_: object):
+        entered.set()
+        await release.wait()
+        return ["Read"], None, tool_catalog
+
+    runner._get_merged_tools = block_tool_setup
+    first = asyncio.create_task(runner.execute_precreated_session(_seed(), tracker, parallel=False))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    second = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+    assert second.is_err
+    assert second.error.details["resume_blocked"] == "process_local_execution_in_progress"
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    release.set()
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+
+
+def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
+    runner = _runner()
+    contract = runner._build_execution_contract(seed=_seed())
+
+    assert (
+        runner._proof_cohort_identity(
+            {
+                "seed_id": _seed().metadata.seed_id,
+                EXECUTION_CONTRACT_PROGRESS_KEY: contract,
+            }
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_publishes_liveness_before_a_running_tracker_is_observable() -> None:
+    """An observer interleaved in create_session cannot false-terminalize it."""
+    creator = _runner()
+    observer = _runner(_CountingRuntime())
+    observed_result: Result[object, OrchestratorError] | None = None
+
+    async def create_session(**kwargs: object) -> Result[SessionTracker, object]:
+        nonlocal observed_result
+        tracker = SessionTracker.create(
+            str(kwargs["execution_id"]),
+            str(kwargs["seed_id"]),
+            session_id=str(kwargs["session_id"]),
+        ).with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: dict(kwargs["execution_contract"])})
+        observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+        observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+        observed_result = await observer.resume_session(tracker.session_id, _seed())
+        return Result.ok(tracker)
+
+    with (
+        patch.object(creator._session_repo, "create_session", create_session),
+        patch.object(
+            creator._session_repo,
+            "track_progress",
+            AsyncMock(return_value=Result.ok(None)),
+        ),
+    ):
+        prepared = await creator.prepare_session(
+            _seed(),
+            execution_id="exec-publish-race",
+            session_id="session-publish-race",
+        )
+
+    try:
+        assert prepared.is_ok
+        assert observed_result is not None and observed_result.is_err
+        assert (
+            observed_result.error.details["resume_blocked"]
+            == "process_local_authority_held_elsewhere"
+        )
+        observer._session_repo.mark_failed.assert_not_awaited()
+    finally:
+        creator._retire_process_local_authority(
+            session_id="session-publish-race",
+            execution_id="exec-publish-race",
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_rolls_back_when_heartbeat_acquire_fails() -> None:
+    runner = _runner()
+    session_id = "session-heartbeat-acquire-failure"
+    execution_id = "exec-heartbeat-acquire-failure"
+
+    with patch(
+        "ouroboros.orchestrator.heartbeat.acquire",
+        side_effect=OSError("lock directory unavailable"),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    assert result.error.message == "Cannot establish process-local execution liveness lease"
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_progress_exception_terminalizes_then_retires_authority() -> None:
+    runner = _runner()
+    session_id = "session-progress-exception"
+    execution_id = "exec-progress-exception"
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    with (
+        patch.object(
+            runner._session_repo, "create_session", AsyncMock(return_value=Result.ok(tracker))
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(side_effect=OSError("event store unavailable")),
+        ),
+        patch.object(runner._session_repo, "mark_failed", mark_failed),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    mark_failed.assert_awaited_once()
+    assert not runner._has_live_process_local_authority(
+        session_id,
+        execution_id,
+        tracker.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY),
+    )
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_rejects_mismatched_repository_tracker_and_retires_lease() -> None:
+    runner = _runner()
+    returned = SessionTracker.create(
+        "exec-other",
+        _seed().metadata.seed_id,
+        session_id="session-other",
+    )
+    session_id = "session-expected"
+    execution_id = "exec-expected"
+
+    with patch.object(
+        runner._session_repo,
+        "create_session",
+        AsyncMock(return_value=Result.ok(returned)),
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert result.is_err
+    assert result.error.message == "Session repository returned an unexpected session identity"
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_foreign_paused_resume_rejects_without_terminalizing_live_owner() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-foreign-paused",
+        execution_id="exec-foreign-paused",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(_paused(tracker)))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        observer._session_repo.mark_failed.assert_not_awaited()
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_precreated_running_tracker_rejects_without_revoking_owner() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-foreign-precreated",
+        execution_id="exec-foreign-precreated",
+    )
+    observer = _runner(_CountingRuntime())
+    observer._get_merged_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
+
+    try:
+        result = await observer.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        observer._get_merged_tools.assert_not_awaited()
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_observer_cannot_terminalize_paused_transition_before_claim_release() -> None:
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-paused-transition",
+        execution_id="exec-paused-transition",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, claimed = owner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert claimed is False
+    observer = _runner(_CountingRuntime())
+    observer._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(_paused(tracker)))
+    observer._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        result = await observer.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        observer._session_repo.mark_failed.assert_not_awaited()
+        assert heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        owner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_paused_unregister_keeps_liveness_lease_until_terminal_retirement() -> None:
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-paused-lease",
+        execution_id="exec-paused-lease",
+    )
+
+    try:
+        runner._register_session(tracker.execution_id, tracker.session_id)
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(
+            tracker.execution_id,
+            tracker.session_id,
+            release_liveness_lease=False,
+        )
+
+        assert tracker.execution_id not in runner.active_sessions
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_execute_handler_resumes_with_the_retained_process_local_runner(
+    tmp_path,
+) -> None:
+    """A same-process MCP resume must reuse its original live capability owner."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-retained",
+        execution_id="exec-handler-retained",
+    )
+    paused_tracker = _paused(tracker)
+    handler_store = _HandlerEventStore()
+    handler = ExecuteSeedHandler(event_store=handler_store)
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    resumed = AsyncMock(
+        return_value=Result.ok(
+            OrchestratorResult(
+                success=False,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Still paused",
+            )
+        )
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch.object(runner, "resume_session", resumed),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "paused"
+        resumed.assert_awaited_once()
+        assert resumed.await_args.args[0] == paused_tracker.session_id
+        assert resumed.await_args.args[1].metadata.seed_id == _seed().metadata.seed_id
+        create_runtime.assert_not_called()
+        assert handler._process_local_resume_owners[paused_tracker.session_id] is runner
+        assert (
+            handler._process_local_owned_event_stores[paused_tracker.session_id]
+            is runner._event_store
+        )
+        runner._event_store.close.assert_not_awaited()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_owned_store_closes_after_terminal_resume(tmp_path) -> None:
+    """The original internally owned store survives pause and closes at terminal state."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-terminal",
+        execution_id="exec-handler-terminal",
+    )
+    paused_tracker = _paused(tracker)
+    completed_tracker = paused_tracker.with_status(SessionStatus.COMPLETED)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    resumed = AsyncMock(
+        return_value=Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Completed",
+            )
+        )
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch.object(runner, "resume_session", resumed),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(
+                    side_effect=[
+                        Result.ok(completed_tracker),
+                        Result.ok(completed_tracker),
+                    ]
+                ),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "completed"
+        create_runtime.assert_not_called()
+        runner._event_store.close.assert_awaited_once()
+        assert paused_tracker.session_id not in handler._process_local_resume_owners
+        assert paused_tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_keeps_concurrent_resume_nonterminal(tmp_path) -> None:
+    """A concurrent retained resume must preserve the paused owner and not fail it."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-concurrent",
+        execution_id="exec-handler-concurrent",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(paused_tracker, runner)
+    in_progress = OrchestratorError(
+        "already claimed",
+        details={"resume_blocked": "process_local_execution_in_progress"},
+    )
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+    mark_failed = AsyncMock()
+
+    try:
+        with (
+            patch.object(
+                runner,
+                "resume_session",
+                AsyncMock(return_value=Result.err(in_progress)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch.object(runner._session_repo, "mark_failed", mark_failed),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("resume must not construct a fresh runtime"),
+            ) as create_runtime,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "paused"
+        create_runtime.assert_not_called()
+        mark_failed.assert_not_awaited()
+        assert handler._process_local_resume_owners[paused_tracker.session_id] is runner
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_handler_returns_typed_concurrent_block_before_worktree_restore(
+    tmp_path,
+) -> None:
+    """A second same-handler resume must not degrade into a worktree-lock error."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-worktree-concurrent",
+        execution_id="exec-handler-worktree-concurrent",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(paused_tracker, runner)
+    workspace = SimpleNamespace(
+        effective_cwd=str(tmp_path),
+        worktree_path=str(tmp_path),
+        branch="ooo/process-local",
+        lock_path=str(tmp_path / "task.lock"),
+    )
+    entered_resume = asyncio.Event()
+    release_resume = asyncio.Event()
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    async def blocking_resume(*_: object) -> Result:
+        entered_resume.set()
+        await release_resume.wait()
+        return Result.ok(
+            OrchestratorResult(
+                success=False,
+                session_id=paused_tracker.session_id,
+                execution_id=paused_tracker.execution_id,
+                final_message="Still paused",
+            )
+        )
+
+    arguments = {
+        "session_id": paused_tracker.session_id,
+        "seed_content": yaml.safe_dump(_seed().to_dict()),
+        "cwd": str(tmp_path),
+        "use_worktree": True,
+        "skip_qa": True,
+    }
+    try:
+        with (
+            patch.object(runner, "resume_session", AsyncMock(side_effect=blocking_resume)),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.maybe_restore_task_workspace",
+                return_value=workspace,
+            ) as restore_workspace,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("retained resume must not construct a fresh runtime"),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            first = asyncio.create_task(handler.handle(arguments, synchronous=True))
+            await asyncio.wait_for(entered_resume.wait(), timeout=1)
+            second = await handler.handle(arguments, synchronous=True)
+
+            assert second.is_err
+            assert second.error.details["resume_blocked"] == "process_local_execution_in_progress"
+            restore_workspace.assert_called_once()
+
+            release_resume.set()
+            first_result = await first
+
+        assert first_result.is_ok
+        assert paused_tracker.session_id not in handler._process_local_resume_handoffs
+    finally:
+        release_resume.set()
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_handler_returns_typed_block_before_worktree_restore(tmp_path) -> None:
+    """A foreign live owner must not be obscured by task-worktree acquisition."""
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-handler-foreign-worktree",
+        execution_id="exec-handler-foreign-worktree",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    try:
+        with (
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.maybe_restore_task_workspace",
+                side_effect=AssertionError("foreign authority must block before workspace restore"),
+            ) as restore_workspace,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError(
+                    "foreign authority must block before runtime construction"
+                ),
+            ) as create_runtime,
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": True,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        restore_workspace.assert_not_called()
+        create_runtime.assert_not_called()
+    finally:
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_retained_owner_closes_its_handler_owned_event_store() -> None:
+    """Evicting an owner that lost its capability must not leak its store."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-handler-stale-store",
+        execution_id="exec-handler-stale-store",
+    )
+    paused_tracker = _paused(tracker)
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        paused_tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+
+    try:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+        retained = await handler._retained_process_local_owner(paused_tracker)
+
+        assert retained is None
+        runner._event_store.close.assert_awaited_once()
+        assert paused_tracker.session_id not in handler._process_local_resume_owners
+        assert paused_tracker.session_id not in handler._process_local_owned_event_stores
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+def test_malformed_heartbeat_timestamp_is_unheld_and_never_raises(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    heartbeat.lock_path("malformed-heartbeat").write_text(f"{os.getpid()}:not-a-float")
+
+    assert heartbeat.is_holder_alive("malformed-heartbeat") is False
+    assert heartbeat.lock_path("malformed-heartbeat").exists()
+
+
+def test_heartbeat_observer_never_deletes_a_lease_replaced_during_stale_check(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "stale-observer-race"
+    path = heartbeat.lock_path(session_id)
+    path.write_text("999999:0")
+    current_pid, current_start = heartbeat.current_process_identity()
+    fresh = f"{current_pid}:{current_start}" if current_start is not None else str(current_pid)
+
+    def replace_with_fresh_lease(_: int, __: float | None) -> bool:
+        path.write_text(fresh)
+        return False
+
+    monkeypatch.setattr(heartbeat, "is_process_identity_alive", replace_with_fresh_lease)
+
+    assert heartbeat.is_holder_alive(session_id) is False
+    assert path.read_text() == fresh
+
+
+def test_heartbeat_acquire_never_overwrites_an_existing_foreign_lease(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "exclusive-lease"
+    path = heartbeat.lock_path(session_id)
+    path.write_text("999999:0")
+
+    if heartbeat.fcntl is None:
+        pytest.skip("advisory lease locks are unavailable on this platform")
+
+    with (
+        patch.object(heartbeat.fcntl, "flock", side_effect=BlockingIOError),
+        pytest.raises(OSError, match="held"),
+    ):
+        heartbeat.acquire(session_id)
+
+    assert path.read_text() == "999999:0"
+
+
+@pytest.mark.parametrize("unsafe_session_id", ("..", "../../outside", "child/name", r"child\name"))
+def test_heartbeat_lock_path_is_contained_for_unsafe_legacy_session_ids(
+    tmp_path,
+    monkeypatch,
+    unsafe_session_id: str,
+) -> None:
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+
+    path = heartbeat.lock_path(unsafe_session_id)
+
+    assert path.parent == tmp_path
+    assert path.name.startswith("__invalid_session_id__")
+
+
+def test_heartbeat_fork_cleanup_closes_inherited_lease_descriptors(tmp_path, monkeypatch) -> None:
+    """The post-fork hook must not let a child keep the parent's advisory lock."""
+    monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+    session_id = "fork-inherited-lease"
+    heartbeat.acquire(session_id)
+    inherited_fd = heartbeat._HELD_LEASE_FDS[session_id]
+
+    try:
+        heartbeat._clear_held_leases_after_fork()
+
+        assert session_id not in heartbeat._HELD_LEASE_FDS
+        with pytest.raises(OSError):
+            os.fstat(inherited_fd)
+    finally:
+        heartbeat.release(session_id)
+
+
+def test_diagnostic_contract_builds_do_not_leak_registry_issuances() -> None:
+    runner = _runner()
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    for _ in range(25):
+        contract = runner._build_execution_contract(seed=_seed())
+        assert contract["foundation_a_authority"]["scope"] == "process_local"
+
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -534,6 +534,7 @@ async def test_terminal_precreated_tracker_retires_a_stale_live_authority() -> N
     terminal = prepared.with_status(SessionStatus.COMPLETED)
     get_tools = AsyncMock(side_effect=AssertionError("tool setup must not run"))
     runner._get_merged_tools = get_tools
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(terminal))
 
     result = await runner.execute_precreated_session(_seed(), terminal, parallel=False)
 
@@ -686,6 +687,63 @@ async def test_resume_setup_cancellation_releases_its_authority_claim() -> None:
         session_id=tracker.session_id,
         execution_id=tracker.execution_id,
     )
+
+
+@pytest.mark.asyncio
+async def test_terminal_tracker_copy_cannot_retire_durable_running_owner(tmp_path) -> None:
+    """Caller status is not durable proof for authority retirement."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'stale-terminal-copy.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _CountingRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-stale-terminal-copy",
+        session_id="session-stale-terminal-copy",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+
+    try:
+        result = await runner.execute_precreated_session(
+            _seed(),
+            tracker.with_status(SessionStatus.COMPLETED),
+            parallel=False,
+        )
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_execution_in_progress"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
 
 
 @pytest.mark.asyncio
@@ -950,6 +1008,77 @@ async def test_post_cas_task_cancellation_retires_durable_terminal_owner(tmp_pat
         assert not heartbeat.is_holder_alive(tracker.session_id)
         assert tracker.execution_id not in runner.active_sessions
     finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_repeated_post_cas_cancellation_drains_terminal_cleanup(tmp_path) -> None:
+    """A second task cancellation cannot interrupt terminal reconciliation."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'post-cas-double-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _SuccessfulRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-post-cas-double-cancel",
+        session_id="session-post-cas-double-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_append = event_store.append
+    original_reconstruct = runner._session_repo.reconstruct_session
+    reconciliation_started = asyncio.Event()
+    allow_reconciliation = asyncio.Event()
+
+    async def _cancel_terminal_projection(event: object):
+        if getattr(event, "type", None) == "execution.terminal":
+            raise asyncio.CancelledError
+        return await original_append(event)  # type: ignore[arg-type]
+
+    async def _delayed_reconstruct(session_id: str):
+        reconciliation_started.set()
+        await allow_reconciliation.wait()
+        return await original_reconstruct(session_id)
+
+    try:
+        with (
+            patch.object(event_store, "append", AsyncMock(side_effect=_cancel_terminal_projection)),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(side_effect=_delayed_reconstruct),
+            ),
+        ):
+            execution = asyncio.create_task(
+                runner.execute_precreated_session(_seed(), tracker, parallel=False)
+            )
+            await reconciliation_started.wait()
+            execution.cancel()
+            allow_reconciliation.set()
+            with pytest.raises(asyncio.CancelledError):
+                await execution
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.COMPLETED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        allow_reconciliation.set()
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,
@@ -1257,6 +1386,81 @@ async def test_unstarted_background_terminal_failure_retains_owner_and_store(tmp
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,
         )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_pending_keeps_handler_owned_store_open(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The outer MCP finally cannot close a store retained for exact-owner retry."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'prepare-owned-store.db'}")
+    await event_store.initialize()
+    handler = ExecuteSeedHandler(agent_runtime_backend="process-local-test")
+    original_prepare = OrchestratorRunner.prepare_session
+    close_mock = AsyncMock()
+
+    async def _prepare_with_terminal_failure(
+        runner: OrchestratorRunner,
+        *args: object,
+        **kwargs: object,
+    ):
+        runner._session_repo.track_progress = AsyncMock(
+            return_value=Result.err(PersistenceError("initial progress unavailable"))
+        )
+        runner._session_repo.mark_failed = AsyncMock(
+            return_value=Result.err(PersistenceError("terminal store unavailable"))
+        )
+        return await original_prepare(runner, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+        lambda **_kwargs: _CountingRuntime(),
+    )
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.EventStore",
+        lambda: event_store,
+    )
+
+    retained_runner: OrchestratorRunner | None = None
+    session_id: str | None = None
+    try:
+        with (
+            patch.object(OrchestratorRunner, "prepare_session", _prepare_with_terminal_failure),
+            patch.object(event_store, "close", close_mock),
+        ):
+            result = await handler.handle(
+                {
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "skip_qa": True,
+                    "use_worktree": False,
+                }
+            )
+
+            assert result.is_err
+            assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+            session_id = result.error.details["session_id"]
+            retained_runner = handler._process_local_resume_owners[session_id]
+            assert handler._process_local_owned_event_stores[session_id] is event_store
+            close_mock.assert_not_awaited()
+            durable = await SessionRepository(event_store).reconstruct_session(session_id)
+            assert durable.is_ok
+            assert durable.value.status == SessionStatus.RUNNING
+            assert heartbeat.is_holder_alive(session_id)
+    finally:
+        if retained_runner is not None and session_id is not None:
+            retained_runner._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=next(
+                    execution_id
+                    for stored_session_id, execution_id in retained_runner._process_local_authorities
+                    if stored_session_id == session_id
+                ),
+            )
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
         await event_store.close()
 
 
@@ -2059,6 +2263,60 @@ async def test_public_cancel_interruption_reconciles_committed_terminal_state() 
 
 
 @pytest.mark.asyncio
+async def test_repeated_public_cancel_interruption_drains_terminal_cleanup() -> None:
+    """A second cancellation cannot restore a committed public reservation."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-public-double-cancel",
+        execution_id="exec-public-double-cancel",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    cancelled_tracker = tracker.with_status(SessionStatus.CANCELLED)
+    reconciliation_started = asyncio.Event()
+    allow_reconciliation = asyncio.Event()
+    session_repo = MagicMock()
+    session_repo.mark_cancelled_if_active = AsyncMock(side_effect=asyncio.CancelledError)
+
+    async def _delayed_reconstruct(_: str):
+        reconciliation_started.set()
+        await allow_reconciliation.wait()
+        return Result.ok(cancelled_tracker)
+
+    session_repo.reconstruct_session = AsyncMock(side_effect=_delayed_reconstruct)
+
+    try:
+        cancellation = asyncio.create_task(
+            request_process_local_cancellation(
+                tracker,
+                session_repo,
+                reason="cancel after committed write",
+                cancelled_by="test",
+            )
+        )
+        await reconciliation_started.wait()
+        cancellation.cancel()
+        allow_reconciliation.set()
+        with pytest.raises(asyncio.CancelledError):
+            await cancellation
+
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        allow_reconciliation.set()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_durable_cancellation_request_crosses_process_boundary() -> None:
     """The file-backed request is visible without sharing Python memory."""
     session_id = "session-cross-process-cancel"
@@ -2380,18 +2638,22 @@ async def test_prepare_cancellation_discards_issuance_and_releases_workspace() -
 
 
 @pytest.mark.asyncio
-async def test_prepare_cancellation_after_registration_retires_lease() -> None:
-    """Cancellation in ``create_session`` cannot strand its early lease."""
+async def test_prepare_cancellation_with_unknown_publication_retains_lease() -> None:
+    """An ambiguous create-session cancellation preserves the exact owner."""
     runner = _runner()
     session_id = "session-prepare-create-cancel"
     execution_id = "exec-prepare-create-cancel"
-    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
 
     with (
         patch.object(
             runner._session_repo,
             "create_session",
             AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch.object(
+            runner._session_repo,
+            "reconstruct_session",
+            AsyncMock(return_value=Result.err(PersistenceError("publication unknown"))),
         ),
         pytest.raises(asyncio.CancelledError),
     ):
@@ -2401,9 +2663,92 @@ async def test_prepare_cancellation_after_registration_retires_lease() -> None:
             session_id=session_id,
         )
 
-    assert (session_id, execution_id) not in runner._process_local_authorities
-    assert not heartbeat.is_holder_alive(session_id)
-    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+    try:
+        assert (session_id, execution_id) in runner._process_local_authorities
+        assert heartbeat.is_holder_alive(session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_after_committed_start_terminalizes_then_retires(
+    tmp_path,
+) -> None:
+    """A committed start event is reconciled even when create_session raises cancellation."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'create-cancel-commit.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    session_id = "session-create-cancel-committed"
+    execution_id = "exec-create-cancel-committed"
+    original_create_session = runner._session_repo.create_session
+
+    async def _commit_then_cancel(**kwargs: object):
+        created = await original_create_session(**kwargs)
+        assert created.is_ok
+        raise asyncio.CancelledError
+
+    try:
+        with (
+            patch.object(runner._session_repo, "create_session", _commit_then_cancel),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await runner.prepare_session(
+                _seed(),
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.FAILED
+        assert (session_id, execution_id) not in runner._process_local_authorities
+        assert not heartbeat.is_holder_alive(session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_exception_after_committed_start_terminalizes_then_retires(tmp_path) -> None:
+    """A post-commit repository exception uses the same publication reconciliation."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'create-error-commit.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    session_id = "session-create-error-committed"
+    execution_id = "exec-create-error-committed"
+    original_create_session = runner._session_repo.create_session
+
+    async def _commit_then_raise(**kwargs: object):
+        created = await original_create_session(**kwargs)
+        assert created.is_ok
+        raise RuntimeError("repository response interrupted after commit")
+
+    try:
+        with patch.object(runner._session_repo, "create_session", _commit_then_raise):
+            result = await runner.prepare_session(
+                _seed(),
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+
+        assert result.is_err
+        durable = await SessionRepository(event_store).reconstruct_session(session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.FAILED
+        assert (session_id, execution_id) not in runner._process_local_authorities
+        assert not heartbeat.is_holder_alive(session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        await event_store.close()
 
 
 @pytest.mark.asyncio
@@ -2429,6 +2774,11 @@ async def test_prepare_cancellation_after_publication_terminalizes_then_retires(
             runner._session_repo,
             "track_progress",
             AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch.object(
+            runner._session_repo,
+            "reconstruct_session",
+            AsyncMock(return_value=Result.ok(tracker)),
         ),
         patch.object(runner._session_repo, "mark_failed", mark_failed),
         pytest.raises(asyncio.CancelledError),
@@ -2518,10 +2868,21 @@ async def test_prepare_rejects_mismatched_repository_tracker_and_retires_lease()
     session_id = "session-expected"
     execution_id = "exec-expected"
 
-    with patch.object(
-        runner._session_repo,
-        "create_session",
-        AsyncMock(return_value=Result.ok(returned)),
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(return_value=Result.ok(returned)),
+        ),
+        patch.object(
+            runner._session_repo,
+            "reconstruct_session",
+            AsyncMock(
+                return_value=Result.err(
+                    PersistenceError(f"No events found for session: {session_id}")
+                )
+            ),
+        ),
     ):
         result = await runner.prepare_session(
             _seed(),

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -83,6 +83,20 @@ class _SuccessfulRuntime(_CountingRuntime):
         yield AgentMessage(type="result", content="completed", data={"subtype": "success"})
 
 
+class _RecoverablePauseRuntime(_CountingRuntime):
+    """Runtime double that requests a durable usage-limit pause."""
+
+    runtime_backend = "codex_cli"
+
+    async def execute_task(self, **_: object):
+        self.execute_calls += 1
+        yield AgentMessage(
+            type="result",
+            content="Usage limit reached. Please try again in 5 hours.",
+            data={"subtype": "error", "error_type": "CodexCliError"},
+        )
+
+
 def _seed() -> Seed:
     return Seed(
         goal="Keep authority process-local",
@@ -174,6 +188,56 @@ async def test_prepare_session_registers_an_opaque_live_generation() -> None:
         tracker.execution_id,
         contract,
     )
+
+
+@pytest.mark.asyncio
+async def test_pause_persistence_failure_keeps_durable_running_owner(tmp_path) -> None:
+    """A failed PAUSED write cannot publish success or orphan durable RUNNING."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'pause-pending.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_RecoverablePauseRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-pause-pending",
+        session_id="session-pause-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+
+    try:
+        with patch.object(
+            runner._session_repo,
+            "mark_paused",
+            AsyncMock(return_value=Result.err(PersistenceError("pause write unavailable"))),
+        ):
+            result = await runner.execute_precreated_session(
+                seed=_seed(),
+                tracker=tracker,
+                parallel=False,
+            )
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "pause_persistence_pending"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        session_events = await event_store.replay("session", tracker.session_id)
+        assert "orchestrator.session.paused" not in [event.type for event in session_events]
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1380,6 +1380,111 @@ async def test_failed_terminal_persistence_intent_replays_before_resume(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_pending_completed_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """A replay cancellation after the COMPLETED CAS cannot preserve authority."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'complete-post-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _SuccessfulRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-complete-post-cas",
+        session_id="session-complete-post-cas",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_mark_completed = runner._session_repo.mark_completed
+    runner._session_repo.mark_completed = AsyncMock(
+        return_value=Result.err(PersistenceError("completion store unavailable"))
+    )
+
+    try:
+        first = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+        assert first.is_err
+
+        async def _commit_then_cancel(*args: object, **kwargs: object):
+            committed = await original_mark_completed(*args, **kwargs)
+            assert committed.is_ok
+            raise asyncio.CancelledError
+
+        runner._session_repo.mark_completed = AsyncMock(side_effect=_commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner.resume_session(tracker.session_id, _seed())
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.COMPLETED
+        assert tracker.session_id not in runner._pending_lifecycle_intents
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_pending_failed_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """A replay cancellation after the FAILED CAS cannot preserve authority."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'failed-post-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_FailedRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-failed-post-cas",
+        session_id="session-failed-post-cas",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_mark_failed = runner._session_repo.mark_failed
+    runner._session_repo.mark_failed = AsyncMock(
+        return_value=Result.err(PersistenceError("failure store unavailable"))
+    )
+
+    try:
+        first = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+        assert first.is_err
+
+        async def _commit_then_cancel(*args: object, **kwargs: object):
+            committed = await original_mark_failed(*args, **kwargs)
+            assert committed.is_ok
+            raise asyncio.CancelledError
+
+        runner._session_repo.mark_failed = AsyncMock(side_effect=_commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner.resume_session(tracker.session_id, _seed())
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.FAILED
+        assert tracker.session_id not in runner._pending_lifecycle_intents
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_uow_rejects_terminal_write_for_live_process_local_owner(tmp_path) -> None:
     """UnitOfWork cannot bypass lifecycle cleanup for a retained paused owner."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'uow-live-owner.db'}")
@@ -1590,6 +1695,144 @@ async def test_prepare_terminal_persistence_retries_before_retiring_authority(tm
             session_id="session-prepare-terminal-retry",
             execution_id="exec-prepare-terminal-retry",
         )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_failure_cleanup_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """Generic failure persistence drains ownership after an interrupted CAS response."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'failure-cleanup-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-failure-cleanup-cas",
+        session_id="session-failure-cleanup-cas",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    original_mark_failed = runner._session_repo.mark_failed
+
+    async def _commit_then_cancel(*args: object, **kwargs: object):
+        committed = await original_mark_failed(*args, **kwargs)
+        assert committed.is_ok
+        raise asyncio.CancelledError
+
+    try:
+        runner._session_repo.mark_failed = AsyncMock(side_effect=_commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner._persist_failure_and_cleanup(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=RuntimeError("runtime failed"),
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.FAILED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_lost_authority_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """Lost-authority terminalization cannot leave a committed FAILED owner live."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'lost-authority-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-lost-authority-cas",
+        session_id="session-lost-authority-cas",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    original_mark_failed = runner._session_repo.mark_failed_if_active
+
+    async def _commit_then_cancel(*args: object, **kwargs: object):
+        committed = await original_mark_failed(*args, **kwargs)
+        assert committed.is_ok and committed.value is True
+        raise asyncio.CancelledError
+
+    try:
+        runner._session_repo.mark_failed_if_active = AsyncMock(side_effect=_commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner._mark_process_local_resume_unavailable(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.FAILED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_preparation_failure_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """Preparation cleanup reconciles FAILED before propagating cancellation."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'prepare-failure-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    runner._session_repo.track_progress = AsyncMock(
+        return_value=Result.err(PersistenceError("initial progress unavailable"))
+    )
+    original_mark_failed = runner._session_repo.mark_failed
+
+    async def _commit_then_cancel(*args: object, **kwargs: object):
+        committed = await original_mark_failed(*args, **kwargs)
+        assert committed.is_ok
+        raise asyncio.CancelledError
+
+    runner._session_repo.mark_failed = AsyncMock(side_effect=_commit_then_cancel)
+    session_id = "session-prepare-failure-cas"
+    execution_id = "exec-prepare-failure-cas"
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await runner.prepare_session(
+                _seed(),
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.FAILED
+        assert (session_id, execution_id) not in runner._process_local_authorities
+        assert not heartbeat.is_holder_alive(session_id)
+        assert execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        runner._unregister_session(execution_id, session_id)
         await event_store.close()
 
 

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -380,6 +380,51 @@ async def test_live_running_tracker_is_not_terminalized_by_another_runner() -> N
 
 
 @pytest.mark.asyncio
+async def test_same_owner_running_resume_preserves_its_worktree_and_claim() -> None:
+    """A concurrent resume must not release an active owner's workspace."""
+    owner = _runner()
+    tracker = await _prepare(
+        owner,
+        session_id="session-live-running-owner",
+        execution_id="exec-live-running-owner",
+    )
+    owner._task_workspace = SimpleNamespace(lock_path="/tmp/process-local-running.lock")
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = owner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    owner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    owner._session_repo.mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    try:
+        with patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock:
+            result = await owner.resume_session(tracker.session_id, _seed())
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "process_local_execution_in_progress"
+        release_lock_mock.assert_not_called()
+        owner._session_repo.mark_failed.assert_not_awaited()
+        assert owner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+    finally:
+        owner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        owner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_terminal_precreated_tracker_retires_a_stale_live_authority() -> None:
     runner = _runner()
     prepared = await _prepare(
@@ -523,6 +568,56 @@ async def test_prepare_rolls_back_when_heartbeat_acquire_fails() -> None:
     assert result.error.message == "Cannot establish process-local execution liveness lease"
     assert (session_id, execution_id) not in runner._process_local_authorities
     assert not heartbeat.is_holder_alive(session_id)
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_discards_issuance_and_releases_workspace() -> None:
+    """Cancellation before durable publication cannot leak a live generation."""
+    runner = _runner()
+    workspace = SimpleNamespace(lock_path="/tmp/process-local-prepare-cancel.lock")
+    runner._task_workspace = workspace
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id="exec-prepare-cancel",
+            session_id="session-prepare-cancel",
+        )
+
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+    release_lock_mock.assert_called_once_with(workspace.lock_path)
+
+
+@pytest.mark.asyncio
+async def test_prepare_unexpected_error_discards_issuance_and_releases_workspace() -> None:
+    """Unexpected pre-registration errors follow the same fail-closed cleanup."""
+    runner = _runner()
+    workspace = SimpleNamespace(lock_path="/tmp/process-local-prepare-error.lock")
+    runner._task_workspace = workspace
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch.object(runner, "_build_execution_contract", side_effect=RuntimeError("boom")),
+        patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+    ):
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-prepare-error",
+            session_id="session-prepare-error",
+        )
+
+    assert result.is_err
+    assert result.error.message == "Failed to prepare process-local execution authority"
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+    release_lock_mock.assert_called_once_with(workspace.lock_path)
 
 
 @pytest.mark.asyncio
@@ -1145,6 +1240,55 @@ async def test_stale_retained_owner_closes_its_handler_owned_event_store() -> No
         handler._process_local_resume_owners.clear()
         handler._process_local_owned_event_stores.clear()
         handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reconstruction", ("raises", "error", "running"))
+async def test_reconcile_retains_live_owner_on_inconclusive_reconstruction(
+    reconstruction: str,
+) -> None:
+    """Read failures and nonterminal snapshots cannot evict a live owner."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id=f"session-handler-inconclusive-{reconstruction}",
+        execution_id=f"exec-handler-inconclusive-{reconstruction}",
+    )
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(
+        tracker,
+        runner,
+        owned_event_store=runner._event_store,
+    )
+    session_repo = MagicMock()
+    if reconstruction == "raises":
+        session_repo.reconstruct_session = AsyncMock(side_effect=OSError("observer unavailable"))
+    elif reconstruction == "error":
+        session_repo.reconstruct_session = AsyncMock(
+            return_value=Result.err("observer unavailable")
+        )
+    else:
+        session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+
+    try:
+        retained, event_store_to_close = await handler._reconcile_process_local_owner(
+            tracker=tracker,
+            runner=runner,
+            session_repo=session_repo,
+        )
+
+        assert retained is True
+        assert event_store_to_close is None
+        assert handler._process_local_resume_owners[tracker.session_id] is runner
+        assert handler._process_local_owned_event_stores[tracker.session_id] is runner._event_store
+        runner._event_store.close.assert_not_awaited()
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -31,6 +31,7 @@ from ouroboros.orchestrator.execution_authority import (
     request_process_local_cancellation,
 )
 from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelExecutionResult
 from ouroboros.orchestrator.runner import (
     EXECUTION_CONTRACT_PROGRESS_KEY,
     OrchestratorError,
@@ -285,6 +286,202 @@ async def test_paused_projection_failure_keeps_durable_paused_owner(tmp_path) ->
         event_types = [event.type for event in session_events]
         assert event_types.count("orchestrator.session.paused") == 1
         assert "orchestrator.session.failed" not in event_types
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_sequential_pause_reconciles_preexisting_terminal_winner(tmp_path) -> None:
+    """A terminal winner immediately before PAUSED retires all live ownership."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'pause-terminal-sequential.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_RecoverablePauseRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-pause-terminal-sequential",
+        session_id="session-pause-terminal-sequential",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_mark_paused = runner._session_repo.mark_paused
+
+    async def terminal_then_pause(*args: object, **kwargs: object):
+        cancelled = await runner._session_repo.mark_cancelled(
+            tracker.session_id,
+            reason="terminal wins before pause",
+        )
+        assert cancelled.is_ok and cancelled.value is True
+        return await original_mark_paused(*args, **kwargs)
+
+    try:
+        with patch.object(runner._session_repo, "mark_paused", terminal_then_pause):
+            result = await runner.execute_precreated_session(
+                seed=_seed(),
+                tracker=tracker,
+                parallel=False,
+            )
+
+        assert result.is_ok
+        assert result.value.success is False
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.CANCELLED
+        events = await event_store.replay("session", tracker.session_id)
+        assert "orchestrator.session.paused" not in [event.type for event in events]
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_parallel_pause_reconciles_preexisting_terminal_winner(tmp_path) -> None:
+    """The parallel pause path projects and cleans up the durable terminal winner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'pause-terminal-parallel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_RecoverablePauseRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-pause-terminal-parallel",
+        session_id="session-pause-terminal-parallel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None and already_claimed is False
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    message = AgentMessage(
+        type="result",
+        content="Usage limit reached. Please try again in 5 hours.",
+        data={"subtype": "error", "error_type": "CodexCliError"},
+    )
+    parallel_result = ParallelExecutionResult(
+        results=(
+            ACExecutionResult(
+                ac_index=0,
+                ac_content=_seed().acceptance_criteria[0],
+                success=False,
+                messages=(message,),
+                final_message=message.content,
+            ),
+        ),
+        success_count=0,
+        failure_count=1,
+        total_messages=1,
+    )
+    original_mark_paused = runner._session_repo.mark_paused
+
+    async def terminal_then_pause(*args: object, **kwargs: object):
+        cancelled = await runner._session_repo.mark_cancelled(
+            tracker.session_id,
+            reason="terminal wins before parallel pause",
+        )
+        assert cancelled.is_ok and cancelled.value is True
+        return await original_mark_paused(*args, **kwargs)
+
+    try:
+        with (
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                AsyncMock(return_value=parallel_result),
+            ),
+            patch.object(runner._session_repo, "mark_paused", terminal_then_pause),
+        ):
+            result = await runner._execute_parallel(
+                seed=_seed(),
+                exec_id=tracker.execution_id,
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+                force_sequential_levels=True,
+            )
+
+        assert result.is_ok
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.CANCELLED
+        events = await event_store.replay("session", tracker.session_id)
+        assert "orchestrator.session.paused" not in [event.type for event in events]
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_pause_reconciles_preexisting_terminal_winner(tmp_path) -> None:
+    """A resumed recoverable failure cannot preserve authority beside CANCELLED."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'pause-terminal-resume.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_RecoverablePauseRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-pause-terminal-resume",
+        session_id="session-pause-terminal-resume",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    initial_pause = await runner._session_repo.mark_paused(
+        tracker.session_id,
+        reason="initial resumable pause",
+    )
+    assert initial_pause.is_ok and initial_pause.value is True
+    original_mark_paused = runner._session_repo.mark_paused
+
+    async def terminal_then_pause(*args: object, **kwargs: object):
+        cancelled = await runner._session_repo.mark_cancelled(
+            tracker.session_id,
+            reason="terminal wins before resumed pause",
+        )
+        assert cancelled.is_ok and cancelled.value is True
+        return await original_mark_paused(*args, **kwargs)
+
+    try:
+        with patch.object(runner._session_repo, "mark_paused", terminal_then_pause):
+            result = await runner.resume_session(tracker.session_id, _seed())
+
+        assert result.is_ok
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.CANCELLED
+        events = await event_store.replay("session", tracker.session_id)
+        assert [event.type for event in events].count("orchestrator.session.paused") == 1
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
     finally:
         runner._retire_process_local_authority(
             session_id=tracker.session_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -35,6 +35,7 @@ from ouroboros.orchestrator.runner import (
     OrchestratorResult,
     OrchestratorRunner,
     clear_cancellation,
+    get_pending_cancellations,
     is_cancellation_requested,
     request_cancellation,
 )
@@ -564,10 +565,27 @@ async def test_precreated_execution_claim_allows_only_one_effectful_caller() -> 
         await first
     release.set()
 
-    assert not runner._has_live_process_local_authority(
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    assert runner._has_live_process_local_authority(
         tracker.session_id,
         tracker.execution_id,
-        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        contract,
+    )
+    assert heartbeat.is_holder_alive(tracker.session_id)
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    runner._release_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    runner._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
     )
 
 
@@ -590,12 +608,28 @@ async def test_precreated_setup_cancellation_releases_its_authority_claim() -> N
     ):
         await runner.execute_precreated_session(_seed(), tracker, parallel=False)
 
-    assert not runner._has_live_process_local_authority(
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    assert runner._has_live_process_local_authority(
         tracker.session_id,
         tracker.execution_id,
-        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        contract,
     )
-    assert not heartbeat.is_holder_alive(tracker.session_id)
+    assert heartbeat.is_holder_alive(tracker.session_id)
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    runner._release_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    runner._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -619,12 +653,193 @@ async def test_resume_setup_cancellation_releases_its_authority_claim() -> None:
     ):
         await runner.resume_session(paused.session_id, _seed())
 
-    assert not runner._has_live_process_local_authority(
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    assert runner._has_live_process_local_authority(
         tracker.session_id,
         tracker.execution_id,
-        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        contract,
     )
-    assert not heartbeat.is_holder_alive(tracker.session_id)
+    assert heartbeat.is_holder_alive(tracker.session_id)
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None
+    assert already_claimed is False
+    runner._release_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    runner._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_failure_persistence_error_preserves_retryable_owner(tmp_path) -> None:
+    """A post-claim setup failure cannot retire authority before FAILED persists."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'setup-pending.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _CountingRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-setup-persistence-pending",
+        session_id="session-setup-persistence-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._get_merged_tools = AsyncMock(side_effect=RuntimeError("tool setup exploded"))
+    runner._session_repo.mark_failed = AsyncMock(
+        return_value=Result.err(PersistenceError("terminal store unavailable"))
+    )
+
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_failure_persistence_error_preserves_retryable_owner(tmp_path) -> None:
+    """An execution exception keeps its lease and releases only the effect claim."""
+
+    class _ExplodingRuntime(_CountingRuntime):
+        async def execute_task(self, **_: object):
+            raise RuntimeError("runtime stream exploded")
+            if False:  # pragma: no cover - makes this an async generator
+                yield AgentMessage(type="result", content="unreachable")
+
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'execute-pending.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _ExplodingRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-runtime-persistence-pending",
+        session_id="session-runtime-persistence-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._session_repo.mark_failed = AsyncMock(
+        return_value=Result.err(PersistenceError("terminal store unavailable"))
+    )
+
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._release_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_persistence_retries_before_retiring_authority(tmp_path) -> None:
+    """Preparation uses bounded recovery before withdrawing its published lease."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'prepare-retry.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    original_mark_failed = runner._session_repo.mark_failed
+    runner._session_repo.track_progress = AsyncMock(
+        return_value=Result.err(PersistenceError("initial progress unavailable"))
+    )
+    terminal_attempts = 0
+
+    async def _mark_failed_with_retry(*args: object, **kwargs: object):
+        nonlocal terminal_attempts
+        terminal_attempts += 1
+        if terminal_attempts == 1:
+            return Result.err(PersistenceError("transient terminal failure"))
+        return await original_mark_failed(*args, **kwargs)
+
+    runner._session_repo.mark_failed = AsyncMock(side_effect=_mark_failed_with_retry)
+    try:
+        result = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-prepare-terminal-retry",
+            session_id="session-prepare-terminal-retry",
+        )
+
+        assert result.is_err
+        durable = await SessionRepository(event_store).reconstruct_session(
+            "session-prepare-terminal-retry"
+        )
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.FAILED
+        assert terminal_attempts == 2
+        assert not heartbeat.is_holder_alive("session-prepare-terminal-retry")
+    finally:
+        runner._retire_process_local_authority(
+            session_id="session-prepare-terminal-retry",
+            execution_id="exec-prepare-terminal-retry",
+        )
+        await event_store.close()
 
 
 @pytest.mark.asyncio
@@ -1542,8 +1757,8 @@ async def test_cancelled_public_terminalization_releases_its_reservation(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_public_cancel_refuses_a_live_foreign_process_owner(tmp_path) -> None:
-    """A non-owning MCP process cannot write terminal state under a live lease."""
+async def test_public_cancel_signals_a_live_foreign_process_owner(tmp_path) -> None:
+    """A non-owning process publishes a request without terminalizing the owner."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'foreign-cancel.db'}")
     await event_store.initialize()
     runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
@@ -1576,10 +1791,76 @@ async def test_public_cancel_refuses_a_live_foreign_process_owner(tmp_path) -> N
                 }
             )
 
-        assert result.is_err
-        assert result.error.is_retriable is True
-        assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+        assert result.is_ok
+        assert result.value.meta["new_status"] == "cancellation_requested"
+        assert result.value.meta["in_flight"] is True
+        assert await is_cancellation_requested(tracker.session_id)
         mark_cancelled.assert_not_awaited()
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_durable_cancellation_request_crosses_process_boundary() -> None:
+    """The file-backed request is visible without sharing Python memory."""
+    session_id = "session-cross-process-cancel"
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover - assertions run in parent
+        os.close(read_fd)
+        try:
+            heartbeat.publish_cancellation_request(session_id)
+            os.write(write_fd, b"1")
+        finally:
+            os.close(write_fd)
+        os._exit(0)
+
+    os.close(write_fd)
+    try:
+        assert os.read(read_fd, 1) == b"1"
+        waited_pid, status = os.waitpid(child_pid, 0)
+        assert waited_pid == child_pid
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
+        assert session_id not in await get_pending_cancellations()
+        assert await is_cancellation_requested(session_id)
+    finally:
+        os.close(read_fd)
+        await clear_cancellation(session_id)
+
+
+@pytest.mark.asyncio
+async def test_owner_consumes_file_backed_cancellation_before_effects(tmp_path) -> None:
+    """A request from another process reaches the owning runner at startup."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'foreign-request.db'}")
+    await event_store.initialize()
+    runtime = _CountingRuntime()
+    runner = OrchestratorRunner(runtime, event_store, MagicMock(), fat_harness_mode=False)
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-consume-foreign-request",
+        session_id="session-consume-foreign-request",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    heartbeat.publish_cancellation_request(tracker.session_id)
+
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_ok
+        assert result.value.success is False
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.CANCELLED
+        assert runtime.execute_calls == 0
+        assert not heartbeat.has_cancellation_request(tracker.session_id)
+        assert not heartbeat.is_holder_alive(tracker.session_id)
     finally:
         await clear_cancellation(tracker.session_id)
         runner._retire_process_local_authority(

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -14,7 +14,13 @@ import yaml
 
 from ouroboros.cli.commands.cancel import _cancel_session
 from ouroboros.core.errors import PersistenceError
-from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    InvestmentSpec,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
@@ -793,6 +799,54 @@ async def test_stale_running_tracker_after_process_loss_terminally_fails_closed(
         execution_id=tracker.execution_id,
     )
     result = await restarted.resume_session(tracker.session_id, _seed())
+
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
+    restarted._session_repo.mark_failed_if_active.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy_gate", ["fat_harness", "investment"])
+async def test_lost_paused_authority_precedes_current_policy_gate(policy_gate: str) -> None:
+    """Current policy cannot mask a persisted paused owner's disappearance."""
+    original = _runner()
+    tracker = await _prepare(
+        original,
+        session_id=f"session-lost-paused-{policy_gate}",
+        execution_id=f"exec-lost-paused-{policy_gate}",
+    )
+    paused = tracker.with_status(SessionStatus.PAUSED)
+    original._retire_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    resumed_seed = _seed()
+    if policy_gate == "investment":
+        resumed_seed = resumed_seed.model_copy(
+            update={
+                "acceptance_criteria": (
+                    AcceptanceCriterionSpec(
+                        description="Protect authority ordering",
+                        investment=InvestmentSpec(
+                            difficulty="medium",
+                            stakes="high",
+                            provenance="declared",
+                            confidence="high",
+                        ),
+                    ),
+                )
+            }
+        )
+    restarted = OrchestratorRunner(
+        _CountingRuntime(),
+        AsyncMock(),
+        MagicMock(),
+        fat_harness_mode=policy_gate == "fat_harness",
+    )
+    restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
+    restarted._session_repo.mark_failed_if_active = AsyncMock(return_value=Result.ok(True))
+
+    result = await restarted.resume_session(paused.session_id, resumed_seed)
 
     assert result.is_err
     assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
@@ -1699,6 +1753,60 @@ async def test_prepare_terminal_persistence_retries_before_retiring_authority(tm
 
 
 @pytest.mark.asyncio
+async def test_prepare_rejects_reused_terminal_session_id(tmp_path) -> None:
+    """A caller-supplied session ID has one immutable start identity."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'session-id-conflict.db'}")
+    await event_store.initialize()
+    original_runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    colliding_runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    session_id = "session-immutable-start"
+    original_execution_id = "exec-immutable-original"
+    collision_execution_id = "exec-immutable-collision"
+    original = await original_runner.prepare_session(
+        _seed(),
+        execution_id=original_execution_id,
+        session_id=session_id,
+    )
+    assert original.is_ok
+    completed = await original_runner._session_repo.mark_completed(session_id, {"done": True})
+    assert completed.is_ok
+    original_runner._retire_process_local_authority(
+        session_id=session_id,
+        execution_id=original_execution_id,
+    )
+
+    try:
+        collision = await colliding_runner.prepare_session(
+            _seed(),
+            execution_id=collision_execution_id,
+            session_id=session_id,
+        )
+
+        assert collision.is_err
+        assert collision.error.details["resume_blocked"] == "session_id_conflict"
+        durable = await SessionRepository(event_store).reconstruct_session(session_id)
+        assert durable.is_ok
+        assert durable.value.execution_id == original_execution_id
+        assert durable.value.status == SessionStatus.COMPLETED
+        events = await event_store.replay("session", session_id)
+        assert [event.type for event in events].count("orchestrator.session.started") == 1
+        assert (session_id, collision_execution_id) not in (
+            colliding_runner._process_local_authorities
+        )
+        assert not heartbeat.is_holder_alive(session_id)
+    finally:
+        original_runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=original_execution_id,
+        )
+        colliding_runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id=collision_execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_failure_cleanup_commit_then_cancel_reconciles_owner(tmp_path) -> None:
     """Generic failure persistence drains ownership after an interrupted CAS response."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'failure-cleanup-cas.db'}")
@@ -1946,6 +2054,69 @@ async def test_repeated_cancellation_after_cancel_cas_drains_owner_cleanup() -> 
             execution_id=tracker.execution_id,
         )
         runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_active_runner_cancel_commit_then_cancel_reconciles_owner(tmp_path) -> None:
+    """Cancellation at the owning runner CAS cannot skip terminal cleanup."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'runner-cancel-cas.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-runner-cancel-cas",
+        session_id="session-runner-cancel-cas",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    generation, already_claimed = runner._claim_process_local_authority_generation(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert generation is not None and already_claimed is False
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    original_mark_cancelled = runner._session_repo.mark_cancelled
+
+    async def _commit_then_cancel(*args: object, **kwargs: object):
+        committed = await original_mark_cancelled(*args, **kwargs)
+        assert committed.is_ok
+        raise asyncio.CancelledError
+
+    await request_cancellation(
+        tracker.session_id,
+        reason="cancel at owner CAS",
+        cancelled_by="mcp_tool",
+    )
+    try:
+        runner._session_repo.mark_cancelled = AsyncMock(side_effect=_commit_then_cancel)
+        with pytest.raises(asyncio.CancelledError):
+            await runner._handle_cancellation(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                messages_processed=0,
+                start_time=tracker.start_time,
+            )
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.CANCELLED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+        await event_store.close()
 
 
 @pytest.mark.asyncio
@@ -3121,7 +3292,7 @@ async def test_public_cancel_unreadable_post_cas_stays_non_effectful_until_retry
         )
 
         assert retried is not None
-        assert retried.disposition is ProcessLocalCancellationDisposition.CANCELLED
+        assert retried.disposition is ProcessLocalCancellationDisposition.ALREADY_TERMINAL
         assert retried.retired is True
         assert not runner._has_live_process_local_authority(
             tracker.session_id,
@@ -3137,6 +3308,64 @@ async def test_public_cancel_unreadable_post_cas_stays_non_effectful_until_retry
             execution_id=tracker.execution_id,
         )
         await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_public_cancel_retry_reclaims_nonterminal_reservation() -> None:
+    """A retryable TERMINALIZING owner retries CAS instead of blocking forever."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-public-nonterminal-retry",
+        execution_id="exec-public-nonterminal-retry",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    session_repo = MagicMock()
+    session_repo.mark_cancelled_if_active = AsyncMock(side_effect=asyncio.CancelledError)
+    session_repo.reconstruct_session = AsyncMock(
+        return_value=Result.err(PersistenceError("winner temporarily unreadable"))
+    )
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_process_local_cancellation(
+                tracker,
+                session_repo,
+                reason="first cancellation attempt",
+                cancelled_by="mcp_tool",
+            )
+
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert generation is None and already_claimed is True
+
+        session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+        session_repo.mark_cancelled_if_active = AsyncMock(return_value=Result.ok(True))
+        retried = await request_process_local_cancellation(
+            tracker,
+            session_repo,
+            reason="retry cancellation CAS",
+            cancelled_by="mcp_tool",
+        )
+
+        assert retried is not None
+        assert retried.disposition is ProcessLocalCancellationDisposition.CANCELLED
+        session_repo.mark_cancelled_if_active.assert_awaited_once()
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -27,6 +27,7 @@ from ouroboros.orchestrator.execution_authority import (
     _ProcessLocalAuthorityLifecycleState,
     _register_process_local_authority_terminal_finalizer,
     _retire_process_local_authority_after_terminal_persistence,
+    request_process_local_cancellation,
 )
 from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 from ouroboros.orchestrator.runner import (
@@ -70,6 +71,16 @@ class _CountingRuntime:
         self.execute_calls += 1
         if False:  # pragma: no cover - process-local guard must stop first
             yield AgentMessage(type="result", content="unreachable")
+
+
+class _SuccessfulRuntime(_CountingRuntime):
+    """Runtime double that completes one sequential execution successfully."""
+
+    runtime_backend = "codex_cli"
+
+    async def execute_task(self, **_: object):
+        self.execute_calls += 1
+        yield AgentMessage(type="result", content="completed", data={"subtype": "success"})
 
 
 def _seed() -> Seed:
@@ -800,6 +811,153 @@ async def test_execution_failure_persistence_error_preserves_retryable_owner(tmp
 
 
 @pytest.mark.asyncio
+async def test_completed_terminal_write_retries_without_changing_to_failed(tmp_path) -> None:
+    """A transient COMPLETED write failure keeps its original terminal intent."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'complete-retry.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _SuccessfulRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-complete-terminal-retry",
+        session_id="session-complete-terminal-retry",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    original_mark_completed = runner._session_repo.mark_completed
+    completion_attempts = 0
+
+    async def _mark_completed_with_retry(*args: object, **kwargs: object):
+        nonlocal completion_attempts
+        completion_attempts += 1
+        if completion_attempts == 1:
+            return Result.err(PersistenceError("transient completion failure"))
+        return await original_mark_completed(*args, **kwargs)
+
+    runner._session_repo.mark_completed = AsyncMock(side_effect=_mark_completed_with_retry)
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_ok
+        assert result.value.success is True
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.COMPLETED
+        assert completion_attempts == 2
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_completed_terminal_persistence_error_preserves_retryable_owner(tmp_path) -> None:
+    """Persistent COMPLETED failure cannot be rewritten as FAILED."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'complete-pending.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _SuccessfulRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-complete-terminal-pending",
+        session_id="session-complete-terminal-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._session_repo.mark_completed = AsyncMock(
+        return_value=Result.err(PersistenceError("completion store unavailable"))
+    )
+    mark_failed = AsyncMock(return_value=Result.ok(None))
+    runner._session_repo.mark_failed = mark_failed
+
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        assert result.is_err
+        assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+        assert result.error.details["requested_status"] == SessionStatus.COMPLETED.value
+        mark_failed.assert_not_awaited()
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_post_cas_task_cancellation_retires_durable_terminal_owner(tmp_path) -> None:
+    """Cancellation during projection cannot leave COMPLETED with live authority."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'post-cas-cancel.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(
+        _SuccessfulRuntime(),
+        event_store,
+        MagicMock(),
+        fat_harness_mode=False,
+    )
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-post-cas-cancel",
+        session_id="session-post-cas-cancel",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_append = event_store.append
+
+    async def _cancel_terminal_projection(event: object):
+        if getattr(event, "type", None) == "execution.terminal":
+            raise asyncio.CancelledError
+        return await original_append(event)  # type: ignore[arg-type]
+
+    try:
+        with patch.object(
+            event_store, "append", AsyncMock(side_effect=_cancel_terminal_projection)
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.COMPLETED
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_prepare_terminal_persistence_retries_before_retiring_authority(tmp_path) -> None:
     """Preparation uses bounded recovery before withdrawing its published lease."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'prepare-retry.db'}")
@@ -1047,6 +1205,62 @@ async def test_unstarted_background_cleanup_terminalizes_and_drains_process_loca
 
 
 @pytest.mark.asyncio
+async def test_unstarted_background_terminal_failure_retains_owner_and_store(tmp_path) -> None:
+    """Unstarted cleanup cannot evict a RUNNING owner when FAILED will not persist."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'unstarted-pending.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-unstarted-pending",
+        session_id="session-unstarted-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    handler = ExecuteSeedHandler(event_store=event_store)
+    handler._remember_process_local_owner(
+        tracker,
+        runner,
+        owned_event_store=event_store,
+    )
+    runner._session_repo.mark_failed_if_active = AsyncMock(
+        return_value=Result.err(PersistenceError("terminal store unavailable"))
+    )
+
+    try:
+        await handler._cleanup_unstarted_process_local_background_task(
+            tracker=tracker,
+            runner=runner,
+            workspace=None,
+            owned_event_store=event_store,
+            retained_resume_handoff=False,
+        )
+
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok
+        assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert handler._process_local_resume_owners[tracker.session_id] is runner
+        assert handler._process_local_owned_event_stores[tracker.session_id] is event_store
+        assert runner._session_repo.mark_failed_if_active.await_count == 3
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_before_first_background_turn_runs_process_local_cleanup(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1097,7 +1311,7 @@ async def test_cancelled_before_first_background_turn_runs_process_local_cleanup
         assert launched.is_ok
         session_id = launched.value.meta["session_id"]
 
-        for _ in range(20):
+        for _ in range(100):
             if not handler._background_tasks:
                 break
             await asyncio.sleep(0)
@@ -1803,6 +2017,45 @@ async def test_public_cancel_signals_a_live_foreign_process_owner(tmp_path) -> N
             execution_id=tracker.execution_id,
         )
         await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_public_cancel_interruption_reconciles_committed_terminal_state() -> None:
+    """Cancellation after the public CAS cannot restore a terminal owner."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-public-post-cas-cancel",
+        execution_id="exec-public-post-cas-cancel",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    cancelled_tracker = tracker.with_status(SessionStatus.CANCELLED)
+    session_repo = MagicMock()
+    session_repo.mark_cancelled_if_active = AsyncMock(side_effect=asyncio.CancelledError)
+    session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(cancelled_tracker))
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_process_local_cancellation(
+                tracker,
+                session_repo,
+                reason="cancel after commit",
+                cancelled_by="test",
+            )
+
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -39,6 +39,7 @@ from ouroboros.orchestrator.runner import (
     OrchestratorResult,
     OrchestratorRunner,
     clear_cancellation,
+    get_cancellation_request,
     get_pending_cancellations,
     is_cancellation_requested,
     request_cancellation,
@@ -1606,17 +1607,28 @@ async def test_cooperative_cancellation_persists_terminal_before_retiring_author
     runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
     runner._report_frugality_retrospective = AsyncMock()
 
-    async def mark_cancelled(*_: object, **__: object) -> Result[None, object]:
+    async def mark_cancelled(
+        _: str,
+        *,
+        reason: str,
+        cancelled_by: str,
+    ) -> Result[None, object]:
         assert runner._has_live_process_local_authority(
             tracker.session_id,
             tracker.execution_id,
             contract,
         )
         assert heartbeat.is_holder_alive(tracker.session_id)
+        assert reason == "CLI requested a careful stop"
+        assert cancelled_by == "user"
         return Result.ok(None)
 
     runner._session_repo.mark_cancelled = mark_cancelled
-    await request_cancellation(tracker.session_id)
+    await request_cancellation(
+        tracker.session_id,
+        reason="CLI requested a careful stop",
+        cancelled_by="user",
+    )
 
     result = await runner._handle_cancellation(
         session_id=tracker.session_id,
@@ -1632,6 +1644,65 @@ async def test_cooperative_cancellation_persists_terminal_before_retiring_author
         contract,
     )
     assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_after_cancel_cas_drains_owner_cleanup() -> None:
+    """Repeated cancellation cannot interrupt post-CAS owner reconciliation."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-post-cas-shield",
+        execution_id="exec-cancel-post-cas-shield",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._session_repo.mark_cancelled = AsyncMock(return_value=Result.ok(True))
+    runner._report_frugality_retrospective = AsyncMock()
+    clear_started = asyncio.Event()
+    allow_clear = asyncio.Event()
+    original_clear = clear_cancellation
+
+    async def _blocked_clear(session_id: str) -> None:
+        clear_started.set()
+        await allow_clear.wait()
+        await original_clear(session_id)
+
+    await request_cancellation(tracker.session_id)
+    try:
+        with patch("ouroboros.orchestrator.runner.clear_cancellation", _blocked_clear):
+            cancellation = asyncio.create_task(
+                runner._handle_cancellation(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    messages_processed=0,
+                    start_time=tracker.start_time,
+                )
+            )
+            await clear_started.wait()
+            cancellation.cancel()
+            cancellation.cancel()
+            allow_clear.set()
+            result = await asyncio.wait_for(cancellation, timeout=2)
+
+        assert result.is_ok
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id not in runner.active_sessions
+        assert not await is_cancellation_requested(tracker.session_id)
+    finally:
+        allow_clear.set()
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
 
 
 @pytest.mark.asyncio
@@ -2312,6 +2383,10 @@ async def test_public_running_cancellation_signals_claimed_process_local_owner(t
             contract,
         )
         assert await is_cancellation_requested(tracker.session_id)
+        request = await get_cancellation_request(tracker.session_id)
+        assert request is not None
+        assert request.reason == "public running cancellation"
+        assert request.cancelled_by == "mcp_tool"
     finally:
         await clear_cancellation(tracker.session_id)
         runner._release_process_local_authority(
@@ -2684,6 +2759,10 @@ async def test_public_cancel_signals_a_live_foreign_process_owner(tmp_path) -> N
         assert result.value.meta["new_status"] == "cancellation_requested"
         assert result.value.meta["in_flight"] is True
         assert await is_cancellation_requested(tracker.session_id)
+        request = heartbeat.read_cancellation_request(tracker.session_id)
+        assert request is not None
+        assert request.reason == "foreign owner safety"
+        assert request.cancelled_by == "mcp_tool"
         mark_cancelled.assert_not_awaited()
     finally:
         await clear_cancellation(tracker.session_id)

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+from ouroboros.core.errors import PersistenceError
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
@@ -23,6 +24,9 @@ from ouroboros.orchestrator.runner import (
     OrchestratorError,
     OrchestratorResult,
     OrchestratorRunner,
+    clear_cancellation,
+    is_cancellation_requested,
+    request_cancellation,
 )
 from ouroboros.orchestrator.session import SessionStatus, SessionTracker
 
@@ -485,6 +489,150 @@ async def test_precreated_execution_claim_allows_only_one_effectful_caller() -> 
     )
 
 
+@pytest.mark.asyncio
+async def test_precreated_setup_cancellation_releases_its_authority_claim() -> None:
+    """A raw cancellation during post-claim setup cannot permanently block resume."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-precreated-setup-cancel",
+        execution_id="exec-precreated-setup-cancel",
+    )
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_setup_cancellation_releases_its_authority_claim() -> None:
+    """A raw cancellation during resume restoration cannot leave ``_claims`` set."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-resume-setup-cancel",
+        execution_id="exec-resume-setup-cancel",
+    )
+    paused = _paused(tracker)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runner.asyncio.to_thread",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.resume_session(paused.session_id, _seed())
+
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_cooperative_cancellation_persists_terminal_before_retiring_authority() -> None:
+    """The live owner remains observable until durable cancellation succeeds."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-terminal-order",
+        execution_id="exec-cancel-terminal-order",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._report_frugality_retrospective = AsyncMock()
+
+    async def mark_cancelled(*_: object, **__: object) -> Result[None, object]:
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        return Result.ok(None)
+
+    runner._session_repo.mark_cancelled = mark_cancelled
+    await request_cancellation(tracker.session_id)
+
+    result = await runner._handle_cancellation(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        messages_processed=0,
+        start_time=tracker.start_time,
+    )
+
+    assert result.is_ok
+    assert not runner._has_live_process_local_authority(
+        tracker.session_id,
+        tracker.execution_id,
+        contract,
+    )
+    assert not heartbeat.is_holder_alive(tracker.session_id)
+
+
+@pytest.mark.asyncio
+async def test_cooperative_cancellation_retains_authority_when_terminal_write_fails() -> None:
+    """A failed durable cancellation cannot be reported after liveness is withdrawn."""
+    runner = _runner()
+    tracker = await _prepare(
+        runner,
+        session_id="session-cancel-terminal-failure",
+        execution_id="exec-cancel-terminal-failure",
+    )
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    runner._register_session(tracker.execution_id, tracker.session_id)
+    runner._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+    runner._session_repo.mark_cancelled = AsyncMock(
+        return_value=Result.err(PersistenceError("durable cancellation unavailable"))
+    )
+    await request_cancellation(tracker.session_id)
+
+    try:
+        result = await runner._handle_cancellation(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+            messages_processed=0,
+            start_time=tracker.start_time,
+        )
+
+        assert result.is_err
+        assert result.error.message == (
+            "Failed to persist cancellation; process-local authority remains live"
+        )
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+        assert tracker.execution_id in runner.active_sessions
+        assert await is_cancellation_requested(tracker.session_id)
+    finally:
+        await clear_cancellation(tracker.session_id)
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
     runner = _runner()
     contract = runner._build_execution_contract(seed=_seed())
@@ -594,6 +742,71 @@ async def test_prepare_cancellation_discards_issuance_and_releases_workspace() -
 
     assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
     release_lock_mock.assert_called_once_with(workspace.lock_path)
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_after_registration_retires_lease() -> None:
+    """Cancellation in ``create_session`` cannot strand its early lease."""
+    runner = _runner()
+    session_id = "session-prepare-create-cancel"
+    execution_id = "exec-prepare-create-cancel"
+    issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
+
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
+    assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+
+
+@pytest.mark.asyncio
+async def test_prepare_cancellation_after_publication_terminalizes_then_retires() -> None:
+    """A cancelled initial-progress write cannot leave RUNNING without an owner."""
+    runner = _runner()
+    session_id = "session-prepare-progress-cancel"
+    execution_id = "exec-prepare-progress-cancel"
+    tracker = SessionTracker.create(
+        execution_id,
+        _seed().metadata.seed_id,
+        session_id=session_id,
+    )
+    mark_failed = AsyncMock(return_value=Result.ok(None))
+
+    with (
+        patch.object(
+            runner._session_repo,
+            "create_session",
+            AsyncMock(return_value=Result.ok(tracker)),
+        ),
+        patch.object(
+            runner._session_repo,
+            "track_progress",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        patch.object(runner._session_repo, "mark_failed", mark_failed),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner.prepare_session(
+            _seed(),
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
+    mark_failed.assert_awaited_once()
+    assert (session_id, execution_id) not in runner._process_local_authorities
+    assert not heartbeat.is_holder_alive(session_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -22,6 +22,7 @@ from ouroboros.mcp.tools.job_handlers import CancelExecutionHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, AgentMessage
+from ouroboros.orchestrator.events import create_session_completed_event
 from ouroboros.orchestrator.execution_authority import (
     _PROCESS_LOCAL_AUTHORITY_REGISTRY,
     ProcessLocalCancellationDisposition,
@@ -43,7 +44,9 @@ from ouroboros.orchestrator.runner import (
     request_cancellation,
 )
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
+from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.uow import UnitOfWork
 
 
 class _CountingRuntime:
@@ -96,6 +99,20 @@ class _RecoverablePauseRuntime(_CountingRuntime):
             type="result",
             content="Usage limit reached. Please try again in 5 hours.",
             data={"subtype": "error", "error_type": "CodexCliError"},
+        )
+
+
+class _FailedRuntime(_CountingRuntime):
+    """Runtime double that produces a non-recoverable failure."""
+
+    runtime_backend = "codex_cli"
+
+    async def execute_task(self, **_: object):
+        self.execute_calls += 1
+        yield AgentMessage(
+            type="result",
+            content="Permanent runtime failure",
+            data={"subtype": "error", "error_type": "RuntimeError"},
         )
 
 
@@ -233,6 +250,20 @@ async def test_pause_persistence_failure_keeps_durable_running_owner(tmp_path) -
         assert tracker.execution_id not in runner.active_sessions
         session_events = await event_store.replay("session", tracker.session_id)
         assert "orchestrator.session.paused" not in [event.type for event in session_events]
+
+        retried = await runner.resume_session(tracker.session_id, _seed())
+        assert retried.is_ok
+        assert retried.value.summary["replayed_pending_lifecycle"] == "paused"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.PAUSED
+        assert runner._adapter.execute_calls == 1
+        assert tracker.session_id not in runner._pending_lifecycle_intents
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
     finally:
         runner._retire_process_local_authority(
             session_id=tracker.session_id,
@@ -1249,6 +1280,7 @@ async def test_completed_terminal_persistence_error_preserves_retryable_owner(tm
     assert prepared.is_ok
     tracker = prepared.value
     contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_mark_completed = runner._session_repo.mark_completed
     runner._session_repo.mark_completed = AsyncMock(
         return_value=Result.err(PersistenceError("completion store unavailable"))
     )
@@ -1265,6 +1297,122 @@ async def test_completed_terminal_persistence_error_preserves_retryable_owner(tm
         durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
         assert durable.is_ok
         assert durable.value.status == SessionStatus.RUNNING
+        assert runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert heartbeat.is_holder_alive(tracker.session_id)
+
+        runner._session_repo.mark_completed = original_mark_completed
+        retried = await runner.resume_session(tracker.session_id, _seed())
+        assert retried.is_ok
+        assert retried.value.success is True
+        assert retried.value.summary["replayed_pending_lifecycle"] == "completed"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.COMPLETED
+        assert runner._adapter.execute_calls == 1
+        assert tracker.session_id not in runner._pending_lifecycle_intents
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_terminal_persistence_intent_replays_before_resume(tmp_path) -> None:
+    """A retained FAILED intent terminalizes before any resumed runtime effect."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'failed-pending-retry.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_FailedRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-failed-terminal-pending",
+        session_id="session-failed-terminal-pending",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    original_mark_failed = runner._session_repo.mark_failed
+    runner._session_repo.mark_failed = AsyncMock(
+        return_value=Result.err(PersistenceError("failure store unavailable"))
+    )
+
+    try:
+        result = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+        assert result.is_err
+        assert result.error.details["requested_status"] == SessionStatus.FAILED.value
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.RUNNING
+        execute_calls_after_failure = runner._adapter.execute_calls
+
+        runner._session_repo.mark_failed = original_mark_failed
+        retried = await runner.resume_session(tracker.session_id, _seed())
+
+        assert retried.is_ok
+        assert retried.value.success is False
+        assert retried.value.summary["replayed_pending_lifecycle"] == "failed"
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.FAILED
+        assert runner._adapter.execute_calls == execute_calls_after_failure
+        assert tracker.session_id not in runner._pending_lifecycle_intents
+        assert not runner._has_live_process_local_authority(
+            tracker.session_id,
+            tracker.execution_id,
+            contract,
+        )
+        assert not heartbeat.is_holder_alive(tracker.session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_uow_rejects_terminal_write_for_live_process_local_owner(tmp_path) -> None:
+    """UnitOfWork cannot bypass lifecycle cleanup for a retained paused owner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'uow-live-owner.db'}")
+    await event_store.initialize()
+    runner = OrchestratorRunner(_CountingRuntime(), event_store, MagicMock())
+    prepared = await runner.prepare_session(
+        _seed(),
+        execution_id="exec-uow-live-owner",
+        session_id="session-uow-live-owner",
+    )
+    assert prepared.is_ok
+    tracker = prepared.value
+    contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
+    paused = await runner._session_repo.mark_paused(tracker.session_id, reason="retained pause")
+    assert paused.is_ok and paused.value is True
+    checkpoint_store = CheckpointStore(base_path=tmp_path / "uow-live-owner-checkpoints")
+    checkpoint_store.initialize()
+    uow = UnitOfWork(event_store, checkpoint_store)
+    uow.add_event(
+        create_session_completed_event(
+            tracker.session_id,
+            summary={"result": "must use owner"},
+            messages_processed=1,
+        )
+    )
+
+    try:
+        committed = await uow.commit()
+
+        assert committed.is_err
+        assert committed.error.details["process_local_authority_live"] is True
+        assert uow.pending_event_count == 1
+        durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
+        assert durable.is_ok and durable.value.status == SessionStatus.PAUSED
         assert runner._has_live_process_local_authority(
             tracker.session_id,
             tracker.execution_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
 import pickle
 from threading import Event
 from types import SimpleNamespace
@@ -5244,6 +5245,104 @@ async def test_execute_handler_resumes_with_the_retained_process_local_runner(
         handler._process_local_resume_owners.clear()
         handler._process_local_owned_event_stores.clear()
         runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_retained_resume_restores_persisted_workspace_lock_when_worktree_flag_is_false(
+    tmp_path,
+) -> None:
+    """A retained resume cannot bypass a persisted workspace lock via ``use_worktree``."""
+    workspace = TaskWorkspace(
+        durable_id="retained-resume-lock",
+        repo_root=str(tmp_path),
+        repo_name="repo",
+        original_cwd=str(tmp_path),
+        effective_cwd=str(tmp_path),
+        worktree_path=str(tmp_path),
+        branch="test/retained-resume-lock",
+        lock_path=str(tmp_path / "retained-resume.lock"),
+    )
+    runner = _runner()
+    runner._task_workspace = workspace
+    tracker = await _prepare(
+        runner,
+        session_id="session-retained-resume-lock",
+        execution_id="exec-retained-resume-lock",
+    )
+    paused_tracker = _paused(tracker)
+    runner._release_task_workspace_for_identity(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+    )
+    assert not Path(workspace.lock_path).exists()
+
+    handler = ExecuteSeedHandler(event_store=_HandlerEventStore())
+    handler._remember_process_local_owner(paused_tracker, runner)
+    observer_repo = MagicMock()
+    observer_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused_tracker))
+
+    async def resume_with_lock(*_: object) -> Result:
+        # The effect boundary is the proof point: restoration must happen before
+        # the retained runner can execute any resumed work.
+        assert Path(workspace.lock_path).exists()
+        assert runner._task_workspace_lock_held is True
+        assert runner._task_workspace is not None
+        runner._task_workspace_users.add((tracker.session_id, tracker.execution_id))
+        return Result.ok(
+            OrchestratorResult(
+                success=False,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                final_message="Still paused",
+            )
+        )
+
+    try:
+        with (
+            patch.object(runner, "resume_session", AsyncMock(side_effect=resume_with_lock)),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(paused_tracker)),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+                return_value=observer_repo,
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+                side_effect=AssertionError("retained resume must not construct a fresh runtime"),
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.resolve_dashboard_run_url",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": paused_tracker.session_id,
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "cwd": str(tmp_path),
+                    "use_worktree": False,
+                    "skip_qa": True,
+                },
+                synchronous=True,
+            )
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "paused"
+    finally:
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
+        runner._release_task_workspace_for_identity(
             session_id=tracker.session_id,
             execution_id=tracker.execution_id,
         )

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -1807,6 +1807,43 @@ async def test_prepare_rejects_reused_terminal_session_id(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_prepare_rejects_terminal_only_session_id(tmp_path) -> None:
+    """Terminal-only legacy history cannot acquire a new live execution owner."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'terminal-only-conflict.db'}")
+    await event_store.initialize()
+    session_id = "session-terminal-only-conflict"
+    runtime = _CountingRuntime()
+    runner = OrchestratorRunner(runtime, event_store, MagicMock())
+    await event_store.append(
+        create_session_completed_event(
+            session_id,
+            summary={"legacy": "terminal-only"},
+            messages_processed=0,
+        )
+    )
+
+    try:
+        collision = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-terminal-only-collision",
+            session_id=session_id,
+        )
+
+        assert collision.is_err
+        assert collision.error.details["resume_blocked"] == "session_id_conflict"
+        assert runtime.execute_calls == 0
+        events = await event_store.replay("session", session_id)
+        assert [event.type for event in events] == ["orchestrator.session.completed"]
+        assert not heartbeat.is_holder_alive(session_id)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=session_id,
+            execution_id="exec-terminal-only-collision",
+        )
+        await event_store.close()
+
+
+@pytest.mark.asyncio
 async def test_failure_cleanup_commit_then_cancel_reconciles_owner(tmp_path) -> None:
     """Generic failure persistence drains ownership after an interrupted CAS response."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'failure-cleanup-cas.db'}")
@@ -2395,6 +2432,86 @@ async def test_prepare_terminal_pending_keeps_handler_owned_store_open(
             durable = await SessionRepository(event_store).reconstruct_session(session_id)
             assert durable.is_ok
             assert durable.value.status == SessionStatus.RUNNING
+            assert heartbeat.is_holder_alive(session_id)
+    finally:
+        if retained_runner is not None and session_id is not None:
+            retained_runner._retire_process_local_authority(
+                session_id=session_id,
+                execution_id=next(
+                    execution_id
+                    for stored_session_id, execution_id in retained_runner._process_local_authorities
+                    if stored_session_id == session_id
+                ),
+            )
+        handler._process_local_resume_owners.clear()
+        handler._process_local_owned_event_stores.clear()
+        handler._process_local_resume_handoffs.clear()
+        await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_pending_retains_owner_when_reconstruction_is_unreadable(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambiguous preparation keeps a callable owner/store without a durable read."""
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'prepare-unreadable.db'}")
+    await event_store.initialize()
+    handler = ExecuteSeedHandler(agent_runtime_backend="process-local-test")
+    original_prepare = OrchestratorRunner.prepare_session
+    close_mock = AsyncMock()
+
+    async def _prepare_with_terminal_failure(
+        runner: OrchestratorRunner,
+        *args: object,
+        **kwargs: object,
+    ):
+        runner._session_repo.track_progress = AsyncMock(
+            return_value=Result.err(PersistenceError("initial progress unavailable"))
+        )
+        runner._session_repo.mark_failed = AsyncMock(
+            return_value=Result.err(PersistenceError("terminal store unavailable"))
+        )
+        return await original_prepare(runner, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+        lambda **_kwargs: _CountingRuntime(),
+    )
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.execution_handlers.EventStore",
+        lambda: event_store,
+    )
+
+    retained_runner: OrchestratorRunner | None = None
+    session_id: str | None = None
+    try:
+        with (
+            patch.object(OrchestratorRunner, "prepare_session", _prepare_with_terminal_failure),
+            patch.object(event_store, "close", close_mock),
+            patch.object(
+                SessionRepository,
+                "reconstruct_session",
+                AsyncMock(side_effect=PersistenceError("session reconstruction unavailable")),
+            ) as reconstruct_mock,
+        ):
+            result = await handler.handle(
+                {
+                    "seed_content": yaml.safe_dump(_seed().to_dict()),
+                    "skip_qa": True,
+                    "use_worktree": False,
+                }
+            )
+
+            assert result.is_err
+            assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+            session_id = result.error.details["session_id"]
+            retained_runner = handler._process_local_resume_owners[session_id]
+            assert handler._process_local_owned_event_stores[session_id] is event_store
+            close_mock.assert_not_awaited()
+            reconstruct_mock.assert_not_awaited()
+            events = await event_store.replay("session", session_id)
+            assert [event.type for event in events] == ["orchestrator.session.started"]
             assert heartbeat.is_holder_alive(session_id)
     finally:
         if retained_runner is not None and session_id is not None:

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ouroboros.config.models import OuroborosConfig
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.core.worktree import TaskWorkspace
 from ouroboros.events.base import BaseEvent
@@ -98,6 +97,18 @@ def _workspace(*, durable_id: str, worktree_path: Path, repo_root: Path) -> Task
         branch=f"ooo/{durable_id}",
         lock_path=str(worktree_path.parent / ".locks" / f"{durable_id}.json"),
     )
+
+
+def _assert_process_local_runtime_contract(contract: dict[str, object]) -> None:
+    """Legacy adapters never contribute a durable runtime execution identity."""
+    routing = contract["model_routing"]
+    assert isinstance(routing, dict)
+    assert routing["runtime_execution"] == {"version": 1, "observed": False}
+    authority = contract["foundation_a_authority"]
+    assert isinstance(authority, dict)
+    assert authority["version"] == 1
+    assert authority["scope"] == "process_local"
+    assert isinstance(authority["correlation_id"], str)
 
 
 @pytest.fixture(autouse=True)
@@ -348,7 +359,7 @@ def test_constructor_model_pin_is_persisted_and_mismatch_is_rejected() -> None:
         )
 
 
-def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> None:
+def test_codex_dynamic_profiles_do_not_create_a_portable_resume_identity() -> None:
     original_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -359,7 +370,7 @@ def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> N
     original_runtime._resolved_fallback_model = "resolved-fallback-model"
     original_runtime._resolved_fallback_profile = None
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(seed=_seed())
 
     resumed_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
@@ -370,33 +381,21 @@ def test_codex_profile_drift_is_rejected_when_constructor_model_is_absent() -> N
     resumed_runtime._codex_profile = "zep-proxy-b"
     resumed_runtime._resolved_fallback_model = "resolved-fallback-model"
     resumed_runtime._resolved_fallback_profile = None
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    persisted_identity = persisted["model_routing"]["runtime_execution"]["identity"]
-    assert persisted_identity == {
-        "codex_config_fingerprint": original_runtime._codex_config_fingerprint,
-        "codex_profile": "zep-proxy-a",
-        "effective_model_observed": True,
-        "fallback_model": "resolved-fallback-model",
-        "fallback_profile": "zep-proxy-a",
-        "kind": "codex_cli_v1",
-        "llm_backend": "codex",
-        "profile_resolution_fingerprint": (original_runtime._profile_resolution_fingerprint),
-        "resume_handle_selector": {
-            "backend": "codex_cli",
-            "kind": "agent_runtime",
-            "selectors": {},
-        },
-        "runtime_profile": "zep-runtime",
-    }
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
+    assert (
+        original_contract["foundation_a_authority"]["correlation_id"]
+        != resumed_contract["foundation_a_authority"]["correlation_id"]
+    )
 
 
-def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
+def test_codex_resolved_fallback_state_stays_out_of_durable_runtime_identity() -> None:
     original_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -404,7 +403,7 @@ def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
     )
     original_runtime._resolved_fallback_model = "gpt-original"
     original_runtime._resolved_fallback_profile = None
-    persisted = OrchestratorRunner(
+    original_contract = OrchestratorRunner(
         original_runtime,
         AsyncMock(),
         MagicMock(),
@@ -417,16 +416,17 @@ def test_codex_resolved_fallback_model_drift_is_rejected() -> None:
     )
     resumed_runtime._resolved_fallback_model = "gpt-changed"
     resumed_runtime._resolved_fallback_profile = None
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
 
-def test_codex_profile_name_alone_does_not_prove_an_effective_model(
+def test_codex_profile_name_alone_stays_process_local(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -441,18 +441,10 @@ def test_codex_profile_name_alone_does_not_prove_an_effective_model(
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     persisted = runner._build_execution_contract(seed=_seed())
 
-    assert (
-        persisted["model_routing"]["runtime_execution"]["identity"]["effective_model_observed"]
-        is False
-    )
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
-def test_non_codex_subclass_does_not_inherit_codex_profile_as_model_identity(
+def test_non_codex_runtime_does_not_inherit_codex_profile_as_model_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -466,17 +458,7 @@ def test_non_codex_subclass_does_not_inherit_codex_profile_as_model_identity(
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     persisted = runner._build_execution_contract(seed=_seed())
 
-    assert persisted["model_routing"]["runtime_execution"]["identity"] == {
-        "kind": "goose_v1",
-        "fallback_model": None,
-        "effective_model_observed": False,
-        "llm_backend": "goose",
-    }
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
 def test_runtime_model_sentinel_is_not_persisted_as_a_constructor_pin(
@@ -498,14 +480,10 @@ def test_runtime_model_sentinel_is_not_persisted_as_a_constructor_pin(
         "observed": True,
         "model": None,
     }
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        runner._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(persisted)
 
 
-def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
+def test_codex_profile_file_changes_do_not_create_a_portable_runtime_identity(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -526,7 +504,7 @@ def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
     )
     original_runtime._codex_profile = "stable-name"
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(seed=_seed())
 
     profile_path.write_text('model_provider = "proxy-b"\n', encoding="utf-8")
     resumed_runtime = CodexCliRuntime(
@@ -535,16 +513,17 @@ def test_codex_profile_file_drift_is_rejected_even_with_native_routing(
         cwd="/tmp/project",
     )
     resumed_runtime._codex_profile = "stable-name"
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
 
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
 
-def test_codex_home_drift_is_rejected_for_persisted_thread_store(
+def test_codex_home_changes_do_not_create_a_portable_runtime_identity(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -558,7 +537,7 @@ def test_codex_home_drift_is_rejected_for_persisted_thread_store(
         model=None,
         cwd="/tmp/project",
     )
-    persisted = OrchestratorRunner(
+    original_contract = OrchestratorRunner(
         original_runtime,
         AsyncMock(),
         MagicMock(),
@@ -570,62 +549,33 @@ def test_codex_home_drift_is_rejected_for_persisted_thread_store(
         model=None,
         cwd="/tmp/project",
     )
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
-
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
-
-
-def test_codex_implementation_role_mapping_drift_is_rejected() -> None:
-    original_config = OuroborosConfig(
-        llm_profiles={
-            "standard": {"providers": {"codex": {"profile": "stable"}}},
-            "frontier": {"providers": {"codex": {"profile": "changed"}}},
-        },
-        llm_role_profiles={
-            "agent_runtime": "standard",
-            "agent_runtime_implementation": "standard",
-        },
-    )
-    drifted_config = original_config.model_copy(
-        update={
-            "llm_role_profiles": {
-                "agent_runtime": "standard",
-                "agent_runtime_implementation": "frontier",
-            }
-        }
-    )
-
-    with patch("ouroboros.providers.profiles.load_config", return_value=original_config):
-        original_runtime = CodexCliRuntime(
-            cli_path="/bin/echo",
-            model=None,
-            cwd="/tmp/project",
-        )
-    persisted = OrchestratorRunner(
-        original_runtime,
+    resumed_contract = OrchestratorRunner(
+        resumed_runtime,
         AsyncMock(),
         MagicMock(),
     )._build_execution_contract(seed=_seed())
 
-    with patch("ouroboros.providers.profiles.load_config", return_value=drifted_config):
-        resumed_runtime = CodexCliRuntime(
-            cli_path="/bin/echo",
-            model=None,
-            cwd="/tmp/project",
-        )
-    resumed = OrchestratorRunner(resumed_runtime, AsyncMock(), MagicMock())
+    _assert_process_local_runtime_contract(original_contract)
+    _assert_process_local_runtime_contract(resumed_contract)
 
-    assert original_runtime._resolved_fallback_profile == "stable"
-    assert resumed_runtime._resolved_fallback_profile == "stable"
-    with pytest.raises(OrchestratorError, match="different runtime execution profile"):
-        resumed._restore_execution_contract(
-            {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
-            seed=_seed(),
-        )
+
+def test_contract_build_never_asks_codex_for_dynamic_execution_identity() -> None:
+    runtime = CodexCliRuntime(
+        cli_path="/bin/echo",
+        model=None,
+        cwd="/tmp/project",
+    )
+    provider = MagicMock(side_effect=AssertionError("dynamic provider must not run"))
+    runtime.execution_identity_contract = provider  # type: ignore[method-assign]
+
+    contract = OrchestratorRunner(
+        runtime,
+        AsyncMock(),
+        MagicMock(),
+    )._build_execution_contract(seed=_seed())
+
+    _assert_process_local_runtime_contract(contract)
+    provider.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -647,7 +597,7 @@ def test_codex_implementation_role_mapping_drift_is_rejected() -> None:
         ),
     ],
 )
-def test_codex_resume_handle_cannot_inject_command_selection(
+def test_process_local_runtime_never_recomputes_a_resume_handle_selector(
     runtime_handle: RuntimeHandle,
 ) -> None:
     runtime = CodexCliRuntime(
@@ -657,12 +607,15 @@ def test_codex_resume_handle_cannot_inject_command_selection(
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    provider = MagicMock(side_effect=AssertionError("selector provider must not run"))
+    runtime.resume_handle_execution_identity_contract = provider  # type: ignore[method-assign]
 
-    with pytest.raises(OrchestratorError, match="different runtime handle selector"):
-        runner._validate_resume_handle_execution_identity(runtime_handle)
+    runner._validate_resume_handle_execution_identity(runtime_handle)
+
+    provider.assert_not_called()
 
 
-def test_codex_default_resume_handle_matches_start_contract() -> None:
+def test_process_local_runtime_default_handle_requires_no_persisted_selector() -> None:
     runtime = CodexCliRuntime(
         cli_path="/bin/echo",
         model=None,
@@ -670,6 +623,8 @@ def test_codex_default_resume_handle_matches_start_contract() -> None:
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    provider = MagicMock(side_effect=AssertionError("selector provider must not run"))
+    runtime.resume_handle_execution_identity_contract = provider  # type: ignore[method-assign]
 
     runner._validate_resume_handle_execution_identity(
         RuntimeHandle(
@@ -677,6 +632,7 @@ def test_codex_default_resume_handle_matches_start_contract() -> None:
             native_session_id="thread-123",
         )
     )
+    provider.assert_not_called()
 
 
 @pytest.mark.parametrize("backend", ["codex_cli", "goose", "pi", "hermes_cli", "opencode"])
@@ -784,7 +740,7 @@ def test_kill_switched_resume_cannot_drift_to_a_new_constructor_model(
         )
 
 
-def test_unpinned_kill_switched_runtime_cannot_resume_without_effective_identity(
+def test_unpinned_kill_switched_runtime_is_limited_to_process_local_resume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
@@ -795,16 +751,14 @@ def test_unpinned_kill_switched_runtime_cannot_resume_without_effective_identity
         "observed": True,
         "model": None,
     }
-    assert persisted["model_routing"]["runtime_execution"] == {
-        "version": 1,
-        "observed": False,
-    }
-
-    with pytest.raises(OrchestratorError, match="effective runtime model is unverifiable"):
-        _runner(constructor_model=None)._restore_execution_contract(
+    _assert_process_local_runtime_contract(persisted)
+    assert (
+        original._restore_execution_contract(
             {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
             seed=_seed(),
         )
+        is False
+    )
 
 
 def test_kill_switched_contract_still_rejects_cross_backend_resume(
@@ -947,7 +901,7 @@ def test_first_legacy_resume_migrates_resolved_contract() -> None:
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_changed_seed_identity_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_seed_identity_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -972,12 +926,12 @@ async def test_legacy_resume_rejects_changed_seed_identity_before_dispatch() -> 
     result = await runner.resume_session("legacy-seed-mismatch", changed_seed)
 
     assert result.is_err
-    assert "different Seed identity" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_changed_seed_goal_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_seed_goal_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -1002,12 +956,12 @@ async def test_legacy_resume_rejects_changed_seed_goal_before_dispatch() -> None
     )
 
     assert result.is_err
-    assert "modified Seed goal" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_legacy_resume_rejects_cross_backend_before_dispatch() -> None:
+async def test_legacy_resume_fails_closed_before_backend_comparison() -> None:
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -1030,7 +984,7 @@ async def test_legacy_resume_rejects_cross_backend_before_dispatch() -> None:
     result = await runner.resume_session("legacy-backend-mismatch", _seed())
 
     assert result.is_err
-    assert "different runtime backend" in result.error.message
+    assert result.error.details["resume_blocked"] == "process_local_resume_unavailable"
     adapter.execute_task.assert_not_called()
 
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1443,7 +1443,7 @@ class TestOrchestratorRunner:
             )
 
         mock_adapter.execute_task = mock_execute
-        mark_paused = AsyncMock(return_value=Result.ok(None))
+        mark_paused = AsyncMock(return_value=Result.ok(True))
         mark_failed = AsyncMock(return_value=Result.ok(None))
 
         with (
@@ -2068,7 +2068,7 @@ class TestOrchestratorRunner:
             patch.object(
                 runner._session_repo,
                 "mark_paused",
-                AsyncMock(return_value=Result.ok(None)),
+                AsyncMock(return_value=Result.ok(True)),
             ) as mark_paused,
             patch.object(
                 runner._session_repo,
@@ -2216,7 +2216,7 @@ class TestOrchestratorRunner:
                 patch.object(
                     runner._session_repo,
                     "mark_paused",
-                    AsyncMock(return_value=Result.ok(None)),
+                    AsyncMock(return_value=Result.ok(True)),
                 ),
                 patch.object(runner._session_repo, "mark_failed", mark_failed),
             ):
@@ -2272,10 +2272,10 @@ class TestOrchestratorRunner:
                 },
             )
 
-        async def mark_paused(*args: Any, **kwargs: Any) -> Result[None, PersistenceError]:
+        async def mark_paused(*args: Any, **kwargs: Any) -> Result[bool, PersistenceError]:
             del args, kwargs
             await request_cancellation(tracker.session_id)
-            return Result.ok(None)
+            return Result.ok(True)
 
         mock_adapter.execute_task = mock_execute
 
@@ -2808,7 +2808,7 @@ class TestOrchestratorRunner:
                 patch.object(
                     runner._session_repo,
                     "mark_paused",
-                    AsyncMock(return_value=Result.ok(None)),
+                    AsyncMock(return_value=Result.ok(True)),
                 ),
             ):
                 result = await runner._execute_parallel(
@@ -2885,10 +2885,10 @@ class TestOrchestratorRunner:
             total_messages=1,
         )
 
-        async def mark_paused(*args: Any, **kwargs: Any) -> Result[None, PersistenceError]:
+        async def mark_paused(*args: Any, **kwargs: Any) -> Result[bool, PersistenceError]:
             del args, kwargs
             await request_cancellation(tracker.session_id)
-            return Result.ok(None)
+            return Result.ok(True)
 
         try:
             with (

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ouroboros.core.errors import ConfigError
+from ouroboros.core.errors import ConfigError, PersistenceError
 from ouroboros.core.seed import (
     AcceptanceCriterionSpec,
     BrownfieldContext,
@@ -46,6 +46,9 @@ from ouroboros.orchestrator.runner import (
     _seed_has_investment_metadata,
     build_system_prompt,
     build_task_prompt,
+    clear_cancellation,
+    is_cancellation_requested,
+    request_cancellation,
 )
 from ouroboros.orchestrator.runtime_error import classify_subprocess_failure
 from ouroboros.orchestrator.session import SessionStatus, SessionTracker
@@ -1482,6 +1485,73 @@ class TestOrchestratorRunner:
         retrospective.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_execute_precreated_pause_persistence_failure_preserves_owner(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Sequential pause must not report success while durable state is still RUNNING."""
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+
+        tracker = SessionTracker.create(
+            "exec_pause_pending",
+            sample_seed.metadata.seed_id,
+            session_id="sess_pause_pending",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            del args, kwargs
+            yield AgentMessage(
+                type="result",
+                content="Usage limit reached. Please try again in 5 hours.",
+                data={"subtype": "error", "error_type": "CodexCliError"},
+            )
+
+        mock_adapter.execute_task = mock_execute
+        mark_paused = AsyncMock(
+            return_value=Result.err(PersistenceError("pause write unavailable"))
+        )
+
+        try:
+            with patch.object(runner._session_repo, "mark_paused", mark_paused):
+                result = await runner.execute_precreated_session(
+                    seed=sample_seed,
+                    tracker=tracker,
+                    parallel=False,
+                )
+
+            assert result.is_err
+            assert result.error.details["resume_blocked"] == "pause_persistence_pending"
+            assert result.error.details["requested_status"] == SessionStatus.PAUSED.value
+            assert runner._has_live_process_local_authority(
+                tracker.session_id,
+                tracker.execution_id,
+                tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+            )
+            assert is_holder_alive(tracker.session_id)
+            assert tracker.execution_id not in runner.active_sessions
+            terminal_events = [
+                call.args[0]
+                for call in mock_event_store.append.await_args_list
+                if getattr(call.args[0], "type", None) == "execution.terminal"
+            ]
+            assert not terminal_events
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+    @pytest.mark.asyncio
     async def test_execute_precreated_mirrors_the_durable_terminal_cas_winner(
         self,
         runner: OrchestratorRunner,
@@ -2024,6 +2094,137 @@ class TestOrchestratorRunner:
             execution_id=running_tracker.execution_id,
         )
 
+    @pytest.mark.asyncio
+    async def test_resume_pause_persistence_failure_preserves_owner(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Resume pause persistence failure must not masquerade as a PAUSED result."""
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+
+        tracker = SessionTracker.create(
+            "exec_resume_pending",
+            "seed_resume",
+            session_id="sess_resume_pause_pending",
+        ).with_status(
+            SessionStatus.PAUSED,
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id="sess_resume_pause_pending",
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            del args, kwargs
+            yield AgentMessage(
+                type="result",
+                content="Codex rejected the resume command",
+                data={
+                    "subtype": "error",
+                    "recoverable": True,
+                    "recovery": {"kind": "resume_retry"},
+                },
+            )
+
+        mock_adapter.execute_task = mock_execute
+
+        try:
+            with (
+                patch.object(
+                    runner._session_repo,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch.object(
+                    runner._session_repo,
+                    "mark_paused",
+                    AsyncMock(return_value=Result.err(PersistenceError("pause write unavailable"))),
+                ),
+            ):
+                result = await runner.resume_session(tracker.session_id, sample_seed)
+
+            assert result.is_err
+            assert result.error.details["resume_blocked"] == "pause_persistence_pending"
+            assert runner._has_live_process_local_authority(
+                tracker.session_id,
+                tracker.execution_id,
+                tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+            )
+            assert is_holder_alive(tracker.session_id)
+            assert tracker.execution_id not in runner.active_sessions
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+    @pytest.mark.asyncio
+    async def test_resume_pause_preserves_late_cancellation_marker(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """A cancellation arriving during resumed pause publication is not acknowledged."""
+        tracker = SessionTracker.create(
+            "exec_resume_cancel",
+            "seed_resume",
+            session_id="sess_resume_pause_cancel",
+        ).with_status(
+            SessionStatus.PAUSED,
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id="sess_resume_pause_cancel",
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            del args, kwargs
+            yield AgentMessage(
+                type="result",
+                content="Codex rejected the resume command",
+                data={
+                    "subtype": "error",
+                    "recoverable": True,
+                    "recovery": {"kind": "resume_retry"},
+                },
+            )
+
+        async def mark_paused(*args: Any, **kwargs: Any) -> Result[None, PersistenceError]:
+            del args, kwargs
+            await request_cancellation(tracker.session_id)
+            return Result.ok(None)
+
+        mock_adapter.execute_task = mock_execute
+
+        try:
+            with (
+                patch.object(
+                    runner._session_repo,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch.object(runner._session_repo, "mark_paused", mark_paused),
+            ):
+                result = await runner.resume_session(tracker.session_id, sample_seed)
+
+            assert result.is_ok
+            assert await is_cancellation_requested(tracker.session_id)
+        finally:
+            await clear_cancellation(tracker.session_id)
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
     def test_recoverable_failure_ignores_ordinary_429(
         self,
         runner: OrchestratorRunner,
@@ -2376,6 +2577,178 @@ class TestOrchestratorRunner:
         assert pause is not None
         assert pause.pause_seconds == 18000
         assert pause.resume_after == now + timedelta(hours=5)
+
+    @pytest.mark.asyncio
+    async def test_parallel_pause_persistence_failure_preserves_owner(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """Parallel pause persistence failure must remain typed and retryable."""
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create(
+            "exec_parallel_pause_pending",
+            sample_seed.metadata.seed_id,
+            session_id="sess_parallel_pause_pending",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._register_session(tracker.execution_id, tracker.session_id)
+        message = AgentMessage(
+            type="result",
+            content="Quota window exhausted. Retry after 2 hours.",
+            data={"subtype": "error", "error_type": "OpenCodeError"},
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=False,
+                    messages=(message,),
+                    final_message=message.content,
+                ),
+            ),
+            success_count=0,
+            failure_count=1,
+            total_messages=1,
+        )
+
+        try:
+            with (
+                patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+                patch(
+                    "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                    AsyncMock(return_value=parallel_result),
+                ),
+                patch.object(
+                    runner._session_repo,
+                    "mark_paused",
+                    AsyncMock(return_value=Result.err(PersistenceError("pause write unavailable"))),
+                ),
+            ):
+                result = await runner._execute_parallel(
+                    seed=sample_seed,
+                    exec_id=tracker.execution_id,
+                    tracker=tracker,
+                    merged_tools=["Read"],
+                    tool_catalog=assemble_session_tool_catalog(["Read"]),
+                    system_prompt="system",
+                    start_time=tracker.start_time,
+                    force_sequential_levels=True,
+                )
+
+            assert result.is_err
+            assert result.error.details["resume_blocked"] == "pause_persistence_pending"
+            assert runner._has_live_process_local_authority(
+                tracker.session_id,
+                tracker.execution_id,
+                tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+            )
+            assert is_holder_alive(tracker.session_id)
+            assert tracker.execution_id not in runner.active_sessions
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+    @pytest.mark.asyncio
+    async def test_parallel_pause_preserves_late_cancellation_marker(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """A cancellation arriving during parallel pause publication remains pending."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create(
+            "exec_parallel_pause_cancel",
+            sample_seed.metadata.seed_id,
+            session_id="sess_parallel_pause_cancel",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._register_session(tracker.execution_id, tracker.session_id)
+        message = AgentMessage(
+            type="result",
+            content="Quota window exhausted. Retry after 2 hours.",
+            data={"subtype": "error", "error_type": "OpenCodeError"},
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=False,
+                    messages=(message,),
+                    final_message=message.content,
+                ),
+            ),
+            success_count=0,
+            failure_count=1,
+            total_messages=1,
+        )
+
+        async def mark_paused(*args: Any, **kwargs: Any) -> Result[None, PersistenceError]:
+            del args, kwargs
+            await request_cancellation(tracker.session_id)
+            return Result.ok(None)
+
+        try:
+            with (
+                patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+                patch(
+                    "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                    AsyncMock(return_value=parallel_result),
+                ),
+                patch.object(runner._session_repo, "mark_paused", mark_paused),
+            ):
+                result = await runner._execute_parallel(
+                    seed=sample_seed,
+                    exec_id=tracker.execution_id,
+                    tracker=tracker,
+                    merged_tools=["Read"],
+                    tool_catalog=assemble_session_tool_catalog(["Read"]),
+                    system_prompt="system",
+                    start_time=tracker.start_time,
+                    force_sequential_levels=True,
+                )
+
+            assert result.is_ok
+            assert await is_cancellation_requested(tracker.session_id)
+        finally:
+            await clear_cancellation(tracker.session_id)
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
 
     @pytest.mark.asyncio
     async def test_resume_session_allows_paused_sessions(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2164,6 +2164,81 @@ class TestOrchestratorRunner:
             runner._unregister_session(tracker.execution_id, tracker.session_id)
 
     @pytest.mark.asyncio
+    async def test_resume_paused_projection_failure_preserves_owner(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Resume auxiliary failure after PAUSED cannot enter generic FAILED cleanup."""
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+
+        tracker = SessionTracker.create(
+            "exec_resume_projection",
+            "seed_resume",
+            session_id="sess_resume_projection",
+        ).with_status(SessionStatus.PAUSED)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            del args, kwargs
+            yield AgentMessage(
+                type="result",
+                content="Codex rejected the resume command",
+                data={
+                    "subtype": "error",
+                    "recoverable": True,
+                    "recovery": {"kind": "resume_retry"},
+                },
+            )
+
+        async def append(event: BaseEvent) -> None:
+            if event.type == "execution.terminal":
+                raise PersistenceError("execution projection unavailable")
+
+        mock_adapter.execute_task = mock_execute
+        mock_event_store.append.side_effect = append
+        mark_failed = AsyncMock(return_value=Result.ok(True))
+
+        try:
+            with (
+                patch.object(
+                    runner._session_repo,
+                    "reconstruct_session",
+                    AsyncMock(return_value=Result.ok(tracker)),
+                ),
+                patch.object(
+                    runner._session_repo,
+                    "mark_paused",
+                    AsyncMock(return_value=Result.ok(None)),
+                ),
+                patch.object(runner._session_repo, "mark_failed", mark_failed),
+            ):
+                result = await runner.resume_session(tracker.session_id, sample_seed)
+
+            assert result.is_ok
+            assert result.value.success is False
+            mark_failed.assert_not_awaited()
+            assert runner._has_live_process_local_authority(
+                tracker.session_id,
+                tracker.execution_id,
+                tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+            )
+            assert is_holder_alive(tracker.session_id)
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+    @pytest.mark.asyncio
     async def test_resume_pause_preserves_late_cancellation_marker(
         self,
         runner: OrchestratorRunner,
@@ -2660,6 +2735,101 @@ class TestOrchestratorRunner:
             )
             assert is_holder_alive(tracker.session_id)
             assert tracker.execution_id not in runner.active_sessions
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+            runner._unregister_session(tracker.execution_id, tracker.session_id)
+
+    @pytest.mark.asyncio
+    async def test_parallel_paused_projection_failure_preserves_owner(
+        self,
+        runner: OrchestratorRunner,
+        mock_event_store: AsyncMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Parallel auxiliary failure after PAUSED cannot escape into FAILED cleanup."""
+        from ouroboros.orchestrator.heartbeat import is_holder_alive
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create(
+            "exec_parallel_projection",
+            sample_seed.metadata.seed_id,
+            session_id="sess_parallel_projection",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+        generation, already_claimed = runner._claim_process_local_authority_generation(
+            tracker.session_id,
+            tracker.execution_id,
+            tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+        )
+        assert generation is not None
+        assert already_claimed is False
+        runner._register_session(tracker.execution_id, tracker.session_id)
+        message = AgentMessage(
+            type="result",
+            content="Quota window exhausted. Retry after 2 hours.",
+            data={"subtype": "error", "error_type": "OpenCodeError"},
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=False,
+                    messages=(message,),
+                    final_message=message.content,
+                ),
+            ),
+            success_count=0,
+            failure_count=1,
+            total_messages=1,
+        )
+
+        async def append(event: BaseEvent) -> None:
+            if event.type == "execution.terminal":
+                raise PersistenceError("execution projection unavailable")
+
+        mock_event_store.append.side_effect = append
+
+        try:
+            with (
+                patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+                patch(
+                    "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                    AsyncMock(return_value=parallel_result),
+                ),
+                patch.object(
+                    runner._session_repo,
+                    "mark_paused",
+                    AsyncMock(return_value=Result.ok(None)),
+                ),
+            ):
+                result = await runner._execute_parallel(
+                    seed=sample_seed,
+                    exec_id=tracker.execution_id,
+                    tracker=tracker,
+                    merged_tools=["Read"],
+                    tool_catalog=assemble_session_tool_catalog(["Read"]),
+                    system_prompt="system",
+                    start_time=tracker.start_time,
+                    force_sequential_levels=True,
+                )
+
+            assert result.is_ok
+            assert result.value.success is False
+            assert runner._has_live_process_local_authority(
+                tracker.session_id,
+                tracker.execution_id,
+                tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY],
+            )
+            assert is_holder_alive(tracker.session_id)
         finally:
             runner._retire_process_local_authority(
                 session_id=tracker.session_id,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1886,17 +1886,29 @@ class TestOrchestratorRunner:
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
             SessionStatus.PAUSED
         )
-        with (
-            patch.object(
-                runner._session_repo,
-                "reconstruct_session",
-                return_value=Result.ok(running_tracker),
-            ),
-            patch.object(runner, "_get_merged_tools", AsyncMock()) as get_merged_tools,
-            patch.object(mock_adapter, "execute_task", AsyncMock()) as execute_task,
-            patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
-        ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume",
+        )
+        try:
+            with (
+                patch.object(
+                    runner._session_repo,
+                    "reconstruct_session",
+                    return_value=Result.ok(running_tracker),
+                ),
+                patch.object(runner, "_get_merged_tools", AsyncMock()) as get_merged_tools,
+                patch.object(mock_adapter, "execute_task", AsyncMock()) as execute_task,
+                patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+            ):
+                result = await runner.resume_session("sess_resume", sample_seed)
+        finally:
+            runner._retire_process_local_authority(
+                session_id="sess_resume",
+                execution_id=running_tracker.execution_id,
+            )
 
         assert result.is_err
         assert "Resume is blocked" in result.error.message
@@ -1904,7 +1916,7 @@ class TestOrchestratorRunner:
         assert result.error.details["resume_blocked"] == "typed_evidence_gate_required"
         get_merged_tools.assert_not_called()
         execute_task.assert_not_called()
-        release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
+        release_lock_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resume_investment_seed_is_blocked_before_ungated_direct_execution(
@@ -1941,18 +1953,30 @@ class TestOrchestratorRunner:
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
             SessionStatus.PAUSED
         )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            investment_seed,
+            session_id="sess_resume",
+        )
 
-        with (
-            patch.object(
-                runner._session_repo,
-                "reconstruct_session",
-                return_value=Result.ok(running_tracker),
-            ),
-            patch.object(runner, "_get_merged_tools", AsyncMock()) as get_merged_tools,
-            patch.object(mock_adapter, "execute_task", AsyncMock()) as execute_task,
-            patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
-        ):
-            result = await runner.resume_session("sess_resume", investment_seed)
+        try:
+            with (
+                patch.object(
+                    runner._session_repo,
+                    "reconstruct_session",
+                    return_value=Result.ok(running_tracker),
+                ),
+                patch.object(runner, "_get_merged_tools", AsyncMock()) as get_merged_tools,
+                patch.object(mock_adapter, "execute_task", AsyncMock()) as execute_task,
+                patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+            ):
+                result = await runner.resume_session("sess_resume", investment_seed)
+        finally:
+            runner._retire_process_local_authority(
+                session_id="sess_resume",
+                execution_id=running_tracker.execution_id,
+            )
 
         assert result.is_err
         assert "Resume is blocked" in result.error.message
@@ -1960,7 +1984,7 @@ class TestOrchestratorRunner:
         assert result.error.details["resume_blocked"] == "investment_authority_required"
         get_merged_tools.assert_not_called()
         execute_task.assert_not_called()
-        release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
+        release_lock_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resume_session_tool_setup_failure_cleans_up_workspace_lock(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -39,6 +39,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelExecutionResult
 from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
 from ouroboros.orchestrator.runner import (
+    EXECUTION_CONTRACT_PROGRESS_KEY,
     OrchestratorError,
     OrchestratorResult,
     OrchestratorRunner,
@@ -61,6 +62,29 @@ def _task_workspace() -> TaskWorkspace:
         branch="ooo/orch_test",
         lock_path="/tmp/worktree/.locks/repo/orch_test.json",
     )
+
+
+def _attach_live_process_local_contract(
+    runner: OrchestratorRunner,
+    tracker: SessionTracker,
+    seed: Seed,
+    *,
+    session_id: str,
+) -> SessionTracker:
+    """Build the same-process capability required by resume-focused tests."""
+    if not isinstance(getattr(runner._adapter, "llm_backend", None), str):
+        runner._adapter.llm_backend = "test-llm"
+    if not isinstance(getattr(runner._adapter, "_model", None), str):
+        runner._adapter._model = "test-model"
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    return tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
 
 
 def test_seed_investment_detection_supports_legacy_string_criteria(sample_seed: Seed) -> None:
@@ -664,7 +688,13 @@ class TestOrchestratorRunner:
         from ouroboros.core.types import Result
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -723,7 +753,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -770,21 +806,27 @@ class TestOrchestratorRunner:
                 session_id="orch_prepared",
             )
 
-        assert result.is_ok
-        assert result.value.session_id == tracker.session_id
-        assert result.value.progress["fat_harness_mode"] is False
-        assert result.value.messages_processed == 0
-        assert runner._execution_contract is not None
-        create_session.assert_awaited_once_with(
-            execution_id="exec_prepared",
-            seed_id=sample_seed.metadata.seed_id,
-            session_id="orch_prepared",
-            seed_goal=sample_seed.goal,
-            # Backend is forwarded so the live dashboard can provider-tag the run.
-            runtime_backend=runner._adapter.runtime_backend,
-            llm_backend=runner._adapter.llm_backend,
-            execution_contract=runner._execution_contract,
-        )
+        try:
+            assert result.is_ok
+            assert result.value.session_id == tracker.session_id
+            assert result.value.progress["fat_harness_mode"] is False
+            assert result.value.messages_processed == 0
+            assert runner._execution_contract is not None
+            create_session.assert_awaited_once_with(
+                execution_id="exec_prepared",
+                seed_id=sample_seed.metadata.seed_id,
+                session_id="orch_prepared",
+                seed_goal=sample_seed.goal,
+                # Backend is forwarded so the live dashboard can provider-tag the run.
+                runtime_backend=runner._adapter.runtime_backend,
+                llm_backend=runner._adapter.llm_backend,
+                execution_contract=runner._execution_contract,
+            )
+        finally:
+            runner._retire_process_local_authority(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
 
     @pytest.mark.asyncio
     async def test_prepare_session_fails_when_initial_contract_cannot_persist(
@@ -828,6 +870,7 @@ class TestOrchestratorRunner:
             "orch_prepared",
             "Failed to persist initial session contract",
             {
+                "session_id": "orch_prepared",
                 "execution_id": "exec_prepared",
                 "fat_harness_mode": False,
                 "cause": "store unavailable",
@@ -862,7 +905,11 @@ class TestOrchestratorRunner:
 
         assert result.is_ok
         assert result.value == orchestrator_result
-        prepare_session.assert_awaited_once_with(sample_seed, execution_id="exec_delegated")
+        prepare_session.assert_awaited_once_with(
+            sample_seed,
+            execution_id="exec_delegated",
+            session_id=None,
+        )
         execute_precreated.assert_awaited_once_with(
             seed=sample_seed,
             tracker=tracker,
@@ -898,7 +945,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -954,7 +1007,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1167,7 +1226,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1255,7 +1320,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1316,7 +1387,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_failed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -1342,6 +1419,12 @@ class TestOrchestratorRunner:
             "exec_usage_limit",
             sample_seed.metadata.seed_id,
             session_id="sess_usage_limit",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
         )
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -1416,7 +1499,13 @@ class TestOrchestratorRunner:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         mark_failed = AsyncMock(return_value=Result.ok(None))
 
@@ -1500,7 +1589,11 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
             fat_harness_mode=False,
         )
-        tracker = SessionTracker.create("exec_setup", sample_seed.metadata.seed_id)
+        tracker = SessionTracker.create(
+            "exec_setup",
+            sample_seed.metadata.seed_id,
+            session_id="orch_setup",
+        )
 
         with (
             patch.object(runner._session_repo, "create_session", return_value=Result.ok(tracker)),
@@ -1515,7 +1608,11 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.execute_seed(sample_seed, execution_id="exec_setup")
+            result = await runner.execute_seed(
+                sample_seed,
+                execution_id="exec_setup",
+                session_id=tracker.session_id,
+            )
 
         assert result.is_err
         unregister_mock.assert_called_once_with("exec_setup", tracker.session_id)
@@ -1539,7 +1636,11 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
             fat_harness_mode=False,
         )
-        tracker = SessionTracker.create("exec_tools", sample_seed.metadata.seed_id)
+        tracker = SessionTracker.create(
+            "exec_tools",
+            sample_seed.metadata.seed_id,
+            session_id="orch_tools",
+        )
 
         with (
             patch.object(runner._session_repo, "create_session", return_value=Result.ok(tracker)),
@@ -1547,7 +1648,11 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.execute_seed(sample_seed, execution_id="exec_tools")
+            result = await runner.execute_seed(
+                sample_seed,
+                execution_id="exec_tools",
+                session_id=tracker.session_id,
+            )
 
         assert result.is_err
         unregister_mock.assert_called_once_with("exec_tools", tracker.session_id)
@@ -1630,9 +1735,8 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
-
         with (
             patch.object(
                 runner._session_repo,
@@ -1686,7 +1790,7 @@ class TestOrchestratorRunner:
             task_workspace=_task_workspace(),
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
 
         with (
@@ -1728,7 +1832,13 @@ class TestOrchestratorRunner:
             fat_harness_mode=False,
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_tool_setup",
         )
 
         with (
@@ -1741,10 +1851,10 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session") as unregister_mock,
             patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_tool_setup", sample_seed)
 
         assert result.is_err
-        unregister_mock.assert_called_once_with("exec_resume", "sess_resume")
+        unregister_mock.assert_called_once_with("exec_resume", "sess_resume_tool_setup")
         release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
 
     @pytest.mark.asyncio
@@ -1775,7 +1885,13 @@ class TestOrchestratorRunner:
     ) -> None:
         """Recoverable resume bootstrap failures should not poison the session."""
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_recoverable",
         )
         runtime_handle = RuntimeHandle(backend="codex_cli", native_session_id="thread-123")
 
@@ -1816,7 +1932,7 @@ class TestOrchestratorRunner:
                 AsyncMock(return_value=False),
             ) as retrospective,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_recoverable", sample_seed)
 
         assert result.is_ok
         assert result.value.success is False
@@ -1824,6 +1940,10 @@ class TestOrchestratorRunner:
         mark_paused.assert_awaited_once()
         mark_failed.assert_not_called()
         retrospective.assert_not_awaited()
+        runner._retire_process_local_authority(
+            session_id="sess_resume_recoverable",
+            execution_id=running_tracker.execution_id,
+        )
 
     def test_recoverable_failure_ignores_ordinary_429(
         self,
@@ -2189,6 +2309,12 @@ class TestOrchestratorRunner:
         paused_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
             SessionStatus.PAUSED
         )
+        paused_tracker = _attach_live_process_local_contract(
+            runner,
+            paused_tracker,
+            sample_seed,
+            session_id="sess_resume_paused",
+        )
         runtime_handle = RuntimeHandle(backend="codex_cli", native_session_id="thread-123")
 
         async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
@@ -2214,7 +2340,7 @@ class TestOrchestratorRunner:
                 AsyncMock(return_value=Result.ok(None)),
             ) as mark_completed,
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_paused", sample_seed)
 
         assert result.is_ok
         assert result.value.success is True
@@ -2317,9 +2443,15 @@ class TestOrchestratorRunner:
             native_session_id="sess_runtime",
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
         running_tracker = running_tracker.with_progress({"runtime": runtime_handle.to_dict()})
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_runtime_handle",
+        )
 
         captured_kwargs: dict[str, Any] = {}
 
@@ -2344,7 +2476,7 @@ class TestOrchestratorRunner:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_completed", mock_mark_completed),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_runtime_handle", sample_seed)
 
         assert result.is_ok
         resume_handle = captured_kwargs["resume_handle"]
@@ -2479,13 +2611,19 @@ class TestOrchestratorRunner:
         """Resume should rebuild workflow state from persisted progress before streaming."""
         runtime_handle = RuntimeHandle(backend="opencode", native_session_id="oc-session-123")
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
         )
         running_tracker = running_tracker.with_progress(
             {
                 "runtime": runtime_handle.to_dict(),
                 "messages_processed": 4,
             }
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_progress",
         )
 
         async def mock_reconstruct(*args: Any, **kwargs: Any):
@@ -2507,7 +2645,7 @@ class TestOrchestratorRunner:
             BaseEvent(
                 type="orchestrator.progress.updated",
                 aggregate_type="session",
-                aggregate_id="sess_resume",
+                aggregate_id="sess_resume_progress",
                 data={
                     "message_type": "assistant",
                     "content_preview": "[AC_COMPLETE: 1] Finished the first criterion.",
@@ -2524,7 +2662,7 @@ class TestOrchestratorRunner:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_completed", mock_mark_completed),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_progress", sample_seed)
 
         assert result.is_ok
         workflow_events = [
@@ -2782,6 +2920,12 @@ class TestOrchestratorRunner:
             fat_harness_mode=True,
         )
         tracker = SessionTracker.create("exec_profile_prompt", sample_seed.metadata.seed_id)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2838,6 +2982,12 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            single_ac_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2893,6 +3043,12 @@ class TestOrchestratorRunner:
         )
         tracker = SessionTracker.create("exec_investment_single", investment_seed.metadata.seed_id)
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -2946,6 +3102,12 @@ class TestOrchestratorRunner:
             investment_seed.metadata.seed_id,
         )
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3004,6 +3166,12 @@ class TestOrchestratorRunner:
             investment_seed.metadata.seed_id,
         )
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            investment_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3049,6 +3217,12 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3084,6 +3258,12 @@ class TestOrchestratorRunner:
 
         tracker = SessionTracker.create("exec_forced", sample_seed.metadata.seed_id)
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
         expected = Result.ok(
             OrchestratorResult(
                 success=True,
@@ -3537,7 +3717,13 @@ class TestOrchestratorRunner:
         from ouroboros.core.types import Result
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4225,7 +4411,13 @@ class TestOrchestratorRunnerWithMCP:
 
         # Mock session creation
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4378,7 +4570,13 @@ class TestCancellationPolling:
         mock_event_store.query_events = AsyncMock(side_effect=[[], [cancel_event]])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_cancelled(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4420,7 +4618,13 @@ class TestCancellationPolling:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def mock_mark_completed(*args: Any, **kwargs: Any):
             return Result.ok(None)
@@ -4458,11 +4662,17 @@ class TestCancellationPolling:
 
         mock_adapter.execute_task = mock_execute
 
-        cancel_event = create_session_cancelled_event("sess_resume", "User requested")
+        cancel_event = create_session_cancelled_event("sess_resume_cancelled", "User requested")
         mock_event_store.query_events = AsyncMock(return_value=[cancel_event])
 
         running_tracker = SessionTracker.create("exec_resume", "seed_1").with_status(
-            SessionStatus.RUNNING
+            SessionStatus.PAUSED
+        )
+        running_tracker = _attach_live_process_local_contract(
+            runner,
+            running_tracker,
+            sample_seed,
+            session_id="sess_resume_cancelled",
         )
 
         async def mock_reconstruct(*args: Any, **kwargs: Any):
@@ -4475,7 +4685,7 @@ class TestCancellationPolling:
             patch.object(runner._session_repo, "reconstruct_session", mock_reconstruct),
             patch.object(runner._session_repo, "mark_cancelled", mock_mark_cancelled),
         ):
-            result = await runner.resume_session("sess_resume", sample_seed)
+            result = await runner.resume_session("sess_resume_cancelled", sample_seed)
 
         assert result.is_ok
         assert result.value.success is False

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1648,7 +1648,7 @@ class TestOrchestratorRunner:
         mock_console: MagicMock,
         sample_seed: Seed,
     ) -> None:
-        """Start-event failures should release the workspace lock and unregister the session."""
+        """A terminal-write failure releases effects but preserves the live lease."""
         from ouroboros.core.types import Result
 
         runner = OrchestratorRunner(
@@ -1684,8 +1684,18 @@ class TestOrchestratorRunner:
             )
 
         assert result.is_err
-        unregister_mock.assert_called_once_with("exec_setup", tracker.session_id)
+        assert result.error.details["resume_blocked"] == "terminal_persistence_pending"
+        unregister_mock.assert_called_once_with(
+            "exec_setup",
+            tracker.session_id,
+            release_liveness_lease=False,
+        )
         release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id="exec_setup",
+        )
+        runner._unregister_session("exec_setup", tracker.session_id)
 
     @pytest.mark.asyncio
     async def test_execute_seed_tool_setup_failure_cleans_up_workspace_lock(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1482,6 +1482,75 @@ class TestOrchestratorRunner:
         retrospective.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_execute_precreated_mirrors_the_durable_terminal_cas_winner(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Seed,
+    ) -> None:
+        """A concurrent terminal winner must replace the requested completion mirror."""
+        tracker = SessionTracker.create(
+            "exec_terminal_cas_winner",
+            sample_seed.metadata.seed_id,
+            session_id="sess_terminal_cas_winner",
+        )
+        tracker = _attach_live_process_local_contract(
+            runner,
+            tracker,
+            sample_seed,
+            session_id=tracker.session_id,
+        )
+        cancelled_tracker = tracker.with_status(SessionStatus.CANCELLED)
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            del args, kwargs
+            yield AgentMessage(
+                type="result",
+                content="Completed after cancellation won",
+                data={"subtype": "success"},
+            )
+
+        mock_adapter.execute_task = mock_execute
+        mark_completed = AsyncMock(return_value=Result.ok(False))
+
+        with (
+            patch.object(runner, "_register_session"),
+            patch.object(runner, "_unregister_session"),
+            patch.object(runner._session_repo, "mark_completed", mark_completed),
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(cancelled_tracker)),
+            ),
+            patch.object(
+                runner,
+                "_report_frugality_retrospective",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            result = await runner.execute_precreated_session(
+                seed=sample_seed,
+                tracker=tracker,
+                parallel=False,
+            )
+
+        assert result.is_ok
+        assert result.value.success is False
+        mark_completed.assert_awaited_once()
+        terminal_events = [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if getattr(call.args[0], "type", None) == "execution.terminal"
+        ]
+        assert terminal_events[-1].data["status"] == SessionStatus.CANCELLED.value
+        assert not [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if getattr(call.args[0], "type", None) == "orchestrator.session.completed"
+        ]
+
+    @pytest.mark.asyncio
     async def test_execute_seed_exception_marks_session_failed(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -5336,7 +5336,7 @@ class TestCancellationPolling:
         )
 
         # Ensure clean state
-        _cancellation_registry.discard("sess_inmem")
+        _cancellation_registry.pop("sess_inmem", None)
 
         await request_cancellation("sess_inmem")
         try:

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -506,11 +506,23 @@ class TestCancelExecution:
                 )
             ]
         )
+        legacy_tracker = SessionTracker.create(
+            "exec_orphan",
+            "seed_orphan",
+            session_id="sess_orphan",
+        )
 
-        with patch.object(
-            runner._session_repo,
-            "mark_cancelled",
-            return_value=Result.ok(None),
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                return_value=Result.ok(legacy_tracker),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                return_value=Result.ok(None),
+            ),
         ):
             result = await runner.cancel_execution(
                 "exec_orphan",
@@ -556,11 +568,23 @@ class TestCancelExecution:
                 )
             ]
         )
+        legacy_tracker = SessionTracker.create(
+            "exec_1",
+            "seed_1",
+            session_id="sess_1",
+        )
 
-        with patch.object(
-            runner._session_repo,
-            "mark_cancelled",
-            return_value=Result.err(PersistenceError("DB error")),
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                return_value=Result.ok(legacy_tracker),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                return_value=Result.err(PersistenceError("DB error")),
+            ),
         ):
             result = await runner.cancel_execution("exec_1")
 

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -608,7 +608,11 @@ class TestInFlightCancellation:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            tracker = SessionTracker.create("exec_test", sample_seed.metadata.seed_id)
+            tracker = SessionTracker.create(
+                str(kwargs["execution_id"]),
+                str(kwargs["seed_id"]),
+                session_id=str(kwargs["session_id"]),
+            )
             return Result.ok(tracker)
 
         # Set up the cancellation to trigger at the right time
@@ -661,7 +665,13 @@ class TestInFlightCancellation:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_test", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         async def tracking_check(session_id):
             check_calls.append(session_id)
@@ -725,7 +735,13 @@ class TestSessionLifecycleTracking:
         mock_event_store.query_events = AsyncMock(return_value=[])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_test", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             with patch.object(runner._session_repo, "mark_completed", return_value=Result.ok(None)):
@@ -757,7 +773,13 @@ class TestSessionLifecycleTracking:
         mock_adapter.execute_task = mock_execute
 
         async def mock_create_session(*args: Any, **kwargs: Any):
-            return Result.ok(SessionTracker.create("exec_crash", sample_seed.metadata.seed_id))
+            return Result.ok(
+                SessionTracker.create(
+                    str(kwargs["execution_id"]),
+                    str(kwargs["seed_id"]),
+                    session_id=str(kwargs["session_id"]),
+                )
+            )
 
         with patch.object(runner._session_repo, "create_session", mock_create_session):
             result = await runner.execute_seed(

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -173,6 +173,30 @@ class TestSessionRegistration:
         assert "exec_1" in runner.active_sessions
         assert runner.active_sessions["exec_1"] == "sess_1"
 
+    def test_register_session_does_not_publish_when_lease_acquisition_fails(
+        self,
+        runner: OrchestratorRunner,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """A rejected foreign lease must not leave a cancel route behind."""
+        from ouroboros.orchestrator import heartbeat
+
+        monkeypatch.setattr(heartbeat, "LOCK_DIR", tmp_path)
+        path = heartbeat.lock_path("sess_held_elsewhere")
+        path.write_text("999999:0")
+
+        if heartbeat.fcntl is None:
+            pytest.skip("requires advisory file locks")
+
+        with (
+            patch.object(heartbeat.fcntl, "flock", side_effect=BlockingIOError),
+            pytest.raises(OSError, match="liveness lease is held"),
+        ):
+            runner._register_session("exec_held_elsewhere", "sess_held_elsewhere")
+
+        assert "exec_held_elsewhere" not in runner.active_sessions
+
     def test_unregister_session(self, runner: OrchestratorRunner) -> None:
         """Test unregistering a session."""
         runner._register_session("exec_1", "sess_1")

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.runner import (
     ExecutionCancelledError,
     OrchestratorRunner,
     clear_cancellation,
+    get_cancellation_request,
     get_pending_cancellations,
     is_cancellation_requested,
     request_cancellation,
@@ -478,7 +479,11 @@ class TestCancelExecution:
         """Test cancelling an in-flight execution signals registry."""
         runner._register_session("exec_1", "sess_1")
 
-        result = await runner.cancel_execution("exec_1", reason="Test cancel")
+        result = await runner.cancel_execution(
+            "exec_1",
+            reason="Test cancel",
+            cancelled_by="mcp_tool",
+        )
 
         assert result.is_ok
         assert result.value["status"] == "cancellation_requested"
@@ -487,6 +492,10 @@ class TestCancelExecution:
         assert result.value["session_id"] == "sess_1"
         # Registry should be populated
         assert await is_cancellation_requested("sess_1")
+        request = await get_cancellation_request("sess_1")
+        assert request is not None
+        assert request.reason == "Test cancel"
+        assert request.cancelled_by == "mcp_tool"
 
     @pytest.mark.asyncio
     async def test_cancel_not_in_flight_looks_up_session(

--- a/tests/unit/orchestrator/test_runner_execution_guidance.py
+++ b/tests/unit/orchestrator/test_runner_execution_guidance.py
@@ -110,7 +110,7 @@ def test_resume_rejects_changed_guidance_content(tmp_path: Path) -> None:
         )
 
 
-def test_proof_cohort_identity_includes_guidance_hash(tmp_path: Path) -> None:
+def test_process_local_contract_never_forms_a_guidance_proof_cohort(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     guided, _store = _runner(tmp_path, ("team",))
     unguided, _store = _runner(tmp_path, ())
@@ -128,10 +128,8 @@ def test_proof_cohort_identity_includes_guidance_hash(tmp_path: Path) -> None:
         }
     )
 
-    assert guided_identity is not None
-    assert unguided_identity is not None
-    assert guided_identity != unguided_identity
-    assert guided_identity[-1] != unguided_identity[-1]
+    assert guided_identity is None
+    assert unguided_identity is None
 
 
 @pytest.mark.asyncio
@@ -155,18 +153,31 @@ async def test_each_new_run_reloads_declared_guidance(tmp_path: Path) -> None:
             AsyncMock(return_value=Result.ok(None)),
         ),
     ):
-        first = await runner.prepare_session(_seed(), execution_id="exec-one")
+        first = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-one",
+            session_id=trackers[0].session_id,
+        )
         assert first.is_ok
         assert runner._execution_contract is not None
         first_hash = runner._execution_contract["guidance"]["rendered_fragment_hash"]
 
         path.write_text("Second version.\n", encoding="utf-8")
-        second = await runner.prepare_session(_seed(), execution_id="exec-two")
+        second = await runner.prepare_session(
+            _seed(),
+            execution_id="exec-two",
+            session_id=trackers[1].session_id,
+        )
         assert second.is_ok
         assert runner._execution_contract is not None
         second_hash = runner._execution_contract["guidance"]["rendered_fragment_hash"]
 
     assert first_hash != second_hash
+    for tracker in trackers:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
 
 def test_legacy_contract_resumes_without_newly_configured_guidance(tmp_path: Path) -> None:
@@ -312,7 +323,12 @@ async def test_execute_seed_delivers_guidance_to_adapter_system_prompt(tmp_path:
         ),
         patch.object(runner, "_evaluate_frugality_proof", AsyncMock()),
     ):
-        result = await runner.execute_seed(_seed(), parallel=False)
+        result = await runner.execute_seed(
+            _seed(),
+            execution_id=tracker.execution_id,
+            session_id=tracker.session_id,
+            parallel=False,
+        )
 
     assert result.is_ok
     assert call_order.index("orchestrator.guidance.injected") < call_order.index(
@@ -335,6 +351,15 @@ async def test_parallel_execution_receives_declared_guidance(tmp_path: Path) -> 
         seed.metadata.seed_id,
         session_id="sess-guidance-parallel",
     )
+    generation = runner._begin_process_local_authority_generation()
+    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    runner._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=contract,
+        generation=generation,
+    )
+    tracker = tracker.with_progress({EXECUTION_CONTRACT_PROGRESS_KEY: contract})
     expected = Result.ok(
         OrchestratorResult(
             success=True,
@@ -344,23 +369,29 @@ async def test_parallel_execution_receives_declared_guidance(tmp_path: Path) -> 
     )
     tool_catalog = assemble_session_tool_catalog(["Read"])
 
-    with (
-        patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
-        patch.object(
-            runner,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
-    ):
-        result = await runner.execute_precreated_session(seed, tracker, parallel=True)
+    try:
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, tool_catalog)),
+            ),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(seed, tracker, parallel=True)
+    finally:
+        runner._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
     assert result is expected
     assert sentinel in execute.await_args.kwargs["system_prompt"]
 
 
 @pytest.mark.asyncio
-async def test_fresh_runner_executes_precreated_session_with_persisted_guidance(
+async def test_fresh_runner_rejects_precreated_session_with_persisted_guidance(
     tmp_path: Path,
 ) -> None:
     sentinel = "GUIDANCE_SENTINEL_PRECREATED"
@@ -394,62 +425,41 @@ async def test_fresh_runner_executes_precreated_session_with_persisted_guidance(
     assert prepared.is_ok
 
     executing_runner, _store = _runner(tmp_path, ())
-    captured: dict[str, Any] = {}
+    get_tools = AsyncMock(side_effect=AssertionError("fresh runner must stop before setup"))
+    executing_runner._get_merged_tools = get_tools
 
-    async def execute_task(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
-        del args
-        captured.update(kwargs)
-        yield AgentMessage(
-            type="result",
-            content="[TASK_COMPLETE]",
-            data={"subtype": "success"},
-        )
-
-    executing_runner._adapter.execute_task = execute_task
-    tool_catalog = assemble_session_tool_catalog(["Read"])
-    with (
-        patch.object(
-            executing_runner._session_repo,
-            "track_progress",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            executing_runner._session_repo,
-            "mark_completed",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            executing_runner,
-            "_check_startup_cancellation",
-            AsyncMock(return_value=False),
-        ),
-        patch.object(
-            executing_runner,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(executing_runner, "_evaluate_frugality_proof", AsyncMock()),
-    ):
+    try:
         result = await executing_runner.execute_precreated_session(
             seed,
             prepared.value,
             parallel=False,
         )
+    finally:
+        preparing_runner._retire_process_local_authority(
+            session_id=prepared.value.session_id,
+            execution_id=prepared.value.execution_id,
+        )
 
-    assert result.is_ok
-    assert executing_runner._project_guidance_ids == ()
-    assert sentinel in captured["system_prompt"]
+    assert result.is_err
+    assert result.error.details["resume_blocked"] == "process_local_authority_held_elsewhere"
+    get_tools.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_path: Path) -> None:
+async def test_same_process_resume_delivers_persisted_guidance_to_adapter_system_prompt(
+    tmp_path: Path,
+) -> None:
     sentinel = "GUIDANCE_SENTINEL_RESUME"
     _write_guidance(tmp_path, "team", f"Preserve project conventions. {sentinel}\n")
     original, _store = _runner(tmp_path, ("team",))
     seed = _seed()
-    persisted_contract = original._build_execution_contract(seed=seed)
+    generation = original._begin_process_local_authority_generation()
+    persisted_contract = original._build_execution_contract(
+        seed=seed,
+        authority_generation=generation,
+    )
 
-    resumed, event_store = _runner(tmp_path, ())
+    resumed, event_store = original, _store
     event_store.replay = AsyncMock(return_value=[])
     tracker = SessionTracker.create(
         "exec-guidance-resume",
@@ -461,6 +471,12 @@ async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_p
             EXECUTION_CONTRACT_PROGRESS_KEY: persisted_contract,
             "messages_processed": 0,
         }
+    )
+    resumed._register_process_local_authority(
+        session_id=tracker.session_id,
+        execution_id=tracker.execution_id,
+        execution_contract=persisted_contract,
+        generation=generation,
     )
     captured: dict[str, Any] = {}
 
@@ -475,33 +491,39 @@ async def test_resume_delivers_persisted_guidance_to_adapter_system_prompt(tmp_p
 
     resumed._adapter.execute_task = execute_task
     tool_catalog = assemble_session_tool_catalog(["Read"])
-    with (
-        patch.object(
-            resumed._session_repo,
-            "reconstruct_session",
-            AsyncMock(return_value=Result.ok(tracker)),
-        ),
-        patch.object(
-            resumed._session_repo,
-            "track_progress",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            resumed._session_repo,
-            "mark_completed",
-            AsyncMock(return_value=Result.ok(None)),
-        ),
-        patch.object(
-            resumed,
-            "_get_merged_tools",
-            AsyncMock(return_value=(["Read"], None, tool_catalog)),
-        ),
-        patch.object(resumed, "_evaluate_frugality_proof", AsyncMock()),
-    ):
-        result = await resumed.resume_session(tracker.session_id, seed)
+    try:
+        with (
+            patch.object(
+                resumed._session_repo,
+                "reconstruct_session",
+                AsyncMock(return_value=Result.ok(tracker)),
+            ),
+            patch.object(
+                resumed._session_repo,
+                "track_progress",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch.object(
+                resumed._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch.object(
+                resumed,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, tool_catalog)),
+            ),
+            patch.object(resumed, "_evaluate_frugality_proof", AsyncMock()),
+        ):
+            result = await resumed.resume_session(tracker.session_id, seed)
+    finally:
+        resumed._retire_process_local_authority(
+            session_id=tracker.session_id,
+            execution_id=tracker.execution_id,
+        )
 
     assert result.is_ok
-    assert resumed._project_guidance_ids == ()
+    assert resumed._project_guidance_ids == ("team",)
     assert sentinel in captured["system_prompt"]
     guidance_events = [
         call.args[0]

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -1171,6 +1171,43 @@ class TestFindOrphanedSessions:
         mock_event_store.get_all_sessions.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_snapshot_reconstructed_terminal_tracker_is_not_orphaned(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Snapshot classification rechecks authoritative reconstructed status."""
+        from ouroboros.persistence.event_store import SessionActivitySnapshot
+
+        old_time = datetime.now(UTC) - timedelta(hours=2)
+        mock_event_store.get_session_activity_snapshots = AsyncMock(
+            return_value=[
+                SessionActivitySnapshot(
+                    session_id="sess_1",
+                    execution_id="exec_sess_1",
+                    seed_id="seed_sess_1",
+                    start_time=old_time.isoformat(),
+                    last_activity=old_time,
+                    status_event_type=None,
+                    runtime_status="running",
+                )
+            ]
+        )
+        repository.reconstruct_session = AsyncMock(
+            return_value=Result.ok(
+                SessionTracker.create(
+                    "exec_sess_1",
+                    "seed_sess_1",
+                    session_id="sess_1",
+                ).with_status(SessionStatus.COMPLETED)
+            )
+        )
+
+        result = await repository.find_orphaned_sessions()
+
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_failed_session_not_orphaned(
         self,
         repository: SessionRepository,

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -1715,6 +1715,43 @@ class TestStaleRuntimeMetadataCleansing:
         assert tracker.status == SessionStatus.CANCELLED
         assert tracker.progress.get("runtime_status") == "cancelled"
 
+    async def test_cancelled_session_ignores_later_running_progress(self) -> None:
+        """A delayed progress checkpoint cannot revive a durable cancellation."""
+        from ouroboros.events.base import BaseEvent
+
+        mock_event_store = AsyncMock()
+        mock_event_store.replay = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id="sess-cancelled-late-progress",
+                    data={"execution_id": "exec", "seed_id": "seed"},
+                ),
+                BaseEvent(
+                    type="orchestrator.session.cancelled",
+                    aggregate_type="session",
+                    aggregate_id="sess-cancelled-late-progress",
+                    data={"reason": "user request", "cancelled_by": "user"},
+                ),
+                BaseEvent(
+                    type="orchestrator.progress.updated",
+                    aggregate_type="session",
+                    aggregate_id="sess-cancelled-late-progress",
+                    data={"progress": {"runtime_status": "running", "phase": "late"}},
+                ),
+            ]
+        )
+        mock_event_store.query_session_related_events = None
+
+        result = await SessionRepository(mock_event_store).reconstruct_session(
+            "sess-cancelled-late-progress"
+        )
+
+        assert result.is_ok
+        assert result.value.status == SessionStatus.CANCELLED
+        assert result.value.progress.get("runtime_status") == "cancelled"
+
     async def test_completed_session_overwrites_stale_runtime_status(self) -> None:
         """runtime_status should reflect 'completed' for completed sessions."""
         from ouroboros.events.base import BaseEvent

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ouroboros.core.types import Result
 from ouroboros.orchestrator.session import (
     SessionRepository,
     SessionStatus,
@@ -1204,6 +1205,64 @@ class TestFindOrphanedSessions:
 
         mock_event_store.get_all_sessions.return_value = [start_event]
         mock_event_store.replay.return_value = [start_event, cancelled_event]
+
+        result = await repository.find_orphaned_sessions()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_late_running_progress_cannot_revive_cancelled_orphan(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Replay-only orphan detection keeps terminal lifecycle absorbing."""
+        old_time = datetime.now(UTC) - timedelta(hours=5)
+        start_event = self._make_start_event("sess_1", timestamp=old_time)
+        cancelled_event = self._make_terminal_event(
+            "sess_1",
+            "orchestrator.session.cancelled",
+            timestamp=old_time + timedelta(minutes=5),
+        )
+        late_running = self._make_progress_event(
+            "sess_1",
+            timestamp=old_time + timedelta(minutes=10),
+        )
+        late_running.data = {
+            "runtime_status": "running",
+            "progress": {"runtime_status": "running"},
+        }
+        mock_event_store.get_all_sessions.return_value = [start_event]
+        mock_event_store.replay.return_value = [start_event, cancelled_event, late_running]
+
+        result = await repository.find_orphaned_sessions()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_reconstructed_terminal_tracker_is_not_appended_as_orphan(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Fallback classification rechecks authoritative reconstructed status."""
+        old_time = datetime.now(UTC) - timedelta(hours=5)
+        start_event = self._make_start_event("sess_1", timestamp=old_time)
+        running_event = self._make_progress_event(
+            "sess_1",
+            timestamp=old_time + timedelta(minutes=10),
+        )
+        mock_event_store.get_all_sessions.return_value = [start_event]
+        mock_event_store.replay.return_value = [start_event, running_event]
+        repository.reconstruct_session = AsyncMock(
+            return_value=Result.ok(
+                SessionTracker.create(
+                    "exec_sess_1",
+                    "seed_sess_1",
+                    session_id="sess_1",
+                ).with_status(SessionStatus.CANCELLED)
+            )
+        )
 
         result = await repository.find_orphaned_sessions()
 

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -153,6 +153,7 @@ class TestSessionRepository:
         """Create a mock event store."""
         store = AsyncMock()
         store.append = AsyncMock()
+        store.append_session_pause_if_active = AsyncMock(return_value=True)
         store.replay = AsyncMock(return_value=[])
         return store
 
@@ -368,7 +369,7 @@ class TestSessionRepository:
         )
 
         assert result.is_ok
-        event = mock_event_store.append.call_args[0][0]
+        event = mock_event_store.append_session_pause_if_active.call_args[0][0]
         assert event.type == "orchestrator.session.paused"
         assert event.data["reason"] == "Codex resume failed before reconnect"
         assert event.data["resume_hint"] == "Retry with --resume after fixing the CLI issue."
@@ -392,7 +393,7 @@ class TestSessionRepository:
         )
 
         assert result.is_ok
-        event = mock_event_store.append.call_args[0][0]
+        event = mock_event_store.append_session_pause_if_active.call_args[0][0]
         assert event.type == "orchestrator.session.paused"
         assert event.data["pause_seconds"] == 18000
         assert event.data["resume_after"] == resume_after.isoformat()

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -527,6 +527,48 @@ class TestShadowReplayHarness:
         assert data["is_decomposed_child"] is True
 
     @pytest.mark.asyncio
+    async def test_verifier_entry_drift_stops_shadow_replay_before_baseline_effect(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        factory = MagicMock()
+        monkeypatch.setattr("ouroboros.orchestrator.runtime_factory.create_agent_runtime", factory)
+        store, events = _capturing_event_store()
+        executor = _executor_with_router(task_cwd=str(tmp_path), store=store)
+        injected = False
+
+        def injected_verifier(**_: object) -> object:
+            nonlocal injected
+            injected = True
+            return object()
+
+        monkeypatch.setattr(
+            ParallelACExecutor,
+            "_run_atomic_verifier_pass",
+            injected_verifier,
+        )
+
+        with isolated_workspace(str(tmp_path)) as isolated_cwd:
+            assert isolated_cwd is not None
+            await run_shadow_replay(
+                executor,
+                runtime_identity=_identity(),
+                execution_id="exec_frugal",
+                session_id="sess",
+                ac_index=1,
+                is_sub_ac=True,
+                prompt="do the thing",
+                system_prompt="system",
+                tools=["Read"],
+                decomposition_trustworthy=True,
+                ac_content="Implement a thing",
+                isolated_cwd=isolated_cwd,
+            )
+
+        factory.assert_not_called()
+        assert injected is False
+        assert _shadow_events(events) == []
+
+    @pytest.mark.asyncio
     async def test_runtime_without_strict_isolation_contract_is_never_executed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -234,6 +234,30 @@ class TestEventStoreAppend:
 
         assert await event_store.replay("session", "sess-raw-terminal-path") == []
 
+    async def test_conditional_pause_preserves_existing_terminal_winner(
+        self, event_store: EventStore
+    ) -> None:
+        """PAUSED cannot be appended behind an explicit terminal winner."""
+        session_id = "sess-terminal-before-pause"
+        cancelled = BaseEvent(
+            type="orchestrator.session.cancelled",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"reason": "terminal wins"},
+        )
+        paused = BaseEvent(
+            type="orchestrator.session.paused",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"reason": "too late"},
+        )
+
+        assert await event_store.append(cancelled) is True
+        assert await event_store.append_session_pause_if_active(paused) is False
+
+        events = await event_store.replay("session", session_id)
+        assert [event.type for event in events] == ["orchestrator.session.cancelled"]
+
     async def test_append_preserves_event_data(
         self, event_store: EventStore, sample_event: BaseEvent
     ) -> None:

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -9,6 +9,7 @@ import pytest
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.execution_runtime_scope import normalize_execution_scope_id
+from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -162,6 +163,76 @@ class TestEventStoreAppend:
 
         replayed = await event_store.replay("ontology", "ont-123")
         assert len(replayed) == 5
+
+    async def test_append_preserves_the_first_terminal_session_event(
+        self, event_store: EventStore
+    ) -> None:
+        """Generic append callers cannot overwrite an earlier terminal winner."""
+        cancelled = BaseEvent(
+            type="orchestrator.session.cancelled",
+            aggregate_type="session",
+            aggregate_id="sess-terminal-winner",
+            data={"reason": "user cancelled"},
+        )
+        completed = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-terminal-winner",
+            data={"summary": {"would_have_overwritten": True}},
+        )
+
+        await event_store.append(cancelled)
+        await event_store.append(completed)
+
+        terminal_events = await event_store.replay("session", "sess-terminal-winner")
+        assert [event.type for event in terminal_events] == ["orchestrator.session.cancelled"]
+
+    async def test_session_terminal_marker_reports_when_another_transition_won(
+        self, event_store: EventStore
+    ) -> None:
+        """Legacy markers must not report a losing terminal transition as success."""
+        repository = SessionRepository(event_store)
+        await repository.create_session(
+            execution_id="exec-terminal-marker-race",
+            seed_id="seed-terminal-marker-race",
+            session_id="sess-terminal-marker-race",
+        )
+
+        completed = await repository.mark_completed("sess-terminal-marker-race")
+        cancelled = await repository.mark_cancelled(
+            "sess-terminal-marker-race",
+            reason="late cancellation",
+        )
+
+        assert completed.is_ok and completed.value is True
+        assert cancelled.is_ok and cancelled.value is False
+        terminal_events = await event_store.replay("session", "sess-terminal-marker-race")
+        assert [event.type for event in terminal_events] == [
+            "orchestrator.session.started",
+            "orchestrator.session.completed",
+        ]
+
+    async def test_raw_terminal_append_paths_are_rejected(self, event_store: EventStore) -> None:
+        """Terminal sessions must use the one-winner public append boundary."""
+        terminal = BaseEvent(
+            type="orchestrator.session.failed",
+            aggregate_type="session",
+            aggregate_id="sess-raw-terminal-path",
+            data={"error": "would bypass terminal CAS"},
+        )
+        benign = BaseEvent(
+            type="orchestrator.progress.updated",
+            aggregate_type="session",
+            aggregate_id="sess-raw-terminal-path",
+            data={"progress": {"messages_processed": 1}},
+        )
+
+        with pytest.raises(PersistenceError, match="one-winner guard"):
+            await event_store.append_with_rowid(terminal)
+        with pytest.raises(PersistenceError, match="cannot be appended in a batch"):
+            await event_store.append_batch([benign, terminal])
+
+        assert await event_store.replay("session", "sess-raw-terminal-path") == []
 
     async def test_append_preserves_event_data(
         self, event_store: EventStore, sample_event: BaseEvent

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -869,6 +869,41 @@ class TestSessionActivitySnapshots:
         assert snapshot.last_activity is not None
         assert snapshot.status_event_type == "orchestrator.session.completed"
 
+    async def test_terminal_status_absorbs_later_running_progress(
+        self, event_store: EventStore
+    ) -> None:
+        session_id = "sess-terminal-with-late-progress"
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"execution_id": "exec-terminal-with-late-progress"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.cancelled",
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"reason": "user requested cancellation"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.progress.updated",
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"progress": {"runtime_status": "running", "phase": "late"}},
+            )
+        )
+
+        snapshots = await event_store.get_session_activity_snapshots()
+        snapshot = next(item for item in snapshots if item.session_id == session_id)
+
+        assert snapshot.status_event_type == "orchestrator.session.cancelled"
+        assert snapshot.runtime_status is None
+
     async def test_includes_progress_only_session_without_started_event(
         self, event_store: EventStore
     ) -> None:

--- a/tests/unit/persistence/test_schema.py
+++ b/tests/unit/persistence/test_schema.py
@@ -1,6 +1,6 @@
 """Unit tests for ouroboros.persistence.schema module."""
 
-from ouroboros.persistence.schema import events_table, metadata
+from ouroboros.persistence.schema import events_table, metadata, session_start_guards_table
 
 
 class TestEventsTableSchema:
@@ -71,9 +71,26 @@ class TestEventsTableIndexes:
         raise AssertionError("No composite index on (aggregate_type, aggregate_id) found")
 
 
+class TestSessionStartGuardsTable:
+    """Test immutable session-start identity guard schema."""
+
+    def test_session_id_is_primary_key(self) -> None:
+        """One guard row can exist for each durable session aggregate."""
+        assert session_start_guards_table.c.session_id.primary_key is True
+
+    def test_guard_records_start_and_execution_identity(self) -> None:
+        """The guard retains both sides of the immutable start binding."""
+        column_names = {column.name for column in session_start_guards_table.columns}
+        assert {"session_id", "start_event_id", "execution_id", "created_at"} <= column_names
+
+
 class TestMetadata:
     """Test SQLAlchemy metadata configuration."""
 
     def test_metadata_contains_events_table(self) -> None:
         """Metadata contains the events table."""
         assert "events" in metadata.tables
+
+    def test_metadata_contains_session_start_guards_table(self) -> None:
+        """Metadata creates the immutable start guard with every writable store."""
+        assert "session_start_guards" in metadata.tables

--- a/tests/unit/persistence/test_uow.py
+++ b/tests/unit/persistence/test_uow.py
@@ -1,10 +1,12 @@
 """Unit tests for ouroboros.persistence.uow module."""
 
+import os
 from pathlib import Path
 
 import pytest
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.events import (
     create_session_cancelled_event,
     create_session_completed_event,
@@ -232,6 +234,58 @@ class TestUnitOfWork:
         assert uow.pending_event_count == 0
         events = await event_store.replay("session", session_id)
         assert [event.type for event in events] == ["orchestrator.session.cancelled"]
+
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires a forked lease owner")
+    async def test_commit_rejects_terminal_event_while_foreign_heartbeat_is_live(
+        self,
+        uow: UnitOfWork,
+        event_store: EventStore,
+    ) -> None:
+        """A foreign process cannot bypass live process-local ownership."""
+        session_id = "sess-uow-foreign-owner"
+        ready_read, ready_write = os.pipe()
+        release_read, release_write = os.pipe()
+        child_pid = os.fork()
+        if child_pid == 0:  # pragma: no cover - assertions run in parent
+            os.close(ready_read)
+            os.close(release_write)
+            try:
+                heartbeat.acquire(session_id)
+                os.write(ready_write, b"1")
+                os.read(release_read, 1)
+            finally:
+                heartbeat.release_if_owned_by_current_process(session_id)
+                os.close(ready_write)
+                os.close(release_read)
+            os._exit(0)
+
+        os.close(ready_write)
+        os.close(release_read)
+        try:
+            assert os.read(ready_read, 1) == b"1"
+            assert heartbeat.is_holder_alive(session_id)
+            uow.add_event(
+                create_session_completed_event(
+                    session_id,
+                    summary={"result": "must be rejected"},
+                    messages_processed=1,
+                )
+            )
+
+            result = await uow.commit()
+
+            assert result.is_err
+            assert result.error.details["heartbeat_owner_live"] is True
+            assert uow.pending_event_count == 1
+            assert await event_store.replay("session", session_id) == []
+        finally:
+            os.write(release_write, b"1")
+            os.close(release_write)
+            os.close(ready_read)
+            waited_pid, status = os.waitpid(child_pid, 0)
+            assert waited_pid == child_pid
+            assert os.WIFEXITED(status)
+            assert os.WEXITSTATUS(status) == 0
 
 
 class TestPhaseTransaction:

--- a/tests/unit/persistence/test_uow.py
+++ b/tests/unit/persistence/test_uow.py
@@ -10,6 +10,7 @@ from ouroboros.orchestrator import heartbeat
 from ouroboros.orchestrator.events import (
     create_session_cancelled_event,
     create_session_completed_event,
+    create_session_started_event,
 )
 from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
@@ -234,6 +235,63 @@ class TestUnitOfWork:
         assert uow.pending_event_count == 0
         events = await event_store.replay("session", session_id)
         assert [event.type for event in events] == ["orchestrator.session.cancelled"]
+
+    async def test_commit_routes_session_start_through_immutable_identity_guard(
+        self,
+        uow: UnitOfWork,
+        event_store: EventStore,
+    ) -> None:
+        """Public start factories remain compatible with UnitOfWork."""
+        session_id = "sess-uow-start"
+        uow.add_event(
+            create_session_started_event(
+                session_id,
+                execution_id="exec-uow-start",
+                seed_id="seed-uow-start",
+                seed_goal="Verify immutable start identity",
+            )
+        )
+
+        result = await uow.commit()
+
+        assert result.is_ok
+        assert uow.pending_event_count == 0
+        events = await event_store.replay("session", session_id)
+        assert [event.type for event in events] == ["orchestrator.session.started"]
+        assert events[0].data["execution_id"] == "exec-uow-start"
+
+    async def test_commit_retains_conflicting_session_start_in_pending(
+        self,
+        uow: UnitOfWork,
+        event_store: EventStore,
+    ) -> None:
+        """A reused session ID fails without appending a second start identity."""
+        session_id = "sess-uow-start-conflict"
+        first = create_session_started_event(
+            session_id,
+            execution_id="exec-uow-start-original",
+            seed_id="seed-uow-start",
+            seed_goal="Original execution",
+        )
+        await event_store.append(first)
+        uow.add_event(
+            create_session_started_event(
+                session_id,
+                execution_id="exec-uow-start-conflict",
+                seed_id="seed-uow-start",
+                seed_goal="Conflicting execution",
+            )
+        )
+
+        result = await uow.commit()
+
+        assert result.is_err
+        assert result.error.details["session_start_conflict"] is True
+        assert uow.pending_event_count == 1
+        events = await event_store.replay("session", session_id)
+        starts = [event for event in events if event.type == "orchestrator.session.started"]
+        assert len(starts) == 1
+        assert starts[0].data["execution_id"] == "exec-uow-start-original"
 
     @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires a forked lease owner")
     async def test_commit_rejects_terminal_event_while_foreign_heartbeat_is_live(

--- a/tests/unit/persistence/test_uow.py
+++ b/tests/unit/persistence/test_uow.py
@@ -5,6 +5,10 @@ from pathlib import Path
 import pytest
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.events import (
+    create_session_cancelled_event,
+    create_session_completed_event,
+)
 from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.persistence.uow import PhaseTransaction, UnitOfWork
@@ -184,6 +188,50 @@ class TestUnitOfWork:
         # Verify both events persisted
         events = await event_store.replay(event1.aggregate_type, event1.aggregate_id)
         assert len(events) == 2
+
+    async def test_commit_routes_terminal_session_event_through_cas(
+        self,
+        uow: UnitOfWork,
+        event_store: EventStore,
+    ) -> None:
+        """Public terminal factories remain compatible with UnitOfWork."""
+        terminal = create_session_completed_event(
+            "sess-uow-terminal",
+            summary={"result": "ok"},
+            messages_processed=3,
+        )
+        uow.add_event(terminal)
+
+        result = await uow.commit()
+
+        assert result.is_ok
+        assert uow.pending_event_count == 0
+        events = await event_store.replay("session", "sess-uow-terminal")
+        assert [event.type for event in events] == ["orchestrator.session.completed"]
+
+    async def test_commit_clears_terminal_cas_loser_from_pending(
+        self,
+        uow: UnitOfWork,
+        event_store: EventStore,
+    ) -> None:
+        """A competing terminal winner is a successful, non-retrying no-op."""
+        session_id = "sess-uow-terminal-loser"
+        winner = create_session_cancelled_event(session_id, reason="cancel won")
+        assert await event_store.append(winner) is True
+        uow.add_event(
+            create_session_completed_event(
+                session_id,
+                summary={"result": "stale"},
+                messages_processed=1,
+            )
+        )
+
+        result = await uow.commit()
+
+        assert result.is_ok
+        assert uow.pending_event_count == 0
+        events = await event_store.replay("session", session_id)
+        assert [event.type for event in events] == ["orchestrator.session.cancelled"]
 
 
 class TestPhaseTransaction:


### PR DESCRIPTION
## Summary

- Replaces the four closed Foundation A attempts (#1682, #1704, #1705, #1706) with a finite process-local authority boundary derived from their review evidence.
- Classifies every current CLI/custom runtime as process-local instead of claiming portability from arbitrary Python object graphs.
- Makes durable session terminal state the single source of truth before execution-terminal projections or local cleanup.

## Changes

### Process-local authority lifecycle

- Adds a registry-minted, PID-bound, non-serializable generation for each live session.
- Represents each session with one lifecycle entry: REGISTERED, CLAIMED, or TERMINALIZING.
- Retains the exact paused runner, adapter, EventStore, heartbeat lease, and workspace identity for supported same-process resume.
- Makes failed preparation cleanup generation-specific, so an exact session/execution collision cannot retire the older legitimate owner.
- Rejects reuse of every existing durable session aggregate without disturbing a live owner.
- Fails lost or foreign authority closed with typed outcomes instead of reconstructing authority from persisted correlation data.

### Terminal persistence and cancellation

- Adds a durable per-session terminal compare-and-set guard so completion, failure, and cancellation have exactly one winner.
- Routes CLI, MCP, JobManager, and runner cancellation through one process-local cancellation protocol.
- Persists the terminal session winner before retiring authority and draining registered finalizers.
- Retries the originally requested terminal intent and never rewrites a failed `COMPLETED` persistence attempt as `FAILED`.
- Preserves an unclaimed same-process owner and heartbeat when terminal persistence remains unavailable, returning typed `terminal_persistence_pending`.
- Reconstructs the durable winner when cancellation interrupts the post-CAS projection/cleanup window.
- Rechecks durable state after publishing local or cross-process cooperative cancellation; a completion winner clears the late marker and returns `already_terminal`.
- Keeps handler-owned EventStores open whenever preparation retains an exact retryable owner.
- Projects the durable winner after CAS loss and keeps replay, snapshots, and orphan classification terminal-absorbing against late RUNNING progress.

### Workspace lifecycle

- Reference-counts runner-wide workspace use across concurrent process-local sessions.
- Reserves exclusion before preparation's first await and before retained-resume worktree restoration.
- Makes workspace cleanup idempotent across runner, handler, callback, and outer `finally` layers.
- Prevents preparation collisions, sibling completion, direct terminal cancellation, and repeated cleanup from releasing a lock still owned by another lifecycle path.

### Review-derived regressions

- Covers the exact-generation collision reported in review 4763470501.
- Covers local and cross-process completion racing cancellation publication from review 4763470501.
- Covers preparation collision, concurrent preparation, retained-resume handoff, last-user release, duplicate cleanup, direct already-terminal cancellation, snapshot/replay orphan filtering, and retained owner/store teardown.
- Covers caller-cancellation propagation after shielded cleanup, terminal-finalizer interruption, and final marker acknowledgement after authority, heartbeat, routing, and workspace retirement across existing-terminal, cancelled, and resumed-terminal paths.
- Documents the supported boundary and 79-condition adversarial exit matrix.

## Notes

- Refs #1681.
- Foundation A grants no dispatch, result reuse, checkpoint, trust, routing, or final-acceptance authority.
- Cross-process continuation for current runtimes is intentionally unsupported; callers must start a new attempt when the live generation is unavailable.
- Cross-process cancellation is supported as a cooperative request; it does not grant a foreign process terminalization authority.
- Foundation B and later routing/acceptance layers remain locked until this boundary is approved.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q tests/unit/orchestrator`: 3227 passed, 1 skipped
- process-local authority lifecycle regressions: 114 passed
- CLI/MCP/JobManager/persistence/session-persistence bundle: 286 passed
- `ruff check src tests` and `ruff format --check src tests`: passed (1113 files)
- `mypy src/ouroboros`: 468 source files passed
- `git diff --check`: passed
