### PR TITLE
fix(claude): fail safely on invalid MCP config

### DIFF
--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -539,11 +539,12 @@ def backend(
 
     prev_quiet = console.quiet
     setup_failed = False
+    setup_returned_failure = False
     try:
         console.quiet = True
         setup_mod.print_error = _tracking_print_error  # type: ignore[assignment]
         if new_backend == "claude":
-            _setup_claude(cli_path)
+            setup_returned_failure = _setup_claude(cli_path) is False
         elif new_backend == "codex":
             _setup_codex(cli_path)
         elif new_backend == "hermes":
@@ -573,6 +574,9 @@ def backend(
 
     if setup_failed:
         pass  # Already warned above
+    elif setup_returned_failure:
+        print_warning("Backend switch aborted because Claude setup could not complete safely.")
+        raise typer.Exit(1)
     elif _setup_had_errors:
         print_warning("Backend switched but some setup steps had issues.")
         print_info("Run [bold]ouroboros setup[/] to verify configuration.")

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -573,7 +573,7 @@ def backend(
         setup_mod.print_error = _orig_print_error  # type: ignore[assignment]
 
     if setup_failed:
-        pass  # Already warned above
+        raise typer.Exit(1)
     elif setup_returned_failure:
         print_warning("Backend switch aborted because Claude setup could not complete safely.")
         raise typer.Exit(1)

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -19,6 +19,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import sys
 from typing import Annotated, Literal
@@ -97,17 +98,77 @@ def _ensure_claude_mcp_entry() -> None:
     legacy timeout key.  Skips the file write when nothing changed.
     """
     mcp_config_path = Path.home() / ".claude" / "mcp.json"
-    mcp_config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        mcp_config_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print_warning(
+            f"Could not create {mcp_config_path.parent} — MCP registration skipped: {exc}"
+        )
+        return
 
-    mcp_data: dict = {}
-    if mcp_config_path.exists():
-        mcp_data = json.loads(mcp_config_path.read_text())
+    try:
+        config_exists = mcp_config_path.exists()
+    except OSError as exc:
+        print_warning(f"Could not inspect {mcp_config_path} — leaving it untouched: {exc}")
+        return
 
-    mcp_data.setdefault("mcpServers", {})
+    mcp_data: dict[str, object] = {}
+    if config_exists:
+        try:
+            mcp_data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError:
+            print_warning(
+                f"Could not decode {mcp_config_path} as UTF-8 — leaving it untouched. "
+                "Fix the file encoding and re-run setup."
+            )
+            return
+        except json.JSONDecodeError:
+            print_warning(
+                f"Could not parse {mcp_config_path} — skipping MCP registration to avoid "
+                "overwriting existing settings. Fix the JSON syntax and re-run setup."
+            )
+            return
+        except OSError as exc:
+            print_warning(f"Could not read {mcp_config_path} — leaving it untouched: {exc}")
+            return
+        if not isinstance(mcp_data, dict):
+            print_warning(f"{mcp_config_path} top-level is not an object — leaving it untouched.")
+            return
 
-    existing = mcp_data["mcpServers"].get("ouroboros")
+    if "mcpServers" not in mcp_data:
+        servers: dict[str, object] = {}
+        mcp_data["mcpServers"] = servers
+    else:
+        raw_servers = mcp_data["mcpServers"]
+        if not isinstance(raw_servers, dict):
+            print_warning(
+                f"{mcp_config_path} 'mcpServers' section is not an object — leaving it untouched."
+            )
+            return
+        servers = raw_servers
+
+    if "ouroboros" not in servers:
+        existing: dict[str, object] | None = None
+    else:
+        raw_existing = servers["ouroboros"]
+        if not isinstance(raw_existing, dict):
+            print_warning(
+                f"{mcp_config_path} mcpServers.ouroboros is not an object — leaving it untouched."
+            )
+            return
+        existing = raw_existing
+        if "command" in existing and not isinstance(existing["command"], str):
+            print_warning(
+                f"{mcp_config_path} mcpServers.ouroboros.command is not a string — "
+                "leaving it untouched."
+            )
+            return
+
     detected = _detect_mcp_entry(package_spec="ouroboros-ai[mcp,claude]")
     needs_write = False
+    registered = False
+    removed_timeout = False
+    updated_entry = False
 
     if existing is None:
         if detected is None:
@@ -116,15 +177,15 @@ def _ensure_claude_mcp_entry() -> None:
                 "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
             )
             return
-        mcp_data["mcpServers"]["ouroboros"] = detected
+        servers["ouroboros"] = detected
         needs_write = True
-        print_success("Registered MCP server in ~/.claude/mcp.json")
+        registered = True
     else:
         # Remove legacy timeout key
         if "timeout" in existing:
             del existing["timeout"]
             needs_write = True
-            print_info("Removed legacy MCP timeout override.")
+            removed_timeout = True
 
         # Update entry to match currently detected install method, but only
         # for known standard commands. Custom entries (docker, nix, etc.) are
@@ -138,14 +199,25 @@ def _ensure_claude_mcp_entry() -> None:
                 existing["command"] = detected["command"]
                 existing["args"] = detected["args"]
                 needs_write = True
-                print_info("Updated MCP server entry to match current install method.")
+                updated_entry = True
 
         if not needs_write:
             print_info("MCP server already registered.")
 
     if needs_write:
-        with mcp_config_path.open("w") as f:
-            json.dump(mcp_data, f, indent=2)
+        try:
+            mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o644
+            _atomic_write_text(mcp_config_path, json.dumps(mcp_data, indent=2), mode=mode)
+        except (OSError, TypeError, ValueError) as exc:
+            print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
+            return
+
+        if registered:
+            print_success("Registered MCP server in ~/.claude/mcp.json")
+        if removed_timeout:
+            print_info("Removed legacy MCP timeout override.")
+        if updated_entry:
+            print_info("Updated MCP server entry to match current install method.")
 
 
 app = typer.Typer(
@@ -2542,6 +2614,8 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o644) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_name, path)
         try:
             os.chmod(path, mode)

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -107,6 +107,13 @@ def _ensure_claude_mcp_entry() -> None:
         return
 
     try:
+        if mcp_config_path.is_symlink():
+            print_warning(
+                f"Could not update {mcp_config_path} because it is a symlink — "
+                "leaving it untouched. Update the linked configuration target manually "
+                "and re-run setup."
+            )
+            return
         config_exists = mcp_config_path.exists()
     except OSError as exc:
         print_warning(f"Could not inspect {mcp_config_path} — leaving it untouched: {exc}")
@@ -2604,6 +2611,9 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o644) -> None:
     """
     import os
     import tempfile
+
+    if path.is_symlink():
+        raise OSError(f"Refusing to replace symlink: {path}")
 
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -127,6 +127,13 @@ def _ensure_claude_mcp_entry() -> None:
                 "and re-run setup."
             )
             return
+        if mcp_config_path.exists() and mcp_config_path.stat().st_nlink > 1:
+            print_warning(
+                f"Could not update {mcp_config_path} because it is hard-linked — "
+                "leaving it untouched. Update the linked configuration manually "
+                "and re-run setup."
+            )
+            return
         config_exists = mcp_config_path.exists()
     except OSError as exc:
         print_warning(f"Could not inspect {mcp_config_path} — leaving it untouched: {exc}")

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -22,7 +22,7 @@ import shutil
 import stat
 import subprocess
 import sys
-from typing import Annotated, Literal
+from typing import Annotated, Literal, NoReturn
 
 from rich.prompt import Prompt
 from rich.table import Table
@@ -62,6 +62,19 @@ from ouroboros.persistence.brownfield import BrownfieldStore
 def _build_uvx_mcp_args(package_spec: str) -> list[str]:
     """Return the canonical uvx args for the requested Ouroboros package spec."""
     return ["--from", package_spec, "ouroboros", "mcp", "serve"]
+
+
+def _reject_json_constant(value: str) -> NoReturn:
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
 
 
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
@@ -122,14 +135,18 @@ def _ensure_claude_mcp_entry() -> None:
     mcp_data: dict[str, object] = {}
     if config_exists:
         try:
-            mcp_data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+            mcp_data = json.loads(
+                mcp_config_path.read_text(encoding="utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_json_constant,
+            )
         except UnicodeDecodeError:
             print_warning(
                 f"Could not decode {mcp_config_path} as UTF-8 — leaving it untouched. "
                 "Fix the file encoding and re-run setup."
             )
             return
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, ValueError):
             print_warning(
                 f"Could not parse {mcp_config_path} — skipping MCP registration to avoid "
                 "overwriting existing settings. Fix the JSON syntax and re-run setup."
@@ -213,7 +230,7 @@ def _ensure_claude_mcp_entry() -> None:
 
     if needs_write:
         try:
-            mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o644
+            mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o600
             _atomic_write_text(mcp_config_path, json.dumps(mcp_data, indent=2), mode=mode)
         except (OSError, TypeError, ValueError) as exc:
             print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
@@ -2601,7 +2618,7 @@ def _bridge_plugin_source_text() -> str | None:
         return None
 
 
-def _atomic_write_text(path: Path, content: str, *, mode: int = 0o644) -> None:
+def _atomic_write_text(path: Path, content: str, *, mode: int = 0o600) -> None:
     """Write *content* to *path* atomically — temp file + ``os.replace``.
 
     Readers always see either the pre-existing file or the final content —
@@ -2615,6 +2632,12 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o644) -> None:
     if path.is_symlink():
         raise OSError(f"Refusing to replace symlink: {path}")
 
+    try:
+        if path.stat().st_nlink > 1:
+            raise OSError(f"Refusing to replace hard-linked file: {path}")
+    except FileNotFoundError:
+        pass
+
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{path.name}.",
@@ -2622,15 +2645,15 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o644) -> None:
         dir=str(path.parent),
     )
     try:
+        if os.name == "posix":
+            os.fchmod(fd, mode)
+        else:
+            os.chmod(tmp_name, mode)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_name, path)
-        try:
-            os.chmod(path, mode)
-        except OSError:
-            pass  # e.g. Windows FAT — not fatal
     except OSError:
         try:
             Path(tmp_name).unlink()

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -490,6 +490,8 @@ def _manifest_target_post_is_operation_consistent(
 
 def _manifest_completed_targets_are_consistent(manifest: dict[str, object]) -> bool:
     phase = manifest.get("phase")
+    if not isinstance(phase, str):
+        return False
     completed_by_phase = {
         "prepared": (),
         "mcp_written": ("mcp",),

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -103,12 +103,16 @@ def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, o
     return {"command": "python3", "args": ["-m", "ouroboros", "mcp", "serve"]}
 
 
-def _ensure_claude_mcp_entry() -> None:
+def _ensure_claude_mcp_entry() -> bool:
     """Ensure ~/.claude/mcp.json has a correct ouroboros MCP entry.
 
     Creates the entry if missing (detecting install method), updates stale
     uvx args (e.g. ouroboros-ai without [claude] extras), and removes the
-    legacy timeout key.  Skips the file write when nothing changed.
+    legacy timeout key. Skips the file write when nothing changed.
+
+    Returns:
+        True when the entry is registered or already usable, False when the
+        existing configuration could not be updated safely.
     """
     mcp_config_path = Path.home() / ".claude" / "mcp.json"
     try:
@@ -117,7 +121,7 @@ def _ensure_claude_mcp_entry() -> None:
         print_warning(
             f"Could not create {mcp_config_path.parent} — MCP registration skipped: {exc}"
         )
-        return
+        return False
 
     try:
         if mcp_config_path.is_symlink():
@@ -126,18 +130,18 @@ def _ensure_claude_mcp_entry() -> None:
                 "leaving it untouched. Update the linked configuration target manually "
                 "and re-run setup."
             )
-            return
+            return False
         if mcp_config_path.exists() and mcp_config_path.stat().st_nlink > 1:
             print_warning(
                 f"Could not update {mcp_config_path} because it is hard-linked — "
                 "leaving it untouched. Update the linked configuration manually "
                 "and re-run setup."
             )
-            return
+            return False
         config_exists = mcp_config_path.exists()
     except OSError as exc:
         print_warning(f"Could not inspect {mcp_config_path} — leaving it untouched: {exc}")
-        return
+        return False
 
     mcp_data: dict[str, object] = {}
     if config_exists:
@@ -152,19 +156,19 @@ def _ensure_claude_mcp_entry() -> None:
                 f"Could not decode {mcp_config_path} as UTF-8 — leaving it untouched. "
                 "Fix the file encoding and re-run setup."
             )
-            return
+            return False
         except (json.JSONDecodeError, ValueError):
             print_warning(
                 f"Could not parse {mcp_config_path} — skipping MCP registration to avoid "
                 "overwriting existing settings. Fix the JSON syntax and re-run setup."
             )
-            return
+            return False
         except OSError as exc:
             print_warning(f"Could not read {mcp_config_path} — leaving it untouched: {exc}")
-            return
+            return False
         if not isinstance(mcp_data, dict):
             print_warning(f"{mcp_config_path} top-level is not an object — leaving it untouched.")
-            return
+            return False
 
     if "mcpServers" not in mcp_data:
         servers: dict[str, object] = {}
@@ -175,7 +179,7 @@ def _ensure_claude_mcp_entry() -> None:
             print_warning(
                 f"{mcp_config_path} 'mcpServers' section is not an object — leaving it untouched."
             )
-            return
+            return False
         servers = raw_servers
 
     if "ouroboros" not in servers:
@@ -186,14 +190,14 @@ def _ensure_claude_mcp_entry() -> None:
             print_warning(
                 f"{mcp_config_path} mcpServers.ouroboros is not an object — leaving it untouched."
             )
-            return
+            return False
         existing = raw_existing
         if "command" in existing and not isinstance(existing["command"], str):
             print_warning(
                 f"{mcp_config_path} mcpServers.ouroboros.command is not a string — "
                 "leaving it untouched."
             )
-            return
+            return False
 
     detected = _detect_mcp_entry(package_spec="ouroboros-ai[mcp,claude]")
     needs_write = False
@@ -207,7 +211,7 @@ def _ensure_claude_mcp_entry() -> None:
                 "Cannot register MCP server: no working ouroboros installation found.\n"
                 "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
             )
-            return
+            return False
         servers["ouroboros"] = detected
         needs_write = True
         registered = True
@@ -241,7 +245,7 @@ def _ensure_claude_mcp_entry() -> None:
             _atomic_write_text(mcp_config_path, json.dumps(mcp_data, indent=2), mode=mode)
         except (OSError, TypeError, ValueError) as exc:
             print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
-            return
+            return False
 
         if registered:
             print_success("Registered MCP server in ~/.claude/mcp.json")
@@ -249,6 +253,8 @@ def _ensure_claude_mcp_entry() -> None:
             print_info("Removed legacy MCP timeout override.")
         if updated_entry:
             print_info("Updated MCP server entry to match current install method.")
+
+    return True
 
 
 app = typer.Typer(
@@ -2370,8 +2376,14 @@ def _setup_goose(goose_path: str) -> None:
     print_info(f"Config saved to: {config_path}")
 
 
-def _setup_claude(claude_path: str) -> None:
+def _setup_claude(claude_path: str) -> bool:
     """Configure Ouroboros for the Claude Code runtime."""
+    # Register/fix MCP before persisting Claude as the active backend. A failed
+    # operator-owned MCP update must not leave config.yaml claiming setup
+    # succeeded when Claude cannot reach the Ouroboros server.
+    if not _ensure_claude_mcp_entry():
+        return False
+
     from ouroboros.config.loader import create_default_config, ensure_config_dir
 
     config_dir = ensure_config_dir()
@@ -2394,11 +2406,9 @@ def _setup_claude(claude_path: str) -> None:
     with config_path.open("w") as f:
         yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
-    # Register/fix MCP server in ~/.claude/mcp.json
-    _ensure_claude_mcp_entry()
-
     print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
     print_info(f"Config saved to: {config_path}")
+    return True
 
 
 def _strip_jsonc(text: str) -> str:
@@ -2656,12 +2666,19 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o600) -> None:
             os.fchmod(fd, mode)
         else:
             os.chmod(tmp_name, mode)
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
+        stream = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with stream as f:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_name, path)
     except OSError:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             Path(tmp_name).unlink()
         except OSError:
@@ -3263,7 +3280,8 @@ def setup(
         if not claude_path:
             print_error("Claude Code CLI not found in PATH.")
             raise typer.Exit(1)
-        _setup_claude(claude_path)
+        if _setup_claude(claude_path) is False:
+            raise typer.Exit(1)
     elif selected in ("codex", "codex_cli"):
         codex_path = available.get("codex")
         if not codex_path:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -175,6 +175,14 @@ _CLAUDE_MCP_RECOVERY_PHASES = {
 }
 
 
+class _ClaudeSetupConflictError(OSError):
+    """The live target no longer matches the transaction generation."""
+
+
+class _ParentDirectoryFsyncError(OSError):
+    """A promoted directory entry could not be made durable."""
+
+
 def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
     return {
         "dev": int(stat_result.st_dev),
@@ -249,10 +257,13 @@ def _fsync_parent_dir(path: Path) -> None:
         return
     fd = -1
     try:
-        fd = os.open(path.parent, os.O_RDONLY)
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        fd = os.open(path.parent, flags)
         os.fsync(fd)
-    except OSError:
-        return
+    except OSError as exc:
+        raise _ParentDirectoryFsyncError(
+            f"Could not fsync parent directory for {path}: {exc}"
+        ) from exc
     finally:
         if fd >= 0:
             try:
@@ -380,24 +391,32 @@ def _promote_text_cas(
     """Promote bytes only if the live path still matches ``expected``."""
     if os.name != "posix":
         if not _claude_setup_file_matches(path, expected):
-            raise OSError(f"{path} changed during setup")
+            raise _ClaudeSetupConflictError(f"{path} changed during setup")
         _atomic_write_text(path, content.decode("utf-8"), mode=mode)
         promoted = _read_claude_setup_file_snapshot(path)
         if promoted is None or not promoted.existed:
             raise OSError(f"Could not verify promoted file: {path}")
         return promoted
 
+    import tempfile
+
     tmp_path = _write_temp_bytes(path, content, mode=mode)
-    backup_path = path.with_name(f".{path.name}.ouroboros-pre")
+    backup_path: Path | None = None
+    claimed_existing = False
+    published = False
     try:
         if expected.existed:
-            try:
-                backup_path.unlink()
-            except FileNotFoundError:
-                pass
             if not _claude_setup_file_matches(path, expected):
-                raise OSError(f"{path} changed during setup")
+                raise _ClaudeSetupConflictError(f"{path} changed during setup")
+            backup_fd, backup_name = tempfile.mkstemp(
+                prefix=f".{path.name}.ouroboros-pre.",
+                suffix=".tmp",
+                dir=str(path.parent),
+            )
+            backup_path = Path(backup_name)
+            os.close(backup_fd)
             os.rename(path, backup_path)
+            claimed_existing = True
             backup_bytes = backup_path.read_bytes()
             if (
                 not _path_matches_snapshot_while_linked(backup_path, expected)
@@ -405,26 +424,46 @@ def _promote_text_cas(
             ):
                 if not path.exists():
                     os.rename(backup_path, path)
-                raise OSError(f"{path} changed during setup")
+                    claimed_existing = False
+                raise _ClaudeSetupConflictError(f"{path} changed during setup")
             try:
                 os.link(tmp_path, path)
+                published = True
                 tmp_path.unlink()
+            except FileExistsError as exc:
+                raise _ClaudeSetupConflictError(f"{path} changed during setup") from exc
             except OSError:
                 if not path.exists():
                     os.rename(backup_path, path)
+                    claimed_existing = False
                 raise
         else:
             if not _claude_setup_file_matches(path, expected):
-                raise OSError(f"{path} changed during setup")
-            os.link(tmp_path, path)
+                raise _ClaudeSetupConflictError(f"{path} changed during setup")
+            try:
+                os.link(tmp_path, path)
+            except FileExistsError as exc:
+                raise _ClaudeSetupConflictError(f"{path} changed during setup") from exc
+            published = True
             tmp_path.unlink()
         _fsync_parent_dir(path)
         promoted = _read_claude_setup_file_snapshot(path)
         if promoted is None or not promoted.existed:
             raise OSError(f"Could not verify promoted file: {path}")
         return promoted
+    except OSError:
+        if claimed_existing and not published and backup_path is not None and not path.exists():
+            try:
+                os.rename(backup_path, path)
+                claimed_existing = False
+            except OSError:
+                pass
+        raise
     finally:
-        for cleanup_path in (tmp_path, backup_path):
+        cleanup_paths = [tmp_path]
+        if backup_path is not None:
+            cleanup_paths.append(backup_path)
+        for cleanup_path in cleanup_paths:
             try:
                 cleanup_path.unlink()
             except FileNotFoundError:
@@ -465,7 +504,6 @@ def _write_claude_mcp_recovery_manifest(
             json.dumps(manifest, indent=2, allow_nan=False) + "\n",
             mode=0o600,
         )
-        _fsync_parent_dir(_claude_mcp_recovery_path(mcp_config_path))
     except (OSError, TypeError, ValueError) as exc:
         print_warning(f"Could not write Claude MCP recovery journal — setup aborted: {exc}")
         return False
@@ -493,13 +531,38 @@ def _update_claude_mcp_recovery_phase(
 def _clear_claude_mcp_recovery(mcp_config_path: Path, *, non_blocking: bool = False) -> bool:
     recovery_path = _claude_mcp_recovery_path(mcp_config_path)
     try:
+        content = recovery_path.read_bytes()
+        mode = stat.S_IMODE(recovery_path.stat().st_mode)
         recovery_path.unlink()
-        _fsync_parent_dir(recovery_path)
     except FileNotFoundError:
         return True
     except OSError as exc:
         print_warning(f"Could not remove Claude MCP recovery journal: {exc}")
         return non_blocking
+    try:
+        _fsync_parent_dir(recovery_path)
+    except _ParentDirectoryFsyncError as exc:
+        fd = -1
+        try:
+            fd = os.open(recovery_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as restore_exc:
+            print_warning(
+                "Could not restore Claude MCP recovery journal after directory fsync "
+                f"failure: {restore_exc}"
+            )
+        finally:
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        print_warning(f"Claude MCP recovery journal cleanup remains pending: {exc}")
+        return False
     return True
 
 
@@ -538,6 +601,165 @@ def _manifest_target(
     return Path(raw_path), pre, content, raw_mode
 
 
+def _manifest_claude_cli_path(manifest: dict[str, object]) -> str | None:
+    updates = manifest.get("config_updates")
+    if isinstance(updates, dict):
+        cli_path = updates.get("orchestrator.cli_path")
+        if isinstance(cli_path, str) and cli_path:
+            return cli_path
+
+    target = _manifest_target(manifest, "config")
+    if target is None or target[2] is None:
+        return None
+    try:
+        data = yaml.safe_load(target[2].decode("utf-8")) or {}
+    except (UnicodeDecodeError, yaml.YAMLError, RecursionError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    orchestrator = data.get("orchestrator")
+    if not isinstance(orchestrator, dict):
+        return None
+    cli_path = orchestrator.get("cli_path")
+    return cli_path if isinstance(cli_path, str) and cli_path else None
+
+
+def _set_manifest_target_stage(
+    manifest: dict[str, object],
+    name: str,
+    *,
+    snapshot: _ClaudeSetupFileSnapshot,
+    content: bytes | None,
+    mode: int,
+) -> bool:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+    raw_target = targets.get(name)
+    if not isinstance(raw_target, dict):
+        return False
+    raw_target["pre"] = _snapshot_to_manifest(snapshot)
+    raw_target["mode"] = mode
+    raw_target["content_b64"] = (
+        base64.b64encode(content).decode("ascii") if content is not None else None
+    )
+    raw_target["sha256"] = hashlib.sha256(content).hexdigest() if content is not None else None
+    raw_target.pop("post", None)
+    return True
+
+
+def _claude_config_snapshot_has_owned_values(
+    snapshot: _ClaudeSetupFileSnapshot,
+    claude_path: str,
+) -> bool:
+    if not snapshot.existed:
+        return False
+    try:
+        data = yaml.safe_load((snapshot.content or b"").decode("utf-8")) or {}
+    except (UnicodeDecodeError, yaml.YAMLError, RecursionError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    orchestrator = data.get("orchestrator")
+    llm = data.get("llm")
+    return (
+        isinstance(orchestrator, dict)
+        and orchestrator.get("runtime_backend") == "claude"
+        and orchestrator.get("cli_path") == claude_path
+        and isinstance(llm, dict)
+        and llm.get("backend") == "claude"
+    )
+
+
+def _promote_live_claude_config_target(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    next_phase: str,
+) -> bool:
+    target = _manifest_target(manifest, "config")
+    claude_path = _manifest_claude_cli_path(manifest)
+    if target is None or claude_path is None:
+        print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
+        return False
+    config_path = target[0]
+
+    for _ in range(4):
+        current = _read_claude_setup_file_snapshot(config_path)
+        if current is None:
+            print_warning(f"Could not snapshot {config_path} safely — Claude setup aborted.")
+            return False
+        content = _merge_claude_config_snapshot(config_path, current, claude_path)
+        if content is None:
+            return False
+        mode = current.mode if current.existed else 0o600
+
+        if current.existed and current.content == content:
+            return _update_claude_mcp_recovery_phase(
+                mcp_config_path,
+                manifest,
+                next_phase,
+                target="config",
+                snapshot=current,
+            )
+
+        if not _set_manifest_target_stage(
+            manifest,
+            "config",
+            snapshot=current,
+            content=content,
+            mode=mode,
+        ):
+            print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
+            return False
+        if not _write_claude_mcp_recovery_manifest(mcp_config_path, manifest):
+            return False
+
+        try:
+            promoted = _promote_text_cas(
+                config_path,
+                content,
+                expected=current,
+                mode=mode,
+            )
+        except _ClaudeSetupConflictError:
+            continue
+        except _ParentDirectoryFsyncError:
+            raise
+        except OSError as exc:
+            print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
+            return False
+        return _update_claude_mcp_recovery_phase(
+            mcp_config_path,
+            manifest,
+            next_phase,
+            target="config",
+            snapshot=promoted,
+        )
+
+    print_warning(f"{config_path} kept changing during setup — Claude setup aborted.")
+    return False
+
+
+def _refresh_manifest_config_post(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+) -> bool:
+    target = _manifest_target(manifest, "config")
+    claude_path = _manifest_claude_cli_path(manifest)
+    if target is None or claude_path is None:
+        return False
+    current = _read_claude_setup_file_snapshot(target[0])
+    if current is None or not _claude_config_snapshot_has_owned_values(current, claude_path):
+        return False
+    return _update_claude_mcp_recovery_phase(
+        mcp_config_path,
+        manifest,
+        "config_written",
+        target="config",
+        snapshot=current,
+    )
+
+
 def _manifest_target_post_matches(manifest: dict[str, object], name: str) -> bool:
     targets = manifest.get("targets")
     if not isinstance(targets, dict):
@@ -568,7 +790,13 @@ def _recover_manifest_target(
         if not _claude_setup_file_matches(path, pre):
             print_warning(f"Claude MCP recovery found external changes in {path} — setup aborted.")
             return False
-        return _update_claude_mcp_recovery_phase(mcp_config_path, manifest, next_phase)
+        return _update_claude_mcp_recovery_phase(
+            mcp_config_path,
+            manifest,
+            next_phase,
+            target=name,
+            snapshot=pre,
+        )
     current = _read_claude_setup_file_snapshot(path)
     if (
         current is not None
@@ -580,6 +808,8 @@ def _recover_manifest_target(
         )
     try:
         promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
+    except _ParentDirectoryFsyncError:
+        raise
     except (OSError, UnicodeDecodeError) as exc:
         print_warning(f"Could not complete Claude setup recovery for {path}: {exc}")
         return False
@@ -646,18 +876,33 @@ def _recover_claude_mcp_activation() -> bool:
                     "setup aborted."
                 )
                 return False
-            if not _recover_manifest_target(mcp_config_path, data, "config", "config_written"):
+            try:
+                config_recovered = _promote_live_claude_config_target(
+                    mcp_config_path, data, "config_written"
+                )
+            except _ParentDirectoryFsyncError as exc:
+                print_warning(f"Claude config recovery remains pending: {exc}")
+                return False
+            if not config_recovered:
                 return False
             continue
         if phase == "config_written":
-            if not _manifest_target_post_matches(data, "mcp") or not _manifest_target_post_matches(
-                data, "config"
-            ):
+            if not _manifest_target_post_matches(data, "mcp"):
                 print_warning("Claude MCP recovery found external changes — setup aborted.")
                 return False
-            if not _recover_manifest_target(
-                mcp_config_path, data, "credentials", "credentials_written"
-            ):
+            if not _manifest_target_post_matches(
+                data, "config"
+            ) and not _refresh_manifest_config_post(mcp_config_path, data):
+                print_warning("Claude MCP recovery found external config changes — setup aborted.")
+                return False
+            try:
+                credentials_recovered = _recover_manifest_target(
+                    mcp_config_path, data, "credentials", "credentials_written"
+                )
+            except _ParentDirectoryFsyncError as exc:
+                print_warning(f"Claude credentials recovery remains pending: {exc}")
+                return False
+            if not credentials_recovered:
                 return False
             continue
         if phase == "credentials_written":
@@ -3031,15 +3276,19 @@ def _validate_existing_credentials_file(credentials_path: Path) -> bool:
     return True
 
 
-def _stage_claude_config(config_path: Path, claude_path: str) -> bytes | None:
+def _merge_claude_config_snapshot(
+    config_path: Path,
+    snapshot: _ClaudeSetupFileSnapshot,
+    claude_path: str,
+) -> bytes | None:
     from ouroboros.config.models import get_default_config
 
     try:
-        if config_path.exists():
-            raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        if snapshot.existed:
+            raw_config = yaml.safe_load((snapshot.content or b"").decode("utf-8")) or {}
         else:
             raw_config = get_default_config().model_dump(mode="json")
-    except (OSError, yaml.YAMLError, RecursionError) as exc:
+    except (UnicodeDecodeError, yaml.YAMLError, RecursionError) as exc:
         print_warning(f"Could not read {config_path} — Claude setup aborted: {exc}")
         return None
     if not isinstance(raw_config, dict):
@@ -3070,6 +3319,14 @@ def _stage_claude_config(config_path: Path, claude_path: str) -> bytes | None:
         print_warning("Could not stage Claude config safely — setup aborted.")
         return None
     return staged_config.encode("utf-8")
+
+
+def _stage_claude_config(config_path: Path, claude_path: str) -> bytes | None:
+    snapshot = _read_claude_setup_file_snapshot(config_path)
+    if snapshot is None:
+        print_warning(f"Could not snapshot {config_path} safely — Claude setup aborted.")
+        return None
+    return _merge_claude_config_snapshot(config_path, snapshot, claude_path)
 
 
 def _stage_claude_credentials(credentials_path: Path) -> bytes | None:
@@ -3107,6 +3364,7 @@ def _build_claude_setup_manifest(
     mcp: _ClaudeSetupStagedFile,
     config: _ClaudeSetupStagedFile,
     credentials: _ClaudeSetupStagedFile,
+    claude_path: str,
 ) -> dict[str, object]:
     targets: dict[str, object] = {}
     for name, staged in (
@@ -3128,6 +3386,11 @@ def _build_claude_setup_manifest(
     return {
         "version": _CLAUDE_MCP_RECOVERY_VERSION,
         "phase": "prepared",
+        "config_updates": {
+            "orchestrator.runtime_backend": "claude",
+            "orchestrator.cli_path": claude_path,
+            "llm.backend": "claude",
+        },
         "targets": targets,
     }
 
@@ -3235,9 +3498,17 @@ def _promote_claude_setup_target(
         if not _claude_setup_file_matches(path, pre):
             print_warning(f"{path} changed during setup — Claude setup aborted.")
             return False
-        return _update_claude_mcp_recovery_phase(mcp_config_path, manifest, phase)
+        return _update_claude_mcp_recovery_phase(
+            mcp_config_path,
+            manifest,
+            phase,
+            target=name,
+            snapshot=pre,
+        )
     try:
         promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
+    except _ParentDirectoryFsyncError:
+        raise
     except (OSError, UnicodeDecodeError) as exc:
         print_warning(f"Could not write {path} — Claude setup aborted: {exc}")
         return False
@@ -3275,7 +3546,7 @@ def _setup_claude(claude_path: str) -> bool:
     )
     if not credentials_snapshot.existed and staged_credentials is None:
         return False
-    staged_config = _stage_claude_config(config_path, claude_path)
+    staged_config = _merge_claude_config_snapshot(config_path, config_snapshot, claude_path)
     staged_mcp = _stage_claude_mcp_content(mcp_config_path)
     if staged_config is None or staged_mcp is None:
         return False
@@ -3300,26 +3571,35 @@ def _setup_claude(claude_path: str) -> bool:
             staged_credentials,
             credentials_snapshot.mode if credentials_snapshot.existed else 0o600,
         ),
+        claude_path=claude_path,
     )
     if not _write_claude_mcp_recovery_manifest(mcp_config_path, manifest):
         return False
 
-    if not _promote_claude_setup_target(mcp_config_path, manifest, "mcp", "mcp_written"):
-        _recover_claude_mcp_activation()
-        return False
-    if not _promote_claude_setup_target(mcp_config_path, manifest, "config", "config_written"):
-        _recover_claude_mcp_activation()
-        return False
-    if not _promote_claude_setup_target(
-        mcp_config_path, manifest, "credentials", "credentials_written"
-    ):
-        _recover_claude_mcp_activation()
+    try:
+        if not _promote_claude_setup_target(mcp_config_path, manifest, "mcp", "mcp_written"):
+            _recover_claude_mcp_activation()
+            return False
+        if not _promote_live_claude_config_target(mcp_config_path, manifest, "config_written"):
+            _recover_claude_mcp_activation()
+            return False
+        if not _promote_claude_setup_target(
+            mcp_config_path, manifest, "credentials", "credentials_written"
+        ):
+            _recover_claude_mcp_activation()
+            return False
+    except _ParentDirectoryFsyncError as exc:
+        print_warning(f"Claude setup durability is pending: {exc}")
         return False
 
     if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "committed"):
         print_warning("Claude MCP recovery journal cleanup is pending.")
-    elif _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "cleanup_pending"):
-        _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
+        return False
+    if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "cleanup_pending"):
+        print_warning("Claude MCP recovery journal cleanup is pending.")
+        return False
+    if not _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True):
+        return False
 
     print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
     if registered:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -15,6 +15,7 @@ import asyncio
 import base64
 from contextlib import contextmanager
 from copy import deepcopy
+import hashlib
 from importlib import metadata as importlib_metadata
 import json
 import math
@@ -24,7 +25,7 @@ import shutil
 import stat
 import subprocess
 import sys
-from typing import Annotated, Literal, NoReturn
+from typing import Annotated, Literal, NamedTuple, NoReturn
 
 from rich.prompt import Prompt
 from rich.table import Table
@@ -123,36 +124,96 @@ def _claude_mcp_recovery_path(mcp_config_path: Path | None = None) -> Path:
     return path.with_name(f"{path.name}.ouroboros-recovery")
 
 
-def _read_claude_mcp_snapshot(mcp_config_path: Path) -> tuple[bool, bytes | None, int] | None:
+class _ClaudeMcpSnapshot(NamedTuple):
+    existed: bool
+    content: bytes | None
+    mode: int
+    identity: dict[str, int] | None
+    content_sha256: str | None
+
+
+def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
+    return {
+        "dev": int(stat_result.st_dev),
+        "ino": int(stat_result.st_ino),
+        "size": int(stat_result.st_size),
+        "mtime_ns": int(stat_result.st_mtime_ns),
+        "ctime_ns": int(stat_result.st_ctime_ns),
+    }
+
+
+def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | None:
     """Return the exact pre-activation MCP snapshot, or ``None`` when unsafe."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    fd = -1
     try:
-        if mcp_config_path.exists():
-            if not mcp_config_path.is_file() or mcp_config_path.is_symlink():
-                return None
-            stat_result = mcp_config_path.stat()
-            if stat_result.st_nlink > 1:
-                return None
-            return True, mcp_config_path.read_bytes(), stat.S_IMODE(stat_result.st_mode)
-        return False, None, 0o600
+        fd = os.open(mcp_config_path, flags)
+    except FileNotFoundError:
+        return _ClaudeMcpSnapshot(False, None, 0o600, None, None)
     except OSError:
         return None
+    try:
+        stat_result = os.fstat(fd)
+        if not stat.S_ISREG(stat_result.st_mode) or stat_result.st_nlink > 1:
+            return None
+        with os.fdopen(fd, "rb") as stream:
+            fd = -1
+            content = stream.read()
+        return _ClaudeMcpSnapshot(
+            True,
+            content,
+            stat.S_IMODE(stat_result.st_mode),
+            _claude_mcp_file_identity(stat_result),
+            hashlib.sha256(content).hexdigest(),
+        )
+    except OSError:
+        return None
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _claude_mcp_snapshot_matches(
+    snapshot: _ClaudeMcpSnapshot,
+    *,
+    identity: dict[str, object] | None,
+    content_sha256: object,
+) -> bool:
+    return (
+        snapshot.existed
+        and snapshot.identity == identity
+        and snapshot.content_sha256 == content_sha256
+    )
 
 
 def _write_claude_mcp_recovery(
     mcp_config_path: Path,
     *,
-    existed: bool,
-    content: bytes | None,
-    mode: int,
+    snapshot: _ClaudeMcpSnapshot,
+    target_config_path: Path,
+    target_config_content: str,
 ) -> bool:
+    encoded_config = target_config_content.encode("utf-8")
     payload: dict[str, object] = {
         "version": 1,
         "state": "pending",
-        "action": "restore" if existed else "remove",
-        "mode": mode,
+        "action": "restore" if snapshot.existed else "remove",
+        "mode": snapshot.mode,
+        "target_config_path": str(target_config_path),
+        "target_config_sha256": hashlib.sha256(encoded_config).hexdigest(),
+        "target_config_b64": base64.b64encode(encoded_config).decode("ascii"),
     }
-    if existed:
-        payload["content_b64"] = base64.b64encode(content or b"").decode("ascii")
+    if snapshot.existed:
+        payload["content_b64"] = base64.b64encode(snapshot.content or b"").decode("ascii")
+        payload["pre_identity"] = snapshot.identity
+        payload["pre_content_sha256"] = snapshot.content_sha256
     try:
         _atomic_write_text(
             _claude_mcp_recovery_path(mcp_config_path),
@@ -161,6 +222,49 @@ def _write_claude_mcp_recovery(
         )
     except (OSError, TypeError, ValueError) as exc:
         print_warning(f"Could not write Claude MCP recovery journal — setup aborted: {exc}")
+        return False
+    return True
+
+
+def _record_claude_mcp_recovery_expected_post_content(mcp_config_path: Path, content: str) -> bool:
+    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
+    try:
+        data = json.loads(recovery_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            print_warning("Claude MCP recovery journal is malformed — setup aborted.")
+            return False
+        data["post_content_sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        _atomic_write_text(
+            recovery_path,
+            json.dumps(data, indent=2, allow_nan=False) + "\n",
+            mode=0o600,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        print_warning(f"Could not record Claude MCP recovery target — setup aborted: {exc}")
+        return False
+    return True
+
+
+def _record_claude_mcp_recovery_post_state(mcp_config_path: Path) -> bool:
+    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
+    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
+    if snapshot is None or not snapshot.existed:
+        print_warning("Could not record Claude MCP recovery target — setup aborted.")
+        return False
+    try:
+        data = json.loads(recovery_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            print_warning("Claude MCP recovery journal is malformed — setup aborted.")
+            return False
+        data["post_identity"] = snapshot.identity
+        data["post_content_sha256"] = snapshot.content_sha256
+        _atomic_write_text(
+            recovery_path,
+            json.dumps(data, indent=2, allow_nan=False) + "\n",
+            mode=0o600,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        print_warning(f"Could not record Claude MCP recovery target — setup aborted: {exc}")
         return False
     return True
 
@@ -193,6 +297,57 @@ def _clear_claude_mcp_recovery(mcp_config_path: Path) -> bool:
     return True
 
 
+def _claude_mcp_target_config_is_committed(data: dict[str, object]) -> bool:
+    raw_path = data.get("target_config_path")
+    raw_sha256 = data.get("target_config_sha256")
+    if not isinstance(raw_path, str) or not isinstance(raw_sha256, str):
+        return False
+    try:
+        content = Path(raw_path).read_bytes()
+    except OSError:
+        return False
+    return hashlib.sha256(content).hexdigest() == raw_sha256
+
+
+def _claude_mcp_current_matches_post_state(mcp_config_path: Path, data: dict[str, object]) -> bool:
+    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
+    if snapshot is None or not snapshot.existed:
+        return False
+    raw_identity = data.get("post_identity")
+    if raw_identity is None:
+        return snapshot.content_sha256 == data.get("post_content_sha256")
+    return _claude_mcp_snapshot_matches(
+        snapshot,
+        identity=raw_identity if isinstance(raw_identity, dict) else None,
+        content_sha256=data.get("post_content_sha256"),
+    )
+
+
+def _recover_claude_mcp_target_config(data: dict[str, object]) -> bool:
+    raw_path = data.get("target_config_path")
+    raw_sha256 = data.get("target_config_sha256")
+    raw_content = data.get("target_config_b64")
+    if (
+        not isinstance(raw_path, str)
+        or not isinstance(raw_sha256, str)
+        or not isinstance(raw_content, str)
+    ):
+        print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
+        return False
+    try:
+        content = base64.b64decode(raw_content.encode("ascii"), validate=True)
+        if hashlib.sha256(content).hexdigest() != raw_sha256:
+            print_warning("Claude MCP recovery journal target config is corrupt — setup aborted.")
+            return False
+        config_path = Path(raw_path)
+        mode = stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else 0o600
+        _atomic_write_text(config_path, content.decode("utf-8"), mode=mode)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print_warning(f"Could not complete Claude config recovery — setup aborted: {exc}")
+        return False
+    return True
+
+
 def _recover_claude_mcp_activation() -> bool:
     """Recover a previously interrupted Claude MCP activation, if any."""
     mcp_config_path = _claude_mcp_config_path()
@@ -215,37 +370,20 @@ def _recover_claude_mcp_activation() -> bool:
         print_warning("Claude MCP recovery journal has unknown state — setup aborted.")
         return False
 
-    action = data.get("action")
-    try:
-        if action == "restore":
-            raw_content = data.get("content_b64")
-            raw_mode = data.get("mode", 0o600)
-            if not isinstance(raw_content, str) or not isinstance(raw_mode, int):
-                print_warning("Claude MCP recovery journal is malformed — setup aborted.")
-                return False
-            content = base64.b64decode(raw_content.encode("ascii"), validate=True)
-            _atomic_write_text(
-                mcp_config_path,
-                content.decode("utf-8"),
-                mode=raw_mode,
-            )
-        elif action == "remove":
-            try:
-                if mcp_config_path.exists():
-                    if not mcp_config_path.is_file() or mcp_config_path.is_symlink():
-                        print_warning(
-                            f"Could not recover Claude MCP registration because {mcp_config_path} "
-                            "is not a regular file."
-                        )
-                        return False
-                    mcp_config_path.unlink()
-            except FileNotFoundError:
-                pass
-        else:
-            print_warning("Claude MCP recovery journal has unknown action — setup aborted.")
-            return False
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        print_warning(f"Could not recover Claude MCP registration — setup aborted: {exc}")
+    if _claude_mcp_target_config_is_committed(data):
+        return _clear_claude_mcp_recovery(mcp_config_path)
+
+    if data.get("action") not in {"restore", "remove"}:
+        print_warning("Claude MCP recovery journal has unknown action — setup aborted.")
+        return False
+
+    if not _claude_mcp_current_matches_post_state(mcp_config_path, data):
+        print_warning(
+            "Claude MCP recovery journal does not match the current MCP config — setup aborted."
+        )
+        return False
+
+    if not _recover_claude_mcp_target_config(data):
         return False
 
     return _clear_claude_mcp_recovery(mcp_config_path)
@@ -277,7 +415,12 @@ def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, o
     return {"command": "python3", "args": ["-m", "ouroboros", "mcp", "serve"]}
 
 
-def _ensure_claude_mcp_entry(*, emit_status: bool = True, recover_pending: bool = True) -> bool:
+def _ensure_claude_mcp_entry(
+    *,
+    emit_status: bool = True,
+    recover_pending: bool = True,
+    expected_snapshot: _ClaudeMcpSnapshot | None = None,
+) -> bool:
     """Ensure ~/.claude/mcp.json has a correct ouroboros MCP entry.
 
     Creates the entry if missing (detecting install method), updates stale
@@ -319,6 +462,22 @@ def _ensure_claude_mcp_entry(*, emit_status: bool = True, recover_pending: bool 
     except OSError as exc:
         print_warning(f"Could not inspect {mcp_config_path} — leaving it untouched: {exc}")
         return False
+
+    if expected_snapshot is not None:
+        current_snapshot = _read_claude_mcp_snapshot(mcp_config_path)
+        if current_snapshot is None:
+            print_warning(f"Could not verify {mcp_config_path} snapshot — leaving it untouched.")
+            return False
+        if expected_snapshot.existed != current_snapshot.existed:
+            print_warning(f"{mcp_config_path} changed during setup — leaving it untouched.")
+            return False
+        if expected_snapshot.existed and not _claude_mcp_snapshot_matches(
+            current_snapshot,
+            identity=expected_snapshot.identity,
+            content_sha256=expected_snapshot.content_sha256,
+        ):
+            print_warning(f"{mcp_config_path} changed during setup — leaving it untouched.")
+            return False
 
     mcp_data: dict[str, object] = {}
     if config_exists:
@@ -412,9 +571,14 @@ def _ensure_claude_mcp_entry(*, emit_status: bool = True, recover_pending: bool 
     if needs_write:
         try:
             mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o600
+            content = json.dumps(mcp_data, indent=2, allow_nan=False)
+            if expected_snapshot is not None and not (
+                _record_claude_mcp_recovery_expected_post_content(mcp_config_path, content)
+            ):
+                return False
             _atomic_write_text(
                 mcp_config_path,
-                json.dumps(mcp_data, indent=2, allow_nan=False),
+                content,
                 mode=mode,
             )
         except (OSError, TypeError, ValueError) as exc:
@@ -2605,59 +2769,36 @@ def _setup_claude(claude_path: str) -> bool:
     if snapshot is None:
         print_warning(f"Could not snapshot {mcp_config_path} safely — Claude setup aborted.")
         return False
-    had_mcp_config, previous_mcp_content, previous_mcp_mode = snapshot
 
     if not _write_claude_mcp_recovery(
         mcp_config_path,
-        existed=had_mcp_config,
-        content=previous_mcp_content,
-        mode=previous_mcp_mode,
+        snapshot=snapshot,
+        target_config_path=config_path,
+        target_config_content=staged_config,
     ):
         return False
 
-    if not _ensure_claude_mcp_entry(emit_status=False, recover_pending=False):
+    if not _ensure_claude_mcp_entry(
+        emit_status=False,
+        recover_pending=False,
+        expected_snapshot=snapshot,
+    ):
         _clear_claude_mcp_recovery(mcp_config_path)
         return False
 
+    if not _record_claude_mcp_recovery_post_state(mcp_config_path):
+        _recover_claude_mcp_activation()
+        return False
+
     if not _ensure_credentials_file(config_dir):
-        if had_mcp_config and previous_mcp_content is not None:
-            try:
-                _atomic_write_text(
-                    mcp_config_path,
-                    previous_mcp_content.decode("utf-8"),
-                    mode=previous_mcp_mode,
-                )
-            except OSError as rollback_exc:
-                print_warning(f"Could not roll back Claude MCP registration: {rollback_exc}")
-        elif mcp_config_path.exists():
-            try:
-                mcp_config_path.unlink()
-            except OSError as rollback_exc:
-                print_warning(
-                    f"Could not remove rolled-back Claude MCP registration: {rollback_exc}"
-                )
+        _recover_claude_mcp_activation()
         return False
 
     try:
         mode = stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else 0o600
         _atomic_write_text(config_path, staged_config, mode=mode)
     except OSError as exc:
-        if had_mcp_config and previous_mcp_content is not None:
-            try:
-                _atomic_write_text(
-                    mcp_config_path,
-                    previous_mcp_content.decode("utf-8"),
-                    mode=previous_mcp_mode,
-                )
-            except OSError as rollback_exc:
-                print_warning(f"Could not roll back Claude MCP registration: {rollback_exc}")
-        elif mcp_config_path.exists():
-            try:
-                mcp_config_path.unlink()
-            except OSError as rollback_exc:
-                print_warning(
-                    f"Could not remove rolled-back Claude MCP registration: {rollback_exc}"
-                )
+        _recover_claude_mcp_activation()
         print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
         return False
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -207,8 +207,8 @@ class _ClaudeSetupConflictError(OSError):
     """The live target no longer matches the transaction generation."""
 
 
-class _ParentDirectoryFsyncError(OSError):
-    """A promoted directory entry could not be made durable."""
+class _ClaudeSetupPromotionError(OSError):
+    """A promotion retained an operator pre-image for recovery."""
 
     def __init__(
         self,
@@ -222,6 +222,10 @@ class _ParentDirectoryFsyncError(OSError):
         self.promoted_snapshot = promoted_snapshot
 
 
+class _ParentDirectoryFsyncError(_ClaudeSetupPromotionError):
+    """A promoted directory entry could not be made durable."""
+
+
 def _expected_claude_setup_target_paths() -> dict[str, Path]:
     config_dir = Path.home() / ".ouroboros"
     return {
@@ -229,6 +233,19 @@ def _expected_claude_setup_target_paths() -> dict[str, Path]:
         "config": config_dir / "config.yaml",
         "credentials": config_dir / "credentials.yaml",
     }
+
+
+def _claude_setup_backup_path_is_canonical(target_path: Path, backup_path: Path) -> bool:
+    return (
+        backup_path.is_absolute()
+        and backup_path.parent == target_path.parent
+        and backup_path.name.startswith(f".{target_path.name}.ouroboros-pre.")
+        and backup_path.name.endswith(".tmp")
+    )
+
+
+def _claude_setup_backup_requires_private_mode(path: Path) -> bool:
+    return path.name in {"mcp.json", "credentials.yaml"}
 
 
 def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
@@ -548,6 +565,28 @@ def _manifest_completed_targets_are_consistent(manifest: dict[str, object]) -> b
     )
 
 
+def _manifest_backup_record_is_valid(
+    target_path: Path,
+    pre: _ClaudeSetupFileSnapshot,
+    operation: str,
+    raw_backup: object,
+) -> bool:
+    if raw_backup is None:
+        return True
+    if not isinstance(raw_backup, dict) or operation != "write" or not pre.existed:
+        return False
+    raw_path = raw_backup.get("path")
+    if not isinstance(raw_path, str):
+        return False
+    backup_path = Path(raw_path)
+    return (
+        _claude_setup_backup_path_is_canonical(target_path, backup_path)
+        and raw_backup.get("pre_sha256") == pre.content_sha256
+        and raw_backup.get("pre_identity") == pre.identity
+        and raw_backup.get("pre_mode") == pre.mode
+    )
+
+
 def _normalize_claude_mcp_recovery_manifest(manifest: dict[str, object]) -> bool:
     targets = manifest.get("targets")
     if not isinstance(targets, dict):
@@ -579,6 +618,21 @@ def _normalize_claude_mcp_recovery_manifest(manifest: dict[str, object]) -> bool
             raw["operation"] = "noop" if decoded_content is None else "write"
         elif not isinstance(raw_operation, str) or raw_operation not in {"write", "noop"}:
             return False
+
+        raw_backup = raw.get("backup")
+        if raw_backup is not None:
+            if not isinstance(raw_backup, dict):
+                return False
+            raw_backup_path = raw_backup.get("path")
+            if not isinstance(raw_backup_path, str):
+                return False
+            backup_path = Path(raw_backup_path)
+            if (
+                not _claude_setup_backup_path_is_canonical(target_path, backup_path)
+                or backup_path in seen_paths
+            ):
+                return False
+            seen_paths.add(backup_path)
     return True
 
 
@@ -622,16 +676,17 @@ def _promote_text_cas(
     *,
     expected: _ClaudeSetupFileSnapshot,
     mode: int,
+    retain_backup_on_failure: bool = True,
 ) -> _ClaudeSetupFileSnapshot:
     """Promote bytes only if the live path still matches ``expected``."""
     if os.name != "posix":
         if not _claude_setup_file_matches(path, expected):
             raise _ClaudeSetupConflictError(f"{path} changed during setup")
         _atomic_write_text(path, content.decode("utf-8"), mode=mode)
-        promoted = _read_claude_setup_file_snapshot(path)
-        if promoted is None or not promoted.existed:
+        written_snapshot = _read_claude_setup_file_snapshot(path)
+        if written_snapshot is None or not written_snapshot.existed:
             raise OSError(f"Could not verify promoted file: {path}")
-        return promoted
+        return written_snapshot
 
     import tempfile
 
@@ -640,6 +695,7 @@ def _promote_text_cas(
     claimed_existing = False
     published = False
     remove_backup = False
+    promoted: _ClaudeSetupFileSnapshot | None = None
     try:
         if expected.existed:
             if not _claude_setup_file_matches(path, expected):
@@ -653,6 +709,8 @@ def _promote_text_cas(
             os.close(backup_fd)
             os.rename(path, backup_path)
             claimed_existing = True
+            if _claude_setup_backup_requires_private_mode(path):
+                os.chmod(backup_path, 0o600)
             backup_bytes = backup_path.read_bytes()
             if (
                 not _path_matches_snapshot_while_linked(backup_path, expected)
@@ -660,6 +718,8 @@ def _promote_text_cas(
             ):
                 if not path.exists():
                     os.rename(backup_path, path)
+                    if _claude_setup_backup_requires_private_mode(path):
+                        os.chmod(path, expected.mode)
                     claimed_existing = False
                 raise _ClaudeSetupConflictError(f"{path} changed during setup")
             try:
@@ -702,6 +762,8 @@ def _promote_text_cas(
         if claimed_existing and not published and backup_path is not None and not path.exists():
             try:
                 os.rename(backup_path, path)
+                if _claude_setup_backup_requires_private_mode(path):
+                    os.chmod(path, expected.mode)
                 claimed_existing = False
             except OSError as restore_exc:
                 raise OSError(
@@ -712,9 +774,39 @@ def _promote_text_cas(
             published
             and backup_path is not None
             and backup_path.exists()
-            and not isinstance(exc, _ParentDirectoryFsyncError)
+            and not retain_backup_on_failure
         ):
-            raise OSError(f"{exc}; previous bytes preserved at {backup_path}") from exc
+            try:
+                os.replace(backup_path, path)
+                if _claude_setup_backup_requires_private_mode(path):
+                    os.chmod(path, expected.mode)
+                _fsync_parent_dir(path)
+                claimed_existing = False
+            except OSError as restore_exc:
+                if not backup_path.exists():
+                    claimed_existing = False
+                    raise OSError(
+                        f"{exc}; previous bytes restored at {path}, but rollback durability "
+                        f"could not be verified: {restore_exc}"
+                    ) from exc
+                raise _ClaudeSetupPromotionError(
+                    f"{exc}; could not restore {path}; previous bytes preserved at "
+                    f"{backup_path}: {restore_exc}",
+                    backup_path=backup_path,
+                    promoted_snapshot=promoted,
+                ) from exc
+            raise OSError(f"{exc}; previous bytes restored at {path}") from exc
+        if (
+            published
+            and backup_path is not None
+            and backup_path.exists()
+            and not isinstance(exc, _ClaudeSetupPromotionError)
+        ):
+            raise _ClaudeSetupPromotionError(
+                f"{exc}; previous bytes preserved at {backup_path}",
+                backup_path=backup_path,
+                promoted_snapshot=promoted,
+            ) from exc
         raise
     finally:
         cleanup_paths = [tmp_path]
@@ -807,8 +899,9 @@ def _clear_claude_mcp_recovery(mcp_config_path: Path, *, non_blocking: bool = Fa
     except FileNotFoundError:
         return True
     except OSError as exc:
-        print_warning(f"Could not remove Claude MCP recovery journal: {exc}")
-        return non_blocking
+        suffix = "; committed cleanup remains pending" if non_blocking else ""
+        print_warning(f"Could not remove Claude MCP recovery journal{suffix}: {exc}")
+        return False
     try:
         _fsync_parent_dir(recovery_path)
     except _ParentDirectoryFsyncError as exc:
@@ -868,6 +961,8 @@ def _manifest_target(
     pre = _snapshot_from_manifest(raw_pre)
     if pre is None:
         return None
+    if not _manifest_backup_record_is_valid(path, pre, raw_operation, raw.get("backup")):
+        return None
     decoded_content = _decode_manifest_target_content(raw)
     if decoded_content is False:
         return None
@@ -884,6 +979,227 @@ def _manifest_target(
             return None
         content = decoded_content
     return path, pre, content, raw_mode
+
+
+def _manifest_target_backup_path(manifest: dict[str, object], name: str) -> Path | None:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return None
+    raw_target = targets.get(name)
+    if not isinstance(raw_target, dict):
+        return None
+    raw_backup = raw_target.get("backup")
+    if not isinstance(raw_backup, dict):
+        return None
+    raw_path = raw_backup.get("path")
+    return Path(raw_path) if isinstance(raw_path, str) else None
+
+
+def _record_manifest_target_backup(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    name: str,
+    backup_path: Path,
+) -> bool:
+    target = _manifest_target(manifest, name)
+    if target is None:
+        return False
+    path, pre, content, _mode = target
+    if (
+        content is None
+        or not pre.existed
+        or not _claude_setup_backup_path_is_canonical(path, backup_path)
+        or not _path_matches_snapshot_while_linked(backup_path, pre)
+    ):
+        return False
+    try:
+        backup_mode = stat.S_IMODE(backup_path.stat().st_mode)
+    except OSError:
+        return False
+    if _claude_setup_backup_requires_private_mode(path) and backup_mode != 0o600:
+        return False
+
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+    raw_target = targets.get(name)
+    if not isinstance(raw_target, dict):
+        return False
+    raw_target["backup"] = {
+        "path": str(backup_path),
+        "pre_sha256": pre.content_sha256,
+        "pre_identity": pre.identity,
+        "pre_mode": pre.mode,
+    }
+    if _write_claude_mcp_recovery_manifest(mcp_config_path, manifest):
+        return True
+    raw_target.pop("backup", None)
+    return False
+
+
+def _journal_promotion_backup(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    name: str,
+    exc: _ClaudeSetupPromotionError,
+) -> None:
+    backup_path = exc.backup_path
+    if backup_path is None or _record_manifest_target_backup(
+        mcp_config_path, manifest, name, backup_path
+    ):
+        return
+
+    target = _manifest_target(manifest, name)
+    if target is None:
+        print_warning("Could not journal retained Claude setup backup — setup aborted.")
+        return
+    path, pre, content, _mode = target
+    try:
+        backup_mode = stat.S_IMODE(backup_path.stat().st_mode)
+    except OSError:
+        backup_mode = -1
+    backup_is_safe = (
+        content is not None
+        and pre.existed
+        and _claude_setup_backup_path_is_canonical(path, backup_path)
+        and _path_matches_snapshot_while_linked(backup_path, pre)
+        and (not _claude_setup_backup_requires_private_mode(path) or backup_mode == 0o600)
+    )
+    if not backup_is_safe:
+        print_warning("Could not journal retained Claude setup backup — setup aborted.")
+        return
+
+    try:
+        os.replace(backup_path, path)
+        os.chmod(path, pre.mode)
+        _fsync_parent_dir(path)
+    except OSError as restore_exc:
+        preserved_at = backup_path if backup_path.exists() else path
+        print_warning(
+            "Could not journal retained Claude setup backup or durably restore its "
+            f"pre-image; operator bytes preserved at {preserved_at}: {restore_exc}"
+        )
+        return
+
+    restored = _read_claude_setup_file_snapshot(path)
+    if (
+        restored is None
+        or not restored.existed
+        or restored.content_sha256 != pre.content_sha256
+        or restored.mode != pre.mode
+        or not _refresh_manifest_target_pre(manifest, name, restored)
+    ):
+        print_warning(
+            "Claude setup pre-image was restored, but its recovery snapshot could not be refreshed."
+        )
+        return
+    if not _write_claude_mcp_recovery_manifest(mcp_config_path, manifest):
+        print_warning(
+            "Claude setup pre-image was restored, but recovery journal cleanup remains pending."
+        )
+        return
+    print_warning("Could not journal retained Claude setup backup; previous bytes were restored.")
+
+
+def _remove_manifest_target_backup(manifest: dict[str, object], name: str) -> bool:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+    raw_target = targets.get(name)
+    if not isinstance(raw_target, dict):
+        return False
+    raw_target.pop("backup", None)
+    return True
+
+
+def _refresh_manifest_target_pre(
+    manifest: dict[str, object],
+    name: str,
+    snapshot: _ClaudeSetupFileSnapshot,
+) -> bool:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+    raw_target = targets.get(name)
+    if not isinstance(raw_target, dict):
+        return False
+    raw_target["pre"] = _snapshot_to_manifest(snapshot)
+    return True
+
+
+def _reconcile_manifest_target_backup(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    name: str,
+) -> bool:
+    backup_path = _manifest_target_backup_path(manifest, name)
+    if backup_path is None:
+        return True
+    target = _manifest_target(manifest, name)
+    if target is None:
+        return False
+    path, pre, content, _mode = target
+    current = _read_claude_setup_file_snapshot(path)
+    backup = _read_claude_setup_file_snapshot(backup_path)
+    if current is None or backup is None:
+        print_warning("Claude setup recovery backup could not be inspected safely — setup aborted.")
+        return False
+
+    backup_exists = backup.existed
+    if backup_exists:
+        if not _path_matches_snapshot_while_linked(backup_path, pre):
+            print_warning(
+                "Claude setup recovery backup does not match its pre-image — setup aborted."
+            )
+            return False
+        if _claude_setup_backup_requires_private_mode(path) and backup.mode != 0o600:
+            print_warning("Claude setup recovery backup permissions are unsafe — setup aborted.")
+            return False
+
+    if not current.existed:
+        if not backup_exists:
+            print_warning(
+                "Claude setup recovery target and backup are both missing — setup aborted."
+            )
+            return False
+        try:
+            os.rename(backup_path, path)
+            os.chmod(path, pre.mode)
+            _fsync_parent_dir(path)
+        except OSError as exc:
+            print_warning(f"Could not restore Claude setup pre-image for {path}: {exc}")
+            return False
+        current = _read_claude_setup_file_snapshot(path)
+        if current is None or not current.existed or current.content_sha256 != pre.content_sha256:
+            print_warning(f"Could not verify restored Claude setup pre-image for {path}.")
+            return False
+        if not _refresh_manifest_target_pre(manifest, name, current):
+            return False
+        if not _remove_manifest_target_backup(manifest, name):
+            return False
+        return _write_claude_mcp_recovery_manifest(mcp_config_path, manifest)
+
+    current_matches_pre = current.content_sha256 == pre.content_sha256 and current.mode == pre.mode
+    current_matches_write = content is not None and _snapshot_content_matches_content(
+        current, content
+    )
+    if not (current_matches_pre or current_matches_write):
+        print_warning("Claude setup recovery found external changes; backup preserved.")
+        return False
+
+    try:
+        _fsync_parent_dir(path)
+        if backup_exists:
+            backup_path.unlink()
+            _fsync_parent_dir(backup_path)
+    except OSError as exc:
+        print_warning(f"Claude setup recovery backup cleanup remains pending: {exc}")
+        return False
+    if current_matches_pre and not _refresh_manifest_target_pre(manifest, name, current):
+        return False
+    if not _remove_manifest_target_backup(manifest, name):
+        return False
+    return _write_claude_mcp_recovery_manifest(mcp_config_path, manifest)
 
 
 def _manifest_noop_target_is_valid(name: str, pre: _ClaudeSetupFileSnapshot) -> bool:
@@ -1046,7 +1362,8 @@ def _promote_live_claude_config_target(
             )
         except _ClaudeSetupConflictError:
             continue
-        except _ParentDirectoryFsyncError:
+        except _ClaudeSetupPromotionError as exc:
+            _journal_promotion_backup(mcp_config_path, manifest, "config", exc)
             raise
         except OSError as exc:
             print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
@@ -1131,7 +1448,8 @@ def _recover_manifest_target(
         )
     try:
         promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
-    except _ParentDirectoryFsyncError:
+    except _ClaudeSetupPromotionError as exc:
+        _journal_promotion_backup(mcp_config_path, manifest, name, exc)
         raise
     except (OSError, UnicodeDecodeError) as exc:
         print_warning(f"Could not complete Claude setup recovery for {path}: {exc}")
@@ -1182,6 +1500,9 @@ def _recover_claude_mcp_activation() -> bool:
         data = _load_claude_mcp_recovery_manifest(recovery_path)
         if data is None:
             return False
+        for target_name in ("mcp", "config", "credentials"):
+            if not _reconcile_manifest_target_backup(mcp_config_path, data, target_name):
+                return False
         phase = data.get("phase")
         if phase in {"committed", "cleanup_pending"}:
             return _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
@@ -1203,7 +1524,7 @@ def _recover_claude_mcp_activation() -> bool:
                 config_recovered = _promote_live_claude_config_target(
                     mcp_config_path, data, "config_written"
                 )
-            except _ParentDirectoryFsyncError as exc:
+            except _ClaudeSetupPromotionError as exc:
                 print_warning(f"Claude config recovery remains pending: {exc}")
                 return False
             if not config_recovered:
@@ -1222,7 +1543,7 @@ def _recover_claude_mcp_activation() -> bool:
                 credentials_recovered = _recover_manifest_target(
                     mcp_config_path, data, "credentials", "credentials_written"
                 )
-            except _ParentDirectoryFsyncError as exc:
+            except _ClaudeSetupPromotionError as exc:
                 print_warning(f"Claude credentials recovery remains pending: {exc}")
                 return False
             if not credentials_recovered:
@@ -1430,6 +1751,7 @@ def _ensure_claude_mcp_entry(
                 content.encode("utf-8"),
                 expected=_ClaudeSetupFileSnapshot(*snapshot),
                 mode=mode,
+                retain_backup_on_failure=False,
             )
         except (OSError, TypeError, ValueError) as exc:
             print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
@@ -3827,7 +4149,8 @@ def _promote_claude_setup_target(
         )
     try:
         promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
-    except _ParentDirectoryFsyncError:
+    except _ClaudeSetupPromotionError as exc:
+        _journal_promotion_backup(mcp_config_path, manifest, name, exc)
         raise
     except (OSError, UnicodeDecodeError) as exc:
         print_warning(f"Could not write {path} — Claude setup aborted: {exc}")
@@ -3989,8 +4312,8 @@ def _setup_claude(claude_path: str) -> bool:
                 removed_timeout=removed_timeout,
                 updated_entry=updated_entry,
             )
-    except _ParentDirectoryFsyncError as exc:
-        print_warning(f"Claude setup durability is pending: {exc}")
+    except _ClaudeSetupPromotionError as exc:
+        print_warning(f"Claude setup recovery is pending: {exc}")
         return False
 
     if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "committed"):

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -293,6 +293,8 @@ def _snapshot_from_manifest(data: dict[str, object]) -> _ClaudeSetupFileSnapshot
     if not isinstance(existed, bool) or not isinstance(mode, int):
         return None
     if not existed:
+        if identity is not None or sha256 is not None or content_b64 is not None:
+            return None
         return _ClaudeSetupFileSnapshot(False, None, mode, None, None)
     if (
         not isinstance(identity, dict)
@@ -491,6 +493,10 @@ def _load_claude_mcp_recovery_manifest(recovery_path: Path) -> dict[str, object]
     if data.get("phase") not in _CLAUDE_MCP_RECOVERY_PHASES:
         print_warning("Claude MCP recovery journal has unknown phase — setup aborted.")
         return None
+    for target_name in ("mcp", "config", "credentials"):
+        if _manifest_target(data, target_name) is None:
+            print_warning("Claude MCP recovery journal target is incomplete — setup aborted.")
+            return None
     return data
 
 
@@ -570,6 +576,8 @@ def _manifest_target(
     manifest: dict[str, object],
     name: str,
 ) -> tuple[Path, _ClaudeSetupFileSnapshot, bytes | None, int] | None:
+    if name not in {"mcp", "config", "credentials"}:
+        return None
     targets = manifest.get("targets")
     if not isinstance(targets, dict):
         return None
@@ -578,10 +586,14 @@ def _manifest_target(
         return None
     raw_path = raw.get("path")
     raw_content = raw.get("content_b64")
+    raw_operation = raw.get("operation")
     raw_mode = raw.get("mode")
     raw_pre = raw.get("pre")
     if (
         not isinstance(raw_path, str)
+        or not raw_path
+        or not isinstance(raw_operation, str)
+        or raw_operation not in {"write", "noop"}
         or not isinstance(raw_mode, int)
         or not isinstance(raw_pre, dict)
     ):
@@ -589,16 +601,62 @@ def _manifest_target(
     pre = _snapshot_from_manifest(raw_pre)
     if pre is None:
         return None
-    content: bytes | None = None
-    if isinstance(raw_content, str):
+    raw_sha = raw.get("sha256")
+    if raw_content is None:
+        if raw_sha is not None or raw_operation != "noop":
+            return None
+        if not _manifest_noop_target_is_valid(name, pre):
+            return None
+        content: bytes | None = None
+    else:
+        if not isinstance(raw_content, str) or not isinstance(raw_sha, str):
+            return None
+        if raw_operation != "write":
+            return None
         try:
             content = base64.b64decode(raw_content.encode("ascii"), validate=True)
         except (ValueError, UnicodeEncodeError):
             return None
-        raw_sha = raw.get("sha256")
-        if not isinstance(raw_sha, str) or hashlib.sha256(content).hexdigest() != raw_sha:
+        if hashlib.sha256(content).hexdigest() != raw_sha:
             return None
     return Path(raw_path), pre, content, raw_mode
+
+
+def _manifest_noop_target_is_valid(name: str, pre: _ClaudeSetupFileSnapshot) -> bool:
+    if not pre.existed or pre.content is None:
+        return False
+    if name == "mcp":
+        try:
+            data = json.loads(
+                pre.content.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_json_constant,
+            )
+            _reject_non_finite_json_numbers(data)
+        except (
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValueError,
+            RecursionError,
+        ):
+            return False
+        if not isinstance(data, dict):
+            return False
+        servers = data.get("mcpServers")
+        entry = servers.get("ouroboros") if isinstance(servers, dict) else None
+        return isinstance(entry, dict) and _is_supported_claude_mcp_entry(entry)
+    if name == "credentials":
+        from ouroboros.config.models import CredentialsConfig
+
+        try:
+            data = yaml.safe_load(pre.content.decode("utf-8"))
+            if data is None:
+                data = {}
+            CredentialsConfig.model_validate(data)
+        except (UnicodeDecodeError, yaml.YAMLError, TypeError, ValueError, RecursionError):
+            return False
+        return True
+    return False
 
 
 def _manifest_claude_cli_path(manifest: dict[str, object]) -> str | None:
@@ -640,6 +698,7 @@ def _set_manifest_target_stage(
         return False
     raw_target["pre"] = _snapshot_to_manifest(snapshot)
     raw_target["mode"] = mode
+    raw_target["operation"] = "write" if content is not None else "noop"
     raw_target["content_b64"] = (
         base64.b64encode(content).decode("ascii") if content is not None else None
     )
@@ -3377,6 +3436,7 @@ def _build_claude_setup_manifest(
             "path": str(staged.path),
             "mode": staged.mode,
             "pre": _snapshot_to_manifest(staged.snapshot),
+            "operation": "write" if content is not None else "noop",
             "content_b64": (
                 base64.b64encode(content).decode("ascii") if content is not None else None
             ),

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from importlib import metadata as importlib_metadata
 import json
+import math
 import os
 from pathlib import Path
 import shutil
@@ -77,6 +78,38 @@ def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, ob
     return result
 
 
+def _reject_non_finite_json_numbers(value: object) -> None:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("non-finite JSON number")
+    if isinstance(value, dict):
+        for item in value.values():
+            _reject_non_finite_json_numbers(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_non_finite_json_numbers(item)
+
+
+def _is_string_list(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _is_supported_claude_mcp_entry(entry: dict[str, object]) -> bool:
+    command = entry.get("command")
+    args = entry.get("args")
+    url = entry.get("url")
+    transport = entry.get("transport")
+
+    if isinstance(command, str):
+        return args is None or _is_string_list(args)
+
+    if isinstance(url, str):
+        if transport not in (None, "sse", "http", "streamable_http"):
+            return False
+        return args is None or _is_string_list(args)
+
+    return False
+
+
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
     """Build the correct MCP entry based on how ouroboros is installed.
 
@@ -103,7 +136,7 @@ def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, o
     return {"command": "python3", "args": ["-m", "ouroboros", "mcp", "serve"]}
 
 
-def _ensure_claude_mcp_entry() -> bool:
+def _ensure_claude_mcp_entry(*, emit_status: bool = True) -> bool:
     """Ensure ~/.claude/mcp.json has a correct ouroboros MCP entry.
 
     Creates the entry if missing (detecting install method), updates stale
@@ -151,6 +184,7 @@ def _ensure_claude_mcp_entry() -> bool:
                 object_pairs_hook=_reject_duplicate_json_keys,
                 parse_constant=_reject_json_constant,
             )
+            _reject_non_finite_json_numbers(mcp_data)
         except UnicodeDecodeError:
             print_warning(
                 f"Could not decode {mcp_config_path} as UTF-8 — leaving it untouched. "
@@ -186,18 +220,10 @@ def _ensure_claude_mcp_entry() -> bool:
         existing: dict[str, object] | None = None
     else:
         raw_existing = servers["ouroboros"]
-        if not isinstance(raw_existing, dict):
-            print_warning(
-                f"{mcp_config_path} mcpServers.ouroboros is not an object — leaving it untouched."
-            )
-            return False
-        existing = raw_existing
-        if "command" in existing and not isinstance(existing["command"], str):
-            print_warning(
-                f"{mcp_config_path} mcpServers.ouroboros.command is not a string — "
-                "leaving it untouched."
-            )
-            return False
+        if not isinstance(raw_existing, dict) or not _is_supported_claude_mcp_entry(raw_existing):
+            existing = None
+        else:
+            existing = raw_existing
 
     detected = _detect_mcp_entry(package_spec="ouroboros-ai[mcp,claude]")
     needs_write = False
@@ -236,22 +262,26 @@ def _ensure_claude_mcp_entry() -> bool:
                 needs_write = True
                 updated_entry = True
 
-        if not needs_write:
+        if not needs_write and emit_status:
             print_info("MCP server already registered.")
 
     if needs_write:
         try:
             mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o600
-            _atomic_write_text(mcp_config_path, json.dumps(mcp_data, indent=2), mode=mode)
+            _atomic_write_text(
+                mcp_config_path,
+                json.dumps(mcp_data, indent=2, allow_nan=False),
+                mode=mode,
+            )
         except (OSError, TypeError, ValueError) as exc:
             print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
             return False
 
-        if registered:
+        if registered and emit_status:
             print_success("Registered MCP server in ~/.claude/mcp.json")
-        if removed_timeout:
+        if removed_timeout and emit_status:
             print_info("Removed legacy MCP timeout override.")
-        if updated_entry:
+        if updated_entry and emit_status:
             print_info("Updated MCP server entry to match current install method.")
 
     return True
@@ -2378,13 +2408,8 @@ def _setup_goose(goose_path: str) -> None:
 
 def _setup_claude(claude_path: str) -> bool:
     """Configure Ouroboros for the Claude Code runtime."""
-    # Register/fix MCP before persisting Claude as the active backend. A failed
-    # operator-owned MCP update must not leave config.yaml claiming setup
-    # succeeded when Claude cannot reach the Ouroboros server.
-    if not _ensure_claude_mcp_entry():
-        return False
-
-    from ouroboros.config.loader import create_default_config, ensure_config_dir
+    from ouroboros.config.loader import ensure_config_dir
+    from ouroboros.config.models import get_default_config
 
     config_dir = ensure_config_dir()
     config_path = config_dir / "config.yaml"
@@ -2392,8 +2417,7 @@ def _setup_claude(claude_path: str) -> bool:
     if config_path.exists():
         config_dict = yaml.safe_load(config_path.read_text()) or {}
     else:
-        create_default_config(config_dir)
-        config_dict = yaml.safe_load(config_path.read_text()) or {}
+        config_dict = get_default_config().model_dump(mode="json")
 
     # Set runtime and LLM backend to claude
     config_dict.setdefault("orchestrator", {})
@@ -2403,8 +2427,40 @@ def _setup_claude(claude_path: str) -> bool:
     config_dict.setdefault("llm", {})
     config_dict["llm"]["backend"] = "claude"
 
-    with config_path.open("w") as f:
-        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+    staged_config = yaml.safe_dump(config_dict, default_flow_style=False, sort_keys=False)
+    staged_loaded = yaml.safe_load(staged_config)
+    if not isinstance(staged_loaded, dict):
+        print_warning("Could not stage Claude config safely — setup aborted.")
+        return False
+
+    mcp_config_path = Path.home() / ".claude" / "mcp.json"
+    had_mcp_config = mcp_config_path.exists()
+    previous_mcp_content = mcp_config_path.read_bytes() if had_mcp_config else None
+    previous_mcp_mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if had_mcp_config else 0o600
+
+    if not _ensure_claude_mcp_entry(emit_status=False):
+        return False
+
+    try:
+        mode = stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else 0o600
+        _atomic_write_text(config_path, staged_config, mode=mode)
+    except OSError as exc:
+        if had_mcp_config and previous_mcp_content is not None:
+            try:
+                _atomic_write_text(
+                    mcp_config_path,
+                    previous_mcp_content.decode("utf-8"),
+                    mode=previous_mcp_mode,
+                )
+            except OSError as rollback_exc:
+                print_warning(f"Could not roll back Claude MCP registration: {rollback_exc}")
+        elif mcp_config_path.exists():
+            try:
+                mcp_config_path.unlink()
+            except OSError as rollback_exc:
+                print_warning(f"Could not remove rolled-back Claude MCP registration: {rollback_exc}")
+        print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
+        return False
 
     print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
     print_info(f"Config saved to: {config_path}")

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -339,24 +339,31 @@ def _claude_mcp_snapshot_matches(
     )
 
 
-def _fsync_parent_dir(path: Path) -> None:
+def _fsync_directory(directory: Path) -> None:
     if os.name != "posix":
         return
     fd = -1
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        fd = os.open(path.parent, flags)
+        fd = os.open(directory, flags)
         os.fsync(fd)
     except OSError as exc:
-        raise _ParentDirectoryFsyncError(
-            f"Could not fsync parent directory for {path}: {exc}"
-        ) from exc
+        raise _ParentDirectoryFsyncError(f"Could not fsync directory {directory}: {exc}") from exc
     finally:
         if fd >= 0:
             try:
                 os.close(fd)
             except OSError:
                 pass
+
+
+def _fsync_parent_dir(path: Path) -> None:
+    _fsync_directory(path.parent)
+
+
+def _fsync_backup_parent_dir(path: Path) -> None:
+    """Durably record a retained pre-image before publishing its replacement."""
+    _fsync_directory(path.parent)
 
 
 def _snapshot_to_manifest(snapshot: _ClaudeSetupFileSnapshot) -> dict[str, object]:
@@ -614,7 +621,12 @@ def _normalize_claude_mcp_recovery_manifest(manifest: dict[str, object]) -> bool
     if not isinstance(targets, dict):
         return False
 
+    scope = manifest.get("scope")
+    if scope not in (None, "mcp"):
+        return False
     expected_paths = _expected_claude_setup_target_paths()
+    if scope == "mcp":
+        expected_paths = {"mcp": expected_paths["mcp"]}
     seen_paths: set[Path] = set()
     for target_name, expected_path in expected_paths.items():
         raw = targets.get(target_name)
@@ -733,6 +745,7 @@ def _promote_text_cas(
             claimed_existing = True
             if _claude_setup_backup_requires_private_mode(path):
                 os.chmod(backup_path, 0o600)
+            _fsync_backup_parent_dir(path)
             backup_bytes = backup_path.read_bytes()
             if (
                 not _path_matches_snapshot_while_linked(backup_path, expected)
@@ -796,11 +809,23 @@ def _promote_text_cas(
                 os.rename(backup_path, path)
                 if _claude_setup_backup_requires_private_mode(path):
                     os.chmod(path, expected.mode)
+                _fsync_parent_dir(path)
                 claimed_existing = False
             except OSError as restore_exc:
                 raise OSError(
                     f"{exc}; could not restore {path}; previous bytes preserved at "
                     f"{backup_path}: {restore_exc}"
+                ) from exc
+        if claimed_existing and not published and backup_path is not None and path.exists():
+            try:
+                backup_path.unlink()
+                _fsync_parent_dir(backup_path)
+                claimed_existing = False
+            except OSError as cleanup_exc:
+                raise _ClaudeSetupPromotionError(
+                    f"{exc}; could not discard the superseded pre-image at "
+                    f"{backup_path}: {cleanup_exc}",
+                    backup_path=backup_path,
                 ) from exc
         if (
             published
@@ -875,7 +900,8 @@ def _load_claude_mcp_recovery_manifest(recovery_path: Path) -> dict[str, object]
     if not _normalize_claude_mcp_recovery_manifest(data):
         print_warning("Claude MCP recovery journal target is incomplete — setup aborted.")
         return None
-    for target_name in ("mcp", "config", "credentials"):
+    target_names = ("mcp",) if data.get("scope") == "mcp" else ("mcp", "config", "credentials")
+    for target_name in target_names:
         if _manifest_target(data, target_name) is None:
             print_warning("Claude MCP recovery journal target is incomplete — setup aborted.")
             return None
@@ -902,6 +928,29 @@ def _write_claude_mcp_recovery_manifest(
         print_warning(f"Could not write Claude MCP recovery journal — setup aborted: {exc}")
         return False
     return True
+
+
+def _build_standalone_claude_mcp_manifest(
+    mcp_config_path: Path,
+    snapshot: _ClaudeSetupFileSnapshot,
+    content: bytes,
+    mode: int,
+) -> dict[str, object]:
+    return {
+        "version": _CLAUDE_MCP_RECOVERY_VERSION,
+        "scope": "mcp",
+        "phase": "prepared",
+        "targets": {
+            "mcp": {
+                "path": str(mcp_config_path),
+                "mode": mode,
+                "pre": _snapshot_to_manifest(snapshot),
+                "operation": "write",
+                "content_b64": base64.b64encode(content).decode("ascii"),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        },
+    }
 
 
 def _update_claude_mcp_recovery_phase(
@@ -1134,6 +1183,37 @@ def _journal_promotion_backup(
         )
         return
     print_warning("Could not journal retained Claude setup backup; previous bytes were restored.")
+
+
+def _journal_standalone_mcp_backup(
+    mcp_config_path: Path,
+    snapshot: _ClaudeSetupFileSnapshot,
+    content: bytes,
+    mode: int,
+    exc: _ClaudeSetupPromotionError,
+) -> bool:
+    backup_path = exc.backup_path
+    if backup_path is None:
+        return False
+    manifest = _build_standalone_claude_mcp_manifest(mcp_config_path, snapshot, content, mode)
+    if _record_manifest_target_backup(mcp_config_path, manifest, "mcp", backup_path):
+        print_warning("Claude MCP update recovery remains pending; re-run setup to finish.")
+        return True
+
+    try:
+        os.replace(backup_path, mcp_config_path)
+        os.chmod(mcp_config_path, snapshot.mode)
+        _fsync_parent_dir(mcp_config_path)
+    except OSError:
+        if _record_manifest_target_backup(mcp_config_path, manifest, "mcp", backup_path):
+            print_warning("Claude MCP update recovery remains pending; re-run setup to finish.")
+            return True
+        print_warning(
+            "Could not journal or durably restore the Claude MCP pre-image; "
+            f"operator bytes remain at {backup_path}."
+        )
+        return False
+    return False
 
 
 def _remove_manifest_target_backup(manifest: dict[str, object], name: str) -> bool:
@@ -1535,9 +1615,28 @@ def _recover_claude_mcp_activation() -> bool:
         data = _load_claude_mcp_recovery_manifest(recovery_path)
         if data is None:
             return False
-        for target_name in ("mcp", "config", "credentials"):
+        target_names = ("mcp",) if data.get("scope") == "mcp" else ("mcp", "config", "credentials")
+        for target_name in target_names:
             if not _reconcile_manifest_target_backup(mcp_config_path, data, target_name):
                 return False
+        if data.get("scope") == "mcp":
+            target = _manifest_target(data, "mcp")
+            if target is None:
+                return False
+            path, pre, content, _mode = target
+            current = _read_claude_setup_file_snapshot(path)
+            current_is_valid = current is not None and (
+                _claude_setup_file_matches(path, pre)
+                or (
+                    content is not None
+                    and current.existed
+                    and _snapshot_content_matches_content(current, content)
+                )
+            )
+            if not current_is_valid:
+                print_warning("Claude MCP recovery found external changes — setup aborted.")
+                return False
+            return _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
         phase = data.get("phase")
         if phase in {"committed", "cleanup_pending"}:
             return _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
@@ -1772,22 +1871,29 @@ def _ensure_claude_mcp_entry(
             print_info("MCP server already registered.")
 
     if needs_write:
+        content = json.dumps(mcp_data, indent=2, allow_nan=False).encode("utf-8")
+        snapshot = expected_snapshot or _read_claude_mcp_snapshot(mcp_config_path)
+        if snapshot is None:
+            print_warning(f"Could not verify {mcp_config_path} snapshot — leaving it untouched.")
+            return False
         try:
             mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o600
-            content = json.dumps(mcp_data, indent=2, allow_nan=False)
-            snapshot = expected_snapshot or _read_claude_mcp_snapshot(mcp_config_path)
-            if snapshot is None:
-                print_warning(
-                    f"Could not verify {mcp_config_path} snapshot — leaving it untouched."
-                )
-                return False
             _promote_text_cas(
                 mcp_config_path,
-                content.encode("utf-8"),
+                content,
                 expected=_ClaudeSetupFileSnapshot(*snapshot),
                 mode=mode,
                 retain_backup_on_failure=False,
             )
+        except _ClaudeSetupPromotionError as exc:
+            _journal_standalone_mcp_backup(
+                mcp_config_path,
+                _ClaudeSetupFileSnapshot(*snapshot),
+                content,
+                mode,
+                exc,
+            )
+            return False
         except (OSError, TypeError, ValueError) as exc:
             print_warning(f"Could not write {mcp_config_path} — leaving it untouched: {exc}")
             return False
@@ -3946,7 +4052,7 @@ def _validate_existing_credentials_file(credentials_path: Path) -> bool:
 
     try:
         load_credentials(credentials_path)
-    except (ConfigError, UnicodeDecodeError, OSError) as exc:
+    except (ConfigError, UnicodeDecodeError, OSError, RecursionError) as exc:
         print_warning(f"Could not validate {credentials_path} — Claude setup aborted: {exc}")
         return False
     return True

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -12,6 +12,7 @@ Also provides brownfield repository management subcommands:
 from __future__ import annotations
 
 import asyncio
+import base64
 from contextlib import contextmanager
 from copy import deepcopy
 from importlib import metadata as importlib_metadata
@@ -97,17 +98,157 @@ def _is_supported_claude_mcp_entry(entry: dict[str, object]) -> bool:
     command = entry.get("command")
     args = entry.get("args")
     url = entry.get("url")
-    transport = entry.get("transport")
+    entry_type = entry.get("type")
 
-    if isinstance(command, str):
-        return args is None or _is_string_list(args)
+    if "args" in entry and not _is_string_list(args):
+        return False
 
-    if isinstance(url, str):
-        if transport not in (None, "sse", "http", "streamable_http"):
+    if isinstance(command, str) and command.strip():
+        if entry_type not in (None, "stdio"):
             return False
-        return args is None or _is_string_list(args)
+        return "url" not in entry
+
+    if isinstance(url, str) and url.strip():
+        return entry_type in {"http", "sse", "streamable-http"}
 
     return False
+
+
+def _claude_mcp_config_path() -> Path:
+    return Path.home() / ".claude" / "mcp.json"
+
+
+def _claude_mcp_recovery_path(mcp_config_path: Path | None = None) -> Path:
+    path = mcp_config_path or _claude_mcp_config_path()
+    return path.with_name(f"{path.name}.ouroboros-recovery")
+
+
+def _read_claude_mcp_snapshot(mcp_config_path: Path) -> tuple[bool, bytes | None, int] | None:
+    """Return the exact pre-activation MCP snapshot, or ``None`` when unsafe."""
+    try:
+        if mcp_config_path.exists():
+            if not mcp_config_path.is_file() or mcp_config_path.is_symlink():
+                return None
+            stat_result = mcp_config_path.stat()
+            if stat_result.st_nlink > 1:
+                return None
+            return True, mcp_config_path.read_bytes(), stat.S_IMODE(stat_result.st_mode)
+        return False, None, 0o600
+    except OSError:
+        return None
+
+
+def _write_claude_mcp_recovery(
+    mcp_config_path: Path,
+    *,
+    existed: bool,
+    content: bytes | None,
+    mode: int,
+) -> bool:
+    payload: dict[str, object] = {
+        "version": 1,
+        "state": "pending",
+        "action": "restore" if existed else "remove",
+        "mode": mode,
+    }
+    if existed:
+        payload["content_b64"] = base64.b64encode(content or b"").decode("ascii")
+    try:
+        _atomic_write_text(
+            _claude_mcp_recovery_path(mcp_config_path),
+            json.dumps(payload, indent=2, allow_nan=False) + "\n",
+            mode=0o600,
+        )
+    except (OSError, TypeError, ValueError) as exc:
+        print_warning(f"Could not write Claude MCP recovery journal — setup aborted: {exc}")
+        return False
+    return True
+
+
+def _mark_claude_mcp_recovery_committed(mcp_config_path: Path) -> None:
+    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
+    try:
+        data = json.loads(recovery_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            data = {}
+        data["state"] = "committed"
+        _atomic_write_text(
+            recovery_path,
+            json.dumps(data, indent=2, allow_nan=False) + "\n",
+            mode=0o600,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        print_warning(f"Could not mark Claude MCP recovery journal complete: {exc}")
+
+
+def _clear_claude_mcp_recovery(mcp_config_path: Path) -> bool:
+    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
+    try:
+        recovery_path.unlink()
+    except FileNotFoundError:
+        return True
+    except OSError as exc:
+        print_warning(f"Could not remove Claude MCP recovery journal: {exc}")
+        return False
+    return True
+
+
+def _recover_claude_mcp_activation() -> bool:
+    """Recover a previously interrupted Claude MCP activation, if any."""
+    mcp_config_path = _claude_mcp_config_path()
+    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
+    try:
+        if not recovery_path.is_file():
+            return True
+        data = json.loads(recovery_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print_warning(f"Could not read Claude MCP recovery journal — setup aborted: {exc}")
+        return False
+    if not isinstance(data, dict):
+        print_warning("Claude MCP recovery journal is malformed — setup aborted.")
+        return False
+
+    if data.get("state") == "committed":
+        return _clear_claude_mcp_recovery(mcp_config_path)
+
+    if data.get("state") != "pending":
+        print_warning("Claude MCP recovery journal has unknown state — setup aborted.")
+        return False
+
+    action = data.get("action")
+    try:
+        if action == "restore":
+            raw_content = data.get("content_b64")
+            raw_mode = data.get("mode", 0o600)
+            if not isinstance(raw_content, str) or not isinstance(raw_mode, int):
+                print_warning("Claude MCP recovery journal is malformed — setup aborted.")
+                return False
+            content = base64.b64decode(raw_content.encode("ascii"), validate=True)
+            _atomic_write_text(
+                mcp_config_path,
+                content.decode("utf-8"),
+                mode=raw_mode,
+            )
+        elif action == "remove":
+            try:
+                if mcp_config_path.exists():
+                    if not mcp_config_path.is_file() or mcp_config_path.is_symlink():
+                        print_warning(
+                            f"Could not recover Claude MCP registration because {mcp_config_path} "
+                            "is not a regular file."
+                        )
+                        return False
+                    mcp_config_path.unlink()
+            except FileNotFoundError:
+                pass
+        else:
+            print_warning("Claude MCP recovery journal has unknown action — setup aborted.")
+            return False
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print_warning(f"Could not recover Claude MCP registration — setup aborted: {exc}")
+        return False
+
+    return _clear_claude_mcp_recovery(mcp_config_path)
 
 
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
@@ -136,7 +277,7 @@ def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, o
     return {"command": "python3", "args": ["-m", "ouroboros", "mcp", "serve"]}
 
 
-def _ensure_claude_mcp_entry(*, emit_status: bool = True) -> bool:
+def _ensure_claude_mcp_entry(*, emit_status: bool = True, recover_pending: bool = True) -> bool:
     """Ensure ~/.claude/mcp.json has a correct ouroboros MCP entry.
 
     Creates the entry if missing (detecting install method), updates stale
@@ -147,7 +288,10 @@ def _ensure_claude_mcp_entry(*, emit_status: bool = True) -> bool:
         True when the entry is registered or already usable, False when the
         existing configuration could not be updated safely.
     """
-    mcp_config_path = Path.home() / ".claude" / "mcp.json"
+    if recover_pending and not _recover_claude_mcp_activation():
+        return False
+
+    mcp_config_path = _claude_mcp_config_path()
     try:
         mcp_config_path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
@@ -2406,6 +2550,26 @@ def _setup_goose(goose_path: str) -> None:
     print_info(f"Config saved to: {config_path}")
 
 
+def _ensure_credentials_file(config_dir: Path) -> bool:
+    """Create the companion credentials file when setup is initializing config."""
+    from ouroboros.config.models import get_default_credentials
+
+    credentials_path = config_dir / "credentials.yaml"
+    try:
+        if credentials_path.exists():
+            return True
+        credentials_dict = get_default_credentials().model_dump(mode="json")
+        _atomic_write_text(
+            credentials_path,
+            yaml.dump(credentials_dict, default_flow_style=False, sort_keys=False),
+            mode=0o600,
+        )
+    except OSError as exc:
+        print_warning(f"Could not write {credentials_path} — setup aborted: {exc}")
+        return False
+    return True
+
+
 def _setup_claude(claude_path: str) -> bool:
     """Configure Ouroboros for the Claude Code runtime."""
     from ouroboros.config.loader import ensure_config_dir
@@ -2433,12 +2597,45 @@ def _setup_claude(claude_path: str) -> bool:
         print_warning("Could not stage Claude config safely — setup aborted.")
         return False
 
-    mcp_config_path = Path.home() / ".claude" / "mcp.json"
-    had_mcp_config = mcp_config_path.exists()
-    previous_mcp_content = mcp_config_path.read_bytes() if had_mcp_config else None
-    previous_mcp_mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if had_mcp_config else 0o600
+    mcp_config_path = _claude_mcp_config_path()
+    if not _recover_claude_mcp_activation():
+        return False
 
-    if not _ensure_claude_mcp_entry(emit_status=False):
+    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
+    if snapshot is None:
+        print_warning(f"Could not snapshot {mcp_config_path} safely — Claude setup aborted.")
+        return False
+    had_mcp_config, previous_mcp_content, previous_mcp_mode = snapshot
+
+    if not _write_claude_mcp_recovery(
+        mcp_config_path,
+        existed=had_mcp_config,
+        content=previous_mcp_content,
+        mode=previous_mcp_mode,
+    ):
+        return False
+
+    if not _ensure_claude_mcp_entry(emit_status=False, recover_pending=False):
+        _clear_claude_mcp_recovery(mcp_config_path)
+        return False
+
+    if not _ensure_credentials_file(config_dir):
+        if had_mcp_config and previous_mcp_content is not None:
+            try:
+                _atomic_write_text(
+                    mcp_config_path,
+                    previous_mcp_content.decode("utf-8"),
+                    mode=previous_mcp_mode,
+                )
+            except OSError as rollback_exc:
+                print_warning(f"Could not roll back Claude MCP registration: {rollback_exc}")
+        elif mcp_config_path.exists():
+            try:
+                mcp_config_path.unlink()
+            except OSError as rollback_exc:
+                print_warning(
+                    f"Could not remove rolled-back Claude MCP registration: {rollback_exc}"
+                )
         return False
 
     try:
@@ -2463,6 +2660,9 @@ def _setup_claude(claude_path: str) -> bool:
                 )
         print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
         return False
+
+    _mark_claude_mcp_recovery_committed(mcp_config_path)
+    _clear_claude_mcp_recovery(mcp_config_path)
 
     print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
     print_info(f"Config saved to: {config_path}")

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -95,22 +95,39 @@ def _is_string_list(value: object) -> bool:
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 
+def _is_string_mapping(value: object) -> bool:
+    return isinstance(value, dict) and all(
+        isinstance(key, str) and isinstance(item, str) for key, item in value.items()
+    )
+
+
 def _is_supported_claude_mcp_entry(entry: dict[str, object]) -> bool:
     command = entry.get("command")
     args = entry.get("args")
+    env = entry.get("env")
     url = entry.get("url")
+    headers = entry.get("headers")
     entry_type = entry.get("type")
 
     if "args" in entry and not _is_string_list(args):
+        return False
+    if "env" in entry and not _is_string_mapping(env):
+        return False
+    if "headers" in entry and not _is_string_mapping(headers):
         return False
 
     if isinstance(command, str) and command.strip():
         if entry_type not in (None, "stdio"):
             return False
-        return "url" not in entry
+        return "url" not in entry and "headers" not in entry
 
     if isinstance(url, str) and url.strip():
-        return entry_type in {"http", "sse", "streamable-http"}
+        return (
+            entry_type in {"http", "sse", "streamable-http"}
+            and "command" not in entry
+            and "args" not in entry
+            and "env" not in entry
+        )
 
     return False
 
@@ -132,6 +149,32 @@ class _ClaudeMcpSnapshot(NamedTuple):
     content_sha256: str | None
 
 
+class _ClaudeSetupFileSnapshot(NamedTuple):
+    existed: bool
+    content: bytes | None
+    mode: int
+    identity: dict[str, int] | None
+    content_sha256: str | None
+
+
+class _ClaudeSetupStagedFile(NamedTuple):
+    path: Path
+    snapshot: _ClaudeSetupFileSnapshot
+    content: bytes | None
+    mode: int
+
+
+_CLAUDE_MCP_RECOVERY_VERSION = 2
+_CLAUDE_MCP_RECOVERY_PHASES = {
+    "prepared",
+    "mcp_written",
+    "config_written",
+    "credentials_written",
+    "committed",
+    "cleanup_pending",
+}
+
+
 def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
     return {
         "dev": int(stat_result.st_dev),
@@ -142,8 +185,8 @@ def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
     }
 
 
-def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | None:
-    """Return the exact pre-activation MCP snapshot, or ``None`` when unsafe."""
+def _read_claude_setup_file_snapshot(path: Path) -> _ClaudeSetupFileSnapshot | None:
+    """Return an exact file snapshot, or ``None`` when the path is unsafe."""
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -151,9 +194,9 @@ def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | Non
         flags |= os.O_NONBLOCK
     fd = -1
     try:
-        fd = os.open(mcp_config_path, flags)
+        fd = os.open(path, flags)
     except FileNotFoundError:
-        return _ClaudeMcpSnapshot(False, None, 0o600, None, None)
+        return _ClaudeSetupFileSnapshot(False, None, 0o600, None, None)
     except OSError:
         return None
     try:
@@ -163,7 +206,7 @@ def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | Non
         with os.fdopen(fd, "rb") as stream:
             fd = -1
             content = stream.read()
-        return _ClaudeMcpSnapshot(
+        return _ClaudeSetupFileSnapshot(
             True,
             content,
             stat.S_IMODE(stat_result.st_mode),
@@ -180,8 +223,16 @@ def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | Non
                 pass
 
 
+def _read_claude_mcp_snapshot(mcp_config_path: Path) -> _ClaudeMcpSnapshot | None:
+    """Return the exact pre-activation MCP snapshot, or ``None`` when unsafe."""
+    snapshot = _read_claude_setup_file_snapshot(mcp_config_path)
+    if snapshot is None:
+        return None
+    return _ClaudeMcpSnapshot(*snapshot)
+
+
 def _claude_mcp_snapshot_matches(
-    snapshot: _ClaudeMcpSnapshot,
+    snapshot: _ClaudeMcpSnapshot | _ClaudeSetupFileSnapshot,
     *,
     identity: dict[str, object] | None,
     content_sha256: object,
@@ -193,200 +244,428 @@ def _claude_mcp_snapshot_matches(
     )
 
 
-def _write_claude_mcp_recovery(
-    mcp_config_path: Path,
-    *,
-    snapshot: _ClaudeMcpSnapshot,
-    target_config_path: Path,
-    target_config_content: str,
-) -> bool:
-    encoded_config = target_config_content.encode("utf-8")
-    payload: dict[str, object] = {
-        "version": 1,
-        "state": "pending",
-        "action": "restore" if snapshot.existed else "remove",
+def _fsync_parent_dir(path: Path) -> None:
+    if os.name != "posix":
+        return
+    fd = -1
+    try:
+        fd = os.open(path.parent, os.O_RDONLY)
+        os.fsync(fd)
+    except OSError:
+        return
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _snapshot_to_manifest(snapshot: _ClaudeSetupFileSnapshot) -> dict[str, object]:
+    return {
+        "existed": snapshot.existed,
         "mode": snapshot.mode,
-        "target_config_path": str(target_config_path),
-        "target_config_sha256": hashlib.sha256(encoded_config).hexdigest(),
-        "target_config_b64": base64.b64encode(encoded_config).decode("ascii"),
+        "identity": snapshot.identity,
+        "sha256": snapshot.content_sha256,
+        "content_b64": (
+            base64.b64encode(snapshot.content or b"").decode("ascii") if snapshot.existed else None
+        ),
     }
-    if snapshot.existed:
-        payload["content_b64"] = base64.b64encode(snapshot.content or b"").decode("ascii")
-        payload["pre_identity"] = snapshot.identity
-        payload["pre_content_sha256"] = snapshot.content_sha256
+
+
+def _snapshot_from_manifest(data: dict[str, object]) -> _ClaudeSetupFileSnapshot | None:
+    existed = data.get("existed")
+    mode = data.get("mode")
+    identity = data.get("identity")
+    sha256 = data.get("sha256")
+    content_b64 = data.get("content_b64")
+    if not isinstance(existed, bool) or not isinstance(mode, int):
+        return None
+    if not existed:
+        return _ClaudeSetupFileSnapshot(False, None, mode, None, None)
+    if (
+        not isinstance(identity, dict)
+        or not isinstance(sha256, str)
+        or not isinstance(content_b64, str)
+    ):
+        return None
+    try:
+        content = base64.b64decode(content_b64.encode("ascii"), validate=True)
+    except (ValueError, UnicodeEncodeError):
+        return None
+    if hashlib.sha256(content).hexdigest() != sha256:
+        return None
+    normalized_identity: dict[str, int] = {}
+    for key in ("dev", "ino", "size", "mtime_ns", "ctime_ns"):
+        value = identity.get(key)
+        if not isinstance(value, int):
+            return None
+        normalized_identity[key] = value
+    return _ClaudeSetupFileSnapshot(True, content, mode, normalized_identity, sha256)
+
+
+def _claude_setup_file_matches(path: Path, snapshot: _ClaudeSetupFileSnapshot) -> bool:
+    current = _read_claude_setup_file_snapshot(path)
+    if current is None or current.existed != snapshot.existed:
+        return False
+    if not snapshot.existed:
+        return True
+    return _claude_mcp_snapshot_matches(
+        current,
+        identity=snapshot.identity,
+        content_sha256=snapshot.content_sha256,
+    )
+
+
+def _path_matches_snapshot_while_linked(path: Path, snapshot: _ClaudeSetupFileSnapshot) -> bool:
+    try:
+        stat_result = path.stat()
+        content = path.read_bytes()
+    except OSError:
+        return False
+    if not snapshot.existed or not stat.S_ISREG(stat_result.st_mode):
+        return False
+    identity = _claude_mcp_file_identity(stat_result)
+    return (
+        snapshot.identity is not None
+        and identity.get("dev") == snapshot.identity.get("dev")
+        and identity.get("ino") == snapshot.identity.get("ino")
+        and identity.get("size") == snapshot.identity.get("size")
+        and identity.get("mtime_ns") == snapshot.identity.get("mtime_ns")
+        and hashlib.sha256(content).hexdigest() == snapshot.content_sha256
+    )
+
+
+def _write_temp_bytes(path: Path, content: bytes, *, mode: int) -> Path:
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if os.name == "posix":
+            os.fchmod(fd, mode)
+        else:
+            os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+    return tmp_path
+
+
+def _promote_text_cas(
+    path: Path,
+    content: bytes,
+    *,
+    expected: _ClaudeSetupFileSnapshot,
+    mode: int,
+) -> _ClaudeSetupFileSnapshot:
+    """Promote bytes only if the live path still matches ``expected``."""
+    if os.name != "posix":
+        if not _claude_setup_file_matches(path, expected):
+            raise OSError(f"{path} changed during setup")
+        _atomic_write_text(path, content.decode("utf-8"), mode=mode)
+        promoted = _read_claude_setup_file_snapshot(path)
+        if promoted is None or not promoted.existed:
+            raise OSError(f"Could not verify promoted file: {path}")
+        return promoted
+
+    tmp_path = _write_temp_bytes(path, content, mode=mode)
+    backup_path = path.with_name(f".{path.name}.ouroboros-pre")
+    try:
+        if expected.existed:
+            try:
+                backup_path.unlink()
+            except FileNotFoundError:
+                pass
+            if not _claude_setup_file_matches(path, expected):
+                raise OSError(f"{path} changed during setup")
+            os.rename(path, backup_path)
+            backup_bytes = backup_path.read_bytes()
+            if (
+                not _path_matches_snapshot_while_linked(backup_path, expected)
+                or hashlib.sha256(backup_bytes).hexdigest() != expected.content_sha256
+            ):
+                if not path.exists():
+                    os.rename(backup_path, path)
+                raise OSError(f"{path} changed during setup")
+            try:
+                os.link(tmp_path, path)
+                tmp_path.unlink()
+            except OSError:
+                if not path.exists():
+                    os.rename(backup_path, path)
+                raise
+        else:
+            if not _claude_setup_file_matches(path, expected):
+                raise OSError(f"{path} changed during setup")
+            os.link(tmp_path, path)
+            tmp_path.unlink()
+        _fsync_parent_dir(path)
+        promoted = _read_claude_setup_file_snapshot(path)
+        if promoted is None or not promoted.existed:
+            raise OSError(f"Could not verify promoted file: {path}")
+        return promoted
+    finally:
+        for cleanup_path in (tmp_path, backup_path):
+            try:
+                cleanup_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+
+def _load_claude_mcp_recovery_manifest(recovery_path: Path) -> dict[str, object] | None:
+    try:
+        data = json.loads(
+            recovery_path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, RecursionError) as exc:
+        print_warning(f"Could not read Claude MCP recovery journal — setup aborted: {exc}")
+        return None
+    if not isinstance(data, dict):
+        print_warning("Claude MCP recovery journal is malformed — setup aborted.")
+        return None
+    if data.get("version") != _CLAUDE_MCP_RECOVERY_VERSION:
+        print_warning("Claude MCP recovery journal has unsupported version — setup aborted.")
+        return None
+    if data.get("phase") not in _CLAUDE_MCP_RECOVERY_PHASES:
+        print_warning("Claude MCP recovery journal has unknown phase — setup aborted.")
+        return None
+    return data
+
+
+def _write_claude_mcp_recovery_manifest(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+) -> bool:
     try:
         _atomic_write_text(
             _claude_mcp_recovery_path(mcp_config_path),
-            json.dumps(payload, indent=2, allow_nan=False) + "\n",
+            json.dumps(manifest, indent=2, allow_nan=False) + "\n",
             mode=0o600,
         )
+        _fsync_parent_dir(_claude_mcp_recovery_path(mcp_config_path))
     except (OSError, TypeError, ValueError) as exc:
         print_warning(f"Could not write Claude MCP recovery journal — setup aborted: {exc}")
         return False
     return True
 
 
-def _record_claude_mcp_recovery_expected_post_content(mcp_config_path: Path, content: str) -> bool:
-    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
-    try:
-        data = json.loads(recovery_path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            print_warning("Claude MCP recovery journal is malformed — setup aborted.")
-            return False
-        data["post_content_sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
-        _atomic_write_text(
-            recovery_path,
-            json.dumps(data, indent=2, allow_nan=False) + "\n",
-            mode=0o600,
-        )
-    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-        print_warning(f"Could not record Claude MCP recovery target — setup aborted: {exc}")
-        return False
-    return True
+def _update_claude_mcp_recovery_phase(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    phase: str,
+    *,
+    target: str | None = None,
+    snapshot: _ClaudeSetupFileSnapshot | None = None,
+) -> bool:
+    manifest["phase"] = phase
+    if target is not None and snapshot is not None:
+        targets = manifest.get("targets")
+        if isinstance(targets, dict):
+            raw_target = targets.get(target)
+            if isinstance(raw_target, dict):
+                raw_target["post"] = _snapshot_to_manifest(snapshot)
+    return _write_claude_mcp_recovery_manifest(mcp_config_path, manifest)
 
 
-def _record_claude_mcp_recovery_post_state(mcp_config_path: Path) -> bool:
-    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
-    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
-    if snapshot is None or not snapshot.existed:
-        print_warning("Could not record Claude MCP recovery target — setup aborted.")
-        return False
-    try:
-        data = json.loads(recovery_path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            print_warning("Claude MCP recovery journal is malformed — setup aborted.")
-            return False
-        data["post_identity"] = snapshot.identity
-        data["post_content_sha256"] = snapshot.content_sha256
-        _atomic_write_text(
-            recovery_path,
-            json.dumps(data, indent=2, allow_nan=False) + "\n",
-            mode=0o600,
-        )
-    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-        print_warning(f"Could not record Claude MCP recovery target — setup aborted: {exc}")
-        return False
-    return True
-
-
-def _mark_claude_mcp_recovery_committed(mcp_config_path: Path) -> None:
-    recovery_path = _claude_mcp_recovery_path(mcp_config_path)
-    try:
-        data = json.loads(recovery_path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            data = {}
-        data["state"] = "committed"
-        _atomic_write_text(
-            recovery_path,
-            json.dumps(data, indent=2, allow_nan=False) + "\n",
-            mode=0o600,
-        )
-    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-        print_warning(f"Could not mark Claude MCP recovery journal complete: {exc}")
-
-
-def _clear_claude_mcp_recovery(mcp_config_path: Path) -> bool:
+def _clear_claude_mcp_recovery(mcp_config_path: Path, *, non_blocking: bool = False) -> bool:
     recovery_path = _claude_mcp_recovery_path(mcp_config_path)
     try:
         recovery_path.unlink()
+        _fsync_parent_dir(recovery_path)
     except FileNotFoundError:
         return True
     except OSError as exc:
         print_warning(f"Could not remove Claude MCP recovery journal: {exc}")
-        return False
+        return non_blocking
     return True
 
 
-def _claude_mcp_target_config_is_committed(data: dict[str, object]) -> bool:
-    raw_path = data.get("target_config_path")
-    raw_sha256 = data.get("target_config_sha256")
-    if not isinstance(raw_path, str) or not isinstance(raw_sha256, str):
+def _manifest_target(
+    manifest: dict[str, object],
+    name: str,
+) -> tuple[Path, _ClaudeSetupFileSnapshot, bytes | None, int] | None:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return None
+    raw = targets.get(name)
+    if not isinstance(raw, dict):
+        return None
+    raw_path = raw.get("path")
+    raw_content = raw.get("content_b64")
+    raw_mode = raw.get("mode")
+    raw_pre = raw.get("pre")
+    if (
+        not isinstance(raw_path, str)
+        or not isinstance(raw_mode, int)
+        or not isinstance(raw_pre, dict)
+    ):
+        return None
+    pre = _snapshot_from_manifest(raw_pre)
+    if pre is None:
+        return None
+    content: bytes | None = None
+    if isinstance(raw_content, str):
+        try:
+            content = base64.b64decode(raw_content.encode("ascii"), validate=True)
+        except (ValueError, UnicodeEncodeError):
+            return None
+        raw_sha = raw.get("sha256")
+        if not isinstance(raw_sha, str) or hashlib.sha256(content).hexdigest() != raw_sha:
+            return None
+    return Path(raw_path), pre, content, raw_mode
+
+
+def _manifest_target_post_matches(manifest: dict[str, object], name: str) -> bool:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
         return False
+    raw = targets.get(name)
+    if not isinstance(raw, dict):
+        return False
+    raw_path = raw.get("path")
+    raw_post = raw.get("post")
+    if not isinstance(raw_path, str) or not isinstance(raw_post, dict):
+        return False
+    post = _snapshot_from_manifest(raw_post)
+    return post is not None and _claude_setup_file_matches(Path(raw_path), post)
+
+
+def _recover_manifest_target(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    name: str,
+    next_phase: str,
+) -> bool:
+    target = _manifest_target(manifest, name)
+    if target is None:
+        print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
+        return False
+    path, pre, content, mode = target
+    if content is None:
+        if not _claude_setup_file_matches(path, pre):
+            print_warning(f"Claude MCP recovery found external changes in {path} — setup aborted.")
+            return False
+        return _update_claude_mcp_recovery_phase(mcp_config_path, manifest, next_phase)
+    current = _read_claude_setup_file_snapshot(path)
+    if (
+        current is not None
+        and current.existed
+        and current.content_sha256 == hashlib.sha256(content).hexdigest()
+    ):
+        return _update_claude_mcp_recovery_phase(
+            mcp_config_path, manifest, next_phase, target=name, snapshot=current
+        )
     try:
-        content = Path(raw_path).read_bytes()
-    except OSError:
+        promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
+    except (OSError, UnicodeDecodeError) as exc:
+        print_warning(f"Could not complete Claude setup recovery for {path}: {exc}")
         return False
-    return hashlib.sha256(content).hexdigest() == raw_sha256
-
-
-def _claude_mcp_current_matches_post_state(mcp_config_path: Path, data: dict[str, object]) -> bool:
-    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
-    if snapshot is None or not snapshot.existed:
-        return False
-    raw_identity = data.get("post_identity")
-    if raw_identity is None:
-        return snapshot.content_sha256 == data.get("post_content_sha256")
-    return _claude_mcp_snapshot_matches(
-        snapshot,
-        identity=raw_identity if isinstance(raw_identity, dict) else None,
-        content_sha256=data.get("post_content_sha256"),
+    return _update_claude_mcp_recovery_phase(
+        mcp_config_path, manifest, next_phase, target=name, snapshot=promoted
     )
 
 
-def _recover_claude_mcp_target_config(data: dict[str, object]) -> bool:
-    raw_path = data.get("target_config_path")
-    raw_sha256 = data.get("target_config_sha256")
-    raw_content = data.get("target_config_b64")
-    if (
-        not isinstance(raw_path, str)
-        or not isinstance(raw_sha256, str)
-        or not isinstance(raw_content, str)
-    ):
+def _recover_prepared_claude_manifest(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+) -> bool | None:
+    target = _manifest_target(manifest, "mcp")
+    if target is None:
         print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
         return False
-    try:
-        content = base64.b64decode(raw_content.encode("ascii"), validate=True)
-        if hashlib.sha256(content).hexdigest() != raw_sha256:
-            print_warning("Claude MCP recovery journal target config is corrupt — setup aborted.")
-            return False
-        config_path = Path(raw_path)
-        mode = stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else 0o600
-        _atomic_write_text(config_path, content.decode("utf-8"), mode=mode)
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        print_warning(f"Could not complete Claude config recovery — setup aborted: {exc}")
+    path, pre, content, _mode = target
+    if _claude_setup_file_matches(path, pre):
+        return None
+    if content is None:
+        print_warning("Claude MCP recovery found external changes — setup aborted.")
         return False
-    return True
+    current = _read_claude_setup_file_snapshot(path)
+    if (
+        current is not None
+        and current.existed
+        and current.content_sha256 == hashlib.sha256(content).hexdigest()
+    ):
+        return _update_claude_mcp_recovery_phase(
+            mcp_config_path, manifest, "mcp_written", target="mcp", snapshot=current
+        )
+    print_warning("Claude MCP recovery found external changes — setup aborted.")
+    return False
 
 
 def _recover_claude_mcp_activation() -> bool:
     """Recover a previously interrupted Claude MCP activation, if any."""
     mcp_config_path = _claude_mcp_config_path()
     recovery_path = _claude_mcp_recovery_path(mcp_config_path)
-    try:
-        if not recovery_path.is_file():
-            return True
-        data = json.loads(recovery_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        print_warning(f"Could not read Claude MCP recovery journal — setup aborted: {exc}")
-        return False
-    if not isinstance(data, dict):
-        print_warning("Claude MCP recovery journal is malformed — setup aborted.")
-        return False
-
-    if data.get("state") == "committed":
-        return _clear_claude_mcp_recovery(mcp_config_path)
-
-    if data.get("state") != "pending":
-        print_warning("Claude MCP recovery journal has unknown state — setup aborted.")
-        return False
-
-    if _claude_mcp_target_config_is_committed(data):
-        return _clear_claude_mcp_recovery(mcp_config_path)
-
-    if data.get("action") not in {"restore", "remove"}:
-        print_warning("Claude MCP recovery journal has unknown action — setup aborted.")
-        return False
-
-    if not _claude_mcp_current_matches_post_state(mcp_config_path, data):
-        print_warning(
-            "Claude MCP recovery journal does not match the current MCP config — setup aborted."
-        )
-        return False
-
-    if not _recover_claude_mcp_target_config(data):
-        return False
-
-    return _clear_claude_mcp_recovery(mcp_config_path)
+    for _ in range(len(_CLAUDE_MCP_RECOVERY_PHASES) + 1):
+        try:
+            if not recovery_path.is_file():
+                return True
+        except OSError as exc:
+            print_warning(f"Could not read Claude MCP recovery journal — setup aborted: {exc}")
+            return False
+        data = _load_claude_mcp_recovery_manifest(recovery_path)
+        if data is None:
+            return False
+        phase = data.get("phase")
+        if phase in {"committed", "cleanup_pending"}:
+            return _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
+        if phase == "prepared":
+            prepared_recovery = _recover_prepared_claude_manifest(mcp_config_path, data)
+            if prepared_recovery is not None:
+                if not prepared_recovery:
+                    return False
+                continue
+            return _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
+        if phase == "mcp_written":
+            if not _manifest_target_post_matches(data, "mcp"):
+                print_warning(
+                    "Claude MCP recovery journal does not match the current MCP config — "
+                    "setup aborted."
+                )
+                return False
+            if not _recover_manifest_target(mcp_config_path, data, "config", "config_written"):
+                return False
+            continue
+        if phase == "config_written":
+            if not _manifest_target_post_matches(data, "mcp") or not _manifest_target_post_matches(
+                data, "config"
+            ):
+                print_warning("Claude MCP recovery found external changes — setup aborted.")
+                return False
+            if not _recover_manifest_target(
+                mcp_config_path, data, "credentials", "credentials_written"
+            ):
+                return False
+            continue
+        if phase == "credentials_written":
+            if not _update_claude_mcp_recovery_phase(mcp_config_path, data, "committed"):
+                return False
+            continue
+    print_warning("Claude MCP recovery journal did not converge — setup aborted.")
+    return False
 
 
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
@@ -494,7 +773,7 @@ def _ensure_claude_mcp_entry(
                 "Fix the file encoding and re-run setup."
             )
             return False
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RecursionError):
             print_warning(
                 f"Could not parse {mcp_config_path} — skipping MCP registration to avoid "
                 "overwriting existing settings. Fix the JSON syntax and re-run setup."
@@ -529,6 +808,10 @@ def _ensure_claude_mcp_entry(
             existing = raw_existing
 
     detected = _detect_mcp_entry(package_spec="ouroboros-ai[mcp,claude]")
+    if detected is not None and (
+        not isinstance(detected, dict) or not _is_supported_claude_mcp_entry(detected)
+    ):
+        detected = None
     needs_write = False
     registered = False
     removed_timeout = False
@@ -572,13 +855,16 @@ def _ensure_claude_mcp_entry(
         try:
             mode = stat.S_IMODE(mcp_config_path.stat().st_mode) if config_exists else 0o600
             content = json.dumps(mcp_data, indent=2, allow_nan=False)
-            if expected_snapshot is not None and not (
-                _record_claude_mcp_recovery_expected_post_content(mcp_config_path, content)
-            ):
+            snapshot = expected_snapshot or _read_claude_mcp_snapshot(mcp_config_path)
+            if snapshot is None:
+                print_warning(
+                    f"Could not verify {mcp_config_path} snapshot — leaving it untouched."
+                )
                 return False
-            _atomic_write_text(
+            _promote_text_cas(
                 mcp_config_path,
-                content,
+                content.encode("utf-8"),
+                expected=_ClaudeSetupFileSnapshot(*snapshot),
                 mode=mode,
             )
         except (OSError, TypeError, ValueError) as exc:
@@ -2734,77 +3020,314 @@ def _ensure_credentials_file(config_dir: Path) -> bool:
     return True
 
 
+def _validate_existing_credentials_file(credentials_path: Path) -> bool:
+    from ouroboros.config.loader import ConfigError, load_credentials
+
+    try:
+        load_credentials(credentials_path)
+    except ConfigError as exc:
+        print_warning(f"Could not validate {credentials_path} — Claude setup aborted: {exc}")
+        return False
+    return True
+
+
+def _stage_claude_config(config_path: Path, claude_path: str) -> bytes | None:
+    from ouroboros.config.models import get_default_config
+
+    try:
+        if config_path.exists():
+            raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        else:
+            raw_config = get_default_config().model_dump(mode="json")
+    except (OSError, yaml.YAMLError, RecursionError) as exc:
+        print_warning(f"Could not read {config_path} — Claude setup aborted: {exc}")
+        return None
+    if not isinstance(raw_config, dict):
+        print_warning(f"{config_path} top-level is not a mapping — Claude setup aborted.")
+        return None
+
+    config_dict = deepcopy(raw_config)
+    orch = config_dict.get("orchestrator")
+    if not isinstance(orch, dict):
+        orch = {}
+        config_dict["orchestrator"] = orch
+    orch["runtime_backend"] = "claude"
+    orch["cli_path"] = claude_path
+
+    llm = config_dict.get("llm")
+    if not isinstance(llm, dict):
+        llm = {}
+        config_dict["llm"] = llm
+    llm["backend"] = "claude"
+
+    try:
+        staged_config = yaml.safe_dump(config_dict, default_flow_style=False, sort_keys=False)
+        staged_loaded = yaml.safe_load(staged_config)
+    except (yaml.YAMLError, RecursionError) as exc:
+        print_warning(f"Could not stage Claude config safely — setup aborted: {exc}")
+        return None
+    if not isinstance(staged_loaded, dict):
+        print_warning("Could not stage Claude config safely — setup aborted.")
+        return None
+    return staged_config.encode("utf-8")
+
+
+def _stage_claude_credentials(credentials_path: Path) -> bytes | None:
+    from ouroboros.config.models import get_default_credentials
+
+    try:
+        credentials_dict = get_default_credentials().model_dump(mode="json")
+        return yaml.safe_dump(credentials_dict, default_flow_style=False, sort_keys=False).encode(
+            "utf-8"
+        )
+    except (yaml.YAMLError, TypeError, ValueError) as exc:
+        print_warning(f"Could not stage {credentials_path} — Claude setup aborted: {exc}")
+        return None
+
+
+def _preflight_claude_setup_path(path: Path, *, label: str) -> _ClaudeSetupFileSnapshot | None:
+    snapshot = _read_claude_setup_file_snapshot(path)
+    if snapshot is None:
+        print_warning(f"Could not snapshot {path} safely — Claude setup aborted.")
+        return None
+    if path.exists() and not snapshot.existed:
+        print_warning(f"Could not inspect {path} safely — Claude setup aborted.")
+        return None
+    if (
+        snapshot.existed
+        and label == "credentials"
+        and not _validate_existing_credentials_file(path)
+    ):
+        return None
+    return snapshot
+
+
+def _build_claude_setup_manifest(
+    *,
+    mcp: _ClaudeSetupStagedFile,
+    config: _ClaudeSetupStagedFile,
+    credentials: _ClaudeSetupStagedFile,
+) -> dict[str, object]:
+    targets: dict[str, object] = {}
+    for name, staged in (
+        ("mcp", mcp),
+        ("config", config),
+        ("credentials", credentials),
+    ):
+        content = staged.content
+        target: dict[str, object] = {
+            "path": str(staged.path),
+            "mode": staged.mode,
+            "pre": _snapshot_to_manifest(staged.snapshot),
+            "content_b64": (
+                base64.b64encode(content).decode("ascii") if content is not None else None
+            ),
+            "sha256": hashlib.sha256(content).hexdigest() if content is not None else None,
+        }
+        targets[name] = target
+    return {
+        "version": _CLAUDE_MCP_RECOVERY_VERSION,
+        "phase": "prepared",
+        "targets": targets,
+    }
+
+
+def _stage_claude_mcp_content(
+    mcp_config_path: Path,
+) -> tuple[bytes | None, bool, bool, bool] | None:
+    config_exists = mcp_config_path.exists()
+    mcp_data: dict[str, object] = {}
+    if config_exists:
+        try:
+            mcp_data = json.loads(
+                mcp_config_path.read_text(encoding="utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+                parse_constant=_reject_json_constant,
+            )
+            _reject_non_finite_json_numbers(mcp_data)
+        except UnicodeDecodeError:
+            print_warning(
+                f"Could not decode {mcp_config_path} as UTF-8 — leaving it untouched. "
+                "Fix the file encoding and re-run setup."
+            )
+            return None
+        except (json.JSONDecodeError, ValueError, RecursionError):
+            print_warning(
+                f"Could not parse {mcp_config_path} — skipping MCP registration to avoid "
+                "overwriting existing settings. Fix the JSON syntax and re-run setup."
+            )
+            return None
+        except OSError as exc:
+            print_warning(f"Could not read {mcp_config_path} — leaving it untouched: {exc}")
+            return None
+        if not isinstance(mcp_data, dict):
+            print_warning(f"{mcp_config_path} top-level is not an object — leaving it untouched.")
+            return None
+
+    if "mcpServers" not in mcp_data:
+        servers: dict[str, object] = {}
+        mcp_data["mcpServers"] = servers
+    else:
+        raw_servers = mcp_data["mcpServers"]
+        if not isinstance(raw_servers, dict):
+            print_warning(
+                f"{mcp_config_path} 'mcpServers' section is not an object — leaving it untouched."
+            )
+            return None
+        servers = raw_servers
+
+    raw_existing = servers.get("ouroboros")
+    existing = (
+        raw_existing
+        if isinstance(raw_existing, dict) and _is_supported_claude_mcp_entry(raw_existing)
+        else None
+    )
+
+    detected = _detect_mcp_entry(package_spec="ouroboros-ai[mcp,claude]")
+    if detected is not None and (
+        not isinstance(detected, dict) or not _is_supported_claude_mcp_entry(detected)
+    ):
+        detected = None
+    registered = False
+    removed_timeout = False
+    updated_entry = False
+    if existing is None:
+        if detected is None:
+            print_warning(
+                "Cannot register MCP server: no working ouroboros installation found.\n"
+                "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            )
+            return None
+        servers["ouroboros"] = detected
+        registered = True
+    else:
+        if "timeout" in existing:
+            del existing["timeout"]
+            removed_timeout = True
+        known_commands = {"uvx", "ouroboros", "python3", "python"}
+        if detected is not None and existing.get("command") in known_commands:
+            if (
+                existing.get("command") != detected["command"]
+                or existing.get("args") != detected["args"]
+            ):
+                existing["command"] = detected["command"]
+                existing["args"] = detected["args"]
+                updated_entry = True
+
+    if not (registered or removed_timeout or updated_entry):
+        return None, registered, removed_timeout, updated_entry
+    content = (json.dumps(mcp_data, indent=2, allow_nan=False) + "\n").encode("utf-8")
+    return content, registered, removed_timeout, updated_entry
+
+
+def _promote_claude_setup_target(
+    mcp_config_path: Path,
+    manifest: dict[str, object],
+    name: str,
+    phase: str,
+) -> bool:
+    target = _manifest_target(manifest, name)
+    if target is None:
+        print_warning("Claude MCP recovery journal is incomplete — setup aborted.")
+        return False
+    path, pre, content, mode = target
+    if content is None:
+        if not _claude_setup_file_matches(path, pre):
+            print_warning(f"{path} changed during setup — Claude setup aborted.")
+            return False
+        return _update_claude_mcp_recovery_phase(mcp_config_path, manifest, phase)
+    try:
+        promoted = _promote_text_cas(path, content, expected=pre, mode=mode)
+    except (OSError, UnicodeDecodeError) as exc:
+        print_warning(f"Could not write {path} — Claude setup aborted: {exc}")
+        return False
+    return _update_claude_mcp_recovery_phase(
+        mcp_config_path, manifest, phase, target=name, snapshot=promoted
+    )
+
+
 def _setup_claude(claude_path: str) -> bool:
     """Configure Ouroboros for the Claude Code runtime."""
     from ouroboros.config.loader import ensure_config_dir
-    from ouroboros.config.models import get_default_config
 
     config_dir = ensure_config_dir()
     config_path = config_dir / "config.yaml"
-
-    if config_path.exists():
-        config_dict = yaml.safe_load(config_path.read_text()) or {}
-    else:
-        config_dict = get_default_config().model_dump(mode="json")
-
-    # Set runtime and LLM backend to claude
-    config_dict.setdefault("orchestrator", {})
-    config_dict["orchestrator"]["runtime_backend"] = "claude"
-    config_dict["orchestrator"]["cli_path"] = claude_path
-
-    config_dict.setdefault("llm", {})
-    config_dict["llm"]["backend"] = "claude"
-
-    staged_config = yaml.safe_dump(config_dict, default_flow_style=False, sort_keys=False)
-    staged_loaded = yaml.safe_load(staged_config)
-    if not isinstance(staged_loaded, dict):
-        print_warning("Could not stage Claude config safely — setup aborted.")
-        return False
-
-    if not _ensure_credentials_file(config_dir):
-        return False
-
+    credentials_path = config_dir / "credentials.yaml"
     mcp_config_path = _claude_mcp_config_path()
+
     if not _recover_claude_mcp_activation():
         return False
 
-    snapshot = _read_claude_mcp_snapshot(mcp_config_path)
-    if snapshot is None:
-        print_warning(f"Could not snapshot {mcp_config_path} safely — Claude setup aborted.")
-        return False
-
-    if not _write_claude_mcp_recovery(
-        mcp_config_path,
-        snapshot=snapshot,
-        target_config_path=config_path,
-        target_config_content=staged_config,
-    ):
-        return False
-
-    if not _ensure_claude_mcp_entry(
-        emit_status=False,
-        recover_pending=False,
-        expected_snapshot=snapshot,
-    ):
-        _clear_claude_mcp_recovery(mcp_config_path)
-        return False
-
-    if not _record_claude_mcp_recovery_post_state(mcp_config_path):
-        _recover_claude_mcp_activation()
-        return False
-
     try:
-        mode = stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else 0o600
-        _atomic_write_text(config_path, staged_config, mode=mode)
+        mcp_config_path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
-        _recover_claude_mcp_activation()
-        print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
+        print_warning(f"Could not create {mcp_config_path.parent} — Claude setup aborted: {exc}")
         return False
 
-    _mark_claude_mcp_recovery_committed(mcp_config_path)
-    _clear_claude_mcp_recovery(mcp_config_path)
+    mcp_snapshot = _preflight_claude_setup_path(mcp_config_path, label="mcp")
+    config_snapshot = _preflight_claude_setup_path(config_path, label="config")
+    credentials_snapshot = _preflight_claude_setup_path(credentials_path, label="credentials")
+    if mcp_snapshot is None or config_snapshot is None or credentials_snapshot is None:
+        return False
+
+    staged_credentials = (
+        None if credentials_snapshot.existed else _stage_claude_credentials(credentials_path)
+    )
+    if not credentials_snapshot.existed and staged_credentials is None:
+        return False
+    staged_config = _stage_claude_config(config_path, claude_path)
+    staged_mcp = _stage_claude_mcp_content(mcp_config_path)
+    if staged_config is None or staged_mcp is None:
+        return False
+
+    mcp_content, registered, removed_timeout, updated_entry = staged_mcp
+    manifest = _build_claude_setup_manifest(
+        mcp=_ClaudeSetupStagedFile(
+            mcp_config_path,
+            mcp_snapshot,
+            mcp_content,
+            mcp_snapshot.mode if mcp_snapshot.existed else 0o600,
+        ),
+        config=_ClaudeSetupStagedFile(
+            config_path,
+            config_snapshot,
+            staged_config,
+            config_snapshot.mode if config_snapshot.existed else 0o600,
+        ),
+        credentials=_ClaudeSetupStagedFile(
+            credentials_path,
+            credentials_snapshot,
+            staged_credentials,
+            credentials_snapshot.mode if credentials_snapshot.existed else 0o600,
+        ),
+    )
+    if not _write_claude_mcp_recovery_manifest(mcp_config_path, manifest):
+        return False
+
+    if not _promote_claude_setup_target(mcp_config_path, manifest, "mcp", "mcp_written"):
+        _recover_claude_mcp_activation()
+        return False
+    if not _promote_claude_setup_target(mcp_config_path, manifest, "config", "config_written"):
+        _recover_claude_mcp_activation()
+        return False
+    if not _promote_claude_setup_target(
+        mcp_config_path, manifest, "credentials", "credentials_written"
+    ):
+        _recover_claude_mcp_activation()
+        return False
+
+    if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "committed"):
+        print_warning("Claude MCP recovery journal cleanup is pending.")
+    elif _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "cleanup_pending"):
+        _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True)
 
     print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
+    if registered:
+        print_success("Registered MCP server in ~/.claude/mcp.json")
+    if removed_timeout:
+        print_info("Removed legacy MCP timeout override.")
+    if updated_entry:
+        print_info("Updated MCP server entry to match current install method.")
     print_info(f"Config saved to: {config_path}")
     return True
 
@@ -3071,6 +3594,7 @@ def _atomic_write_text(path: Path, content: str, *, mode: int = 0o600) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_name, path)
+        _fsync_parent_dir(path)
     except OSError:
         if fd >= 0:
             try:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -248,6 +248,28 @@ def _claude_setup_backup_requires_private_mode(path: Path) -> bool:
     return path.name in {"mcp.json", "credentials.yaml"}
 
 
+def _claude_setup_mode_is_replay_safe(mode: int) -> bool:
+    return 0 <= mode <= 0o777 and mode & 0o022 == 0
+
+
+def _canonical_claude_setup_replay_mode(
+    name: str,
+    path: Path,
+    pre: _ClaudeSetupFileSnapshot,
+    operation: str,
+) -> int | None:
+    if operation == "write" and name == "credentials" and pre.existed:
+        return None
+    if operation == "write" and (
+        name == "credentials"
+        or (not pre.existed and _claude_setup_backup_requires_private_mode(path))
+    ):
+        return 0o600
+    if not pre.existed:
+        return 0o600
+    return pre.mode if _claude_setup_mode_is_replay_safe(pre.mode) else None
+
+
 def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
     return {
         "dev": int(stat_result.st_dev),
@@ -756,7 +778,17 @@ def _promote_text_cas(
                 backup_path=preserved_backup,
                 promoted_snapshot=promoted,
             ) from exc
-        remove_backup = True
+        if backup_path is not None and backup_path.exists():
+            try:
+                backup_path.unlink()
+                _fsync_parent_dir(backup_path)
+            except OSError as exc:
+                raise _ClaudeSetupPromotionError(
+                    f"Could not remove Claude setup backup after promoting {path}: {exc}",
+                    backup_path=backup_path if backup_path.exists() else None,
+                    promoted_snapshot=promoted,
+                ) from exc
+            claimed_existing = False
         return promoted
     except OSError as exc:
         if claimed_existing and not published and backup_path is not None and not path.exists():
@@ -960,6 +992,9 @@ def _manifest_target(
         return None
     pre = _snapshot_from_manifest(raw_pre)
     if pre is None:
+        return None
+    canonical_mode = _canonical_claude_setup_replay_mode(name, path, pre, raw_operation)
+    if canonical_mode is None or raw_mode != canonical_mode:
         return None
     if not _manifest_backup_record_is_valid(path, pre, raw_operation, raw.get("backup")):
         return None

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -2761,6 +2761,9 @@ def _setup_claude(claude_path: str) -> bool:
         print_warning("Could not stage Claude config safely — setup aborted.")
         return False
 
+    if not _ensure_credentials_file(config_dir):
+        return False
+
     mcp_config_path = _claude_mcp_config_path()
     if not _recover_claude_mcp_activation():
         return False
@@ -2787,10 +2790,6 @@ def _setup_claude(claude_path: str) -> bool:
         return False
 
     if not _record_claude_mcp_recovery_post_state(mcp_config_path):
-        _recover_claude_mcp_activation()
-        return False
-
-    if not _ensure_credentials_file(config_dir):
         _recover_claude_mcp_activation()
         return False
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -183,6 +183,15 @@ class _ParentDirectoryFsyncError(OSError):
     """A promoted directory entry could not be made durable."""
 
 
+def _expected_claude_setup_target_paths() -> dict[str, Path]:
+    config_dir = Path.home() / ".ouroboros"
+    return {
+        "mcp": _claude_mcp_config_path(),
+        "config": config_dir / "config.yaml",
+        "credentials": config_dir / "credentials.yaml",
+    }
+
+
 def _claude_mcp_file_identity(stat_result: os.stat_result) -> dict[str, int]:
     return {
         "dev": int(stat_result.st_dev),
@@ -330,6 +339,20 @@ def _claude_setup_file_matches(path: Path, snapshot: _ClaudeSetupFileSnapshot) -
     )
 
 
+def _decode_manifest_target_content(raw: dict[str, object]) -> bytes | None | Literal[False]:
+    raw_content = raw.get("content_b64")
+    raw_sha = raw.get("sha256")
+    if raw_content is None:
+        return None if raw_sha is None else False
+    if not isinstance(raw_content, str) or not isinstance(raw_sha, str):
+        return False
+    try:
+        content = base64.b64decode(raw_content.encode("ascii"), validate=True)
+    except (ValueError, UnicodeEncodeError):
+        return False
+    return content if hashlib.sha256(content).hexdigest() == raw_sha else False
+
+
 def _path_matches_snapshot_while_linked(path: Path, snapshot: _ClaudeSetupFileSnapshot) -> bool:
     try:
         stat_result = path.stat()
@@ -347,6 +370,175 @@ def _path_matches_snapshot_while_linked(path: Path, snapshot: _ClaudeSetupFileSn
         and identity.get("mtime_ns") == snapshot.identity.get("mtime_ns")
         and hashlib.sha256(content).hexdigest() == snapshot.content_sha256
     )
+
+
+def _staged_mcp_content_is_valid(content: bytes) -> bool:
+    try:
+        data = json.loads(
+            content.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+        _reject_non_finite_json_numbers(data)
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+        RecursionError,
+    ):
+        return False
+    if not isinstance(data, dict):
+        return False
+    servers = data.get("mcpServers")
+    entry = servers.get("ouroboros") if isinstance(servers, dict) else None
+    return isinstance(entry, dict) and _is_supported_claude_mcp_entry(entry)
+
+
+def _staged_config_content_has_owned_values(content: bytes, claude_path: str) -> bool:
+    return _claude_config_snapshot_has_owned_values(
+        _ClaudeSetupFileSnapshot(
+            True,
+            content,
+            0o600,
+            None,
+            hashlib.sha256(content).hexdigest(),
+        ),
+        claude_path,
+    )
+
+
+def _staged_credentials_content_is_valid(content: bytes) -> bool:
+    from ouroboros.config.models import CredentialsConfig
+
+    try:
+        data = yaml.safe_load(content.decode("utf-8"))
+        if data is None:
+            data = {}
+        CredentialsConfig.model_validate(data)
+    except (UnicodeDecodeError, yaml.YAMLError, TypeError, ValueError, RecursionError):
+        return False
+    return True
+
+
+def _manifest_config_update_claude_path(manifest: dict[str, object]) -> str | None:
+    updates = manifest.get("config_updates")
+    if not isinstance(updates, dict):
+        return None
+    cli_path = updates.get("orchestrator.cli_path")
+    return cli_path if isinstance(cli_path, str) and cli_path else None
+
+
+def _staged_target_content_is_valid(
+    manifest: dict[str, object],
+    name: str,
+    content: bytes,
+) -> bool:
+    if name == "mcp":
+        return _staged_mcp_content_is_valid(content)
+    if name == "config":
+        claude_path = _manifest_config_update_claude_path(manifest)
+        return claude_path is not None and _staged_config_content_has_owned_values(
+            content, claude_path
+        )
+    if name == "credentials":
+        return _staged_credentials_content_is_valid(content)
+    return False
+
+
+def _snapshot_content_matches_content(
+    snapshot: _ClaudeSetupFileSnapshot,
+    content: bytes,
+) -> bool:
+    return (
+        snapshot.existed
+        and snapshot.content is not None
+        and snapshot.content_sha256 == hashlib.sha256(content).hexdigest()
+    )
+
+
+def _manifest_target_post_is_operation_consistent(
+    manifest: dict[str, object],
+    name: str,
+) -> bool:
+    target = _manifest_target(manifest, name)
+    if target is None:
+        return False
+    path, pre, content, _mode = target
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+    raw = targets.get(name)
+    if not isinstance(raw, dict):
+        return False
+    raw_post = raw.get("post")
+    if not isinstance(raw_post, dict):
+        return False
+    post = _snapshot_from_manifest(raw_post)
+    if post is None or not _claude_setup_file_matches(path, post):
+        return False
+    if content is None:
+        return post == pre
+    if name == "config":
+        if _snapshot_content_matches_content(post, content):
+            return True
+        claude_path = _manifest_config_update_claude_path(manifest)
+        if claude_path is None:
+            return False
+        return _claude_config_snapshot_has_owned_values(post, claude_path)
+    return _snapshot_content_matches_content(post, content)
+
+
+def _manifest_completed_targets_are_consistent(manifest: dict[str, object]) -> bool:
+    phase = manifest.get("phase")
+    completed_by_phase = {
+        "prepared": (),
+        "mcp_written": ("mcp",),
+        "config_written": ("mcp", "config"),
+        "credentials_written": ("mcp", "config", "credentials"),
+        "committed": ("mcp", "config", "credentials"),
+        "cleanup_pending": ("mcp", "config", "credentials"),
+    }
+    completed_targets = completed_by_phase.get(phase)
+    if completed_targets is None:
+        return False
+    return all(
+        _manifest_target_post_is_operation_consistent(manifest, target_name)
+        for target_name in completed_targets
+    )
+
+
+def _normalize_claude_mcp_recovery_manifest(manifest: dict[str, object]) -> bool:
+    targets = manifest.get("targets")
+    if not isinstance(targets, dict):
+        return False
+
+    expected_paths = _expected_claude_setup_target_paths()
+    seen_paths: set[Path] = set()
+    for target_name, expected_path in expected_paths.items():
+        raw = targets.get(target_name)
+        if not isinstance(raw, dict):
+            return False
+        raw_path = raw.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            return False
+        target_path = Path(raw_path)
+        if (
+            not target_path.is_absolute()
+            or target_path != expected_path
+            or target_path in seen_paths
+        ):
+            return False
+        seen_paths.add(target_path)
+
+        raw_operation = raw.get("operation")
+        if raw_operation is None:
+            decoded_content = _decode_manifest_target_content(raw)
+            if decoded_content is False:
+                return False
+            raw["operation"] = "noop" if decoded_content is None else "write"
+        elif not isinstance(raw_operation, str) or raw_operation not in {"write", "noop"}:
+            return False
+    return True
 
 
 def _write_temp_bytes(path: Path, content: bytes, *, mode: int) -> Path:
@@ -493,10 +685,19 @@ def _load_claude_mcp_recovery_manifest(recovery_path: Path) -> dict[str, object]
     if data.get("phase") not in _CLAUDE_MCP_RECOVERY_PHASES:
         print_warning("Claude MCP recovery journal has unknown phase — setup aborted.")
         return None
+    if not _normalize_claude_mcp_recovery_manifest(data):
+        print_warning("Claude MCP recovery journal target is incomplete — setup aborted.")
+        return None
     for target_name in ("mcp", "config", "credentials"):
         if _manifest_target(data, target_name) is None:
             print_warning("Claude MCP recovery journal target is incomplete — setup aborted.")
             return None
+    if not _manifest_completed_targets_are_consistent(data):
+        print_warning(
+            "Claude MCP recovery journal phase is inconsistent and does not match current "
+            "targets — setup aborted."
+        )
+        return None
     return data
 
 
@@ -585,7 +786,6 @@ def _manifest_target(
     if not isinstance(raw, dict):
         return None
     raw_path = raw.get("path")
-    raw_content = raw.get("content_b64")
     raw_operation = raw.get("operation")
     raw_mode = raw.get("mode")
     raw_pre = raw.get("pre")
@@ -598,28 +798,29 @@ def _manifest_target(
         or not isinstance(raw_pre, dict)
     ):
         return None
+    path = Path(raw_path)
+    expected_path = _expected_claude_setup_target_paths()[name]
+    if not path.is_absolute() or path != expected_path:
+        return None
     pre = _snapshot_from_manifest(raw_pre)
     if pre is None:
         return None
-    raw_sha = raw.get("sha256")
-    if raw_content is None:
-        if raw_sha is not None or raw_operation != "noop":
+    decoded_content = _decode_manifest_target_content(raw)
+    if decoded_content is False:
+        return None
+    if decoded_content is None:
+        if raw_operation != "noop":
             return None
         if not _manifest_noop_target_is_valid(name, pre):
             return None
         content: bytes | None = None
     else:
-        if not isinstance(raw_content, str) or not isinstance(raw_sha, str):
-            return None
         if raw_operation != "write":
             return None
-        try:
-            content = base64.b64decode(raw_content.encode("ascii"), validate=True)
-        except (ValueError, UnicodeEncodeError):
+        if not _staged_target_content_is_valid(manifest, name, decoded_content):
             return None
-        if hashlib.sha256(content).hexdigest() != raw_sha:
-            return None
-    return Path(raw_path), pre, content, raw_mode
+        content = decoded_content
+    return path, pre, content, raw_mode
 
 
 def _manifest_noop_target_is_valid(name: str, pre: _ClaudeSetupFileSnapshot) -> bool:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -2458,7 +2458,9 @@ def _setup_claude(claude_path: str) -> bool:
             try:
                 mcp_config_path.unlink()
             except OSError as rollback_exc:
-                print_warning(f"Could not remove rolled-back Claude MCP registration: {rollback_exc}")
+                print_warning(
+                    f"Could not remove rolled-back Claude MCP registration: {rollback_exc}"
+                )
         print_warning(f"Could not write {config_path} — Claude setup aborted: {exc}")
         return False
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -122,13 +122,41 @@ def _is_supported_claude_mcp_entry(entry: dict[str, object]) -> bool:
         return "url" not in entry and "headers" not in entry
 
     if isinstance(url, str) and url.strip():
-        return (
-            entry_type in {"http", "sse", "streamable-http"}
-            and "command" not in entry
-            and "args" not in entry
-            and "env" not in entry
-        )
+        if entry_type in {"http", "sse", "streamable-http"}:
+            return "command" not in entry and "args" not in entry and "env" not in entry
+        if entry_type in {"ws", "websocket"}:
+            return (
+                url.startswith(("ws://", "wss://"))
+                and "command" not in entry
+                and "args" not in entry
+                and "env" not in entry
+            )
 
+    return False
+
+
+def _is_setup_managed_claude_mcp_entry(entry: dict[str, object]) -> bool:
+    command = entry.get("command")
+    raw_args = entry.get("args")
+    if (
+        not isinstance(command, str)
+        or not isinstance(raw_args, list)
+        or not all(isinstance(item, str) for item in raw_args)
+    ):
+        return False
+    args = [item for item in raw_args if isinstance(item, str)]
+    if command == "uvx":
+        package_spec = args[1] if len(args) >= 2 else ""
+        return (
+            len(args) >= 5
+            and args[0] == "--from"
+            and (package_spec == "ouroboros-ai" or package_spec.startswith("ouroboros-ai["))
+            and args[2:5] == ["ouroboros", "mcp", "serve"]
+        )
+    if command == "ouroboros":
+        return args[:2] == ["mcp", "serve"]
+    if command in {"python", "python3"}:
+        return args[:4] == ["-m", "ouroboros", "mcp", "serve"]
     return False
 
 
@@ -181,6 +209,17 @@ class _ClaudeSetupConflictError(OSError):
 
 class _ParentDirectoryFsyncError(OSError):
     """A promoted directory entry could not be made durable."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        backup_path: Path | None = None,
+        promoted_snapshot: _ClaudeSetupFileSnapshot | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.backup_path = backup_path
+        self.promoted_snapshot = promoted_snapshot
 
 
 def _expected_claude_setup_target_paths() -> dict[str, Path]:
@@ -600,6 +639,7 @@ def _promote_text_cas(
     backup_path: Path | None = None
     claimed_existing = False
     published = False
+    remove_backup = False
     try:
         if expected.existed:
             if not _claude_setup_file_matches(path, expected):
@@ -628,11 +668,6 @@ def _promote_text_cas(
                 tmp_path.unlink()
             except FileExistsError as exc:
                 raise _ClaudeSetupConflictError(f"{path} changed during setup") from exc
-            except OSError:
-                if not path.exists():
-                    os.rename(backup_path, path)
-                    claimed_existing = False
-                raise
         else:
             if not _claude_setup_file_matches(path, expected):
                 raise _ClaudeSetupConflictError(f"{path} changed during setup")
@@ -642,22 +677,48 @@ def _promote_text_cas(
                 raise _ClaudeSetupConflictError(f"{path} changed during setup") from exc
             published = True
             tmp_path.unlink()
-        _fsync_parent_dir(path)
         promoted = _read_claude_setup_file_snapshot(path)
         if promoted is None or not promoted.existed:
             raise OSError(f"Could not verify promoted file: {path}")
+        try:
+            _fsync_parent_dir(path)
+        except _ParentDirectoryFsyncError as exc:
+            preserved_backup = (
+                backup_path if backup_path is not None and backup_path.exists() else None
+            )
+            suffix = (
+                f"; previous bytes preserved at {preserved_backup}"
+                if preserved_backup is not None
+                else ""
+            )
+            raise _ParentDirectoryFsyncError(
+                f"{exc}{suffix}",
+                backup_path=preserved_backup,
+                promoted_snapshot=promoted,
+            ) from exc
+        remove_backup = True
         return promoted
-    except OSError:
+    except OSError as exc:
         if claimed_existing and not published and backup_path is not None and not path.exists():
             try:
                 os.rename(backup_path, path)
                 claimed_existing = False
-            except OSError:
-                pass
+            except OSError as restore_exc:
+                raise OSError(
+                    f"{exc}; could not restore {path}; previous bytes preserved at "
+                    f"{backup_path}: {restore_exc}"
+                ) from exc
+        if (
+            published
+            and backup_path is not None
+            and backup_path.exists()
+            and not isinstance(exc, _ParentDirectoryFsyncError)
+        ):
+            raise OSError(f"{exc}; previous bytes preserved at {backup_path}") from exc
         raise
     finally:
         cleanup_paths = [tmp_path]
-        if backup_path is not None:
+        if backup_path is not None and (remove_backup or not claimed_existing):
             cleanup_paths.append(backup_path)
         for cleanup_path in cleanup_paths:
             try:
@@ -1335,17 +1396,13 @@ def _ensure_claude_mcp_entry(
         needs_write = True
         registered = True
     else:
-        # Remove legacy timeout key
-        if "timeout" in existing:
+        setup_managed = _is_setup_managed_claude_mcp_entry(existing)
+        if setup_managed and "timeout" in existing:
             del existing["timeout"]
             needs_write = True
             removed_timeout = True
 
-        # Update entry to match currently detected install method, but only
-        # for known standard commands. Custom entries (docker, nix, etc.) are
-        # left untouched so we don't break user-managed configurations.
-        _KNOWN_COMMANDS = {"uvx", "ouroboros", "python3", "python"}
-        if detected is not None and existing.get("command") in _KNOWN_COMMANDS:
+        if setup_managed and detected is not None:
             if (
                 existing.get("command") != detected["command"]
                 or existing.get("args") != detected["args"]
@@ -3532,7 +3589,7 @@ def _validate_existing_credentials_file(credentials_path: Path) -> bool:
 
     try:
         load_credentials(credentials_path)
-    except ConfigError as exc:
+    except (ConfigError, UnicodeDecodeError, OSError) as exc:
         print_warning(f"Could not validate {credentials_path} — Claude setup aborted: {exc}")
         return False
     return True
@@ -3727,11 +3784,11 @@ def _stage_claude_mcp_content(
         servers["ouroboros"] = detected
         registered = True
     else:
-        if "timeout" in existing:
+        setup_managed = _is_setup_managed_claude_mcp_entry(existing)
+        if setup_managed and "timeout" in existing:
             del existing["timeout"]
             removed_timeout = True
-        known_commands = {"uvx", "ouroboros", "python3", "python"}
-        if detected is not None and existing.get("command") in known_commands:
+        if setup_managed and detected is not None:
             if (
                 existing.get("command") != detected["command"]
                 or existing.get("args") != detected["args"]
@@ -3778,6 +3835,66 @@ def _promote_claude_setup_target(
     return _update_claude_mcp_recovery_phase(
         mcp_config_path, manifest, phase, target=name, snapshot=promoted
     )
+
+
+def _claude_setup_live_state_is_committed(
+    mcp_config_path: Path,
+    config_path: Path,
+    credentials_path: Path,
+    claude_path: str,
+) -> bool:
+    mcp_snapshot = _read_claude_setup_file_snapshot(mcp_config_path)
+    config_snapshot = _read_claude_setup_file_snapshot(config_path)
+    credentials_snapshot = _read_claude_setup_file_snapshot(credentials_path)
+    if mcp_snapshot is None or config_snapshot is None or credentials_snapshot is None:
+        return False
+    return (
+        _manifest_noop_target_is_valid("mcp", mcp_snapshot)
+        and _claude_config_snapshot_has_owned_values(config_snapshot, claude_path)
+        and _manifest_noop_target_is_valid("credentials", credentials_snapshot)
+    )
+
+
+def _report_claude_setup_success(
+    claude_path: str,
+    config_path: Path,
+    *,
+    registered: bool,
+    removed_timeout: bool,
+    updated_entry: bool,
+) -> None:
+    print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
+    if registered:
+        print_success("Registered MCP server in ~/.claude/mcp.json")
+    if removed_timeout:
+        print_info("Removed legacy MCP timeout override.")
+    if updated_entry:
+        print_info("Updated MCP server entry to match current install method.")
+    print_info(f"Config saved to: {config_path}")
+
+
+def _complete_recovered_claude_setup(
+    mcp_config_path: Path,
+    config_path: Path,
+    credentials_path: Path,
+    claude_path: str,
+    *,
+    registered: bool,
+    removed_timeout: bool,
+    updated_entry: bool,
+) -> bool:
+    if not _recover_claude_mcp_activation() or not _claude_setup_live_state_is_committed(
+        mcp_config_path, config_path, credentials_path, claude_path
+    ):
+        return False
+    _report_claude_setup_success(
+        claude_path,
+        config_path,
+        registered=registered,
+        removed_timeout=removed_timeout,
+        updated_entry=updated_entry,
+    )
+    return True
 
 
 def _setup_claude(claude_path: str) -> bool:
@@ -3841,37 +3958,81 @@ def _setup_claude(claude_path: str) -> bool:
 
     try:
         if not _promote_claude_setup_target(mcp_config_path, manifest, "mcp", "mcp_written"):
-            _recover_claude_mcp_activation()
-            return False
+            return _complete_recovered_claude_setup(
+                mcp_config_path,
+                config_path,
+                credentials_path,
+                claude_path,
+                registered=registered,
+                removed_timeout=removed_timeout,
+                updated_entry=updated_entry,
+            )
         if not _promote_live_claude_config_target(mcp_config_path, manifest, "config_written"):
-            _recover_claude_mcp_activation()
-            return False
+            return _complete_recovered_claude_setup(
+                mcp_config_path,
+                config_path,
+                credentials_path,
+                claude_path,
+                registered=registered,
+                removed_timeout=removed_timeout,
+                updated_entry=updated_entry,
+            )
         if not _promote_claude_setup_target(
             mcp_config_path, manifest, "credentials", "credentials_written"
         ):
-            _recover_claude_mcp_activation()
-            return False
+            return _complete_recovered_claude_setup(
+                mcp_config_path,
+                config_path,
+                credentials_path,
+                claude_path,
+                registered=registered,
+                removed_timeout=removed_timeout,
+                updated_entry=updated_entry,
+            )
     except _ParentDirectoryFsyncError as exc:
         print_warning(f"Claude setup durability is pending: {exc}")
         return False
 
     if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "committed"):
         print_warning("Claude MCP recovery journal cleanup is pending.")
-        return False
+        return _complete_recovered_claude_setup(
+            mcp_config_path,
+            config_path,
+            credentials_path,
+            claude_path,
+            registered=registered,
+            removed_timeout=removed_timeout,
+            updated_entry=updated_entry,
+        )
     if not _update_claude_mcp_recovery_phase(mcp_config_path, manifest, "cleanup_pending"):
         print_warning("Claude MCP recovery journal cleanup is pending.")
-        return False
+        return _complete_recovered_claude_setup(
+            mcp_config_path,
+            config_path,
+            credentials_path,
+            claude_path,
+            registered=registered,
+            removed_timeout=removed_timeout,
+            updated_entry=updated_entry,
+        )
     if not _clear_claude_mcp_recovery(mcp_config_path, non_blocking=True):
-        return False
+        return _complete_recovered_claude_setup(
+            mcp_config_path,
+            config_path,
+            credentials_path,
+            claude_path,
+            registered=registered,
+            removed_timeout=removed_timeout,
+            updated_entry=updated_entry,
+        )
 
-    print_success(f"Configured Claude Code runtime (CLI: {claude_path})")
-    if registered:
-        print_success("Registered MCP server in ~/.claude/mcp.json")
-    if removed_timeout:
-        print_info("Removed legacy MCP timeout override.")
-    if updated_entry:
-        print_info("Updated MCP server entry to match current install method.")
-    print_info(f"Config saved to: {config_path}")
+    _report_claude_setup_success(
+        claude_path,
+        config_path,
+        registered=registered,
+        removed_timeout=removed_timeout,
+        updated_entry=updated_entry,
+    )
     return True
 
 

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -173,6 +173,20 @@ class TestConfigBackend:
         assert result.exit_code == 0
         mock_setup.assert_called_once_with("/usr/bin/claude")
 
+    def test_switch_to_claude_fails_when_setup_cannot_register_mcp(
+        self, codex_config_dir: Path
+    ) -> None:
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=codex_config_dir),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("ouroboros.cli.commands.setup._setup_claude", return_value=False),
+        ):
+            result = runner.invoke(app, ["backend", "claude"])
+
+        assert result.exit_code == 1
+        assert "Switched backend" not in result.output
+        assert "aborted" in result.output
+
     def test_switch_to_hermes_delegates_to_setup(self, config_dir: Path) -> None:
         """config backend hermes should delegate to _setup_hermes."""
         with (

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -186,6 +186,9 @@ class TestConfigBackend:
         assert result.exit_code == 1
         assert "Switched backend" not in result.output
         assert "aborted" in result.output
+        config = yaml.safe_load((codex_config_dir / "config.yaml").read_text())
+        assert config["orchestrator"]["runtime_backend"] == "codex"
+        assert config["llm"]["backend"] == "codex"
 
     def test_switch_to_hermes_delegates_to_setup(self, config_dir: Path) -> None:
         """config backend hermes should delegate to _setup_hermes."""

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -190,6 +190,21 @@ class TestConfigBackend:
         assert config["orchestrator"]["runtime_backend"] == "codex"
         assert config["llm"]["backend"] == "codex"
 
+    def test_switch_to_claude_exits_nonzero_when_setup_raises(self, codex_config_dir: Path) -> None:
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=codex_config_dir),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch(
+                "ouroboros.cli.commands.setup._setup_claude",
+                side_effect=OSError("setup exploded"),
+            ),
+        ):
+            result = runner.invoke(app, ["backend", "claude"])
+
+        assert result.exit_code == 1
+        assert "Switched backend" not in result.output
+        assert "setup steps failed" in result.output
+
     def test_switch_to_hermes_delegates_to_setup(self, config_dir: Path) -> None:
         """config backend hermes should delegate to _setup_hermes."""
         with (

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1153,6 +1153,162 @@ class TestCodexSetup:
 class TestClaudeSetup:
     """Tests for Claude-specific setup behavior."""
 
+    def test_malformed_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = '{"mcpServers": BROKEN JSON}'
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        warning.assert_called_once()
+        assert "Could not parse" in warning.call_args.args[0]
+
+    @pytest.mark.parametrize(
+        "original_content",
+        [
+            "null",
+            "[]",
+            '{"mcpServers": null}',
+            '{"mcpServers": []}',
+            '{"mcpServers": {"ouroboros": null}}',
+            '{"mcpServers": {"ouroboros": "disabled"}}',
+        ],
+        ids=[
+            "null-top-level",
+            "array-top-level",
+            "null-servers",
+            "array-servers",
+            "null-ouroboros-entry",
+            "scalar-ouroboros-entry",
+        ],
+    )
+    def test_invalid_mcp_json_shape_warns_without_overwriting(
+        self,
+        tmp_path: Path,
+        original_content: str,
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        warning.assert_called_once()
+        assert "leaving it untouched" in warning.call_args.args[0]
+
+    @pytest.mark.parametrize("invalid_command", [[], {}], ids=["array", "object"])
+    def test_invalid_mcp_command_shape_warns_without_overwriting(
+        self,
+        tmp_path: Path,
+        invalid_command: object,
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = json.dumps(
+            {"mcpServers": {"ouroboros": {"command": invalid_command, "timeout": 600}}}
+        )
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": []},
+            ),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        warning.assert_called_once()
+        assert "command" in warning.call_args.args[0]
+
+    def test_non_utf8_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = b"\xff\xfe\x00"
+        claude_config.write_bytes(original_content)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_bytes() == original_content
+        warning.assert_called_once()
+        assert "decode" in warning.call_args.args[0]
+
+    def test_mcp_directory_creation_failure_warns_without_crashing(self, tmp_path: Path) -> None:
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("pathlib.Path.mkdir", side_effect=OSError("read-only filesystem")),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        warning.assert_called_once()
+        assert "Could not create" in warning.call_args.args[0]
+        assert not (tmp_path / ".claude" / "mcp.json").exists()
+
+    def test_mcp_existence_check_failure_warns_without_crashing(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("pathlib.Path.exists", side_effect=OSError("stat denied")),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        warning.assert_called_once()
+        assert "Could not inspect" in warning.call_args.args[0]
+
+    def test_mcp_write_failure_preserves_existing_file_and_cleans_temp(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = '{"mcpServers": {}}\n'
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": []},
+            ),
+            patch("os.fsync", wraps=os.fsync) as fsync,
+            patch("os.replace", side_effect=OSError("disk full")),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
+        fsync.assert_called_once()
+        success.assert_not_called()
+        warning.assert_called_once()
+        assert "Could not write" in warning.call_args.args[0]
+
     def test_setup_claude_removes_legacy_timeout_override(self, tmp_path: Path) -> None:
         """Claude setup should no longer persist the legacy 600s MCP timeout."""
         config_dir = tmp_path / ".ouroboros"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1280,6 +1280,29 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "Could not inspect" in warning.call_args.args[0]
 
+    def test_symlinked_mcp_json_warns_without_replacing_link(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        managed_config = tmp_path / "managed-mcp.json"
+        original_content = '{"mcpServers": {"managed": {"command": "custom"}}}\n'
+        managed_config.write_text(original_content, encoding="utf-8")
+        claude_config = claude_dir / "mcp.json"
+        claude_config.symlink_to(managed_config)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.is_symlink()
+        assert claude_config.resolve() == managed_config
+        assert managed_config.read_text(encoding="utf-8") == original_content
+        detect.assert_not_called()
+        warning.assert_called_once()
+        assert "symlink" in warning.call_args.args[0]
+
     def test_mcp_write_failure_preserves_existing_file_and_cleans_temp(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1254,6 +1254,53 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "decode" in warning.call_args.args[0]
 
+    @pytest.mark.parametrize(
+        "original_content",
+        [
+            '{"mcpServers": {"existing": {}}, "mcpServers": {}}',
+            '{"mcpServers": {"existing": NaN}}',
+        ],
+    )
+    def test_non_standard_mcp_json_warns_without_overwriting(
+        self, tmp_path: Path, original_content: str
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        warning.assert_called_once()
+        assert "Could not parse" in warning.call_args.args[0]
+
+    def test_hard_linked_mcp_json_warns_without_replacing_link(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        managed_config = tmp_path / "managed-mcp.json"
+        original_content = '{"mcpServers": {"managed": {"command": "custom"}}}\n'
+        managed_config.write_text(original_content, encoding="utf-8")
+        claude_config = claude_dir / "mcp.json"
+        claude_config.hardlink_to(managed_config)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+        ):
+            setup_cmd._ensure_claude_mcp_entry()
+
+        assert claude_config.stat().st_ino == managed_config.stat().st_ino
+        assert managed_config.read_text(encoding="utf-8") == original_content
+        detect.assert_not_called()
+        warning.assert_called_once()
+        assert "hard-linked" in warning.call_args.args[0]
+
     def test_mcp_directory_creation_failure_warns_without_crashing(self, tmp_path: Path) -> None:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1880,6 +1880,16 @@ class TestClaudeSetup:
         claude_config = claude_dir / "mcp.json"
         original_content = '{"mcpServers": {}}\n'
         claude_config.write_text(original_content, encoding="utf-8")
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_fsync_parent = setup_cmd._fsync_parent_dir
+        failed = False
+
+        def fail_post_publish_fsync(path: Path) -> None:
+            nonlocal failed
+            if path == claude_config and not failed:
+                failed = True
+                raise setup_cmd._ParentDirectoryFsyncError("directory fsync failed")
+            real_fsync_parent(path)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1887,13 +1897,17 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
                 return_value={"command": "uvx", "args": []},
             ),
-            patch("os.fsync", side_effect=OSError("fsync failed")),
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=fail_post_publish_fsync,
+            ),
         ):
             registered = setup_cmd._ensure_claude_mcp_entry()
 
         assert registered is False
         assert claude_config.read_text(encoding="utf-8") == original_content
         assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
+        assert not recovery_path.exists()
 
     def test_setup_claude_rolls_forward_config_after_config_commit_failure(
         self, tmp_path: Path
@@ -2349,12 +2363,14 @@ class TestClaudeSetup:
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
             patch("pathlib.Path.unlink", fail_recovery_unlink),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
-        assert configured is True
+        assert configured is False
         assert recovery_path.exists()
         assert json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "cleanup_pending"
+        success.assert_not_called()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
             recovered = setup_cmd._recover_claude_mcp_activation()
@@ -2551,6 +2567,87 @@ class TestClaudeSetup:
 
         assert recovered is True
         assert not recovery_path.exists()
+
+    @pytest.mark.parametrize("backup_path_kind", ["relative", "outside"])
+    def test_setup_claude_recovery_rejects_forged_backup_path(
+        self, tmp_path: Path, backup_path_kind: str
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="prepared")
+        )
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        mcp_target = targets["mcp"]
+        assert isinstance(mcp_target, dict)
+        pre = mcp_target["pre"]
+        assert isinstance(pre, dict)
+        forged_path = (
+            ".mcp.json.ouroboros-pre.forged.tmp"
+            if backup_path_kind == "relative"
+            else str(tmp_path / ".mcp.json.ouroboros-pre.forged.tmp")
+        )
+        mcp_target["backup"] = {
+            "path": forged_path,
+            "pre_sha256": pre["sha256"],
+            "pre_identity": pre["identity"],
+            "pre_mode": pre["mode"],
+        }
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert "incomplete" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_preserves_backup_for_externally_rebased_config(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="mcp_written")
+        )
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        config_target = targets["config"]
+        assert isinstance(config_target, dict)
+        pre = config_target["pre"]
+        assert isinstance(pre, dict)
+        backup_path = config_path.with_name(f".{config_path.name}.ouroboros-pre.operator.tmp")
+        os.rename(config_path, backup_path)
+        external_content = (
+            b"operator:\n  changed: true\n"
+            b"orchestrator:\n  runtime_backend: claude\n"
+            b"  cli_path: /usr/local/bin/claude\n"
+            b"llm:\n  backend: claude\n"
+        )
+        config_path.write_bytes(external_content)
+        config_target["backup"] = {
+            "path": str(backup_path),
+            "pre_sha256": pre["sha256"],
+            "pre_identity": pre["identity"],
+            "pre_mode": pre["mode"],
+        }
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert backup_path.exists()
+        assert config_path.read_bytes() == external_content
+        assert "external changes" in warning.call_args.args[0]
 
     @pytest.mark.parametrize(
         (
@@ -2901,6 +2998,45 @@ class TestClaudeSetup:
         assert raised.value.promoted_snapshot is not None
         assert raised.value.promoted_snapshot.content == b"setup-after"
 
+    @pytest.mark.parametrize(
+        ("name", "operator_content"),
+        [
+            (
+                "mcp.json",
+                b'{"mcpServers":{"ouroboros":{"type":"http","url":"https://example.test",'
+                b'"headers":{"Authorization":"Bearer secret"}}}}',
+            ),
+            ("credentials.yaml", b"providers:\n  openai:\n    api_key: secret\n"),
+        ],
+    )
+    def test_cas_retained_secret_backup_is_private(
+        self, tmp_path: Path, name: str, operator_content: bytes
+    ) -> None:
+        target = tmp_path / name
+        target.write_bytes(operator_content)
+        target.chmod(0o644)
+        snapshot = setup_cmd._read_claude_setup_file_snapshot(target)
+        assert snapshot is not None
+
+        with (
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=setup_cmd._ParentDirectoryFsyncError("directory fsync failed"),
+            ),
+            pytest.raises(setup_cmd._ParentDirectoryFsyncError),
+        ):
+            setup_cmd._promote_text_cas(
+                target,
+                b"setup-after",
+                expected=snapshot,
+                mode=0o600,
+            )
+
+        backups = list(tmp_path.glob(f".{target.name}.ouroboros-pre.*.tmp"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == operator_content
+        assert backups[0].stat().st_mode & 0o777 == 0o600
+
     def test_cas_publish_and_restore_failure_preserves_original_backup(
         self, tmp_path: Path
     ) -> None:
@@ -2934,15 +3070,20 @@ class TestClaudeSetup:
         assert len(backups) == 1
         assert backups[0].read_bytes() == b"operator-before"
 
-    def test_setup_claude_parent_fsync_failure_leaves_recovery_pending(
+    def test_setup_claude_recovery_restores_missing_mcp_from_journaled_backup(
         self, tmp_path: Path
     ) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
         config_path = config_dir / "config.yaml"
         config_path.write_text("{}", encoding="utf-8")
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
         claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
         mcp_path = claude_dir / "mcp.json"
+        original_mcp = b'{"mcpServers": {}}\n'
+        mcp_path.write_bytes(original_mcp)
+        mcp_path.chmod(0o644)
         recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
         real_fsync_parent = setup_cmd._fsync_parent_dir
 
@@ -2969,7 +3110,70 @@ class TestClaudeSetup:
         assert configured is False
         assert mcp_path.exists()
         assert recovery_path.exists()
-        assert json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "prepared"
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        assert manifest["phase"] == "prepared"
+        backup_path = Path(manifest["targets"]["mcp"]["backup"]["path"])
+        assert backup_path.read_bytes() == original_mcp
+        assert backup_path.stat().st_mode & 0o777 == 0o600
+        success.assert_not_called()
+
+        mcp_path.unlink()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert mcp_path.read_bytes() == original_mcp
+        assert mcp_path.stat().st_mode & 0o777 == 0o644
+        assert not backup_path.exists()
+        assert not recovery_path.exists()
+
+    def test_setup_claude_journals_backup_after_post_publish_verification_failure(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        original_mcp = b'{"mcpServers": {}}\n'
+        mcp_path.write_bytes(original_mcp)
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_snapshot = setup_cmd._read_claude_setup_file_snapshot
+        mcp_reads = 0
+
+        def fail_promoted_mcp_snapshot(path: Path):
+            nonlocal mcp_reads
+            snapshot = real_snapshot(path)
+            if path == mcp_path:
+                mcp_reads += 1
+                if mcp_reads == 3:
+                    return None
+            return snapshot
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._read_claude_setup_file_snapshot",
+                side_effect=fail_promoted_mcp_snapshot,
+            ),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert recovery_path.exists()
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        backup_path = Path(manifest["targets"]["mcp"]["backup"]["path"])
+        assert backup_path.read_bytes() == original_mcp
         success.assert_not_called()
 
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -2977,6 +3181,142 @@ class TestClaudeSetup:
 
         assert recovered is True
         assert not recovery_path.exists()
+        assert not backup_path.exists()
+        assert list(claude_dir.glob(".mcp.json.ouroboros-pre.*.tmp")) == []
+
+    def test_setup_claude_restores_preimage_when_backup_journal_write_fails(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        original_mcp = b'{"mcpServers": {}}\n'
+        mcp_path.write_bytes(original_mcp)
+        mcp_path.chmod(0o644)
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_fsync_parent = setup_cmd._fsync_parent_dir
+        real_write_manifest = setup_cmd._write_claude_mcp_recovery_manifest
+        failed_fsync = False
+        journal_writes = 0
+
+        def fail_mcp_parent_fsync(path: Path) -> None:
+            nonlocal failed_fsync
+            if path == mcp_path and not failed_fsync:
+                failed_fsync = True
+                raise setup_cmd._ParentDirectoryFsyncError("directory fsync failed")
+            real_fsync_parent(path)
+
+        def fail_backup_record(path: Path, manifest: dict[str, object]) -> bool:
+            nonlocal journal_writes
+            journal_writes += 1
+            if journal_writes == 2:
+                return False
+            return real_write_manifest(path, manifest)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=fail_mcp_parent_fsync,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._write_claude_mcp_recovery_manifest",
+                side_effect=fail_backup_record,
+            ),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert mcp_path.read_bytes() == original_mcp
+        assert mcp_path.stat().st_mode & 0o777 == 0o644
+        assert list(claude_dir.glob(".mcp.json.ouroboros-pre.*.tmp")) == []
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        assert "backup" not in manifest["targets"]["mcp"]
+        success.assert_not_called()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
+
+    def test_setup_claude_recovery_retries_missing_config_from_journaled_backup(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = b"custom:\n  keep: true\n"
+        config_path.write_bytes(original_config)
+        config_path.chmod(0o640)
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        mcp_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "ouroboros": {
+                            "command": "docker",
+                            "args": ["run", "ouroboros-mcp"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_fsync_parent = setup_cmd._fsync_parent_dir
+        failed = False
+
+        def fail_config_parent_fsync(path: Path) -> None:
+            nonlocal failed
+            if path == config_path and not failed:
+                failed = True
+                raise setup_cmd._ParentDirectoryFsyncError("directory fsync failed")
+            real_fsync_parent(path)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=fail_config_parent_fsync,
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        assert manifest["phase"] == "mcp_written"
+        backup_path = Path(manifest["targets"]["config"]["backup"]["path"])
+        assert backup_path.read_bytes() == original_config
+
+        config_path.unlink()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not backup_path.exists()
+        assert not recovery_path.exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["custom"]["keep"] is True
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
+        assert config_path.stat().st_mode & 0o777 == 0o640
 
     def test_mcp_update_preserves_existing_mode(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1212,6 +1212,52 @@ class TestClaudeSetup:
         assert not (config_dir / "config.yaml").exists()
         success.assert_not_called()
 
+    def test_setup_claude_fresh_activation_creates_credentials_for_config_exists(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+            from ouroboros.config.loader import config_exists
+
+            exists_after_activation = config_exists()
+
+        assert configured is True
+        assert exists_after_activation is True
+        assert (config_dir / "config.yaml").exists()
+        credentials_path = config_dir / "credentials.yaml"
+        assert credentials_path.exists()
+        assert credentials_path.stat().st_mode & 0o777 == 0o600
+
+    def test_setup_claude_preserves_existing_credentials(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        credentials_path = config_dir / "credentials.yaml"
+        credentials_path.write_text("providers:\n  custom: keep\n", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is True
+        assert credentials_path.read_text(encoding="utf-8") == "providers:\n  custom: keep\n"
+
     def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -1285,16 +1331,26 @@ class TestClaudeSetup:
             None,
             "disabled",
             {"command": []},
+            {"command": ""},
+            {"command": "uvx", "args": None},
             {"command": "uvx", "args": "--from ouroboros-ai"},
-            {"url": "https://example.test/mcp", "transport": "ftp"},
+            {"url": "https://example.test/mcp", "type": "ftp"},
+            {"url": "", "type": "http"},
+            {"url": "https://example.test/mcp", "type": None},
+            {"url": "https://example.test/mcp", "type": 123},
             {"args": ["mcp", "serve"]},
         ],
         ids=[
             "null-entry",
             "scalar-entry",
             "non-string-command",
+            "empty-command",
+            "null-args",
             "non-list-args",
             "unsupported-url-transport",
+            "empty-url",
+            "null-type",
+            "wrong-type-type",
             "missing-command-and-url",
         ],
     )
@@ -1327,11 +1383,19 @@ class TestClaudeSetup:
     @pytest.mark.parametrize(
         "entry",
         [
-            {"url": "https://example.test/mcp", "transport": "sse"},
-            {"url": "https://example.test/mcp", "transport": "http", "args": []},
+            {"url": "https://example.test/mcp", "type": "sse"},
+            {"url": "https://example.test/mcp", "type": "http"},
+            {"url": "https://example.test/mcp", "type": "streamable-http", "args": []},
+            {"command": "docker"},
             {"command": "docker", "args": ["run", "--rm", "ouroboros-mcp"]},
         ],
-        ids=["sse-url", "http-url-with-args", "custom-command"],
+        ids=[
+            "sse-url",
+            "http-url",
+            "streamable-http-url-with-args",
+            "custom-command-no-args",
+            "custom-command",
+        ],
     )
     def test_supported_existing_mcp_entry_is_preserved(
         self,
@@ -1451,6 +1515,59 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "Could not inspect" in warning.call_args.args[0]
 
+    def test_setup_claude_snapshot_directory_fails_closed(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_config = tmp_path / ".claude" / "mcp.json"
+        claude_config.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        assert claude_config.is_dir()
+        detect.assert_not_called()
+        assert "Could not snapshot" in warning.call_args.args[0]
+
+    def test_setup_claude_snapshot_oserror_fails_closed(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("pathlib.Path.read_bytes", side_effect=OSError("permission denied")),
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        detect.assert_not_called()
+        assert "Could not snapshot" in warning.call_args.args[0]
+
     def test_symlinked_mcp_json_warns_without_replacing_link(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
@@ -1564,6 +1681,138 @@ class TestClaudeSetup:
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
         assert claude_config.read_text(encoding="utf-8") == original_mcp
         success.assert_not_called()
+
+    def test_setup_claude_leaves_recovery_when_config_and_rollback_write_fail(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_mcp = json.dumps({"mcpServers": {"existing": {"command": "custom"}}})
+        claude_config.write_text(original_mcp, encoding="utf-8")
+
+        real_atomic_write = setup_cmd._atomic_write_text
+        mcp_write_seen = False
+
+        def fail_config_and_rollback(path: Path, content: str, *, mode: int = 0o600) -> None:
+            nonlocal mcp_write_seen
+            if path == config_path:
+                raise OSError("config activation failed")
+            if path == claude_config and not mcp_write_seen:
+                mcp_write_seen = True
+                real_atomic_write(path, content, mode=mode)
+                return
+            if path == claude_config:
+                raise OSError("rollback failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text",
+                side_effect=fail_config_and_rollback,
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        assert json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
+        assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning"),
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert claude_config.read_text(encoding="utf-8") == original_mcp
+        assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+
+    def test_setup_claude_recovery_removes_created_mcp_after_unlink_rollback_failure(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("orchestrator:\n  runtime_backend: codex\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+
+        real_atomic_write = setup_cmd._atomic_write_text
+
+        def fail_config(path: Path, content: str, *, mode: int = 0o600) -> None:
+            if path == config_path:
+                raise OSError("config activation failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("ouroboros.cli.commands.setup._atomic_write_text", side_effect=fail_config),
+            patch("pathlib.Path.unlink", side_effect=OSError("unlink denied")),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert (claude_dir / "mcp.json").exists()
+        assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not (claude_dir / "mcp.json").exists()
+        assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+
+    def test_setup_claude_success_with_recovery_unlink_failure_is_not_rolled_back_later(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("pathlib.Path.unlink", side_effect=OSError("unlink denied")),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is True
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        assert recovery_path.exists()
+        assert json.loads(recovery_path.read_text(encoding="utf-8"))["state"] == "committed"
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert (claude_dir / "mcp.json").exists()
+        assert not recovery_path.exists()
 
     def test_atomic_write_closes_descriptor_when_mode_application_fails(
         self, tmp_path: Path

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -1153,6 +1155,72 @@ class TestCodexSetup:
 class TestClaudeSetup:
     """Tests for Claude-specific setup behavior."""
 
+    def _make_valid_claude_recovery_manifest(
+        self,
+        tmp_path: Path,
+        *,
+        phase: str,
+    ) -> tuple[Path, Path, Path, Path, dict[str, object]]:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            "orchestrator:\n  runtime_backend: claude\n  cli_path: /usr/local/bin/claude\n"
+            "llm:\n  backend: claude\n",
+            encoding="utf-8",
+        )
+        credentials_path = config_dir / "credentials.yaml"
+        credentials_path.write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        mcp_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "ouroboros": {
+                            "command": "docker",
+                            "args": ["run", "ouroboros-mcp"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        mcp_snapshot = setup_cmd._read_claude_setup_file_snapshot(mcp_path)
+        config_snapshot = setup_cmd._read_claude_setup_file_snapshot(config_path)
+        credentials_snapshot = setup_cmd._read_claude_setup_file_snapshot(credentials_path)
+        assert mcp_snapshot is not None
+        assert config_snapshot is not None
+        assert credentials_snapshot is not None
+        manifest = setup_cmd._build_claude_setup_manifest(
+            mcp=setup_cmd._ClaudeSetupStagedFile(mcp_path, mcp_snapshot, None, mcp_snapshot.mode),
+            config=setup_cmd._ClaudeSetupStagedFile(
+                config_path, config_snapshot, config_snapshot.content, config_snapshot.mode
+            ),
+            credentials=setup_cmd._ClaudeSetupStagedFile(
+                credentials_path, credentials_snapshot, None, credentials_snapshot.mode
+            ),
+            claude_path="/usr/local/bin/claude",
+        )
+        manifest["phase"] = phase
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        if phase in {
+            "mcp_written",
+            "config_written",
+            "credentials_written",
+            "committed",
+            "cleanup_pending",
+        }:
+            targets["mcp"]["post"] = setup_cmd._snapshot_to_manifest(mcp_snapshot)
+        if phase in {"config_written", "credentials_written", "committed", "cleanup_pending"}:
+            targets["config"]["post"] = setup_cmd._snapshot_to_manifest(config_snapshot)
+        if phase in {"credentials_written", "committed", "cleanup_pending"}:
+            targets["credentials"]["post"] = setup_cmd._snapshot_to_manifest(credentials_snapshot)
+        return claude_dir, mcp_path, config_path, credentials_path, manifest
+
     def test_malformed_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
@@ -2243,6 +2311,177 @@ class TestClaudeSetup:
         assert recovered is False
         assert recovery_path.exists()
         assert "unsupported version" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_rejects_forged_credentials_target_path(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="config_written")
+        )
+        victim_path = tmp_path / "victim.yaml"
+        victim_path.write_text("operator: keep\n", encoding="utf-8")
+        staged_credentials = b"providers: {}\n"
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        credentials_target = targets["credentials"]
+        assert isinstance(credentials_target, dict)
+        credentials_target["path"] = str(victim_path)
+        credentials_target["operation"] = "write"
+        credentials_target["content_b64"] = base64.b64encode(staged_credentials).decode("ascii")
+        credentials_target["sha256"] = hashlib.sha256(staged_credentials).hexdigest()
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert victim_path.read_text(encoding="utf-8") == "operator: keep\n"
+        assert credentials_path.read_text(encoding="utf-8") == "providers: {}\n"
+        assert "incomplete" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_rejects_malformed_staged_credentials_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="config_written")
+        )
+        invalid_credentials = b"providers:\n  openai: {}\n"
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        credentials_target = targets["credentials"]
+        assert isinstance(credentials_target, dict)
+        credentials_target["operation"] = "write"
+        credentials_target["content_b64"] = base64.b64encode(invalid_credentials).decode("ascii")
+        credentials_target["sha256"] = hashlib.sha256(invalid_credentials).hexdigest()
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert credentials_path.read_text(encoding="utf-8") == "providers: {}\n"
+        assert "incomplete" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_rejects_completed_phase_without_post_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="credentials_written")
+        )
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        credentials_target = targets["credentials"]
+        assert isinstance(credentials_target, dict)
+        credentials_target.pop("post")
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert "phase is inconsistent" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_rejects_write_phase_with_stale_post_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, mcp_path, _config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="mcp_written")
+        )
+        original_snapshot = setup_cmd._read_claude_setup_file_snapshot(mcp_path)
+        assert original_snapshot is not None
+        staged_mcp = json.dumps(
+            {"mcpServers": {"ouroboros": {"command": "uvx", "args": ["ouroboros"]}}},
+            indent=2,
+        ).encode("utf-8")
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        mcp_target = targets["mcp"]
+        assert isinstance(mcp_target, dict)
+        mcp_target["operation"] = "write"
+        mcp_target["content_b64"] = base64.b64encode(staged_mcp).decode("ascii")
+        mcp_target["sha256"] = hashlib.sha256(staged_mcp).hexdigest()
+        mcp_target["post"] = setup_cmd._snapshot_to_manifest(original_snapshot)
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert "phase is inconsistent" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_accepts_live_rebased_config_post_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="config_written")
+        )
+        config_path.write_text(
+            "custom:\n  concurrent: keep\n"
+            "orchestrator:\n  runtime_backend: claude\n  cli_path: /usr/local/bin/claude\n"
+            "llm:\n  backend: claude\n",
+            encoding="utf-8",
+        )
+        config_snapshot = setup_cmd._read_claude_setup_file_snapshot(config_path)
+        assert config_snapshot is not None
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        targets["config"]["post"] = setup_cmd._snapshot_to_manifest(config_snapshot)
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["custom"]["concurrent"] == "keep"
+
+    def test_setup_claude_recovery_derives_legacy_v2_operations_for_cleanup_pending(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, _credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="cleanup_pending")
+        )
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        for raw_target in targets.values():
+            assert isinstance(raw_target, dict)
+            raw_target.pop("operation")
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
 
     @pytest.mark.parametrize(
         (

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1557,7 +1557,7 @@ class TestClaudeSetup:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
-            patch("pathlib.Path.read_bytes", side_effect=OSError("permission denied")),
+            patch("os.fdopen", side_effect=OSError("permission denied")),
             patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
             patch("ouroboros.cli.commands.setup.print_warning") as warning,
         ):
@@ -1567,6 +1567,23 @@ class TestClaudeSetup:
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
         detect.assert_not_called()
         assert "Could not snapshot" in warning.call_args.args[0]
+
+    def test_setup_claude_snapshot_opens_no_follow_and_nonblocking(self, tmp_path: Path) -> None:
+        claude_config = tmp_path / ".claude" / "mcp.json"
+        claude_config.parent.mkdir()
+        claude_config.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+
+        real_open = os.open
+
+        with patch("os.open", wraps=real_open) as open_mock:
+            snapshot = setup_cmd._read_claude_mcp_snapshot(claude_config)
+
+        assert snapshot is not None
+        flags = open_mock.call_args.args[1]
+        if hasattr(os, "O_NOFOLLOW"):
+            assert flags & os.O_NOFOLLOW
+        if hasattr(os, "O_NONBLOCK"):
+            assert flags & os.O_NONBLOCK
 
     def test_symlinked_mcp_json_warns_without_replacing_link(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
@@ -1643,7 +1660,9 @@ class TestClaudeSetup:
         assert claude_config.read_text(encoding="utf-8") == original_content
         assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
 
-    def test_setup_claude_rolls_back_mcp_when_config_commit_fails(self, tmp_path: Path) -> None:
+    def test_setup_claude_rolls_forward_config_after_config_commit_failure(
+        self, tmp_path: Path
+    ) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
         config_path = config_dir / "config.yaml"
@@ -1679,10 +1698,78 @@ class TestClaudeSetup:
 
         assert configured is False
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
-        assert claude_config.read_text(encoding="utf-8") == original_mcp
+        assert json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
+        assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
         success.assert_not_called()
 
-    def test_setup_claude_leaves_recovery_when_config_and_rollback_write_fail(
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
+
+    def test_setup_claude_config_failure_preserves_concurrent_mcp_replacement(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_mcp = json.dumps({"mcpServers": {"old": {"command": "old-cli"}}})
+        claude_config.write_text(original_mcp, encoding="utf-8")
+        newer_external_mcp = json.dumps({"mcpServers": {"external": {"command": "external-cli"}}})
+
+        real_atomic_write = setup_cmd._atomic_write_text
+
+        def fail_config_after_external_replacement(
+            path: Path, content: str, *, mode: int = 0o600
+        ) -> None:
+            if path == config_path:
+                claude_config.write_text(newer_external_mcp, encoding="utf-8")
+                raise OSError("config activation failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text",
+                side_effect=fail_config_after_external_replacement,
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        assert claude_config.read_text(encoding="utf-8") == newer_external_mcp
+        assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert claude_config.read_text(encoding="utf-8") == newer_external_mcp
+        assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
+        assert "does not match" in warning.call_args.args[0]
+
+    def test_setup_claude_leaves_recovery_when_config_recovery_write_fails(
         self, tmp_path: Path
     ) -> None:
         config_dir = tmp_path / ".ouroboros"
@@ -1700,18 +1787,10 @@ class TestClaudeSetup:
         claude_config.write_text(original_mcp, encoding="utf-8")
 
         real_atomic_write = setup_cmd._atomic_write_text
-        mcp_write_seen = False
 
-        def fail_config_and_rollback(path: Path, content: str, *, mode: int = 0o600) -> None:
-            nonlocal mcp_write_seen
+        def fail_config_and_recovery(path: Path, content: str, *, mode: int = 0o600) -> None:
             if path == config_path:
                 raise OSError("config activation failed")
-            if path == claude_config and not mcp_write_seen:
-                mcp_write_seen = True
-                real_atomic_write(path, content, mode=mode)
-                return
-            if path == claude_config:
-                raise OSError("rollback failed")
             real_atomic_write(path, content, mode=mode)
 
         with (
@@ -1723,7 +1802,7 @@ class TestClaudeSetup:
             ),
             patch(
                 "ouroboros.cli.commands.setup._atomic_write_text",
-                side_effect=fail_config_and_rollback,
+                side_effect=fail_config_and_recovery,
             ),
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
@@ -1740,10 +1819,12 @@ class TestClaudeSetup:
             recovered = setup_cmd._recover_claude_mcp_activation()
 
         assert recovered is True
-        assert claude_config.read_text(encoding="utf-8") == original_mcp
         assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
 
-    def test_setup_claude_recovery_removes_created_mcp_after_unlink_rollback_failure(
+    def test_setup_claude_recovery_finishes_config_after_created_mcp_commit_failure(
         self, tmp_path: Path
     ) -> None:
         config_dir = tmp_path / ".ouroboros"
@@ -1779,8 +1860,11 @@ class TestClaudeSetup:
             recovered = setup_cmd._recover_claude_mcp_activation()
 
         assert recovered is True
-        assert not (claude_dir / "mcp.json").exists()
+        assert (claude_dir / "mcp.json").exists()
         assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
 
     def test_setup_claude_success_with_recovery_unlink_failure_is_not_rolled_back_later(
         self, tmp_path: Path
@@ -1813,6 +1897,99 @@ class TestClaudeSetup:
         assert recovered is True
         assert (claude_dir / "mcp.json").exists()
         assert not recovery_path.exists()
+
+    def test_setup_claude_pending_journal_after_config_commit_does_not_rollback_mcp(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+
+        real_atomic_write = setup_cmd._atomic_write_text
+        real_unlink = Path.unlink
+
+        def fail_commit_marker(path: Path, content: str, *, mode: int = 0o600) -> None:
+            if path == recovery_path and '"state": "committed"' in content:
+                raise OSError("marker write failed")
+            real_atomic_write(path, content, mode=mode)
+
+        def fail_recovery_unlink(path: Path, *args: object, **kwargs: object) -> None:
+            if path == recovery_path:
+                raise OSError("unlink denied")
+            real_unlink(path, *args, **kwargs)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text", side_effect=fail_commit_marker
+            ),
+            patch("pathlib.Path.unlink", fail_recovery_unlink),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is True
+        assert recovery_path.exists()
+        assert json.loads(recovery_path.read_text(encoding="utf-8"))["state"] == "pending"
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
+        assert (claude_dir / "mcp.json").exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
+
+    def test_setup_claude_post_state_record_failure_remains_roll_forward_recoverable(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {"orchestrator": {"runtime_backend": "codex"}}
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+
+        real_atomic_write = setup_cmd._atomic_write_text
+        recovery_writes = 0
+
+        def fail_post_state_record(path: Path, content: str, *, mode: int = 0o600) -> None:
+            nonlocal recovery_writes
+            if path == recovery_path:
+                recovery_writes += 1
+                if recovery_writes == 3:
+                    raise OSError("post-state write failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text",
+                side_effect=fail_post_state_record,
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert not recovery_path.exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
 
     def test_atomic_write_closes_descriptor_when_mode_application_fails(
         self, tmp_path: Path

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1361,6 +1361,32 @@ class TestClaudeSetup:
             == "providers:\n  custom:\n    api_key: keep\n"
         )
 
+    def test_setup_claude_invalid_utf8_credentials_fail_closed(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+        credentials_path = config_dir / "credentials.yaml"
+        original_credentials = b"\xff\xfe\x00secret"
+        credentials_path.write_bytes(original_credentials)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        mcp_path.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert credentials_path.read_bytes() == original_credentials
+        assert json.loads(mcp_path.read_text(encoding="utf-8")) == {"mcpServers": {}}
+        assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
+        assert "Could not validate" in warning.call_args.args[0]
+
     def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -1499,11 +1525,22 @@ class TestClaudeSetup:
         "entry",
         [
             {"url": "https://example.test/mcp", "type": "sse"},
-            {"url": "https://example.test/mcp", "type": "http"},
+            {
+                "url": "https://example.test/mcp",
+                "type": "http",
+                "timeout": 45,
+                "metadata": {"owner": "operator"},
+            },
             {
                 "url": "https://example.test/mcp",
                 "type": "streamable-http",
                 "headers": {"Authorization": "Bearer test"},
+            },
+            {
+                "url": "wss://example.test/mcp",
+                "type": "websocket",
+                "timeout": 90,
+                "metadata": {"owner": "operator"},
             },
             {"command": "docker", "env": {"CUSTOM": "1"}},
             {"command": "docker"},
@@ -1513,6 +1550,7 @@ class TestClaudeSetup:
             "sse-url",
             "http-url",
             "streamable-http-url-with-headers",
+            "websocket-url-with-custom-fields",
             "custom-command-env",
             "custom-command-no-args",
             "custom-command",
@@ -1543,6 +1581,37 @@ class TestClaudeSetup:
         assert (
             json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
             == entry
+        )
+
+    def test_operator_uvx_entry_with_custom_args_and_timeout_is_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        operator_entry = {
+            "command": "uvx",
+            "args": ["--from", "ouroboros-ai-wrapper", "custom-mcp"],
+            "timeout": 120,
+            "env": {"CUSTOM": "keep"},
+        }
+        claude_config.write_text(
+            json.dumps({"mcpServers": {"ouroboros": operator_entry}}), encoding="utf-8"
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        assert registered is True
+        assert (
+            json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
+            == operator_entry
         )
 
     def test_non_utf8_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
@@ -2675,7 +2744,7 @@ class TestClaudeSetup:
         assert config["orchestrator"]["runtime_backend"] == "claude"
         assert config["llm"]["backend"] == "claude"
 
-    def test_setup_claude_post_state_record_failure_remains_roll_forward_recoverable(
+    def test_setup_claude_post_state_record_failure_returns_success_after_recovery(
         self, tmp_path: Path
     ) -> None:
         config_dir = tmp_path / ".ouroboros"
@@ -2708,14 +2777,16 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._atomic_write_text",
                 side_effect=fail_post_state_record,
             ),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
-        assert configured is False
+        assert configured is True
         assert not recovery_path.exists()
         config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         assert config["orchestrator"]["runtime_backend"] == "claude"
         assert config["llm"]["backend"] == "claude"
+        assert success.call_args_list[0].args[0].startswith("Configured Claude Code runtime")
 
     def test_atomic_write_closes_descriptor_when_mode_application_fails(
         self, tmp_path: Path
@@ -2801,6 +2872,67 @@ class TestClaudeSetup:
         assert promoted.content == b"after"
         assert target.read_text(encoding="utf-8") == "after"
         assert operator_sidecar.read_text(encoding="utf-8") == "operator-owned"
+
+    def test_cas_post_publish_fsync_failure_preserves_original_backup(self, tmp_path: Path) -> None:
+        target = tmp_path / "config.yaml"
+        target.write_bytes(b"operator-before")
+        snapshot = setup_cmd._read_claude_setup_file_snapshot(target)
+        assert snapshot is not None
+
+        with (
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=setup_cmd._ParentDirectoryFsyncError("directory fsync failed"),
+            ),
+            pytest.raises(setup_cmd._ParentDirectoryFsyncError) as raised,
+        ):
+            setup_cmd._promote_text_cas(
+                target,
+                b"setup-after",
+                expected=snapshot,
+                mode=0o600,
+            )
+
+        backups = list(tmp_path.glob(f".{target.name}.ouroboros-pre.*.tmp"))
+        assert target.read_bytes() == b"setup-after"
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == b"operator-before"
+        assert raised.value.backup_path == backups[0]
+        assert raised.value.promoted_snapshot is not None
+        assert raised.value.promoted_snapshot.content == b"setup-after"
+
+    def test_cas_publish_and_restore_failure_preserves_original_backup(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "credentials.yaml"
+        target.write_bytes(b"operator-before")
+        snapshot = setup_cmd._read_claude_setup_file_snapshot(target)
+        assert snapshot is not None
+        real_rename = os.rename
+
+        def fail_restore(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            source = Path(src)
+            destination = Path(dst)
+            if destination == target and ".ouroboros-pre." in source.name:
+                raise OSError("restore failed")
+            real_rename(src, dst)
+
+        with (
+            patch("os.link", side_effect=OSError("publish failed")),
+            patch("os.rename", side_effect=fail_restore),
+            pytest.raises(OSError, match="preserved at"),
+        ):
+            setup_cmd._promote_text_cas(
+                target,
+                b"setup-after",
+                expected=snapshot,
+                mode=0o600,
+            )
+
+        backups = list(tmp_path.glob(f".{target.name}.ouroboros-pre.*.tmp"))
+        assert not target.exists()
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == b"operator-before"
 
     def test_setup_claude_parent_fsync_failure_leaves_recovery_pending(
         self, tmp_path: Path
@@ -3013,6 +3145,39 @@ class TestClaudeSetup:
         # Custom command (docker) should be left untouched
         assert claude_mcp["mcpServers"]["ouroboros"]["command"] == "docker"
         assert claude_mcp["mcpServers"]["ouroboros"]["args"] == custom_args
+
+    def test_setup_claude_preserves_websocket_entry_and_custom_fields(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+        credentials_path = config_dir / "credentials.yaml"
+        credentials_path.write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        websocket_entry = {
+            "type": "websocket",
+            "url": "wss://example.test/mcp",
+            "timeout": 90,
+            "headers": {"Authorization": "Bearer operator"},
+            "metadata": {"owner": "operator"},
+        }
+        claude_config.write_text(
+            json.dumps({"mcpServers": {"ouroboros": websocket_entry}}), encoding="utf-8"
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is True
+        assert (
+            json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
+            == websocket_entry
+        )
 
     def test_setup_claude_updates_stale_standard_entry(self, tmp_path: Path) -> None:
         """Stale standard entry (e.g. python3) should be updated to detected method."""

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1248,23 +1248,15 @@ class TestClaudeSetup:
         claude_dir = tmp_path / ".claude"
         mcp_path = claude_dir / "mcp.json"
         recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
-        real_atomic_write = setup_cmd._atomic_write_text
-
-        def fail_credentials_write(path: Path, content: str, *, mode: int = 0o600) -> None:
-            if path == credentials_path:
-                raise OSError("credentials write failed")
-            real_atomic_write(path, content, mode=mode)
-
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch(
-                "ouroboros.cli.commands.setup._atomic_write_text",
-                side_effect=fail_credentials_write,
+                "ouroboros.cli.commands.setup._stage_claude_credentials",
+                return_value=None,
             ),
             patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
-            patch("ouroboros.cli.commands.setup.print_warning") as warning,
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
             from ouroboros.config.loader import config_exists
@@ -1278,13 +1270,12 @@ class TestClaudeSetup:
         assert not mcp_path.exists()
         assert not recovery_path.exists()
         detect.assert_not_called()
-        assert "credentials.yaml" in warning.call_args.args[0]
 
     def test_setup_claude_preserves_existing_credentials(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
         credentials_path = config_dir / "credentials.yaml"
-        credentials_path.write_text("providers:\n  custom: keep\n", encoding="utf-8")
+        credentials_path.write_text("providers:\n  custom:\n    api_key: keep\n", encoding="utf-8")
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1297,7 +1288,10 @@ class TestClaudeSetup:
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
         assert configured is True
-        assert credentials_path.read_text(encoding="utf-8") == "providers:\n  custom: keep\n"
+        assert (
+            credentials_path.read_text(encoding="utf-8")
+            == "providers:\n  custom:\n    api_key: keep\n"
+        )
 
     def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
@@ -1375,10 +1369,16 @@ class TestClaudeSetup:
             {"command": ""},
             {"command": "uvx", "args": None},
             {"command": "uvx", "args": "--from ouroboros-ai"},
+            {"command": "uvx", "args": [], "env": {"OK": 1}},
+            {"command": "uvx", "args": [], "headers": {"X-Test": "value"}},
+            {"command": "uvx", "args": [], "url": "https://example.test/mcp"},
             {"url": "https://example.test/mcp", "type": "ftp"},
             {"url": "", "type": "http"},
             {"url": "https://example.test/mcp", "type": None},
             {"url": "https://example.test/mcp", "type": 123},
+            {"url": "https://example.test/mcp", "type": "streamable-http", "args": []},
+            {"url": "https://example.test/mcp", "type": "streamable-http", "env": {}},
+            {"url": "https://example.test/mcp", "type": "streamable-http", "headers": {"X": 1}},
             {"args": ["mcp", "serve"]},
         ],
         ids=[
@@ -1388,10 +1388,16 @@ class TestClaudeSetup:
             "empty-command",
             "null-args",
             "non-list-args",
+            "bad-env",
+            "stdio-headers",
+            "stdio-url",
             "unsupported-url-transport",
             "empty-url",
             "null-type",
             "wrong-type-type",
+            "url-with-stdio-args",
+            "url-with-stdio-env",
+            "url-bad-headers",
             "missing-command-and-url",
         ],
     )
@@ -1426,14 +1432,20 @@ class TestClaudeSetup:
         [
             {"url": "https://example.test/mcp", "type": "sse"},
             {"url": "https://example.test/mcp", "type": "http"},
-            {"url": "https://example.test/mcp", "type": "streamable-http", "args": []},
+            {
+                "url": "https://example.test/mcp",
+                "type": "streamable-http",
+                "headers": {"Authorization": "Bearer test"},
+            },
+            {"command": "docker", "env": {"CUSTOM": "1"}},
             {"command": "docker"},
             {"command": "docker", "args": ["run", "--rm", "ouroboros-mcp"]},
         ],
         ids=[
             "sse-url",
             "http-url",
-            "streamable-http-url-with-args",
+            "streamable-http-url-with-headers",
+            "custom-command-env",
             "custom-command-no-args",
             "custom-command",
         ],
@@ -1610,6 +1622,33 @@ class TestClaudeSetup:
         detect.assert_not_called()
         assert "Could not snapshot" in warning.call_args.args[0]
 
+    def test_setup_claude_credentials_directory_fails_closed(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {"orchestrator": {"runtime_backend": "codex"}}
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        credentials_path = config_dir / "credentials.yaml"
+        credentials_path.mkdir()
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        mcp_path.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        assert json.loads(mcp_path.read_text(encoding="utf-8")) == {"mcpServers": {}}
+        detect.assert_not_called()
+        assert "credentials.yaml" in warning.call_args.args[0]
+
     def test_setup_claude_snapshot_opens_no_follow_and_nonblocking(self, tmp_path: Path) -> None:
         claude_config = tmp_path / ".claude" / "mcp.json"
         claude_config.parent.mkdir()
@@ -1626,6 +1665,23 @@ class TestClaudeSetup:
             assert flags & os.O_NOFOLLOW
         if hasattr(os, "O_NONBLOCK"):
             assert flags & os.O_NONBLOCK
+
+    def test_setup_claude_deep_json_recursion_fails_closed(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = "[" * 2000 + "]" * 2000
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        assert registered is False
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        assert "Could not parse" in warning.call_args.args[0]
 
     def test_symlinked_mcp_json_warns_without_replacing_link(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
@@ -1665,8 +1721,9 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
                 return_value={"command": "uvx", "args": []},
             ),
-            patch("os.fsync", wraps=os.fsync) as fsync,
-            patch("os.replace", side_effect=OSError("disk full")),
+            patch(
+                "ouroboros.cli.commands.setup._promote_text_cas", side_effect=OSError("disk full")
+            ),
             patch("ouroboros.cli.commands.setup.print_success") as success,
             patch("ouroboros.cli.commands.setup.print_warning") as warning,
         ):
@@ -1674,7 +1731,6 @@ class TestClaudeSetup:
 
         assert claude_config.read_text(encoding="utf-8") == original_content
         assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
-        fsync.assert_called_once()
         success.assert_not_called()
         warning.assert_called_once()
         assert "Could not write" in warning.call_args.args[0]
@@ -1719,12 +1775,18 @@ class TestClaudeSetup:
         original_mcp = json.dumps({"mcpServers": {"existing": {"command": "custom"}}})
         claude_config.write_text(original_mcp, encoding="utf-8")
 
-        real_atomic_write = setup_cmd._atomic_write_text
+        real_promote = setup_cmd._promote_text_cas
 
-        def fail_config_write(path: Path, content: str, *, mode: int = 0o600) -> None:
+        def fail_config_write(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
             if path == config_path:
                 raise OSError("config activation failed")
-            real_atomic_write(path, content, mode=mode)
+            return real_promote(path, content, expected=expected, mode=mode)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1733,7 +1795,7 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
-            patch("ouroboros.cli.commands.setup._atomic_write_text", side_effect=fail_config_write),
+            patch("ouroboros.cli.commands.setup._promote_text_cas", side_effect=fail_config_write),
             patch("ouroboros.cli.commands.setup.print_success") as success,
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
@@ -1771,15 +1833,19 @@ class TestClaudeSetup:
         claude_config.write_text(original_mcp, encoding="utf-8")
         newer_external_mcp = json.dumps({"mcpServers": {"external": {"command": "external-cli"}}})
 
-        real_atomic_write = setup_cmd._atomic_write_text
+        real_promote = setup_cmd._promote_text_cas
 
         def fail_config_after_external_replacement(
-            path: Path, content: str, *, mode: int = 0o600
-        ) -> None:
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
             if path == config_path:
                 claude_config.write_text(newer_external_mcp, encoding="utf-8")
                 raise OSError("config activation failed")
-            real_atomic_write(path, content, mode=mode)
+            return real_promote(path, content, expected=expected, mode=mode)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1789,7 +1855,7 @@ class TestClaudeSetup:
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
             patch(
-                "ouroboros.cli.commands.setup._atomic_write_text",
+                "ouroboros.cli.commands.setup._promote_text_cas",
                 side_effect=fail_config_after_external_replacement,
             ),
         ):
@@ -1811,6 +1877,86 @@ class TestClaudeSetup:
         assert (claude_dir / "mcp.json.ouroboros-recovery").exists()
         assert "does not match" in warning.call_args.args[0]
 
+    def test_setup_claude_mcp_cas_preserves_concurrent_replacement(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_mcp = json.dumps({"mcpServers": {"old": {"command": "old-cli"}}})
+        claude_config.write_text(original_mcp, encoding="utf-8")
+        external_mcp = json.dumps({"mcpServers": {"external": {"command": "external-cli"}}})
+
+        real_rename = os.rename
+
+        def replace_before_mcp_claim(src: Path | str, dst: Path | str) -> None:
+            if Path(src) == claude_config:
+                claude_config.write_text(external_mcp, encoding="utf-8")
+            real_rename(src, dst)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("os.rename", side_effect=replace_before_mcp_claim),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert claude_config.read_text(encoding="utf-8") == external_mcp
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {}
+
+    def test_setup_claude_recovery_preserves_external_config_edit(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("orchestrator:\n  runtime_backend: codex\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+
+        real_promote = setup_cmd._promote_text_cas
+
+        def fail_config_once(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
+            if path == config_path:
+                raise OSError("config activation failed")
+            return real_promote(path, content, expected=expected, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("ouroboros.cli.commands.setup._promote_text_cas", side_effect=fail_config_once),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        config_path.write_text("orchestrator:\n  runtime_backend: gemini\n", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert "gemini" in config_path.read_text(encoding="utf-8")
+        assert recovery_path.exists()
+        assert "changed during setup" in warning.call_args.args[0]
+
     def test_setup_claude_leaves_recovery_when_config_recovery_write_fails(
         self, tmp_path: Path
     ) -> None:
@@ -1828,12 +1974,18 @@ class TestClaudeSetup:
         original_mcp = json.dumps({"mcpServers": {"existing": {"command": "custom"}}})
         claude_config.write_text(original_mcp, encoding="utf-8")
 
-        real_atomic_write = setup_cmd._atomic_write_text
+        real_promote = setup_cmd._promote_text_cas
 
-        def fail_config_and_recovery(path: Path, content: str, *, mode: int = 0o600) -> None:
+        def fail_config_and_recovery(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
             if path == config_path:
                 raise OSError("config activation failed")
-            real_atomic_write(path, content, mode=mode)
+            return real_promote(path, content, expected=expected, mode=mode)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1843,7 +1995,7 @@ class TestClaudeSetup:
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
             patch(
-                "ouroboros.cli.commands.setup._atomic_write_text",
+                "ouroboros.cli.commands.setup._promote_text_cas",
                 side_effect=fail_config_and_recovery,
             ),
         ):
@@ -1875,12 +2027,25 @@ class TestClaudeSetup:
         config_path.write_text("orchestrator:\n  runtime_backend: codex\n", encoding="utf-8")
         claude_dir = tmp_path / ".claude"
 
-        real_atomic_write = setup_cmd._atomic_write_text
+        real_promote = setup_cmd._promote_text_cas
 
-        def fail_config(path: Path, content: str, *, mode: int = 0o600) -> None:
+        def fail_config(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
             if path == config_path:
                 raise OSError("config activation failed")
-            real_atomic_write(path, content, mode=mode)
+            return real_promote(path, content, expected=expected, mode=mode)
+
+        real_unlink = Path.unlink
+
+        def fail_recovery_unlink(path: Path, *args: object, **kwargs: object) -> None:
+            if path == claude_dir / "mcp.json.ouroboros-recovery":
+                raise OSError("unlink denied")
+            real_unlink(path, *args, **kwargs)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1889,8 +2054,8 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
-            patch("ouroboros.cli.commands.setup._atomic_write_text", side_effect=fail_config),
-            patch("pathlib.Path.unlink", side_effect=OSError("unlink denied")),
+            patch("ouroboros.cli.commands.setup._promote_text_cas", side_effect=fail_config),
+            patch("pathlib.Path.unlink", fail_recovery_unlink),
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
@@ -1916,6 +2081,13 @@ class TestClaudeSetup:
         config_path = config_dir / "config.yaml"
         config_path.write_text("{}", encoding="utf-8")
         claude_dir = tmp_path / ".claude"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_unlink = Path.unlink
+
+        def fail_recovery_unlink(path: Path, *args: object, **kwargs: object) -> None:
+            if path == recovery_path:
+                raise OSError("unlink denied")
+            real_unlink(path, *args, **kwargs)
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
@@ -1924,14 +2096,13 @@ class TestClaudeSetup:
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
                 return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
-            patch("pathlib.Path.unlink", side_effect=OSError("unlink denied")),
+            patch("pathlib.Path.unlink", fail_recovery_unlink),
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
         assert configured is True
-        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
         assert recovery_path.exists()
-        assert json.loads(recovery_path.read_text(encoding="utf-8"))["state"] == "committed"
+        assert json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "cleanup_pending"
 
         with patch("pathlib.Path.home", return_value=tmp_path):
             recovered = setup_cmd._recover_claude_mcp_activation()
@@ -1939,6 +2110,24 @@ class TestClaudeSetup:
         assert recovered is True
         assert (claude_dir / "mcp.json").exists()
         assert not recovery_path.exists()
+
+    def test_setup_claude_unsupported_recovery_journal_version_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text('{"version": 999, "phase": "prepared"}\n', encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert "unsupported version" in warning.call_args.args[0]
 
     def test_setup_claude_pending_journal_after_config_commit_does_not_rollback_mcp(
         self, tmp_path: Path
@@ -1954,7 +2143,7 @@ class TestClaudeSetup:
         real_unlink = Path.unlink
 
         def fail_commit_marker(path: Path, content: str, *, mode: int = 0o600) -> None:
-            if path == recovery_path and '"state": "committed"' in content:
+            if path == recovery_path and '"phase": "committed"' in content:
                 raise OSError("marker write failed")
             real_atomic_write(path, content, mode=mode)
 
@@ -1979,7 +2168,9 @@ class TestClaudeSetup:
 
         assert configured is True
         assert recovery_path.exists()
-        assert json.loads(recovery_path.read_text(encoding="utf-8"))["state"] == "pending"
+        assert (
+            json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "credentials_written"
+        )
 
         with patch("pathlib.Path.home", return_value=tmp_path):
             recovered = setup_cmd._recover_claude_mcp_activation()
@@ -2055,6 +2246,32 @@ class TestClaudeSetup:
         setup_cmd._atomic_write_text(target, "{}")
 
         assert target.stat().st_mode & 0o777 == 0o600
+
+    def test_atomic_write_fsyncs_parent_directory_after_promotion(self, tmp_path: Path) -> None:
+        target = tmp_path / "config.json"
+        opened_dirs: list[int] = []
+        real_open = os.open
+        real_close = os.close
+
+        def tracking_open(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            flags: int,
+            mode: int = 0o777,
+        ):
+            fd = real_open(path, flags, mode)
+            if Path(path) == tmp_path:
+                opened_dirs.append(fd)
+            return fd
+
+        with (
+            patch("os.open", side_effect=tracking_open),
+            patch("os.fsync", wraps=os.fsync) as fsync,
+            patch("os.close", wraps=real_close),
+        ):
+            setup_cmd._atomic_write_text(target, "{}")
+
+        assert opened_dirs
+        assert any(call.args[0] in opened_dirs for call in fsync.call_args_list)
 
     def test_mcp_update_preserves_existing_mode(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1387,6 +1387,22 @@ class TestClaudeSetup:
         assert not (claude_dir / "mcp.json.ouroboros-recovery").exists()
         assert "Could not validate" in warning.call_args.args[0]
 
+    def test_setup_claude_recursive_credentials_fail_closed(self, tmp_path: Path) -> None:
+        credentials_path = tmp_path / "credentials.yaml"
+        credentials_path.write_text("providers: {}\n", encoding="utf-8")
+
+        with (
+            patch(
+                "ouroboros.config.loader.load_credentials",
+                side_effect=RecursionError("maximum recursion depth exceeded"),
+            ),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            valid = setup_cmd._validate_existing_credentials_file(credentials_path)
+
+        assert valid is False
+        assert "Could not validate" in warning.call_args.args[0]
+
     def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -1909,6 +1925,61 @@ class TestClaudeSetup:
         assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
         assert not recovery_path.exists()
 
+    def test_mcp_rollback_failure_is_bound_to_recovery_journal(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = b'{"mcpServers": {}}\n'
+        claude_config.write_bytes(original_content)
+        snapshot = setup_cmd._read_claude_mcp_snapshot(claude_config)
+        assert snapshot is not None
+        backup_path = claude_dir / ".mcp.json.ouroboros-pre.rollback.tmp"
+        staged_content: bytes | None = None
+
+        def fail_promotion(
+            _path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+            retain_backup_on_failure: bool = True,
+        ) -> None:
+            nonlocal staged_content
+            os.rename(claude_config, backup_path)
+            backup_path.chmod(0o600)
+            staged_content = content
+            claude_config.write_bytes(content)
+            raise setup_cmd._ClaudeSetupPromotionError("rollback failed", backup_path=backup_path)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": []},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._promote_text_cas",
+                side_effect=fail_promotion,
+            ),
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        assert registered is False
+        assert recovery_path.exists()
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        assert manifest["scope"] == "mcp"
+        assert manifest["targets"]["mcp"]["backup"]["path"] == str(backup_path)
+        assert staged_content is not None
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert claude_config.read_bytes() == staged_content
+        assert not backup_path.exists()
+        assert not recovery_path.exists()
+
     def test_setup_claude_rolls_forward_config_after_config_commit_failure(
         self, tmp_path: Path
     ) -> None:
@@ -2170,6 +2241,7 @@ class TestClaudeSetup:
         assert configured is False
         assert claude_config.read_text(encoding="utf-8") == external_mcp
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {}
+        assert list(claude_dir.glob(".mcp.json.ouroboros-pre.*.tmp")) == []
 
     def test_setup_claude_recovery_rebases_external_unrelated_config_edit(
         self, tmp_path: Path

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -2459,6 +2459,72 @@ class TestClaudeSetup:
         assert credentials_path.read_text(encoding="utf-8") == "providers: {}\n"
         assert "incomplete" in warning.call_args.args[0]
 
+    @pytest.mark.parametrize("forged_mode", [0o666, 0o777, 0o1600])
+    def test_setup_claude_recovery_rejects_forged_credentials_replay_mode(
+        self, tmp_path: Path, forged_mode: int
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="config_written")
+        )
+        credentials_path.unlink()
+        missing_credentials = setup_cmd._read_claude_setup_file_snapshot(credentials_path)
+        assert missing_credentials is not None
+        staged_credentials = b"providers: {}\n"
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        credentials_target = targets["credentials"]
+        assert isinstance(credentials_target, dict)
+        credentials_target["pre"] = setup_cmd._snapshot_to_manifest(missing_credentials)
+        credentials_target["operation"] = "write"
+        credentials_target["mode"] = forged_mode
+        credentials_target["content_b64"] = base64.b64encode(staged_credentials).decode("ascii")
+        credentials_target["sha256"] = hashlib.sha256(staged_credentials).hexdigest()
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert not credentials_path.exists()
+        assert "incomplete" in warning.call_args.args[0]
+
+    def test_setup_claude_recovery_rejects_credentials_write_over_existing_preimage(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir, _mcp_path, _config_path, credentials_path, manifest = (
+            self._make_valid_claude_recovery_manifest(tmp_path, phase="config_written")
+        )
+        original_credentials = credentials_path.read_bytes()
+        staged_credentials = b"providers: {}\n"
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        credentials_target = targets["credentials"]
+        assert isinstance(credentials_target, dict)
+        credentials_target["operation"] = "write"
+        credentials_target["mode"] = 0o600
+        credentials_target["content_b64"] = base64.b64encode(staged_credentials).decode("ascii")
+        credentials_target["sha256"] = hashlib.sha256(staged_credentials).hexdigest()
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert credentials_path.read_bytes() == original_credentials
+        assert "incomplete" in warning.call_args.args[0]
+
     def test_setup_claude_recovery_rejects_completed_phase_without_post_snapshot(
         self, tmp_path: Path
     ) -> None:
@@ -3174,6 +3240,67 @@ class TestClaudeSetup:
         manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
         backup_path = Path(manifest["targets"]["mcp"]["backup"]["path"])
         assert backup_path.read_bytes() == original_mcp
+        success.assert_not_called()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
+        assert not backup_path.exists()
+        assert list(claude_dir.glob(".mcp.json.ouroboros-pre.*.tmp")) == []
+
+    def test_setup_claude_journals_backup_after_successful_promotion_unlink_failure(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        original_mcp = b'{"mcpServers": {}}\n'
+        mcp_path.write_bytes(original_mcp)
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_unlink = Path.unlink
+        backup_unlink_failed = False
+
+        def fail_mcp_backup_unlink(path: Path, *args: object, **kwargs: object) -> None:
+            nonlocal backup_unlink_failed
+            if (
+                not backup_unlink_failed
+                and path.parent == claude_dir
+                and path.name.startswith(".mcp.json.ouroboros-pre.")
+                and path.name.endswith(".tmp")
+            ):
+                backup_unlink_failed = True
+                raise OSError("backup unlink denied")
+            real_unlink(path, *args, **kwargs)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("pathlib.Path.unlink", fail_mcp_backup_unlink),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert backup_unlink_failed is True
+        assert recovery_path.exists()
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        backup_path = Path(manifest["targets"]["mcp"]["backup"]["path"])
+        assert backup_path.read_bytes() == original_mcp
+        assert (
+            manifest["targets"]["mcp"]["backup"]["pre_sha256"]
+            == hashlib.sha256(original_mcp).hexdigest()
+        )
         success.assert_not_called()
 
         with patch("pathlib.Path.home", return_value=tmp_path):

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1194,6 +1194,24 @@ class TestClaudeSetup:
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
         success.assert_not_called()
 
+    def test_setup_claude_mcp_failure_does_not_create_config_file(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text("{broken json", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert not (config_dir / "config.yaml").exists()
+        success.assert_not_called()
+
     def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -1233,16 +1251,12 @@ class TestClaudeSetup:
             "[]",
             '{"mcpServers": null}',
             '{"mcpServers": []}',
-            '{"mcpServers": {"ouroboros": null}}',
-            '{"mcpServers": {"ouroboros": "disabled"}}',
         ],
         ids=[
             "null-top-level",
             "array-top-level",
             "null-servers",
             "array-servers",
-            "null-ouroboros-entry",
-            "scalar-ouroboros-entry",
         ],
     )
     def test_invalid_mcp_json_shape_warns_without_overwriting(
@@ -1265,33 +1279,85 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "leaving it untouched" in warning.call_args.args[0]
 
-    @pytest.mark.parametrize("invalid_command", [[], {}], ids=["array", "object"])
-    def test_invalid_mcp_command_shape_warns_without_overwriting(
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            None,
+            "disabled",
+            {"command": []},
+            {"command": "uvx", "args": "--from ouroboros-ai"},
+            {"url": "https://example.test/mcp", "transport": "ftp"},
+            {"args": ["mcp", "serve"]},
+        ],
+        ids=[
+            "null-entry",
+            "scalar-entry",
+            "non-string-command",
+            "non-list-args",
+            "unsupported-url-transport",
+            "missing-command-and-url",
+        ],
+    )
+    def test_malformed_ouroboros_mcp_entry_is_replaced(
         self,
         tmp_path: Path,
-        invalid_command: object,
+        entry: object,
     ) -> None:
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         claude_config = claude_dir / "mcp.json"
-        original_content = json.dumps(
-            {"mcpServers": {"ouroboros": {"command": invalid_command, "timeout": 600}}}
-        )
-        claude_config.write_text(original_content, encoding="utf-8")
+        claude_config.write_text(json.dumps({"mcpServers": {"ouroboros": entry}}), encoding="utf-8")
 
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch(
                 "ouroboros.cli.commands.setup._detect_mcp_entry",
-                return_value={"command": "uvx", "args": []},
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
             ),
-            patch("ouroboros.cli.commands.setup.print_warning") as warning,
         ):
-            setup_cmd._ensure_claude_mcp_entry()
+            registered = setup_cmd._ensure_claude_mcp_entry()
 
-        assert claude_config.read_text(encoding="utf-8") == original_content
-        warning.assert_called_once()
-        assert "command" in warning.call_args.args[0]
+        assert registered is True
+        claude_mcp = json.loads(claude_config.read_text(encoding="utf-8"))
+        assert claude_mcp["mcpServers"]["ouroboros"] == {
+            "command": "uvx",
+            "args": ["--from", "ouroboros-ai[mcp,claude]"],
+        }
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            {"url": "https://example.test/mcp", "transport": "sse"},
+            {"url": "https://example.test/mcp", "transport": "http", "args": []},
+            {"command": "docker", "args": ["run", "--rm", "ouroboros-mcp"]},
+        ],
+        ids=["sse-url", "http-url-with-args", "custom-command"],
+    )
+    def test_supported_existing_mcp_entry_is_preserved(
+        self,
+        tmp_path: Path,
+        entry: dict[str, object],
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text(json.dumps({"mcpServers": {"ouroboros": entry}}), encoding="utf-8")
+        mtime_before = claude_config.stat().st_mtime
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        assert registered is True
+        assert claude_config.stat().st_mtime == mtime_before
+        assert json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"][
+            "ouroboros"
+        ] == entry
 
     def test_non_utf8_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"
@@ -1315,6 +1381,7 @@ class TestClaudeSetup:
         [
             '{"mcpServers": {"existing": {}}, "mcpServers": {}}',
             '{"mcpServers": {"existing": NaN}}',
+            '{"mcpServers": {"existing": 1e9999}}',
         ],
     )
     def test_non_standard_mcp_json_warns_without_overwriting(
@@ -1457,6 +1524,45 @@ class TestClaudeSetup:
         assert registered is False
         assert claude_config.read_text(encoding="utf-8") == original_content
         assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
+
+    def test_setup_claude_rolls_back_mcp_when_config_commit_fails(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_mcp = json.dumps({"mcpServers": {"existing": {"command": "custom"}}})
+        claude_config.write_text(original_mcp, encoding="utf-8")
+
+        real_atomic_write = setup_cmd._atomic_write_text
+
+        def fail_config_write(path: Path, content: str, *, mode: int = 0o600) -> None:
+            if path == config_path:
+                raise OSError("config activation failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("ouroboros.cli.commands.setup._atomic_write_text", side_effect=fail_config_write),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        assert claude_config.read_text(encoding="utf-8") == original_mcp
+        success.assert_not_called()
 
     def test_atomic_write_closes_descriptor_when_mode_application_fails(
         self, tmp_path: Path

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -2244,6 +2244,145 @@ class TestClaudeSetup:
         assert recovery_path.exists()
         assert "unsupported version" in warning.call_args.args[0]
 
+    @pytest.mark.parametrize(
+        (
+            "target_name",
+            "phase",
+            "target_exists",
+            "operation",
+            "content_b64",
+            "sha256",
+        ),
+        [
+            ("mcp", "prepared", False, "noop", None, None),
+            ("mcp", "prepared", True, {"invalid": True}, None, None),
+            ("mcp", "prepared", True, "noop", 123, None),
+            ("mcp", "prepared", True, "write", "e30=", None),
+            ("config", "mcp_written", True, "noop", None, None),
+            ("config", "mcp_written", True, "write", None, "deadbeef"),
+            ("credentials", "config_written", False, "noop", None, None),
+            ("credentials", "config_written", True, "noop", None, "deadbeef"),
+            ("credentials", "config_written", True, "write", "e30=", None),
+        ],
+        ids=[
+            "missing-mcp-noop",
+            "mcp-invalid-operation-shape",
+            "mcp-non-string-content",
+            "mcp-content-without-hash",
+            "config-noop-forbidden",
+            "config-null-content-with-hash",
+            "missing-credentials-noop",
+            "credentials-null-content-with-hash",
+            "credentials-content-without-hash",
+        ],
+    )
+    def test_setup_claude_malformed_target_manifest_fails_closed(
+        self,
+        tmp_path: Path,
+        target_name: str,
+        phase: str,
+        target_exists: bool,
+        operation: object,
+        content_b64: object,
+        sha256: object,
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            "orchestrator:\n  runtime_backend: claude\n  cli_path: /usr/local/bin/claude\n"
+            "llm:\n  backend: claude\n",
+            encoding="utf-8",
+        )
+        credentials_path = config_dir / "credentials.yaml"
+        credentials_path.write_text("providers: {}\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        mcp_path = claude_dir / "mcp.json"
+        mcp_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "ouroboros": {
+                            "command": "docker",
+                            "args": ["run", "ouroboros-mcp"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        target_paths = {
+            "mcp": mcp_path,
+            "config": config_path,
+            "credentials": credentials_path,
+        }
+        target_path = target_paths[target_name]
+        if not target_exists:
+            target_path.unlink()
+
+        snapshots = {
+            name: setup_cmd._read_claude_setup_file_snapshot(path)
+            for name, path in target_paths.items()
+        }
+        assert all(snapshot is not None for snapshot in snapshots.values())
+        mcp_snapshot = snapshots["mcp"]
+        config_snapshot = snapshots["config"]
+        credentials_snapshot = snapshots["credentials"]
+        assert mcp_snapshot is not None
+        assert config_snapshot is not None
+        assert credentials_snapshot is not None
+
+        manifest = setup_cmd._build_claude_setup_manifest(
+            mcp=setup_cmd._ClaudeSetupStagedFile(
+                mcp_path,
+                mcp_snapshot,
+                None if mcp_snapshot.existed else b'{"mcpServers": {}}\n',
+                mcp_snapshot.mode if mcp_snapshot.existed else 0o600,
+            ),
+            config=setup_cmd._ClaudeSetupStagedFile(
+                config_path,
+                config_snapshot,
+                config_snapshot.content,
+                config_snapshot.mode,
+            ),
+            credentials=setup_cmd._ClaudeSetupStagedFile(
+                credentials_path,
+                credentials_snapshot,
+                None if credentials_snapshot.existed else b"providers: {}\n",
+                credentials_snapshot.mode if credentials_snapshot.existed else 0o600,
+            ),
+            claude_path="/usr/local/bin/claude",
+        )
+        manifest["phase"] = phase
+        targets = manifest["targets"]
+        assert isinstance(targets, dict)
+        if phase in {"mcp_written", "config_written"}:
+            targets["mcp"]["post"] = setup_cmd._snapshot_to_manifest(mcp_snapshot)
+        if phase == "config_written":
+            targets["config"]["post"] = setup_cmd._snapshot_to_manifest(config_snapshot)
+
+        raw_target = targets[target_name]
+        raw_target["operation"] = operation
+        raw_target["content_b64"] = content_b64
+        raw_target["sha256"] = sha256
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        recovery_path.write_text(json.dumps(manifest), encoding="utf-8")
+        before = target_path.read_bytes() if target_path.exists() else None
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is False
+        assert recovery_path.exists()
+        assert (target_path.read_bytes() if target_path.exists() else None) == before
+        assert "incomplete" in warning.call_args.args[0]
+
     def test_setup_claude_commit_marker_failure_remains_retryable_without_rollback(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1170,6 +1170,62 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "Could not parse" in warning.call_args.args[0]
 
+    def test_setup_claude_malformed_mcp_does_not_persist_backend(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text("{broken json", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+        success.assert_not_called()
+
+    def test_setup_cli_exits_when_claude_mcp_registration_fails(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = {
+            "orchestrator": {"runtime_backend": "codex"},
+            "llm": {"backend": "codex"},
+        }
+        config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text("{broken json", encoding="utf-8")
+
+        runner = CliRunner()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_runtimes",
+                return_value={"claude": "/usr/local/bin/claude"},
+            ),
+        ):
+            result = runner.invoke(
+                setup_cmd.app,
+                ["--runtime", "claude", "--non-interactive"],
+            )
+
+        assert result.exit_code == 1
+        assert "Setup complete!" not in result.output
+        assert "Configured Claude Code runtime" not in result.output
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == original_config
+
     @pytest.mark.parametrize(
         "original_content",
         [
@@ -1379,6 +1435,71 @@ class TestClaudeSetup:
         warning.assert_called_once()
         assert "Could not write" in warning.call_args.args[0]
 
+    def test_mcp_fsync_failure_preserves_existing_file_and_cleans_temp(
+        self, tmp_path: Path
+    ) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        original_content = '{"mcpServers": {}}\n'
+        claude_config.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": []},
+            ),
+            patch("os.fsync", side_effect=OSError("fsync failed")),
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        assert registered is False
+        assert claude_config.read_text(encoding="utf-8") == original_content
+        assert list(claude_dir.glob(f".{claude_config.name}.*.tmp")) == []
+
+    def test_atomic_write_closes_descriptor_when_mode_application_fails(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "config.json"
+
+        with (
+            patch("os.fchmod", side_effect=OSError("fchmod failed")),
+            patch("os.close", wraps=os.close) as close,
+            pytest.raises(OSError, match="fchmod failed"),
+        ):
+            setup_cmd._atomic_write_text(target, "{}")
+
+        close.assert_called_once()
+        assert not target.exists()
+        assert list(tmp_path.glob(f".{target.name}.*.tmp")) == []
+
+    def test_atomic_write_new_file_uses_private_mode(self, tmp_path: Path) -> None:
+        target = tmp_path / "config.json"
+
+        setup_cmd._atomic_write_text(target, "{}")
+
+        assert target.stat().st_mode & 0o777 == 0o600
+
+    def test_mcp_update_preserves_existing_mode(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+        claude_config.chmod(0o640)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": []},
+            ),
+        ):
+            registered = setup_cmd._ensure_claude_mcp_entry()
+
+        assert registered is True
+        assert claude_config.stat().st_mode & 0o777 == 0o640
+
     def test_setup_claude_removes_legacy_timeout_override(self, tmp_path: Path) -> None:
         """Claude setup should no longer persist the legacy 600s MCP timeout."""
         config_dir = tmp_path / ".ouroboros"
@@ -1407,6 +1528,19 @@ class TestClaudeSetup:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={
+                    "command": "uvx",
+                    "args": [
+                        "--from",
+                        "ouroboros-ai[mcp,claude]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                    ],
+                },
+            ),
         ):
             setup_cmd._setup_claude("/usr/local/bin/claude")
 
@@ -1575,6 +1709,10 @@ class TestClaudeSetup:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": current_args},
+            ),
         ):
             setup_cmd._setup_claude("/usr/local/bin/claude")
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1815,6 +1815,115 @@ class TestClaudeSetup:
         assert config["orchestrator"]["runtime_backend"] == "claude"
         assert config["llm"]["backend"] == "claude"
 
+    def test_setup_claude_noop_mcp_recovers_after_config_promotion_failure(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("custom:\n  keep: true\n", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        existing_mcp = {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "docker",
+                    "args": ["run", "ouroboros-mcp"],
+                }
+            }
+        }
+        claude_config.write_text(json.dumps(existing_mcp), encoding="utf-8")
+
+        real_promote = setup_cmd._promote_text_cas
+
+        def fail_config_once(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
+            if path == config_path:
+                raise OSError("config activation failed")
+            return real_promote(path, content, expected=expected, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch("ouroboros.cli.commands.setup._promote_text_cas", side_effect=fail_config_once),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        assert configured is False
+        assert recovery_path.exists()
+        manifest = json.loads(recovery_path.read_text(encoding="utf-8"))
+        assert manifest["phase"] == "mcp_written"
+        assert manifest["targets"]["mcp"]["post"] == manifest["targets"]["mcp"]["pre"]
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
+        assert json.loads(claude_config.read_text(encoding="utf-8")) == existing_mcp
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["custom"]["keep"] is True
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["llm"]["backend"] == "claude"
+
+    def test_setup_claude_rebases_concurrent_unrelated_config_edit(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("custom:\n  original: true\n", encoding="utf-8")
+        external_config = {
+            "custom": {"original": True, "concurrent": "preserve"},
+            "orchestrator": {"unrelated": "keep"},
+        }
+        real_promote = setup_cmd._promote_text_cas
+        edited = False
+
+        def edit_before_first_config_promotion(
+            path: Path,
+            content: bytes,
+            *,
+            expected: setup_cmd._ClaudeSetupFileSnapshot,
+            mode: int,
+        ) -> setup_cmd._ClaudeSetupFileSnapshot:
+            nonlocal edited
+            if path == config_path and not edited:
+                edited = True
+                config_path.write_text(yaml.safe_dump(external_config), encoding="utf-8")
+            return real_promote(path, content, expected=expected, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._promote_text_cas",
+                side_effect=edit_before_first_config_promotion,
+            ),
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is True
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["custom"] == external_config["custom"]
+        assert config["orchestrator"]["unrelated"] == "keep"
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["orchestrator"]["cli_path"] == "/usr/local/bin/claude"
+        assert config["llm"]["backend"] == "claude"
+
     def test_setup_claude_config_failure_preserves_concurrent_mcp_replacement(
         self, tmp_path: Path
     ) -> None:
@@ -1911,7 +2020,9 @@ class TestClaudeSetup:
         assert claude_config.read_text(encoding="utf-8") == external_mcp
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {}
 
-    def test_setup_claude_recovery_preserves_external_config_edit(self, tmp_path: Path) -> None:
+    def test_setup_claude_recovery_rebases_external_unrelated_config_edit(
+        self, tmp_path: Path
+    ) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
         config_path = config_dir / "config.yaml"
@@ -1944,18 +2055,22 @@ class TestClaudeSetup:
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
         assert configured is False
-        config_path.write_text("orchestrator:\n  runtime_backend: gemini\n", encoding="utf-8")
+        config_path.write_text(
+            "custom:\n  concurrent: preserve\norchestrator:\n  unrelated: keep\n",
+            encoding="utf-8",
+        )
 
-        with (
-            patch("pathlib.Path.home", return_value=tmp_path),
-            patch("ouroboros.cli.commands.setup.print_warning") as warning,
-        ):
+        with patch("pathlib.Path.home", return_value=tmp_path):
             recovered = setup_cmd._recover_claude_mcp_activation()
 
-        assert recovered is False
-        assert "gemini" in config_path.read_text(encoding="utf-8")
-        assert recovery_path.exists()
-        assert "changed during setup" in warning.call_args.args[0]
+        assert recovered is True
+        assert not recovery_path.exists()
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["custom"]["concurrent"] == "preserve"
+        assert config["orchestrator"]["unrelated"] == "keep"
+        assert config["orchestrator"]["runtime_backend"] == "claude"
+        assert config["orchestrator"]["cli_path"] == "/usr/local/bin/claude"
+        assert config["llm"]["backend"] == "claude"
 
     def test_setup_claude_leaves_recovery_when_config_recovery_write_fails(
         self, tmp_path: Path
@@ -2129,7 +2244,7 @@ class TestClaudeSetup:
         assert recovery_path.exists()
         assert "unsupported version" in warning.call_args.args[0]
 
-    def test_setup_claude_pending_journal_after_config_commit_does_not_rollback_mcp(
+    def test_setup_claude_commit_marker_failure_remains_retryable_without_rollback(
         self, tmp_path: Path
     ) -> None:
         config_dir = tmp_path / ".ouroboros"
@@ -2166,7 +2281,7 @@ class TestClaudeSetup:
         ):
             configured = setup_cmd._setup_claude("/usr/local/bin/claude")
 
-        assert configured is True
+        assert configured is False
         assert recovery_path.exists()
         assert (
             json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "credentials_written"
@@ -2272,6 +2387,86 @@ class TestClaudeSetup:
 
         assert opened_dirs
         assert any(call.args[0] in opened_dirs for call in fsync.call_args_list)
+
+    def test_atomic_write_parent_fsync_failure_is_reported(self, tmp_path: Path) -> None:
+        target = tmp_path / "config.json"
+
+        with (
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=OSError("directory fsync failed"),
+            ),
+            pytest.raises(OSError, match="directory fsync failed"),
+        ):
+            setup_cmd._atomic_write_text(target, "{}")
+
+        assert target.read_text(encoding="utf-8") == "{}"
+
+    @pytest.mark.parametrize("name", ["mcp.json", "config.yaml", "credentials.yaml"])
+    def test_cas_promotion_preserves_operator_fixed_sidecar(
+        self, tmp_path: Path, name: str
+    ) -> None:
+        target = tmp_path / name
+        target.write_text("before", encoding="utf-8")
+        snapshot = setup_cmd._read_claude_setup_file_snapshot(target)
+        assert snapshot is not None
+        operator_sidecar = target.with_name(f".{target.name}.ouroboros-pre")
+        operator_sidecar.write_text("operator-owned", encoding="utf-8")
+
+        promoted = setup_cmd._promote_text_cas(
+            target,
+            b"after",
+            expected=snapshot,
+            mode=0o600,
+        )
+
+        assert promoted.content == b"after"
+        assert target.read_text(encoding="utf-8") == "after"
+        assert operator_sidecar.read_text(encoding="utf-8") == "operator-owned"
+
+    def test_setup_claude_parent_fsync_failure_leaves_recovery_pending(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        claude_dir = tmp_path / ".claude"
+        mcp_path = claude_dir / "mcp.json"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_fsync_parent = setup_cmd._fsync_parent_dir
+
+        def fail_mcp_parent_fsync(path: Path) -> None:
+            if path == mcp_path:
+                raise setup_cmd._ParentDirectoryFsyncError("directory fsync failed")
+            real_fsync_parent(path)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_mcp_entry",
+                return_value={"command": "uvx", "args": ["--from", "ouroboros-ai[mcp,claude]"]},
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._fsync_parent_dir",
+                side_effect=fail_mcp_parent_fsync,
+            ),
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        assert configured is False
+        assert mcp_path.exists()
+        assert recovery_path.exists()
+        assert json.loads(recovery_path.read_text(encoding="utf-8"))["phase"] == "prepared"
+        success.assert_not_called()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            recovered = setup_cmd._recover_claude_mcp_activation()
+
+        assert recovered is True
+        assert not recovery_path.exists()
 
     def test_mcp_update_preserves_existing_mode(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1239,6 +1239,47 @@ class TestClaudeSetup:
         assert credentials_path.exists()
         assert credentials_path.stat().st_mode & 0o777 == 0o600
 
+    def test_setup_claude_fresh_credentials_failure_leaves_activation_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        credentials_path = config_dir / "credentials.yaml"
+        claude_dir = tmp_path / ".claude"
+        mcp_path = claude_dir / "mcp.json"
+        recovery_path = claude_dir / "mcp.json.ouroboros-recovery"
+        real_atomic_write = setup_cmd._atomic_write_text
+
+        def fail_credentials_write(path: Path, content: str, *, mode: int = 0o600) -> None:
+            if path == credentials_path:
+                raise OSError("credentials write failed")
+            real_atomic_write(path, content, mode=mode)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text",
+                side_effect=fail_credentials_write,
+            ),
+            patch("ouroboros.cli.commands.setup._detect_mcp_entry") as detect,
+            patch("ouroboros.cli.commands.setup.print_warning") as warning,
+        ):
+            configured = setup_cmd._setup_claude("/usr/local/bin/claude")
+            from ouroboros.config.loader import config_exists
+
+            exists_after_failure = config_exists()
+
+        assert configured is False
+        assert exists_after_failure is False
+        assert not (config_dir / "config.yaml").exists()
+        assert not credentials_path.exists()
+        assert not mcp_path.exists()
+        assert not recovery_path.exists()
+        detect.assert_not_called()
+        assert "credentials.yaml" in warning.call_args.args[0]
+
     def test_setup_claude_preserves_existing_credentials(self, tmp_path: Path) -> None:
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -1550,6 +1591,7 @@ class TestClaudeSetup:
             "llm": {"backend": "codex"},
         }
         config_path.write_text(yaml.safe_dump(original_config), encoding="utf-8")
+        (config_dir / "credentials.yaml").write_text("providers: {}\n", encoding="utf-8")
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         (claude_dir / "mcp.json").write_text('{"mcpServers": {}}\n', encoding="utf-8")

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1355,9 +1355,10 @@ class TestClaudeSetup:
 
         assert registered is True
         assert claude_config.stat().st_mtime == mtime_before
-        assert json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"][
-            "ouroboros"
-        ] == entry
+        assert (
+            json.loads(claude_config.read_text(encoding="utf-8"))["mcpServers"]["ouroboros"]
+            == entry
+        )
 
     def test_non_utf8_mcp_json_warns_without_overwriting(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"


### PR DESCRIPTION
## Summary

Claude setup currently assumes ~/.claude/mcp.json is readable, UTF-8 JSON with the expected object shapes, and writable in place. This can crash setup or truncate the existing configuration.

This change validates every read boundary fail-closed, preserves explicit null and incompatible shapes, handles non-UTF-8 and filesystem errors, writes through the existing atomic writer with file fsync, preserves the existing mode, and prints success only after replacement succeeds.

## Test plan

- [x] 178 tests in tests/unit/cli/test_setup.py
- [x] Malformed JSON, top-level/section/entry null and array shapes, invalid command types
- [x] Non-UTF-8 bytes, mkdir/exists/read/stat/write/fsync/replace failures
- [x] Original bytes and temporary-file cleanup verified on failed writes
- [x] Ruff check and format clean
- [x] Full mypy src/ clean across 467 source files
- [x] Python compileall clean on changed source and tests

## Related issues

No duplicate issue or pull request matched this malformed-Claude-config failure mode.