### PR TITLE
fix(interview): atomically persist resumable artifacts

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -115,9 +115,7 @@ def _fsync_parent_directory(file_path: Path) -> bool:
     try:
         directory_fd = os.open(file_path.parent, flags)
     except OSError as error:
-        if error.errno in (errno.EINVAL, errno.ENOTSUP):
-            return True
-        return False
+        return error.errno in (errno.EINVAL, errno.ENOTSUP)
     durability_confirmed = True
     try:
         try:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -105,9 +105,9 @@ _TOOLLESS_INTERVIEW_BASE_PROMPT = """## Role Boundaries
 """
 
 
-def _fsync_parent_directory(file_path: Path) -> None:
+def _fsync_parent_directory(file_path: Path) -> bool:
     if os.name != "posix":
-        return
+        return True
 
     flags = os.O_RDONLY
     if hasattr(os, "O_DIRECTORY"):
@@ -116,19 +116,24 @@ def _fsync_parent_directory(file_path: Path) -> None:
         directory_fd = os.open(file_path.parent, flags)
     except OSError as error:
         if error.errno in (errno.EINVAL, errno.ENOTSUP):
-            return
-        raise
+            return True
+        return False
+    durability_confirmed = True
     try:
         try:
             os.fsync(directory_fd)
         except OSError as error:
             if error.errno not in (errno.EINVAL, errno.ENOTSUP):
-                raise
+                durability_confirmed = False
     finally:
-        os.close(directory_fd)
+        try:
+            os.close(directory_fd)
+        except OSError:
+            durability_confirmed = False
+    return durability_confirmed
 
 
-def _atomic_write_text(file_path: Path, content: str) -> None:
+def _atomic_write_text(file_path: Path, content: str) -> bool:
     try:
         existing_mode = stat.S_IMODE(file_path.stat().st_mode)
     except FileNotFoundError:
@@ -155,7 +160,7 @@ def _atomic_write_text(file_path: Path, content: str) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp_path, file_path)
-        _fsync_parent_directory(file_path)
+        return _fsync_parent_directory(file_path)
     finally:
         if raw_fd is not None:
             try:
@@ -1104,11 +1109,18 @@ class InterviewEngine:
             # Serialize while still on the event-loop (CPU-bound, not I/O)
             content = state.model_dump_json(indent=2)
 
-            def _sync_write() -> None:
+            def _sync_write() -> bool:
                 with _file_lock(file_path, exclusive=True):
-                    _atomic_write_text(file_path, content)
+                    return _atomic_write_text(file_path, content)
 
-            await asyncio.to_thread(_sync_write)
+            durability_confirmed = await asyncio.to_thread(_sync_write)
+
+            if not durability_confirmed:
+                log.warning(
+                    "interview.state_save_durability_uncertain",
+                    interview_id=state.interview_id,
+                    file_path=str(file_path),
+                )
 
             log.info(
                 "interview.state_saved",

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -8,8 +8,12 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+import errno
 import functools
+import os
 from pathlib import Path
+import stat
+import tempfile
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -99,6 +103,69 @@ _TOOLLESS_INTERVIEW_BASE_PROMPT = """## Role Boundaries
 - Prefer scope, non-goal, success criteria, ownership, risk, and verification questions.
 - For brownfield work, focus on intent and decisions rather than discovering what exists.
 """
+
+
+def _fsync_parent_directory(file_path: Path) -> None:
+    if os.name != "posix":
+        return
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        directory_fd = os.open(file_path.parent, flags)
+    except OSError as error:
+        if error.errno in (errno.EINVAL, errno.ENOTSUP):
+            return
+        raise
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError as error:
+            if error.errno not in (errno.EINVAL, errno.ENOTSUP):
+                raise
+    finally:
+        os.close(directory_fd)
+
+
+def _atomic_write_text(file_path: Path, content: str) -> None:
+    try:
+        existing_mode = stat.S_IMODE(file_path.stat().st_mode)
+    except FileNotFoundError:
+        existing_mode = None
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{file_path.name}.",
+        suffix=".tmp",
+        dir=str(file_path.parent),
+    )
+    raw_fd: int | None = fd
+    tmp_path = Path(tmp_name)
+    try:
+        if existing_mode is not None:
+            if os.name == "posix":
+                os.fchmod(fd, existing_mode)
+            else:
+                tmp_path.chmod(existing_mode)
+
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        raw_fd = None
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, file_path)
+        _fsync_parent_directory(file_path)
+    finally:
+        if raw_fd is not None:
+            try:
+                os.close(raw_fd)
+            except OSError:
+                pass
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
 
 
 class InterviewPerspective(StrEnum):
