### PR TITLE
fix(mcp): expose evolve input guidance through FastMCP

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -240,13 +240,19 @@ def _build_tool_signature_with_aliases(
             }
             if p.required:
                 field_kwargs["default"] = ...
-            elif p.default is None:
-                field_kwargs["default_factory"] = lambda: None
             else:
                 field_kwargs["default"] = p.default
+                if p.default is None:
+                    field_kwargs["json_schema_extra"] = lambda schema, extra=schema_extra: (
+                        schema.pop("default", None),
+                        schema.update(extra),
+                    )[-1]
             default = Field(**field_kwargs)
         elif not p.required and p.default is None:
-            default = Field(default_factory=lambda: None)
+            default = Field(
+                default=None,
+                json_schema_extra=lambda schema: schema.pop("default", None),
+            )
 
         if p.required:
             sig_params.append(
@@ -290,7 +296,7 @@ def _validate_parameter_constraints(
         if parameter.name not in arguments:
             continue
         value = arguments[parameter.name]
-        if parameter.enum is not None and value not in parameter.enum:
+        if value is not None and parameter.enum is not None and value not in parameter.enum:
             raise ValueError(
                 f"Invalid value for {parameter.name}: expected one of {parameter.enum}"
             )
@@ -301,7 +307,8 @@ def _validate_parameter_constraints(
         if expected_type is None:
             continue
         if any(
-            not isinstance(item, expected_type) or (expected_type is int and isinstance(item, bool))
+            not isinstance(item, expected_type)
+            or (item_type in {"integer", "number"} and isinstance(item, bool))
             for item in value
         ):
             raise ValueError(f"Invalid items for {parameter.name}: expected {item_type} values")

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -15,8 +15,9 @@ import os
 from pathlib import Path
 import re
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
+from pydantic import Field
 import structlog
 
 from ouroboros.config._model_defaults import DEFAULT_SONNET_MODEL
@@ -226,12 +227,16 @@ def _build_tool_signature_with_aliases(
         alias_to_original[parameter_name] = p.name
 
         python_type = _TOOL_TYPE_MAP.get(p.type, Any)
+        annotation: Any = python_type if p.required else python_type | None
+        if p.description:
+            annotation = Annotated[annotation, Field(description=p.description)]
+
         if p.required:
             sig_params.append(
                 inspect.Parameter(
                     name=parameter_name,
                     kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=python_type,
+                    annotation=annotation,
                 )
             )
         else:
@@ -241,7 +246,7 @@ def _build_tool_signature_with_aliases(
                     name=parameter_name,
                     kind=inspect.Parameter.KEYWORD_ONLY,
                     default=default,
-                    annotation=python_type | None,
+                    annotation=annotation,
                 )
             )
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -227,7 +227,11 @@ def _build_tool_signature_with_aliases(
         alias_to_original[parameter_name] = p.name
 
         python_type = _TOOL_TYPE_MAP.get(p.type, Any)
-        default = p.default if p.default is not None else None
+        default: Any = (
+            Field(default_factory=lambda: None)
+            if not p.required and p.default is None
+            else p.default
+        )
         if p.description or p.enum is not None or p.items is not None:
             schema_extra: dict[str, Any] = {}
             if p.enum is not None:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 import re
 import time
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 import structlog
@@ -227,38 +227,40 @@ def _build_tool_signature_with_aliases(
         alias_to_original[parameter_name] = p.name
 
         python_type = _TOOL_TYPE_MAP.get(p.type, Any)
+        default = p.default if p.default is not None else None
         if p.description or p.enum is not None or p.items is not None:
             schema_extra: dict[str, Any] = {}
             if p.enum is not None:
                 schema_extra["enum"] = list(p.enum)
             if p.items is not None:
                 schema_extra["items"] = p.items
-            annotation = Annotated[
-                python_type,
-                Field(
-                    description=p.description or None,
-                    json_schema_extra=schema_extra or None,
-                ),
-            ]
-        else:
-            annotation = python_type
+            field_default: Any = ... if p.required else default
+            default = Field(
+                default=field_default,
+                description=p.description or None,
+                json_schema_extra=schema_extra or None,
+            )
 
         if p.required:
             sig_params.append(
                 inspect.Parameter(
                     name=parameter_name,
                     kind=inspect.Parameter.KEYWORD_ONLY,
-                    annotation=annotation,
+                    annotation=python_type,
+                    default=(
+                        default
+                        if p.description or p.enum is not None or p.items is not None
+                        else inspect.Parameter.empty
+                    ),
                 )
             )
         else:
-            default = p.default if p.default is not None else None
             sig_params.append(
                 inspect.Parameter(
                     name=parameter_name,
                     kind=inspect.Parameter.KEYWORD_ONLY,
                     default=default,
-                    annotation=annotation,
+                    annotation=python_type,
                 )
             )
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -227,23 +227,26 @@ def _build_tool_signature_with_aliases(
         alias_to_original[parameter_name] = p.name
 
         python_type = _TOOL_TYPE_MAP.get(p.type, Any)
-        default: Any = (
-            Field(default_factory=lambda: None)
-            if not p.required and p.default is None
-            else p.default
-        )
+        default: Any = inspect.Parameter.empty if p.required else p.default
         if p.description or p.enum is not None or p.items is not None:
             schema_extra: dict[str, Any] = {}
             if p.enum is not None:
                 schema_extra["enum"] = list(p.enum)
             if p.items is not None:
                 schema_extra["items"] = p.items
-            field_default: Any = ... if p.required else default
-            default = Field(
-                default=field_default,
-                description=p.description or None,
-                json_schema_extra=schema_extra or None,
-            )
+            field_kwargs: dict[str, Any] = {
+                "description": p.description or None,
+                "json_schema_extra": schema_extra or None,
+            }
+            if p.required:
+                field_kwargs["default"] = ...
+            elif p.default is None:
+                field_kwargs["default_factory"] = lambda: None
+            else:
+                field_kwargs["default"] = p.default
+            default = Field(**field_kwargs)
+        elif not p.required and p.default is None:
+            default = Field(default_factory=lambda: None)
 
         if p.required:
             sig_params.append(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -227,9 +227,21 @@ def _build_tool_signature_with_aliases(
         alias_to_original[parameter_name] = p.name
 
         python_type = _TOOL_TYPE_MAP.get(p.type, Any)
-        annotation: Any = python_type if p.required else python_type | None
-        if p.description:
-            annotation = Annotated[annotation, Field(description=p.description)]
+        if p.description or p.enum is not None or p.items is not None:
+            schema_extra: dict[str, Any] = {}
+            if p.enum is not None:
+                schema_extra["enum"] = list(p.enum)
+            if p.items is not None:
+                schema_extra["items"] = p.items
+            annotation = Annotated[
+                python_type,
+                Field(
+                    description=p.description or None,
+                    json_schema_extra=schema_extra or None,
+                ),
+            ]
+        else:
+            annotation = python_type
 
         if p.required:
             sig_params.append(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -8,7 +8,7 @@ handling, and server lifecycle.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import inspect
 import keyword
 import os
@@ -239,7 +239,15 @@ def _build_tool_signature_with_aliases(
                 "json_schema_extra": schema_extra or None,
             }
             if p.required:
+                # A required parameter still validates as required, but JSON Schema
+                # permits a `default` annotation on it and
+                # `MCPToolDefinition.to_input_schema()` emits one. Pydantic drops
+                # the value along with `Field(default=...)`, so carry it through
+                # `json_schema_extra` to keep both surfaces describing the same tool.
                 field_kwargs["default"] = ...
+                if p.default is not None:
+                    schema_extra["default"] = p.default
+                    field_kwargs["json_schema_extra"] = schema_extra
             else:
                 field_kwargs["default"] = p.default
                 if p.default is None:
@@ -284,13 +292,26 @@ def _validate_parameter_constraints(
     parameters: tuple[MCPToolParameter, ...],
     arguments: dict[str, Any],
 ) -> None:
-    expected_types: dict[str, type | tuple[type, ...]] = {
-        "string": str,
-        "integer": int,
-        "number": (int, float),
-        "boolean": bool,
-        "object": dict,
-        "array": list,
+    def _is_integer(item: Any) -> bool:
+        # JSON Schema `type: integer` matches any number with zero fractional
+        # part, so `1.0` is a valid integer while `1.5` is not. Booleans are
+        # excluded even though `bool` subclasses `int`.
+        if isinstance(item, bool):
+            return False
+        if isinstance(item, int):
+            return True
+        return isinstance(item, float) and item.is_integer()
+
+    def _is_number(item: Any) -> bool:
+        return not isinstance(item, bool) and isinstance(item, int | float)
+
+    item_validators: dict[str, Callable[[Any], bool]] = {
+        "string": lambda item: isinstance(item, str),
+        "integer": _is_integer,
+        "number": _is_number,
+        "boolean": lambda item: isinstance(item, bool),
+        "object": lambda item: isinstance(item, dict),
+        "array": lambda item: isinstance(item, list),
     }
     for parameter in parameters:
         if parameter.name not in arguments:
@@ -303,14 +324,10 @@ def _validate_parameter_constraints(
         if parameter.items is None or not isinstance(value, list):
             continue
         item_type = parameter.items.get("type")
-        expected_type = expected_types.get(item_type or "")
-        if expected_type is None:
+        is_valid_item = item_validators.get(item_type or "")
+        if is_valid_item is None:
             continue
-        if any(
-            not isinstance(item, expected_type)
-            or (item_type in {"integer", "number"} and isinstance(item, bool))
-            for item in value
-        ):
+        if any(not is_valid_item(item) for item in value):
             raise ValueError(f"Invalid items for {parameter.name}: expected {item_type} values")
 
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -274,6 +274,39 @@ def _build_tool_signature_with_aliases(
     return inspect.Signature(parameters=sig_params), alias_to_original
 
 
+def _validate_parameter_constraints(
+    parameters: tuple[MCPToolParameter, ...],
+    arguments: dict[str, Any],
+) -> None:
+    expected_types: dict[str, type | tuple[type, ...]] = {
+        "string": str,
+        "integer": int,
+        "number": (int, float),
+        "boolean": bool,
+        "object": dict,
+        "array": list,
+    }
+    for parameter in parameters:
+        if parameter.name not in arguments:
+            continue
+        value = arguments[parameter.name]
+        if parameter.enum is not None and value not in parameter.enum:
+            raise ValueError(
+                f"Invalid value for {parameter.name}: expected one of {parameter.enum}"
+            )
+        if parameter.items is None or not isinstance(value, list):
+            continue
+        item_type = parameter.items.get("type")
+        expected_type = expected_types.get(item_type or "")
+        if expected_type is None:
+            continue
+        if any(
+            not isinstance(item, expected_type) or (expected_type is int and isinstance(item, bool))
+            for item in value
+        ):
+            raise ValueError(f"Invalid items for {parameter.name}: expected {item_type} values")
+
+
 _PROJECT_ROOT_MARKERS = (
     # VCS (most universal — nearly every project has one)
     ".git",
@@ -1056,6 +1089,11 @@ class MCPServerAdapter:
                         for key, value in normalized_kwargs.items()
                         if value is not None or key not in optional_parameter_names
                     }
+
+                    _validate_parameter_constraints(
+                        h.definition.parameters,
+                        normalized_kwargs,
+                    )
 
                     # Route through call_tool() to enforce security checks.
                     # FastMCP does not provide credentials, so:

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -272,7 +272,11 @@ class EvolveStepHandler(BridgeAwareMixin):
                     name="seed_content",
                     type=ToolInputType.STRING,
                     description=(
-                        "Seed YAML content for Gen 1. "
+                        "Seed YAML text for Gen 1. Pass a YAML-formatted string "
+                        "(for example, newline-delimited 'goal: ...' fields), not "
+                        "JSON-shaped text or an object literal; some MCP clients may "
+                        "otherwise coerce the value to an object before Ouroboros "
+                        "receives it. "
                         "Omit for Gen 2+ (seed reconstructed from events)."
                     ),
                     required=False,

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1391,6 +1391,9 @@ class TestServeTransport:
         execute_schema = evolve_tool.inputSchema["properties"]["execute"]
         assert execute_schema["type"] == "boolean"
         assert "null" not in execute_schema.get("type", [])
+        seed_schema = evolve_tool.inputSchema["properties"]["seed_content"]
+        assert "default" not in seed_schema
+        assert "seed_content" not in evolve_tool.inputSchema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_fastmcp_path_enforces_security(self):

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -27,6 +27,7 @@ from ouroboros.mcp.server.adapter import (
     _project_dir_from_seed,
     _safe_cwd,
     _to_fastmcp_tool_result,
+    _validate_parameter_constraints,
     validate_transport,
 )
 from ouroboros.mcp.tools import job_handlers as job_handlers_module
@@ -183,6 +184,26 @@ class TestMCPServerAdapter:
             "max_tokens": "max.tokens",
             "_class": "class",
         }
+
+    def test_validate_parameter_constraints_rejects_enum_and_array_items(self) -> None:
+        parameters = (
+            MCPToolParameter(
+                name="mode",
+                type=ToolInputType.STRING,
+                enum=("fast", "safe"),
+            ),
+            MCPToolParameter(
+                name="labels",
+                type=ToolInputType.ARRAY,
+                items={"type": "string"},
+            ),
+        )
+
+        _validate_parameter_constraints(parameters, {"mode": "fast", "labels": ["ok"]})
+        with pytest.raises(ValueError, match="mode"):
+            _validate_parameter_constraints(parameters, {"mode": "unsafe"})
+        with pytest.raises(ValueError, match="labels"):
+            _validate_parameter_constraints(parameters, {"labels": ["ok", 1]})
 
     def test_legacy_execution_report_maps_to_task_results_not_ac_verdicts(self) -> None:
         """Legacy AC PASS/FAIL execution lines are worker task completion signals."""
@@ -1407,12 +1428,12 @@ class TestServeTransport:
                     description="A tool with an omitted optional parameter",
                     parameters=(
                         MCPToolParameter(
-                            name="required-input",
+                            name="required_input",
                             type=ToolInputType.STRING,
                             required=True,
                         ),
                         MCPToolParameter(
-                            name="optional-input",
+                            name="optional_input",
                             type=ToolInputType.STRING,
                             default=None,
                             description="Optional input",
@@ -1436,11 +1457,11 @@ class TestServeTransport:
 
         await adapter._mcp_server.call_tool(
             "optional_tool",
-            {"required-input": "provided"},
+            {"required_input": "provided"},
         )
 
         handler.handle_mock.assert_awaited_once_with(
-            {"required-input": "provided", "optional-input": None}
+            {"required_input": "provided", "optional_input": None}
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1326,6 +1326,31 @@ class TestServeTransport:
         assert "/mcp" in route_paths
 
     @pytest.mark.asyncio
+    async def test_real_fastmcp_tools_list_preserves_parameter_descriptions(self) -> None:
+        from unittest.mock import patch
+
+        fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
+        from ouroboros.mcp.tools.definitions import StartEvolveStepHandler
+
+        adapter = MCPServerAdapter()
+        adapter.register_tool(StartEvolveStepHandler())
+
+        with patch.object(
+            fastmcp_module.FastMCP,
+            "run_stdio_async",
+            new=AsyncMock(),
+        ):
+            await adapter.serve(transport="stdio")
+
+        tools = await adapter._mcp_server.list_tools()
+        tool = next(item for item in tools if item.name == "ouroboros_start_evolve_step")
+        description = tool.inputSchema["properties"]["seed_content"]["description"]
+
+        assert "YAML-formatted string" in description
+        assert "not JSON-shaped text or an object literal" in description
+        assert "before Ouroboros receives it" in description
+
+    @pytest.mark.asyncio
     async def test_fastmcp_path_enforces_security(self):
         """FastMCP tool wrapper routes through call_tool to enforce security checks."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1355,8 +1355,8 @@ class TestServeTransport:
         from unittest.mock import patch
 
         fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
-        from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
         from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler
+        from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
         from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
 
         adapter = MCPServerAdapter()

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1374,7 +1374,13 @@ class TestServeTransport:
         tools = {tool.name: tool for tool in await adapter._mcp_server.list_tools()}
 
         brownfield_action = tools["ouroboros_brownfield"].inputSchema["properties"]["action"]
-        assert brownfield_action["enum"] == ["scan", "register", "query", "set_default", "set_defaults"]
+        assert brownfield_action["enum"] == [
+            "scan",
+            "register",
+            "query",
+            "set_default",
+            "set_defaults",
+        ]
 
         authoring_client_gates = tools["ouroboros_generate_seed"].inputSchema["properties"][
             "client_gates"

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1438,6 +1438,17 @@ class TestServeTransport:
                             default=None,
                             description="Optional input",
                         ),
+                        MCPToolParameter(
+                            name="optional_mode",
+                            type=ToolInputType.STRING,
+                            enum=("fast", "safe"),
+                            default=None,
+                        ),
+                        MCPToolParameter(
+                            name="scores",
+                            type=ToolInputType.ARRAY,
+                            items={"type": "number"},
+                        ),
                     ),
                 )
 
@@ -1457,12 +1468,32 @@ class TestServeTransport:
 
         await adapter._mcp_server.call_tool(
             "optional_tool",
-            {"required_input": "provided"},
+            {"required_input": "provided", "scores": [1.5]},
         )
 
         handler.handle_mock.assert_awaited_once_with(
-            {"required_input": "provided", "optional_input": None}
+            {
+                "required_input": "provided",
+                "optional_input": None,
+                "optional_mode": None,
+                "scores": [1.5],
+            }
         )
+
+        with pytest.raises(Exception, match="Invalid value for optional_mode"):
+            await adapter._mcp_server.call_tool(
+                "optional_tool",
+                {
+                    "required_input": "provided",
+                    "optional_mode": "unsafe",
+                    "scores": [1.5],
+                },
+            )
+        with pytest.raises(Exception, match="Invalid items for scores"):
+            await adapter._mcp_server.call_tool(
+                "optional_tool",
+                {"required_input": "provided", "scores": [True]},
+            )
 
     @pytest.mark.asyncio
     async def test_fastmcp_path_enforces_security(self):

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1396,6 +1396,54 @@ class TestServeTransport:
         assert "seed_content" not in evolve_tool.inputSchema.get("required", [])
 
     @pytest.mark.asyncio
+    async def test_real_fastmcp_invocation_passes_none_for_omitted_optional_parameter(self) -> None:
+        fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
+
+        class OptionalParameterHandler(MockToolHandler):
+            @property
+            def definition(self) -> MCPToolDefinition:
+                return MCPToolDefinition(
+                    name="optional_tool",
+                    description="A tool with an omitted optional parameter",
+                    parameters=(
+                        MCPToolParameter(
+                            name="required-input",
+                            type=ToolInputType.STRING,
+                            required=True,
+                        ),
+                        MCPToolParameter(
+                            name="optional-input",
+                            type=ToolInputType.STRING,
+                            default=None,
+                            description="Optional input",
+                        ),
+                    ),
+                )
+
+        from unittest.mock import patch
+
+        adapter = MCPServerAdapter()
+        handler = OptionalParameterHandler(name="optional_tool")
+        adapter.register_tool(handler)
+        with (
+            patch.object(
+                fastmcp_module.FastMCP,
+                "run_stdio_async",
+                new=AsyncMock(),
+            ),
+        ):
+            await adapter.serve(transport="stdio")
+
+        await adapter._mcp_server.call_tool(
+            "optional_tool",
+            {"required-input": "provided"},
+        )
+
+        handler.handle_mock.assert_awaited_once_with(
+            {"required-input": "provided", "optional-input": None}
+        )
+
+    @pytest.mark.asyncio
     async def test_fastmcp_path_enforces_security(self):
         """FastMCP tool wrapper routes through call_tool to enforce security checks."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1351,6 +1351,42 @@ class TestServeTransport:
         assert "before Ouroboros receives it" in description
 
     @pytest.mark.asyncio
+    async def test_real_fastmcp_tools_list_preserves_parameter_schema_metadata(self) -> None:
+        from unittest.mock import patch
+
+        fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
+        from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
+        from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler
+        from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
+
+        adapter = MCPServerAdapter()
+        adapter.register_tool(BrownfieldHandler())
+        adapter.register_tool(GenerateSeedHandler())
+        adapter.register_tool(StartEvolveStepHandler())
+
+        with patch.object(
+            fastmcp_module.FastMCP,
+            "run_stdio_async",
+            new=AsyncMock(),
+        ):
+            await adapter.serve(transport="stdio")
+
+        tools = {tool.name: tool for tool in await adapter._mcp_server.list_tools()}
+
+        brownfield_action = tools["ouroboros_brownfield"].inputSchema["properties"]["action"]
+        assert brownfield_action["enum"] == ["scan", "register", "query", "set_default", "set_defaults"]
+
+        authoring_client_gates = tools["ouroboros_generate_seed"].inputSchema["properties"][
+            "client_gates"
+        ]
+        assert authoring_client_gates["items"] == {"type": "string"}
+
+        evolve_tool = tools["ouroboros_start_evolve_step"]
+        execute_schema = evolve_tool.inputSchema["properties"]["execute"]
+        assert execute_schema["type"] == "boolean"
+        assert "null" not in execute_schema.get("type", [])
+
+    @pytest.mark.asyncio
     async def test_fastmcp_path_enforces_security(self):
         """FastMCP tool wrapper routes through call_tool to enforce security checks."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1417,7 +1417,14 @@ class TestServeTransport:
         assert "seed_content" not in evolve_tool.inputSchema.get("required", [])
 
     @pytest.mark.asyncio
-    async def test_real_fastmcp_invocation_passes_none_for_omitted_optional_parameter(self) -> None:
+    async def test_real_fastmcp_invocation_omits_unset_optional_parameters(self) -> None:
+        """Omitted optionals must not reach the handler as explicit `None`.
+
+        #1538 classified forwarding an unset optional as `None` a bug — in-process
+        callers see a missing key while plugin-MCP callers saw `key present, value
+        None`, which crashed handlers doing `.get(k, [])`. #1726 normalized that at
+        the wrapper chokepoint, so the contract asserted here is omission, not None.
+        """
         fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
 
         class OptionalParameterHandler(MockToolHandler):
@@ -1480,11 +1487,12 @@ class TestServeTransport:
         handler.handle_mock.assert_awaited_once_with(
             {
                 "required_input": "provided",
-                "optional_input": None,
-                "optional_mode": None,
                 "scores": [1.5],
             }
         )
+        forwarded = handler.handle_mock.await_args.args[0]
+        assert "optional_input" not in forwarded
+        assert "optional_mode" not in forwarded
 
         with pytest.raises(Exception, match="Invalid value for optional_mode"):
             await adapter._mcp_server.call_tool(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from structlog.testing import capture_logs
@@ -1417,6 +1417,68 @@ class TestServeTransport:
         assert "seed_content" not in evolve_tool.inputSchema.get("required", [])
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
+    async def test_required_parameter_default_survives_into_fastmcp_schema(self) -> None:
+        """A required parameter may still carry a `default` annotation.
+
+        `MCPToolDefinition.to_input_schema()` emits `default` for required
+        parameters, and JSON Schema permits it. Pydantic discards the value along
+        with `Field(default=...)`, so the two surfaces must be pinned against each
+        other or they silently describe different tools.
+        """
+        fastmcp_module = pytest.importorskip("mcp.server.fastmcp")
+
+        class DefaultedRequiredHandler(MockToolHandler):
+            @property
+            def definition(self) -> MCPToolDefinition:
+                return MCPToolDefinition(
+                    name="defaulted_tool",
+                    description="A required parameter carrying a default",
+                    parameters=(
+                        MCPToolParameter(
+                            name="mode",
+                            type=ToolInputType.STRING,
+                            required=True,
+                            default="safe",
+                            description="Execution mode",
+                        ),
+                    ),
+                )
+
+        adapter = MCPServerAdapter()
+        handler = DefaultedRequiredHandler(name="defaulted_tool")
+        adapter.register_tool(handler)
+        with patch.object(fastmcp_module.FastMCP, "run_stdio_async", new=AsyncMock()):
+            await adapter.serve(transport="stdio")
+
+        tools = await adapter._mcp_server.list_tools()
+        tool = next(t for t in tools if t.name == "defaulted_tool")
+        mode_schema = tool.inputSchema["properties"]["mode"]
+
+        canonical = handler.definition.to_input_schema()["properties"]["mode"]
+        assert canonical["default"] == "safe"
+        assert mode_schema["default"] == "safe", "FastMCP schema dropped the canonical default"
+        assert "mode" in tool.inputSchema["required"], "the default must not make it optional"
+
+    def test_integer_array_items_accept_integral_floats(self) -> None:
+        """JSON Schema `type: integer` matches any number with no fractional part.
+
+        The advertised schema accepts `[1.0]`, so runtime validation must not
+        reject it on Python `int` identity alone.
+        """
+        parameter = MCPToolParameter(
+            name="nums",
+            type=ToolInputType.ARRAY,
+            required=False,
+            items={"type": "integer"},
+        )
+        for accepted in ([1], [1.0], [2.0, 3]):
+            _validate_parameter_constraints((parameter,), {"nums": accepted})
+
+        for rejected in ([1.5], [True], ["1"]):
+            with pytest.raises(ValueError, match="Invalid items for nums"):
+                _validate_parameter_constraints((parameter,), {"nums": rejected})
+
     async def test_real_fastmcp_invocation_omits_unset_optional_parameters(self) -> None:
         """Omitted optionals must not reach the handler as explicit `None`.
 

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1432,21 +1432,27 @@ class TestServeTransport:
                             type=ToolInputType.STRING,
                             required=True,
                         ),
+                        # `MCPToolParameter.required` defaults to True, so an
+                        # optional parameter must say so explicitly — `default=None`
+                        # alone does not make it optional.
                         MCPToolParameter(
                             name="optional_input",
                             type=ToolInputType.STRING,
+                            required=False,
                             default=None,
                             description="Optional input",
                         ),
                         MCPToolParameter(
                             name="optional_mode",
                             type=ToolInputType.STRING,
+                            required=False,
                             enum=("fast", "safe"),
                             default=None,
                         ),
                         MCPToolParameter(
                             name="scores",
                             type=ToolInputType.ARRAY,
+                            required=False,
                             items={"type": "number"},
                         ),
                     ),

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2371,6 +2371,26 @@ class TestAsyncJobHandlers:
         handler = StartEvolveStepHandler()
         assert handler.definition.name == "ouroboros_start_evolve_step"
 
+    def test_start_evolve_step_inherits_seed_yaml_text_schema(self) -> None:
+        evolve_seed = next(
+            parameter
+            for parameter in EvolveStepHandler().definition.parameters
+            if parameter.name == "seed_content"
+        )
+        start_definition = StartEvolveStepHandler().definition
+        start_seed = next(
+            parameter
+            for parameter in start_definition.parameters
+            if parameter.name == "seed_content"
+        )
+
+        assert evolve_seed.type == ToolInputType.STRING
+        assert start_seed.type == ToolInputType.STRING
+        assert start_seed.description == evolve_seed.description
+        assert "YAML-formatted string" in start_seed.description
+        assert "not JSON-shaped text or an object literal" in start_seed.description
+        assert "before Ouroboros receives it" in start_seed.description
+
     def test_evolve_step_has_no_fixed_mcp_timeout_by_default(self) -> None:
         """evolve_step uses progress-aware controls rather than a hard 2h wall clock."""
         handler = EvolveStepHandler()


### PR DESCRIPTION
## Summary

- propagate MCP parameter descriptions into the Python signatures FastMCP uses to build its public tools/list schema
- clarify that evolve seed_content is YAML-formatted text and should not be sent as JSON-shaped text or an object literal
- cover the actual FastMCP transport boundary, addressing the maintainer feedback that closed #1689

This remains a schema/documentation fix. It does not add server-side coercion or claim to fix client-side MCP coercion.

## Test plan

- [x] Full repository suite: 12,950 passed, 8 skipped
- [x] MCP unit suite: 1,385 passed
- [x] Focused adapter and definition tests: 206 passed
- [x] Real FastMCP tools/list regression confirms seed_content guidance is client-visible
- [x] Ruff check and format clean
- [x] Full mypy src/ clean across 466 source files

## Related issues

Closes #1686
Follow-up to #1689