### PR TITLE
fix(release): sync bundled setup version marker

### DIFF
--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -282,7 +282,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.39.1 -->
+<!-- ooo:VERSION:0.50.5 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parent.parent
 PLUGIN_JSON = ROOT / ".claude-plugin" / "plugin.json"
 MARKETPLACE_JSON = ROOT / ".claude-plugin" / "marketplace.json"
 SETUP_SKILL_MD = ROOT / "skills" / "setup" / "SKILL.md"
+BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
 
 
 def get_version() -> str:
@@ -178,19 +179,22 @@ def main() -> None:
             print(f"  DRIFT {path.relative_to(ROOT)} ({old} != {version})")
             changed = True
 
-    # Sync setup SKILL.md template version marker
-    if SETUP_SKILL_MD.exists():
-        text = SETUP_SKILL_MD.read_text()
+    for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
+        if not path.exists():
+            print(f"  SKIP  {path.relative_to(ROOT)} (not found)")
+            continue
+
+        text = path.read_text()
         marker_match = re.search(r"<!-- ooo:VERSION:([\d\w.]+) -->", text)
         old_marker = marker_match.group(1) if marker_match else "?"
         if old_marker == version:
-            print(f"  OK    {SETUP_SKILL_MD.relative_to(ROOT)} ({old_marker})")
+            print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
         elif write:
-            update_version_marker(SETUP_SKILL_MD, version)
-            print(f"  WRITE {SETUP_SKILL_MD.relative_to(ROOT)} ({old_marker} -> {version})")
+            update_version_marker(path, version)
+            print(f"  WRITE {path.relative_to(ROOT)} ({old_marker} -> {version})")
             changed = True
         else:
-            print(f"  DRIFT {SETUP_SKILL_MD.relative_to(ROOT)} ({old_marker} != {version})")
+            print(f"  DRIFT {path.relative_to(ROOT)} ({old_marker} != {version})")
             changed = True
 
     if changed and not write:

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -169,20 +169,38 @@ def main() -> None:
             sys.exit(f"Error: expected exactly one version marker in {path.relative_to(ROOT)}")
         setup_markers[path] = (text, marker_matches[0].group(1))
 
-    changed = False
+    json_targets: list[tuple[Path, str | None, object, str]] = []
     for path, nested in targets:
+        if not path.exists():
+            continue
+
+        try:
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                raise TypeError("top-level JSON value must be an object")
+            target: object = data
+            if nested:
+                for key in nested.split("."):
+                    if key.isdigit():
+                        if not isinstance(target, list):
+                            raise TypeError("numeric path component requires an array")
+                        target = target[int(key)]
+                    else:
+                        if not isinstance(target, dict):
+                            raise TypeError("named path component requires an object")
+                        target = target[key]
+                if not isinstance(target, dict):
+                    raise TypeError("version target must be an object")
+            old = target.get("version", "?")
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError) as exc:
+            sys.exit(f"Error: could not validate {path.relative_to(ROOT)}: {exc}")
+        json_targets.append((path, nested, data, str(old)))
+
+    changed = False
+    for path, nested, _data, old in json_targets:
         if not path.exists():
             print(f"  SKIP  {path.relative_to(ROOT)} (not found)")
             continue
-
-        data = json.loads(path.read_text())
-        if nested:
-            target = data
-            for key in nested.split("."):
-                target = target[int(key)] if key.isdigit() else target[key]
-            old = target.get("version", "?")
-        else:
-            old = data.get("version", "?")
 
         if old == version:
             print(f"  OK    {path.relative_to(ROOT)} ({old})")

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -159,6 +159,16 @@ def main() -> None:
         (MARKETPLACE_JSON, "plugins.0"),
     ]
 
+    setup_markers: dict[Path, tuple[str, str]] = {}
+    for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
+        if not path.exists():
+            sys.exit(f"Error: required setup skill not found: {path.relative_to(ROOT)}")
+        text = path.read_text()
+        marker_matches = list(VERSION_MARKER_RE.finditer(text))
+        if len(marker_matches) != 1:
+            sys.exit(f"Error: expected exactly one version marker in {path.relative_to(ROOT)}")
+        setup_markers[path] = (text, marker_matches[0].group(1))
+
     changed = False
     for path, nested in targets:
         if not path.exists():
@@ -184,15 +194,7 @@ def main() -> None:
             print(f"  DRIFT {path.relative_to(ROOT)} ({old} != {version})")
             changed = True
 