@@ -1039,7 +1106,7 @@ class InterviewEngine:
 
             def _sync_write() -> None:
                 with _file_lock(file_path, exclusive=True):
-                    file_path.write_text(content, encoding="utf-8")
+                    _atomic_write_text(file_path, content)
 
             await asyncio.to_thread(_sync_write)
 

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -39,6 +39,7 @@ from ouroboros.bigbang.interview import (
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
     InterviewState,
+    _atomic_write_text,
     initial_context_summary_missing,
     prompt_safe_initial_context,
 )
@@ -1180,7 +1181,7 @@ class PMInterviewEngine:
             ensure_ascii=False,
             indent=2,
         )
-        filepath.write_text(json_content, encoding="utf-8")
+        _atomic_write_text(filepath, json_content)
 
         log.info(
             "pm.seed_saved",

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -1181,7 +1181,14 @@ class PMInterviewEngine:
             ensure_ascii=False,
             indent=2,
         )
-        _atomic_write_text(filepath, json_content)
+        durability_confirmed = _atomic_write_text(filepath, json_content)
+
+        if not durability_confirmed:
+            log.warning(
+                "pm.seed_save_durability_uncertain",
+                path=str(filepath),
+                pm_id=seed.pm_id,
+            )
 
         log.info(
             "pm.seed_saved",

--- a/tests/unit/bigbang/test_interview_async_io.py
+++ b/tests/unit/bigbang/test_interview_async_io.py
@@ -9,6 +9,12 @@ See: https://github.com/Q00/ouroboros/issues/284
 
 from __future__ import annotations
 
+import errno
+import os
+from pathlib import Path
+import stat
+import tempfile
+from typing import IO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,6 +26,27 @@ from ouroboros.bigbang.interview import (
     InterviewStatus,
 )
 from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+
+class _PartialWriteHandle:
+    def __init__(self, handle: IO[str]) -> None:
+        self._handle = handle
+
+    def __enter__(self) -> _PartialWriteHandle:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self._handle.close()
+
+    def write(self, content: str) -> int:
+        _ = self._handle.write(content[:1])
+        raise RuntimeError("interrupted write")
+
+    def flush(self) -> None:
+        self._handle.flush()
+
+    def fileno(self) -> int:
+        return self._handle.fileno()
 
 
 def _make_engine(tmp_path) -> InterviewEngine:
@@ -74,6 +101,119 @@ class TestSaveStateUsesThread:
         # The saved file should exist on disk
         saved_path = result.value
         assert saved_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_save_state_preserves_existing_file_on_replace_failure(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+        saved_path = engine._state_file_path(state.interview_id)
+        saved_path.write_text("original\n", encoding="utf-8")
+
+        with (
+            patch("tempfile.mkstemp", wraps=tempfile.mkstemp) as mock_mkstemp,
+            patch("os.fsync") as mock_fsync,
+            patch("os.replace", side_effect=OSError("boom")),
+        ):
+            result = await engine.save_state(state)
+
+        assert result.is_err
+        assert saved_path.read_text(encoding="utf-8") == "original\n"
+        assert mock_mkstemp.call_count == 1
+        assert mock_mkstemp.call_args.kwargs["dir"] == str(saved_path.parent)
+        mock_fsync.assert_called_once()
+        assert {path.name for path in saved_path.parent.iterdir()} == {
+            saved_path.name,
+            f"{saved_path.name}.lock",
+        }
+
+    @pytest.mark.asyncio
+    async def test_save_state_closes_raw_fd_when_fdopen_fails(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+        created_fds: list[int] = []
+        created_paths: list[Path] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def _recording_mkstemp(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            created_fds.append(fd)
+            created_paths.append(Path(name))
+            return fd, name
+
+        with (
+            patch("tempfile.mkstemp", side_effect=_recording_mkstemp),
+            patch("os.fdopen", side_effect=RuntimeError("fdopen failed")),
+            pytest.raises(RuntimeError, match="fdopen failed"),
+        ):
+            await engine.save_state(state)
+
+        with pytest.raises(OSError):
+            os.fstat(created_fds[0])
+        assert not created_paths[0].exists()
+
+    @pytest.mark.asyncio
+    async def test_save_state_removes_partial_temp_on_non_oserror_write(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+        saved_path = engine._state_file_path(state.interview_id)
+        saved_path.write_text("original\n", encoding="utf-8")
+        real_fdopen = os.fdopen
+
+        def _interrupting_fdopen(fd, *args, **kwargs):
+            return _PartialWriteHandle(real_fdopen(fd, *args, **kwargs))
+
+        with (
+            patch("os.fdopen", side_effect=_interrupting_fdopen),
+            pytest.raises(RuntimeError, match="interrupted write"),
+        ):
+            await engine.save_state(state)
+
+        assert saved_path.read_text(encoding="utf-8") == "original\n"
+        assert {path.name for path in saved_path.parent.iterdir()} == {
+            saved_path.name,
+            f"{saved_path.name}.lock",
+        }
+
+    @pytest.mark.asyncio
+    async def test_save_state_preserves_existing_mode(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+        saved_path = engine._state_file_path(state.interview_id)
+        saved_path.write_text("original\n", encoding="utf-8")
+        saved_path.chmod(0o640)
+        expected_mode = stat.S_IMODE(saved_path.stat().st_mode)
+
+        result = await engine.save_state(state)
+
+        assert result.is_ok
+        assert stat.S_IMODE(saved_path.stat().st_mode) == expected_mode
+
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    @pytest.mark.asyncio
+    async def test_save_state_fsyncs_file_and_parent_directory(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+
+        with patch("os.fsync", wraps=os.fsync) as mock_fsync:
+            result = await engine.save_state(state)
+
+        assert result.is_ok
+        assert mock_fsync.call_count == 2
+
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    @pytest.mark.asyncio
+    async def test_save_state_allows_unsupported_directory_fsync(self, tmp_path) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+
+        with patch(
+            "os.fsync",
+            side_effect=(None, OSError(errno.EINVAL, "directory fsync unsupported")),
+        ) as mock_fsync:
+            result = await engine.save_state(state)
+
+        assert result.is_ok
+        assert mock_fsync.call_count == 2
 
     @pytest.mark.asyncio
     async def test_save_state_roundtrip(self, tmp_path) -> None:

--- a/tests/unit/bigbang/test_interview_async_io.py
+++ b/tests/unit/bigbang/test_interview_async_io.py
@@ -217,9 +217,7 @@ class TestSaveStateUsesThread:
 
     @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
     @pytest.mark.asyncio
-    async def test_save_state_reports_success_when_post_replace_fsync_fails(
-        self, tmp_path
-    ) -> None:
+    async def test_save_state_reports_success_when_post_replace_fsync_fails(self, tmp_path) -> None:
         engine = _make_engine(tmp_path)
         state = _make_state()
 

--- a/tests/unit/bigbang/test_interview_async_io.py
+++ b/tests/unit/bigbang/test_interview_async_io.py
@@ -215,6 +215,26 @@ class TestSaveStateUsesThread:
         assert result.is_ok
         assert mock_fsync.call_count == 2
 
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    @pytest.mark.asyncio
+    async def test_save_state_reports_success_when_post_replace_fsync_fails(
+        self, tmp_path
+    ) -> None:
+        engine = _make_engine(tmp_path)
+        state = _make_state()
+
+        with patch(
+            "os.fsync",
+            side_effect=(None, OSError(errno.EIO, "directory fsync failed")),
+        ) as mock_fsync:
+            result = await engine.save_state(state)
+
+        assert result.is_ok
+        assert mock_fsync.call_count == 2
+        load_result = await engine.load_state(state.interview_id)
+        assert load_result.is_ok
+        assert load_result.value.interview_id == state.interview_id
+
     @pytest.mark.asyncio
     async def test_save_state_roundtrip(self, tmp_path) -> None:
         """save_state writes valid JSON that load_state can read back."""

--- a/tests/unit/bigbang/test_pm_seed_save.py
+++ b/tests/unit/bigbang/test_pm_seed_save.py
@@ -230,6 +230,22 @@ class TestPMSeedSaveJSON:
         assert result.exists()
         assert mock_fsync.call_count == 2
 
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    def test_reports_success_when_post_replace_fsync_fails(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+        seeds_dir = tmp_path / "seeds"
+
+        with patch(
+            "os.fsync",
+            side_effect=(None, OSError(errno.EIO, "directory fsync failed")),
+        ) as mock_fsync:
+            result = engine.save_pm_seed(seed, output_dir=seeds_dir)
+
+        assert result.exists()
+        assert json.loads(result.read_text(encoding="utf-8"))["pm_id"] == seed.pm_id
+        assert mock_fsync.call_count == 2
+
     def test_default_output_dir_is_ouroboros_seeds(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/bigbang/test_pm_seed_save.py
+++ b/tests/unit/bigbang/test_pm_seed_save.py
@@ -6,15 +6,41 @@ with correct naming, content roundtrip, and directory creation.
 
 from __future__ import annotations
 
+import errno
 import json
+import os
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+import stat
+import tempfile
+from typing import IO
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from ouroboros.bigbang.pm_interview import PMInterviewEngine
 from ouroboros.bigbang.pm_seed import PMSeed, UserStory
 from ouroboros.bigbang.question_classifier import QuestionClassifier
+
+
+class _PartialWriteHandle:
+    def __init__(self, handle: IO[str]) -> None:
+        self._handle = handle
+
+    def __enter__(self) -> _PartialWriteHandle:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self._handle.close()
+
+    def write(self, content: str) -> int:
+        _ = self._handle.write(content[:1])
+        raise RuntimeError("interrupted write")
+
+    def flush(self) -> None:
+        self._handle.flush()
+
+    def fileno(self) -> int:
+        return self._handle.fileno()
 
 
 def _make_engine(tmp_path: Path) -> PMInterviewEngine:
@@ -95,6 +121,114 @@ class TestPMSeedSaveJSON:
 
         assert seeds_dir.exists()
         assert filepath.exists()
+
+    def test_preserves_existing_file_on_replace_failure(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+        seeds_dir = tmp_path / "seeds"
+        seeds_dir.mkdir()
+        saved_path = seeds_dir / f"{seed.pm_id}.json"
+        saved_path.write_text("original\n", encoding="utf-8")
+
+        with (
+            patch("tempfile.mkstemp", wraps=tempfile.mkstemp) as mock_mkstemp,
+            patch("os.fsync") as mock_fsync,
+            patch("os.replace", side_effect=OSError("boom")),
+        ):
+            with pytest.raises(OSError):
+                engine.save_pm_seed(seed, output_dir=seeds_dir)
+
+        assert saved_path.read_text(encoding="utf-8") == "original\n"
+        assert mock_mkstemp.call_count == 1
+        assert mock_mkstemp.call_args.kwargs["dir"] == str(seeds_dir)
+        mock_fsync.assert_called_once()
+        assert {path.name for path in seeds_dir.iterdir()} == {saved_path.name}
+
+    def test_closes_raw_fd_when_fdopen_fails(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+        seeds_dir = tmp_path / "seeds"
+        created_fds: list[int] = []
+        created_paths: list[Path] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def _recording_mkstemp(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            created_fds.append(fd)
+            created_paths.append(Path(name))
+            return fd, name
+
+        with (
+            patch("tempfile.mkstemp", side_effect=_recording_mkstemp),
+            patch("os.fdopen", side_effect=RuntimeError("fdopen failed")),
+            pytest.raises(RuntimeError, match="fdopen failed"),
+        ):
+            engine.save_pm_seed(seed, output_dir=seeds_dir)
+
+        with pytest.raises(OSError):
+            os.fstat(created_fds[0])
+        assert not created_paths[0].exists()
+
+    def test_removes_partial_temp_on_non_oserror_write(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+        seeds_dir = tmp_path / "seeds"
+        seeds_dir.mkdir()
+        saved_path = seeds_dir / f"{seed.pm_id}.json"
+        saved_path.write_text("original\n", encoding="utf-8")
+        real_fdopen = os.fdopen
+
+        def _interrupting_fdopen(fd, *args, **kwargs):
+            return _PartialWriteHandle(real_fdopen(fd, *args, **kwargs))
+
+        with (
+            patch("os.fdopen", side_effect=_interrupting_fdopen),
+            pytest.raises(RuntimeError, match="interrupted write"),
+        ):
+            engine.save_pm_seed(seed, output_dir=seeds_dir)
+
+        assert saved_path.read_text(encoding="utf-8") == "original\n"
+        assert {path.name for path in seeds_dir.iterdir()} == {saved_path.name}
+
+    def test_preserves_existing_file_mode(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+        seeds_dir = tmp_path / "seeds"
+        seeds_dir.mkdir()
+        saved_path = seeds_dir / f"{seed.pm_id}.json"
+        saved_path.write_text("original\n", encoding="utf-8")
+        saved_path.chmod(0o640)
+        expected_mode = stat.S_IMODE(saved_path.stat().st_mode)
+
+        result = engine.save_pm_seed(seed, output_dir=seeds_dir)
+
+        assert result == saved_path
+        assert stat.S_IMODE(saved_path.stat().st_mode) == expected_mode
+
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    def test_fsyncs_file_and_parent_directory(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+
+        with patch("os.fsync", wraps=os.fsync) as mock_fsync:
+            result = engine.save_pm_seed(seed, output_dir=tmp_path / "seeds")
+
+        assert result.exists()
+        assert mock_fsync.call_count == 2
+
+    @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
+    def test_allows_unsupported_directory_fsync(self, tmp_path: Path) -> None:
+        engine = _make_engine(tmp_path)
+        seed = _make_seed()
+
+        with patch(
+            "os.fsync",
+            side_effect=(None, OSError(errno.ENOTSUP, "directory fsync unsupported")),
+        ) as mock_fsync:
+            result = engine.save_pm_seed(seed, output_dir=tmp_path / "seeds")
+
+        assert result.exists()
+        assert mock_fsync.call_count == 2
 
     def test_default_output_dir_is_ouroboros_seeds(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Interview state and PM seed JSON are resume-critical, but direct overwrites can leave a truncated file after an interrupted write.

This change uses a shared private same-directory atomic writer for both paths: preserve existing permission bits, fsync content, replace atomically, fsync the POSIX parent directory where supported, and clean up descriptors and temporary files on failure. Existing interview locking and public APIs remain unchanged.

## Test plan

- [x] 650 tests in tests/unit/bigbang
- [x] 31 focused atomic-save, failure-injection, mode, fsync, and round-trip tests
- [x] Partial-write, fdopen, fsync, replace, and directory-fsync failure paths preserve prior bytes and clean up
- [x] Existing destination modes are preserved
- [x] Ruff check and format clean
- [x] MyPy clean on changed source files
- [x] Python compileall clean on changed source and tests

## Related issues

No duplicate issue or pull request matched these two direct resume-artifact save paths.