-    for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
-        if not path.exists():
-            sys.exit(f"Error: required setup skill not found: {path.relative_to(ROOT)}")
-
-        text = path.read_text()
-        marker_matches = list(VERSION_MARKER_RE.finditer(text))
-        if len(marker_matches) != 1:
-            sys.exit(f"Error: expected exactly one version marker in {path.relative_to(ROOT)}")
-        old_marker = marker_matches[0].group(1)
+    for path, (_text, old_marker) in setup_markers.items():
         if old_marker == version:
             print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
         elif write:

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -19,6 +19,7 @@ PLUGIN_JSON = ROOT / ".claude-plugin" / "plugin.json"
 MARKETPLACE_JSON = ROOT / ".claude-plugin" / "marketplace.json"
 SETUP_SKILL_MD = ROOT / "skills" / "setup" / "SKILL.md"
 BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([\d\w.]+) -->")
 
 
 def get_version() -> str:
@@ -96,14 +97,18 @@ def normalize_version(v: str) -> str:
 def update_version_marker(path: Path, version: str) -> bool:
     """Update <!-- ooo:VERSION:X.Y.Z --> marker in a text file."""
     text = path.read_text()
-    new_text = re.sub(
-        r"<!-- ooo:VERSION:[\d\w.]+ -->",
-        f"<!-- ooo:VERSION:{version} -->",
-        text,
-    )
+    matches = list(VERSION_MARKER_RE.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one version marker in {path}")
+
+    new_text = VERSION_MARKER_RE.sub(f"<!-- ooo:VERSION:{version} -->", text)
     if text == new_text:
         return False
     path.write_text(new_text)
+
+    updated_matches = list(VERSION_MARKER_RE.finditer(path.read_text()))
+    if len(updated_matches) != 1 or updated_matches[0].group(1) != version:
+        raise RuntimeError(f"failed to verify version marker update in {path}")
     return True
 
 
@@ -181,16 +186,19 @@ def main() -> None:
 
     for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
         if not path.exists():
-            print(f"  SKIP  {path.relative_to(ROOT)} (not found)")
-            continue
+            sys.exit(f"Error: required setup skill not found: {path.relative_to(ROOT)}")
 
         text = path.read_text()
-        marker_match = re.search(r"<!-- ooo:VERSION:([\d\w.]+) -->", text)
-        old_marker = marker_match.group(1) if marker_match else "?"
+        marker_matches = list(VERSION_MARKER_RE.finditer(text))
+        if len(marker_matches) != 1:
+            sys.exit(f"Error: expected exactly one version marker in {path.relative_to(ROOT)}")
+        old_marker = marker_matches[0].group(1)
         if old_marker == version:
             print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
         elif write:
-            update_version_marker(path, version)
+            updated = update_version_marker(path, version)
+            if not updated:
+                sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
             print(f"  WRITE {path.relative_to(ROOT)} ({old_marker} -> {version})")
             changed = True
         else:

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -172,7 +172,7 @@ def main() -> None:
     json_targets: list[tuple[Path, str | None, object, str]] = []
     for path, nested in targets:
         if not path.exists():
-            continue
+            sys.exit(f"Error: required plugin metadata not found: {path.relative_to(ROOT)}")
 
         try:
             data = json.loads(path.read_text())

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -90,8 +90,14 @@ def normalize_version(v: str) -> str:
     e.g. 0.26.0b4 -> 0.26.0b4, 0.26.0.dev3 -> 0.26.0, 0.26.0b4.dev1 -> 0.26.0b4
     """
     # Match semver + optional pre-release (a/alpha/b/beta/rc + number)
-    m = re.match(r"(\d+\.\d+\.\d+(?:(?:a|alpha|b|beta|rc)\d*)?)", v)
-    return m.group(1) if m else v
+    # and an optional hatch-vcs development suffix.
+    match = re.fullmatch(
+        r"(?P<public>\d+\.\d+\.\d+(?:(?:a|alpha|b|beta|rc)\d*)?)(?:\.dev\d+)?",
+        v,
+    )
+    if match is None:
+        raise ValueError(f"unsupported version: {v}")
+    return match.group("public")
 
 
 def update_version_marker(path: Path, version: str) -> bool:
@@ -148,7 +154,10 @@ def main() -> None:
             explicit_version = sys.argv[i + 1]
 
     raw_version = explicit_version or get_version()
-    version = normalize_version(raw_version)
+    try:
+        version = normalize_version(raw_version)
+    except ValueError as exc:
+        sys.exit(f"Error: {exc}")
 
     print(f"Source version: {raw_version}")
     print(f"Plugin version: {version}")
@@ -191,10 +200,12 @@ def main() -> None:
                         target = target[key]
                 if not isinstance(target, dict):
                     raise TypeError("version target must be an object")
-            old = target.get("version", "?")
+            old = target.get("version")
+            if not isinstance(old, str):
+                raise TypeError("version must be a string")
         except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError) as exc:
             sys.exit(f"Error: could not validate {path.relative_to(ROOT)}: {exc}")
-        json_targets.append((path, nested, data, str(old)))
+        json_targets.append((path, nested, data, old))
 
     changed = False
     for path, nested, _data, old in json_targets:

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -136,3 +136,41 @@ def test_main_write_fails_when_setup_marker_is_missing(
         assert marketplace_json.read_text() == original_marketplace_json
     else:
         raise AssertionError("missing version marker must fail")
+
+
+def test_main_write_preflights_json_targets_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [}\n')
+    original_plugin_json = plugin_json.read_text()
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    try:
+        sync_plugin_version.main()
+    except SystemExit as exc:
+        assert "could not validate" in str(exc)
+        assert plugin_json.read_text() == original_plugin_json
+    else:
+        raise AssertionError("invalid marketplace JSON must fail before mutation")

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -114,6 +114,8 @@ def test_main_write_fails_when_setup_marker_is_missing(
     bundled_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nbundled\n")
     plugin_json.write_text('{"version": "1.2.4"}\n')
     marketplace_json.write_text('{"plugins": [{"version": "1.2.4"}]}\n')
+    original_plugin_json = plugin_json.read_text()
+    original_marketplace_json = marketplace_json.read_text()
 
     monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
     monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
@@ -130,5 +132,7 @@ def test_main_write_fails_when_setup_marker_is_missing(
         sync_plugin_version.main()
     except SystemExit as exc:
         assert "expected exactly one version marker" in str(exc)
+        assert plugin_json.read_text() == original_plugin_json
+        assert marketplace_json.read_text() == original_marketplace_json
     else:
         raise AssertionError("missing version marker must fail")

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 _SCRIPT_PATH = Path(__file__).parent.parent.parent.parent / "scripts" / "sync-plugin-version.py"
 _spec = importlib.util.spec_from_file_location("sync_plugin_version", str(_SCRIPT_PATH))
+assert _spec is not None
 sync_plugin_version = importlib.util.module_from_spec(_spec)
 assert _spec.loader is not None
 _spec.loader.exec_module(sync_plugin_version)
@@ -22,3 +23,42 @@ def test_git_describe_fallback_preserves_exact_tag_version() -> None:
 
 def test_plugin_metadata_version_normalizes_dev_suffix_to_public_version() -> None:
     assert sync_plugin_version.normalize_version("0.39.2.dev28") == "0.39.2"
+
+
+def test_main_write_updates_both_setup_skill_markers(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+
+    source_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.4"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.4"}]}\n')
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    sync_plugin_version.main()
+
+    captured = capsys.readouterr()
+    assert "WRITE skills/setup/SKILL.md (0.39.1 -> 1.2.4)" in captured.out
+    assert "WRITE .claude-plugin/skills/setup/SKILL.md (0.39.1 -> 1.2.4)" in captured.out
+    assert source_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nsource\n"
+    assert bundled_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nbundled\n"

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -62,3 +62,73 @@ def test_main_write_updates_both_setup_skill_markers(
     assert "WRITE .claude-plugin/skills/setup/SKILL.md (0.39.1 -> 1.2.4)" in captured.out
     assert source_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nsource\n"
     assert bundled_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nbundled\n"
+
+
+def test_main_write_fails_when_required_setup_skill_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nsource\n")
+    plugin_json.write_text('{"version": "1.2.4"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.4"}]}\n')
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    try:
+        sync_plugin_version.main()
+    except SystemExit as exc:
+        assert "required setup skill not found" in str(exc)
+    else:
+        raise AssertionError("missing required setup skill must fail")
+
+
+def test_main_write_fails_when_setup_marker_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("source without marker\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.4"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.4"}]}\n')
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    try:
+        sync_plugin_version.main()
+    except SystemExit as exc:
+        assert "expected exactly one version marker" in str(exc)
+    else:
+        raise AssertionError("missing version marker must fail")

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _SCRIPT_PATH = Path(__file__).parent.parent.parent.parent / "scripts" / "sync-plugin-version.py"
 _spec = importlib.util.spec_from_file_location("sync_plugin_version", str(_SCRIPT_PATH))
 assert _spec is not None
@@ -174,3 +176,48 @@ def test_main_write_preflights_json_targets_before_mutation(
         assert plugin_json.read_text() == original_plugin_json
     else:
         raise AssertionError("invalid marketplace JSON must fail before mutation")
+
+
+@pytest.mark.parametrize("missing_target", ["plugin", "marketplace"])
+def test_main_write_fails_before_mutation_when_required_json_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+    missing_target: str,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:0.39.1 -->\nbundled\n")
+    if missing_target != "plugin":
+        plugin_json.write_text('{"version": "1.2.3"}\n')
+    if missing_target != "marketplace":
+        marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+
+    original_source = source_skill.read_text()
+    original_bundled = bundled_skill.read_text()
+    existing_json = marketplace_json if missing_target == "plugin" else plugin_json
+    original_json = existing_json.read_text()
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    with pytest.raises(SystemExit, match="required plugin metadata not found"):
+        sync_plugin_version.main()
+
+    assert source_skill.read_text() == original_source
+    assert bundled_skill.read_text() == original_bundled
+    assert existing_json.read_text() == original_json

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -23,8 +23,27 @@ def test_git_describe_fallback_preserves_exact_tag_version() -> None:
     assert sync_plugin_version.version_from_git_describe("v0.39.1") == "0.39.1"
 
 
-def test_plugin_metadata_version_normalizes_dev_suffix_to_public_version() -> None:
-    assert sync_plugin_version.normalize_version("0.39.2.dev28") == "0.39.2"
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("0.39.2.dev28", "0.39.2"),
+        ("1.2.3a1", "1.2.3a1"),
+        ("1.2.3b4", "1.2.3b4"),
+        ("1.2.3rc2", "1.2.3rc2"),
+        ("1.2.3b4.dev1", "1.2.3b4"),
+    ],
+)
+def test_plugin_metadata_version_normalizes_supported_versions(
+    version: str,
+    expected: str,
+) -> None:
+    assert sync_plugin_version.normalize_version(version) == expected
+
+
+@pytest.mark.parametrize("version", ["not-a-version", "1.2", "1.2.3garbage"])
+def test_plugin_metadata_version_rejects_unsupported_versions(version: str) -> None:
+    with pytest.raises(ValueError, match="unsupported version"):
+        sync_plugin_version.normalize_version(version)
 
 
 def test_main_write_updates_both_setup_skill_markers(
@@ -221,3 +240,97 @@ def test_main_write_fails_before_mutation_when_required_json_is_missing(
     assert source_skill.read_text() == original_source
     assert bundled_skill.read_text() == original_bundled
     assert existing_json.read_text() == original_json
+
+
+@pytest.mark.parametrize(
+    ("plugin_version", "marketplace_version"),
+    [
+        (None, "1.2.3"),
+        (123, "1.2.3"),
+        ("1.2.3", None),
+        ("1.2.3", 123),
+    ],
+)
+def test_main_write_rejects_missing_or_non_string_json_version_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+    plugin_version: object,
+    marketplace_version: object,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+
+    plugin_payload = {} if plugin_version is None else {"version": plugin_version}
+    marketplace_plugin = {} if marketplace_version is None else {"version": marketplace_version}
+    plugin_json.write_text(__import__("json").dumps(plugin_payload) + "\n")
+    marketplace_json.write_text(__import__("json").dumps({"plugins": [marketplace_plugin]}) + "\n")
+    original_plugin = plugin_json.read_text()
+    original_marketplace = marketplace_json.read_text()
+    original_source = source_skill.read_text()
+    original_bundled = bundled_skill.read_text()
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    with pytest.raises(SystemExit, match="version must be a string"):
+        sync_plugin_version.main()
+
+    assert plugin_json.read_text() == original_plugin
+    assert marketplace_json.read_text() == original_marketplace
+    assert source_skill.read_text() == original_source
+    assert bundled_skill.read_text() == original_bundled
+
+
+def test_main_write_rejects_unsupported_source_version_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+    originals = {
+        path: path.read_text()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.3garbage"],
+    )
+
+    with pytest.raises(SystemExit, match="unsupported version"):
+        sync_plugin_version.main()
+
+    for path, original in originals.items():
+        assert path.read_text() == original


### PR DESCRIPTION
## Summary

The release sync script updated the source setup skill but skipped the separately bundled Claude plugin copy. As a result, the bundled marker remained at 0.39.1 while the released source and plugin metadata were at 0.50.5.

This change includes both setup skill paths in the existing marker-only sync loop. It deliberately does not copy either skill file over the other because their surrounding instructions differ.

## Test plan

- [x] 4 sync-script unit tests pass
- [x] Isolated dry-run reports both Markdown and both JSON targets without changing bytes
- [x] Isolated write updates all four versions while preserving unrelated Markdown prose and JSON data
- [x] Repository 0.50.5 dry-run reports all four targets OK
- [x] Ruff check and format clean
- [x] Full mypy src and scripts clean across 480 files

## Related issues

No existing issue or pull request matched this release-sync drift.