### PR TITLE
feat(orchestrator): separate AC attempts from final acceptance

### DIFF
--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -25,9 +25,9 @@ sufficient. The implementation audit found six contract gaps:
 
 1. The observer waits with `wait_for="ac_change"` and does not request the linked
    event stream, so deliver verdicts and frugality events cannot wake it.
-2. `execution.ac.outcome_finalized` is emitted after intermediate attempts as well
+2. `execution.ac.attempt_judged` is emitted after intermediate attempts as well
    as final attempts. It does not prove that retry and alternate-harness ownership
-   is closed.
+   is closed; only `execution.ac.acceptance_finalized` closes the terminal episode.
 3. Model-routing events do not explicitly record whether an escalation occurred,
    and deliver-verdict events have no lineage-stable semantic AC identity.
 4. Seed-QA blocking mutates Auto state but emits no dedicated gate-block event.
@@ -112,8 +112,10 @@ Required data:
 - `failed`
 
 This event is the authoritative proof that the conductor may consider a
-successor. `execution.ac.outcome_finalized` remains attempt-level telemetry and
-MUST NOT independently trigger a mutating conductor action.
+successor. `execution.ac.attempt_judged` (and the historical
+`execution.ac.outcome_finalized` alias) remains attempt-level telemetry and
+MUST NOT independently trigger a mutating conductor action. The terminal
+`execution.ac.acceptance_finalized` event is the only final admission fact.
 
 ### Model escalation evidence
 

--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -603,7 +603,9 @@ Proactive briefings use existing relay `kind` values with structured `subtype`:
 - `progress_advanced / level_started`
 - `progress_advanced / ac_routing`
 - `progress_advanced / harness_changed`
-- `progress_advanced / ac_verified`
+- `progress_advanced / ac_attempt_judged`
+- `progress_advanced / ac_accepted`
+- `progress_advanced / ac_rejected`
 
 Default cadence:
 
@@ -612,7 +614,8 @@ Default cadence:
 - discovery: only on material target change;
 - level start/completion: once per level;
 - model/harness: initial dispatch and changes only;
-- AC completion: once with compact evidence;
+- provisional AC attempt judgment: once per retry attempt with compact evidence;
+- final AC acceptance/rejection: once per terminal root decision;
 - raw logs and unchanged heartbeats: never.
 
 The user can request an on-demand AC assurance view at any time. That view shows

--- a/docs/rfc/foundation-b-attempt-acceptance.md
+++ b/docs/rfc/foundation-b-attempt-acceptance.md
@@ -1,0 +1,98 @@
+# Foundation B — Attempt versus final acceptance
+
+## Scope
+
+Foundation B separates observations made during an AC attempt from the one
+final acceptance decision for that AC authority generation. It does not add
+dispatch, routing, capsules, cross-run trust, or provider-specific policy.
+
+## Event contract
+
+### `execution.ac.attempt_judged`
+
+This is provisional telemetry emitted by the outer verify/retry layer after an
+individual runtime attempt has been judged. A root AC may have several of
+these events, one for each `retry_attempt`. It never grants acceptance and
+must not trigger a successor, route change, or final cleanup.
+
+Required fields:
+
+```json
+{
+  "execution_id": "exec_...",
+  "session_id": "sess_...",
+  "root_ac_index": 0,
+  "retry_attempt": 1,
+  "attempt_number": 2,
+  "success": false,
+  "outcome": "failed",
+  "is_decomposed": true
+}
+```
+
+The existing `execution.ac.outcome_finalized` name is retained only as a
+legacy read alias for historical rows. New producers emit
+`execution.ac.attempt_judged`; consumers must not treat either event as final
+acceptance.
+
+### `execution.ac.acceptance_finalized`
+
+This is the Final Gate's durable decision after the complete same-authority
+attempt episode has closed and the session terminal state is known. It is the
+only event that can declare `accepted: true`. A final rejected/blocked/cancelled
+disposition may be recorded with `accepted: false`, but it never authorizes a
+new attempt.
+
+Required fields:
+
+```json
+{
+  "execution_id": "exec_...",
+  "session_id": "sess_...",
+  "authority_correlation_id": "...",
+  "root_ac_index": 0,
+  "final_retry_attempt": 1,
+  "accepted": true,
+  "disposition": "accepted",
+  "outcome": "succeeded",
+  "terminal_status": "completed"
+}
+```
+
+The durable uniqueness key is
+`(authority_correlation_id, root_ac_index)`. The EventStore inserts the event
+and its guard row in one transaction. A duplicate append is an idempotent
+no-op only when the existing payload is byte-for-byte equivalent; a conflicting
+payload is a persistence error and never becomes a second final decision.
+
+No final acceptance event is emitted for a recoverable `PAUSED` transition.
+The retained owner must resume the same authority generation and publish the
+decision only after a later terminal outcome. A terminal cancellation or
+failure records `accepted: false` with its explicit disposition so replay can
+distinguish a rejected final gate from an unfinished attempt.
+
+## Consumer rules
+
+- Frugality proof pairs attempt-axis telemetry with the latest
+  `execution.ac.acceptance_finalized` record, never with an intermediate
+  `outcome_finalized` row.
+- MCP recovery uses attempt judgments for diagnostic failure evidence and the
+  final acceptance event for terminal disposition.
+- Attention relay reports attempt verification from `attempt_judged` and final
+  acceptance from `acceptance_finalized` as distinct subtypes.
+- Checkpoint/replay and escalation correlation use `retry_attempt` from
+  `attempt_judged`, and use the authority-keyed final event only to close an
+  episode.
+- Historical `execution.ac.outcome_finalized` rows remain readable as
+  provisional attempt telemetry, so old runs cannot be reinterpreted as final
+  acceptance.
+
+## Invariants
+
+1. Only the Final Gate emits `accepted: true`.
+2. One authority generation and root AC have at most one durable final event.
+3. A final event cannot be overwritten by a later attempt judgment.
+4. A paused episode has no final event until it resumes and reaches a terminal
+   disposition.
+5. Duplicate or contradictory final payloads fail closed.
+

--- a/docs/rfc/foundation-b-attempt-acceptance.md
+++ b/docs/rfc/foundation-b-attempt-acceptance.md
@@ -49,7 +49,7 @@ Required fields:
 {
   "execution_id": "exec_...",
   "session_id": "sess_...",
-  "authority_correlation_id": "...",
+  "acceptance_generation_id": "foundation-b/v1:<sha256(session_id, execution_id)>...",
   "root_ac_index": 0,
   "final_retry_attempt": 1,
   "accepted": true,
@@ -60,7 +60,13 @@ Required fields:
 ```
 
 The durable uniqueness key is
-`(authority_correlation_id, root_ac_index)`. The terminal session transition
+`(acceptance_generation_id, root_ac_index)`. The generation is derived from the
+immutable `(session_id, execution_id)` pair and belongs exclusively to
+Foundation B. It is deliberately not Foundation A's process-local authority
+correlation or fingerprint; A's live identity is diagnostic only and can never
+authorize final acceptance or replay.
+
+The terminal session transition
 carries the complete root decision set as a replayable finalization plan. The
 EventStore writes the winning terminal session event, every acceptance guard,
 and every acceptance event in one transaction. A duplicate append is an

--- a/docs/rfc/foundation-b-attempt-acceptance.md
+++ b/docs/rfc/foundation-b-attempt-acceptance.md
@@ -60,10 +60,19 @@ Required fields:
 ```
 
 The durable uniqueness key is
-`(authority_correlation_id, root_ac_index)`. The EventStore inserts the event
-and its guard row in one transaction. A duplicate append is an idempotent
-no-op only when the existing payload is byte-for-byte equivalent; a conflicting
-payload is a persistence error and never becomes a second final decision.
+`(authority_correlation_id, root_ac_index)`. The terminal session transition
+carries the complete root decision set as a replayable finalization plan. The
+EventStore writes the winning terminal session event, every acceptance guard,
+and every acceptance event in one transaction. A duplicate append is an
+idempotent no-op only when the existing payload is byte-for-byte equivalent; a
+conflicting payload is a persistence error and rolls back the terminal winner
+instead of becoming a second final decision.
+
+If a caller is replaying an already-terminal session, it reconstructs the
+authority contract from that session's immutable start/progress data rather
+than from runner-global mutable state. Resume, exception, and cancellation
+paths use the same finalization plan/finalizer. A paused episode carries no
+plan and therefore remains resumable until a later terminal transition.
 
 No final acceptance event is emitted for a recoverable `PAUSED` transition.
 The retained owner must resume the same authority generation and publish the
@@ -95,4 +104,3 @@ distinguish a rejected final gate from an unfinished attempt.
 4. A paused episode has no final event until it resumes and reaches a terminal
    disposition.
 5. Duplicate or contradictory final payloads fail closed.
-

--- a/docs/rfc/frugality-proof-producers.md
+++ b/docs/rfc/frugality-proof-producers.md
@@ -42,7 +42,11 @@ the right run's row.
 | `execution.ac.token_attribution.reported` | **implemented on this branch** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `token_spend` | AC2 |
 | `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
 | `execution.ac.shadow_replay` | **implemented, fail-closed without an isolation-attested runtime** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `baseline_token_spend`, `baseline_mode`, `baseline_tier`, `baseline_model`, `decomposition_trustworthy` | AC5 |
-| `execution.ac.outcome_finalized` | **implemented in the outer verify/retry layer** | run anchor, `root_ac_index`, `retry_attempt`, `success`, `is_decomposed` | admission |
+| `execution.ac.attempt_judged` | **implemented in the outer verify/retry layer** | run anchor, `root_ac_index`, `retry_attempt`, `attempt_number`, `success`, `outcome`, `is_decomposed` | provisional attempt telemetry |
+| `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `authority_correlation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
+
+`execution.ac.outcome_finalized` remains readable as a historical alias for
+attempt telemetry. It is not a final-admission signal.
 
 All retry attempts for a logical child are paired before aggregation. Token spend
 and baseline spend are summed attempt-for-attempt, while grounding regression is an

--- a/docs/rfc/frugality-proof-producers.md
+++ b/docs/rfc/frugality-proof-producers.md
@@ -43,7 +43,7 @@ the right run's row.
 | `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
 | `execution.ac.shadow_replay` | **implemented, fail-closed without an isolation-attested runtime** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `baseline_token_spend`, `baseline_mode`, `baseline_tier`, `baseline_model`, `decomposition_trustworthy` | AC5 |
 | `execution.ac.attempt_judged` | **implemented in the outer verify/retry layer** | run anchor, `root_ac_index`, `retry_attempt`, `attempt_number`, `success`, `outcome`, `is_decomposed` | provisional attempt telemetry |
-| `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `authority_correlation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
+| `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `acceptance_generation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
 
 `execution.ac.outcome_finalized` remains readable as a historical alias for
 attempt telemetry. It is not a final-admission signal.

--- a/docs/rfc/frugality-proof-producers.md
+++ b/docs/rfc/frugality-proof-producers.md
@@ -31,19 +31,21 @@ cannot enter a proof row yet.
 
 The gate (`frugality_proof.py`, shipped in #1478) reads these event types and fields.
 Producers must emit them keyed by the same `ac_id` the model event uses, and must
-carry the **run anchor** (`seed_run_id`, or `execution_id`) on every event: the proof
-spans runs and the same logical `ac_id` recurs each run, so `assemble_triads()` keys
-rows by `(run, ac_id)`. An axis event without the run anchor cannot be attributed to
-the right run's row.
+carry the **run anchor** (`seed_run_id`, or `execution_id`) plus the orchestration
+`session_id` on every event: the proof spans runs and the same logical `ac_id` recurs
+each run, while multiple sessions may share one execution id. `assemble_triads()`
+therefore keys rows by `(run, session, ac_id)`. An axis event without the run anchor
+or session identity is legacy evidence and can be attached only when the matching
+run/root has one unambiguous session; otherwise it remains uncounted.
 
 | Event type | Producer | Required fields | Seed AC |
 |---|---|---|---|
-| `execution.ac.model_routed` | **done** | `model_tier`, `model`, `model_mode`, `is_decomposed_child`, `root_ac_index`, `retry_attempt`, `ac_id`, run anchor | routing contract |
-| `execution.ac.token_attribution.reported` | **implemented on this branch** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `token_spend` | AC2 |
-| `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
-| `execution.ac.shadow_replay` | **implemented, fail-closed without an isolation-attested runtime** | `ac_id`, run anchor, `root_ac_index`, `retry_attempt`, `baseline_token_spend`, `baseline_mode`, `baseline_tier`, `baseline_model`, `decomposition_trustworthy` | AC5 |
-| `execution.ac.attempt_judged` | **implemented in the outer verify/retry layer** | run anchor, `root_ac_index`, `retry_attempt`, `attempt_number`, `success`, `outcome`, `is_decomposed` | provisional attempt telemetry |
-| `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `acceptance_generation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
+| `execution.ac.model_routed` | **done** | `model_tier`, `model`, `model_mode`, `is_decomposed_child`, `root_ac_index`, `retry_attempt`, `ac_id`, run anchor, `session_id` | routing contract |
+| `execution.ac.token_attribution.reported` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `token_spend` | AC2 |
+| `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
+| `execution.ac.shadow_replay` | **implemented, fail-closed without an isolation-attested runtime** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `baseline_token_spend`, `baseline_mode`, `baseline_tier`, `baseline_model`, `decomposition_trustworthy` | AC5 |
+| `execution.ac.attempt_judged` | **implemented in the outer verify/retry layer** | run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `attempt_number`, `success`, `outcome`, `is_decomposed` | provisional attempt telemetry |
+| `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `session_id`, `acceptance_generation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
 
 `execution.ac.outcome_finalized` remains readable as a historical alias for
 attempt telemetry. It is not a final-admission signal.

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import inspect
 import os
 from typing import Annotated
 from uuid import uuid4
@@ -33,6 +34,7 @@ from ouroboros.events.hitl import (
 )
 from ouroboros.orchestrator.execution_authority import (
     ProcessLocalCancellationDisposition,
+    collect_cancellation_acceptance_plan,
     request_process_local_cancellation,
 )
 
@@ -182,11 +184,32 @@ async def _cancel_session(
         return None
 
     # Historical sessions have no live Foundation A capability to coordinate.
-    cancel_result = await repo.mark_cancelled(
-        session_id=session_id,
-        reason=reason,
-        cancelled_by="user",
+    raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+    expected_root_indices = (
+        range(raw_total_acs)
+        if isinstance(raw_total_acs, int)
+        and not isinstance(raw_total_acs, bool)
+        and raw_total_acs >= 0
+        else None
     )
+    try:
+        acceptance_finalizations = await collect_cancellation_acceptance_plan(
+            session_id=session_id,
+            execution_id=tracker.execution_id,
+            event_store=event_store,
+            expected_root_indices=expected_root_indices,
+        )
+    except Exception as exc:
+        print_error(f"Failed to build cancellation acceptance plan: {exc}")
+        return None
+    mark_cancelled_kwargs = {
+        "session_id": session_id,
+        "reason": reason,
+        "cancelled_by": "user",
+    }
+    if "acceptance_finalizations" in inspect.signature(repo.mark_cancelled).parameters:
+        mark_cancelled_kwargs["acceptance_finalizations"] = acceptance_finalizations
+    cancel_result = await repo.mark_cancelled(**mark_cancelled_kwargs)
 
     if cancel_result.is_err:
         print_error(f"Failed to cancel session {session_id}: {cancel_result.error}")
@@ -300,11 +323,35 @@ async def _cancel_all_running(
             continue
 
         # Historical sessions have no live Foundation A capability to coordinate.
-        cancel_result = await repo.mark_cancelled(
-            session_id=session_id,
-            reason=reason,
-            cancelled_by="user",
+        raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+        expected_root_indices = (
+            range(raw_total_acs)
+            if isinstance(raw_total_acs, int)
+            and not isinstance(raw_total_acs, bool)
+            and raw_total_acs >= 0
+            else None
         )
+        try:
+            acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                session_id=session_id,
+                execution_id=tracker.execution_id,
+                event_store=event_store,
+                expected_root_indices=expected_root_indices,
+            )
+        except Exception as exc:
+            retryable_failed += 1
+            console.print(
+                f"  [yellow]Retry required:[/] {session_id} (acceptance plan failed: {exc})"
+            )
+            continue
+        mark_cancelled_kwargs = {
+            "session_id": session_id,
+            "reason": reason,
+            "cancelled_by": "user",
+        }
+        if "acceptance_finalizations" in inspect.signature(repo.mark_cancelled).parameters:
+            mark_cancelled_kwargs["acceptance_finalizations"] = acceptance_finalizations
+        cancel_result = await repo.mark_cancelled(**mark_cancelled_kwargs)
 
         if cancel_result.is_ok and cancel_result.value is not False:
             cancelled += 1

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -37,6 +37,7 @@ from ouroboros.orchestrator.execution_authority import (
     collect_cancellation_acceptance_plan,
     request_process_local_cancellation,
 )
+from ouroboros.orchestrator.session import ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY
 
 app = typer.Typer(
     name="cancel",
@@ -184,13 +185,9 @@ async def _cancel_session(
         return None
 
     # Historical sessions have no live Foundation A capability to coordinate.
-    raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+    raw_root_indices = tracker.progress.get(ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY)
     expected_root_indices = (
-        range(raw_total_acs)
-        if isinstance(raw_total_acs, int)
-        and not isinstance(raw_total_acs, bool)
-        and raw_total_acs >= 0
-        else None
+        tuple(raw_root_indices) if isinstance(raw_root_indices, (list, tuple)) else None
     )
     try:
         acceptance_finalizations = await collect_cancellation_acceptance_plan(
@@ -323,13 +320,9 @@ async def _cancel_all_running(
             continue
 
         # Historical sessions have no live Foundation A capability to coordinate.
-        raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+        raw_root_indices = tracker.progress.get(ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY)
         expected_root_indices = (
-            range(raw_total_acs)
-            if isinstance(raw_total_acs, int)
-            and not isinstance(raw_total_acs, bool)
-            and raw_total_acs >= 0
-            else None
+            tuple(raw_root_indices) if isinstance(raw_root_indices, (list, tuple)) else None
         )
         try:
             acceptance_finalizations = await collect_cancellation_acceptance_plan(

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -129,8 +129,9 @@ Interpret observer `relay_events` semantically:
 - `discovery_summary`: bounded targets and purpose only—never raw commands,
   searches, tool output, or model reasoning;
 - `level_started` / `level_completed`, `ac_routing`, `harness_changed`, and
-  `ac_verified`: report only material changes and say "currently running with"
-  because routing can escalate;
+  `ac_attempt_judged`: report only material changes and say "currently running
+  with" because routing can escalate; treat `ac_accepted` and `ac_rejected` as
+  terminal root decisions, not provisional attempt evidence;
 - `attention_required`: surface immediately;
 - Synapse `queued`/`delivering`: pending or claimed, not applied;
   `applied`/`completed`: runtime-proven and may contain a bounded AC reply;

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 import inspect
+import json
 import logging
 import time
 from typing import Any
@@ -19,6 +20,7 @@ from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
+from ouroboros.orchestrator.evidence.common import validate_attempt_judgment_payload
 from ouroboros.orchestrator.execution_authority import (
     ProcessLocalCancellationDisposition,
     request_process_local_cancellation,
@@ -130,6 +132,23 @@ def _safe_result_payload(result: Any) -> dict[str, Any]:
         "meta": _safe_meta(getattr(result, "meta", {})),
         "text_content": getattr(result, "text_content", str(result)),
     }
+
+
+def _canonical_acceptance_payload(payload: Mapping[str, Any]) -> str:
+    """Return a stable representation for idempotent plan-entry comparison."""
+    return json.dumps(dict(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _event_belongs_to_linked_session(event: BaseEvent, snapshot: JobSnapshot) -> bool:
+    """Bind execution-stream fallback evidence to the job's linked session."""
+    session_id = snapshot.links.session_id
+    execution_id = snapshot.links.execution_id
+    if not session_id or not execution_id:
+        return False
+    if event.aggregate_id != execution_id:
+        return False
+    data = event.data
+    return data.get("session_id") == session_id
 
 
 _JOB_TTL = timedelta(hours=1)
@@ -1327,6 +1346,7 @@ class JobManager:
                 operation="mcp_recover_authoritative_acceptance",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
+        current_format = ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY in start_event.data
 
         terminal_event = next(
             (
@@ -1341,7 +1361,21 @@ class JobManager:
             ),
             None,
         )
-        if terminal_event is None or "acceptance_finalizations" not in terminal_event.data:
+        if terminal_event is None:
+            if current_format:
+                raise PersistenceError(
+                    "Current-format linked session has no terminal acceptance plan.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            return None
+        if "acceptance_finalizations" not in terminal_event.data:
+            if current_format:
+                raise PersistenceError(
+                    "Current-format linked terminal session is missing its acceptance plan.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
             return None
         terminal_status = {
             "orchestrator.session.completed": "completed",
@@ -1412,11 +1446,18 @@ class JobManager:
                 )
             existing = planned_by_root.get(root)
             if existing is not None:
-                raise PersistenceError(
-                    "Linked terminal acceptance plan contains duplicate root decisions.",
-                    operation="mcp_recover_authoritative_acceptance",
-                    details={"session_id": session_id, "execution_id": execution_id},
-                )
+                if _canonical_acceptance_payload(existing) != _canonical_acceptance_payload(
+                    payload
+                ):
+                    raise PersistenceError(
+                        "Linked terminal acceptance plan contains conflicting root decisions.",
+                        operation="mcp_recover_authoritative_acceptance",
+                        details={"session_id": session_id, "execution_id": execution_id},
+                    )
+                # EventStore treats byte-equivalent duplicate entries in the
+                # same terminal plan as idempotent guard hits. Canonicalize
+                # them here so recovery mirrors the durable writer exactly.
+                continue
             planned_by_root[root] = payload
 
         if expected_roots is not None and set(planned_by_root) != expected_roots:
@@ -1491,22 +1532,17 @@ class JobManager:
         """
         if not snapshot.links.execution_id:
             return None
-        terminal_events = await self._event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            event_type="execution.terminal",
-            limit=1,
-        )
-        terminal_data = terminal_events[0].data if terminal_events else None
-        if terminal_data is None:
-            # Foundation B commits the session terminal event and all final
-            # acceptance events atomically. The older execution.terminal
-            # projection can still be missing after a crash, so recover from
-            # that authoritative state instead of manufacturing INTERRUPTED.
-            try:
-                authoritative = await self._read_authoritative_session_acceptance(snapshot)
-            except PersistenceError:
-                return None
-            if authoritative is None or authoritative.terminal_status != "completed":
+
+        # Foundation B's terminal session plan is authoritative whenever it is
+        # present. An older execution.terminal projection must not override
+        # that Final Gate decision, even when multiple sessions share an
+        # execution aggregate.
+        try:
+            authoritative = await self._read_authoritative_session_acceptance(snapshot)
+        except PersistenceError:
+            return None
+        if authoritative is not None:
+            if authoritative.terminal_status != "completed":
                 return None
             if any(
                 event.data.get("accepted") is not True for event in authoritative.acceptance_events
@@ -1518,16 +1554,41 @@ class JobManager:
                 if isinstance(final_message, str) and final_message.strip():
                     return final_message.strip()
             return "Execution complete"
+
+        terminal_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="execution.terminal",
+            limit=None,
+        )
+        terminal_event = next(
+            (
+                event
+                for event in reversed(terminal_events)
+                if _event_belongs_to_linked_session(event, snapshot)
+            ),
+            None,
+        )
+        terminal_data = terminal_event.data if terminal_event is not None else None
+        if terminal_data is None:
+            return None
         if terminal_data.get("status") != "completed":
             return None
 
         workflow_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="workflow.progress.updated",
-            limit=1,
+            limit=None,
         )
-        if workflow_events:
-            data = workflow_events[0].data
+        workflow_event = next(
+            (
+                event
+                for event in reversed(workflow_events)
+                if _event_belongs_to_linked_session(event, snapshot)
+            ),
+            None,
+        )
+        if workflow_event is not None:
+            data = workflow_event.data
             completed = data.get("completed_count")
             total = data.get("total_count")
             if (
@@ -1547,19 +1608,35 @@ class JobManager:
         terminal_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="execution.terminal",
-            limit=1,
+            limit=None,
         )
-        if not terminal_events or terminal_events[0].data.get("status") != "failed":
+        terminal_event = next(
+            (
+                event
+                for event in reversed(terminal_events)
+                if _event_belongs_to_linked_session(event, snapshot)
+            ),
+            None,
+        )
+        if terminal_event is None or terminal_event.data.get("status") != "failed":
             return None
 
         workflow_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="workflow.progress.updated",
-            limit=1,
+            limit=None,
         )
-        if not workflow_events:
+        workflow_event = next(
+            (
+                event
+                for event in reversed(workflow_events)
+                if _event_belongs_to_linked_session(event, snapshot)
+            ),
+            None,
+        )
+        if workflow_event is None:
             return None
-        data = workflow_events[0].data
+        data = workflow_event.data
         completed = data.get("completed_count")
         total = data.get("total_count")
         phase = str(data.get("current_phase") or "")
@@ -1600,50 +1677,6 @@ class JobManager:
         """
         if not snapshot.links.execution_id:
             return None
-        if await self._has_active_execution_session(snapshot.links.execution_id):
-            return None
-
-        terminal_events = await self._event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            event_type="execution.terminal",
-            limit=1,
-        )
-        terminal_failure_events = []
-        if terminal_events:
-            status = terminal_events[0].data.get("status")
-            if status == "completed":
-                return None
-            if status not in {"failed", "cancelled", "interrupted"}:
-                return None
-            terminal_failure_events.append(terminal_events[0])
-        failed_session_events = await self._event_store.query_execution_related_events(
-            snapshot.links.execution_id,
-            event_type="execution.session.failed",
-            limit=None,
-        )
-        failed_attempt_events = await self._event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            event_type="execution.ac.attempt_judged",
-            limit=20,
-        )
-        # Keep the historical event name readable for pre-Foundation-B runs.
-        failed_attempt_events.extend(
-            await self._event_store.query_events(
-                aggregate_id=snapshot.links.execution_id,
-                event_type="execution.ac.outcome_finalized",
-                limit=20,
-            )
-        )
-        final_acceptance_events = await self._event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            event_type="execution.ac.acceptance_finalized",
-            limit=None,
-        )
-        scoped_final_acceptance_events = [
-            event
-            for event in final_acceptance_events
-            if event.data.get("session_id") == snapshot.links.session_id
-        ]
         try:
             authoritative = await self._read_authoritative_session_acceptance(snapshot)
         except PersistenceError:
@@ -1651,30 +1684,108 @@ class JobManager:
         if authoritative is not None:
             if authoritative.terminal_status == "completed":
                 return None
-            terminal_failure_events.append(authoritative.terminal_event)
+            terminal_failure_events = [authoritative.terminal_event]
+            failed_session_events: list[BaseEvent] = []
             failed_outcomes = [
                 event
                 for event in authoritative.acceptance_events
                 if event.data.get("accepted") is False
             ]
-        elif scoped_final_acceptance_events:
-            # A current-session final event without its complete atomic terminal
-            # plan is malformed historical state, not trustworthy failure proof.
-            return None
-        # A final acceptance is the Final Gate's authoritative disposition.
-        # Provisional failed attempts are diagnostic only and must not
-        # override a later accepted final event during dead-owner recovery.
         else:
-            if not terminal_failure_events and not allow_nonterminal_evidence:
+            if await self._has_active_execution_session(snapshot.links.execution_id):
                 return None
-            failed_outcomes = [
+
+            terminal_events = await self._event_store.query_events(
+                aggregate_id=snapshot.links.execution_id,
+                event_type="execution.terminal",
+                limit=None,
+            )
+            terminal_failure_events = []
+            terminal_event = next(
+                (
+                    event
+                    for event in reversed(terminal_events)
+                    if _event_belongs_to_linked_session(event, snapshot)
+                ),
+                None,
+            )
+            if terminal_event is not None:
+                status = terminal_event.data.get("status")
+                if status == "completed":
+                    return None
+                if status not in {"failed", "cancelled", "interrupted"}:
+                    return None
+                terminal_failure_events.append(terminal_event)
+
+            failed_session_events = [
                 event
-                for event in failed_attempt_events
-                if event.data.get("success") is False
-                or str(event.data.get("outcome") or "").casefold() == "failed"
-                or str(event.data.get("disposition") or "").casefold()
-                in {"rejected", "blocked", "cancelled"}
+                for event in await self._event_store.query_execution_related_events(
+                    snapshot.links.execution_id,
+                    event_type="execution.session.failed",
+                    limit=None,
+                )
+                if event.data.get("execution_id") == snapshot.links.execution_id
             ]
+
+            raw_attempt_events = await self._event_store.query_events(
+                aggregate_id=snapshot.links.execution_id,
+                event_type="execution.ac.attempt_judged",
+                limit=None,
+            )
+            # Keep the historical event name readable for pre-Foundation-B runs.
+            raw_attempt_events.extend(
+                await self._event_store.query_events(
+                    aggregate_id=snapshot.links.execution_id,
+                    event_type="execution.ac.outcome_finalized",
+                    limit=None,
+                )
+            )
+            failed_attempt_events: list[BaseEvent] = []
+            for event in raw_attempt_events:
+                if not _event_belongs_to_linked_session(event, snapshot):
+                    continue
+                try:
+                    judgment = validate_attempt_judgment_payload(
+                        event.data,
+                        event_type=event.type,
+                        aggregate_id=event.aggregate_id,
+                        expected_execution_id=snapshot.links.execution_id,
+                        expected_session_id=snapshot.links.session_id,
+                    )
+                except ValueError:
+                    # A malformed linked attempt is not trustworthy recovery
+                    # evidence. Fail closed instead of laundering it into a job
+                    # failure or falling back to another retry marker.
+                    return None
+                if not judgment.success:
+                    failed_attempt_events.append(event)
+
+            final_acceptance_events = await self._event_store.query_events(
+                aggregate_id=snapshot.links.execution_id,
+                event_type="execution.ac.acceptance_finalized",
+                limit=None,
+            )
+            scoped_final_acceptance_events = [
+                event
+                for event in final_acceptance_events
+                if _event_belongs_to_linked_session(event, snapshot)
+            ]
+            if scoped_final_acceptance_events:
+                # A current-session final event without its complete atomic
+                # terminal plan is malformed historical state, not trustworthy
+                # failure proof.
+                return None
+
+            # Provisional failed attempts are diagnostic only and must never
+            # determine terminal job disposition.  A dead owner with only
+            # attempt telemetry is interrupted by the owner-recovery path;
+            # only durable terminal/session failure evidence may become a
+            # linked MCP failure.
+            if not terminal_failure_events and (
+                not failed_session_events or not allow_nonterminal_evidence
+            ):
+                return None
+            failed_outcomes = failed_attempt_events
         if not terminal_failure_events and not failed_session_events and not failed_outcomes:
             return None
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -1424,17 +1424,29 @@ class JobManager:
         final_acceptance_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="execution.ac.acceptance_finalized",
-            limit=20,
+            limit=None,
         )
-        failed_outcomes = [
-            event
-            for event in [*failed_attempt_events, *final_acceptance_events]
-            if event.data.get("success") is False
-            or event.data.get("accepted") is False
-            or str(event.data.get("outcome") or "").casefold() == "failed"
-            or str(event.data.get("disposition") or "").casefold()
-            in {"rejected", "blocked", "cancelled"}
-        ]
+        # A final acceptance is the Final Gate's authoritative disposition.
+        # Provisional failed attempts are diagnostic only and must not
+        # override a later accepted final event during dead-owner recovery.
+        if final_acceptance_events:
+            failed_outcomes = [
+                event
+                for event in final_acceptance_events
+                if event.data.get("accepted") is False
+                or str(event.data.get("outcome") or "").casefold() == "failed"
+                or str(event.data.get("disposition") or "").casefold()
+                in {"rejected", "blocked", "cancelled"}
+            ]
+        else:
+            failed_outcomes = [
+                event
+                for event in failed_attempt_events
+                if event.data.get("success") is False
+                or str(event.data.get("outcome") or "").casefold() == "failed"
+                or str(event.data.get("disposition") or "").casefold()
+                in {"rejected", "blocked", "cancelled"}
+            ]
         if not terminal_failure_events and not failed_session_events and not failed_outcomes:
             return None
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -30,7 +30,11 @@ from ouroboros.orchestrator.heartbeat import (
     is_process_identity_alive,
 )
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
-from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.orchestrator.session import (
+    ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY,
+    SessionRepository,
+    SessionStatus,
+)
 from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import (
     EventStore,
@@ -2220,13 +2224,11 @@ class JobManager:
                     collect_cancellation_acceptance_plan,
                 )
 
-                raw_total_acs = latest_session.value.progress.get("total_acceptance_criteria")
+                raw_root_indices = latest_session.value.progress.get(
+                    ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY
+                )
                 expected_root_indices = (
-                    range(raw_total_acs)
-                    if isinstance(raw_total_acs, int)
-                    and not isinstance(raw_total_acs, bool)
-                    and raw_total_acs >= 0
-                    else None
+                    tuple(raw_root_indices) if isinstance(raw_root_indices, (list, tuple)) else None
                 )
                 acceptance_finalizations = await collect_cancellation_acceptance_plan(
                     session_id=snapshot.links.session_id,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -1328,6 +1328,16 @@ class JobManager:
                 limit=None,
             )
             if not final_acceptance_events:
+                # An explicit empty plan is authoritative for a valid zero-AC
+                # execution.  A missing plan remains inconclusive and must not
+                # be promoted to a completed MCP job.
+                if session_completed.data.get("acceptance_finalizations") == []:
+                    summary = session_completed.data.get("summary")
+                    if isinstance(summary, dict):
+                        final_message = summary.get("final_message")
+                        if isinstance(final_message, str) and final_message.strip():
+                            return final_message.strip()
+                    return "Execution complete"
                 return None
             for acceptance_event in final_acceptance_events:
                 try:
@@ -2206,10 +2216,37 @@ class JobManager:
                 SessionStatus.CANCELLED,
             }
             if not latest_terminal:
-                cancel_result = await repo.mark_cancelled(
+                from ouroboros.orchestrator.execution_authority import (
+                    collect_cancellation_acceptance_plan,
+                )
+
+                raw_total_acs = latest_session.value.progress.get("total_acceptance_criteria")
+                expected_root_indices = (
+                    range(raw_total_acs)
+                    if isinstance(raw_total_acs, int)
+                    and not isinstance(raw_total_acs, bool)
+                    and raw_total_acs >= 0
+                    else None
+                )
+                acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                    session_id=snapshot.links.session_id,
+                    execution_id=snapshot.links.execution_id or latest_session.value.execution_id,
+                    event_store=self._event_store,
+                    expected_root_indices=expected_root_indices,
+                )
+                mark_cancelled = repo.mark_cancelled
+                mark_cancelled_kwargs: dict[str, Any] = {
+                    "reason": "Background job cancelled",
+                    "cancelled_by": "mcp_job_manager",
+                }
+                # Preserve compatibility with injected legacy repositories;
+                # the production SessionRepository accepts the plan-bearing
+                # terminal CAS above.
+                if "acceptance_finalizations" in inspect.signature(mark_cancelled).parameters:
+                    mark_cancelled_kwargs["acceptance_finalizations"] = acceptance_finalizations
+                cancel_result = await mark_cancelled(
                     snapshot.links.session_id,
-                    reason="Background job cancelled",
-                    cancelled_by="mcp_job_manager",
+                    **mark_cancelled_kwargs,
                 )
                 if cancel_result.is_err:
                     raise ValueError(

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -32,7 +32,10 @@ from ouroboros.orchestrator.heartbeat import (
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.checkpoint import CheckpointStore
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import (
+    EventStore,
+    validate_acceptance_finalization_payload,
+)
 
 
 class JobStatus(StrEnum):
@@ -1299,9 +1302,55 @@ class JobManager:
             event_type="execution.terminal",
             limit=1,
         )
-        if not terminal_events:
-            return None
-        terminal_data = terminal_events[0].data
+        terminal_data = terminal_events[0].data if terminal_events else None
+        if terminal_data is None:
+            # Foundation B commits the session terminal event and all final
+            # acceptance events atomically. The older execution.terminal
+            # projection can still be missing after a crash, so recover from
+            # that authoritative state instead of manufacturing INTERRUPTED.
+            session_id = snapshot.links.session_id
+            if not session_id:
+                return None
+            session_events = await self._event_store.replay("session", session_id)
+            session_completed = next(
+                (
+                    event
+                    for event in reversed(session_events)
+                    if event.type == "orchestrator.session.completed"
+                ),
+                None,
+            )
+            if session_completed is None:
+                return None
+            final_acceptance_events = await self._event_store.query_events(
+                aggregate_id=snapshot.links.execution_id,
+                event_type="execution.ac.acceptance_finalized",
+                limit=None,
+            )
+            if not final_acceptance_events:
+                return None
+            for acceptance_event in final_acceptance_events:
+                try:
+                    validate_acceptance_finalization_payload(
+                        acceptance_event.data,
+                        aggregate_id=acceptance_event.aggregate_id,
+                    )
+                except PersistenceError:
+                    return None
+                data = acceptance_event.data
+                if (
+                    data.get("session_id") != session_id
+                    or data.get("execution_id") != snapshot.links.execution_id
+                    or data.get("terminal_status") != "completed"
+                    or data.get("accepted") is not True
+                ):
+                    return None
+            summary = session_completed.data.get("summary")
+            if isinstance(summary, dict):
+                final_message = summary.get("final_message")
+                if isinstance(final_message, str) and final_message.strip():
+                    return final_message.strip()
+            return "Execution complete"
         if terminal_data.get("status") != "completed":
             return None
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -145,10 +145,17 @@ def _event_belongs_to_linked_session(event: BaseEvent, snapshot: JobSnapshot) ->
     execution_id = snapshot.links.execution_id
     if not session_id or not execution_id:
         return False
-    if event.aggregate_id != execution_id:
-        return False
     data = event.data
-    return data.get("session_id") == session_id
+    if event.aggregate_id != execution_id and data.get("execution_id") != execution_id:
+        return False
+    orchestrator_session_id = data.get("orchestrator_session_id")
+    if orchestrator_session_id is not None:
+        return orchestrator_session_id == session_id
+    # Parent execution projections historically stored the orchestration
+    # session directly in ``session_id``. Child runtime lifecycle events must
+    # carry the explicit field above; without it, a child aggregate is not
+    # trusted as evidence for a parent job.
+    return event.aggregate_id == execution_id and data.get("session_id") == session_id
 
 
 _JOB_TTL = timedelta(hours=1)
@@ -1686,6 +1693,7 @@ class JobManager:
                 return None
             terminal_failure_events = [authoritative.terminal_event]
             failed_session_events: list[BaseEvent] = []
+            foreign_failed_session_events: list[BaseEvent] = []
             failed_outcomes = [
                 event
                 for event in authoritative.acceptance_events
@@ -1717,14 +1725,23 @@ class JobManager:
                     return None
                 terminal_failure_events.append(terminal_event)
 
-            failed_session_events = [
-                event
-                for event in await self._event_store.query_execution_related_events(
+            all_failed_session_events = list(
+                await self._event_store.query_execution_related_events(
                     snapshot.links.execution_id,
                     event_type="execution.session.failed",
                     limit=None,
                 )
+            )
+            failed_session_events = [
+                event
+                for event in all_failed_session_events
+                if _event_belongs_to_linked_session(event, snapshot)
+            ]
+            foreign_failed_session_events = [
+                event
+                for event in all_failed_session_events
                 if event.data.get("execution_id") == snapshot.links.execution_id
+                and not _event_belongs_to_linked_session(event, snapshot)
             ]
 
             raw_attempt_events = await self._event_store.query_events(
@@ -1741,6 +1758,7 @@ class JobManager:
                 )
             )
             failed_attempt_events: list[BaseEvent] = []
+            failed_legacy_outcome_events: list[BaseEvent] = []
             for event in raw_attempt_events:
                 if not _event_belongs_to_linked_session(event, snapshot):
                     continue
@@ -1759,6 +1777,8 @@ class JobManager:
                     return None
                 if not judgment.success:
                     failed_attempt_events.append(event)
+                    if event.type == "execution.ac.outcome_finalized":
+                        failed_legacy_outcome_events.append(event)
 
             final_acceptance_events = await self._event_store.query_events(
                 aggregate_id=snapshot.links.execution_id,
@@ -1776,13 +1796,15 @@ class JobManager:
                 # failure proof.
                 return None
 
-            # Provisional failed attempts are diagnostic only and must never
-            # determine terminal job disposition.  A dead owner with only
-            # attempt telemetry is interrupted by the owner-recovery path;
-            # only durable terminal/session failure evidence may become a
-            # linked MCP failure.
-            if not terminal_failure_events and (
-                not failed_session_events or not allow_nonterminal_evidence
+            # Current ``attempt_judged`` failures are diagnostic only and must
+            # never determine terminal job disposition. A dead owner with only
+            # that provisional telemetry is interrupted by owner recovery. The
+            # historical ``outcome_finalized`` alias remains a compatibility
+            # fallback for pre-Foundation-B sessions.
+            if (
+                not terminal_failure_events
+                and not failed_session_events
+                and (not failed_legacy_outcome_events or not allow_nonterminal_evidence)
             ):
                 return None
             failed_outcomes = failed_attempt_events
@@ -1790,7 +1812,8 @@ class JobManager:
             return None
 
         detail = None
-        for event in [*terminal_failure_events, *failed_session_events, *failed_outcomes]:
+        detail_events = [*terminal_failure_events, *failed_session_events, *failed_outcomes]
+        for event in detail_events:
             data = event.data
             for key in ("error", "error_message", "final_message", "message"):
                 value = data.get(key)
@@ -1799,6 +1822,19 @@ class JobManager:
                     break
             if detail:
                 break
+        if not detail and failed_outcomes and foreign_failed_session_events:
+            # A foreign child session never contributes failure evidence. Its
+            # diagnostic text may still explain a target-session failure that
+            # is already established by a target outcome-finalized event.
+            for event in foreign_failed_session_events:
+                data = event.data
+                for key in ("error", "error_message", "final_message", "message"):
+                    value = data.get(key)
+                    if isinstance(value, str) and value.strip():
+                        detail = value.strip()
+                        break
+                if detail:
+                    break
 
         base = (
             "Linked execution failed before the MCP job reached a terminal event "

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -1408,16 +1408,32 @@ class JobManager:
             event_type="execution.session.failed",
             limit=None,
         )
-        failed_outcome_events = await self._event_store.query_events(
+        failed_attempt_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
-            event_type="execution.ac.outcome_finalized",
+            event_type="execution.ac.attempt_judged",
+            limit=20,
+        )
+        # Keep the historical event name readable for pre-Foundation-B runs.
+        failed_attempt_events.extend(
+            await self._event_store.query_events(
+                aggregate_id=snapshot.links.execution_id,
+                event_type="execution.ac.outcome_finalized",
+                limit=20,
+            )
+        )
+        final_acceptance_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="execution.ac.acceptance_finalized",
             limit=20,
         )
         failed_outcomes = [
             event
-            for event in failed_outcome_events
+            for event in [*failed_attempt_events, *final_acceptance_events]
             if event.data.get("success") is False
+            or event.data.get("accepted") is False
             or str(event.data.get("outcome") or "").casefold() == "failed"
+            or str(event.data.get("disposition") or "").casefold()
+            in {"rejected", "blocked", "cancelled"}
         ]
         if not terminal_failure_events and not failed_session_events and not failed_outcomes:
             return None

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -1570,7 +1570,7 @@ class JobManager:
         terminal_event = next(
             (
                 event
-                for event in reversed(terminal_events)
+                for event in terminal_events
                 if _event_belongs_to_linked_session(event, snapshot)
             ),
             None,
@@ -1589,7 +1589,7 @@ class JobManager:
         workflow_event = next(
             (
                 event
-                for event in reversed(workflow_events)
+                for event in workflow_events
                 if _event_belongs_to_linked_session(event, snapshot)
             ),
             None,
@@ -1620,7 +1620,7 @@ class JobManager:
         terminal_event = next(
             (
                 event
-                for event in reversed(terminal_events)
+                for event in terminal_events
                 if _event_belongs_to_linked_session(event, snapshot)
             ),
             None,
@@ -1636,7 +1636,7 @@ class JobManager:
         workflow_event = next(
             (
                 event
-                for event in reversed(workflow_events)
+                for event in workflow_events
                 if _event_belongs_to_linked_session(event, snapshot)
             ),
             None,
@@ -1712,7 +1712,7 @@ class JobManager:
             terminal_event = next(
                 (
                     event
-                    for event in reversed(terminal_events)
+                    for event in terminal_events
                     if _event_belongs_to_linked_session(event, snapshot)
                 ),
                 None,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -89,6 +89,15 @@ class JobSnapshot:
             JobStatus.CANCELLED,
             JobStatus.INTERRUPTED,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class _AuthoritativeSessionAcceptance:
+    """Validated terminal session plan and its atomically persisted events."""
+
+    terminal_status: str
+    terminal_event: BaseEvent
+    acceptance_events: tuple[BaseEvent, ...]
 
 
 def _safe_meta(value: Any) -> Any:
@@ -1289,6 +1298,187 @@ class JobManager:
         )
         return True
 
+    async def _read_authoritative_session_acceptance(
+        self,
+        snapshot: JobSnapshot,
+    ) -> _AuthoritativeSessionAcceptance | None:
+        """Validate the complete Foundation B terminal plan for one linked session.
+
+        ``None`` means that no Foundation B terminal plan is present. A present
+        but malformed, incomplete, mis-scoped, or partially persisted plan raises
+        ``PersistenceError`` so recovery fails closed instead of falling back to
+        provisional attempt telemetry.
+        """
+        session_id = snapshot.links.session_id
+        execution_id = snapshot.links.execution_id
+        if not session_id or not execution_id:
+            return None
+
+        session_events = await self._event_store.replay("session", session_id)
+        start_event = next(
+            (event for event in session_events if event.type == "orchestrator.session.started"),
+            None,
+        )
+        if start_event is None:
+            return None
+        if start_event.data.get("execution_id") != execution_id:
+            raise PersistenceError(
+                "Linked session start belongs to a different execution.",
+                operation="mcp_recover_authoritative_acceptance",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+
+        terminal_event = next(
+            (
+                event
+                for event in reversed(session_events)
+                if event.type
+                in {
+                    "orchestrator.session.completed",
+                    "orchestrator.session.failed",
+                    "orchestrator.session.cancelled",
+                }
+            ),
+            None,
+        )
+        if terminal_event is None or "acceptance_finalizations" not in terminal_event.data:
+            return None
+        terminal_status = {
+            "orchestrator.session.completed": "completed",
+            "orchestrator.session.failed": "failed",
+            "orchestrator.session.cancelled": "cancelled",
+        }[terminal_event.type]
+        raw_plan = terminal_event.data.get("acceptance_finalizations")
+        if not isinstance(raw_plan, list):
+            raise PersistenceError(
+                "Linked terminal session has a malformed acceptance plan.",
+                operation="mcp_recover_authoritative_acceptance",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+
+        expected_roots: set[int] | None = None
+        if ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY in start_event.data:
+            raw_roots = start_event.data[ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY]
+            if not isinstance(raw_roots, list):
+                raise PersistenceError(
+                    "Linked session has a malformed durable acceptance root set.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            expected_roots = set()
+            for raw_root in raw_roots:
+                if (
+                    isinstance(raw_root, bool)
+                    or not isinstance(raw_root, int)
+                    or raw_root < 0
+                    or raw_root in expected_roots
+                ):
+                    raise PersistenceError(
+                        "Linked session has an invalid durable acceptance root set.",
+                        operation="mcp_recover_authoritative_acceptance",
+                        details={"session_id": session_id, "execution_id": execution_id},
+                    )
+                expected_roots.add(raw_root)
+
+        planned_by_root: dict[int, dict[str, Any]] = {}
+        for raw_payload in raw_plan:
+            if not isinstance(raw_payload, Mapping):
+                raise PersistenceError(
+                    "Linked terminal acceptance plan contains a malformed entry.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            payload = dict(raw_payload)
+            try:
+                _generation, root = validate_acceptance_finalization_payload(
+                    payload,
+                    aggregate_id=execution_id,
+                )
+            except PersistenceError as exc:
+                raise PersistenceError(
+                    "Linked terminal acceptance plan contains invalid final evidence.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                ) from exc
+            if (
+                payload.get("session_id") != session_id
+                or payload.get("execution_id") != execution_id
+                or payload.get("terminal_status") != terminal_status
+            ):
+                raise PersistenceError(
+                    "Linked terminal acceptance plan is mis-scoped.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            existing = planned_by_root.get(root)
+            if existing is not None:
+                raise PersistenceError(
+                    "Linked terminal acceptance plan contains duplicate root decisions.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            planned_by_root[root] = payload
+
+        if expected_roots is not None and set(planned_by_root) != expected_roots:
+            raise PersistenceError(
+                "Linked terminal acceptance plan is incomplete for its durable root set.",
+                operation="mcp_recover_authoritative_acceptance",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "expected_root_indices": sorted(expected_roots),
+                    "planned_root_indices": sorted(planned_by_root),
+                },
+            )
+
+        all_final_events = await self._event_store.query_events(
+            aggregate_id=execution_id,
+            event_type="execution.ac.acceptance_finalized",
+            limit=None,
+        )
+        scoped_events = tuple(
+            event for event in all_final_events if event.data.get("session_id") == session_id
+        )
+        persisted_by_root: dict[int, dict[str, Any]] = {}
+        for acceptance_event in scoped_events:
+            try:
+                _generation, root = validate_acceptance_finalization_payload(
+                    acceptance_event.data,
+                    aggregate_id=acceptance_event.aggregate_id,
+                )
+            except PersistenceError as exc:
+                raise PersistenceError(
+                    "Linked session contains malformed persisted final acceptance.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                ) from exc
+            payload = dict(acceptance_event.data)
+            existing = persisted_by_root.get(root)
+            if existing is not None:
+                raise PersistenceError(
+                    "Linked session contains duplicate persisted final acceptance.",
+                    operation="mcp_recover_authoritative_acceptance",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            persisted_by_root[root] = payload
+
+        if persisted_by_root != planned_by_root:
+            raise PersistenceError(
+                "Linked terminal plan and persisted final acceptance set disagree.",
+                operation="mcp_recover_authoritative_acceptance",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "planned_root_indices": sorted(planned_by_root),
+                    "persisted_root_indices": sorted(persisted_by_root),
+                },
+            )
+        return _AuthoritativeSessionAcceptance(
+            terminal_status=terminal_status,
+            terminal_event=terminal_event,
+            acceptance_events=scoped_events,
+        )
+
     async def _derive_completed_execution_result(self, snapshot: JobSnapshot) -> str | None:
         """Return a terminal result when linked execution state proves completion.
 
@@ -1312,54 +1502,17 @@ class JobManager:
             # acceptance events atomically. The older execution.terminal
             # projection can still be missing after a crash, so recover from
             # that authoritative state instead of manufacturing INTERRUPTED.
-            session_id = snapshot.links.session_id
-            if not session_id:
+            try:
+                authoritative = await self._read_authoritative_session_acceptance(snapshot)
+            except PersistenceError:
                 return None
-            session_events = await self._event_store.replay("session", session_id)
-            session_completed = next(
-                (
-                    event
-                    for event in reversed(session_events)
-                    if event.type == "orchestrator.session.completed"
-                ),
-                None,
-            )
-            if session_completed is None:
+            if authoritative is None or authoritative.terminal_status != "completed":
                 return None
-            final_acceptance_events = await self._event_store.query_events(
-                aggregate_id=snapshot.links.execution_id,
-                event_type="execution.ac.acceptance_finalized",
-                limit=None,
-            )
-            if not final_acceptance_events:
-                # An explicit empty plan is authoritative for a valid zero-AC
-                # execution.  A missing plan remains inconclusive and must not
-                # be promoted to a completed MCP job.
-                if session_completed.data.get("acceptance_finalizations") == []:
-                    summary = session_completed.data.get("summary")
-                    if isinstance(summary, dict):
-                        final_message = summary.get("final_message")
-                        if isinstance(final_message, str) and final_message.strip():
-                            return final_message.strip()
-                    return "Execution complete"
+            if any(
+                event.data.get("accepted") is not True for event in authoritative.acceptance_events
+            ):
                 return None
-            for acceptance_event in final_acceptance_events:
-                try:
-                    validate_acceptance_finalization_payload(
-                        acceptance_event.data,
-                        aggregate_id=acceptance_event.aggregate_id,
-                    )
-                except PersistenceError:
-                    return None
-                data = acceptance_event.data
-                if (
-                    data.get("session_id") != session_id
-                    or data.get("execution_id") != snapshot.links.execution_id
-                    or data.get("terminal_status") != "completed"
-                    or data.get("accepted") is not True
-                ):
-                    return None
-            summary = session_completed.data.get("summary")
+            summary = authoritative.terminal_event.data.get("summary")
             if isinstance(summary, dict):
                 final_message = summary.get("final_message")
                 if isinstance(final_message, str) and final_message.strip():
@@ -1463,9 +1616,6 @@ class JobManager:
             if status not in {"failed", "cancelled", "interrupted"}:
                 return None
             terminal_failure_events.append(terminal_events[0])
-        if not terminal_failure_events and not allow_nonterminal_evidence:
-            return None
-
         failed_session_events = await self._event_store.query_execution_related_events(
             snapshot.links.execution_id,
             event_type="execution.session.failed",
@@ -1489,19 +1639,34 @@ class JobManager:
             event_type="execution.ac.acceptance_finalized",
             limit=None,
         )
+        scoped_final_acceptance_events = [
+            event
+            for event in final_acceptance_events
+            if event.data.get("session_id") == snapshot.links.session_id
+        ]
+        try:
+            authoritative = await self._read_authoritative_session_acceptance(snapshot)
+        except PersistenceError:
+            return None
+        if authoritative is not None:
+            if authoritative.terminal_status == "completed":
+                return None
+            terminal_failure_events.append(authoritative.terminal_event)
+            failed_outcomes = [
+                event
+                for event in authoritative.acceptance_events
+                if event.data.get("accepted") is False
+            ]
+        elif scoped_final_acceptance_events:
+            # A current-session final event without its complete atomic terminal
+            # plan is malformed historical state, not trustworthy failure proof.
+            return None
         # A final acceptance is the Final Gate's authoritative disposition.
         # Provisional failed attempts are diagnostic only and must not
         # override a later accepted final event during dead-owner recovery.
-        if final_acceptance_events:
-            failed_outcomes = [
-                event
-                for event in final_acceptance_events
-                if event.data.get("accepted") is False
-                or str(event.data.get("outcome") or "").casefold() == "failed"
-                or str(event.data.get("disposition") or "").casefold()
-                in {"rejected", "blocked", "cancelled"}
-            ]
         else:
+            if not terminal_failure_events and not allow_nonterminal_evidence:
+                return None
             failed_outcomes = [
                 event
                 for event in failed_attempt_events

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -66,12 +66,37 @@ def _strings(value: object, *, limit: int = _MAX_LIST) -> list[str]:
     return result
 
 
+def _is_session_scoped_event(event: BaseEvent) -> bool:
+    return event.type.startswith(("execution.", "control.session.signal."))
+
+
+def _event_session_id(event: BaseEvent) -> str | None:
+    """Return the authoritative orchestration session carried by an event.
+
+    Execution and Synapse control events can share an aggregate across
+    concurrent orchestration sessions.  New events carry the explicit
+    ``orchestrator_session_id`` field; older execution projections used
+    ``session_id``.  An explicit field always wins so a stale fallback cannot
+    make a foreign event look local.
+    """
+    if not _is_session_scoped_event(event):
+        return None
+    data = event.data
+    explicit = data.get("orchestrator_session_id")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit
+    legacy = data.get("session_id")
+    if isinstance(legacy, str) and legacy.strip():
+        return legacy
+    return None
+
+
 def _scope(event: BaseEvent, *, job_id: str | None) -> dict[str, object]:
     data = event.data
     return {
         "job_id": job_id,
         "execution_id": _text(data.get("execution_id"), limit=96),
-        "session_id": _text(data.get("session_id"), limit=96),
+        "session_id": _text(_event_session_id(event), limit=96),
         "lineage_id": _text(data.get("lineage_id"), limit=96),
         "semantic_ac_key": _text(data.get("semantic_ac_key"), limit=96),
         "root_ac_index": (
@@ -209,26 +234,6 @@ def _event_order(events: Iterable[BaseEvent]) -> list[BaseEvent]:
     return sorted(events, key=lambda event: (event.timestamp, event.id))
 
 
-def _execution_event_session_id(event: BaseEvent) -> str | None:
-    """Return the authoritative orchestration session carried by an event.
-
-    Execution aggregates are shared by multiple orchestration sessions.  New
-    runtime events carry the explicit ``orchestrator_session_id`` field; older
-    parent projections used ``session_id``.  An explicit field always wins so
-    a stale fallback cannot make a foreign event look local.
-    """
-    if not event.type.startswith("execution."):
-        return None
-    data = event.data
-    explicit = data.get("orchestrator_session_id")
-    if isinstance(explicit, str) and explicit.strip():
-        return explicit
-    legacy = data.get("session_id")
-    if isinstance(legacy, str) and legacy.strip():
-        return legacy
-    return None
-
-
 def _history_for_session(
     history_events: Iterable[BaseEvent], *, session_id: str | None
 ) -> list[BaseEvent]:
@@ -244,8 +249,7 @@ def _history_for_session(
     return [
         event
         for event in history_events
-        if not event.type.startswith("execution.")
-        or _execution_event_session_id(event) == session_id
+        if not _is_session_scoped_event(event) or _event_session_id(event) == session_id
     ]
 
 

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -227,6 +227,7 @@ def _proactive_relays(
     new_event_ids: set[str],
     *,
     job_id: str | None,
+    session_id: str | None,
 ) -> list[dict[str, object]]:
     relays: list[dict[str, object]] = []
     last_route_by_ac: dict[str, tuple[object, ...]] = {}
@@ -400,6 +401,12 @@ def _proactive_relays(
                 )
             )
         elif event.type == "execution.ac.acceptance_finalized":
+            # A linked execution stream may contain multiple orchestration
+            # sessions. Final acceptance is authority-bearing and must only be
+            # relayed for the job's linked session; exposing another session's
+            # acceptance under this job is a false progress claim.
+            if session_id is not None and data.get("session_id") != session_id:
+                continue
             relays.append(
                 _progress(
                     event,
@@ -444,6 +451,7 @@ def classify_relay_events(
     *,
     new_event_ids: set[str] | None = None,
     job_id: str | None = None,
+    session_id: str | None = None,
     available_tools: Set[str] | None = None,
 ) -> list[dict[str, object]]:
     """Classify bounded proactive and attention relay envelopes.
@@ -455,7 +463,12 @@ def classify_relay_events(
     history = _event_order(history_events)
     registered = available_tools or frozenset()
     new_ids = new_event_ids if new_event_ids is not None else {event.id for event in history}
-    relays = _proactive_relays(history, new_ids, job_id=job_id)
+    relays = _proactive_relays(
+        history,
+        new_ids,
+        job_id=job_id,
+        session_id=session_id,
+    )
 
     recovery_by_key: dict[str, BaseEvent] = {}
     for event in history:

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -381,14 +381,10 @@ def _proactive_relays(
                     },
                 )
             )
-        elif (
-            event.type
-            in {
-                "execution.ac.attempt_judged",
-                "execution.ac.outcome_finalized",
-            }
-            and data.get("success") is True
-        ):
+        elif event.type in {
+            "execution.ac.attempt_judged",
+            "execution.ac.outcome_finalized",
+        }:
             relays.append(
                 _progress(
                     event,

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -209,6 +209,46 @@ def _event_order(events: Iterable[BaseEvent]) -> list[BaseEvent]:
     return sorted(events, key=lambda event: (event.timestamp, event.id))
 
 
+def _execution_event_session_id(event: BaseEvent) -> str | None:
+    """Return the authoritative orchestration session carried by an event.
+
+    Execution aggregates are shared by multiple orchestration sessions.  New
+    runtime events carry the explicit ``orchestrator_session_id`` field; older
+    parent projections used ``session_id``.  An explicit field always wins so
+    a stale fallback cannot make a foreign event look local.
+    """
+    if not event.type.startswith("execution."):
+        return None
+    data = event.data
+    explicit = data.get("orchestrator_session_id")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit
+    legacy = data.get("session_id")
+    if isinstance(legacy, str) and legacy.strip():
+        return legacy
+    return None
+
+
+def _history_for_session(
+    history_events: Iterable[BaseEvent], *, session_id: str | None
+) -> list[BaseEvent]:
+    """Drop unscoped/foreign execution evidence before any relay correlation.
+
+    Job and lineage events remain available because those aggregates are the
+    relay's own scope.  Execution events, however, may be interleaved for
+    several sessions under one execution id and must be fail-closed when a
+    linked session is known.
+    """
+    if session_id is None:
+        return list(history_events)
+    return [
+        event
+        for event in history_events
+        if not event.type.startswith("execution.")
+        or _execution_event_session_id(event) == session_id
+    ]
+
+
 def _latest_configuration_before(
     history: Sequence[BaseEvent],
     target: BaseEvent,
@@ -460,7 +500,10 @@ def classify_relay_events(
     ``new_event_ids`` limits emission to the current cursor page; omitting it
     performs the terminal full-history scan.
     """
-    history = _event_order(history_events)
+    # A linked execution aggregate can contain evidence from more than one
+    # orchestration session.  Filter before building route/recovery streaks so
+    # foreign events cannot create actionable or progress relays for this job.
+    history = _event_order(_history_for_session(history_events, session_id=session_id))
     registered = available_tools or frozenset()
     new_ids = new_event_ids if new_event_ids is not None else {event.id for event in history}
     relays = _proactive_relays(

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -381,10 +381,14 @@ def _proactive_relays(
                     },
                 )
             )
-        elif event.type in {
-            "execution.ac.attempt_judged",
-            "execution.ac.outcome_finalized",
-        } and data.get("success") is True:
+        elif (
+            event.type
+            in {
+                "execution.ac.attempt_judged",
+                "execution.ac.outcome_finalized",
+            }
+            and data.get("success") is True
+        ):
             relays.append(
                 _progress(
                     event,
@@ -404,9 +408,7 @@ def _proactive_relays(
                 _progress(
                     event,
                     kind="progress_advanced",
-                    subtype=(
-                        "ac_accepted" if data.get("accepted") is True else "ac_rejected"
-                    ),
+                    subtype=("ac_accepted" if data.get("accepted") is True else "ac_rejected"),
                     job_id=job_id,
                     evidence={
                         "root_ac_index": data.get("root_ac_index"),

--- a/src/ouroboros/mcp/tools/attention_relay.py
+++ b/src/ouroboros/mcp/tools/attention_relay.py
@@ -29,7 +29,9 @@ PROACTIVE_SOURCE_EVENT_TYPES = frozenset(
         "execution.decomposition.level_completed",
         "execution.ac.model_routed",
         "execution.ac.alt_harness_redispatched",
+        "execution.ac.attempt_judged",
         "execution.ac.outcome_finalized",
+        "execution.ac.acceptance_finalized",
         "control.session.signal.queued",
         "control.session.signal.applied",
         "control.session.signal.completed",
@@ -379,17 +381,39 @@ def _proactive_relays(
                     },
                 )
             )
-        elif event.type == "execution.ac.outcome_finalized" and data.get("success") is True:
+        elif event.type in {
+            "execution.ac.attempt_judged",
+            "execution.ac.outcome_finalized",
+        } and data.get("success") is True:
             relays.append(
                 _progress(
                     event,
                     kind="progress_advanced",
-                    subtype="ac_verified",
+                    subtype="ac_attempt_judged",
                     job_id=job_id,
                     evidence={
                         "root_ac_index": data.get("root_ac_index"),
                         "retry_attempt": data.get("retry_attempt"),
+                        "attempt_number": data.get("attempt_number"),
                         "outcome": data.get("outcome"),
+                    },
+                )
+            )
+        elif event.type == "execution.ac.acceptance_finalized":
+            relays.append(
+                _progress(
+                    event,
+                    kind="progress_advanced",
+                    subtype=(
+                        "ac_accepted" if data.get("accepted") is True else "ac_rejected"
+                    ),
+                    job_id=job_id,
+                    evidence={
+                        "root_ac_index": data.get("root_ac_index"),
+                        "final_retry_attempt": data.get("final_retry_attempt"),
+                        "accepted": data.get("accepted"),
+                        "disposition": data.get("disposition"),
+                        "terminal_status": data.get("terminal_status"),
                     },
                 )
             )

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -78,6 +78,7 @@ from ouroboros.orchestrator.execution_authority import (
     _has_live_process_local_authority_registration,
     _register_process_local_authority_terminal_finalizer,
     _retire_process_local_authority_after_terminal_persistence,
+    collect_terminal_acceptance_plan,
     valid_process_local_authority_contract,
 )
 from ouroboros.orchestrator.heartbeat import is_holder_alive
@@ -1754,6 +1755,53 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     # cancellation, which reaches the cleanup below.
                     background_started = True
                     try:
+
+                        async def _mark_background_failed(error_message: str) -> Any:
+                            """Persist fallback failure through Foundation B's terminal plan."""
+                            acceptance_finalizations: list[dict[str, Any]] | None = None
+                            try:
+                                acceptance_finalizations = await collect_terminal_acceptance_plan(
+                                    session_id=_tracker.session_id,
+                                    execution_id=_tracker.execution_id,
+                                    event_store=_event_store,
+                                    terminal_status="failed",
+                                )
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception as exc:
+                                # A current-format EventStore rejects a missing or
+                                # incomplete plan, preserving fail-closed semantics;
+                                # historical/mock repositories retain compatibility.
+                                log.warning(
+                                    "mcp.tool.execute_seed.background_failure_plan_unavailable",
+                                    session_id=_tracker.session_id,
+                                    execution_id=_tracker.execution_id,
+                                    error=str(exc),
+                                )
+                            mark_failed_kwargs: dict[str, Any] = {
+                                "error_message": error_message,
+                            }
+                            try:
+                                supports_plan = (
+                                    "acceptance_finalizations"
+                                    in inspect.signature(_session_repo.mark_failed).parameters
+                                )
+                            except (TypeError, ValueError):
+                                supports_plan = False
+                            if supports_plan:
+                                # An explicit empty plan is valid for historical
+                                # zero-root sessions and is rejected by current
+                                # EventStore sessions whose durable roots differ.
+                                mark_failed_kwargs["acceptance_finalizations"] = (
+                                    acceptance_finalizations
+                                    if acceptance_finalizations is not None
+                                    else []
+                                )
+                            return await _session_repo.mark_failed(
+                                _tracker.session_id,
+                                **mark_failed_kwargs,
+                            )
+
                         if _resume_existing:
                             result = await _runner.resume_session(_tracker.session_id, _seed)
                         else:
@@ -1775,10 +1823,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                     resume_blocked=result.error.details.get("resume_blocked"),
                                 )
                                 return
-                            mark_result = await _session_repo.mark_failed(
-                                _tracker.session_id,
-                                error_message=str(result.error),
-                            )
+                            mark_result = await _mark_background_failed(str(result.error))
                             if mark_result.is_err:
                                 log.error(
                                     "mcp.tool.execute_seed.background_mark_failed_error",
@@ -1839,9 +1884,8 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             session_id=_tracker.session_id,
                         )
                         try:
-                            mark_result = await _session_repo.mark_failed(
-                                _tracker.session_id,
-                                error_message="Unexpected error in background execution",
+                            mark_result = await _mark_background_failed(
+                                "Unexpected error in background execution"
                             )
                             if mark_result.is_err:
                                 log.error(

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -43,7 +43,11 @@ from ouroboros.orchestrator.execution_authority import (
     ProcessLocalCancellationDisposition,
     request_process_local_cancellation,
 )
-from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.orchestrator.session import (
+    ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY,
+    SessionRepository,
+    SessionStatus,
+)
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
@@ -875,13 +879,9 @@ class CancelExecutionHandler:
                 collect_cancellation_acceptance_plan,
             )
 
-            raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+            raw_root_indices = tracker.progress.get(ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY)
             expected_root_indices = (
-                range(raw_total_acs)
-                if isinstance(raw_total_acs, int)
-                and not isinstance(raw_total_acs, bool)
-                and raw_total_acs >= 0
-                else None
+                tuple(raw_root_indices) if isinstance(raw_root_indices, (list, tuple)) else None
             )
             acceptance_finalizations = await collect_cancellation_acceptance_plan(
                 session_id=tracker.session_id,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -1791,6 +1791,7 @@ class JobWaitHandler:
                 history_events,
                 new_event_ids=new_event_ids,
                 job_id=snapshot.job_id,
+                session_id=snapshot.links.session_id,
                 available_tools=self.available_conductor_tools,
             )
             if snapshot.is_terminal:
@@ -2130,6 +2131,7 @@ class JobResultHandler:
                 for relay in classify_relay_events(
                     history_events,
                     job_id=snapshot.job_id,
+                    session_id=snapshot.links.session_id,
                     available_tools=self.available_conductor_tools,
                 )
                 if relay.get("kind") == "attention_required"

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -871,10 +871,29 @@ class CancelExecutionHandler:
 
             # Historical/non-Foundation-A sessions have no live capability to
             # protect, so retain their established direct cancellation path.
+            from ouroboros.orchestrator.execution_authority import (
+                collect_cancellation_acceptance_plan,
+            )
+
+            raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+            expected_root_indices = (
+                range(raw_total_acs)
+                if isinstance(raw_total_acs, int)
+                and not isinstance(raw_total_acs, bool)
+                and raw_total_acs >= 0
+                else None
+            )
+            acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                session_id=tracker.session_id,
+                execution_id=execution_id,
+                event_store=self._event_store,
+                expected_root_indices=expected_root_indices,
+            )
             cancel_result = await self._session_repo.mark_cancelled(
                 session_id=tracker.session_id,
                 reason=reason,
                 cancelled_by="mcp_tool",
+                acceptance_finalizations=acceptance_finalizations,
             )
             if cancel_result.is_err:
                 return Result.err(

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -142,7 +142,10 @@ def _event_aggregate_type(event: object) -> str | None:
 
 
 def _event_session_anchor(event: object, data: Mapping[str, object]) -> str | None:
-    for key in ("session_id", "orchestrator_session_id"):
+    # Child runtime events may carry both their native runtime session and the
+    # parent orchestration session. Retrospective authority follows the latter;
+    # acceptance/axis events that only carry ``session_id`` remain compatible.
+    for key in ("orchestrator_session_id", "session_id"):
         value = data.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -25,6 +25,8 @@ from ouroboros.orchestrator.evidence.common import (
     strict_bool,
 )
 from ouroboros.orchestrator.frugality_proof import (
+    EVENT_AC_ACCEPTANCE_FINALIZED,
+    EVENT_AC_ATTEMPT_JUDGED,
     EVENT_AC_OUTCOME_FINALIZED,
     EVENT_DELIVER_VERDICT,
     EVENT_EFFORT_ROUTED,
@@ -139,6 +141,8 @@ def build_frugality_retrospective(
     outcome_attempts_seen: dict[int, set[int]] = {}
     invalid_outcome_attempts: set[tuple[int, int]] = set()
     invalid_outcome_roots: set[int] = set()
+    acceptance_by_root: dict[int, list[tuple[int, bool, str, str | None]]] = {}
+    invalid_acceptance_roots: set[int] = set()
 
     for position, event in enumerate(event_list):
         current_type = event_type(event)
@@ -163,32 +167,59 @@ def build_frugality_retrospective(
                 attempt.token_events.append((current_id, data.get("token_spend")))
             continue
 
-        if current_type != EVENT_AC_OUTCOME_FINALIZED:
+        if current_type in {EVENT_AC_ATTEMPT_JUDGED, EVENT_AC_OUTCOME_FINALIZED}:
+            root_ac_index = parse_root_ac_index(data)
+            retry_attempt = parse_retry_attempt(data)
+            success = strict_bool(data.get("success"))
+            outcome = _normalized_outcome(data, success=success) if success is not None else None
+            if root_ac_index is None:
+                anonymous_invalid_attempts.add(invalid_identity)
+                continue
+            if retry_attempt is None:
+                invalid_outcome_roots.add(root_ac_index)
+                anonymous_invalid_attempts.add(invalid_identity)
+                continue
+            outcome_attempts_seen.setdefault(root_ac_index, set()).add(retry_attempt)
+            if success is None or outcome is None:
+                invalid_outcome_attempts.add((root_ac_index, retry_attempt))
+                continue
+            outcomes_by_root.setdefault(root_ac_index, {}).setdefault(retry_attempt, []).append(
+                _OutcomeEvidence(
+                    root_ac_index=root_ac_index,
+                    retry_attempt=retry_attempt,
+                    success=success,
+                    outcome=outcome,
+                    event_id=current_id,
+                )
+            )
+            continue
+
+        if current_type != EVENT_AC_ACCEPTANCE_FINALIZED:
             continue
 
         root_ac_index = parse_root_ac_index(data)
-        retry_attempt = parse_retry_attempt(data)
-        success = strict_bool(data.get("success"))
-        outcome = _normalized_outcome(data, success=success) if success is not None else None
-        if root_ac_index is None:
-            anonymous_invalid_attempts.add(invalid_identity)
+        retry_attempt = data.get("final_retry_attempt")
+        accepted = strict_bool(data.get("accepted"))
+        outcome = _normalized_outcome(data, success=accepted) if accepted is not None else None
+        disposition = _non_empty_string(data.get("disposition"))
+        terminal_status = _non_empty_string(data.get("terminal_status"))
+        if (
+            root_ac_index is None
+            or isinstance(retry_attempt, bool)
+            or not isinstance(retry_attempt, int)
+            or retry_attempt < 0
+            or accepted is None
+            or outcome is None
+            or disposition is None
+            or terminal_status is None
+        ):
+            if root_ac_index is not None:
+                invalid_acceptance_roots.add(root_ac_index)
+            else:
+                anonymous_invalid_attempts.add(invalid_identity)
             continue
-        if retry_attempt is None:
-            invalid_outcome_roots.add(root_ac_index)
-            anonymous_invalid_attempts.add(invalid_identity)
-            continue
-        outcome_attempts_seen.setdefault(root_ac_index, set()).add(retry_attempt)
-        if success is None or outcome is None:
-            invalid_outcome_attempts.add((root_ac_index, retry_attempt))
-            continue
-        outcomes_by_root.setdefault(root_ac_index, {}).setdefault(retry_attempt, []).append(
-            _OutcomeEvidence(
-                root_ac_index=root_ac_index,
-                retry_attempt=retry_attempt,
-                success=success,
-                outcome=outcome,
-                event_id=current_id,
-            )
+        acceptance_by_root.setdefault(root_ac_index, []).append(
+            (retry_attempt, accepted, outcome, current_id)
         )
 
     measured: dict[_AttemptKey, tuple[float, str | None]] = {}
@@ -224,6 +255,25 @@ def build_frugality_retrospective(
             invalid_outcome_attempts.add((root_ac_index, latest_attempt))
             continue
         latest_outcomes[root_ac_index] = records[0]
+
+    # When the Final Gate event is present it is the terminal source of truth;
+    # historical outcome-finalized rows remain a provisional fallback only for
+    # old runs that predate Foundation B.
+    for root_ac_index, records in acceptance_by_root.items():
+        unique_records = set(records)
+        if root_ac_index in invalid_acceptance_roots or len(unique_records) != 1:
+            invalid_outcome_roots.add(root_ac_index)
+            latest_outcomes.pop(root_ac_index, None)
+            continue
+        acceptance_record: tuple[int, bool, str, str | None] = next(iter(unique_records))
+        retry_attempt, accepted, outcome, acceptance_event_id = acceptance_record
+        latest_outcomes[root_ac_index] = _OutcomeEvidence(
+            root_ac_index=root_ac_index,
+            retry_attempt=retry_attempt,
+            success=accepted,
+            outcome=outcome,
+            event_id=acceptance_event_id,
+        )
 
     retry_keys: set[_AttemptKey] = set()
     retry_latest_attempts: list[int] = []

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -34,6 +34,7 @@ from ouroboros.orchestrator.frugality_proof import (
     EVENT_SHADOW_REPLAY,
     EVENT_TOKEN_ATTRIBUTION,
 )
+from ouroboros.persistence.event_store import validate_acceptance_finalization_payload
 
 if TYPE_CHECKING:
     from ouroboros.persistence.event_store import EventStore
@@ -197,27 +198,28 @@ def build_frugality_retrospective(
         if current_type != EVENT_AC_ACCEPTANCE_FINALIZED:
             continue
 
-        root_ac_index = parse_root_ac_index(data)
-        retry_attempt = data.get("final_retry_attempt")
-        accepted = strict_bool(data.get("accepted"))
-        outcome = _normalized_outcome(data, success=accepted) if accepted is not None else None
-        disposition = _non_empty_string(data.get("disposition"))
-        event_terminal_status = _non_empty_string(data.get("terminal_status"))
-        if (
-            root_ac_index is None
-            or isinstance(retry_attempt, bool)
-            or not isinstance(retry_attempt, int)
-            or retry_attempt < 0
-            or accepted is None
-            or outcome is None
-            or disposition is None
-            or event_terminal_status is None
-        ):
-            if root_ac_index is not None:
-                invalid_acceptance_roots.add(root_ac_index)
+        candidate_root = parse_root_ac_index(data)
+        try:
+            _generation, root_ac_index = validate_acceptance_finalization_payload(
+                data,
+                aggregate_id=getattr(event, "aggregate_id", None),
+            )
+        except Exception:
+            if candidate_root is not None:
+                invalid_acceptance_roots.add(candidate_root)
             else:
                 anonymous_invalid_attempts.add(invalid_identity)
             continue
+        if (
+            data.get("execution_id") != execution_id
+            or data.get("session_id") != session_id
+            or data.get("terminal_status") != terminal_status
+        ):
+            invalid_acceptance_roots.add(root_ac_index)
+            continue
+        retry_attempt = data["final_retry_attempt"]
+        accepted = data["accepted"]
+        outcome = data["outcome"]
         acceptance_by_root.setdefault(root_ac_index, []).append(
             (retry_attempt, accepted, outcome, current_id)
         )

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -202,7 +202,7 @@ def build_frugality_retrospective(
         accepted = strict_bool(data.get("accepted"))
         outcome = _normalized_outcome(data, success=accepted) if accepted is not None else None
         disposition = _non_empty_string(data.get("disposition"))
-        terminal_status = _non_empty_string(data.get("terminal_status"))
+        event_terminal_status = _non_empty_string(data.get("terminal_status"))
         if (
             root_ac_index is None
             or isinstance(retry_attempt, bool)
@@ -211,7 +211,7 @@ def build_frugality_retrospective(
             or accepted is None
             or outcome is None
             or disposition is None
-            or terminal_status is None
+            or event_terminal_status is None
         ):
             if root_ac_index is not None:
                 invalid_acceptance_roots.add(root_ac_index)
@@ -274,6 +274,13 @@ def build_frugality_retrospective(
             outcome=outcome,
             event_id=acceptance_event_id,
         )
+
+    # A malformed final event is authoritative evidence that this root cannot
+    # be safely reconstructed. Do not fall back to a provisional attempt and
+    # accidentally report a misleading terminal outcome.
+    for root_ac_index in invalid_acceptance_roots:
+        invalid_outcome_roots.add(root_ac_index)
+        latest_outcomes.pop(root_ac_index, None)
 
     retry_keys: set[_AttemptKey] = set()
     retry_latest_attempts: list[int] = []
@@ -339,7 +346,10 @@ def build_frugality_retrospective(
         )
 
     invalid_count = (
-        len(invalid_attempt_keys) + len(anonymous_invalid_attempts) + len(invalid_outcome_attempts)
+        len(invalid_attempt_keys)
+        + len(anonymous_invalid_attempts)
+        + len(invalid_outcome_attempts)
+        + len(invalid_acceptance_roots)
     )
     payload: dict[str, Any] = {
         "execution_id": execution_id,

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -123,6 +123,70 @@ def _proof_reference(events: Iterable[object]) -> str | None:
     return None
 
 
+def _event_aggregate_id(event: object) -> str | None:
+    value = (
+        event.get("aggregate_id")
+        if isinstance(event, Mapping)
+        else getattr(event, "aggregate_id", None)
+    )
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _event_aggregate_type(event: object) -> str | None:
+    value = (
+        event.get("aggregate_type")
+        if isinstance(event, Mapping)
+        else getattr(event, "aggregate_type", None)
+    )
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _event_session_anchor(event: object, data: Mapping[str, object]) -> str | None:
+    for key in ("session_id", "orchestrator_session_id"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if _event_aggregate_type(event) == "session":
+        return _event_aggregate_id(event)
+    return None
+
+
+def _session_scoped_events(
+    events: Iterable[object], *, execution_id: str, session_id: str
+) -> list[object]:
+    """Keep only evidence belonging to one execution/session authority.
+
+    Current producers put the orchestration session on every frugality event,
+    while older execution-scoped telemetry may omit it.  Sessionless rows are
+    retained only when the supplied stream has no competing explicit session;
+    if two sessions share an execution, ambiguity fails closed instead of
+    allowing one session's evidence to leak into the other.
+    """
+    materialized = list(events)
+    explicit_sessions = {
+        anchor
+        for event in materialized
+        for anchor in [_event_session_anchor(event, event_data(event))]
+        if anchor is not None
+    }
+    scoped: list[object] = []
+    for event in materialized:
+        data = event_data(event)
+        event_execution = data.get("execution_id")
+        if isinstance(event_execution, str) and event_execution != execution_id:
+            continue
+        if _event_aggregate_type(event) == "session" and _event_aggregate_id(event) != session_id:
+            continue
+        anchor = _event_session_anchor(event, data)
+        if anchor is not None:
+            if anchor == session_id:
+                scoped.append(event)
+            continue
+        if not explicit_sessions or explicit_sessions == {session_id}:
+            scoped.append(event)
+    return scoped
+
+
 def build_frugality_retrospective(
     events: Iterable[object],
     *,
@@ -134,7 +198,11 @@ def build_frugality_retrospective(
     if terminal_status not in HARD_FINAL_STATUSES:
         return None
 
-    event_list = list(events)
+    event_list = _session_scoped_events(
+        events,
+        execution_id=execution_id,
+        session_id=session_id,
+    )
     attempts: dict[_AttemptKey, _AttemptEvidence] = {}
     invalid_attempt_keys: set[_AttemptKey] = set()
     anonymous_invalid_attempts: set[str] = set()
@@ -144,6 +212,7 @@ def build_frugality_retrospective(
     invalid_outcome_roots: set[int] = set()
     acceptance_by_root: dict[int, list[tuple[int, bool, str, str | None]]] = {}
     invalid_acceptance_roots: set[int] = set()
+    acceptance_generations: set[str] = set()
 
     for position, event in enumerate(event_list):
         current_type = event_type(event)
@@ -202,7 +271,7 @@ def build_frugality_retrospective(
         try:
             _generation, root_ac_index = validate_acceptance_finalization_payload(
                 data,
-                aggregate_id=getattr(event, "aggregate_id", None),
+                aggregate_id=_event_aggregate_id(event),
             )
         except Exception:
             if candidate_root is not None:
@@ -220,6 +289,7 @@ def build_frugality_retrospective(
         retry_attempt = data["final_retry_attempt"]
         accepted = data["accepted"]
         outcome = data["outcome"]
+        acceptance_generations.add(_generation)
         acceptance_by_root.setdefault(root_ac_index, []).append(
             (retry_attempt, accepted, outcome, current_id)
         )
@@ -374,6 +444,8 @@ def build_frugality_retrospective(
     proof_reference = _proof_reference(event_list)
     if proof_reference is not None:
         payload["proof_reference"] = proof_reference
+    if len(acceptance_generations) == 1:
+        payload["acceptance_generation_id"] = next(iter(acceptance_generations))
     return payload
 
 
@@ -393,17 +465,28 @@ async def report_frugality_retrospective(
     if terminal_status not in HARD_FINAL_STATUSES:
         return False
     events = await event_store.query_execution_related_events(execution_id, limit=None)
-    if any(event_type(event) == FRUGALITY_RETROSPECTIVE_EVENT_TYPE for event in events):
+    scoped_events = _session_scoped_events(
+        events,
+        execution_id=execution_id,
+        session_id=session_id,
+    )
+    if any(event_type(event) == FRUGALITY_RETROSPECTIVE_EVENT_TYPE for event in scoped_events):
         return False
     payload = build_frugality_retrospective(
-        events,
+        scoped_events,
         execution_id=execution_id,
         session_id=session_id,
         terminal_status=terminal_status,
     )
     if payload is None:
         return False
-    await event_store.append(create_frugality_retrospective_event(execution_id, payload))
+    await event_store.append(
+        create_frugality_retrospective_event(
+            execution_id,
+            payload,
+            session_id=session_id,
+        )
+    )
     return True
 
 

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -927,6 +927,7 @@ class ACRuntimeHandleManager:
         runtime_handle: RuntimeHandle | None,
         execution_id: str | None = None,
         session_id: str | None = None,
+        orchestrator_session_id: str | None = None,
         result_summary: str | None = None,
         success: bool | None = None,
         error: str | None = None,
@@ -959,6 +960,7 @@ class ACRuntimeHandleManager:
                     runtime_handle.to_persisted_dict() if runtime_handle is not None else None
                 ),
                 "session_id": effective_session_id,
+                "orchestrator_session_id": orchestrator_session_id,
                 "server_session_id": server_session_id,
                 "success": success,
                 "result_summary": result_summary,

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -754,11 +754,30 @@ def create_execution_terminal_event(
 def create_frugality_retrospective_event(
     execution_id: str,
     data: dict[str, Any],
+    *,
+    session_id: str | None = None,
 ) -> BaseEvent:
-    """Create the deterministic v1 execution-finalized frugality evidence event."""
+    """Create a deterministic, session-scoped v1 retrospective event.
+
+    Execution ids can be intentionally shared by multiple orchestration
+    sessions.  Include the session (and, when present, acceptance generation)
+    in the event identity so one session's retrospective cannot deduplicate or
+    overwrite another's.
+    """
+    resolved_session_id = session_id or (
+        data.get("session_id") if isinstance(data.get("session_id"), str) else None
+    )
+    generation = (
+        data.get("acceptance_generation_id")
+        if isinstance(data.get("acceptance_generation_id"), str)
+        else None
+    )
+    identity_scope = "\x00".join(
+        (execution_id, resolved_session_id or "", generation or "")
+    )
     event_id = uuid5(
         NAMESPACE_URL,
-        f"ouroboros:{FRUGALITY_RETROSPECTIVE_EVENT_TYPE}:v1:{execution_id}",
+        f"ouroboros:{FRUGALITY_RETROSPECTIVE_EVENT_TYPE}:v1:{identity_scope}",
     )
     return BaseEvent(
         id=str(event_id),

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -772,9 +772,7 @@ def create_frugality_retrospective_event(
         if isinstance(data.get("acceptance_generation_id"), str)
         else None
     )
-    identity_scope = "\x00".join(
-        (execution_id, resolved_session_id or "", generation or "")
-    )
+    identity_scope = "\x00".join((execution_id, resolved_session_id or "", generation or ""))
     event_id = uuid5(
         NAMESPACE_URL,
         f"ouroboros:{FRUGALITY_RETROSPECTIVE_EVENT_TYPE}:v1:{identity_scope}",

--- a/src/ouroboros/orchestrator/evidence/common.py
+++ b/src/ouroboros/orchestrator/evidence/common.py
@@ -3,9 +3,140 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import math
 
 _MAX_LEAF_RESULT_CHARS = 1200
+
+_ATTEMPT_JUDGED_EVENT = "execution.ac.attempt_judged"
+_HISTORICAL_ATTEMPT_JUDGED_EVENT = "execution.ac.outcome_finalized"
+_ATTEMPT_OUTCOMES = frozenset(
+    {"succeeded", "satisfied_externally", "failed", "blocked", "invalid", "cancelled"}
+)
+_SUCCESSFUL_ATTEMPT_OUTCOMES = frozenset({"succeeded", "satisfied_externally"})
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptJudgmentContract:
+    """Normalized, semantically validated outer AC attempt telemetry."""
+
+    root_ac_index: int
+    retry_attempt: int
+    attempt_number: int
+    success: bool
+    outcome: str
+    is_decomposed: bool
+
+
+def validate_attempt_judgment_payload(
+    data: Mapping[str, object],
+    *,
+    event_type: str | None = None,
+    aggregate_id: str | None = None,
+    expected_execution_id: str | None = None,
+    expected_session_id: str | None = None,
+) -> AttemptJudgmentContract:
+    """Validate and normalize the shared attempt-judgment contract.
+
+    New ``execution.ac.attempt_judged`` events are strict: they must carry the
+    one-based ``attempt_number`` and the boolean ``is_decomposed`` marker. The
+    historical ``execution.ac.outcome_finalized`` alias remains readable with
+    those two fields omitted, but any supplied value is still validated. Both
+    forms must agree on the retry number, success flag, and canonical outcome.
+    """
+    if event_type not in {None, _ATTEMPT_JUDGED_EVENT, _HISTORICAL_ATTEMPT_JUDGED_EVENT}:
+        raise ValueError(f"unsupported attempt judgment event type: {event_type!r}")
+    is_current = event_type in {None, _ATTEMPT_JUDGED_EVENT}
+
+    raw_root = data.get("root_ac_index")
+    root = (
+        raw_root
+        if isinstance(raw_root, int) and not isinstance(raw_root, bool) and raw_root >= 0
+        else None
+    )
+    if root is None and not is_current:
+        root = parse_root_ac_index(data)
+    if root is None:
+        raise ValueError("attempt judgment requires a non-negative root_ac_index")
+    for alias in ("parent_ac_index", "ac_index"):
+        if alias not in data:
+            continue
+        alias_root = data.get(alias)
+        if (
+            isinstance(alias_root, bool)
+            or not isinstance(alias_root, int)
+            or alias_root < 0
+            or alias_root != root
+        ):
+            raise ValueError("attempt judgment root aliases are inconsistent")
+    retry = parse_retry_attempt(data)
+    if retry is None:
+        raise ValueError("attempt judgment requires a non-negative retry_attempt")
+
+    raw_attempt_number = data.get("attempt_number")
+    if raw_attempt_number is None:
+        if is_current:
+            raise ValueError("attempt_judged requires attempt_number")
+        attempt_number = retry + 1
+    elif (
+        isinstance(raw_attempt_number, bool)
+        or not isinstance(raw_attempt_number, int)
+        or raw_attempt_number < 1
+        or raw_attempt_number != retry + 1
+    ):
+        raise ValueError("attempt_number must equal retry_attempt + 1")
+    else:
+        attempt_number = raw_attempt_number
+
+    raw_decomposed = data.get("is_decomposed")
+    if raw_decomposed is None:
+        if is_current:
+            raise ValueError("attempt_judged requires is_decomposed")
+        is_decomposed = False
+    elif not isinstance(raw_decomposed, bool):
+        raise ValueError("is_decomposed must be a boolean")
+    else:
+        is_decomposed = raw_decomposed
+
+    success = data.get("success")
+    if not isinstance(success, bool):
+        raise ValueError("attempt judgment requires a boolean success")
+    outcome = data.get("outcome")
+    if not isinstance(outcome, str) or outcome not in _ATTEMPT_OUTCOMES:
+        raise ValueError("attempt judgment requires a canonical outcome")
+    if success != (outcome in _SUCCESSFUL_ATTEMPT_OUTCOMES):
+        raise ValueError("success and outcome are contradictory")
+
+    execution_id = data.get("execution_id")
+    session_id = data.get("session_id")
+    if is_current:
+        if (
+            not isinstance(execution_id, str)
+            or not execution_id
+            or execution_id != execution_id.strip()
+            or not isinstance(session_id, str)
+            or not session_id
+            or session_id != session_id.strip()
+        ):
+            raise ValueError("attempt_judged requires execution_id and session_id")
+    elif expected_execution_id is not None or aggregate_id is not None:
+        if not isinstance(execution_id, str) or not execution_id:
+            raise ValueError("attempt judgment requires execution_id")
+    if expected_execution_id is not None and execution_id != expected_execution_id:
+        raise ValueError("attempt judgment execution identity does not match")
+    if aggregate_id is not None and execution_id != aggregate_id:
+        raise ValueError("attempt judgment aggregate identity does not match")
+    if expected_session_id is not None and session_id != expected_session_id:
+        raise ValueError("attempt judgment session identity does not match")
+
+    return AttemptJudgmentContract(
+        root_ac_index=root,
+        retry_attempt=retry,
+        attempt_number=attempt_number,
+        success=success,
+        outcome=outcome,
+        is_decomposed=is_decomposed,
+    )
 
 
 def finite_number(value: object) -> float | None:

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -69,6 +69,7 @@ _RATE_GATE_BUCKET_HELPER_NAMES = (
 _PROCESS_LOCAL_AUTHORITY_CONSTRUCTION_TOKEN = object()
 _SAFE_PROCESS_LOCAL_SESSION_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 _LOG = logging.getLogger(__name__)
+_ACCEPTANCE_ROOT_INDICES_KEY = "acceptance_root_indices"
 
 
 async def _await_process_local_cleanup(awaitable: Awaitable[Any]) -> Any:
@@ -823,6 +824,54 @@ async def collect_terminal_acceptance_plan(
             details={"session_id": session_id, "execution_id": execution_id},
         )
 
+    durable_root_indices: set[int] | None = None
+    replay = getattr(event_store, "replay", None)
+    if callable(replay):
+        try:
+            session_events = await replay("session", session_id)
+        except Exception:
+            session_events = None
+        if isinstance(session_events, list):
+            start_event = next(
+                (
+                    item
+                    for item in session_events
+                    if getattr(item, "type", None) == "orchestrator.session.started"
+                ),
+                None,
+            )
+            if start_event is not None:
+                start_data = getattr(start_event, "data", {})
+                if not isinstance(start_data, Mapping):
+                    raise PersistenceError(
+                        "Durable session-start metadata is malformed.",
+                        operation="collect_terminal_acceptance_plan",
+                        details={"session_id": session_id},
+                    )
+                raw_roots = start_data.get(_ACCEPTANCE_ROOT_INDICES_KEY)
+                if raw_roots is not None:
+                    if isinstance(raw_roots, (str, bytes, bytearray)) or not isinstance(
+                        raw_roots, Iterable
+                    ):
+                        raise PersistenceError(
+                            "Durable acceptance root set is malformed.",
+                            operation="collect_terminal_acceptance_plan",
+                            details={"session_id": session_id},
+                        )
+                    durable_root_indices = set()
+                    for raw_root in raw_roots:
+                        if (
+                            isinstance(raw_root, bool)
+                            or not isinstance(raw_root, int)
+                            or raw_root < 0
+                        ):
+                            raise PersistenceError(
+                                "Durable acceptance root set contains an invalid root.",
+                                operation="collect_terminal_acceptance_plan",
+                                details={"session_id": session_id},
+                            )
+                        durable_root_indices.add(raw_root)
+
     attempts: list[Any] = []
     for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
         try:
@@ -864,6 +913,25 @@ async def collect_terminal_acceptance_plan(
     latest_by_root: dict[int, tuple[int, int]] = {}
     for item in attempts:
         data = getattr(item, "data", {})
+        aggregate_id = getattr(item, "aggregate_id", None)
+        if not isinstance(data, Mapping):
+            raise PersistenceError(
+                "Cancellation attempt telemetry must contain a mapping payload.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        if aggregate_id is not None and aggregate_id != execution_id:
+            raise PersistenceError(
+                "Cancellation attempt telemetry has a mismatched aggregate identity.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        if data.get("execution_id") != execution_id or data.get("session_id") != session_id:
+            raise PersistenceError(
+                "Cancellation attempt telemetry belongs to a different execution or session.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
         root = data.get("root_ac_index")
         retry = data.get("retry_attempt")
         event_type = getattr(item, "type", None)
@@ -878,6 +946,27 @@ async def collect_terminal_acceptance_plan(
         ):
             raise PersistenceError(
                 "Cancellation attempt telemetry has an invalid root or retry identity.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        success = data.get("success")
+        raw_outcome = data.get("outcome")
+        if not isinstance(success, bool) or not isinstance(raw_outcome, str):
+            raise PersistenceError(
+                "Cancellation attempt telemetry has an incomplete outcome contract.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        if raw_outcome not in {
+            "succeeded",
+            "satisfied_externally",
+            "failed",
+            "blocked",
+            "invalid",
+            "cancelled",
+        } or success != (raw_outcome in {"succeeded", "satisfied_externally"}):
+            raise PersistenceError(
+                "Cancellation attempt telemetry has contradictory success/outcome fields.",
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
@@ -926,6 +1015,14 @@ async def collect_terminal_acceptance_plan(
                     details={"root_ac_index": raw_root},
                 )
             expected_roots.add(raw_root)
+    if durable_root_indices is not None:
+        if expected_root_indices is not None and expected_roots != durable_root_indices:
+            raise PersistenceError(
+                "Terminal acceptance plan does not match the durable session root set.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        expected_roots = durable_root_indices
 
     plan: list[dict[str, Any]] = []
     for root in sorted(latest_by_root.keys() | expected_roots):
@@ -1041,13 +1138,9 @@ async def request_process_local_cancellation(
     progress = getattr(tracker, "progress", None)
     expected_root_indices: tuple[int, ...] | None = None
     if isinstance(progress, Mapping):
-        raw_total_acs = progress.get("total_acceptance_criteria")
-        if (
-            isinstance(raw_total_acs, int)
-            and not isinstance(raw_total_acs, bool)
-            and raw_total_acs >= 0
-        ):
-            expected_root_indices = tuple(range(raw_total_acs))
+        raw_root_indices = progress.get(_ACCEPTANCE_ROOT_INDICES_KEY)
+        if isinstance(raw_root_indices, (list, tuple)):
+            expected_root_indices = tuple(raw_root_indices)
     authority = (
         progress.get("execution_contract", {}).get("foundation_a_authority")
         if isinstance(progress, Mapping) and isinstance(progress.get("execution_contract"), Mapping)

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -968,14 +968,25 @@ async def collect_terminal_acceptance_plan(
                 details={"session_id": session_id, "execution_id": execution_id},
             )
         if aggregate_id is not None and aggregate_id != execution_id:
+            # A shared execution aggregate may contain attempts from another
+            # orchestration session.  Query/replay selection must scope those
+            # records out before validating their payload.
+            continue
+        event_session_id = data.get("session_id")
+        event_execution_id = data.get("execution_id")
+        if event_session_id != session_id:
+            if event_session_id is None:
+                raise PersistenceError(
+                    "Cancellation attempt telemetry is missing its session identity.",
+                    operation="collect_terminal_acceptance_plan",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            # Telemetry for a different session is unrelated to this terminal
+            # acceptance plan, even when the execution aggregate is shared.
+            continue
+        if event_execution_id != execution_id:
             raise PersistenceError(
-                "Cancellation attempt telemetry has a mismatched aggregate identity.",
-                operation="collect_terminal_acceptance_plan",
-                details={"session_id": session_id, "execution_id": execution_id},
-            )
-        if data.get("execution_id") != execution_id or data.get("session_id") != session_id:
-            raise PersistenceError(
-                "Cancellation attempt telemetry belongs to a different execution or session.",
+                "Cancellation attempt telemetry has a mismatched execution identity.",
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
@@ -1009,15 +1020,36 @@ async def collect_terminal_acceptance_plan(
     for item in attempts:
         data = getattr(item, "data", {})
         event_type = getattr(item, "type", None)
+        aggregate_id = getattr(item, "aggregate_id", None)
+        if aggregate_id is not None and aggregate_id != execution_id:
+            continue
+        if not isinstance(data, Mapping):
+            raise PersistenceError(
+                "Cancellation attempt telemetry must contain a mapping payload.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        event_session_id = data.get("session_id")
+        event_execution_id = data.get("execution_id")
+        if event_session_id != session_id:
+            if event_session_id is None:
+                raise PersistenceError(
+                    "Cancellation attempt telemetry is missing its session identity.",
+                    operation="collect_terminal_acceptance_plan",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
+            continue
+        if event_execution_id != execution_id:
+            raise PersistenceError(
+                "Cancellation attempt telemetry has a mismatched execution identity.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
         try:
             judgment = validate_attempt_judgment_payload(
                 data,
                 event_type=event_type,
-                aggregate_id=(
-                    getattr(item, "aggregate_id", None)
-                    if isinstance(getattr(item, "aggregate_id", None), str)
-                    else None
-                ),
+                aggregate_id=(aggregate_id if isinstance(aggregate_id, str) else None),
                 expected_execution_id=execution_id,
                 expected_session_id=session_id,
             )

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -28,6 +28,7 @@ from typing import Any
 import uuid
 
 from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.evidence.common import validate_attempt_judgment_payload
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier, structural_atomic_verifier
 from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
@@ -802,8 +803,9 @@ async def collect_terminal_acceptance_plan(
     selects the latest provisional judgment for each observed root.  Read
     failures, malformed judgments, and conflicting duplicates fail closed so
     cancellation cannot commit a terminal winner without its exact decision
-    set. Preparation failures legitimately produce an empty plan; terminal
-    retries reconstruct a non-empty plan from the same durable attempt stream.
+    set. Current-format preparation failures reconstruct explicit rejecting
+    decisions for every durable root; zero-AC sessions use an explicit empty
+    plan. Terminal retries reconstruct the same plan from durable telemetry.
     """
     from ouroboros.core.errors import PersistenceError
     from ouroboros.persistence.event_store import acceptance_generation_id_for_session
@@ -826,51 +828,90 @@ async def collect_terminal_acceptance_plan(
 
     durable_root_indices: set[int] | None = None
     replay = getattr(event_store, "replay", None)
-    if callable(replay):
-        try:
-            session_events = await replay("session", session_id)
-        except Exception:
+    if not callable(replay):
+        raise PersistenceError(
+            "Cannot finalize a terminal session without readable session-start metadata.",
+            operation="collect_terminal_acceptance_plan",
+            details={"session_id": session_id, "execution_id": execution_id},
+        )
+    try:
+        replay_result = replay("session", session_id)
+        if inspect.isawaitable(replay_result):
+            session_events = await replay_result
+        elif isinstance(replay_result, list):
+            # A historical repository adapter exposed replay synchronously.
+            # Keep that compatibility only for the legacy path; the current
+            # EventStore implementation is asynchronous and therefore remains
+            # fail-closed on unreadable durable metadata below.
+            session_events = replay_result
+        else:
             session_events = None
-        if isinstance(session_events, list):
-            start_event = next(
-                (
-                    item
-                    for item in session_events
-                    if getattr(item, "type", None) == "orchestrator.session.started"
-                ),
-                None,
+    except Exception as exc:
+        raise PersistenceError(
+            "Cannot finalize a terminal session while session-start metadata is unreadable.",
+            operation="collect_terminal_acceptance_plan",
+            details={"session_id": session_id, "execution_id": execution_id},
+        ) from exc
+    if not isinstance(session_events, list):
+        # A legacy/mock repository may not implement session replay yet.  Keep
+        # that compatibility path only when no current-format root contract is
+        # available; a durable current session remains fail-closed below.
+        if expected_root_indices is not None:
+            raise PersistenceError(
+                "Session replay returned an invalid event stream.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
             )
-            if start_event is not None:
-                start_data = getattr(start_event, "data", {})
-                if not isinstance(start_data, Mapping):
+        session_events = []
+    start_event = next(
+        (
+            item
+            for item in session_events
+            if getattr(item, "type", None) == "orchestrator.session.started"
+        ),
+        None,
+    )
+    if start_event is not None:
+        start_data = getattr(start_event, "data", {})
+        if not isinstance(start_data, Mapping):
+            raise PersistenceError(
+                "Durable session-start metadata is malformed.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id},
+            )
+        if start_data.get("execution_id") != execution_id:
+            raise PersistenceError(
+                "Durable session-start execution identity does not match.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        if _ACCEPTANCE_ROOT_INDICES_KEY in start_data:
+            raw_roots = start_data[_ACCEPTANCE_ROOT_INDICES_KEY]
+            if isinstance(raw_roots, (str, bytes, bytearray)) or not isinstance(
+                raw_roots, Iterable
+            ):
+                raise PersistenceError(
+                    "Durable acceptance root set is malformed.",
+                    operation="collect_terminal_acceptance_plan",
+                    details={"session_id": session_id},
+                )
+            durable_root_indices = set()
+            durable_root_values: list[int] = []
+            for raw_root in raw_roots:
+                if isinstance(raw_root, bool) or not isinstance(raw_root, int) or raw_root < 0:
                     raise PersistenceError(
-                        "Durable session-start metadata is malformed.",
+                        "Durable acceptance root set contains an invalid root.",
                         operation="collect_terminal_acceptance_plan",
                         details={"session_id": session_id},
                     )
-                raw_roots = start_data.get(_ACCEPTANCE_ROOT_INDICES_KEY)
-                if raw_roots is not None:
-                    if isinstance(raw_roots, (str, bytes, bytearray)) or not isinstance(
-                        raw_roots, Iterable
-                    ):
-                        raise PersistenceError(
-                            "Durable acceptance root set is malformed.",
-                            operation="collect_terminal_acceptance_plan",
-                            details={"session_id": session_id},
-                        )
-                    durable_root_indices = set()
-                    for raw_root in raw_roots:
-                        if (
-                            isinstance(raw_root, bool)
-                            or not isinstance(raw_root, int)
-                            or raw_root < 0
-                        ):
-                            raise PersistenceError(
-                                "Durable acceptance root set contains an invalid root.",
-                                operation="collect_terminal_acceptance_plan",
-                                details={"session_id": session_id},
-                            )
-                        durable_root_indices.add(raw_root)
+                durable_root_values.append(raw_root)
+                durable_root_indices.add(raw_root)
+            if len(durable_root_values) != len(durable_root_indices):
+                raise PersistenceError(
+                    "Durable acceptance root set contains duplicate roots.",
+                    operation="collect_terminal_acceptance_plan",
+                    details={"session_id": session_id, "execution_id": execution_id},
+                )
 
     attempts: list[Any] = []
     for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
@@ -895,6 +936,12 @@ async def collect_terminal_acceptance_plan(
                 attempts.extend(
                     item for item in replayed if getattr(item, "type", None) == event_type
                 )
+                continue
+            if durable_root_indices is None and expected_root_indices is None:
+                # Historical/mock stores without a readable execution stream
+                # cannot contribute observed roots; the terminal fallback plan
+                # remains explicit and is still validated by EventStore when a
+                # durable current session exists.
                 continue
             _LOG.warning(
                 "process_local_authority.cancellation_acceptance_scan_failed",
@@ -932,55 +979,58 @@ async def collect_terminal_acceptance_plan(
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
-        root = data.get("root_ac_index")
-        retry = data.get("retry_attempt")
         event_type = getattr(item, "type", None)
-        if (
-            isinstance(root, bool)
-            or not isinstance(root, int)
-            or root < 0
-            or isinstance(retry, bool)
-            or not isinstance(retry, int)
-            or retry < 0
-            or event_type not in event_priority
-        ):
+        if event_type not in event_priority:
             raise PersistenceError(
-                "Cancellation attempt telemetry has an invalid root or retry identity.",
+                "Cancellation attempt telemetry has an invalid event type.",
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
-        success = data.get("success")
-        raw_outcome = data.get("outcome")
-        if not isinstance(success, bool) or not isinstance(raw_outcome, str):
+        try:
+            judgment = validate_attempt_judgment_payload(
+                data,
+                event_type=event_type,
+                aggregate_id=aggregate_id if isinstance(aggregate_id, str) else None,
+                expected_execution_id=execution_id,
+                expected_session_id=session_id,
+            )
+        except ValueError as exc:
             raise PersistenceError(
-                "Cancellation attempt telemetry has an incomplete outcome contract.",
+                f"Cancellation attempt telemetry violates the attempt contract: {exc}",
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
-            )
-        if raw_outcome not in {
-            "succeeded",
-            "satisfied_externally",
-            "failed",
-            "blocked",
-            "invalid",
-            "cancelled",
-        } or success != (raw_outcome in {"succeeded", "satisfied_externally"}):
-            raise PersistenceError(
-                "Cancellation attempt telemetry has contradictory success/outcome fields.",
-                operation="collect_terminal_acceptance_plan",
-                details={"session_id": session_id, "execution_id": execution_id},
-            )
-        candidate = (retry, event_priority[event_type])
-        latest_by_root[root] = max(latest_by_root.get(root, (-1, -1)), candidate)
+            ) from exc
+        candidate = (judgment.retry_attempt, event_priority[event_type])
+        latest_by_root[judgment.root_ac_index] = max(
+            latest_by_root.get(judgment.root_ac_index, (-1, -1)), candidate
+        )
 
     selected_by_root: dict[int, list[Any]] = {}
     for item in attempts:
         data = getattr(item, "data", {})
-        root = data.get("root_ac_index")
+        event_type = getattr(item, "type", None)
+        try:
+            judgment = validate_attempt_judgment_payload(
+                data,
+                event_type=event_type,
+                aggregate_id=(
+                    getattr(item, "aggregate_id", None)
+                    if isinstance(getattr(item, "aggregate_id", None), str)
+                    else None
+                ),
+                expected_execution_id=execution_id,
+                expected_session_id=session_id,
+            )
+        except ValueError as exc:
+            raise PersistenceError(
+                f"Cancellation attempt telemetry violates the attempt contract: {exc}",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            ) from exc
+        root = judgment.root_ac_index
         if root not in latest_by_root:
             continue
-        event_type = getattr(item, "type", None)
-        candidate = (data.get("retry_attempt"), event_priority.get(event_type, -1))
+        candidate = (judgment.retry_attempt, event_priority.get(event_type, -1))
         if candidate == latest_by_root[root]:
             selected_by_root.setdefault(root, []).append(item)
 
@@ -1007,6 +1057,7 @@ async def collect_terminal_acceptance_plan(
 
     expected_roots: set[int] = set()
     if expected_root_indices is not None:
+        expected_root_values: list[int] = []
         for raw_root in expected_root_indices:
             if isinstance(raw_root, bool) or not isinstance(raw_root, int) or raw_root < 0:
                 raise PersistenceError(
@@ -1014,13 +1065,31 @@ async def collect_terminal_acceptance_plan(
                     operation="collect_terminal_acceptance_plan",
                     details={"root_ac_index": raw_root},
                 )
+            expected_root_values.append(raw_root)
             expected_roots.add(raw_root)
+        if len(expected_root_values) != len(expected_roots):
+            raise PersistenceError(
+                "Terminal acceptance planning has duplicate expected roots.",
+                operation="collect_terminal_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
     if durable_root_indices is not None:
         if expected_root_indices is not None and expected_roots != durable_root_indices:
             raise PersistenceError(
                 "Terminal acceptance plan does not match the durable session root set.",
                 operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
+            )
+        unexpected_roots = set(latest_by_root) - durable_root_indices
+        if unexpected_roots:
+            raise PersistenceError(
+                "Attempt telemetry contains roots outside the durable session root set.",
+                operation="collect_terminal_acceptance_plan",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "unexpected_root_indices": sorted(unexpected_roots),
+                },
             )
         expected_roots = durable_root_indices
 

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -784,13 +784,14 @@ def _retire_process_local_authority_generation(
     return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
 
 
-async def collect_cancellation_acceptance_plan(
+async def collect_terminal_acceptance_plan(
     *,
     session_id: str,
     execution_id: str,
     event_store: Any,
+    terminal_status: str,
 ) -> list[dict[str, Any]]:
-    """Build the one cancellation plan used by every terminal writer.
+    """Build the one terminal acceptance plan used by every terminal writer.
 
     The collector is intentionally independent of runner-global state and of
     Foundation A's process-local correlation ID.  It derives a deterministic
@@ -798,17 +799,25 @@ async def collect_cancellation_acceptance_plan(
     selects the latest provisional judgment for each observed root.  Read
     failures, malformed judgments, and conflicting duplicates fail closed so
     cancellation cannot commit a terminal winner without its exact decision
-    set.
+    set. Preparation failures legitimately produce an empty plan; terminal
+    retries reconstruct a non-empty plan from the same durable attempt stream.
     """
     from ouroboros.core.errors import PersistenceError
     from ouroboros.persistence.event_store import acceptance_generation_id_for_session
+
+    if terminal_status not in {"completed", "failed", "cancelled"}:
+        raise PersistenceError(
+            "Terminal acceptance planning requires a hard terminal status.",
+            operation="collect_terminal_acceptance_plan",
+            details={"terminal_status": terminal_status},
+        )
 
     acceptance_generation_id = acceptance_generation_id_for_session(session_id, execution_id)
     query_events = getattr(event_store, "query_events", None)
     if not callable(query_events):
         raise PersistenceError(
             "Cannot finalize cancellation without readable attempt telemetry.",
-            operation="collect_cancellation_acceptance_plan",
+            operation="collect_terminal_acceptance_plan",
             details={"session_id": session_id, "execution_id": execution_id},
         )
 
@@ -829,7 +838,7 @@ async def collect_cancellation_acceptance_plan(
             )
             raise PersistenceError(
                 "Cannot finalize cancellation while attempt telemetry is unreadable.",
-                operation="collect_cancellation_acceptance_plan",
+                operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             ) from exc
 
@@ -854,7 +863,7 @@ async def collect_cancellation_acceptance_plan(
         ):
             raise PersistenceError(
                 "Cancellation attempt telemetry has an invalid root or retry identity.",
-                operation="collect_cancellation_acceptance_plan",
+                operation="collect_terminal_acceptance_plan",
                 details={"session_id": session_id, "execution_id": execution_id},
             )
         candidate = (retry, event_priority[event_type])
@@ -895,7 +904,7 @@ async def collect_cancellation_acceptance_plan(
             else:
                 raise PersistenceError(
                     "Cancellation attempt telemetry has a non-canonical outcome.",
-                    operation="collect_cancellation_acceptance_plan",
+                    operation="collect_terminal_acceptance_plan",
                     details={
                         "session_id": session_id,
                         "execution_id": execution_id,
@@ -907,7 +916,7 @@ async def collect_cancellation_acceptance_plan(
         if len(normalized_outcomes) != 1:
             raise PersistenceError(
                 "Cancellation attempt telemetry has conflicting latest judgments.",
-                operation="collect_cancellation_acceptance_plan",
+                operation="collect_terminal_acceptance_plan",
                 details={
                     "session_id": session_id,
                     "execution_id": execution_id,
@@ -916,6 +925,19 @@ async def collect_cancellation_acceptance_plan(
                 },
             )
         outcome = next(iter(normalized_outcomes))
+        accepted = terminal_status == "completed" and outcome in {
+            "succeeded",
+            "satisfied_externally",
+        }
+        disposition = (
+            "accepted"
+            if accepted
+            else (
+                "cancelled"
+                if terminal_status == "cancelled"
+                else ("rejected" if outcome in {"succeeded", "satisfied_externally"} else outcome)
+            )
+        )
         plan.append(
             {
                 "execution_id": execution_id,
@@ -923,13 +945,28 @@ async def collect_cancellation_acceptance_plan(
                 "acceptance_generation_id": acceptance_generation_id,
                 "root_ac_index": root,
                 "final_retry_attempt": retry,
-                "accepted": False,
-                "disposition": "cancelled",
+                "accepted": accepted,
+                "disposition": disposition,
                 "outcome": outcome,
-                "terminal_status": "cancelled",
+                "terminal_status": terminal_status,
             }
         )
     return plan
+
+
+async def collect_cancellation_acceptance_plan(
+    *,
+    session_id: str,
+    execution_id: str,
+    event_store: Any,
+) -> list[dict[str, Any]]:
+    """Build the cancellation plan used by every cancellation writer."""
+    return await collect_terminal_acceptance_plan(
+        session_id=session_id,
+        execution_id=execution_id,
+        event_store=event_store,
+        terminal_status="cancelled",
+    )
 
 
 async def request_process_local_cancellation(

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -10,7 +10,7 @@ exact live object for this process; it is never made portable by introspection.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 import hashlib
@@ -790,6 +790,8 @@ async def collect_terminal_acceptance_plan(
     execution_id: str,
     event_store: Any,
     terminal_status: str,
+    expected_root_indices: Iterable[int] | None = None,
+    fallback_outcome: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build the one terminal acceptance plan used by every terminal writer.
 
@@ -832,6 +834,19 @@ async def collect_terminal_acceptance_plan(
                 )
             )
         except Exception as exc:
+            # Some legacy/test stores expose replay but not the newer filtered
+            # query API.  Replay is still the same durable source of truth; use
+            # it before treating telemetry as unreadable.
+            replay = getattr(event_store, "replay", None)
+            try:
+                replayed = await replay("execution", execution_id) if callable(replay) else None
+            except Exception:
+                replayed = None
+            if isinstance(replayed, list):
+                attempts.extend(
+                    item for item in replayed if getattr(item, "type", None) == event_type
+                )
+                continue
             _LOG.warning(
                 "process_local_authority.cancellation_acceptance_scan_failed",
                 extra={"session_id": session_id, "execution_id": execution_id},
@@ -880,7 +895,6 @@ async def collect_terminal_acceptance_plan(
         if candidate == latest_by_root[root]:
             selected_by_root.setdefault(root, []).append(item)
 
-    plan: list[dict[str, Any]] = []
     canonical_outcomes = {
         "succeeded",
         "satisfied_externally",
@@ -889,21 +903,67 @@ async def collect_terminal_acceptance_plan(
         "invalid",
         "cancelled",
     }
-    for root in sorted(latest_by_root):
-        retry, _priority = latest_by_root[root]
-        normalized_outcomes: set[str] = set()
-        for item in selected_by_root.get(root, []):
-            data = getattr(item, "data", {})
-            raw_outcome = data.get("outcome")
-            if isinstance(raw_outcome, str) and raw_outcome in canonical_outcomes:
-                outcome = raw_outcome
-            elif (raw_outcome is None or raw_outcome == "") and isinstance(
-                data.get("success"), bool
-            ):
-                outcome = "succeeded" if data["success"] else "cancelled"
-            else:
+    if fallback_outcome is None:
+        fallback_outcome = {
+            "completed": "failed",
+            "failed": "blocked",
+            "cancelled": "cancelled",
+        }[terminal_status]
+    if fallback_outcome not in canonical_outcomes:
+        raise PersistenceError(
+            "Terminal acceptance planning has a non-canonical fallback outcome.",
+            operation="collect_terminal_acceptance_plan",
+            details={"fallback_outcome": fallback_outcome},
+        )
+
+    expected_roots: set[int] = set()
+    if expected_root_indices is not None:
+        for raw_root in expected_root_indices:
+            if isinstance(raw_root, bool) or not isinstance(raw_root, int) or raw_root < 0:
                 raise PersistenceError(
-                    "Cancellation attempt telemetry has a non-canonical outcome.",
+                    "Terminal acceptance planning has an invalid expected root.",
+                    operation="collect_terminal_acceptance_plan",
+                    details={"root_ac_index": raw_root},
+                )
+            expected_roots.add(raw_root)
+
+    plan: list[dict[str, Any]] = []
+    for root in sorted(latest_by_root.keys() | expected_roots):
+        retry, _priority = latest_by_root.get(root, (0, -1))
+        selected = selected_by_root.get(root, [])
+        if not selected:
+            # A root can be decided without an attempt event (for example a
+            # dependency-blocked or externally-satisfied AC).  When the
+            # caller supplies the durable seed root set, retain a deterministic
+            # non-accepting decision rather than silently dropping that root.
+            retry = 0
+            outcome = fallback_outcome
+        else:
+            normalized_outcomes: set[str] = set()
+            for item in selected:
+                data = getattr(item, "data", {})
+                raw_outcome = data.get("outcome")
+                if isinstance(raw_outcome, str) and raw_outcome in canonical_outcomes:
+                    outcome = raw_outcome
+                elif (raw_outcome is None or raw_outcome == "") and isinstance(
+                    data.get("success"), bool
+                ):
+                    outcome = "succeeded" if data["success"] else "cancelled"
+                else:
+                    raise PersistenceError(
+                        "Cancellation attempt telemetry has a non-canonical outcome.",
+                        operation="collect_terminal_acceptance_plan",
+                        details={
+                            "session_id": session_id,
+                            "execution_id": execution_id,
+                            "root_ac_index": root,
+                            "retry_attempt": retry,
+                        },
+                    )
+                normalized_outcomes.add(outcome)
+            if len(normalized_outcomes) != 1:
+                raise PersistenceError(
+                    "Cancellation attempt telemetry has conflicting latest judgments.",
                     operation="collect_terminal_acceptance_plan",
                     details={
                         "session_id": session_id,
@@ -912,19 +972,7 @@ async def collect_terminal_acceptance_plan(
                         "retry_attempt": retry,
                     },
                 )
-            normalized_outcomes.add(outcome)
-        if len(normalized_outcomes) != 1:
-            raise PersistenceError(
-                "Cancellation attempt telemetry has conflicting latest judgments.",
-                operation="collect_terminal_acceptance_plan",
-                details={
-                    "session_id": session_id,
-                    "execution_id": execution_id,
-                    "root_ac_index": root,
-                    "retry_attempt": retry,
-                },
-            )
-        outcome = next(iter(normalized_outcomes))
+            outcome = next(iter(normalized_outcomes))
         accepted = terminal_status == "completed" and outcome in {
             "succeeded",
             "satisfied_externally",
@@ -959,6 +1007,7 @@ async def collect_cancellation_acceptance_plan(
     session_id: str,
     execution_id: str,
     event_store: Any,
+    expected_root_indices: Iterable[int] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the cancellation plan used by every cancellation writer."""
     return await collect_terminal_acceptance_plan(
@@ -966,6 +1015,8 @@ async def collect_cancellation_acceptance_plan(
         execution_id=execution_id,
         event_store=event_store,
         terminal_status="cancelled",
+        expected_root_indices=expected_root_indices,
+        fallback_outcome="cancelled",
     )
 
 
@@ -988,6 +1039,15 @@ async def request_process_local_cancellation(
     session_id = getattr(tracker, "session_id", None)
     execution_id = getattr(tracker, "execution_id", None)
     progress = getattr(tracker, "progress", None)
+    expected_root_indices: tuple[int, ...] | None = None
+    if isinstance(progress, Mapping):
+        raw_total_acs = progress.get("total_acceptance_criteria")
+        if (
+            isinstance(raw_total_acs, int)
+            and not isinstance(raw_total_acs, bool)
+            and raw_total_acs >= 0
+        ):
+            expected_root_indices = tuple(range(raw_total_acs))
     authority = (
         progress.get("execution_contract", {}).get("foundation_a_authority")
         if isinstance(progress, Mapping) and isinstance(progress.get("execution_contract"), Mapping)
@@ -1165,6 +1225,7 @@ async def request_process_local_cancellation(
             session_id=session_id,
             execution_id=execution_id,
             event_store=getattr(session_repo, "_event_store", None),
+            expected_root_indices=expected_root_indices,
         )
         cancel_result = await session_repo.mark_cancelled_if_active(
             session_id=session_id,

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -784,6 +784,154 @@ def _retire_process_local_authority_generation(
     return _PROCESS_LOCAL_AUTHORITY_REGISTRY.retire(session_id, execution_id, adapter)
 
 
+async def collect_cancellation_acceptance_plan(
+    *,
+    session_id: str,
+    execution_id: str,
+    event_store: Any,
+) -> list[dict[str, Any]]:
+    """Build the one cancellation plan used by every terminal writer.
+
+    The collector is intentionally independent of runner-global state and of
+    Foundation A's process-local correlation ID.  It derives a deterministic
+    Foundation B generation from the durable session/execution identity, then
+    selects the latest provisional judgment for each observed root.  Read
+    failures, malformed judgments, and conflicting duplicates fail closed so
+    cancellation cannot commit a terminal winner without its exact decision
+    set.
+    """
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.persistence.event_store import acceptance_generation_id_for_session
+
+    acceptance_generation_id = acceptance_generation_id_for_session(session_id, execution_id)
+    query_events = getattr(event_store, "query_events", None)
+    if not callable(query_events):
+        raise PersistenceError(
+            "Cannot finalize cancellation without readable attempt telemetry.",
+            operation="collect_cancellation_acceptance_plan",
+            details={"session_id": session_id, "execution_id": execution_id},
+        )
+
+    attempts: list[Any] = []
+    for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
+        try:
+            attempts.extend(
+                await query_events(
+                    aggregate_id=execution_id,
+                    event_type=event_type,
+                    limit=None,
+                )
+            )
+        except Exception as exc:
+            _LOG.warning(
+                "process_local_authority.cancellation_acceptance_scan_failed",
+                extra={"session_id": session_id, "execution_id": execution_id},
+            )
+            raise PersistenceError(
+                "Cannot finalize cancellation while attempt telemetry is unreadable.",
+                operation="collect_cancellation_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            ) from exc
+
+    event_priority = {
+        "execution.ac.attempt_judged": 1,
+        "execution.ac.outcome_finalized": 0,
+    }
+    latest_by_root: dict[int, tuple[int, int]] = {}
+    for item in attempts:
+        data = getattr(item, "data", {})
+        root = data.get("root_ac_index")
+        retry = data.get("retry_attempt")
+        event_type = getattr(item, "type", None)
+        if (
+            isinstance(root, bool)
+            or not isinstance(root, int)
+            or root < 0
+            or isinstance(retry, bool)
+            or not isinstance(retry, int)
+            or retry < 0
+            or event_type not in event_priority
+        ):
+            raise PersistenceError(
+                "Cancellation attempt telemetry has an invalid root or retry identity.",
+                operation="collect_cancellation_acceptance_plan",
+                details={"session_id": session_id, "execution_id": execution_id},
+            )
+        candidate = (retry, event_priority[event_type])
+        latest_by_root[root] = max(latest_by_root.get(root, (-1, -1)), candidate)
+
+    selected_by_root: dict[int, list[Any]] = {}
+    for item in attempts:
+        data = getattr(item, "data", {})
+        root = data.get("root_ac_index")
+        if root not in latest_by_root:
+            continue
+        event_type = getattr(item, "type", None)
+        candidate = (data.get("retry_attempt"), event_priority.get(event_type, -1))
+        if candidate == latest_by_root[root]:
+            selected_by_root.setdefault(root, []).append(item)
+
+    plan: list[dict[str, Any]] = []
+    canonical_outcomes = {
+        "succeeded",
+        "satisfied_externally",
+        "failed",
+        "blocked",
+        "invalid",
+        "cancelled",
+    }
+    for root in sorted(latest_by_root):
+        retry, _priority = latest_by_root[root]
+        normalized_outcomes: set[str] = set()
+        for item in selected_by_root.get(root, []):
+            data = getattr(item, "data", {})
+            raw_outcome = data.get("outcome")
+            if isinstance(raw_outcome, str) and raw_outcome in canonical_outcomes:
+                outcome = raw_outcome
+            elif (raw_outcome is None or raw_outcome == "") and isinstance(
+                data.get("success"), bool
+            ):
+                outcome = "succeeded" if data["success"] else "cancelled"
+            else:
+                raise PersistenceError(
+                    "Cancellation attempt telemetry has a non-canonical outcome.",
+                    operation="collect_cancellation_acceptance_plan",
+                    details={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "root_ac_index": root,
+                        "retry_attempt": retry,
+                    },
+                )
+            normalized_outcomes.add(outcome)
+        if len(normalized_outcomes) != 1:
+            raise PersistenceError(
+                "Cancellation attempt telemetry has conflicting latest judgments.",
+                operation="collect_cancellation_acceptance_plan",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "root_ac_index": root,
+                    "retry_attempt": retry,
+                },
+            )
+        outcome = next(iter(normalized_outcomes))
+        plan.append(
+            {
+                "execution_id": execution_id,
+                "session_id": session_id,
+                "acceptance_generation_id": acceptance_generation_id,
+                "root_ac_index": root,
+                "final_retry_attempt": retry,
+                "accepted": False,
+                "disposition": "cancelled",
+                "outcome": outcome,
+                "terminal_status": "cancelled",
+            }
+        )
+    return plan
+
+
 async def request_process_local_cancellation(
     tracker: object,
     session_repo: Any,
@@ -976,10 +1124,16 @@ async def request_process_local_cancellation(
             cancelled_by=cancelled_by,
         )
         cancellation_request_published = True
+        acceptance_finalizations = await collect_cancellation_acceptance_plan(
+            session_id=session_id,
+            execution_id=execution_id,
+            event_store=getattr(session_repo, "_event_store", None),
+        )
         cancel_result = await session_repo.mark_cancelled_if_active(
             session_id=session_id,
             reason=reason,
             cancelled_by=cancelled_by,
+            acceptance_finalizations=acceptance_finalizations,
         )
     except BaseException as operation_error:
         cleanup_cancellation: asyncio.CancelledError | None = None

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -19,8 +19,10 @@ A triad row joins three measured axes by ``ac_id``:
   accepted-leaf journal evidence (seed AC4).
 * **baseline** — ``execution.ac.shadow_replay`` (baseline_token_spend at parent
   model tier), emitted only by the opt-in isolated replay experiment (seed AC5).
-* **acceptance** — ``execution.ac.outcome_finalized``. Proof rows remain provisional
-  until the seed-level verify/retry layer authoritatively accepts their root AC.
+* **attempt judgment** — ``execution.ac.attempt_judged`` (with
+  ``execution.ac.outcome_finalized`` retained as a historical read alias).
+* **acceptance** — ``execution.ac.acceptance_finalized``. Proof rows remain
+  provisional until the Final Gate authoritatively accepts their root AC.
 
 A row only ``counts_in_proof`` when the lower model tier was ENFORCED, every retry
 attempt has a paired token/deliver/shadow measurement, the root AC was finally
@@ -64,7 +66,9 @@ EVENT_MODEL_ROUTED = "execution.ac.model_routed"
 EVENT_TOKEN_ATTRIBUTION = "execution.ac.token_attribution.reported"
 EVENT_DELIVER_VERDICT = "execution.ac.deliver_verdict"
 EVENT_SHADOW_REPLAY = "execution.ac.shadow_replay"
+EVENT_AC_ATTEMPT_JUDGED = "execution.ac.attempt_judged"
 EVENT_AC_OUTCOME_FINALIZED = "execution.ac.outcome_finalized"
+EVENT_AC_ACCEPTANCE_FINALIZED = "execution.ac.acceptance_finalized"
 
 EFFORT_MODE_ENFORCED = "enforced"
 MODEL_MODE_ENFORCED = "enforced"
@@ -236,11 +240,13 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     single implicit run — the original single-run behavior, preserved.
     """
     acc: dict[tuple[str | None, str], dict] = {}
-    finalized: dict[
+    judged: dict[
         tuple[str | None, int],
         dict[int, list[tuple[bool | None, bool | None]]],
     ] = {}
-    finalized_invalid: set[tuple[str | None, int]] = set()
+    judged_invalid: set[tuple[str | None, int]] = set()
+    acceptance: dict[tuple[str | None, int], list[tuple[str, int, bool, str, str]]] = {}
+    acceptance_invalid: set[tuple[str | None, int]] = set()
 
     def merge_root(row: dict, data: Mapping) -> None:
         observed = parse_root_ac_index(data)
@@ -273,7 +279,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     for event in events:
         etype = _event_type(event)
         data = _event_data(event)
-        if etype == EVENT_AC_OUTCOME_FINALIZED:
+        if etype in {EVENT_AC_ATTEMPT_JUDGED, EVENT_AC_OUTCOME_FINALIZED}:
             run_key = execution_run_anchor(data)
             root_index = parse_root_ac_index(data)
             attempt = parse_retry_attempt(data)
@@ -286,13 +292,46 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 # that root. Ignoring it would let the assembler fall back to an
                 # older successful marker and potentially PASS after the producer
                 # emitted a newer-but-corrupt authoritative outcome.
-                finalized_invalid.add((run_key, root_index))
+                judged_invalid.add((run_key, root_index))
                 continue
             # Preserve malformed booleans as ``None`` instead of dropping the
             # marker. If this is the latest root attempt, admission must fail closed
             # rather than falling back to an older successful marker.
-            finalized.setdefault((run_key, root_index), {}).setdefault(attempt, []).append(
+            judged.setdefault((run_key, root_index), {}).setdefault(attempt, []).append(
                 (success, is_decomposed)
+            )
+        elif etype == EVENT_AC_ACCEPTANCE_FINALIZED:
+            run_key = execution_run_anchor(data)
+            root_index = parse_root_ac_index(data)
+            authority = data.get("authority_correlation_id")
+            final_attempt = data.get("final_retry_attempt")
+            accepted = _strict_bool(data.get("accepted"))
+            disposition = data.get("disposition")
+            terminal_status = data.get("terminal_status")
+            if (
+                root_index is None
+                or not isinstance(authority, str)
+                or not authority.strip()
+                or isinstance(final_attempt, bool)
+                or not isinstance(final_attempt, int)
+                or final_attempt < 0
+                or accepted is None
+                or not isinstance(disposition, str)
+                or not disposition.strip()
+                or not isinstance(terminal_status, str)
+                or not terminal_status.strip()
+            ):
+                if root_index is not None:
+                    acceptance_invalid.add((run_key, root_index))
+                continue
+            acceptance.setdefault((run_key, root_index), []).append(
+                (
+                    authority.strip(),
+                    final_attempt,
+                    accepted,
+                    disposition.strip(),
+                    terminal_status.strip(),
+                )
             )
         elif etype == EVENT_EFFORT_ROUTED:
             row = slot(data)
@@ -469,26 +508,41 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         )
 
         root_index = v.get("root_ac_index")
-        final_markers = (
-            finalized.get((v.get("seed_run_id"), root_index), {})
-            if isinstance(root_index, int)
-            else {}
-        )
         authoritatively_accepted = False
-        if final_markers:
-            final_attempt = max(final_markers)
-            final_records = final_markers[final_attempt]
-            # The outer marker is authoritative only when there is exactly one
-            # unambiguous result for its latest attempt, that result is a successful
-            # decomposition, and this child actually participated in that final
-            # attempt. This prevents failed/stale child rows from hitchhiking on a
-            # later atomic root success.
-            authoritatively_accepted = (
-                (v.get("seed_run_id"), root_index) not in finalized_invalid
-                and len(final_records) == 1
-                and final_records[0] == (True, True)
-                and final_attempt in attempt_sets[0]
-            )
+        acceptance_records = (
+            acceptance.get((v.get("seed_run_id"), root_index), [])
+            if isinstance(root_index, int)
+            else []
+        )
+        if acceptance_records:
+            unique_acceptance = set(acceptance_records)
+            if (
+                (v.get("seed_run_id"), root_index) not in acceptance_invalid
+                and len(unique_acceptance) == 1
+            ):
+                _authority, final_attempt, accepted, disposition, terminal_status = next(
+                    iter(unique_acceptance)
+                )
+                judged_key = (v.get("seed_run_id"), root_index)
+                judged_records = judged.get(judged_key, {})
+                judged_latest = max(judged_records) if judged_records else None
+                judged_latest_records = (
+                    judged_records.get(judged_latest, []) if judged_latest is not None else []
+                )
+                # Final acceptance is authoritative only when the Final Gate
+                # explicitly accepted the root after its last observed attempt.
+                # Attempt judgments remain telemetry and cannot substitute for it.
+                authoritatively_accepted = (
+                    accepted
+                    and disposition == "accepted"
+                    and terminal_status == "completed"
+                    and final_attempt in attempt_sets[0]
+                    and final_attempt == max(attempt_sets[0])
+                    and judged_key not in judged_invalid
+                    and judged_latest == final_attempt
+                    and len(judged_latest_records) == 1
+                    and judged_latest_records[0] == (True, True)
+                )
 
         delivery_values = list(deliveries.values())
         grounding_regression = (

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -516,10 +516,9 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         )
         if acceptance_records:
             unique_acceptance = set(acceptance_records)
-            if (
-                (v.get("seed_run_id"), root_index) not in acceptance_invalid
-                and len(unique_acceptance) == 1
-            ):
+            if (v.get("seed_run_id"), root_index) not in acceptance_invalid and len(
+                unique_acceptance
+            ) == 1:
                 _authority, final_attempt, accepted, disposition, terminal_status = next(
                     iter(unique_acceptance)
                 )

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -255,6 +255,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     judged_invalid: set[tuple[str | None, str | None, int]] = set()
     acceptance: dict[tuple[str | None, str | None, int], list[tuple[str, int, bool, str, str]]] = {}
     acceptance_invalid: set[tuple[str | None, str | None, int]] = set()
+    acceptance_sessions: set[str] = set()
 
     def session_anchor(data: Mapping) -> str | None:
         value = data.get("session_id")
@@ -370,6 +371,8 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                     terminal_status.strip(),
                 )
             )
+            if session_id is not None:
+                acceptance_sessions.add(session_id)
         elif etype == EVENT_EFFORT_ROUTED:
             row = slot(data)
             if row is None:
@@ -547,7 +550,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         candidates = [
             key for key in acc if key[0] == run_key and key[1] is not None and key[2] == ac_id
         ]
-        if len(candidates) == 1:
+        if len(candidates) == 1 and len(acceptance_sessions) <= 1:
             target_key = candidates[0]
             merge_legacy_row(acc[target_key], acc[legacy_key])
             del acc[legacy_key]

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -101,6 +101,10 @@ class FrugalityTriadRow:
 
     ac_id: str
     seed_run_id: str | None = None
+    # Acceptance authority is scoped to the orchestration session (and its
+    # deterministic generation), not merely to a caller-supplied execution id.
+    session_id: str | None = None
+    acceptance_generation_id: str | None = None
     root_ac_index: int | None = None
     is_decomposed_child: bool = False
     decomposition_trustworthy: bool = True
@@ -233,22 +237,28 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     missing-axis rows; only the parallel executor's per-AC events (which carry
     ``ac_id``) contribute.
 
-    Rows are keyed by ``(run, ac_id)`` — **not** ``ac_id`` alone — because the proof
+    Rows are keyed by ``(run, session, ac_id)`` — **not** ``ac_id`` alone — because the proof
     spans runs (``min_runs``) and the same logical AC id recurs every run. Keying by
     ``ac_id`` only would let a later run's events overwrite an earlier run's in the
-    same slot, collapsing valid cross-run evidence to the last run. The run anchor is
+    same slot, collapsing valid cross-run evidence to the last run. The session anchor
+    additionally prevents two legitimate sessions that share an execution id from
+    contaminating one another. The run anchor is
     each event's ``seed_run_id`` (falling back to ``execution_id``); a logical AC
     therefore yields one row per run it ran in. Events carrying no run anchor share a
     single implicit run — the original single-run behavior, preserved.
     """
-    acc: dict[tuple[str | None, str], dict] = {}
+    acc: dict[tuple[str | None, str | None, str], dict] = {}
     judged: dict[
-        tuple[str | None, int],
+        tuple[str | None, str | None, int],
         dict[int, list[tuple[bool | None, bool | None]]],
     ] = {}
-    judged_invalid: set[tuple[str | None, int]] = set()
-    acceptance: dict[tuple[str | None, int], list[tuple[str, int, bool, str, str]]] = {}
-    acceptance_invalid: set[tuple[str | None, int]] = set()
+    judged_invalid: set[tuple[str | None, str | None, int]] = set()
+    acceptance: dict[tuple[str | None, str | None, int], list[tuple[str, int, bool, str, str]]] = {}
+    acceptance_invalid: set[tuple[str | None, str | None, int]] = set()
+
+    def session_anchor(data: Mapping) -> str | None:
+        value = data.get("session_id")
+        return value.strip() if isinstance(value, str) and value.strip() else None
 
     def merge_root(row: dict, data: Mapping) -> None:
         observed = parse_root_ac_index(data)
@@ -276,13 +286,18 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         if not ac_id:
             return None
         run_key = execution_run_anchor(data)
-        return acc.setdefault((run_key, str(ac_id)), {"ac_id": str(ac_id), "seed_run_id": run_key})
+        session_id = session_anchor(data)
+        return acc.setdefault(
+            (run_key, session_id, str(ac_id)),
+            {"ac_id": str(ac_id), "seed_run_id": run_key, "session_id": session_id},
+        )
 
     for event in events:
         etype = _event_type(event)
         data = _event_data(event)
         if etype in {EVENT_AC_ATTEMPT_JUDGED, EVENT_AC_OUTCOME_FINALIZED}:
             run_key = execution_run_anchor(data)
+            session_id = session_anchor(data)
             root_index = parse_root_ac_index(data)
             if root_index is None:
                 continue
@@ -302,17 +317,18 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 # that root. Ignoring it would let the assembler fall back to an
                 # older successful marker and potentially PASS after the producer
                 # emitted a newer-but-corrupt authoritative outcome.
-                judged_invalid.add((run_key, root_index))
+                judged_invalid.add((run_key, session_id, root_index))
                 continue
             attempt = judgment.retry_attempt
             # Preserve malformed booleans as ``None`` instead of dropping the
             # marker. If this is the latest root attempt, admission must fail closed
             # rather than falling back to an older successful marker.
-            judged.setdefault((run_key, root_index), {}).setdefault(attempt, []).append(
+            judged.setdefault((run_key, session_id, root_index), {}).setdefault(attempt, []).append(
                 (judgment.success, judgment.is_decomposed)
             )
         elif etype == EVENT_AC_ACCEPTANCE_FINALIZED:
             run_key = execution_run_anchor(data)
+            session_id = session_anchor(data)
             root_index = parse_root_ac_index(data)
             final_attempt = data.get("final_retry_attempt")
             accepted = _strict_bool(data.get("accepted"))
@@ -343,9 +359,9 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 or not terminal_status.strip()
             ):
                 if root_index is not None:
-                    acceptance_invalid.add((run_key, root_index))
+                    acceptance_invalid.add((run_key, session_id, root_index))
                 continue
-            acceptance.setdefault((run_key, root_index), []).append(
+            acceptance.setdefault((run_key, session_id, root_index), []).append(
                 (
                     acceptance_generation,
                     final_attempt,
@@ -489,6 +505,53 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 # on the denominator can turn an ordinary row into a false PASS.
                 row["baseline_invalid"] = True
 
+    # A few historical producers emitted execution-scoped axis telemetry
+    # without ``session_id``. If exactly one explicit session row exists for the
+    # same run/AC, attach that legacy evidence to it. With multiple sessions the
+    # evidence is ambiguous and remains isolated (and therefore cannot count).
+    def merge_legacy_row(target: dict, source: dict) -> None:
+        for key, value in source.items():
+            if key in {"ac_id", "seed_run_id", "session_id"}:
+                continue
+            if key.endswith("_invalid"):
+                if value:
+                    target[key] = True
+                continue
+            if isinstance(value, set):
+                target.setdefault(key, set()).update(value)
+                continue
+            if isinstance(value, dict):
+                destination = target.setdefault(key, {})
+                duplicate_flag = {
+                    "models_by_attempt": "model_invalid",
+                    "tokens_by_attempt": "token_spend_invalid",
+                    "deliveries_by_attempt": "deliver_invalid",
+                    "baselines_by_attempt": "baseline_invalid",
+                }.get(key)
+                for item_key, item_value in value.items():
+                    if item_key in destination:
+                        if duplicate_flag is not None:
+                            target[duplicate_flag] = True
+                    else:
+                        destination[item_key] = item_value
+                continue
+            if key not in target:
+                target[key] = value
+            elif target[key] != value and key in {"root_ac_index", "is_decomposed_child"}:
+                target[
+                    "root_index_invalid" if key == "root_ac_index" else "decomposition_flag_invalid"
+                ] = True
+
+    for legacy_key in [key for key in acc if key[1] is None]:
+        run_key, _session_id, ac_id = legacy_key
+        candidates = [
+            key for key in acc if key[0] == run_key and key[1] is not None and key[2] == ac_id
+        ]
+        if len(candidates) == 1:
+            target_key = candidates[0]
+            merge_legacy_row(acc[target_key], acc[legacy_key])
+            del acc[legacy_key]
+
     rows: list[FrugalityTriadRow] = []
     for v in acc.values():
         models = v.get("models_by_attempt", {})
@@ -530,20 +593,38 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
 
         root_index = v.get("root_ac_index")
         authoritatively_accepted = False
-        acceptance_records = (
-            acceptance.get((v.get("seed_run_id"), root_index), [])
-            if isinstance(root_index, int)
-            else []
-        )
+        run_key = v.get("seed_run_id")
+        row_session_id = v.get("session_id")
+        acceptance_key: tuple[str | None, str | None, int] | None = None
+        acceptance_records: list[tuple[str, int, bool, str, str]] = []
+        if isinstance(root_index, int):
+            if row_session_id is not None:
+                acceptance_key = (run_key, row_session_id, root_index)
+                acceptance_records = acceptance.get(acceptance_key, [])
+            else:
+                # Legacy axis telemetry predates the explicit session field. It
+                # may be associated only when exactly one session/generation is
+                # present for this run/root; multiple sessions are ambiguous and
+                # therefore fail closed instead of being merged.
+                candidates = [
+                    (key, records)
+                    for key, records in acceptance.items()
+                    if key[0] == run_key and key[2] == root_index
+                ]
+                candidate_sessions = {key[1] for key, _records in candidates}
+                if len(candidate_sessions) == 1 and len(candidates) == 1:
+                    acceptance_key, acceptance_records = candidates[0]
         if acceptance_records:
             unique_acceptance = set(acceptance_records)
-            if (v.get("seed_run_id"), root_index) not in acceptance_invalid and len(
-                unique_acceptance
-            ) == 1:
-                _authority, final_attempt, accepted, disposition, terminal_status = next(
+            if (
+                acceptance_key is not None
+                and acceptance_key not in acceptance_invalid
+                and len(unique_acceptance) == 1
+            ):
+                authority, final_attempt, accepted, disposition, terminal_status = next(
                     iter(unique_acceptance)
                 )
-                judged_key = (v.get("seed_run_id"), root_index)
+                judged_key = (acceptance_key[0], acceptance_key[1], root_index)
                 judged_records = judged.get(judged_key, {})
                 judged_latest = max(judged_records) if judged_records else None
                 judged_latest_records = (
@@ -563,6 +644,8 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                     and len(judged_latest_records) == 1
                     and judged_latest_records[0] == (True, True)
                 )
+                v["session_id"] = acceptance_key[1]
+                v["acceptance_generation_id"] = authority
 
         delivery_values = list(deliveries.values())
         grounding_regression = (
@@ -583,6 +666,8 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
             FrugalityTriadRow(
                 ac_id=v["ac_id"],
                 seed_run_id=v.get("seed_run_id"),
+                session_id=v.get("session_id"),
+                acceptance_generation_id=v.get("acceptance_generation_id"),
                 root_ac_index=root_index if isinstance(root_index, int) else None,
                 is_decomposed_child=(
                     bool(v.get("is_decomposed_child"))

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -255,7 +255,6 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     judged_invalid: set[tuple[str | None, str | None, int]] = set()
     acceptance: dict[tuple[str | None, str | None, int], list[tuple[str, int, bool, str, str]]] = {}
     acceptance_invalid: set[tuple[str | None, str | None, int]] = set()
-    acceptance_sessions: set[str] = set()
 
     def session_anchor(data: Mapping) -> str | None:
         value = data.get("session_id")
@@ -371,8 +370,6 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                     terminal_status.strip(),
                 )
             )
-            if session_id is not None:
-                acceptance_sessions.add(session_id)
         elif etype == EVENT_EFFORT_ROUTED:
             row = slot(data)
             if row is None:
@@ -550,8 +547,25 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         candidates = [
             key for key in acc if key[0] == run_key and key[1] is not None and key[2] == ac_id
         ]
-        if len(candidates) == 1 and len(acceptance_sessions) <= 1:
-            target_key = candidates[0]
+        if len(candidates) != 1:
+            continue
+        target_key = candidates[0]
+        target = acc[target_key]
+        target_root = target.get("root_ac_index")
+        scoped_acceptance_sessions = {
+            key[1]
+            for key in acceptance
+            if key[0] == run_key
+            and (target_root is None or key[2] == target_root)
+            and key[1] is not None
+        }
+        # Legacy axis telemetry may be attached only when the matching run/root
+        # has one unambiguous acceptance session.  Sessions from other runs or
+        # unrelated roots must not poison this row, while two sessions sharing
+        # the same run/root remain fail-closed.
+        if len(scoped_acceptance_sessions) <= 1 and (
+            not scoped_acceptance_sessions or target_key[1] in scoped_acceptance_sessions
+        ):
             merge_legacy_row(acc[target_key], acc[legacy_key])
             del acc[legacy_key]
 

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -59,6 +59,7 @@ from ouroboros.orchestrator.evidence.common import (
 from ouroboros.orchestrator.evidence.common import (
     strict_bool as _strict_bool,
 )
+from ouroboros.persistence.event_store import validate_acceptance_finalization_payload
 
 # -- Event-type contract the producers must emit -----------------------------
 EVENT_EFFORT_ROUTED = "execution.ac.effort_routed"
@@ -303,15 +304,25 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         elif etype == EVENT_AC_ACCEPTANCE_FINALIZED:
             run_key = execution_run_anchor(data)
             root_index = parse_root_ac_index(data)
-            authority = data.get("authority_correlation_id")
             final_attempt = data.get("final_retry_attempt")
             accepted = _strict_bool(data.get("accepted"))
             disposition = data.get("disposition")
             terminal_status = data.get("terminal_status")
+            aggregate_id = (
+                event.get("aggregate_id")
+                if isinstance(event, Mapping)
+                else getattr(event, "aggregate_id", None)
+            )
+            try:
+                acceptance_generation, _ = validate_acceptance_finalization_payload(
+                    data,
+                    aggregate_id=aggregate_id if isinstance(aggregate_id, str) else None,
+                )
+            except Exception:
+                acceptance_generation = None
             if (
                 root_index is None
-                or not isinstance(authority, str)
-                or not authority.strip()
+                or acceptance_generation is None
                 or isinstance(final_attempt, bool)
                 or not isinstance(final_attempt, int)
                 or final_attempt < 0
@@ -326,7 +337,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 continue
             acceptance.setdefault((run_key, root_index), []).append(
                 (
-                    authority.strip(),
+                    acceptance_generation,
                     final_attempt,
                     accepted,
                     disposition.strip(),

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -52,6 +52,7 @@ from ouroboros.orchestrator.evidence.common import (
     execution_run_anchor,
     parse_retry_attempt,
     parse_root_ac_index,
+    validate_attempt_judgment_payload,
 )
 from ouroboros.orchestrator.evidence.common import (
     finite_number as _finite_number,
@@ -283,23 +284,32 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         if etype in {EVENT_AC_ATTEMPT_JUDGED, EVENT_AC_OUTCOME_FINALIZED}:
             run_key = execution_run_anchor(data)
             root_index = parse_root_ac_index(data)
-            attempt = parse_retry_attempt(data)
-            success = _strict_bool(data.get("success"))
-            is_decomposed = _strict_bool(data.get("is_decomposed"))
             if root_index is None:
                 continue
-            if attempt is None:
+            aggregate_id = (
+                event.get("aggregate_id")
+                if isinstance(event, Mapping)
+                else getattr(event, "aggregate_id", None)
+            )
+            try:
+                judgment = validate_attempt_judgment_payload(
+                    data,
+                    event_type=etype,
+                    aggregate_id=aggregate_id if isinstance(aggregate_id, str) else None,
+                )
+            except ValueError:
                 # A malformed marker for a known root must poison admission for
                 # that root. Ignoring it would let the assembler fall back to an
                 # older successful marker and potentially PASS after the producer
                 # emitted a newer-but-corrupt authoritative outcome.
                 judged_invalid.add((run_key, root_index))
                 continue
+            attempt = judgment.retry_attempt
             # Preserve malformed booleans as ``None`` instead of dropping the
             # marker. If this is the latest root attempt, admission must fail closed
             # rather than falling back to an older successful marker.
             judged.setdefault((run_key, root_index), {}).setdefault(attempt, []).append(
-                (success, is_decomposed)
+                (judgment.success, judgment.is_decomposed)
             )
         elif etype == EVENT_AC_ACCEPTANCE_FINALIZED:
             run_key = execution_run_anchor(data)

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -183,6 +183,7 @@ class LeafDispatcher:
                                 runtime_handle=state.runtime_handle,
                                 execution_id=execution_context_id,
                                 session_id=state.ac_session_id,
+                                orchestrator_session_id=session_id,
                             )
                             emitted_recovery_turn_ids.add(replacement_turn_id)
 
@@ -226,6 +227,7 @@ class LeafDispatcher:
                         runtime_handle=state.runtime_handle,
                         execution_id=execution_context_id,
                         session_id=persisted_session_id,
+                        orchestrator_session_id=session_id,
                     )
                     lifecycle_emitted = True
                     executor._remember_ac_runtime_handle(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -260,6 +260,7 @@ from ouroboros.orchestrator.evidence_schema import (
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ExecutionAuthorityLiveBinding,
+    canonical_workspace_authority,
 )
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
@@ -2457,12 +2458,36 @@ class ParallelACExecutor:
                 load_result = self._checkpoint_store.load(seed_id)
                 if hasattr(load_result, "is_ok") and load_result.is_ok and load_result.value:
                     cp = load_result.value
-                    if cp.phase == "parallel_execution":
+                    checkpoint_state = cp.state if isinstance(cp.state, Mapping) else {}
+                    current_workspace_identity = canonical_workspace_authority(
+                        self._task_cwd
+                        or getattr(self._adapter, "working_directory", None)
+                        or os.getcwd()
+                    )
+                    checkpoint_matches_invocation = (
+                        cp.seed_id == seed_id
+                        and cp.phase == "parallel_execution"
+                        and checkpoint_state.get("session_id") == session_id
+                        and checkpoint_state.get("execution_id") == execution_id
+                        and checkpoint_state.get("workspace_identity") == current_workspace_identity
+                    )
+                    if checkpoint_matches_invocation:
                         resume_from_level = cp.state.get("completed_levels", 0)
                         for idx, status in cp.state.get("ac_statuses", {}).items():
                             ac_statuses[int(idx)] = status
+                        for idx, retry_attempt in checkpoint_state.get(
+                            "ac_retry_attempts", {}
+                        ).items():
+                            if (
+                                isinstance(retry_attempt, int)
+                                and not isinstance(retry_attempt, bool)
+                                and retry_attempt >= 0
+                            ):
+                                ac_retry_attempts[int(idx)] = retry_attempt
                         for idx in cp.state.get("failed_indices", []):
                             failed_indices.add(int(idx))
+                        for idx in checkpoint_state.get("blocked_indices", []):
+                            blocked_indices.add(int(idx))
                         completed_count = cp.state.get("completed_count", 0)
                         # Restore level contexts so subsequent levels
                         # have access to completed levels' output
@@ -2484,12 +2509,37 @@ class ParallelACExecutor:
                             restored_contexts=len(level_contexts),
                         )
                         # Reconstruct all_results for completed/failed/skipped ACs.
+                        restored_outcomes = checkpoint_state.get("ac_outcomes", {})
                         for prev_stage in execution_plan.stages[:resume_from_level]:
                             for ac_idx in self._get_stage_ac_indices(prev_stage):
                                 if ac_idx >= total_acs:
                                     continue
                                 status = ac_statuses.get(ac_idx, "pending")
-                                is_completed = status == "completed"
+                                raw_outcome = (
+                                    restored_outcomes.get(str(ac_idx))
+                                    if isinstance(restored_outcomes, Mapping)
+                                    else None
+                                )
+                                outcome = (
+                                    raw_outcome
+                                    if isinstance(raw_outcome, str)
+                                    and raw_outcome
+                                    in {
+                                        "succeeded",
+                                        "satisfied_externally",
+                                        "failed",
+                                        "blocked",
+                                        "invalid",
+                                    }
+                                    else (
+                                        "succeeded"
+                                        if status == "completed"
+                                        else "blocked"
+                                        if status == "skipped"
+                                        else "failed"
+                                    )
+                                )
+                                is_completed = outcome in {"succeeded", "satisfied_externally"}
                                 is_skipped = status == "skipped"
                                 all_results.append(
                                     ACExecutionResult(
@@ -2501,18 +2551,26 @@ class ParallelACExecutor:
                                         ),
                                         error=(
                                             "Skipped: dependency failed"
-                                            if is_skipped
+                                            if outcome == "blocked" or is_skipped
                                             else None
                                             if is_completed
                                             else "Failed (restored from checkpoint)"
                                         ),
                                         retry_attempt=ac_retry_attempts.get(ac_idx, 0),
+                                        outcome=ACExecutionOutcome(outcome),
                                     )
                                 )
                         self._console.print(
                             f"[cyan]Resuming from level {resume_from_level + 1} "
                             f"(checkpoint recovered, "
                             f"{len(level_contexts)} level context(s) restored)[/cyan]"
+                        )
+                    elif cp.phase == "parallel_execution":
+                        log.info(
+                            "parallel_executor.recovery.checkpoint_identity_mismatch",
+                            seed_id=seed_id,
+                            session_id=session_id,
+                            execution_id=execution_id,
                         )
             except Exception as e:
                 log.warning(
@@ -2707,6 +2765,12 @@ class ParallelACExecutor:
                     )
                     all_results.append(satisfied_result)
                     stage_ac_results.append(satisfied_result)
+                    await self._emit_ac_attempt_judged(
+                        result=satisfied_result,
+                        root_ac_index=ac_idx,
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
                     ac_statuses[ac_idx] = "completed"
                     completed_count += 1
                     level_success += 1
@@ -2730,6 +2794,12 @@ class ParallelACExecutor:
                     )
                     all_results.append(blocked_result)
                     stage_ac_results.append(blocked_result)
+                    await self._emit_ac_attempt_judged(
+                        result=blocked_result,
+                        root_ac_index=ac_idx,
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
                     blocked_indices.add(ac_idx)
                     ac_statuses[ac_idx] = "skipped"
                     log.info(
@@ -2838,6 +2908,12 @@ class ParallelACExecutor:
                             failed_indices.add(ac_idx)
                             level_failed += 1
                             ac_statuses[ac_idx] = "failed"
+                            await self._emit_ac_attempt_judged(
+                                result=ac_result,
+                                root_ac_index=ac_idx,
+                                session_id=session_id,
+                                execution_id=execution_id,
+                            )
 
                             log.error(
                                 "parallel_executor.ac.exception",
@@ -2873,6 +2949,12 @@ class ParallelACExecutor:
                             failed_indices.add(ac_idx)
                             level_failed += 1
                             ac_statuses[ac_idx] = "failed"
+                            await self._emit_ac_attempt_judged(
+                                result=ac_result,
+                                root_ac_index=ac_idx,
+                                session_id=session_id,
+                                execution_id=execution_id,
+                            )
                             log.error(
                                 "parallel_executor.ac.stall_abandoned",
                                 session_id=session_id,
@@ -3039,9 +3121,26 @@ class ParallelACExecutor:
                             state={
                                 "session_id": session_id,
                                 "execution_id": execution_id,
+                                "workspace_identity": canonical_workspace_authority(
+                                    self._task_cwd
+                                    or getattr(self._adapter, "working_directory", None)
+                                    or os.getcwd()
+                                ),
                                 "completed_levels": level_idx + 1,
                                 "ac_statuses": {str(k): v for k, v in ac_statuses.items()},
+                                "ac_retry_attempts": {
+                                    str(k): v for k, v in ac_retry_attempts.items()
+                                },
+                                "ac_outcomes": {
+                                    str(result.ac_index): (
+                                        result.outcome.value
+                                        if result.outcome is not None
+                                        else ("succeeded" if result.success else "failed")
+                                    )
+                                    for result in all_results
+                                },
                                 "failed_indices": sorted(failed_indices),
+                                "blocked_indices": sorted(blocked_indices),
                                 "completed_count": completed_count,
                                 "level_contexts": serialize_level_contexts(level_contexts),
                                 "decomposition_decisions": {

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1283,6 +1283,77 @@ class _VerifyGateOutcome:
     workspace_digest: str | None = None
 
 
+def _serialize_verify_gate_outcome(outcome: object) -> dict[str, object] | None:
+    """Encode verify evidence into the JSON-safe checkpoint state."""
+    if not isinstance(outcome, _VerifyGateOutcome):
+        return None
+    return {
+        "passed": outcome.passed,
+        "reason": outcome.reason,
+        "output_tail": outcome.output_tail,
+        "missing_artifacts": list(outcome.missing_artifacts),
+        "workspace_mutated": outcome.workspace_mutated,
+        "workspace_digest": outcome.workspace_digest,
+    }
+
+
+def _deserialize_verify_gate_outcome(value: object) -> _VerifyGateOutcome | None:
+    """Decode checkpointed verify evidence, rejecting malformed payloads."""
+    if not isinstance(value, Mapping):
+        return None
+    passed = value.get("passed")
+    reason = value.get("reason")
+    output_tail = value.get("output_tail")
+    raw_missing = value.get("missing_artifacts", ())
+    workspace_mutated = value.get("workspace_mutated", False)
+    workspace_digest = value.get("workspace_digest")
+    if not isinstance(passed, bool) or not isinstance(output_tail, str):
+        return None
+    if reason is not None and not isinstance(reason, str):
+        return None
+    if not isinstance(raw_missing, (list, tuple)) or not all(
+        isinstance(item, str) for item in raw_missing
+    ):
+        return None
+    if not isinstance(workspace_mutated, bool):
+        return None
+    if workspace_digest is not None and not isinstance(workspace_digest, str):
+        return None
+    return _VerifyGateOutcome(
+        passed=passed,
+        reason=reason,
+        output_tail=output_tail,
+        missing_artifacts=tuple(raw_missing),
+        workspace_mutated=workspace_mutated,
+        workspace_digest=workspace_digest,
+    )
+
+
+def _checkpoint_result_retry_attempts(
+    results: list[ACExecutionResult],
+) -> dict[str, int]:
+    """Persist each result's actual attempt identity, not scheduler counters."""
+    return {
+        str(result.ac_index): result.retry_attempt
+        for result in results
+        if isinstance(result.retry_attempt, int)
+        and not isinstance(result.retry_attempt, bool)
+        and result.retry_attempt >= 0
+    }
+
+
+def _checkpoint_verify_gate_outcomes(
+    results: list[ACExecutionResult],
+) -> dict[str, dict[str, object]]:
+    """Persist all available per-result verify evidence for crash replay."""
+    serialized: dict[str, dict[str, object]] = {}
+    for result in results:
+        outcome = _serialize_verify_gate_outcome(result.verify_gate_outcome)
+        if outcome is not None:
+            serialized[str(result.ac_index)] = outcome
+    return serialized
+
+
 def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
     """Return the expected artifacts absent relative to ``cwd``.
 
@@ -2529,6 +2600,10 @@ class ParallelACExecutor:
                                 and retry_attempt >= 0
                             ):
                                 ac_retry_attempts[int(idx)] = retry_attempt
+                        raw_result_retry_attempts = checkpoint_state.get(
+                            "result_retry_attempts", {}
+                        )
+                        raw_verify_gate_outcomes = checkpoint_state.get("verify_gate_outcomes", {})
                         for idx in cp.state.get("failed_indices", []):
                             failed_indices.add(int(idx))
                         for idx in checkpoint_state.get("blocked_indices", []):
@@ -2589,6 +2664,23 @@ class ParallelACExecutor:
                                 )
                                 is_completed = outcome in {"succeeded", "satisfied_externally"}
                                 is_skipped = status == "skipped"
+                                raw_result_retry_attempt = (
+                                    raw_result_retry_attempts.get(str(ac_idx))
+                                    if isinstance(raw_result_retry_attempts, Mapping)
+                                    else None
+                                )
+                                restored_retry_attempt = (
+                                    raw_result_retry_attempt
+                                    if isinstance(raw_result_retry_attempt, int)
+                                    and not isinstance(raw_result_retry_attempt, bool)
+                                    and raw_result_retry_attempt >= 0
+                                    else ac_retry_attempts.get(ac_idx, 0)
+                                )
+                                raw_verify_gate = (
+                                    raw_verify_gate_outcomes.get(str(ac_idx))
+                                    if isinstance(raw_verify_gate_outcomes, Mapping)
+                                    else None
+                                )
                                 all_results.append(
                                     ACExecutionResult(
                                         ac_index=ac_idx,
@@ -2604,8 +2696,11 @@ class ParallelACExecutor:
                                             if is_completed
                                             else "Failed (restored from checkpoint)"
                                         ),
-                                        retry_attempt=ac_retry_attempts.get(ac_idx, 0),
+                                        retry_attempt=restored_retry_attempt,
                                         outcome=ACExecutionOutcome(outcome),
+                                        verify_gate_outcome=_deserialize_verify_gate_outcome(
+                                            raw_verify_gate
+                                        ),
                                     )
                                 )
                         self._console.print(
@@ -3211,6 +3306,12 @@ class ParallelACExecutor:
                                 "ac_retry_attempts": {
                                     str(k): v for k, v in ac_retry_attempts.items()
                                 },
+                                "result_retry_attempts": _checkpoint_result_retry_attempts(
+                                    all_results
+                                ),
+                                "verify_gate_outcomes": _checkpoint_verify_gate_outcomes(
+                                    all_results
+                                ),
                                 "ac_outcomes": {
                                     str(result.ac_index): (
                                         result.outcome.value
@@ -3267,9 +3368,9 @@ class ParallelACExecutor:
         ) or (post_coordinator_revalidation_required and not post_coordinator_revalidated)
         if needs_post_coordinator_revalidation:
             # The coordinator may have edited files after a worker's verify
-            # gate passed.  Re-run every success contract against the settled
-            # workspace; contract-less successes fail closed because there is
-            # no deterministic post-mutation evidence to bind to acceptance.
+            # gate passed.  Reconcile every success contract against the
+            # settled workspace; arbitrary verify_command contracts are not
+            # replayed because no deterministic external-effect boundary exists.
             all_results = await self._revalidate_results_after_coordinator(
                 seed=seed,
                 results=all_results,
@@ -3347,6 +3448,8 @@ class ParallelACExecutor:
                             "completed_levels": total_levels,
                             "ac_statuses": {str(k): v for k, v in ac_statuses.items()},
                             "ac_retry_attempts": {str(k): v for k, v in ac_retry_attempts.items()},
+                            "result_retry_attempts": _checkpoint_result_retry_attempts(all_results),
+                            "verify_gate_outcomes": _checkpoint_verify_gate_outcomes(all_results),
                             "ac_outcomes": {
                                 str(result.ac_index): (
                                     result.outcome.value
@@ -3534,11 +3637,13 @@ class ParallelACExecutor:
     ) -> list[ACExecutionResult]:
         """Bind successful ACs to the workspace settled by the coordinator.
 
-        A cached verify result is intentionally not reused here.  The
+        A cached command result is intentionally not replayed here.  The
         coordinator is an effectful writer and can invalidate a previously
-        passing command after the worker-level gate.  Re-running the explicit
-        success contract is deterministic; description-only ACs fail closed
-        because no independent post-mutation contract exists.
+        passing command after the worker-level gate, while an unrestricted
+        shell replay could duplicate external effects.  Command-bearing ACs
+        therefore fail closed; artifact-only contracts are checked against the
+        settled workspace and description-only ACs fail closed because no
+        independent post-mutation contract exists.
         """
         from ouroboros.events.base import BaseEvent
 
@@ -3670,8 +3775,11 @@ class ParallelACExecutor:
 
         Verify gates run as each AC completes, while later ACs can still touch
         the same workspace.  Before terminal acceptance, re-check every
-        successful contract's artifact leg and invalidate the complete success
-        set when any verify command was observed mutating the workspace.
+        successful contract's artifact leg and cached workspace identity. A
+        stale command result is rejected rather than replayed because an
+        unrestricted shell command may have effects outside the workspace.
+        Invalidate the complete success set when any verify command was
+        observed mutating the workspace.
         """
         from ouroboros.events.base import BaseEvent
         from ouroboros.orchestrator.failure_taxonomy import FailureClass
@@ -3779,25 +3887,16 @@ class ParallelACExecutor:
 
                 if cached_digest != final_digest:
                     # A later worker changed the workspace after this command
-                    # passed.  Re-run the explicit contract exactly once at the
-                    # final boundary, where its result can be bound to the
-                    # settled workspace.  Coordinator-triggered revalidation is
-                    # excluded above because arbitrary commands may have
-                    # external effects that cannot be safely replayed.
-                    rerun = await _invoke_execution_authority_entry(
-                        self,
-                        _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
-                        spec=spec,
-                        cwd=cwd,
+                    # passed.  Do not replay an unrestricted shell contract:
+                    # effects outside the workspace (DB/API/deployment writes)
+                    # cannot be detected by the digest.  The stale evidence is
+                    # therefore rejected at the final boundary.
+                    individual_failures[result.ac_index] = (
+                        "Final acceptance rejected because the workspace changed "
+                        "after verify_command completed; replaying verify_command "
+                        "is not permitted.",
+                        outcome,
                     )
-                    result = replace(result, verify_gate_outcome=rerun)
-                    if rerun.workspace_mutated:
-                        verify_mutated_workspace = True
-                    if not rerun.passed:
-                        individual_failures[result.ac_index] = (
-                            f"Final workspace verify gate failed: {rerun.reason}",
-                            rerun,
-                        )
                     settled.append(result)
                     continue
 
@@ -7008,7 +7107,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     outcome=ACExecutionOutcome.SUCCEEDED,
                     verify_gate_outcome=outcome,
                 )
-            return result
+            if cached_outcome is outcome:
+                return result
+            return replace(result, verify_gate_outcome=outcome)
         if not result.success:
             return result
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -6273,7 +6273,7 @@ Respond with either ATOMIC or the structured JSON object only.
             verify_gate_outcome=outcome,
         )
 
-    async def _emit_ac_outcome_finalized(
+    async def _emit_ac_attempt_judged(
         self,
         *,
         result: ACExecutionResult,
@@ -6513,7 +6513,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     execution_id=execution_id,
                 )
                 results[position] = gated
-                await self._emit_ac_outcome_finalized(
+                await self._emit_ac_attempt_judged(
                     result=gated,
                     root_ac_index=ac_idx,
                     session_id=session_id,
@@ -6604,7 +6604,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                 results[position_by_idx[ac_idx]] = gated
                 if isinstance(gated, ACExecutionResult):
-                    await self._emit_ac_outcome_finalized(
+                    await self._emit_ac_attempt_judged(
                         result=gated,
                         root_ac_index=ac_idx,
                         session_id=session_id,
@@ -6728,7 +6728,7 @@ Respond with either ATOMIC or the structured JSON object only.
                                 execution_id=execution_id,
                             )
                             results[position_by_idx[ac_idx]] = finalized_alt
-                            await self._emit_ac_outcome_finalized(
+                            await self._emit_ac_attempt_judged(
                                 result=finalized_alt,
                                 root_ac_index=ac_idx,
                                 session_id=session_id,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3382,6 +3382,26 @@ class ParallelACExecutor:
                         error=str(exc),
                     )
 
+        # All ACs have now finished (including any coordinator reconciliation).
+        # Reconcile verify evidence against the settled shared workspace before
+        # the runner constructs the terminal acceptance plan.
+        all_results = await self._settle_verify_gate_results(
+            seed=seed,
+            results=all_results,
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+        settled_by_index = {result.ac_index: result for result in all_results}
+        stage_results = [
+            replace(
+                stage,
+                results=tuple(
+                    settled_by_index.get(result.ac_index, result) for result in stage.results
+                ),
+            )
+            for stage in stage_results
+        ]
+
         # Aggregate results - sort by AC index for consistent ordering
         sorted_results = sorted(all_results, key=lambda r: r.ac_index)
         total_duration = (datetime.now(UTC) - start_time).total_seconds()
@@ -3638,6 +3658,111 @@ class ParallelACExecutor:
                 for result in revalidated
             ]
         return revalidated
+
+    async def _settle_verify_gate_results(
+        self,
+        *,
+        seed: Seed,
+        results: list[ACExecutionResult],
+        session_id: str,
+        execution_id: str,
+    ) -> list[ACExecutionResult]:
+        """Fail closed when final shared-workspace evidence is no longer valid.
+
+        Verify gates run as each AC completes, while later ACs can still touch
+        the same workspace.  Before terminal acceptance, re-check every
+        successful contract's artifact leg and invalidate the complete success
+        set when any verify command was observed mutating the workspace.
+        """
+        from ouroboros.events.base import BaseEvent
+        from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+        successful_contracts: dict[int, AcceptanceCriterionSpec] = {}
+        verify_mutated_workspace = False
+        for result in results:
+            outcome = result.verify_gate_outcome
+            verify_mutated_workspace = verify_mutated_workspace or bool(
+                isinstance(outcome, _VerifyGateOutcome) and outcome.workspace_mutated
+            )
+            if not result.success or not (0 <= result.ac_index < len(seed.acceptance_criteria)):
+                continue
+            spec = seed.acceptance_criteria[result.ac_index]
+            if isinstance(spec, AcceptanceCriterionSpec) and (
+                spec.verify_command or spec.expected_artifacts
+            ):
+                successful_contracts[id(result)] = spec
+
+        if not successful_contracts and not verify_mutated_workspace:
+            return results
+
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        final_digest = self._workspace_content_digest(cwd)
+        settled: list[ACExecutionResult] = []
+        for result in results:
+            if not result.success:
+                settled.append(result)
+                continue
+            spec = successful_contracts.get(id(result))
+            should_invalidate = verify_mutated_workspace or spec is not None
+            if not should_invalidate:
+                settled.append(result)
+                continue
+            missing_artifacts = (
+                _missing_expected_artifacts(spec.expected_artifacts, cwd)
+                if spec is not None
+                else ()
+            )
+            reason: str | None = None
+            if verify_mutated_workspace:
+                reason = (
+                    "Final acceptance rejected because a verify_command mutated the "
+                    "workspace or its digest could not be revalidated."
+                )
+            elif final_digest is None:
+                reason = "Final workspace digest unavailable for acceptance evidence."
+            elif missing_artifacts:
+                reason = "Final expected_artifacts missing: " + ", ".join(missing_artifacts)
+
+            if reason is None:
+                settled.append(result)
+                continue
+
+            await self._safe_emit_event(
+                BaseEvent(
+                    type="execution.verify.failed",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id or session_id,
+                    data={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "ac_index": result.ac_index,
+                        "ac_content": result.ac_content,
+                        "verify_command": spec.verify_command if spec is not None else None,
+                        "expected_artifacts": (
+                            list(spec.expected_artifacts) if spec is not None else []
+                        ),
+                        "missing_artifacts": list(missing_artifacts),
+                        "reason": reason,
+                        "failure_class": FailureClass.EVIDENCE_MISSING.value,
+                        "final_workspace_revalidation": True,
+                    },
+                )
+            )
+            settled.append(
+                replace(
+                    result,
+                    success=False,
+                    error=reason,
+                    final_message=reason,
+                    outcome=ACExecutionOutcome.FAILED,
+                    atomic_verifier_verdict=VerifierVerdict(
+                        passed=False,
+                        reasons=(reason,),
+                        failure_class=FailureClass.EVIDENCE_MISSING.value,
+                    ),
+                )
+            )
+        return settled
 
     def _coerce_decomposition_decision(
         self,
@@ -6600,6 +6725,26 @@ Respond with either ATOMIC or the structured JSON object only.
         command = spec.verify_command
         if not command:
             return _VerifyGateOutcome(passed=True, reason=None, output_tail="")
+        workspace_before = self._workspace_content_digest(cwd)
+
+        def workspace_mutation_outcome(output_tail: str) -> _VerifyGateOutcome | None:
+            workspace_after = self._workspace_content_digest(cwd)
+            if (
+                workspace_before is None
+                or workspace_after is None
+                or workspace_before != workspace_after
+            ):
+                return _VerifyGateOutcome(
+                    passed=False,
+                    reason=(
+                        "verify_command mutated the workspace or its digest could not be "
+                        "revalidated"
+                    ),
+                    output_tail=output_tail,
+                    workspace_mutated=True,
+                )
+            return None
+
         subprocess_kwargs: dict[str, Any] = {}
         if os.name != "nt":
             subprocess_kwargs["start_new_session"] = True
@@ -6633,6 +6778,9 @@ Respond with either ATOMIC or the structured JSON object only.
                     proc.kill()
             with contextlib.suppress(Exception):
                 await proc.wait()
+            mutated = workspace_mutation_outcome("")
+            if mutated is not None:
+                return mutated
             return _VerifyGateOutcome(
                 passed=False,
                 reason=(f"verify_command timed out after {self._verify_command_timeout_seconds}s"),
@@ -6641,6 +6789,9 @@ Respond with either ATOMIC or the structured JSON object only.
 
         combined = (stdout_bytes or b"").decode("utf-8", errors="replace")
         tail = combined[-_VERIFY_OUTPUT_TAIL_CHARS:]
+        mutated = workspace_mutation_outcome(tail)
+        if mutated is not None:
+            return mutated
         returncode = proc.returncode
         if returncode != 0:
             return _VerifyGateOutcome(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1279,6 +1279,7 @@ class _VerifyGateOutcome:
     reason: str | None
     output_tail: str
     missing_artifacts: tuple[str, ...] = ()
+    workspace_mutated: bool = False
 
 
 def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
@@ -1325,6 +1326,7 @@ def _revalidate_cached_verify_gate_outcome(
         reason="expected_artifacts missing: " + ", ".join(missing_artifacts),
         output_tail=outcome.output_tail,
         missing_artifacts=missing_artifacts,
+        workspace_mutated=outcome.workspace_mutated,
     )
 
 
@@ -2244,6 +2246,7 @@ class ParallelACExecutor:
         runtime_handle: RuntimeHandle | None,
         execution_id: str | None = None,
         session_id: str | None = None,
+        orchestrator_session_id: str | None = None,
         result_summary: str | None = None,
         success: bool | None = None,
         error: str | None = None,
@@ -2255,6 +2258,7 @@ class ParallelACExecutor:
             runtime_handle=runtime_handle,
             execution_id=execution_id,
             session_id=session_id,
+            orchestrator_session_id=orchestrator_session_id,
             result_summary=result_summary,
             success=success,
             error=error,
@@ -2441,6 +2445,9 @@ class ParallelACExecutor:
         # before that writer runs is not authoritative until the settled
         # workspace has been checked again at the final boundary.
         coordinator_mutated_workspace = False
+        post_coordinator_revalidation_required = False
+        post_coordinator_revalidated = False
+        post_coordinator_revalidation_workspace_digest: str | None = None
 
         total_levels = execution_plan.total_stages
         total_acs = len(seed.acceptance_criteria)
@@ -2477,6 +2484,37 @@ class ParallelACExecutor:
                         and checkpoint_state.get("workspace_identity") == current_workspace_identity
                     )
                     if checkpoint_matches_invocation:
+                        coordinator_mutated_workspace = bool(
+                            checkpoint_state.get("coordinator_mutated_workspace", False)
+                        )
+                        post_coordinator_revalidation_required = bool(
+                            checkpoint_state.get("post_coordinator_revalidation_required", False)
+                        )
+                        post_coordinator_revalidated = bool(
+                            checkpoint_state.get("post_coordinator_revalidated", False)
+                        )
+                        raw_final_digest = checkpoint_state.get(
+                            "final_workspace_digest",
+                            checkpoint_state.get("post_coordinator_revalidation_workspace_digest"),
+                        )
+                        if isinstance(raw_final_digest, str) and raw_final_digest:
+                            post_coordinator_revalidation_workspace_digest = raw_final_digest
+                        # A checkpoint may have been written before the final
+                        # revalidation.  Never let its provisional successes be
+                        # accepted on recovery without replaying that boundary.
+                        if post_coordinator_revalidation_required:
+                            current_digest = self._workspace_content_digest(
+                                self._task_cwd
+                                or getattr(self._adapter, "working_directory", None)
+                                or os.getcwd()
+                            )
+                            if (
+                                not post_coordinator_revalidated
+                                or current_digest is None
+                                or current_digest != post_coordinator_revalidation_workspace_digest
+                            ):
+                                coordinator_mutated_workspace = True
+                                post_coordinator_revalidated = False
                         resume_from_level = cp.state.get("completed_levels", 0)
                         for idx, status in cp.state.get("ac_statuses", {}).items():
                             ac_statuses[int(idx)] = status
@@ -2514,7 +2552,10 @@ class ParallelACExecutor:
                             restored_contexts=len(level_contexts),
                         )
                         # Reconstruct all_results for completed/failed/skipped ACs.
-                        restored_outcomes = checkpoint_state.get("ac_outcomes", {})
+                        restored_outcomes = checkpoint_state.get(
+                            "revalidated_ac_outcomes",
+                            checkpoint_state.get("ac_outcomes", {}),
+                        )
                         for prev_stage in execution_plan.stages[:resume_from_level]:
                             for ac_idx in self._get_stage_ac_indices(prev_stage):
                                 if ac_idx >= total_acs:
@@ -3103,6 +3144,10 @@ class ParallelACExecutor:
                             or workspace_changed
                             or self._coordinator_review_may_mutate_workspace(review)
                         )
+                        if coordinator_mutated_workspace:
+                            post_coordinator_revalidation_required = True
+                            post_coordinator_revalidated = False
+                            post_coordinator_revalidation_workspace_digest = None
                         await self._emit_coordinator_runtime_events(
                             execution_id=execution_id,
                             session_id=session_id,
@@ -3145,6 +3190,17 @@ class ParallelACExecutor:
                                     self._task_cwd
                                     or getattr(self._adapter, "working_directory", None)
                                     or os.getcwd()
+                                ),
+                                "coordinator_mutated_workspace": coordinator_mutated_workspace,
+                                "post_coordinator_revalidation_required": (
+                                    post_coordinator_revalidation_required
+                                ),
+                                "post_coordinator_revalidated": post_coordinator_revalidated,
+                                "post_coordinator_revalidation_workspace_digest": (
+                                    post_coordinator_revalidation_workspace_digest
+                                ),
+                                "final_workspace_digest": (
+                                    post_coordinator_revalidation_workspace_digest
                                 ),
                                 "completed_levels": level_idx + 1,
                                 "ac_statuses": {str(k): v for k, v in ac_statuses.items()},
@@ -3202,7 +3258,10 @@ class ParallelACExecutor:
             # All levels done — cancel the background progress emitter
             outer_tg.cancel_scope.cancel()
 
-        if coordinator_mutated_workspace:
+        needs_post_coordinator_revalidation = (
+            coordinator_mutated_workspace and not post_coordinator_revalidated
+        ) or (post_coordinator_revalidation_required and not post_coordinator_revalidated)
+        if needs_post_coordinator_revalidation:
             # The coordinator may have edited files after a worker's verify
             # gate passed.  Re-run every success contract against the settled
             # workspace; contract-less successes fail closed because there is
@@ -3213,6 +3272,35 @@ class ParallelACExecutor:
                 session_id=session_id,
                 execution_id=execution_id,
             )
+            post_coordinator_revalidation_required = True
+            post_coordinator_revalidated = True
+            post_coordinator_revalidation_workspace_digest = self._workspace_content_digest(
+                self._task_cwd or self._adapter.working_directory or os.getcwd()
+            )
+            if post_coordinator_revalidation_workspace_digest is None:
+                # The final evidence must be bound to a readable workspace. A
+                # successful command without a final digest is not durable
+                # acceptance evidence.
+                final_digest_error = (
+                    "Final workspace digest unavailable after coordinator revalidation."
+                )
+                all_results = [
+                    replace(
+                        result,
+                        success=False,
+                        error=final_digest_error,
+                        final_message=final_digest_error,
+                        outcome=ACExecutionOutcome.FAILED,
+                    )
+                    if result.success
+                    and result.outcome
+                    in {
+                        ACExecutionOutcome.SUCCEEDED,
+                        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+                    }
+                    else result
+                    for result in all_results
+                ]
             by_index = {result.ac_index: result for result in all_results}
             stage_results = [
                 replace(
@@ -3223,6 +3311,76 @@ class ParallelACExecutor:
                 )
                 for stage in stage_results
             ]
+
+            # Persist the post-coordinator verdict after, not before, the
+            # revalidation.  A crash after the old checkpoint write therefore
+            # resumes through this same boundary instead of reviving stale ACs.
+            if self._checkpoint_store:
+                try:
+                    from ouroboros.persistence.checkpoint import CheckpointData
+
+                    seed_id = getattr(seed, "id", session_id)
+                    checkpoint = CheckpointData.create(
+                        seed_id=seed_id,
+                        phase="parallel_execution",
+                        state={
+                            "session_id": session_id,
+                            "execution_id": execution_id,
+                            "workspace_identity": canonical_workspace_authority(
+                                self._task_cwd
+                                or getattr(self._adapter, "working_directory", None)
+                                or os.getcwd()
+                            ),
+                            "coordinator_mutated_workspace": coordinator_mutated_workspace,
+                            "post_coordinator_revalidation_required": (
+                                post_coordinator_revalidation_required
+                            ),
+                            "post_coordinator_revalidated": post_coordinator_revalidated,
+                            "post_coordinator_revalidation_workspace_digest": (
+                                post_coordinator_revalidation_workspace_digest
+                            ),
+                            "final_workspace_digest": post_coordinator_revalidation_workspace_digest,
+                            "completed_levels": total_levels,
+                            "ac_statuses": {str(k): v for k, v in ac_statuses.items()},
+                            "ac_retry_attempts": {str(k): v for k, v in ac_retry_attempts.items()},
+                            "ac_outcomes": {
+                                str(result.ac_index): (
+                                    result.outcome.value
+                                    if result.outcome is not None
+                                    else ("succeeded" if result.success else "failed")
+                                )
+                                for result in all_results
+                            },
+                            "revalidated_ac_outcomes": {
+                                str(result.ac_index): (
+                                    result.outcome.value
+                                    if result.outcome is not None
+                                    else ("succeeded" if result.success else "failed")
+                                )
+                                for result in all_results
+                            },
+                            "failed_indices": sorted(failed_indices),
+                            "blocked_indices": sorted(blocked_indices),
+                            "completed_count": completed_count,
+                            "level_contexts": serialize_level_contexts(level_contexts),
+                            "decomposition_decisions": {
+                                node_id: record.to_dict()
+                                for node_id, record in self._decomposition_decisions.items()
+                            },
+                        },
+                    )
+                    save_result = self._checkpoint_store.save(checkpoint)
+                    if not getattr(save_result, "is_ok", False):
+                        log.warning(
+                            "parallel_executor.final_revalidation_checkpoint_save_failed",
+                            seed_id=seed_id,
+                            error=str(getattr(save_result, "error", "unknown error")),
+                        )
+                except Exception as exc:
+                    log.warning(
+                        "parallel_executor.final_revalidation_checkpoint_save_failed",
+                        error=str(exc),
+                    )
 
         # Aggregate results - sort by AC index for consistent ordering
         sorted_results = sorted(all_results, key=lambda r: r.ac_index)
@@ -3317,6 +3475,15 @@ class ParallelACExecutor:
                         digest.update(relative.as_posix().encode("utf-8", "surrogateescape"))
                         digest.update(b"\0")
                         digest.update(os.readlink(path).encode("utf-8", "surrogateescape"))
+                    elif path.is_dir():
+                        # Empty-directory creation/removal is observable workspace
+                        # state.  Hash a directory marker as well as its mode so a
+                        # coordinator cannot evade revalidation by only changing
+                        # the tree shape.
+                        digest.update(b"D\0")
+                        digest.update(relative.as_posix().encode("utf-8", "surrogateescape"))
+                        digest.update(b"\0")
+                        digest.update(str(stat.st_mode).encode("ascii"))
                     elif path.is_file():
                         digest.update(b"F\0")
                         digest.update(relative.as_posix().encode("utf-8", "surrogateescape"))
@@ -3352,6 +3519,7 @@ class ParallelACExecutor:
 
         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
         revalidated: list[ACExecutionResult] = []
+        verify_mutated_workspace = False
         for result in results:
             if not result.success or result.outcome not in {
                 ACExecutionOutcome.SUCCEEDED,
@@ -3399,12 +3567,29 @@ class ParallelACExecutor:
                 )
                 continue
 
+            workspace_before_verify = self._workspace_content_digest(cwd)
             outcome = await _invoke_execution_authority_entry(
                 self,
                 _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
                 spec=spec,
                 cwd=cwd,
             )
+            workspace_after_verify = self._workspace_content_digest(cwd)
+            if (
+                workspace_before_verify is None
+                or workspace_after_verify is None
+                or workspace_before_verify != workspace_after_verify
+            ):
+                outcome = replace(
+                    outcome,
+                    passed=False,
+                    reason=(
+                        "verify_command mutated the workspace or its digest could not be "
+                        "revalidated"
+                    ),
+                    workspace_mutated=True,
+                )
+            verify_mutated_workspace = verify_mutated_workspace or outcome.workspace_mutated
             if not outcome.passed:
                 reason = f"Final workspace verify gate failed: {outcome.reason}"
                 detail = reason
@@ -3425,6 +3610,33 @@ class ParallelACExecutor:
                 continue
 
             revalidated.append(replace(result, verify_gate_outcome=outcome))
+
+        if verify_mutated_workspace:
+            # A verifier is an observation boundary, not another writer.  If
+            # any final verifier changed the shared workspace (or its digest
+            # became unreadable), every success observed before or after that
+            # command is stale.  Fail closed for the complete finalization set.
+            reason = (
+                "Final acceptance rejected because a verify_command mutated the "
+                "workspace or its digest could not be revalidated."
+            )
+            revalidated = [
+                replace(
+                    result,
+                    success=False,
+                    error=reason,
+                    final_message=reason,
+                    outcome=ACExecutionOutcome.FAILED,
+                )
+                if result.success
+                and result.outcome
+                in {
+                    ACExecutionOutcome.SUCCEEDED,
+                    ACExecutionOutcome.SATISFIED_EXTERNALLY,
+                }
+                else result
+                for result in revalidated
+            ]
         return revalidated
 
     def _coerce_decomposition_decision(
@@ -6019,6 +6231,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 runtime_handle=runtime_handle,
                 execution_id=execution_context_id,
                 session_id=ac_session_id,
+                orchestrator_session_id=session_id,
                 result_summary=result_final_message or None,
                 success=success,
                 error=(
@@ -6087,6 +6300,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 runtime_handle=dispatch_state.runtime_handle,
                 execution_id=execution_context_id,
                 session_id=dispatch_state.ac_session_id,
+                orchestrator_session_id=session_id,
                 success=False,
                 error=str(e),
             )

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1280,6 +1280,7 @@ class _VerifyGateOutcome:
     output_tail: str
     missing_artifacts: tuple[str, ...] = ()
     workspace_mutated: bool = False
+    workspace_digest: str | None = None
 
 
 def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
@@ -1327,6 +1328,7 @@ def _revalidate_cached_verify_gate_outcome(
         output_tail=outcome.output_tail,
         missing_artifacts=missing_artifacts,
         workspace_mutated=outcome.workspace_mutated,
+        workspace_digest=outcome.workspace_digest,
     )
 
 
@@ -2769,6 +2771,7 @@ class ParallelACExecutor:
                     # failure, execute the AC normally instead.
                     spec = seed.acceptance_criteria[ac_idx]
                     verification_status = "assumed"
+                    gate: _VerifyGateOutcome | None = None
                     if (
                         self._run_verify_commands
                         and isinstance(spec, AcceptanceCriterionSpec)
@@ -2808,6 +2811,7 @@ class ParallelACExecutor:
                         final_message="\n".join(notes),
                         retry_attempt=ac_retry_attempts[ac_idx],
                         outcome=ACExecutionOutcome.SATISFIED_EXTERNALLY,
+                        verify_gate_outcome=gate,
                     )
                     all_results.append(satisfied_result)
                     stage_ac_results.append(satisfied_result)
@@ -3390,6 +3394,7 @@ class ParallelACExecutor:
             results=all_results,
             session_id=session_id,
             execution_id=execution_id,
+            coordinator_revalidated=post_coordinator_revalidated,
         )
         settled_by_index = {result.ac_index: result for result in all_results}
         stage_results = [
@@ -3539,7 +3544,6 @@ class ParallelACExecutor:
 
         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
         revalidated: list[ACExecutionResult] = []
-        verify_mutated_workspace = False
         for result in results:
             if not result.success or result.outcome not in {
                 ACExecutionOutcome.SUCCEEDED,
@@ -3587,76 +3591,70 @@ class ParallelACExecutor:
                 )
                 continue
 
-            workspace_before_verify = self._workspace_content_digest(cwd)
-            outcome = await _invoke_execution_authority_entry(
-                self,
-                _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
-                spec=spec,
-                cwd=cwd,
-            )
-            workspace_after_verify = self._workspace_content_digest(cwd)
-            if (
-                workspace_before_verify is None
-                or workspace_after_verify is None
-                or workspace_before_verify != workspace_after_verify
-            ):
-                outcome = replace(
-                    outcome,
-                    passed=False,
-                    reason=(
-                        "verify_command mutated the workspace or its digest could not be "
-                        "revalidated"
-                    ),
-                    workspace_mutated=True,
+            if spec.verify_command:
+                # A verify command is an arbitrary shell contract and may have
+                # external effects that the workspace digest cannot observe.
+                # Never replay it after a coordinator mutation; fail closed at
+                # this boundary instead of executing an effectful command twice.
+                reason = (
+                    "Final acceptance rejected because the coordinator changed the "
+                    "workspace and replaying verify_command is not permitted."
                 )
-            verify_mutated_workspace = verify_mutated_workspace or outcome.workspace_mutated
-            if not outcome.passed:
-                reason = f"Final workspace verify gate failed: {outcome.reason}"
-                detail = reason
-                if outcome.output_tail:
-                    detail = (
-                        f"{reason}\n--- verify_command output (tail) ---\n{outcome.output_tail}"
+                await self._safe_emit_event(
+                    BaseEvent(
+                        type="execution.verify.failed",
+                        aggregate_type="execution",
+                        aggregate_id=execution_id or session_id,
+                        data={
+                            "session_id": session_id,
+                            "execution_id": execution_id,
+                            "ac_index": result.ac_index,
+                            "verify_command": spec.verify_command,
+                            "expected_artifacts": list(spec.expected_artifacts),
+                            "reason": reason,
+                            "failure_class": "evidence_missing",
+                            "final_workspace_revalidation": True,
+                            "verify_replay_blocked": True,
+                        },
                     )
+                )
                 revalidated.append(
                     replace(
                         result,
                         success=False,
-                        error=detail,
-                        final_message=detail,
+                        error=reason,
+                        final_message=reason,
                         outcome=ACExecutionOutcome.FAILED,
-                        verify_gate_outcome=outcome,
                     )
                 )
                 continue
 
-            revalidated.append(replace(result, verify_gate_outcome=outcome))
+            missing_artifacts = _missing_expected_artifacts(spec.expected_artifacts, cwd)
+            if missing_artifacts:
+                reason = "Final expected_artifacts missing: " + ", ".join(missing_artifacts)
+                revalidated.append(
+                    replace(
+                        result,
+                        success=False,
+                        error=reason,
+                        final_message=reason,
+                        outcome=ACExecutionOutcome.FAILED,
+                    )
+                )
+                continue
 
-        if verify_mutated_workspace:
-            # A verifier is an observation boundary, not another writer.  If
-            # any final verifier changed the shared workspace (or its digest
-            # became unreadable), every success observed before or after that
-            # command is stale.  Fail closed for the complete finalization set.
-            reason = (
-                "Final acceptance rejected because a verify_command mutated the "
-                "workspace or its digest could not be revalidated."
-            )
-            revalidated = [
+            revalidated.append(
                 replace(
                     result,
-                    success=False,
-                    error=reason,
-                    final_message=reason,
-                    outcome=ACExecutionOutcome.FAILED,
+                    verify_gate_outcome=_VerifyGateOutcome(
+                        passed=True,
+                        reason=None,
+                        output_tail="",
+                        workspace_digest=self._workspace_content_digest(cwd),
+                    ),
                 )
-                if result.success
-                and result.outcome
-                in {
-                    ACExecutionOutcome.SUCCEEDED,
-                    ACExecutionOutcome.SATISFIED_EXTERNALLY,
-                }
-                else result
-                for result in revalidated
-            ]
+            )
+
         return revalidated
 
     async def _settle_verify_gate_results(
@@ -3666,6 +3664,7 @@ class ParallelACExecutor:
         results: list[ACExecutionResult],
         session_id: str,
         execution_id: str,
+        coordinator_revalidated: bool = False,
     ) -> list[ACExecutionResult]:
         """Fail closed when final shared-workspace evidence is no longer valid.
 
@@ -3676,6 +3675,9 @@ class ParallelACExecutor:
         """
         from ouroboros.events.base import BaseEvent
         from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+        if not self._run_verify_commands:
+            return results
 
         successful_contracts: dict[int, AcceptanceCriterionSpec] = {}
         verify_mutated_workspace = False
@@ -3690,7 +3692,7 @@ class ParallelACExecutor:
             if isinstance(spec, AcceptanceCriterionSpec) and (
                 spec.verify_command or spec.expected_artifacts
             ):
-                successful_contracts[id(result)] = spec
+                successful_contracts[result.ac_index] = spec
 
         if not successful_contracts and not verify_mutated_workspace:
             return results
@@ -3698,35 +3700,135 @@ class ParallelACExecutor:
         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
         final_digest = self._workspace_content_digest(cwd)
         settled: list[ACExecutionResult] = []
+        individual_failures: dict[int, tuple[str, _VerifyGateOutcome | None]] = {}
+
         for result in results:
             if not result.success:
                 settled.append(result)
                 continue
-            spec = successful_contracts.get(id(result))
-            should_invalidate = verify_mutated_workspace or spec is not None
-            if not should_invalidate:
+
+            spec = successful_contracts.get(result.ac_index)
+            if spec is None:
+                # A mutating final verifier invalidates all successes, including
+                # description-only ACs.  Defer the replacement until every
+                # final verifier has been inspected.
                 settled.append(result)
                 continue
-            missing_artifacts = (
-                _missing_expected_artifacts(spec.expected_artifacts, cwd)
-                if spec is not None
-                else ()
-            )
-            reason: str | None = None
+
             if verify_mutated_workspace:
-                reason = (
-                    "Final acceptance rejected because a verify_command mutated the "
-                    "workspace or its digest could not be revalidated."
-                )
-            elif final_digest is None:
-                reason = "Final workspace digest unavailable for acceptance evidence."
-            elif missing_artifacts:
-                reason = "Final expected_artifacts missing: " + ", ".join(missing_artifacts)
-
-            if reason is None:
+                # Once one final verifier has changed (or made unreadable) the
+                # workspace, do not execute any additional arbitrary commands.
+                # The complete success set will be invalidated below.
                 settled.append(result)
                 continue
 
+            outcome = result.verify_gate_outcome
+            if not isinstance(outcome, _VerifyGateOutcome):
+                individual_failures[result.ac_index] = (
+                    "Final verify gate evidence is unavailable for acceptance.",
+                    None,
+                )
+                settled.append(result)
+                continue
+
+            if not outcome.passed:
+                individual_failures[result.ac_index] = (
+                    f"Final workspace verify gate failed: {outcome.reason}",
+                    outcome,
+                )
+                settled.append(result)
+                continue
+
+            missing_artifacts = _missing_expected_artifacts(spec.expected_artifacts, cwd)
+            if final_digest is None:
+                individual_failures[result.ac_index] = (
+                    "Final workspace digest unavailable for acceptance evidence.",
+                    outcome,
+                )
+                settled.append(result)
+                continue
+            if missing_artifacts:
+                individual_failures[result.ac_index] = (
+                    "Final expected_artifacts missing: " + ", ".join(missing_artifacts),
+                    outcome,
+                )
+                settled.append(result)
+                continue
+
+            if spec.verify_command:
+                if coordinator_revalidated:
+                    # Coordinator revalidation deliberately refuses to replay
+                    # arbitrary shell contracts.  A command-bearing success
+                    # that survived that boundary is therefore not admissible.
+                    individual_failures[result.ac_index] = (
+                        "Final acceptance rejected because coordinator revalidation "
+                        "did not replay verify_command.",
+                        outcome,
+                    )
+                    settled.append(result)
+                    continue
+
+                cached_digest = outcome.workspace_digest
+                if cached_digest is None:
+                    individual_failures[result.ac_index] = (
+                        "Final verify gate workspace digest unavailable for acceptance.",
+                        outcome,
+                    )
+                    settled.append(result)
+                    continue
+
+                if cached_digest != final_digest:
+                    # A later worker changed the workspace after this command
+                    # passed.  Re-run the explicit contract exactly once at the
+                    # final boundary, where its result can be bound to the
+                    # settled workspace.  Coordinator-triggered revalidation is
+                    # excluded above because arbitrary commands may have
+                    # external effects that cannot be safely replayed.
+                    rerun = await _invoke_execution_authority_entry(
+                        self,
+                        _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                        spec=spec,
+                        cwd=cwd,
+                    )
+                    result = replace(result, verify_gate_outcome=rerun)
+                    if rerun.workspace_mutated:
+                        verify_mutated_workspace = True
+                    if not rerun.passed:
+                        individual_failures[result.ac_index] = (
+                            f"Final workspace verify gate failed: {rerun.reason}",
+                            rerun,
+                        )
+                    settled.append(result)
+                    continue
+
+            settled.append(result)
+
+        if verify_mutated_workspace:
+            # A verifier is an observation boundary, not another writer.  If
+            # any final verifier changed the shared workspace (or its digest
+            # became unreadable), every success observed before or after that
+            # command is stale.  Fail closed for the complete finalization set.
+            mutation_reason = (
+                "Final acceptance rejected because a verify_command mutated the "
+                "workspace or its digest could not be revalidated."
+            )
+            individual_failures = {
+                result.ac_index: (mutation_reason, result.verify_gate_outcome)
+                for result in settled
+                if result.success
+            }
+
+        finalized: list[ACExecutionResult] = []
+        for result in settled:
+            failure = individual_failures.get(result.ac_index)
+            if failure is None:
+                finalized.append(result)
+                continue
+            reason, outcome = failure
+            spec = successful_contracts.get(result.ac_index)
+            missing_artifacts = (
+                list(outcome.missing_artifacts) if isinstance(outcome, _VerifyGateOutcome) else []
+            )
             await self._safe_emit_event(
                 BaseEvent(
                     type="execution.verify.failed",
@@ -3741,14 +3843,14 @@ class ParallelACExecutor:
                         "expected_artifacts": (
                             list(spec.expected_artifacts) if spec is not None else []
                         ),
-                        "missing_artifacts": list(missing_artifacts),
+                        "missing_artifacts": missing_artifacts,
                         "reason": reason,
                         "failure_class": FailureClass.EVIDENCE_MISSING.value,
                         "final_workspace_revalidation": True,
                     },
                 )
             )
-            settled.append(
+            finalized.append(
                 replace(
                     result,
                     success=False,
@@ -3762,7 +3864,7 @@ class ParallelACExecutor:
                     ),
                 )
             )
-        return settled
+        return finalized
 
     def _coerce_decomposition_decision(
         self,
@@ -6720,11 +6822,17 @@ Respond with either ATOMIC or the structured JSON object only.
                 reason="expected_artifacts missing: " + ", ".join(missing_artifacts),
                 output_tail="",
                 missing_artifacts=missing_artifacts,
+                workspace_digest=self._workspace_content_digest(cwd),
             )
 
         command = spec.verify_command
         if not command:
-            return _VerifyGateOutcome(passed=True, reason=None, output_tail="")
+            return _VerifyGateOutcome(
+                passed=True,
+                reason=None,
+                output_tail="",
+                workspace_digest=self._workspace_content_digest(cwd),
+            )
         workspace_before = self._workspace_content_digest(cwd)
 
         def workspace_mutation_outcome(output_tail: str) -> _VerifyGateOutcome | None:
@@ -6742,6 +6850,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     ),
                     output_tail=output_tail,
                     workspace_mutated=True,
+                    workspace_digest=workspace_after,
                 )
             return None
 
@@ -6785,6 +6894,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 passed=False,
                 reason=(f"verify_command timed out after {self._verify_command_timeout_seconds}s"),
                 output_tail="",
+                workspace_digest=self._workspace_content_digest(cwd),
             )
 
         combined = (stdout_bytes or b"").decode("utf-8", errors="replace")
@@ -6798,6 +6908,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 passed=False,
                 reason=f"verify_command exited with status {returncode}",
                 output_tail=tail,
+                workspace_digest=self._workspace_content_digest(cwd),
             )
         if spec.output_assertion and spec.output_assertion not in combined:
             return _VerifyGateOutcome(
@@ -6806,8 +6917,14 @@ Respond with either ATOMIC or the structured JSON object only.
                     f"output_assertion {spec.output_assertion!r} not found in verify_command output"
                 ),
                 output_tail=tail,
+                workspace_digest=self._workspace_content_digest(cwd),
             )
-        return _VerifyGateOutcome(passed=True, reason=None, output_tail=tail)
+        return _VerifyGateOutcome(
+            passed=True,
+            reason=None,
+            output_tail=tail,
+            workspace_digest=self._workspace_content_digest(cwd),
+        )
 
     async def _apply_verify_gate(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -6281,19 +6281,19 @@ Respond with either ATOMIC or the structured JSON object only.
         session_id: str,
         execution_id: str,
     ) -> None:
-        """Persist the outer verify/retry layer's authoritative AC outcome.
+        """Persist one provisional outer verify/retry attempt judgment.
 
         Leaf-level deliver and shadow events are provisional because they are
-        emitted before the seed-level success contract runs.  The deterministic
-        frugality proof requires this marker and admits only roots whose latest
-        retry was finally accepted.  Event persistence remains observe-only: if
-        the marker is dropped, the proof fails closed by excluding the rows.
+        emitted before the seed-level success contract runs.  This marker is
+        deliberately telemetry only: it never grants acceptance or dispatch
+        authority.  ``execution.ac.outcome_finalized`` remains readable as a
+        historical alias, but new producers use ``attempt_judged``.
         """
         from ouroboros.events.base import BaseEvent
 
         await self._safe_emit_event(
             BaseEvent(
-                type="execution.ac.outcome_finalized",
+                type="execution.ac.attempt_judged",
                 aggregate_type="execution",
                 aggregate_id=execution_id or session_id,
                 data={
@@ -6302,9 +6302,11 @@ Respond with either ATOMIC or the structured JSON object only.
                     "root_ac_index": root_ac_index,
                     "ac_index": root_ac_index,
                     "retry_attempt": result.retry_attempt,
+                    "attempt_number": result.attempt_number,
                     "success": result.success,
-                    "outcome": result.outcome.value if result.outcome is not None else None,
+                    "outcome": result.outcome.value if result.outcome is not None else "failed",
                     "is_decomposed": result.is_decomposed,
+                    "is_decomposed_child": result.is_decomposed,
                 },
             )
         )

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -33,6 +33,7 @@ import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from functools import wraps
+import hashlib
 import json
 import math
 import os
@@ -2436,6 +2437,10 @@ class ParallelACExecutor:
         blocked_indices: set[int] = set()
         stage_results: list[ParallelExecutionStageResult] = []
         level_contexts = list(reconciled_level_contexts or [])
+        # A coordinator is an effectful writer.  Acceptance evidence collected
+        # before that writer runs is not authoritative until the settled
+        # workspace has been checked again at the final boundary.
+        coordinator_mutated_workspace = False
 
         total_levels = execution_plan.total_stages
         total_acs = len(seed.acceptance_criteria)
@@ -3077,11 +3082,26 @@ class ParallelACExecutor:
                             conflicts=conflicts,
                         )
                         _invoke_execution_authority_guard(self)
+                        workspace_root = (
+                            self._task_cwd or self._adapter.working_directory or os.getcwd()
+                        )
+                        workspace_before = self._workspace_content_digest(workspace_root)
                         review = await self._authority_coordinator_review(
                             execution_id=execution_id,
                             conflicts=conflicts,
                             level_context=level_ctx,
                             level_number=level_num,
+                        )
+                        workspace_after = self._workspace_content_digest(workspace_root)
+                        workspace_changed = (
+                            workspace_before is None
+                            or workspace_after is None
+                            or workspace_before != workspace_after
+                        )
+                        coordinator_mutated_workspace = (
+                            coordinator_mutated_workspace
+                            or workspace_changed
+                            or self._coordinator_review_may_mutate_workspace(review)
                         )
                         await self._emit_coordinator_runtime_events(
                             execution_id=execution_id,
@@ -3182,6 +3202,28 @@ class ParallelACExecutor:
             # All levels done — cancel the background progress emitter
             outer_tg.cancel_scope.cancel()
 
+        if coordinator_mutated_workspace:
+            # The coordinator may have edited files after a worker's verify
+            # gate passed.  Re-run every success contract against the settled
+            # workspace; contract-less successes fail closed because there is
+            # no deterministic post-mutation evidence to bind to acceptance.
+            all_results = await self._revalidate_results_after_coordinator(
+                seed=seed,
+                results=all_results,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            by_index = {result.ac_index: result for result in all_results}
+            stage_results = [
+                replace(
+                    stage,
+                    results=tuple(
+                        by_index.get(result.ac_index, result) for result in stage.results
+                    ),
+                )
+                for stage in stage_results
+            ]
+
         # Aggregate results - sort by AC index for consistent ordering
         sorted_results = sorted(all_results, key=lambda r: r.ac_index)
         total_duration = (datetime.now(UTC) - start_time).total_seconds()
@@ -3221,6 +3263,169 @@ class ParallelACExecutor:
             total_messages=total_messages,
             total_duration_seconds=total_duration,
         )
+
+    @staticmethod
+    def _coordinator_review_may_mutate_workspace(review: Any) -> bool:
+        """Return whether a coordinator review could have changed the workspace.
+
+        Coordinator sessions are allowed to use ``Edit`` and ``Bash``.  The
+        structured review summary is not treated as proof of a mutation: a
+        model can report a proposed fix without applying one.  The caller also
+        compares workspace digests around the review, so direct writes remain
+        observable even when a runtime omits tool messages.
+        """
+        if review is None:
+            return False
+        for message in getattr(review, "messages", ()) or ():
+            if getattr(message, "tool_name", None) in {"Write", "Edit", "Bash"}:
+                return True
+        return False
+
+    @staticmethod
+    def _workspace_content_digest(cwd: str) -> str | None:
+        """Hash the observable workspace tree for coordinator mutation checks.
+
+        The digest intentionally excludes runtime/cache directories that are
+        not part of the task workspace contract.  Read failures return
+        ``None`` so the caller fails closed instead of trusting pre-coordinator
+        evidence it could not compare.
+        """
+        ignored_directories = {
+            ".git",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".venv",
+            "node_modules",
+        }
+        try:
+            root = Path(cwd).expanduser().resolve(strict=False)
+            if not root.is_dir():
+                return hashlib.sha256(
+                    f"missing-workspace\0{root}".encode("utf-8", "surrogateescape")
+                ).hexdigest()
+            digest = hashlib.sha256()
+            paths = sorted(root.rglob("*"), key=lambda path: path.as_posix())
+            for path in paths:
+                relative = path.relative_to(root)
+                if any(part in ignored_directories for part in relative.parts):
+                    continue
+                try:
+                    stat = path.lstat()
+                    if path.is_symlink():
+                        digest.update(b"L\0")
+                        digest.update(relative.as_posix().encode("utf-8", "surrogateescape"))
+                        digest.update(b"\0")
+                        digest.update(os.readlink(path).encode("utf-8", "surrogateescape"))
+                    elif path.is_file():
+                        digest.update(b"F\0")
+                        digest.update(relative.as_posix().encode("utf-8", "surrogateescape"))
+                        digest.update(b"\0")
+                        digest.update(str(stat.st_mode).encode("ascii"))
+                        digest.update(b"\0")
+                        with path.open("rb") as handle:
+                            while chunk := handle.read(1024 * 1024):
+                                digest.update(chunk)
+                except (OSError, ValueError):
+                    return None
+            return digest.hexdigest()
+        except (OSError, ValueError):
+            return None
+
+    async def _revalidate_results_after_coordinator(
+        self,
+        *,
+        seed: Seed,
+        results: list[ACExecutionResult],
+        session_id: str,
+        execution_id: str,
+    ) -> list[ACExecutionResult]:
+        """Bind successful ACs to the workspace settled by the coordinator.
+
+        A cached verify result is intentionally not reused here.  The
+        coordinator is an effectful writer and can invalidate a previously
+        passing command after the worker-level gate.  Re-running the explicit
+        success contract is deterministic; description-only ACs fail closed
+        because no independent post-mutation contract exists.
+        """
+        from ouroboros.events.base import BaseEvent
+
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        revalidated: list[ACExecutionResult] = []
+        for result in results:
+            if not result.success or result.outcome not in {
+                ACExecutionOutcome.SUCCEEDED,
+                ACExecutionOutcome.SATISFIED_EXTERNALLY,
+            }:
+                revalidated.append(result)
+                continue
+
+            spec = (
+                seed.acceptance_criteria[result.ac_index]
+                if 0 <= result.ac_index < len(seed.acceptance_criteria)
+                else None
+            )
+            has_contract = isinstance(spec, AcceptanceCriterionSpec) and bool(
+                spec.verify_command or spec.expected_artifacts
+            )
+            if not self._run_verify_commands or not has_contract:
+                reason = (
+                    "Final workspace changed during coordinator reconciliation; "
+                    "the AC has no deterministic post-coordinator success contract."
+                )
+                await self._safe_emit_event(
+                    BaseEvent(
+                        type="execution.verify.failed",
+                        aggregate_type="execution",
+                        aggregate_id=execution_id or session_id,
+                        data={
+                            "session_id": session_id,
+                            "execution_id": execution_id,
+                            "ac_index": result.ac_index,
+                            "reason": reason,
+                            "failure_class": "evidence_missing",
+                            "final_workspace_revalidation": True,
+                        },
+                    )
+                )
+                revalidated.append(
+                    replace(
+                        result,
+                        success=False,
+                        error=reason,
+                        final_message=reason,
+                        outcome=ACExecutionOutcome.FAILED,
+                    )
+                )
+                continue
+
+            outcome = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_RUN_AC_VERIFY_GATE,
+                spec=spec,
+                cwd=cwd,
+            )
+            if not outcome.passed:
+                reason = f"Final workspace verify gate failed: {outcome.reason}"
+                detail = reason
+                if outcome.output_tail:
+                    detail = (
+                        f"{reason}\n--- verify_command output (tail) ---\n{outcome.output_tail}"
+                    )
+                revalidated.append(
+                    replace(
+                        result,
+                        success=False,
+                        error=detail,
+                        final_message=detail,
+                        outcome=ACExecutionOutcome.FAILED,
+                        verify_gate_outcome=outcome,
+                    )
+                )
+                continue
+
+            revalidated.append(replace(result, verify_gate_outcome=outcome))
+        return revalidated
 
     def _coerce_decomposition_decision(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -7269,21 +7269,30 @@ class OrchestratorRunner:
             if outcome is None and default_outcome is not None:
                 outcome = default_outcome
             if not isinstance(outcome, str) or not outcome.strip():
-                outcome = "blocked" if result is None else ("failed" if not result.success else "succeeded")
+                outcome = (
+                    "blocked"
+                    if result is None
+                    else ("failed" if not result.success else "succeeded")
+                )
             retry_attempt = getattr(result, "retry_attempt", 0) if result is not None else 0
-            if isinstance(retry_attempt, bool) or not isinstance(retry_attempt, int) or retry_attempt < 0:
+            if (
+                isinstance(retry_attempt, bool)
+                or not isinstance(retry_attempt, int)
+                or retry_attempt < 0
+            ):
                 retry_attempt = 0
             accepted = bool(
                 terminal_status == SessionStatus.COMPLETED.value
                 and (
                     root_ac_index in accepted_root_indices
                     if accepted_root_indices is not None
-                    else result is not None
-                    and outcome in {"succeeded", "satisfied_externally"}
+                    else result is not None and outcome in {"succeeded", "satisfied_externally"}
                 )
             )
-            disposition = "accepted" if accepted else (
-                "cancelled" if terminal_status == SessionStatus.CANCELLED.value else outcome
+            disposition = (
+                "accepted"
+                if accepted
+                else ("cancelled" if terminal_status == SessionStatus.CANCELLED.value else outcome)
             )
             await self._event_store.append(
                 BaseEvent(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from contextlib import aclosing
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 import hashlib
@@ -31,6 +32,7 @@ import math
 import os
 from pathlib import Path
 import re
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 from uuid import uuid4
 
@@ -101,6 +103,7 @@ from ouroboros.orchestrator.execution_authority import (
     _register_process_local_authority_terminal_finalizer,
     _release_process_local_authority_generation,
     _retire_process_local_authority_generation,
+    collect_cancellation_acceptance_plan,
     constructor_model_contract,
     request_process_local_cancellation,
     runtime_execution_proves_effective_model,
@@ -154,6 +157,7 @@ from ouroboros.orchestrator.session import (
 )
 from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 from ouroboros.persistence.checkpoint import CheckpointStore
+from ouroboros.persistence.event_store import acceptance_generation_id_for_session
 from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.resilience.lateral import ThinkingPersona
 from ouroboros.resilience.recovery import (
@@ -243,6 +247,7 @@ class _PendingLifecycleIntent:
     messages_processed: int = 0
     cancelled_by: str = "runner"
     pause: RecoverableFailurePause | None = None
+    acceptance_finalizations: list[dict[str, Any]] | None = None
 
 
 # =============================================================================
@@ -846,6 +851,7 @@ class OrchestratorRunner:
             )
         self._apply_efficiency_mode_to_router()
         self._execution_contract: dict[str, Any] | None = None
+        self._execution_contract_restore_lock = RLock()
         self._process_local_authorities: dict[
             tuple[str, str], _ProcessLocalAuthorityGeneration
         ] = {}
@@ -1806,6 +1812,13 @@ class OrchestratorRunner:
         execution_contract: Mapping[str, Any] | None = None,
     ) -> tuple[SessionStatus | None, Result[OrchestratorResult, OrchestratorError] | None]:
         """Persist one durable failure winner before withdrawing ownership."""
+        if seed is None:
+            return None, self._terminal_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                requested_status=SessionStatus.FAILED,
+                cause=PersistenceError("Cannot persist FAILED without the seed acceptance plan."),
+            )
         reconciled_during_exception = False
         acceptance_finalizations = (
             self._build_terminal_acceptance_finalizations(
@@ -1846,6 +1859,7 @@ class OrchestratorRunner:
                     error_message=str(error),
                     error_type=type(error).__name__,
                     messages_processed=messages_processed,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
                 if isinstance(persistence_error, asyncio.CancelledError):
                     self._preserve_process_local_owner_for_retry(
@@ -1872,25 +1886,6 @@ class OrchestratorRunner:
             await self._cleanup_terminal_process_local_state(
                 session_id=session_id,
                 execution_id=execution_id,
-            )
-        if seed is not None:
-            await self._emit_terminal_acceptance_finalized(
-                seed=seed,
-                parallel_result=None,
-                execution_id=execution_id,
-                session_id=session_id,
-                terminal_status=durable_status.value,
-                accepted_root_indices=(
-                    set(range(len(seed.acceptance_criteria)))
-                    if durable_status is SessionStatus.COMPLETED
-                    else set()
-                ),
-                default_outcome=(
-                    "succeeded"
-                    if durable_status is SessionStatus.COMPLETED
-                    else durable_status.value
-                ),
-                execution_contract=execution_contract,
             )
         try:
             await self._event_store.append(
@@ -2792,6 +2787,11 @@ class OrchestratorRunner:
         winner, otherwise completion and public cancellation can produce
         contradictory terminal streams.
         """
+        terminal_plan = (
+            [dict(item) for item in acceptance_finalizations]
+            if acceptance_finalizations is not None
+            else None
+        )
         intent = _PendingLifecycleIntent(
             execution_id=execution_id,
             status=requested_status,
@@ -2801,15 +2801,14 @@ class OrchestratorRunner:
             error_type=error_type,
             messages_processed=messages_processed,
             cancelled_by=cancelled_by,
+            acceptance_finalizations=terminal_plan,
         )
         result: Any = None
         last_error: object | None = None
         for attempt in range(3):
             try:
                 acceptance_kwargs = (
-                    {"acceptance_finalizations": acceptance_finalizations}
-                    if acceptance_finalizations is not None
-                    else {}
+                    {"acceptance_finalizations": terminal_plan} if terminal_plan is not None else {}
                 )
                 if requested_status is SessionStatus.COMPLETED:
                     result = await self._session_repo.mark_completed(
@@ -2992,6 +2991,51 @@ class OrchestratorRunner:
                 cause=exc,
             )
 
+        replayed_acceptance_finalizations = intent.acceptance_finalizations
+        if intent.status is SessionStatus.CANCELLED and replayed_acceptance_finalizations is None:
+            # ``None`` means the previous owner failed before it could obtain
+            # the exact telemetry snapshot.  Never replay that intent as an
+            # unplanned terminal cancellation: re-collect the plan first and
+            # retain it for the next retry if persistence still fails.
+            try:
+                replayed_acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    event_store=self._event_store,
+                )
+            except asyncio.CancelledError:
+                self._preserve_process_local_owner_for_retry(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                raise
+            except Exception as exc:
+                return self._cancellation_persistence_pending_result(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    cause=exc,
+                    acceptance_finalizations=None,
+                    cancellation_reason=intent.error_message,
+                    cancelled_by=intent.cancelled_by,
+                )
+            self._pending_lifecycle_intents[tracker.session_id] = replace(
+                intent,
+                acceptance_finalizations=[dict(item) for item in replayed_acceptance_finalizations],
+            )
+        elif (
+            intent.status in {SessionStatus.COMPLETED, SessionStatus.FAILED}
+            and replayed_acceptance_finalizations is None
+        ):
+            # A terminal intent without a captured plan is not replayable.
+            # Keeping it pending is safer than committing a lifecycle winner
+            # that can never be joined to its complete root decision set.
+            return self._terminal_persistence_pending_result(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                requested_status=intent.status,
+                cause=PersistenceError("Pending terminal intent is missing its acceptance plan."),
+            )
+
         resolved_status: SessionStatus
         try:
             if intent.status is SessionStatus.PAUSED:
@@ -3034,6 +3078,7 @@ class OrchestratorRunner:
                     error_type=intent.error_type,
                     messages_processed=intent.messages_processed,
                     cancelled_by=intent.cancelled_by,
+                    acceptance_finalizations=replayed_acceptance_finalizations,
                 )
         except asyncio.CancelledError:
             if (
@@ -4003,6 +4048,33 @@ class OrchestratorRunner:
             )
             return True
         return False
+
+    def _restore_execution_contract_snapshot(
+        self,
+        progress: Mapping[str, Any],
+        *,
+        seed: Seed | None = None,
+        authority_generation: _ProcessLocalAuthorityGeneration | None = None,
+    ) -> tuple[bool, dict[str, Any]]:
+        """Restore and return one immutable invocation-local contract snapshot.
+
+        The legacy restore routine updates runner configuration as a side
+        effect.  Serialize that mutation and copy the resulting contract
+        inside the same worker-thread critical section so a concurrent resume
+        can never copy another session's authority after the await boundary.
+        """
+        with self._execution_contract_restore_lock:
+            changed = self._restore_execution_contract(
+                progress,
+                seed=seed,
+                authority_generation=authority_generation,
+            )
+            if not isinstance(self._execution_contract, Mapping):
+                raise OrchestratorError(
+                    message="Cannot resume without a restored execution contract",
+                    details={"invalid": "execution_contract"},
+                )
+            return changed, deepcopy(dict(self._execution_contract))
 
     @staticmethod
     def _proof_cohort_identity(
@@ -5224,6 +5296,9 @@ class OrchestratorRunner:
         session_id: str,
         execution_id: str,
         cause: object,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
+        cancellation_reason: str | None = None,
+        cancelled_by: str = "runner",
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Leave a failed cancellation write retryable without stranding a claim.
 
@@ -5237,6 +5312,14 @@ class OrchestratorRunner:
             session_id=session_id,
             execution_id=execution_id,
         )
+        if acceptance_finalizations is not None or cancellation_reason is not None:
+            self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                execution_id=execution_id,
+                status=SessionStatus.CANCELLED,
+                error_message=cancellation_reason or "Execution cancelled",
+                cancelled_by=cancelled_by,
+                acceptance_finalizations=acceptance_finalizations,
+            )
         return Result.err(
             OrchestratorError(
                 message="Failed to persist cancellation; process-local authority remains live",
@@ -5361,11 +5444,6 @@ class OrchestratorRunner:
         # cancellation that the durable session never recorded.
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
-        session_contract = None
-        if session_result.is_ok:
-            persisted_contract = session_result.value.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
-            if isinstance(persisted_contract, Mapping):
-                session_contract = dict(persisted_contract)
         # An unreadable snapshot cannot prove that a terminal state already
         # exists.  Continue through ``mark_cancelled`` while retaining the live
         # owner; that append is the authoritative terminal write and preserves
@@ -5389,12 +5467,6 @@ class OrchestratorRunner:
 
             async def _reconcile_existing_terminal_owner() -> None:
                 try:
-                    await self._emit_cancellation_acceptance_finalized(
-                        execution_id=execution_id,
-                        session_id=session_id,
-                        terminal_status=terminal_status,
-                        execution_contract=session_contract,
-                    )
                     if not execution_terminal_events:
                         await self._event_store.append(
                             create_execution_terminal_event(
@@ -5436,11 +5508,30 @@ class OrchestratorRunner:
                 )
             )
 
+        # Compute the complete observed-root decision set before the terminal
+        # CAS.  The terminal session event carries this exact plan so a
+        # cancellation cannot commit a durable winner and then lose its final
+        # acceptance records to interruption.
+        try:
+            cancellation_acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                session_id=session_id,
+                execution_id=execution_id,
+                event_store=self._event_store,
+            )
+        except Exception as exc:
+            return self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=exc,
+                cancellation_reason=cancellation_reason,
+                cancelled_by=cancelled_by,
+            )
         try:
             cancel_result = await self._session_repo.mark_cancelled(
                 session_id,
                 reason=cancellation_reason,
                 cancelled_by=cancelled_by,
+                acceptance_finalizations=cancellation_acceptance_finalizations,
             )
         except asyncio.CancelledError:
             if (
@@ -5450,6 +5541,13 @@ class OrchestratorRunner:
                 )
                 is None
             ):
+                self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                    execution_id=execution_id,
+                    status=SessionStatus.CANCELLED,
+                    error_message=cancellation_reason,
+                    cancelled_by=cancelled_by,
+                    acceptance_finalizations=cancellation_acceptance_finalizations,
+                )
                 self._preserve_process_local_owner_for_retry(
                     session_id=session_id,
                     execution_id=execution_id,
@@ -5476,6 +5574,9 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
                 cause=exc,
+                acceptance_finalizations=cancellation_acceptance_finalizations,
+                cancellation_reason=cancellation_reason,
+                cancelled_by=cancelled_by,
             )
         if cancel_result is not None and cancel_result.is_err:
             log.warning(
@@ -5487,6 +5588,9 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
                 cause=cancel_result.error,
+                acceptance_finalizations=cancellation_acceptance_finalizations,
+                cancellation_reason=cancellation_reason,
+                cancelled_by=cancelled_by,
             )
         if cancel_result is not None and cancel_result.value is False:
             # The session became terminal after the initial reconstruction but
@@ -5515,12 +5619,6 @@ class OrchestratorRunner:
         # durable CAS has committed.
         async def _reconcile_cancelled_owner() -> None:
             try:
-                await self._emit_cancellation_acceptance_finalized(
-                    execution_id=execution_id,
-                    session_id=session_id,
-                    terminal_status=SessionStatus.CANCELLED,
-                    execution_contract=session_contract,
-                )
                 await self._event_store.append(
                     create_execution_terminal_event(
                         execution_id=execution_id,
@@ -5563,109 +5661,6 @@ class OrchestratorRunner:
                 duration_seconds=duration,
             )
         )
-
-    async def _emit_cancellation_acceptance_finalized(
-        self,
-        *,
-        execution_id: str,
-        session_id: str,
-        terminal_status: SessionStatus = SessionStatus.CANCELLED,
-        execution_contract: Mapping[str, Any] | None = None,
-    ) -> None:
-        """Close observed root-AC episodes using the durable terminal winner."""
-        contract = execution_contract or self._execution_contract
-        authority_contract = contract.get("foundation_a_authority") if contract else None
-        authority = (
-            authority_contract.get("correlation_id")
-            if isinstance(authority_contract, Mapping)
-            else None
-        )
-        if not isinstance(authority, str) or not authority.strip():
-            return
-        attempts: list[Any] = []
-        for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
-            try:
-                attempts.extend(
-                    await self._event_store.query_events(
-                        aggregate_id=execution_id,
-                        event_type=event_type,
-                        limit=None,
-                    )
-                )
-            except Exception:
-                # Cancellation remains a valid durable terminal result even
-                # when optional attempt telemetry cannot be read. A later
-                # reconciler can replay the finalization plan from the
-                # terminal session event when one was persisted.
-                log.warning(
-                    "orchestrator.runner.cancellation_acceptance_scan_failed",
-                    execution_id=execution_id,
-                    session_id=session_id,
-                    event_type=event_type,
-                )
-                return
-        latest_by_root: dict[int, int] = {}
-        for event in attempts:
-            root = event.data.get("root_ac_index")
-            retry = event.data.get("retry_attempt", 0)
-            if (
-                isinstance(root, int)
-                and not isinstance(root, bool)
-                and root >= 0
-                and isinstance(retry, int)
-                and not isinstance(retry, bool)
-                and retry >= 0
-            ):
-                latest_by_root[root] = max(latest_by_root.get(root, 0), retry)
-        from ouroboros.events.base import BaseEvent
-
-        latest_event_by_root: dict[int, Any] = {}
-        for event in attempts:
-            root = event.data.get("root_ac_index")
-            if root not in latest_by_root:
-                continue
-            retry = event.data.get("retry_attempt", 0)
-            if retry == latest_by_root[root]:
-                latest_event_by_root[root] = event
-
-        for root, retry in latest_by_root.items():
-            latest = latest_event_by_root.get(root)
-            latest_data = latest.data if latest is not None else {}
-            outcome = str(latest_data.get("outcome") or "").strip()
-            if not outcome:
-                outcome = (
-                    "succeeded" if latest_data.get("success") is True else terminal_status.value
-                )
-            accepted = bool(
-                terminal_status is SessionStatus.COMPLETED
-                and (
-                    latest_data.get("success") is True
-                    or outcome in {"succeeded", "satisfied_externally"}
-                )
-            )
-            disposition = (
-                "accepted"
-                if accepted
-                else ("cancelled" if terminal_status is SessionStatus.CANCELLED else outcome)
-            )
-            await self._event_store.append(
-                BaseEvent(
-                    type="execution.ac.acceptance_finalized",
-                    aggregate_type="execution",
-                    aggregate_id=execution_id or session_id,
-                    data={
-                        "execution_id": execution_id,
-                        "session_id": session_id,
-                        "authority_correlation_id": authority.strip(),
-                        "root_ac_index": root,
-                        "final_retry_attempt": retry,
-                        "accepted": accepted,
-                        "disposition": disposition,
-                        "outcome": outcome,
-                        "terminal_status": terminal_status.value,
-                    },
-                )
-            )
 
     async def execute_seed(
         self,
@@ -6738,24 +6733,6 @@ class OrchestratorRunner:
                     else SessionStatus.FAILED.value
                 )
             )
-            await self._emit_terminal_acceptance_finalized(
-                seed=seed,
-                parallel_result=None,
-                execution_id=exec_id,
-                session_id=tracker.session_id,
-                terminal_status=terminal_status,
-                accepted_root_indices=(
-                    set(range(len(seed.acceptance_criteria)))
-                    if terminal_status == SessionStatus.COMPLETED.value
-                    else set()
-                ),
-                default_outcome=(
-                    "succeeded"
-                    if terminal_status == SessionStatus.COMPLETED.value
-                    else terminal_status
-                ),
-                execution_contract=execution_contract,
-            )
             terminal_event = create_execution_terminal_event(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
@@ -7264,14 +7241,6 @@ class OrchestratorRunner:
                 else SessionStatus.FAILED.value
             )
         )
-        await self._emit_terminal_acceptance_finalized(
-            seed=seed,
-            parallel_result=parallel_result,
-            execution_id=exec_id,
-            session_id=tracker.session_id,
-            terminal_status=terminal_status,
-            execution_contract=execution_contract,
-        )
         terminal_event = create_execution_terminal_event(
             execution_id=exec_id,
             session_id=tracker.session_id,
@@ -7375,22 +7344,11 @@ class OrchestratorRunner:
         """Build the complete root decision set before terminal CAS."""
         if terminal_status == SessionStatus.PAUSED.value:
             return []
-        contract = execution_contract
-        if contract is None:
-            contract = self._execution_contract
-        authority_contract = contract.get("foundation_a_authority") if contract else None
-        authority_correlation_id = (
-            authority_contract.get("correlation_id")
-            if isinstance(authority_contract, Mapping)
-            else None
+        del execution_contract
+        acceptance_generation_id = acceptance_generation_id_for_session(
+            session_id,
+            execution_id,
         )
-        if not isinstance(authority_correlation_id, str) or not authority_correlation_id.strip():
-            log.error(
-                "orchestrator.runner.acceptance_finalization_missing_authority",
-                execution_id=execution_id,
-                session_id=session_id,
-            )
-            return []
 
         results_by_index: dict[int, Any] = {}
         for result in getattr(parallel_result, "results", ()):
@@ -7435,13 +7393,19 @@ class OrchestratorRunner:
             disposition = (
                 "accepted"
                 if accepted
-                else ("cancelled" if terminal_status == SessionStatus.CANCELLED.value else outcome)
+                else (
+                    "cancelled"
+                    if terminal_status == SessionStatus.CANCELLED.value
+                    else (
+                        "rejected" if outcome in {"succeeded", "satisfied_externally"} else outcome
+                    )
+                )
             )
             finalizations.append(
                 {
                     "execution_id": execution_id,
                     "session_id": session_id,
-                    "authority_correlation_id": authority_correlation_id.strip(),
+                    "acceptance_generation_id": acceptance_generation_id,
                     "root_ac_index": root_ac_index,
                     "final_retry_attempt": retry_attempt,
                     "accepted": accepted,
@@ -7451,48 +7415,6 @@ class OrchestratorRunner:
                 }
             )
         return finalizations
-
-    async def _emit_terminal_acceptance_finalized(
-        self,
-        *,
-        seed: Seed,
-        parallel_result: Any,
-        execution_id: str,
-        session_id: str,
-        terminal_status: str,
-        accepted_root_indices: set[int] | None = None,
-        default_outcome: str | None = None,
-        execution_contract: Mapping[str, Any] | None = None,
-    ) -> None:
-        """Have the terminal Final Gate publish one decision per root AC.
-
-        Attempt judgments are deliberately insufficient for admission. This
-        method runs only after the session CAS has produced a terminal status;
-        a paused episode therefore has no final acceptance event. The
-        EventStore's authority/root CAS makes retries and duplicate observers
-        idempotent while rejecting contradictory payloads.
-        """
-        finalizations = self._build_terminal_acceptance_finalizations(
-            seed=seed,
-            parallel_result=parallel_result,
-            execution_id=execution_id,
-            session_id=session_id,
-            terminal_status=terminal_status,
-            accepted_root_indices=accepted_root_indices,
-            default_outcome=default_outcome,
-            execution_contract=execution_contract,
-        )
-        from ouroboros.events.base import BaseEvent
-
-        for finalization in finalizations:
-            await self._event_store.append(
-                BaseEvent(
-                    type="execution.ac.acceptance_finalized",
-                    aggregate_type="execution",
-                    aggregate_id=execution_id or session_id,
-                    data=finalization,
-                )
-            )
 
     async def resume_session(
         self,
@@ -7754,18 +7676,13 @@ class OrchestratorRunner:
             )
 
         try:
-            execution_contract_changed = await asyncio.to_thread(
-                self._restore_execution_contract,
+            execution_contract_changed, execution_contract = await asyncio.to_thread(
+                self._restore_execution_contract_snapshot,
                 tracker.progress,
                 seed=seed,
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
-            execution_contract = (
-                dict(self._execution_contract)
-                if isinstance(self._execution_contract, Mapping)
-                else dict(raw_contract)
-            )
         except asyncio.CancelledError:
             cancellation_result = (
                 await self._drain_requested_cancellation_before_pre_execution_cleanup(
@@ -7826,9 +7743,9 @@ class OrchestratorRunner:
                     start_time=datetime.now(UTC),
                 )
 
-            if execution_contract_changed and self._execution_contract is not None:
+            if execution_contract_changed:
                 contract_progress = {
-                    EXECUTION_CONTRACT_PROGRESS_KEY: self._execution_contract,
+                    EXECUTION_CONTRACT_PROGRESS_KEY: execution_contract,
                     "messages_processed": tracker.messages_processed,
                 }
                 persisted_contract = await self._session_repo.track_progress(
@@ -8223,24 +8140,6 @@ Note: This is a resumed session. Please continue from where execution was interr
                     if durable_terminal_status is not None
                     else SessionStatus.FAILED.value
                 )
-            )
-            await self._emit_terminal_acceptance_finalized(
-                seed=seed,
-                parallel_result=None,
-                execution_id=tracker.execution_id,
-                session_id=session_id,
-                terminal_status=terminal_status,
-                accepted_root_indices=(
-                    set(range(len(seed.acceptance_criteria)))
-                    if terminal_status == SessionStatus.COMPLETED.value
-                    else set()
-                ),
-                default_outcome=(
-                    "succeeded"
-                    if terminal_status == SessionStatus.COMPLETED.value
-                    else terminal_status
-                ),
-                execution_contract=execution_contract,
             )
             terminal_event = create_execution_terminal_event(
                 execution_id=tracker.execution_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -899,6 +899,11 @@ class OrchestratorRunner:
         self._announced_param_degradations: set[tuple[str, str]] = set()
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
+        # Resume restores invocation-specific routing/guidance into runner
+        # fields for compatibility with the existing execution path. Serialize
+        # the whole resume invocation so one session cannot observe another
+        # session's restored contract between those mutations and first use.
+        self._resume_lock = asyncio.Lock()
 
     def _apply_efficiency_mode_to_router(self) -> None:
         """Apply the public efficiency preference to the resolved tier router."""
@@ -7573,6 +7578,15 @@ class OrchestratorRunner:
         return finalizations
 
     async def resume_session(
+        self,
+        session_id: str,
+        seed: Seed,
+    ) -> Result[OrchestratorResult, OrchestratorError]:
+        """Serialize resume invocations that temporarily restore runner state."""
+        async with self._resume_lock:
+            return await self._resume_session_impl(session_id, seed)
+
+    async def _resume_session_impl(
         self,
         session_id: str,
         seed: Seed,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -5919,17 +5919,29 @@ class OrchestratorRunner:
         self._task_workspace_reservations.discard(authority_generation)
         self._execution_contract = execution_contract
 
+        create_session_kwargs: dict[str, Any] = {
+            "execution_id": exec_id,
+            "seed_id": seed.metadata.seed_id,
+            "session_id": resolved_session_id,
+            "seed_goal": seed.goal,
+            "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+            "llm_backend": getattr(self._adapter, "llm_backend", None),
+            "execution_contract": execution_contract,
+        }
         try:
-            session_result = await self._session_repo.create_session(
-                execution_id=exec_id,
-                seed_id=seed.metadata.seed_id,
-                session_id=resolved_session_id,
-                seed_goal=seed.goal,
-                runtime_backend=getattr(self._adapter, "runtime_backend", None),
-                llm_backend=getattr(self._adapter, "llm_backend", None),
-                execution_contract=execution_contract,
-                acceptance_root_indices=range(len(seed.acceptance_criteria)),
-            )
+            if (
+                "acceptance_root_indices"
+                in inspect.signature(self._session_repo.create_session).parameters
+            ):
+                create_session_kwargs["acceptance_root_indices"] = range(
+                    len(seed.acceptance_criteria)
+                )
+        except (TypeError, ValueError):
+            # Legacy/mock repositories may not expose an inspectable signature;
+            # the durable SessionRepository path always does.
+            pass
+        try:
+            session_result = await self._session_repo.create_session(**create_session_kwargs)
         except asyncio.CancelledError:
             await self._reconcile_session_publication_interruption(
                 session_id=resolved_session_id,
@@ -6035,7 +6047,6 @@ class OrchestratorRunner:
             "fat_harness_mode": self._fat_harness_mode,
             "messages_processed": 0,
             EXECUTION_CONTRACT_PROGRESS_KEY: execution_contract,
-            ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY: list(range(len(seed.acceptance_criteria))),
         }
         if self._task_workspace is not None:
             initial_progress["workspace"] = self._task_workspace.to_progress_dict()

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -149,6 +149,7 @@ from ouroboros.orchestrator.runtime_param_negotiation import (
     runtime_capabilities_for,
 )
 from ouroboros.orchestrator.session import (
+    ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY,
     SESSION_RUNTIME_IDENTITY_PROGRESS_KEY,
     SESSION_START_IDENTITY_PROGRESS_KEY,
     SessionRepository,
@@ -5097,13 +5098,9 @@ class OrchestratorRunner:
             )
 
         # Historical sessions have no live Foundation A capability to coordinate.
-        raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+        raw_root_indices = tracker.progress.get(ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY)
         expected_root_indices = (
-            range(raw_total_acs)
-            if isinstance(raw_total_acs, int)
-            and not isinstance(raw_total_acs, bool)
-            and raw_total_acs >= 0
-            else None
+            tuple(raw_root_indices) if isinstance(raw_root_indices, (list, tuple)) else None
         )
         try:
             acceptance_finalizations = await collect_cancellation_acceptance_plan(
@@ -5444,6 +5441,7 @@ class OrchestratorRunner:
         execution_id: str,
         messages_processed: int,
         start_time: datetime,
+        expected_root_indices: Iterable[int] | None = None,
     ) -> Result[OrchestratorResult, OrchestratorError] | None:
         """Persist a published cancellation before abandoning a claimed setup.
 
@@ -5468,6 +5466,7 @@ class OrchestratorRunner:
                 execution_id=execution_id,
                 messages_processed=messages_processed,
                 start_time=start_time,
+                expected_root_indices=expected_root_indices,
             )
         )
         repeated_cancellation: asyncio.CancelledError | None = None
@@ -5929,6 +5928,7 @@ class OrchestratorRunner:
                 runtime_backend=getattr(self._adapter, "runtime_backend", None),
                 llm_backend=getattr(self._adapter, "llm_backend", None),
                 execution_contract=execution_contract,
+                acceptance_root_indices=range(len(seed.acceptance_criteria)),
             )
         except asyncio.CancelledError:
             await self._reconcile_session_publication_interruption(
@@ -6035,6 +6035,7 @@ class OrchestratorRunner:
             "fat_harness_mode": self._fat_harness_mode,
             "messages_processed": 0,
             EXECUTION_CONTRACT_PROGRESS_KEY: execution_contract,
+            ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY: list(range(len(seed.acceptance_criteria))),
         }
         if self._task_workspace is not None:
             initial_progress["workspace"] = self._task_workspace.to_progress_dict()
@@ -6233,6 +6234,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -6249,6 +6251,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -6391,6 +6394,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -6412,6 +6416,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -7804,6 +7809,7 @@ class OrchestratorRunner:
                     execution_id=tracker.execution_id,
                     messages_processed=tracker.messages_processed,
                     start_time=tracker.start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -7825,6 +7831,7 @@ class OrchestratorRunner:
                     execution_id=tracker.execution_id,
                     messages_processed=tracker.messages_processed,
                     start_time=tracker.start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -7942,6 +7949,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     execution_id=tracker.execution_id,
                     messages_processed=tracker.messages_processed,
                     start_time=tracker.start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:
@@ -7958,6 +7966,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     execution_id=tracker.execution_id,
                     messages_processed=tracker.messages_processed,
                     start_time=tracker.start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             )
             if cancellation_result is not None:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -104,6 +104,7 @@ from ouroboros.orchestrator.execution_authority import (
     _release_process_local_authority_generation,
     _retire_process_local_authority_generation,
     collect_cancellation_acceptance_plan,
+    collect_terminal_acceptance_plan,
     constructor_model_contract,
     request_process_local_cancellation,
     runtime_execution_proves_effective_model,
@@ -2549,12 +2550,46 @@ class OrchestratorRunner:
         """Terminally record a lost local capability without trying a fallback."""
         error = self._process_local_resume_unavailable_error(session_id, execution_id)
         last_error: object | None = None
+        acceptance_finalizations: list[dict[str, Any]] | None = None
+        try:
+            acceptance_finalizations = await collect_terminal_acceptance_plan(
+                session_id=session_id,
+                execution_id=execution_id,
+                event_store=self._event_store,
+                terminal_status=SessionStatus.FAILED.value,
+            )
+        except (Exception, asyncio.CancelledError) as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+            last_error = exc
+
+        if acceptance_finalizations is None:
+            self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                execution_id=execution_id,
+                status=SessionStatus.FAILED,
+                error_message=error.message,
+                error_details=dict(error.details),
+                acceptance_finalizations=None,
+            )
+            return OrchestratorError(
+                message="Failed to collect lost process-local authority acceptance plan",
+                details={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "requested_status": SessionStatus.FAILED.value,
+                    "cause": str(last_error),
+                    "resume_blocked": "terminal_persistence_pending",
+                    "terminal_persistence_pending": True,
+                },
+            )
+
         for attempt in range(3):
             try:
                 result = await self._session_repo.mark_failed_if_active(
                     session_id,
                     error.message,
                     error.details,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
             except (Exception, asyncio.CancelledError) as exc:
                 durable_status = await self._reconcile_durable_terminal_and_cleanup(
@@ -2571,6 +2606,7 @@ class OrchestratorRunner:
                         status=SessionStatus.FAILED,
                         error_message=error.message,
                         error_details=dict(error.details),
+                        acceptance_finalizations=acceptance_finalizations,
                     )
                     self._preserve_process_local_owner_for_retry(
                         session_id=session_id,
@@ -2606,6 +2642,7 @@ class OrchestratorRunner:
             status=SessionStatus.FAILED,
             error_message=error.message,
             error_details=dict(error.details),
+            acceptance_finalizations=acceptance_finalizations,
         )
         return OrchestratorError(
             message="Failed to persist lost process-local authority terminal state",
@@ -2641,6 +2678,7 @@ class OrchestratorRunner:
                     tracker.session_id,
                     message,
                     dict(details),
+                    acceptance_finalizations=[],
                 )
             except (Exception, asyncio.CancelledError) as exc:
                 durable_status = await self._reconcile_durable_terminal_and_cleanup(
@@ -2658,6 +2696,7 @@ class OrchestratorRunner:
                         error_message=message,
                         error_details=dict(details),
                         messages_processed=tracker.messages_processed,
+                        acceptance_finalizations=[],
                     )
                     self._preserve_process_local_owner_for_retry(
                         session_id=tracker.session_id,
@@ -2685,6 +2724,7 @@ class OrchestratorRunner:
             error_message=message,
             error_details=dict(details),
             messages_processed=tracker.messages_processed,
+            acceptance_finalizations=[],
         )
         return str(last_error)
 
@@ -3026,14 +3066,32 @@ class OrchestratorRunner:
             intent.status in {SessionStatus.COMPLETED, SessionStatus.FAILED}
             and replayed_acceptance_finalizations is None
         ):
-            # A terminal intent without a captured plan is not replayable.
-            # Keeping it pending is safer than committing a lifecycle winner
-            # that can never be joined to its complete root decision set.
-            return self._terminal_persistence_pending_result(
-                session_id=tracker.session_id,
-                execution_id=tracker.execution_id,
-                requested_status=intent.status,
-                cause=PersistenceError("Pending terminal intent is missing its acceptance plan."),
+            # Preparation and lost-authority failures may have been interrupted
+            # before the first plan snapshot was retained. Reconstruct the exact
+            # plan from durable attempt telemetry before retrying the terminal CAS.
+            try:
+                replayed_acceptance_finalizations = await collect_terminal_acceptance_plan(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    event_store=self._event_store,
+                    terminal_status=intent.status.value,
+                )
+            except asyncio.CancelledError:
+                self._preserve_process_local_owner_for_retry(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                )
+                raise
+            except Exception as exc:
+                return self._terminal_persistence_pending_result(
+                    session_id=tracker.session_id,
+                    execution_id=tracker.execution_id,
+                    requested_status=intent.status,
+                    cause=exc,
+                )
+            self._pending_lifecycle_intents[tracker.session_id] = replace(
+                intent,
+                acceptance_finalizations=[dict(item) for item in replayed_acceptance_finalizations],
             )
 
         resolved_status: SessionStatus

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -5634,9 +5634,7 @@ class OrchestratorRunner:
             outcome = str(latest_data.get("outcome") or "").strip()
             if not outcome:
                 outcome = (
-                    "succeeded"
-                    if latest_data.get("success") is True
-                    else terminal_status.value
+                    "succeeded" if latest_data.get("success") is True else terminal_status.value
                 )
             accepted = bool(
                 terminal_status is SessionStatus.COMPLETED
@@ -5645,8 +5643,10 @@ class OrchestratorRunner:
                     or outcome in {"succeeded", "satisfied_externally"}
                 )
             )
-            disposition = "accepted" if accepted else (
-                "cancelled" if terminal_status is SessionStatus.CANCELLED else outcome
+            disposition = (
+                "accepted"
+                if accepted
+                else ("cancelled" if terminal_status is SessionStatus.CANCELLED else outcome)
             )
             await self._event_store.append(
                 BaseEvent(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1802,9 +1802,24 @@ class OrchestratorRunner:
         execution_id: str,
         error: BaseException,
         messages_processed: int = 0,
+        seed: Seed | None = None,
+        execution_contract: Mapping[str, Any] | None = None,
     ) -> tuple[SessionStatus | None, Result[OrchestratorResult, OrchestratorError] | None]:
         """Persist one durable failure winner before withdrawing ownership."""
         reconciled_during_exception = False
+        acceptance_finalizations = (
+            self._build_terminal_acceptance_finalizations(
+                seed=seed,
+                parallel_result=None,
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status=SessionStatus.FAILED.value,
+                default_outcome="failed",
+                execution_contract=execution_contract,
+            )
+            if seed is not None
+            else None
+        )
         try:
             durable_status = await self._persist_session_terminal_status(
                 session_id=session_id,
@@ -1813,6 +1828,7 @@ class OrchestratorRunner:
                 error_message=str(error),
                 error_type=type(error).__name__,
                 messages_processed=messages_processed,
+                acceptance_finalizations=acceptance_finalizations,
             )
         except (Exception, asyncio.CancelledError) as persistence_error:
             durable_status = await self._reconcile_durable_terminal_and_cleanup(
@@ -1856,6 +1872,25 @@ class OrchestratorRunner:
             await self._cleanup_terminal_process_local_state(
                 session_id=session_id,
                 execution_id=execution_id,
+            )
+        if seed is not None:
+            await self._emit_terminal_acceptance_finalized(
+                seed=seed,
+                parallel_result=None,
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status=durable_status.value,
+                accepted_root_indices=(
+                    set(range(len(seed.acceptance_criteria)))
+                    if durable_status is SessionStatus.COMPLETED
+                    else set()
+                ),
+                default_outcome=(
+                    "succeeded"
+                    if durable_status is SessionStatus.COMPLETED
+                    else durable_status.value
+                ),
+                execution_contract=execution_contract,
             )
         try:
             await self._event_store.append(
@@ -2748,6 +2783,7 @@ class OrchestratorRunner:
         error_type: str | None = None,
         messages_processed: int = 0,
         cancelled_by: str = "runner",
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> SessionStatus:
         """Persist one terminal winner and return the authoritative status.
 
@@ -2770,11 +2806,17 @@ class OrchestratorRunner:
         last_error: object | None = None
         for attempt in range(3):
             try:
+                acceptance_kwargs = (
+                    {"acceptance_finalizations": acceptance_finalizations}
+                    if acceptance_finalizations is not None
+                    else {}
+                )
                 if requested_status is SessionStatus.COMPLETED:
                     result = await self._session_repo.mark_completed(
                         session_id,
                         summary,
                         messages_processed=messages_processed,
+                        **acceptance_kwargs,
                     )
                 elif requested_status is SessionStatus.FAILED:
                     result = await self._session_repo.mark_failed(
@@ -2783,12 +2825,14 @@ class OrchestratorRunner:
                         error_details,
                         error_type=error_type,
                         messages_processed=messages_processed,
+                        **acceptance_kwargs,
                     )
                 elif requested_status is SessionStatus.CANCELLED:
                     result = await self._session_repo.mark_cancelled(
                         session_id,
                         reason=error_message or "Execution cancelled",
                         cancelled_by=cancelled_by,
+                        **acceptance_kwargs,
                     )
                 else:
                     raise ValueError(
@@ -5317,6 +5361,11 @@ class OrchestratorRunner:
         # cancellation that the durable session never recorded.
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
+        session_contract = None
+        if session_result.is_ok:
+            persisted_contract = session_result.value.progress.get(EXECUTION_CONTRACT_PROGRESS_KEY)
+            if isinstance(persisted_contract, Mapping):
+                session_contract = dict(persisted_contract)
         # An unreadable snapshot cannot prove that a terminal state already
         # exists.  Continue through ``mark_cancelled`` while retaining the live
         # owner; that append is the authoritative terminal write and preserves
@@ -5343,6 +5392,8 @@ class OrchestratorRunner:
                     await self._emit_cancellation_acceptance_finalized(
                         execution_id=execution_id,
                         session_id=session_id,
+                        terminal_status=terminal_status,
+                        execution_contract=session_contract,
                     )
                     if not execution_terminal_events:
                         await self._event_store.append(
@@ -5467,6 +5518,8 @@ class OrchestratorRunner:
                 await self._emit_cancellation_acceptance_finalized(
                     execution_id=execution_id,
                     session_id=session_id,
+                    terminal_status=SessionStatus.CANCELLED,
+                    execution_contract=session_contract,
                 )
                 await self._event_store.append(
                     create_execution_terminal_event(
@@ -5516,9 +5569,11 @@ class OrchestratorRunner:
         *,
         execution_id: str,
         session_id: str,
+        terminal_status: SessionStatus = SessionStatus.CANCELLED,
+        execution_contract: Mapping[str, Any] | None = None,
     ) -> None:
-        """Close observed root-AC episodes as rejected on terminal cancellation."""
-        contract = self._execution_contract
+        """Close observed root-AC episodes using the durable terminal winner."""
+        contract = execution_contract or self._execution_contract
         authority_contract = contract.get("foundation_a_authority") if contract else None
         authority = (
             authority_contract.get("correlation_id")
@@ -5529,13 +5584,26 @@ class OrchestratorRunner:
             return
         attempts: list[Any] = []
         for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
-            attempts.extend(
-                await self._event_store.query_events(
-                    aggregate_id=execution_id,
-                    event_type=event_type,
-                    limit=100,
+            try:
+                attempts.extend(
+                    await self._event_store.query_events(
+                        aggregate_id=execution_id,
+                        event_type=event_type,
+                        limit=None,
+                    )
                 )
-            )
+            except Exception:
+                # Cancellation remains a valid durable terminal result even
+                # when optional attempt telemetry cannot be read. A later
+                # reconciler can replay the finalization plan from the
+                # terminal session event when one was persisted.
+                log.warning(
+                    "orchestrator.runner.cancellation_acceptance_scan_failed",
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    event_type=event_type,
+                )
+                return
         latest_by_root: dict[int, int] = {}
         for event in attempts:
             root = event.data.get("root_ac_index")
@@ -5551,7 +5619,35 @@ class OrchestratorRunner:
                 latest_by_root[root] = max(latest_by_root.get(root, 0), retry)
         from ouroboros.events.base import BaseEvent
 
+        latest_event_by_root: dict[int, Any] = {}
+        for event in attempts:
+            root = event.data.get("root_ac_index")
+            if root not in latest_by_root:
+                continue
+            retry = event.data.get("retry_attempt", 0)
+            if retry == latest_by_root[root]:
+                latest_event_by_root[root] = event
+
         for root, retry in latest_by_root.items():
+            latest = latest_event_by_root.get(root)
+            latest_data = latest.data if latest is not None else {}
+            outcome = str(latest_data.get("outcome") or "").strip()
+            if not outcome:
+                outcome = (
+                    "succeeded"
+                    if latest_data.get("success") is True
+                    else terminal_status.value
+                )
+            accepted = bool(
+                terminal_status is SessionStatus.COMPLETED
+                and (
+                    latest_data.get("success") is True
+                    or outcome in {"succeeded", "satisfied_externally"}
+                )
+            )
+            disposition = "accepted" if accepted else (
+                "cancelled" if terminal_status is SessionStatus.CANCELLED else outcome
+            )
             await self._event_store.append(
                 BaseEvent(
                     type="execution.ac.acceptance_finalized",
@@ -5563,10 +5659,10 @@ class OrchestratorRunner:
                         "authority_correlation_id": authority.strip(),
                         "root_ac_index": root,
                         "final_retry_attempt": retry,
-                        "accepted": False,
-                        "disposition": "cancelled",
-                        "outcome": "cancelled",
-                        "terminal_status": SessionStatus.CANCELLED.value,
+                        "accepted": accepted,
+                        "disposition": disposition,
+                        "outcome": outcome,
+                        "terminal_status": terminal_status.value,
                     },
                 )
             )
@@ -6058,11 +6154,19 @@ class OrchestratorRunner:
                 session_id=tracker.session_id,
                 execution_id=tracker.execution_id,
                 error=exc,
+                seed=seed,
+                execution_contract=(
+                    dict(raw_contract) if isinstance(raw_contract, Mapping) else None
+                ),
             )
             if persistence_pending is not None:
                 return persistence_pending
             return Result.err(exc)
-        self._execution_contract = dict(raw_contract)
+        # Keep the immutable per-session contract local to this invocation.
+        # ``self._execution_contract`` is retained for legacy helpers, but it
+        # must never be the source of acceptance authority under concurrency.
+        execution_contract = dict(raw_contract) if isinstance(raw_contract, Mapping) else None
+        self._execution_contract = execution_contract
 
         log.info(
             "orchestrator.runner.execute_started",
@@ -6145,6 +6249,7 @@ class OrchestratorRunner:
                     "tool_catalog": tool_catalog,
                     "system_prompt": system_prompt,
                     "start_time": start_time,
+                    "execution_contract": execution_contract,
                 }
                 if externally_satisfied_acs:
                     parallel_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
@@ -6223,6 +6328,8 @@ class OrchestratorRunner:
                 session_id=tracker.session_id,
                 execution_id=exec_id,
                 error=e,
+                seed=seed,
+                execution_contract=execution_contract,
             )
             if persistence_pending is not None:
                 return persistence_pending
@@ -6505,18 +6612,30 @@ class OrchestratorRunner:
 
             durable_terminal_status: SessionStatus | None = None
             completion_summary: dict[str, Any] | None = None
+            acceptance_finalizations: list[dict[str, Any]] | None = None
             if success:
                 completion_summary = {
                     "final_message": final_message[:500],
                     "messages_processed": messages_processed,
                     **self._task_summary(),
                 }
+                acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                    seed=seed,
+                    parallel_result=None,
+                    execution_id=exec_id,
+                    session_id=tracker.session_id,
+                    terminal_status=SessionStatus.COMPLETED.value,
+                    accepted_root_indices=set(range(len(seed.acceptance_criteria))),
+                    default_outcome="succeeded",
+                    execution_contract=execution_contract,
+                )
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                     requested_status=SessionStatus.COMPLETED,
                     summary=completion_summary,
                     messages_processed=messages_processed,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
                 success = durable_terminal_status is SessionStatus.COMPLETED
                 if not success:
@@ -6571,12 +6690,22 @@ class OrchestratorRunner:
                         f"{pause_status.value}."
                     )
             else:
+                acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                    seed=seed,
+                    parallel_result=None,
+                    execution_id=exec_id,
+                    session_id=tracker.session_id,
+                    terminal_status=SessionStatus.FAILED.value,
+                    default_outcome="failed",
+                    execution_contract=execution_contract,
+                )
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                     requested_status=SessionStatus.FAILED,
                     error_message=final_message,
                     messages_processed=messages_processed,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
                 success = durable_terminal_status is SessionStatus.COMPLETED
                 if durable_terminal_status is not SessionStatus.FAILED:
@@ -6625,6 +6754,7 @@ class OrchestratorRunner:
                     if terminal_status == SessionStatus.COMPLETED.value
                     else terminal_status
                 ),
+                execution_contract=execution_contract,
             )
             terminal_event = create_execution_terminal_event(
                 execution_id=exec_id,
@@ -6750,6 +6880,8 @@ class OrchestratorRunner:
                 execution_id=exec_id,
                 error=e,
                 messages_processed=messages_processed,
+                seed=seed,
+                execution_contract=execution_contract,
             )
             if persistence_pending is not None:
                 return persistence_pending
@@ -6786,6 +6918,7 @@ class OrchestratorRunner:
         tool_catalog: SessionToolCatalog,
         system_prompt: str,
         start_time: datetime,
+        execution_contract: Mapping[str, Any] | None = None,
         externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
         force_sequential_levels: bool = False,
     ) -> Result[OrchestratorResult, OrchestratorError]:
@@ -7011,13 +7144,23 @@ class OrchestratorRunner:
         }
 
         durable_terminal_status: SessionStatus | None = None
+        acceptance_finalizations: list[dict[str, Any]] | None = None
         if success:
+            acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                seed=seed,
+                parallel_result=parallel_result,
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status=SessionStatus.COMPLETED.value,
+                execution_contract=execution_contract,
+            )
             durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
                 requested_status=SessionStatus.COMPLETED,
                 summary=execution_summary,
                 messages_processed=parallel_result.total_messages,
+                acceptance_finalizations=acceptance_finalizations,
             )
             success = durable_terminal_status is SessionStatus.COMPLETED
             if not success:
@@ -7072,6 +7215,14 @@ class OrchestratorRunner:
                     f"{pause_status.value}."
                 )
         else:
+            acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                seed=seed,
+                parallel_result=parallel_result,
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status=SessionStatus.FAILED.value,
+                execution_contract=execution_contract,
+            )
             durable_terminal_status = await self._persist_session_terminal_status(
                 session_id=tracker.session_id,
                 execution_id=exec_id,
@@ -7083,6 +7234,7 @@ class OrchestratorRunner:
                     f"{parallel_result.invalid_count} invalid"
                 ),
                 messages_processed=parallel_result.total_messages,
+                acceptance_finalizations=acceptance_finalizations,
             )
             success = durable_terminal_status is SessionStatus.COMPLETED
             if durable_terminal_status is not SessionStatus.FAILED:
@@ -7118,6 +7270,7 @@ class OrchestratorRunner:
             execution_id=exec_id,
             session_id=tracker.session_id,
             terminal_status=terminal_status,
+            execution_contract=execution_contract,
         )
         terminal_event = create_execution_terminal_event(
             execution_id=exec_id,
@@ -7207,7 +7360,7 @@ class OrchestratorRunner:
             )
         )
 
-    async def _emit_terminal_acceptance_finalized(
+    def _build_terminal_acceptance_finalizations(
         self,
         *,
         seed: Seed,
@@ -7217,18 +7370,14 @@ class OrchestratorRunner:
         terminal_status: str,
         accepted_root_indices: set[int] | None = None,
         default_outcome: str | None = None,
-    ) -> None:
-        """Have the terminal Final Gate publish one decision per root AC.
-
-        Attempt judgments are deliberately insufficient for admission. This
-        method runs only after the session CAS has produced a terminal status;
-        a paused episode therefore has no final acceptance event. The
-        EventStore's authority/root CAS makes retries and duplicate observers
-        idempotent while rejecting contradictory payloads.
-        """
+        execution_contract: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build the complete root decision set before terminal CAS."""
         if terminal_status == SessionStatus.PAUSED.value:
-            return
-        contract = self._execution_contract
+            return []
+        contract = execution_contract
+        if contract is None:
+            contract = self._execution_contract
         authority_contract = contract.get("foundation_a_authority") if contract else None
         authority_correlation_id = (
             authority_contract.get("correlation_id")
@@ -7236,17 +7385,12 @@ class OrchestratorRunner:
             else None
         )
         if not isinstance(authority_correlation_id, str) or not authority_correlation_id.strip():
-            # Low-level unit callers can invoke ``_execute_parallel`` with a
-            # synthetic tracker that was never prepared through Foundation A.
-            # Such a call has no authority generation to attribute, so it must
-            # not mint an unbound final event. Public prepared-session paths
-            # always carry this correlation and therefore continue below.
             log.error(
                 "orchestrator.runner.acceptance_finalization_missing_authority",
                 execution_id=execution_id,
                 session_id=session_id,
             )
-            return
+            return []
 
         results_by_index: dict[int, Any] = {}
         for result in getattr(parallel_result, "results", ()):
@@ -7261,8 +7405,7 @@ class OrchestratorRunner:
                 )
             results_by_index[ac_index] = result
 
-        from ouroboros.events.base import BaseEvent
-
+        finalizations: list[dict[str, Any]] = []
         for root_ac_index in range(len(seed.acceptance_criteria)):
             result = results_by_index.get(root_ac_index)
             outcome = getattr(getattr(result, "outcome", None), "value", None)
@@ -7294,22 +7437,60 @@ class OrchestratorRunner:
                 if accepted
                 else ("cancelled" if terminal_status == SessionStatus.CANCELLED.value else outcome)
             )
+            finalizations.append(
+                {
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "authority_correlation_id": authority_correlation_id.strip(),
+                    "root_ac_index": root_ac_index,
+                    "final_retry_attempt": retry_attempt,
+                    "accepted": accepted,
+                    "disposition": disposition,
+                    "outcome": outcome.strip(),
+                    "terminal_status": terminal_status,
+                }
+            )
+        return finalizations
+
+    async def _emit_terminal_acceptance_finalized(
+        self,
+        *,
+        seed: Seed,
+        parallel_result: Any,
+        execution_id: str,
+        session_id: str,
+        terminal_status: str,
+        accepted_root_indices: set[int] | None = None,
+        default_outcome: str | None = None,
+        execution_contract: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Have the terminal Final Gate publish one decision per root AC.
+
+        Attempt judgments are deliberately insufficient for admission. This
+        method runs only after the session CAS has produced a terminal status;
+        a paused episode therefore has no final acceptance event. The
+        EventStore's authority/root CAS makes retries and duplicate observers
+        idempotent while rejecting contradictory payloads.
+        """
+        finalizations = self._build_terminal_acceptance_finalizations(
+            seed=seed,
+            parallel_result=parallel_result,
+            execution_id=execution_id,
+            session_id=session_id,
+            terminal_status=terminal_status,
+            accepted_root_indices=accepted_root_indices,
+            default_outcome=default_outcome,
+            execution_contract=execution_contract,
+        )
+        from ouroboros.events.base import BaseEvent
+
+        for finalization in finalizations:
             await self._event_store.append(
                 BaseEvent(
                     type="execution.ac.acceptance_finalized",
                     aggregate_type="execution",
                     aggregate_id=execution_id or session_id,
-                    data={
-                        "execution_id": execution_id,
-                        "session_id": session_id,
-                        "authority_correlation_id": authority_correlation_id.strip(),
-                        "root_ac_index": root_ac_index,
-                        "final_retry_attempt": retry_attempt,
-                        "accepted": accepted,
-                        "disposition": disposition,
-                        "outcome": outcome.strip(),
-                        "terminal_status": terminal_status,
-                    },
+                    data=finalization,
                 )
             )
 
@@ -7580,6 +7761,11 @@ class OrchestratorRunner:
                 authority_generation=authority_generation,
             )
             self._execution_guidance_delivery_mode()
+            execution_contract = (
+                dict(self._execution_contract)
+                if isinstance(self._execution_contract, Mapping)
+                else dict(raw_contract)
+            )
         except asyncio.CancelledError:
             cancellation_result = (
                 await self._drain_requested_cancellation_before_pre_execution_cleanup(
@@ -7616,6 +7802,10 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=tracker.execution_id,
                 error=exc,
+                seed=seed,
+                execution_contract=(
+                    dict(raw_contract) if isinstance(raw_contract, Mapping) else None
+                ),
             )
             if persistence_pending is not None:
                 return persistence_pending
@@ -7757,6 +7947,8 @@ Note: This is a resumed session. Please continue from where execution was interr
                 execution_id=tracker.execution_id,
                 error=e,
                 messages_processed=tracker.messages_processed,
+                seed=seed,
+                execution_contract=execution_contract,
             )
             if persistence_pending is not None:
                 return persistence_pending
@@ -7912,7 +8104,18 @@ Note: This is a resumed session. Please continue from where execution was interr
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
             durable_terminal_status: SessionStatus | None = None
+            acceptance_finalizations: list[dict[str, Any]] | None = None
             if success:
+                acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                    seed=seed,
+                    parallel_result=None,
+                    execution_id=tracker.execution_id,
+                    session_id=session_id,
+                    terminal_status=SessionStatus.COMPLETED.value,
+                    accepted_root_indices=set(range(len(seed.acceptance_criteria))),
+                    default_outcome="succeeded",
+                    execution_contract=execution_contract,
+                )
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=session_id,
                     execution_id=tracker.execution_id,
@@ -7922,6 +8125,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                         **self._task_summary(),
                     },
                     messages_processed=messages_processed,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
                 success = durable_terminal_status is SessionStatus.COMPLETED
                 if not success:
@@ -7975,12 +8179,22 @@ Note: This is a resumed session. Please continue from where execution was interr
                         f"{pause_status.value}."
                     )
             else:
+                acceptance_finalizations = self._build_terminal_acceptance_finalizations(
+                    seed=seed,
+                    parallel_result=None,
+                    execution_id=tracker.execution_id,
+                    session_id=session_id,
+                    terminal_status=SessionStatus.FAILED.value,
+                    default_outcome="failed",
+                    execution_contract=execution_contract,
+                )
                 durable_terminal_status = await self._persist_session_terminal_status(
                     session_id=session_id,
                     execution_id=tracker.execution_id,
                     requested_status=SessionStatus.FAILED,
                     error_message=final_message,
                     messages_processed=messages_processed,
+                    acceptance_finalizations=acceptance_finalizations,
                 )
                 success = durable_terminal_status is SessionStatus.COMPLETED
                 if durable_terminal_status is not SessionStatus.FAILED:
@@ -8009,6 +8223,24 @@ Note: This is a resumed session. Please continue from where execution was interr
                     if durable_terminal_status is not None
                     else SessionStatus.FAILED.value
                 )
+            )
+            await self._emit_terminal_acceptance_finalized(
+                seed=seed,
+                parallel_result=None,
+                execution_id=tracker.execution_id,
+                session_id=session_id,
+                terminal_status=terminal_status,
+                accepted_root_indices=(
+                    set(range(len(seed.acceptance_criteria)))
+                    if terminal_status == SessionStatus.COMPLETED.value
+                    else set()
+                ),
+                default_outcome=(
+                    "succeeded"
+                    if terminal_status == SessionStatus.COMPLETED.value
+                    else terminal_status
+                ),
+                execution_contract=execution_contract,
             )
             terminal_event = create_execution_terminal_event(
                 execution_id=tracker.execution_id,
@@ -8132,6 +8364,8 @@ Note: This is a resumed session. Please continue from where execution was interr
                 execution_id=tracker.execution_id,
                 error=e,
                 messages_processed=messages_processed,
+                seed=seed,
+                execution_contract=execution_contract,
             )
             if persistence_pending is not None:
                 return persistence_pending

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -20,7 +20,7 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from contextlib import aclosing
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
@@ -1821,19 +1821,41 @@ class OrchestratorRunner:
                 cause=PersistenceError("Cannot persist FAILED without the seed acceptance plan."),
             )
         reconciled_during_exception = False
-        acceptance_finalizations = (
-            self._build_terminal_acceptance_finalizations(
-                seed=seed,
-                parallel_result=None,
-                execution_id=execution_id,
-                session_id=session_id,
-                terminal_status=SessionStatus.FAILED.value,
-                default_outcome="failed",
-                execution_contract=execution_contract,
-            )
-            if seed is not None
-            else None
-        )
+        acceptance_finalizations: list[dict[str, Any]] | None = None
+        if seed is not None:
+            try:
+                # The exception path may run after one or more retries have
+                # already emitted durable attempt judgments.  Rebuild from
+                # that telemetry instead of fabricating retry-0/failed facts.
+                acceptance_finalizations = await collect_terminal_acceptance_plan(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    event_store=self._event_store,
+                    terminal_status=SessionStatus.FAILED.value,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
+                    fallback_outcome="failed",
+                )
+            except (Exception, asyncio.CancelledError) as planning_error:
+                if isinstance(planning_error, asyncio.CancelledError):
+                    self._preserve_process_local_owner_for_retry(
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                    raise
+                self._pending_lifecycle_intents[session_id] = _PendingLifecycleIntent(
+                    execution_id=execution_id,
+                    status=SessionStatus.FAILED,
+                    error_message=str(error),
+                    error_type=type(error).__name__,
+                    messages_processed=messages_processed,
+                    acceptance_finalizations=None,
+                )
+                return None, self._terminal_persistence_pending_result(
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    requested_status=SessionStatus.FAILED,
+                    cause=planning_error,
+                )
         try:
             durable_status = await self._persist_session_terminal_status(
                 session_id=session_id,
@@ -5075,10 +5097,34 @@ class OrchestratorRunner:
             )
 
         # Historical sessions have no live Foundation A capability to coordinate.
+        raw_total_acs = tracker.progress.get("total_acceptance_criteria")
+        expected_root_indices = (
+            range(raw_total_acs)
+            if isinstance(raw_total_acs, int)
+            and not isinstance(raw_total_acs, bool)
+            and raw_total_acs >= 0
+            else None
+        )
+        try:
+            acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                session_id=session_id,
+                execution_id=execution_id,
+                event_store=self._event_store,
+                expected_root_indices=expected_root_indices,
+            )
+        except Exception as exc:
+            return self._cancellation_persistence_pending_result(
+                session_id=session_id,
+                execution_id=execution_id,
+                cause=exc,
+                cancellation_reason=reason,
+                cancelled_by=cancelled_by,
+            )
         cancel_result = await self._session_repo.mark_cancelled(
             session_id=session_id,
             reason=reason,
             cancelled_by=cancelled_by,
+            acceptance_finalizations=acceptance_finalizations,
         )
 
         if cancel_result.is_err:
@@ -5462,6 +5508,7 @@ class OrchestratorRunner:
         execution_id: str,
         messages_processed: int,
         start_time: datetime,
+        expected_root_indices: Iterable[int] | None = None,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Handle a detected cancellation by marking the session and returning a result.
 
@@ -5575,6 +5622,7 @@ class OrchestratorRunner:
                 session_id=session_id,
                 execution_id=execution_id,
                 event_store=self._event_store,
+                expected_root_indices=expected_root_indices,
             )
         except Exception as exc:
             return self._cancellation_persistence_pending_result(
@@ -5622,6 +5670,7 @@ class OrchestratorRunner:
                     execution_id=execution_id,
                     messages_processed=messages_processed,
                     start_time=start_time,
+                    expected_root_indices=expected_root_indices,
                 )
             log.warning(
                 "orchestrator.runner.mark_cancelled_raised",
@@ -5662,6 +5711,7 @@ class OrchestratorRunner:
                     execution_id=execution_id,
                     messages_processed=messages_processed,
                     start_time=start_time,
+                    expected_root_indices=expected_root_indices,
                 )
             return self._cancellation_persistence_pending_result(
                 session_id=session_id,
@@ -6237,6 +6287,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
 
             # Build prompts with strategy. The fat-harness default path must use
@@ -6451,6 +6502,7 @@ class OrchestratorRunner:
                                     execution_id=exec_id,
                                     messages_processed=messages_processed,
                                     start_time=start_time,
+                                    expected_root_indices=range(len(seed.acceptance_criteria)),
                                 )
                                 break
 
@@ -6885,6 +6937,7 @@ class OrchestratorRunner:
                     execution_id=exec_id,
                     messages_processed=messages_processed,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             if await self._cleanup_if_durable_terminal(
                 session_id=tracker.session_id,
@@ -7102,6 +7155,7 @@ class OrchestratorRunner:
                 execution_id=exec_id,
                 messages_processed=0,
                 start_time=start_time,
+                expected_root_indices=range(len(seed.acceptance_criteria)),
             )
 
         try:
@@ -7134,6 +7188,7 @@ class OrchestratorRunner:
                 execution_id=exec_id,
                 messages_processed=parallel_result.total_messages,
                 start_time=start_time,
+                expected_root_indices=range(len(seed.acceptance_criteria)),
             )
 
         # Calculate duration
@@ -7632,6 +7687,7 @@ class OrchestratorRunner:
                         execution_id=tracker.execution_id,
                         messages_processed=tracker.messages_processed,
                         start_time=datetime.now(UTC),
+                        expected_root_indices=range(len(seed.acceptance_criteria)),
                     )
             except asyncio.CancelledError:
                 self._release_process_local_authority(
@@ -7799,6 +7855,7 @@ class OrchestratorRunner:
                     execution_id=tracker.execution_id,
                     messages_processed=tracker.messages_processed,
                     start_time=datetime.now(UTC),
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
 
             if execution_contract_changed:
@@ -7977,6 +8034,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                                     execution_id=tracker.execution_id,
                                     messages_processed=messages_processed,
                                     start_time=start_time,
+                                    expected_root_indices=range(len(seed.acceptance_criteria)),
                                 )
                                 break
 
@@ -8291,6 +8349,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     execution_id=tracker.execution_id,
                     messages_processed=messages_processed,
                     start_time=start_time,
+                    expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
             if await self._cleanup_if_durable_terminal(
                 session_id=session_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -5340,6 +5340,10 @@ class OrchestratorRunner:
 
             async def _reconcile_existing_terminal_owner() -> None:
                 try:
+                    await self._emit_cancellation_acceptance_finalized(
+                        execution_id=execution_id,
+                        session_id=session_id,
+                    )
                     if not execution_terminal_events:
                         await self._event_store.append(
                             create_execution_terminal_event(
@@ -5460,6 +5464,10 @@ class OrchestratorRunner:
         # durable CAS has committed.
         async def _reconcile_cancelled_owner() -> None:
             try:
+                await self._emit_cancellation_acceptance_finalized(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                )
                 await self._event_store.append(
                     create_execution_terminal_event(
                         execution_id=execution_id,
@@ -5502,6 +5510,66 @@ class OrchestratorRunner:
                 duration_seconds=duration,
             )
         )
+
+    async def _emit_cancellation_acceptance_finalized(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+    ) -> None:
+        """Close observed root-AC episodes as rejected on terminal cancellation."""
+        contract = self._execution_contract
+        authority_contract = contract.get("foundation_a_authority") if contract else None
+        authority = (
+            authority_contract.get("correlation_id")
+            if isinstance(authority_contract, Mapping)
+            else None
+        )
+        if not isinstance(authority, str) or not authority.strip():
+            return
+        attempts: list[Any] = []
+        for event_type in ("execution.ac.attempt_judged", "execution.ac.outcome_finalized"):
+            attempts.extend(
+                await self._event_store.query_events(
+                    aggregate_id=execution_id,
+                    event_type=event_type,
+                    limit=100,
+                )
+            )
+        latest_by_root: dict[int, int] = {}
+        for event in attempts:
+            root = event.data.get("root_ac_index")
+            retry = event.data.get("retry_attempt", 0)
+            if (
+                isinstance(root, int)
+                and not isinstance(root, bool)
+                and root >= 0
+                and isinstance(retry, int)
+                and not isinstance(retry, bool)
+                and retry >= 0
+            ):
+                latest_by_root[root] = max(latest_by_root.get(root, 0), retry)
+        from ouroboros.events.base import BaseEvent
+
+        for root, retry in latest_by_root.items():
+            await self._event_store.append(
+                BaseEvent(
+                    type="execution.ac.acceptance_finalized",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id or session_id,
+                    data={
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "authority_correlation_id": authority.strip(),
+                        "root_ac_index": root,
+                        "final_retry_attempt": retry,
+                        "accepted": False,
+                        "disposition": "cancelled",
+                        "outcome": "cancelled",
+                        "terminal_status": SessionStatus.CANCELLED.value,
+                    },
+                )
+            )
 
     async def execute_seed(
         self,
@@ -6541,6 +6609,23 @@ class OrchestratorRunner:
                     else SessionStatus.FAILED.value
                 )
             )
+            await self._emit_terminal_acceptance_finalized(
+                seed=seed,
+                parallel_result=None,
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status=terminal_status,
+                accepted_root_indices=(
+                    set(range(len(seed.acceptance_criteria)))
+                    if terminal_status == SessionStatus.COMPLETED.value
+                    else set()
+                ),
+                default_outcome=(
+                    "succeeded"
+                    if terminal_status == SessionStatus.COMPLETED.value
+                    else terminal_status
+                ),
+            )
             terminal_event = create_execution_terminal_event(
                 execution_id=exec_id,
                 session_id=tracker.session_id,
@@ -7027,6 +7112,13 @@ class OrchestratorRunner:
                 else SessionStatus.FAILED.value
             )
         )
+        await self._emit_terminal_acceptance_finalized(
+            seed=seed,
+            parallel_result=parallel_result,
+            execution_id=exec_id,
+            session_id=tracker.session_id,
+            terminal_status=terminal_status,
+        )
         terminal_event = create_execution_terminal_event(
             execution_id=exec_id,
             session_id=tracker.session_id,
@@ -7114,6 +7206,103 @@ class OrchestratorRunner:
                 duration_seconds=duration,
             )
         )
+
+    async def _emit_terminal_acceptance_finalized(
+        self,
+        *,
+        seed: Seed,
+        parallel_result: Any,
+        execution_id: str,
+        session_id: str,
+        terminal_status: str,
+        accepted_root_indices: set[int] | None = None,
+        default_outcome: str | None = None,
+    ) -> None:
+        """Have the terminal Final Gate publish one decision per root AC.
+
+        Attempt judgments are deliberately insufficient for admission. This
+        method runs only after the session CAS has produced a terminal status;
+        a paused episode therefore has no final acceptance event. The
+        EventStore's authority/root CAS makes retries and duplicate observers
+        idempotent while rejecting contradictory payloads.
+        """
+        if terminal_status == SessionStatus.PAUSED.value:
+            return
+        contract = self._execution_contract
+        authority_contract = contract.get("foundation_a_authority") if contract else None
+        authority_correlation_id = (
+            authority_contract.get("correlation_id")
+            if isinstance(authority_contract, Mapping)
+            else None
+        )
+        if not isinstance(authority_correlation_id, str) or not authority_correlation_id.strip():
+            # Low-level unit callers can invoke ``_execute_parallel`` with a
+            # synthetic tracker that was never prepared through Foundation A.
+            # Such a call has no authority generation to attribute, so it must
+            # not mint an unbound final event. Public prepared-session paths
+            # always carry this correlation and therefore continue below.
+            log.error(
+                "orchestrator.runner.acceptance_finalization_missing_authority",
+                execution_id=execution_id,
+                session_id=session_id,
+            )
+            return
+
+        results_by_index: dict[int, Any] = {}
+        for result in getattr(parallel_result, "results", ()):
+            ac_index = getattr(result, "ac_index", None)
+            if isinstance(ac_index, bool) or not isinstance(ac_index, int) or ac_index < 0:
+                continue
+            if ac_index in results_by_index:
+                raise PersistenceError(
+                    "Final acceptance received duplicate root AC results.",
+                    operation="runner.emit_terminal_acceptance_finalized",
+                    details={"root_ac_index": ac_index, "execution_id": execution_id},
+                )
+            results_by_index[ac_index] = result
+
+        from ouroboros.events.base import BaseEvent
+
+        for root_ac_index in range(len(seed.acceptance_criteria)):
+            result = results_by_index.get(root_ac_index)
+            outcome = getattr(getattr(result, "outcome", None), "value", None)
+            if outcome is None and default_outcome is not None:
+                outcome = default_outcome
+            if not isinstance(outcome, str) or not outcome.strip():
+                outcome = "blocked" if result is None else ("failed" if not result.success else "succeeded")
+            retry_attempt = getattr(result, "retry_attempt", 0) if result is not None else 0
+            if isinstance(retry_attempt, bool) or not isinstance(retry_attempt, int) or retry_attempt < 0:
+                retry_attempt = 0
+            accepted = bool(
+                terminal_status == SessionStatus.COMPLETED.value
+                and (
+                    root_ac_index in accepted_root_indices
+                    if accepted_root_indices is not None
+                    else result is not None
+                    and outcome in {"succeeded", "satisfied_externally"}
+                )
+            )
+            disposition = "accepted" if accepted else (
+                "cancelled" if terminal_status == SessionStatus.CANCELLED.value else outcome
+            )
+            await self._event_store.append(
+                BaseEvent(
+                    type="execution.ac.acceptance_finalized",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id or session_id,
+                    data={
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "authority_correlation_id": authority_correlation_id.strip(),
+                        "root_ac_index": root_ac_index,
+                        "final_retry_attempt": retry_attempt,
+                        "accepted": accepted,
+                        "disposition": disposition,
+                        "outcome": outcome.strip(),
+                        "terminal_status": terminal_status,
+                    },
+                )
+            )
 
     async def resume_session(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -2695,13 +2695,40 @@ class OrchestratorRunner:
         manufacturing an unowned durable RUNNING session.
         """
         last_error: object | None = None
+        acceptance_finalizations: list[dict[str, Any]] | None = None
+        try:
+            # Preparation failures happen before the executor has emitted any
+            # attempt telemetry.  The collector still reconstructs a complete
+            # rejecting plan from the immutable session root set, so a current
+            # session cannot become terminal with missing root decisions.
+            acceptance_finalizations = await collect_terminal_acceptance_plan(
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                event_store=self._event_store,
+                terminal_status=SessionStatus.FAILED.value,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Fail closed when the durable telemetry/root contract is unreadable:
+            # omitting the plan makes current-format EventStore CAS reject the
+            # terminal transition and leaves a replayable pending intent.
+            log.warning(
+                "orchestrator.runner.prepare_terminal_plan_unavailable",
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+                error=str(exc),
+            )
         for attempt in range(3):
             try:
+                mark_failed_kwargs: dict[str, Any] = {}
+                if acceptance_finalizations is not None:
+                    mark_failed_kwargs["acceptance_finalizations"] = acceptance_finalizations
                 result = await self._session_repo.mark_failed(
                     tracker.session_id,
                     message,
                     dict(details),
-                    acceptance_finalizations=[],
+                    **mark_failed_kwargs,
                 )
             except (Exception, asyncio.CancelledError) as exc:
                 durable_status = await self._reconcile_durable_terminal_and_cleanup(
@@ -2719,7 +2746,7 @@ class OrchestratorRunner:
                         error_message=message,
                         error_details=dict(details),
                         messages_processed=tracker.messages_processed,
-                        acceptance_finalizations=[],
+                        acceptance_finalizations=acceptance_finalizations,
                     )
                     self._preserve_process_local_owner_for_retry(
                         session_id=tracker.session_id,
@@ -2747,7 +2774,7 @@ class OrchestratorRunner:
             error_message=message,
             error_details=dict(details),
             messages_processed=tracker.messages_processed,
-            acceptance_finalizations=[],
+            acceptance_finalizations=acceptance_finalizations,
         )
         return str(last_error)
 

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -1507,6 +1507,19 @@ class SessionRepository:
                         session_id=tracker.session_id,
                         execution_id=tracker.execution_id,
                         event_store=self._event_store,
+                        expected_root_indices=(
+                            range(tracker.progress["total_acceptance_criteria"])
+                            if isinstance(
+                                tracker.progress.get("total_acceptance_criteria"),
+                                int,
+                            )
+                            and not isinstance(
+                                tracker.progress.get("total_acceptance_criteria"),
+                                bool,
+                            )
+                            and tracker.progress["total_acceptance_criteria"] >= 0
+                            else None
+                        ),
                     )
                     result = await self.mark_cancelled(
                         session_id=tracker.session_id,

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -1031,6 +1031,8 @@ class SessionRepository:
         session_id: str,
         reason: str,
         cancelled_by: str = "user",
+        *,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> Result[bool, PersistenceError]:
         """Cancel an active session without overwriting another terminal result.
 
@@ -1038,7 +1040,12 @@ class SessionRepository:
         persistence failure. All terminal writers now use the same CAS boundary;
         this compatibility name delegates to the canonical method.
         """
-        return await self.mark_cancelled(session_id, reason, cancelled_by)
+        return await self.mark_cancelled(
+            session_id,
+            reason,
+            cancelled_by,
+            acceptance_finalizations=acceptance_finalizations,
+        )
 
     async def reconstruct_session(
         self,
@@ -1461,17 +1468,69 @@ class SessionRepository:
 
         cancelled: list[SessionTracker] = []
 
+        # Orphan cleanup is another terminal writer.  Route it through the
+        # same process-local cancellation protocol as user/MCP cancellation so
+        # the Foundation B acceptance plan is collected before the terminal
+        # session CAS.  Import lazily to keep the session model independent of
+        # the authority registry at module import time.
+        from ouroboros.orchestrator.execution_authority import (
+            ProcessLocalCancellationDisposition,
+            collect_cancellation_acceptance_plan,
+            request_process_local_cancellation,
+        )
+
         for tracker in orphaned:
-            result = await self.mark_cancelled(
-                session_id=tracker.session_id,
-                reason=(
-                    f"Auto-cancelled on startup: session was {tracker.status.value} "
-                    f"with no activity for over {staleness_threshold}"
-                ),
+            reason = (
+                f"Auto-cancelled on startup: session was {tracker.status.value} "
+                f"with no activity for over {staleness_threshold}"
+            )
+            outcome = await request_process_local_cancellation(
+                tracker,
+                self,
+                reason=reason,
                 cancelled_by="auto_cleanup",
             )
 
-            if result.is_ok and result.value is not False:
+            if outcome is None:
+                # Historical sessions may not carry Foundation A's persisted
+                # process-local contract.  Keep the compatibility fallback,
+                # but still use the same B plan and atomic terminal CAS.
+                try:
+                    acceptance_finalizations = await collect_cancellation_acceptance_plan(
+                        session_id=tracker.session_id,
+                        execution_id=tracker.execution_id,
+                        event_store=self._event_store,
+                    )
+                    result = await self.mark_cancelled(
+                        session_id=tracker.session_id,
+                        reason=reason,
+                        cancelled_by="auto_cleanup",
+                        acceptance_finalizations=acceptance_finalizations,
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "orchestrator.auto_cleanup.cancel_failed",
+                        session_id=tracker.session_id,
+                        error=str(exc),
+                    )
+                    continue
+                if result.is_ok and result.value is not False:
+                    cancelled.append(tracker)
+                    print(
+                        f"[ouroboros] Auto-cancelled orphaned session "
+                        f"{tracker.session_id} (execution={tracker.execution_id}, "
+                        f"previous_status={tracker.status.value})",
+                        file=sys.stderr,
+                    )
+                elif result.is_err:
+                    log.warning(
+                        "orchestrator.auto_cleanup.cancel_failed",
+                        session_id=tracker.session_id,
+                        error=str(result.error),
+                    )
+                continue
+
+            if outcome.disposition is ProcessLocalCancellationDisposition.CANCELLED:
                 cancelled.append(tracker)
                 # Log to stderr so it's visible in MCP stdio mode
                 print(
@@ -1480,7 +1539,7 @@ class SessionRepository:
                     f"previous_status={tracker.status.value})",
                     file=sys.stderr,
                 )
-            elif result.is_ok:
+            elif outcome.disposition is ProcessLocalCancellationDisposition.ALREADY_TERMINAL:
                 log.info(
                     "orchestrator.auto_cleanup.terminal_transition_preserved",
                     session_id=tracker.session_id,
@@ -1495,8 +1554,13 @@ class SessionRepository:
                 log.warning(
                     "orchestrator.auto_cleanup.cancel_failed",
                     session_id=tracker.session_id,
-                    error=str(result.error),
+                    error=str(outcome.error),
                 )
+
+            # Continue with the next stale session even if one cancellation
+            # remains retryable; a single unreadable telemetry stream must not
+            # prevent cleanup of unrelated orphaned sessions.
+            continue
 
         log.info(
             "orchestrator.auto_cleanup.complete",

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -22,7 +22,7 @@ Usage:
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -47,6 +47,22 @@ log = get_logger(__name__)
 # able to overwrite that identity.
 SESSION_START_IDENTITY_PROGRESS_KEY = "_session_start_identity"
 SESSION_RUNTIME_IDENTITY_PROGRESS_KEY = "_session_runtime_identity"
+ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY = "acceptance_root_indices"
+
+
+def _normalize_acceptance_root_indices(value: object) -> list[int] | None:
+    """Normalize the immutable root set persisted at session publication."""
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Iterable):
+        raise ValueError("acceptance_root_indices must be an iterable of non-negative integers")
+    roots: set[int] = set()
+    for raw_root in value:
+        if isinstance(raw_root, bool) or not isinstance(raw_root, int) or raw_root < 0:
+            raise ValueError("acceptance_root_indices must contain non-negative integers")
+        roots.add(raw_root)
+    return sorted(roots)
+
 
 _STABLE_RUNTIME_RESUME_BACKENDS: dict[str, str] = {
     "codex": "codex_cli",
@@ -648,6 +664,7 @@ class SessionRepository:
         runtime_backend: str | None = None,
         llm_backend: str | None = None,
         execution_contract: Mapping[str, Any] | None = None,
+        acceptance_root_indices: Iterable[int] | None = None,
     ) -> Result[SessionTracker, PersistenceError]:
         """Create a new session and persist start event.
 
@@ -663,6 +680,9 @@ class SessionRepository:
             execution_contract: Resolved immutable run inputs needed for safe
                 resume and proof-cohort attribution. The same payload is also
                 written to the initial progress checkpoint by the runner.
+            acceptance_root_indices: Immutable root AC indices persisted before
+                the session is exposed, so pre-execution terminalization cannot
+                lose undecided roots.
 
         Returns:
             Result containing new SessionTracker.
@@ -674,6 +694,10 @@ class SessionRepository:
             "seed_id": seed_id,
             "start_time": tracker.start_time.isoformat(),
         }
+        if acceptance_root_indices is not None:
+            event_data[ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY] = _normalize_acceptance_root_indices(
+                acceptance_root_indices
+            )
         if seed_goal:
             event_data["seed_goal"] = seed_goal
         if runtime_backend:
@@ -1144,6 +1168,12 @@ class SessionRepository:
             last_progress: dict[str, Any] = {
                 SESSION_START_IDENTITY_PROGRESS_KEY: start_identity,
             }
+            if ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY in start_event.data:
+                last_progress[ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY] = (
+                    _normalize_acceptance_root_indices(
+                        start_event.data[ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY]
+                    )
+                )
             if "execution_contract" in start_event.data:
                 start_execution_contract = start_event.data.get("execution_contract")
                 # The start event is the durable fallback for the immutable run
@@ -1508,16 +1538,11 @@ class SessionRepository:
                         execution_id=tracker.execution_id,
                         event_store=self._event_store,
                         expected_root_indices=(
-                            range(tracker.progress["total_acceptance_criteria"])
+                            tuple(tracker.progress[ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY])
                             if isinstance(
-                                tracker.progress.get("total_acceptance_criteria"),
-                                int,
+                                tracker.progress.get(ACCEPTANCE_ROOT_INDICES_PROGRESS_KEY),
+                                (list, tuple),
                             )
-                            and not isinstance(
-                                tracker.progress.get("total_acceptance_criteria"),
-                                bool,
-                            )
-                            and tracker.progress["total_acceptance_criteria"] >= 0
                             else None
                         ),
                     )

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -888,6 +888,8 @@ class SessionRepository:
         session_id: str,
         error_message: str,
         error_details: dict[str, Any] | None = None,
+        *,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> Result[bool, PersistenceError]:
         """Fail an active session without overwriting an existing terminal result.
 
@@ -895,7 +897,12 @@ class SessionRepository:
         already durable. All terminal writers now use the same CAS boundary;
         this compatibility name delegates to the canonical method.
         """
-        return await self.mark_failed(session_id, error_message, error_details)
+        return await self.mark_failed(
+            session_id,
+            error_message,
+            error_details,
+            acceptance_finalizations=acceptance_finalizations,
+        )
 
     async def mark_paused(
         self,

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -762,6 +762,7 @@ class SessionRepository:
         summary: dict[str, Any] | None = None,
         *,
         messages_processed: int = 0,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> Result[bool, PersistenceError]:
         """Mark session as completed.
 
@@ -774,15 +775,18 @@ class SessionRepository:
             Result whose value is ``True`` when this completion became durable,
             or ``False`` when another terminal transition already won.
         """
+        data: dict[str, Any] = {
+            "summary": summary or {},
+            "messages_processed": max(messages_processed, 0),
+            "completed_at": datetime.now(UTC).isoformat(),
+        }
+        if acceptance_finalizations is not None:
+            data["acceptance_finalizations"] = acceptance_finalizations
         event = BaseEvent(
             type="orchestrator.session.completed",
             aggregate_type="session",
             aggregate_id=session_id,
-            data={
-                "summary": summary or {},
-                "messages_processed": max(messages_processed, 0),
-                "completed_at": datetime.now(UTC).isoformat(),
-            },
+            data=data,
         )
 
         try:
@@ -820,6 +824,7 @@ class SessionRepository:
         *,
         error_type: str | None = None,
         messages_processed: int = 0,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> Result[bool, PersistenceError]:
         """Mark session as failed.
 
@@ -834,17 +839,20 @@ class SessionRepository:
             Result whose value is ``True`` when this failure became durable,
             or ``False`` when another terminal transition already won.
         """
+        data: dict[str, Any] = {
+            "error": error_message,
+            "error_details": error_details or {},
+            "error_type": error_type,
+            "messages_processed": max(messages_processed, 0),
+            "failed_at": datetime.now(UTC).isoformat(),
+        }
+        if acceptance_finalizations is not None:
+            data["acceptance_finalizations"] = acceptance_finalizations
         event = BaseEvent(
             type="orchestrator.session.failed",
             aggregate_type="session",
             aggregate_id=session_id,
-            data={
-                "error": error_message,
-                "error_details": error_details or {},
-                "error_type": error_type,
-                "messages_processed": max(messages_processed, 0),
-                "failed_at": datetime.now(UTC).isoformat(),
-            },
+            data=data,
         )
 
         try:
@@ -961,6 +969,8 @@ class SessionRepository:
         session_id: str,
         reason: str,
         cancelled_by: str = "user",
+        *,
+        acceptance_finalizations: list[dict[str, Any]] | None = None,
     ) -> Result[bool, PersistenceError]:
         """Mark session as cancelled.
 
@@ -973,15 +983,18 @@ class SessionRepository:
             Result whose value is ``True`` when this cancellation became
             durable, or ``False`` when another terminal transition already won.
         """
+        data: dict[str, Any] = {
+            "reason": reason,
+            "cancelled_by": cancelled_by,
+            "cancelled_at": datetime.now(UTC).isoformat(),
+        }
+        if acceptance_finalizations is not None:
+            data["acceptance_finalizations"] = acceptance_finalizations
         event = BaseEvent(
             type="orchestrator.session.cancelled",
             aggregate_type="session",
             aggregate_id=session_id,
-            data={
-                "reason": reason,
-                "cancelled_by": cancelled_by,
-                "cancelled_at": datetime.now(UTC).isoformat(),
-            },
+            data=data,
         )
 
         try:

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -875,6 +875,41 @@ class EventStore:
         # malformed envelope must not even transiently acquire a terminal or
         # acceptance winner that a caller could mistake for a committed CAS.
         acceptance_events = _validated_terminal_acceptance_events(event)
+        if acceptance_events:
+            # The payload's self-consistent session/execution pair is not
+            # sufficient: bind it to the immutable durable session-start
+            # identity before either CAS can win.  Without this check a caller
+            # could finalize ``exec_other`` under a session that started
+            # ``exec_real`` and permanently consume the wrong root guard.
+            started_execution_id = await self._resolve_execution_id_for_session(event.aggregate_id)
+            if started_execution_id is None:
+                raise PersistenceError(
+                    "Final acceptance requires a durable session-start execution identity.",
+                    operation="append_session_terminal_if_active",
+                    details={
+                        "session_id": event.aggregate_id,
+                        "acceptance_identity_missing": True,
+                    },
+                )
+            mismatched = next(
+                (
+                    acceptance_event.data.get("execution_id")
+                    for acceptance_event in acceptance_events
+                    if acceptance_event.data.get("execution_id") != started_execution_id
+                ),
+                None,
+            )
+            if mismatched is not None:
+                raise PersistenceError(
+                    "Final acceptance execution_id does not match the durable session start.",
+                    operation="append_session_terminal_if_active",
+                    details={
+                        "session_id": event.aggregate_id,
+                        "started_execution_id": started_execution_id,
+                        "acceptance_execution_id": mismatched,
+                        "acceptance_identity_conflict": True,
+                    },
+                )
 
         for attempt in range(3):
             try:

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -104,20 +104,15 @@ def _is_ac_acceptance_finalized_event(event: object) -> bool:
 
 
 def _acceptance_payload_digest(event: BaseEvent) -> str:
-    """Hash only stable final-decision fields for idempotent replay."""
+    """Hash the complete canonical payload for idempotent replay.
+
+    The authority/root guard is only idempotent for an equivalent final event.
+    Hashing a hand-picked subset silently treats a payload with additional
+    semantics as a duplicate, which is unsafe for fail-closed replay.
+    """
     payload = {
-        key: event.data.get(key)
-        for key in (
-            "execution_id",
-            "session_id",
-            "authority_correlation_id",
-            "root_ac_index",
-            "final_retry_attempt",
-            "accepted",
-            "disposition",
-            "outcome",
-            "terminal_status",
-        )
+        "event_version": event.event_version,
+        "data": event.data,
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
@@ -203,6 +198,30 @@ def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
             details={"event_type": event.type, "event_id": event.id},
         )
     return authority.strip(), root_index
+
+
+def _acceptance_event_from_terminal_payload(payload: object) -> BaseEvent:
+    """Reconstruct one acceptance event carried by a terminalization plan."""
+    if not isinstance(payload, Mapping):
+        raise PersistenceError(
+            "Terminal acceptance plan entries must be mappings.",
+            operation="append_session_terminal_if_active",
+            details={"acceptance_plan_invalid": True},
+        )
+    data = dict(payload)
+    execution_id = data.get("execution_id")
+    if not isinstance(execution_id, str) or not execution_id.strip():
+        raise PersistenceError(
+            "Terminal acceptance plan requires an execution_id.",
+            operation="append_session_terminal_if_active",
+            details={"acceptance_plan_invalid": True},
+        )
+    return BaseEvent(
+        type=_AC_ACCEPTANCE_FINALIZED_EVENT_TYPE,
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data=data,
+    )
 
 
 def _normalized_mapping_keys(value: Mapping[object, object]) -> set[str]:
@@ -752,6 +771,21 @@ class EventStore:
                                 await conn.rollback()
                             return False
 
+                        acceptance_plan = event.data.get("acceptance_finalizations", ())
+                        if acceptance_plan is None:
+                            acceptance_plan = ()
+                        if not isinstance(acceptance_plan, (list, tuple)):
+                            raise PersistenceError(
+                                "Terminal acceptance plan must be a list.",
+                                operation="append_session_terminal_if_active",
+                                details={"acceptance_plan_invalid": True},
+                            )
+                        for payload in acceptance_plan:
+                            await self._append_ac_acceptance_in_transaction(
+                                conn,
+                                _acceptance_event_from_terminal_payload(payload),
+                            )
+
                         await conn.execute(events_table.insert().values(**event.to_db_dict()))
                         if sqlite:
                             await conn.commit()
@@ -783,6 +817,71 @@ class EventStore:
             details={"event_id": event.id, "event_type": event.type},
         )
 
+    async def _append_ac_acceptance_in_transaction(
+        self,
+        conn: Any,
+        event: BaseEvent,
+    ) -> bool:
+        """Append one acceptance event using an already-open transaction."""
+        authority_correlation_id, root_ac_index = _acceptance_key_fields(event)
+        payload_digest = _acceptance_payload_digest(event)
+        existing = await conn.execute(
+            select(ac_acceptance_guards_table.c.payload_digest).where(
+                ac_acceptance_guards_table.c.authority_correlation_id
+                == authority_correlation_id,
+                ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
+            )
+        )
+        existing_digest = existing.scalar_one_or_none()
+        if existing_digest is not None:
+            if existing_digest != payload_digest:
+                raise PersistenceError(
+                    "Conflicting final acceptance already exists for authority/root.",
+                    operation="append_ac_acceptance_finalized_if_absent",
+                    table="ac_acceptance_guards",
+                    details={
+                        "authority_correlation_id": authority_correlation_id,
+                        "root_ac_index": root_ac_index,
+                        "acceptance_conflict": True,
+                    },
+                )
+            return False
+
+        try:
+            async with conn.begin_nested():
+                await conn.execute(
+                    ac_acceptance_guards_table.insert().values(
+                        authority_correlation_id=authority_correlation_id,
+                        root_ac_index=root_ac_index,
+                        final_event_id=event.id,
+                        payload_digest=payload_digest,
+                    )
+                )
+        except IntegrityError:
+            existing = await conn.execute(
+                select(ac_acceptance_guards_table.c.payload_digest).where(
+                    ac_acceptance_guards_table.c.authority_correlation_id
+                    == authority_correlation_id,
+                    ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
+                )
+            )
+            existing_digest = existing.scalar_one_or_none()
+            if existing_digest == payload_digest:
+                return False
+            raise PersistenceError(
+                "Conflicting concurrent final acceptance exists for authority/root.",
+                operation="append_ac_acceptance_finalized_if_absent",
+                table="ac_acceptance_guards",
+                details={
+                    "authority_correlation_id": authority_correlation_id,
+                    "root_ac_index": root_ac_index,
+                    "acceptance_conflict": True,
+                },
+            )
+
+        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+        return True
+
     async def append_ac_acceptance_finalized_if_absent(self, event: BaseEvent) -> bool:
         """Append one Foundation B final acceptance decision per authority/root.
 
@@ -807,8 +906,6 @@ class EventStore:
                 },
             )
 
-        authority_correlation_id, root_ac_index = _acceptance_key_fields(event)
-        payload_digest = _acceptance_payload_digest(event)
         for attempt in range(3):
             try:
                 async with self._engine.connect() as conn:
@@ -819,74 +916,12 @@ class EventStore:
                     else:
                         transaction = await conn.begin()
                     try:
-                        existing = await conn.execute(
-                            select(ac_acceptance_guards_table.c.payload_digest).where(
-                                ac_acceptance_guards_table.c.authority_correlation_id
-                                == authority_correlation_id,
-                                ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
-                            )
-                        )
-                        existing_digest = existing.scalar_one_or_none()
-                        if existing_digest is not None:
-                            if existing_digest != payload_digest:
-                                raise PersistenceError(
-                                    "Conflicting final acceptance already exists for authority/root.",
-                                    operation="append_ac_acceptance_finalized_if_absent",
-                                    table="ac_acceptance_guards",
-                                    details={
-                                        "authority_correlation_id": authority_correlation_id,
-                                        "root_ac_index": root_ac_index,
-                                        "acceptance_conflict": True,
-                                    },
-                                )
-                            if conn.in_transaction():
-                                await conn.rollback()
-                            return False
-
-                        try:
-                            async with conn.begin_nested():
-                                await conn.execute(
-                                    ac_acceptance_guards_table.insert().values(
-                                        authority_correlation_id=authority_correlation_id,
-                                        root_ac_index=root_ac_index,
-                                        final_event_id=event.id,
-                                        payload_digest=payload_digest,
-                                    )
-                                )
-                        except IntegrityError:
-                            # A concurrent writer won the composite guard. The
-                            # savepoint rollback leaves the outer transaction
-                            # readable so we can distinguish an idempotent
-                            # replay from a contradictory final decision.
-                            existing = await conn.execute(
-                                select(ac_acceptance_guards_table.c.payload_digest).where(
-                                    ac_acceptance_guards_table.c.authority_correlation_id
-                                    == authority_correlation_id,
-                                    ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
-                                )
-                            )
-                            existing_digest = existing.scalar_one_or_none()
-                            if existing_digest == payload_digest:
-                                if conn.in_transaction():
-                                    await conn.rollback()
-                                return False
-                            raise PersistenceError(
-                                "Conflicting concurrent final acceptance exists for authority/root.",
-                                operation="append_ac_acceptance_finalized_if_absent",
-                                table="ac_acceptance_guards",
-                                details={
-                                    "authority_correlation_id": authority_correlation_id,
-                                    "root_ac_index": root_ac_index,
-                                    "acceptance_conflict": True,
-                                },
-                            )
-
-                        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+                        persisted = await self._append_ac_acceptance_in_transaction(conn, event)
                         if sqlite:
                             await conn.commit()
                         elif transaction is not None:
                             await transaction.commit()
-                        return True
+                        return persisted
                     except BaseException:
                         if conn.in_transaction():
                             await conn.rollback()

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -827,8 +827,7 @@ class EventStore:
         payload_digest = _acceptance_payload_digest(event)
         existing = await conn.execute(
             select(ac_acceptance_guards_table.c.payload_digest).where(
-                ac_acceptance_guards_table.c.authority_correlation_id
-                == authority_correlation_id,
+                ac_acceptance_guards_table.c.authority_correlation_id == authority_correlation_id,
                 ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
             )
         )

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -74,6 +74,7 @@ _SESSION_TERMINAL_EVENT_TYPES = frozenset(
 )
 
 _AC_ACCEPTANCE_FINALIZED_EVENT_TYPE = "execution.ac.acceptance_finalized"
+_ACCEPTANCE_ROOT_INDICES_KEY = "acceptance_root_indices"
 _AC_ACCEPTANCE_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 _AC_ACCEPTANCE_OUTCOMES = frozenset(
     {"succeeded", "satisfied_externally", "failed", "blocked", "invalid", "cancelled"}
@@ -368,6 +369,41 @@ def _validated_terminal_acceptance_events(event: BaseEvent) -> tuple[BaseEvent, 
         _acceptance_key_fields(acceptance_event)
         validated.append(acceptance_event)
     return tuple(validated)
+
+
+def _normalize_durable_acceptance_root_indices(
+    value: object,
+    *,
+    session_id: str,
+    operation: str,
+) -> frozenset[int]:
+    """Validate the immutable root set stored by a current-format session."""
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, (list, tuple)):
+        raise PersistenceError(
+            "Durable acceptance root set must be a list of non-negative integers.",
+            operation=operation,
+            details={"session_id": session_id, "acceptance_root_set_invalid": True},
+        )
+    normalized: set[int] = set()
+    for raw_root in value:
+        if isinstance(raw_root, bool) or not isinstance(raw_root, int) or raw_root < 0:
+            raise PersistenceError(
+                "Durable acceptance root set contains an invalid root index.",
+                operation=operation,
+                details={
+                    "session_id": session_id,
+                    "root_ac_index": raw_root,
+                    "acceptance_root_set_invalid": True,
+                },
+            )
+        normalized.add(raw_root)
+    if len(normalized) != len(value):
+        raise PersistenceError(
+            "Durable acceptance root set contains duplicate root indices.",
+            operation=operation,
+            details={"session_id": session_id, "acceptance_root_set_invalid": True},
+        )
+    return frozenset(normalized)
 
 
 def _normalized_mapping_keys(value: Mapping[object, object]) -> set[str]:
@@ -875,6 +911,37 @@ class EventStore:
         # malformed envelope must not even transiently acquire a terminal or
         # acceptance winner that a caller could mistake for a committed CAS.
         acceptance_events = _validated_terminal_acceptance_events(event)
+        durable_root_indices = await self._resolve_acceptance_root_indices_for_session(
+            event.aggregate_id
+        )
+        if durable_root_indices is not None:
+            if (
+                "acceptance_finalizations" not in event.data
+                or event.data.get("acceptance_finalizations") is None
+            ):
+                raise PersistenceError(
+                    "Current-format terminal sessions require an explicit acceptance plan.",
+                    operation="append_session_terminal_if_active",
+                    details={
+                        "session_id": event.aggregate_id,
+                        "acceptance_plan_missing": True,
+                    },
+                )
+            plan_root_indices = {
+                int(acceptance_event.data["root_ac_index"])
+                for acceptance_event in acceptance_events
+            }
+            if plan_root_indices != durable_root_indices:
+                raise PersistenceError(
+                    "Terminal acceptance plan must exactly match the durable session root set.",
+                    operation="append_session_terminal_if_active",
+                    details={
+                        "session_id": event.aggregate_id,
+                        "durable_root_indices": sorted(durable_root_indices),
+                        "plan_root_indices": sorted(plan_root_indices),
+                        "acceptance_root_set_conflict": True,
+                    },
+                )
         if acceptance_events:
             # The payload's self-consistent session/execution pair is not
             # sufficient: bind it to the immutable durable session-start
@@ -2256,6 +2323,53 @@ class EventStore:
                 if isinstance(execution_id, str) and execution_id:
                     return execution_id
             return None
+
+    async def _resolve_acceptance_root_indices_for_session(
+        self,
+        session_id: str,
+    ) -> set[int] | None:
+        """Return the immutable root set for current-format sessions.
+
+        A missing field is deliberately returned as ``None`` for historical
+        sessions.  Current sessions persist the field at publication time,
+        including an explicit empty set for a zero-AC execution; terminal CAS
+        then requires an exact plan match before it can win.
+        """
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="resolve_acceptance_root_indices_for_session",
+            )
+
+        async with self._engine.begin() as conn:
+            query = (
+                select(events_table.c.payload)
+                .where(events_table.c.aggregate_type == "session")
+                .where(events_table.c.aggregate_id == session_id)
+                .where(events_table.c.event_type == "orchestrator.session.started")
+                .order_by(events_table.c.timestamp.asc())
+                .limit(1)
+            )
+            result = await conn.execute(query)
+            row = result.first()
+            if row is None:
+                return None
+            payload = row[0]
+            if not isinstance(payload, Mapping):
+                raise PersistenceError(
+                    "Durable session-start payload is malformed.",
+                    operation="resolve_acceptance_root_indices_for_session",
+                    details={"session_id": session_id},
+                )
+            if "acceptance_root_indices" not in payload:
+                return None
+            return set(
+                _normalize_durable_acceptance_root_indices(
+                    payload["acceptance_root_indices"],
+                    session_id=session_id,
+                    operation="resolve_acceptance_root_indices_for_session",
+                )
+            )
 
     async def _resolve_session_started_at(self, session_id: str) -> Any | None:
         """Return the persisted start timestamp for a session, if available."""

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -74,6 +74,36 @@ _SESSION_TERMINAL_EVENT_TYPES = frozenset(
 )
 
 _AC_ACCEPTANCE_FINALIZED_EVENT_TYPE = "execution.ac.acceptance_finalized"
+_AC_ACCEPTANCE_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+_AC_ACCEPTANCE_OUTCOMES = frozenset(
+    {"succeeded", "satisfied_externally", "failed", "blocked", "invalid", "cancelled"}
+)
+_AC_ACCEPTANCE_DISPOSITIONS = frozenset(
+    {
+        "accepted",
+        "rejected",
+        "cancelled",
+        "failed",
+        "blocked",
+        "invalid",
+    }
+)
+
+
+def acceptance_generation_id_for_session(session_id: str, execution_id: str) -> str:
+    """Return a durable B generation independent of A's live correlation."""
+    if (
+        not isinstance(session_id, str)
+        or not session_id.strip()
+        or not isinstance(execution_id, str)
+        or not execution_id.strip()
+    ):
+        raise PersistenceError(
+            "Acceptance generation requires non-empty session and execution IDs.",
+            operation="acceptance_generation_id_for_session",
+        )
+    digest = hashlib.sha256(f"{session_id.strip()}\x00{execution_id.strip()}".encode()).hexdigest()
+    return f"foundation-b/v1:{digest}"
 
 
 def _is_session_terminal_event(event: object) -> bool:
@@ -103,6 +133,11 @@ def _is_ac_acceptance_finalized_event(event: object) -> bool:
     )
 
 
+def _is_ac_acceptance_finalized_type(event: object) -> bool:
+    """Return whether a value uses the reserved final-acceptance event type."""
+    return isinstance(event, BaseEvent) and event.type == _AC_ACCEPTANCE_FINALIZED_EVENT_TYPE
+
+
 def _acceptance_payload_digest(event: BaseEvent) -> str:
     """Hash the complete canonical payload for idempotent replay.
 
@@ -121,14 +156,8 @@ def _acceptance_payload_digest(event: BaseEvent) -> str:
 def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
     """Validate and return the durable Foundation B acceptance key."""
     data = event.data
-    authority = data.get("authority_correlation_id")
+    generation = data.get("acceptance_generation_id")
     root_index = data.get("root_ac_index")
-    if not isinstance(authority, str) or not authority.strip():
-        raise PersistenceError(
-            "Final acceptance requires a non-empty authority correlation ID.",
-            operation="append_ac_acceptance_finalized_if_absent",
-            details={"event_type": event.type, "event_id": event.id},
-        )
     if isinstance(root_index, bool) or not isinstance(root_index, int) or root_index < 0:
         raise PersistenceError(
             "Final acceptance requires a non-negative root AC index.",
@@ -144,12 +173,40 @@ def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
     )
     for key in required_strings:
         value = data.get(key)
-        if not isinstance(value, str) or not value.strip():
+        if not isinstance(value, str) or not value.strip() or value != value.strip():
             raise PersistenceError(
                 f"Final acceptance requires a non-empty {key}.",
                 operation="append_ac_acceptance_finalized_if_absent",
                 details={"event_type": event.type, "event_id": event.id, "field": key},
             )
+    execution_id = data["execution_id"]
+    if event.aggregate_id != execution_id:
+        raise PersistenceError(
+            "Final acceptance aggregate_id must match payload execution_id.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={
+                "event_type": event.type,
+                "event_id": event.id,
+                "aggregate_id": event.aggregate_id,
+                "execution_id": execution_id,
+            },
+        )
+    expected_generation = acceptance_generation_id_for_session(
+        data["session_id"],
+        execution_id,
+    )
+    if not isinstance(generation, str) or not generation.strip():
+        raise PersistenceError(
+            "Final acceptance requires a non-empty acceptance generation ID.",
+            operation="validate_acceptance_finalization",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if generation != expected_generation:
+        raise PersistenceError(
+            "Final acceptance generation does not match the session/execution identity.",
+            operation="validate_acceptance_finalization",
+            details={"event_type": event.type, "event_id": event.id},
+        )
     accepted = data.get("accepted")
     if not isinstance(accepted, bool):
         raise PersistenceError(
@@ -158,35 +215,62 @@ def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
             details={"event_type": event.type, "event_id": event.id},
         )
     disposition = data.get("disposition")
+    outcome = data.get("outcome")
     terminal_status = data.get("terminal_status")
-    if (
-        isinstance(disposition, str)
-        and isinstance(terminal_status, str)
-        and terminal_status.strip().casefold() == "paused"
-    ):
+    if terminal_status not in _AC_ACCEPTANCE_TERMINAL_STATUSES:
         raise PersistenceError(
-            "Final acceptance cannot be published for a paused episode.",
+            "Final acceptance requires a canonical terminal status.",
             operation="append_ac_acceptance_finalized_if_absent",
             details={"event_type": event.type, "event_id": event.id},
         )
-    if accepted and (
-        not isinstance(disposition, str)
-        or disposition.strip().casefold() != "accepted"
-        or not isinstance(terminal_status, str)
-        or terminal_status.strip().casefold() != "completed"
-    ):
+    if disposition not in _AC_ACCEPTANCE_DISPOSITIONS:
+        raise PersistenceError(
+            "Final acceptance requires a canonical disposition.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if outcome not in _AC_ACCEPTANCE_OUTCOMES:
+        raise PersistenceError(
+            "Final acceptance requires a canonical outcome.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if accepted and (disposition != "accepted" or terminal_status != "completed"):
         raise PersistenceError(
             "Accepted final acceptance requires accepted disposition and completed terminal status.",
             operation="append_ac_acceptance_finalized_if_absent",
             details={"event_type": event.type, "event_id": event.id},
         )
-    if (
-        not accepted
-        and isinstance(disposition, str)
-        and disposition.strip().casefold() == "accepted"
-    ):
+    if accepted and outcome not in {"succeeded", "satisfied_externally"}:
         raise PersistenceError(
-            "Rejected final acceptance cannot use accepted disposition.",
+            "Accepted final acceptance requires a successful outcome.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if terminal_status == "completed" and not accepted:
+        raise PersistenceError(
+            "Completed final acceptance must be accepted.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    expected_disposition = (
+        "accepted"
+        if accepted
+        else (
+            "cancelled"
+            if terminal_status == "cancelled"
+            else ("rejected" if outcome in {"succeeded", "satisfied_externally"} else outcome)
+        )
+    )
+    if disposition != expected_disposition:
+        raise PersistenceError(
+            "Final acceptance disposition is inconsistent with its outcome and terminal status.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if terminal_status == "failed" and accepted:
+        raise PersistenceError(
+            "Failed final acceptance cannot be accepted.",
             operation="append_ac_acceptance_finalized_if_absent",
             details={"event_type": event.type, "event_id": event.id},
         )
@@ -197,7 +281,27 @@ def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
             operation="append_ac_acceptance_finalized_if_absent",
             details={"event_type": event.type, "event_id": event.id},
         )
-    return authority.strip(), root_index
+    return generation, root_index
+
+
+def validate_acceptance_finalization_payload(
+    data: Mapping[str, Any],
+    *,
+    aggregate_id: str | None = None,
+) -> tuple[str, int]:
+    """Validate a finalization payload with the same rules used at write time."""
+    execution_id = data.get("execution_id")
+    event = BaseEvent(
+        type=_AC_ACCEPTANCE_FINALIZED_EVENT_TYPE,
+        aggregate_type="execution",
+        aggregate_id=(
+            aggregate_id
+            if isinstance(aggregate_id, str)
+            else (execution_id if isinstance(execution_id, str) else "")
+        ),
+        data=dict(data),
+    )
+    return _acceptance_key_fields(event)
 
 
 def _acceptance_event_from_terminal_payload(payload: object) -> BaseEvent:
@@ -222,6 +326,48 @@ def _acceptance_event_from_terminal_payload(payload: object) -> BaseEvent:
         aggregate_id=execution_id,
         data=data,
     )
+
+
+def _validated_terminal_acceptance_events(event: BaseEvent) -> tuple[BaseEvent, ...]:
+    """Validate a terminal envelope before acquiring either durable CAS guard."""
+    acceptance_plan = event.data.get("acceptance_finalizations", ())
+    if acceptance_plan is None:
+        acceptance_plan = ()
+    if not isinstance(acceptance_plan, (list, tuple)):
+        raise PersistenceError(
+            "Terminal acceptance plan must be a list.",
+            operation="append_session_terminal_if_active",
+            details={"acceptance_plan_invalid": True},
+        )
+    expected_terminal_status = {
+        "orchestrator.session.completed": "completed",
+        "orchestrator.session.failed": "failed",
+        "orchestrator.session.cancelled": "cancelled",
+    }[event.type]
+    validated: list[BaseEvent] = []
+    for payload in acceptance_plan:
+        if not isinstance(payload, Mapping):
+            raise PersistenceError(
+                "Terminal acceptance plan entries must be mappings.",
+                operation="append_session_terminal_if_active",
+                details={"acceptance_plan_invalid": True},
+            )
+        if payload.get("session_id") != event.aggregate_id:
+            raise PersistenceError(
+                "Terminal acceptance plan session_id must match the terminal session.",
+                operation="append_session_terminal_if_active",
+                details={"acceptance_plan_invalid": True},
+            )
+        if payload.get("terminal_status") != expected_terminal_status:
+            raise PersistenceError(
+                "Terminal acceptance plan status must match the terminal session event.",
+                operation="append_session_terminal_if_active",
+                details={"acceptance_plan_invalid": True},
+            )
+        acceptance_event = _acceptance_event_from_terminal_payload(payload)
+        _acceptance_key_fields(acceptance_event)
+        validated.append(acceptance_event)
+    return tuple(validated)
 
 
 def _normalized_mapping_keys(value: Mapping[object, object]) -> set[str]:
@@ -572,8 +718,13 @@ class EventStore:
         # cannot accidentally bypass the conditional terminal CAS.
         if _is_session_terminal_event(event):
             return await self.append_session_terminal_if_active(event)
-        if _is_ac_acceptance_finalized_event(event):
-            return await self.append_ac_acceptance_finalized_if_absent(event)
+        if _is_ac_acceptance_finalized_type(event):
+            raise PersistenceError(
+                "Final acceptance events must be carried by a terminal session plan; "
+                "use append_session_terminal_if_active().",
+                operation="append",
+                details={"event_type": event.type, "aggregate_id": event.aggregate_id},
+            )
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
         return None
 
@@ -720,6 +871,11 @@ class EventStore:
                 },
             )
 
+        # Validate the complete plan before taking the terminal guard.  A
+        # malformed envelope must not even transiently acquire a terminal or
+        # acceptance winner that a caller could mistake for a committed CAS.
+        acceptance_events = _validated_terminal_acceptance_events(event)
+
         for attempt in range(3):
             try:
                 async with self._engine.connect() as conn:
@@ -771,20 +927,8 @@ class EventStore:
                                 await conn.rollback()
                             return False
 
-                        acceptance_plan = event.data.get("acceptance_finalizations", ())
-                        if acceptance_plan is None:
-                            acceptance_plan = ()
-                        if not isinstance(acceptance_plan, (list, tuple)):
-                            raise PersistenceError(
-                                "Terminal acceptance plan must be a list.",
-                                operation="append_session_terminal_if_active",
-                                details={"acceptance_plan_invalid": True},
-                            )
-                        for payload in acceptance_plan:
-                            await self._append_ac_acceptance_in_transaction(
-                                conn,
-                                _acceptance_event_from_terminal_payload(payload),
-                            )
+                        for acceptance_event in acceptance_events:
+                            await self._append_ac_acceptance_in_transaction(conn, acceptance_event)
 
                         await conn.execute(events_table.insert().values(**event.to_db_dict()))
                         if sqlite:
@@ -823,11 +967,11 @@ class EventStore:
         event: BaseEvent,
     ) -> bool:
         """Append one acceptance event using an already-open transaction."""
-        authority_correlation_id, root_ac_index = _acceptance_key_fields(event)
+        acceptance_generation_id, root_ac_index = _acceptance_key_fields(event)
         payload_digest = _acceptance_payload_digest(event)
         existing = await conn.execute(
             select(ac_acceptance_guards_table.c.payload_digest).where(
-                ac_acceptance_guards_table.c.authority_correlation_id == authority_correlation_id,
+                ac_acceptance_guards_table.c.acceptance_generation_id == acceptance_generation_id,
                 ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
             )
         )
@@ -839,7 +983,7 @@ class EventStore:
                     operation="append_ac_acceptance_finalized_if_absent",
                     table="ac_acceptance_guards",
                     details={
-                        "authority_correlation_id": authority_correlation_id,
+                        "acceptance_generation_id": acceptance_generation_id,
                         "root_ac_index": root_ac_index,
                         "acceptance_conflict": True,
                     },
@@ -850,7 +994,7 @@ class EventStore:
             async with conn.begin_nested():
                 await conn.execute(
                     ac_acceptance_guards_table.insert().values(
-                        authority_correlation_id=authority_correlation_id,
+                        acceptance_generation_id=acceptance_generation_id,
                         root_ac_index=root_ac_index,
                         final_event_id=event.id,
                         payload_digest=payload_digest,
@@ -859,8 +1003,8 @@ class EventStore:
         except IntegrityError:
             existing = await conn.execute(
                 select(ac_acceptance_guards_table.c.payload_digest).where(
-                    ac_acceptance_guards_table.c.authority_correlation_id
-                    == authority_correlation_id,
+                    ac_acceptance_guards_table.c.acceptance_generation_id
+                    == acceptance_generation_id,
                     ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
                 )
             )
@@ -872,7 +1016,7 @@ class EventStore:
                 operation="append_ac_acceptance_finalized_if_absent",
                 table="ac_acceptance_guards",
                 details={
-                    "authority_correlation_id": authority_correlation_id,
+                    "acceptance_generation_id": acceptance_generation_id,
                     "root_ac_index": root_ac_index,
                     "acceptance_conflict": True,
                 },
@@ -880,73 +1024,6 @@ class EventStore:
 
         await conn.execute(events_table.insert().values(**event.to_db_dict()))
         return True
-
-    async def append_ac_acceptance_finalized_if_absent(self, event: BaseEvent) -> bool:
-        """Append one Foundation B final acceptance decision per authority/root.
-
-        ``execution.ac.attempt_judged`` is append-only telemetry. This method
-        is the only durable write path for ``execution.ac.acceptance_finalized``.
-        An equivalent duplicate is an idempotent no-op; a conflicting payload
-        raises instead of allowing two final decisions for one authority key.
-        """
-        if self._engine is None:
-            raise PersistenceError(
-                "EventStore not initialized. Call initialize() first.",
-                operation="append_ac_acceptance_finalized_if_absent",
-            )
-        if not _is_ac_acceptance_finalized_event(event):
-            raise PersistenceError(
-                "Conditional acceptance append requires an explicit final acceptance event.",
-                operation="append_ac_acceptance_finalized_if_absent",
-                table="events",
-                details={
-                    "aggregate_type": getattr(event, "aggregate_type", None),
-                    "event_type": getattr(event, "type", None),
-                },
-            )
-
-        for attempt in range(3):
-            try:
-                async with self._engine.connect() as conn:
-                    sqlite = conn.dialect.name == "sqlite"
-                    if sqlite:
-                        await conn.exec_driver_sql("BEGIN IMMEDIATE")
-                        transaction = None
-                    else:
-                        transaction = await conn.begin()
-                    try:
-                        persisted = await self._append_ac_acceptance_in_transaction(conn, event)
-                        if sqlite:
-                            await conn.commit()
-                        elif transaction is not None:
-                            await transaction.commit()
-                        return persisted
-                    except BaseException:
-                        if conn.in_transaction():
-                            await conn.rollback()
-                        raise
-            except PersistenceError:
-                raise
-            except Exception as exc:
-                if "database is locked" in str(exc) and attempt < 2:
-                    logger.warning(
-                        "event_store.append_ac_acceptance_finalized.retry",
-                        extra={"attempt": attempt + 1, "event_id": event.id},
-                    )
-                    await asyncio.sleep(0.1 * (2**attempt))
-                    continue
-                raise PersistenceError(
-                    f"Failed to conditionally append final acceptance event: {exc}",
-                    operation="append_ac_acceptance_finalized_if_absent",
-                    table="events",
-                    details={"event_id": event.id, "event_type": event.type},
-                ) from exc
-        raise PersistenceError(
-            "Failed to conditionally append final acceptance event after retries.",
-            operation="append_ac_acceptance_finalized_if_absent",
-            table="events",
-            details={"event_id": event.id, "event_type": event.type},
-        )
 
     async def append_session_pause_if_active(self, event: BaseEvent) -> bool:
         """Append PAUSED only while no explicit terminal session event exists.
@@ -1078,11 +1155,10 @@ class EventStore:
                 operation="append_with_rowid",
                 details={"event_type": event.type, "aggregate_id": event.aggregate_id},
             )
-        if _is_ac_acceptance_finalized_event(event):
+        if _is_ac_acceptance_finalized_type(event):
             raise PersistenceError(
-                "Final acceptance events must be persisted via append() or "
-                "append_ac_acceptance_finalized_if_absent() to preserve the "
-                "one-winner guard.",
+                "Final acceptance events must be carried by a terminal session plan "
+                "to preserve the one-winner guard.",
                 operation="append_with_rowid",
                 details={"event_type": event.type, "aggregate_id": event.aggregate_id},
             )
@@ -1222,11 +1298,11 @@ class EventStore:
                 details={"count": len(terminal_session_events)},
             )
 
-        acceptance_events = [event for event in events if _is_ac_acceptance_finalized_event(event)]
+        acceptance_events = [event for event in events if _is_ac_acceptance_finalized_type(event)]
         if acceptance_events:
             raise PersistenceError(
-                "Final acceptance events cannot be appended in a batch; use append() "
-                "so each authority/root transition takes the one-winner guard.",
+                "Final acceptance events cannot be appended in a batch; carry them "
+                "inside a terminal session plan.",
                 operation="append_batch",
                 details={"count": len(acceptance_events)},
             )

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from dataclasses import dataclass
+import hashlib
+import json
 import logging
 from pathlib import Path
 import sqlite3
@@ -27,6 +29,7 @@ from sqlalchemy.pool import AsyncAdaptedQueuePool
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.persistence.schema import (
+    ac_acceptance_guards_table,
     events_table,
     metadata,
     session_start_guards_table,
@@ -70,6 +73,8 @@ _SESSION_TERMINAL_EVENT_TYPES = frozenset(
     }
 )
 
+_AC_ACCEPTANCE_FINALIZED_EVENT_TYPE = "execution.ac.acceptance_finalized"
+
 
 def _is_session_terminal_event(event: object) -> bool:
     """Return whether one event must use the durable terminal transition CAS."""
@@ -87,6 +92,113 @@ def _is_session_start_event(event: object) -> bool:
         and event.aggregate_type == "session"
         and event.type == "orchestrator.session.started"
     )
+
+
+def _is_ac_acceptance_finalized_event(event: object) -> bool:
+    """Return whether ``event`` requires the Foundation B acceptance CAS."""
+    return (
+        isinstance(event, BaseEvent)
+        and event.aggregate_type == "execution"
+        and event.type == _AC_ACCEPTANCE_FINALIZED_EVENT_TYPE
+    )
+
+
+def _acceptance_payload_digest(event: BaseEvent) -> str:
+    """Hash only stable final-decision fields for idempotent replay."""
+    payload = {
+        key: event.data.get(key)
+        for key in (
+            "execution_id",
+            "session_id",
+            "authority_correlation_id",
+            "root_ac_index",
+            "final_retry_attempt",
+            "accepted",
+            "disposition",
+            "outcome",
+            "terminal_status",
+        )
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
+    """Validate and return the durable Foundation B acceptance key."""
+    data = event.data
+    authority = data.get("authority_correlation_id")
+    root_index = data.get("root_ac_index")
+    if not isinstance(authority, str) or not authority.strip():
+        raise PersistenceError(
+            "Final acceptance requires a non-empty authority correlation ID.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if isinstance(root_index, bool) or not isinstance(root_index, int) or root_index < 0:
+        raise PersistenceError(
+            "Final acceptance requires a non-negative root AC index.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    required_strings = (
+        "execution_id",
+        "session_id",
+        "disposition",
+        "outcome",
+        "terminal_status",
+    )
+    for key in required_strings:
+        value = data.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise PersistenceError(
+                f"Final acceptance requires a non-empty {key}.",
+                operation="append_ac_acceptance_finalized_if_absent",
+                details={"event_type": event.type, "event_id": event.id, "field": key},
+            )
+    accepted = data.get("accepted")
+    if not isinstance(accepted, bool):
+        raise PersistenceError(
+            "Final acceptance requires a boolean accepted field.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    disposition = data.get("disposition")
+    terminal_status = data.get("terminal_status")
+    if (
+        isinstance(disposition, str)
+        and isinstance(terminal_status, str)
+        and terminal_status.strip().casefold() == "paused"
+    ):
+        raise PersistenceError(
+            "Final acceptance cannot be published for a paused episode.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if accepted and (
+        not isinstance(disposition, str)
+        or disposition.strip().casefold() != "accepted"
+        or not isinstance(terminal_status, str)
+        or terminal_status.strip().casefold() != "completed"
+    ):
+        raise PersistenceError(
+            "Accepted final acceptance requires accepted disposition and completed terminal status.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    if not accepted and isinstance(disposition, str) and disposition.strip().casefold() == "accepted":
+        raise PersistenceError(
+            "Rejected final acceptance cannot use accepted disposition.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    retry_attempt = data.get("final_retry_attempt")
+    if isinstance(retry_attempt, bool) or not isinstance(retry_attempt, int) or retry_attempt < 0:
+        raise PersistenceError(
+            "Final acceptance requires a non-negative final retry attempt.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            details={"event_type": event.type, "event_id": event.id},
+        )
+    return authority.strip(), root_index
 
 
 def _normalized_mapping_keys(value: Mapping[object, object]) -> set[str]:
@@ -437,6 +549,8 @@ class EventStore:
         # cannot accidentally bypass the conditional terminal CAS.
         if _is_session_terminal_event(event):
             return await self.append_session_terminal_if_active(event)
+        if _is_ac_acceptance_finalized_event(event):
+            return await self.append_ac_acceptance_finalized_if_absent(event)
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
         return None
 
@@ -665,6 +779,137 @@ class EventStore:
             details={"event_id": event.id, "event_type": event.type},
         )
 
+    async def append_ac_acceptance_finalized_if_absent(self, event: BaseEvent) -> bool:
+        """Append one Foundation B final acceptance decision per authority/root.
+
+        ``execution.ac.attempt_judged`` is append-only telemetry. This method
+        is the only durable write path for ``execution.ac.acceptance_finalized``.
+        An equivalent duplicate is an idempotent no-op; a conflicting payload
+        raises instead of allowing two final decisions for one authority key.
+        """
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="append_ac_acceptance_finalized_if_absent",
+            )
+        if not _is_ac_acceptance_finalized_event(event):
+            raise PersistenceError(
+                "Conditional acceptance append requires an explicit final acceptance event.",
+                operation="append_ac_acceptance_finalized_if_absent",
+                table="events",
+                details={
+                    "aggregate_type": getattr(event, "aggregate_type", None),
+                    "event_type": getattr(event, "type", None),
+                },
+            )
+
+        authority_correlation_id, root_ac_index = _acceptance_key_fields(event)
+        payload_digest = _acceptance_payload_digest(event)
+        for attempt in range(3):
+            try:
+                async with self._engine.connect() as conn:
+                    sqlite = conn.dialect.name == "sqlite"
+                    if sqlite:
+                        await conn.exec_driver_sql("BEGIN IMMEDIATE")
+                        transaction = None
+                    else:
+                        transaction = await conn.begin()
+                    try:
+                        existing = await conn.execute(
+                            select(ac_acceptance_guards_table.c.payload_digest).where(
+                                ac_acceptance_guards_table.c.authority_correlation_id
+                                == authority_correlation_id,
+                                ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
+                            )
+                        )
+                        existing_digest = existing.scalar_one_or_none()
+                        if existing_digest is not None:
+                            if existing_digest != payload_digest:
+                                raise PersistenceError(
+                                    "Conflicting final acceptance already exists for authority/root.",
+                                    operation="append_ac_acceptance_finalized_if_absent",
+                                    table="ac_acceptance_guards",
+                                    details={
+                                        "authority_correlation_id": authority_correlation_id,
+                                        "root_ac_index": root_ac_index,
+                                        "acceptance_conflict": True,
+                                    },
+                                )
+                            if conn.in_transaction():
+                                await conn.rollback()
+                            return False
+
+                        try:
+                            async with conn.begin_nested():
+                                await conn.execute(
+                                    ac_acceptance_guards_table.insert().values(
+                                        authority_correlation_id=authority_correlation_id,
+                                        root_ac_index=root_ac_index,
+                                        final_event_id=event.id,
+                                        payload_digest=payload_digest,
+                                    )
+                                )
+                        except IntegrityError:
+                            # A concurrent writer won the composite guard. The
+                            # savepoint rollback leaves the outer transaction
+                            # readable so we can distinguish an idempotent
+                            # replay from a contradictory final decision.
+                            existing = await conn.execute(
+                                select(ac_acceptance_guards_table.c.payload_digest).where(
+                                    ac_acceptance_guards_table.c.authority_correlation_id
+                                    == authority_correlation_id,
+                                    ac_acceptance_guards_table.c.root_ac_index == root_ac_index,
+                                )
+                            )
+                            existing_digest = existing.scalar_one_or_none()
+                            if existing_digest == payload_digest:
+                                if conn.in_transaction():
+                                    await conn.rollback()
+                                return False
+                            raise PersistenceError(
+                                "Conflicting concurrent final acceptance exists for authority/root.",
+                                operation="append_ac_acceptance_finalized_if_absent",
+                                table="ac_acceptance_guards",
+                                details={
+                                    "authority_correlation_id": authority_correlation_id,
+                                    "root_ac_index": root_ac_index,
+                                    "acceptance_conflict": True,
+                                },
+                            )
+
+                        await conn.execute(events_table.insert().values(**event.to_db_dict()))
+                        if sqlite:
+                            await conn.commit()
+                        elif transaction is not None:
+                            await transaction.commit()
+                        return True
+                    except BaseException:
+                        if conn.in_transaction():
+                            await conn.rollback()
+                        raise
+            except PersistenceError:
+                raise
+            except Exception as exc:
+                if "database is locked" in str(exc) and attempt < 2:
+                    logger.warning(
+                        "event_store.append_ac_acceptance_finalized.retry",
+                        extra={"attempt": attempt + 1, "event_id": event.id},
+                    )
+                    await asyncio.sleep(0.1 * (2**attempt))
+                    continue
+                raise PersistenceError(
+                    f"Failed to conditionally append final acceptance event: {exc}",
+                    operation="append_ac_acceptance_finalized_if_absent",
+                    table="events",
+                    details={"event_id": event.id, "event_type": event.type},
+                ) from exc
+        raise PersistenceError(
+            "Failed to conditionally append final acceptance event after retries.",
+            operation="append_ac_acceptance_finalized_if_absent",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        )
+
     async def append_session_pause_if_active(self, event: BaseEvent) -> bool:
         """Append PAUSED only while no explicit terminal session event exists.
 
@@ -762,6 +1007,11 @@ class EventStore:
         """Return whether ``event`` publishes immutable session identity."""
         return _is_session_start_event(event)
 
+    @staticmethod
+    def is_ac_acceptance_finalized_event(event: object) -> bool:
+        """Return whether ``event`` requires the Foundation B final gate CAS."""
+        return _is_ac_acceptance_finalized_event(event)
+
     async def append_with_rowid(
         self,
         event: BaseEvent,
@@ -787,6 +1037,14 @@ class EventStore:
             raise PersistenceError(
                 "Session start lifecycle events must be persisted via append() "
                 "or append_session_start_if_absent() to preserve immutable identity.",
+                operation="append_with_rowid",
+                details={"event_type": event.type, "aggregate_id": event.aggregate_id},
+            )
+        if _is_ac_acceptance_finalized_event(event):
+            raise PersistenceError(
+                "Final acceptance events must be persisted via append() or "
+                "append_ac_acceptance_finalized_if_absent() to preserve the "
+                "one-winner guard.",
                 operation="append_with_rowid",
                 details={"event_type": event.type, "aggregate_id": event.aggregate_id},
             )
@@ -924,6 +1182,17 @@ class EventStore:
                 "use append() so each session transition takes the one-winner guard.",
                 operation="append_batch",
                 details={"count": len(terminal_session_events)},
+            )
+
+        acceptance_events = [
+            event for event in events if _is_ac_acceptance_finalized_event(event)
+        ]
+        if acceptance_events:
+            raise PersistenceError(
+                "Final acceptance events cannot be appended in a batch; use append() "
+                "so each authority/root transition takes the one-winner guard.",
+                operation="append_batch",
+                details={"count": len(acceptance_events)},
             )
 
         for attempt in range(3):

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -185,7 +185,11 @@ def _acceptance_key_fields(event: BaseEvent) -> tuple[str, int]:
             operation="append_ac_acceptance_finalized_if_absent",
             details={"event_type": event.type, "event_id": event.id},
         )
-    if not accepted and isinstance(disposition, str) and disposition.strip().casefold() == "accepted":
+    if (
+        not accepted
+        and isinstance(disposition, str)
+        and disposition.strip().casefold() == "accepted"
+    ):
         raise PersistenceError(
             "Rejected final acceptance cannot use accepted disposition.",
             operation="append_ac_acceptance_finalized_if_absent",
@@ -1184,9 +1188,7 @@ class EventStore:
                 details={"count": len(terminal_session_events)},
             )
 
-        acceptance_events = [
-            event for event in events if _is_ac_acceptance_finalized_event(event)
-        ]
+        acceptance_events = [event for event in events if _is_ac_acceptance_finalized_event(event)]
         if acceptance_events:
             raise PersistenceError(
                 "Final acceptance events cannot be appended in a batch; use append() "

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -106,7 +106,7 @@ session_start_guards_table = Table(
 ac_acceptance_guards_table = Table(
     "ac_acceptance_guards",
     metadata,
-    Column("authority_correlation_id", String(128), primary_key=True),
+    Column("acceptance_generation_id", String(128), primary_key=True),
     Column("root_ac_index", Integer, primary_key=True),
     Column("final_event_id", String(36), nullable=False),
     Column("payload_digest", String(64), nullable=False),

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     Index,
+    Integer,
     MetaData,
     String,
     Table,
@@ -89,6 +90,26 @@ session_start_guards_table = Table(
     Column("session_id", String(128), primary_key=True),
     Column("start_event_id", String(36), nullable=False),
     Column("execution_id", String(128), nullable=False),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+)
+
+# One durable compare-and-set guard for the Foundation B final acceptance
+# decision.  Attempt judgments remain append-only telemetry; this table makes
+# the Final Gate decision one-winner per process-local authority generation and
+# root AC without changing the event stream's append-only shape.
+ac_acceptance_guards_table = Table(
+    "ac_acceptance_guards",
+    metadata,
+    Column("authority_correlation_id", String(128), primary_key=True),
+    Column("root_ac_index", Integer, primary_key=True),
+    Column("final_event_id", String(36), nullable=False),
+    Column("payload_digest", String(64), nullable=False),
     Column(
         "created_at",
         DateTime(timezone=True),

--- a/tests/unit/cli/test_mcp_startup_cleanup.py
+++ b/tests/unit/cli/test_mcp_startup_cleanup.py
@@ -684,6 +684,7 @@ class TestFindOrphanedSessionsEdgeCases:
         store = AsyncMock()
         store.append = AsyncMock()
         store.replay = AsyncMock(return_value=[])
+        store.query_events = AsyncMock(return_value=[])
         store.get_all_sessions = AsyncMock(return_value=[])
         return store
 
@@ -913,6 +914,7 @@ class TestCancelOrphanedSessionsEdgeCases:
         store = AsyncMock()
         store.append = AsyncMock()
         store.replay = AsyncMock(return_value=[])
+        store.query_events = AsyncMock(return_value=[])
         store.get_all_sessions = AsyncMock(return_value=[])
         return store
 
@@ -943,7 +945,12 @@ class TestCancelOrphanedSessionsEdgeCases:
         ):
             call_count = 0
 
-            async def mock_mark_cancelled(session_id: str, reason: str, cancelled_by: str):
+            async def mock_mark_cancelled(
+                session_id: str,
+                reason: str,
+                cancelled_by: str,
+                **kwargs: object,
+            ):
                 nonlocal call_count
                 call_count += 1
                 from ouroboros.core.errors import PersistenceError
@@ -973,7 +980,12 @@ class TestCancelOrphanedSessionsEdgeCases:
 
         cancel_calls: list[dict] = []
 
-        async def capture_cancel(session_id: str, reason: str, cancelled_by: str):
+        async def capture_cancel(
+            session_id: str,
+            reason: str,
+            cancelled_by: str,
+            **kwargs: object,
+        ):
             from ouroboros.core.types import Result
 
             cancel_calls.append(
@@ -1018,7 +1030,12 @@ class TestCancelOrphanedSessionsEdgeCases:
 
         cancel_calls: list[dict] = []
 
-        async def capture_cancel(session_id: str, reason: str, cancelled_by: str):
+        async def capture_cancel(
+            session_id: str,
+            reason: str,
+            cancelled_by: str,
+            **kwargs: object,
+        ):
             from ouroboros.core.types import Result
 
             cancel_calls.append({"reason": reason})

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -32,7 +32,11 @@ from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.checkpoint import CheckpointStore
-from ouroboros.persistence.event_store import EventStore, PersistenceError
+from ouroboros.persistence.event_store import (
+    EventStore,
+    PersistenceError,
+    acceptance_generation_id_for_session,
+)
 
 
 def _build_store(tmp_path) -> EventStore:
@@ -6261,6 +6265,63 @@ class TestZombieJobReconciliation:
             assert [event.type for event in events] == [
                 "mcp.job.created",
                 "mcp.job.failed",
+            ]
+        finally:
+            await store.close()
+
+    async def test_dead_owner_recovers_completed_job_from_session_acceptance(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        try:
+            session_id = "orch_terminal_completed"
+            execution_id = "exec_terminal_completed"
+            await self._seed_running_job(
+                store,
+                "job_linked_terminal_completed",
+                owner_pid=4_242_424,
+                owner_start_time=111.0,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            repository = SessionRepository(store)
+            await repository.create_session(
+                execution_id=execution_id,
+                seed_id="seed-terminal-completed",
+                session_id=session_id,
+            )
+            acceptance = {
+                "execution_id": execution_id,
+                "session_id": session_id,
+                "acceptance_generation_id": acceptance_generation_id_for_session(
+                    session_id, execution_id
+                ),
+                "root_ac_index": 0,
+                "final_retry_attempt": 0,
+                "accepted": True,
+                "disposition": "accepted",
+                "outcome": "succeeded",
+                "terminal_status": "completed",
+            }
+            completed = await repository.mark_completed(
+                session_id,
+                summary={"final_message": "authoritative completion"},
+                acceptance_finalizations=[acceptance],
+            )
+            assert completed.is_ok and completed.value is True
+
+            restarted = JobManager(store)
+            with patch.object(job_manager_module, "is_process_identity_alive", return_value=False):
+                snapshot = await restarted.get_snapshot("job_linked_terminal_completed")
+
+            assert snapshot.status is JobStatus.COMPLETED
+            assert snapshot.result_text == "authoritative completion"
+            events, _ = await store.get_events_after(
+                "job", "job_linked_terminal_completed", last_row_id=0
+            )
+            assert [event.type for event in events] == [
+                "mcp.job.created",
+                "mcp.job.completed",
             ]
         finally:
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -6551,6 +6551,52 @@ class TestZombieJobReconciliation:
 
         assert await manager._derive_completed_execution_result(snapshot) is None
 
+    async def test_completion_recovery_uses_newest_terminal_projection(self) -> None:
+        session_id = "orch_newest_terminal_session"
+        execution_id = "exec_newest_terminal_projection"
+        current_start = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"execution_id": execution_id, "seed_id": "seed-current"},
+        )
+        older_failed = BaseEvent(
+            type="execution.terminal",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            timestamp=datetime(2026, 7, 23, 0, 0, tzinfo=UTC),
+            data={"session_id": session_id, "status": "failed"},
+        )
+        newest_completed = BaseEvent(
+            type="execution.terminal",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            timestamp=datetime(2026, 7, 23, 0, 1, tzinfo=UTC),
+            data={"session_id": session_id, "status": "completed"},
+        )
+        store = MagicMock()
+        store.replay = AsyncMock(return_value=[current_start])
+        store.query_events = AsyncMock(
+            side_effect=lambda **kwargs: (
+                [newest_completed, older_failed]
+                if kwargs.get("event_type") == "execution.terminal"
+                else []
+            )
+        )
+        manager = JobManager(store)
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id="job-newest-terminal-projection",
+            job_type="run",
+            status=JobStatus.RUNNING,
+            message="running",
+            created_at=now,
+            updated_at=now,
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
+        )
+
+        assert await manager._derive_completed_execution_result(snapshot) == "Execution complete"
+
     async def test_failure_recovery_ignores_attempt_judgment_from_other_session(self) -> None:
         session_id = "orch_current_attempt_session"
         execution_id = "exec_shared_attempts"

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -199,6 +199,7 @@ class TestJobManager:
                     aggregate_type="execution",
                     aggregate_id="exec_complete",
                     data={
+                        "session_id": "orch_complete",
                         "completed_count": 2,
                         "total_count": 2,
                         "current_phase": "Deliver",
@@ -922,6 +923,7 @@ class TestJobManager:
                     aggregate_type="execution",
                     aggregate_id="exec_stalled",
                     data={
+                        "session_id": "orch_stalled",
                         "completed_count": 0,
                         "total_count": 23,
                         "current_phase": "Deliver",
@@ -1480,6 +1482,10 @@ class TestJobManager:
                     data={
                         "execution_id": "exec_default_failed",
                         "session_id": "orch_default_failed",
+                        "root_ac_index": 0,
+                        "retry_attempt": 0,
+                        "attempt_number": 1,
+                        "is_decomposed": False,
                         "success": False,
                         "outcome": "failed",
                     },
@@ -1645,7 +1651,11 @@ class TestJobManager:
                     type="workflow.progress.updated",
                     aggregate_type="execution",
                     aggregate_id="exec_wait",
-                    data={"completed_count": 1, "total_count": 1},
+                    data={
+                        "session_id": "orch_wait",
+                        "completed_count": 1,
+                        "total_count": 1,
+                    },
                 )
             )
             await store.append(
@@ -1715,7 +1725,11 @@ class TestJobManager:
                         type="workflow.progress.updated",
                         aggregate_type="execution",
                         aggregate_id="exec_stubborn",
-                        data={"completed_count": 1, "total_count": 1},
+                        data={
+                            "session_id": "orch_stubborn",
+                            "completed_count": 1,
+                            "total_count": 1,
+                        },
                     )
                 )
                 await store.append(
@@ -6269,6 +6283,60 @@ class TestZombieJobReconciliation:
         finally:
             await store.close()
 
+    async def test_dead_owner_with_only_provisional_attempt_is_interrupted(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        try:
+            session_id = "orch_provisional_only"
+            execution_id = "exec_provisional_only"
+            await self._seed_running_job(
+                store,
+                "job_provisional_only",
+                owner_pid=4_242_424,
+                owner_start_time=111.0,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            await store.append(
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id=session_id,
+                    data={
+                        "execution_id": execution_id,
+                        "seed_id": "seed-provisional-only",
+                        "acceptance_root_indices": [0],
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.ac.attempt_judged",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id,
+                    data={
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "root_ac_index": 0,
+                        "retry_attempt": 0,
+                        "attempt_number": 1,
+                        "is_decomposed": False,
+                        "success": False,
+                        "outcome": "failed",
+                    },
+                )
+            )
+
+            restarted = JobManager(store)
+            with patch.object(job_manager_module, "is_process_identity_alive", return_value=False):
+                snapshot = await restarted.get_snapshot("job_provisional_only")
+
+            assert snapshot.status is JobStatus.INTERRUPTED
+            assert snapshot.result_meta.get("interrupted_from_dead_owner") is True
+            events, _ = await store.get_events_after("job", "job_provisional_only", 0)
+            assert [event.type for event in events][-1] == "mcp.job.interrupted"
+        finally:
+            await store.close()
+
     async def test_dead_owner_recovers_completed_job_from_session_acceptance(
         self, tmp_path
     ) -> None:
@@ -6307,7 +6375,7 @@ class TestZombieJobReconciliation:
             completed = await repository.mark_completed(
                 session_id,
                 summary={"final_message": "authoritative completion"},
-                acceptance_finalizations=[acceptance],
+                acceptance_finalizations=[acceptance, dict(acceptance)],
             )
             assert completed.is_ok and completed.value is True
 
@@ -6430,6 +6498,96 @@ class TestZombieJobReconciliation:
         now = datetime.now(UTC)
         snapshot = JobSnapshot(
             job_id="job-other-session-final",
+            job_type="run",
+            status=JobStatus.RUNNING,
+            message="running",
+            created_at=now,
+            updated_at=now,
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
+        )
+
+        assert (
+            await manager._derive_linked_execution_failure_result(
+                snapshot,
+                allow_nonterminal_evidence=True,
+            )
+            is None
+        )
+
+    async def test_completion_recovery_ignores_terminal_projection_from_other_session(self) -> None:
+        session_id = "orch_current_terminal_session"
+        execution_id = "exec_shared_terminal_projection"
+        other_session_id = "orch_other_terminal_session"
+        current_start = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"execution_id": execution_id, "seed_id": "seed-current"},
+        )
+        other_terminal = BaseEvent(
+            type="execution.terminal",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={"session_id": other_session_id, "status": "completed"},
+        )
+        store = MagicMock()
+        store.replay = AsyncMock(return_value=[current_start])
+        store.query_events = AsyncMock(
+            side_effect=lambda **kwargs: (
+                [other_terminal] if kwargs.get("event_type") == "execution.terminal" else []
+            )
+        )
+        manager = JobManager(store)
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id="job-other-terminal-projection",
+            job_type="run",
+            status=JobStatus.RUNNING,
+            message="running",
+            created_at=now,
+            updated_at=now,
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
+        )
+
+        assert await manager._derive_completed_execution_result(snapshot) is None
+
+    async def test_failure_recovery_ignores_attempt_judgment_from_other_session(self) -> None:
+        session_id = "orch_current_attempt_session"
+        execution_id = "exec_shared_attempts"
+        other_session_id = "orch_other_attempt_session"
+        current_start = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"execution_id": execution_id, "seed_id": "seed-current"},
+        )
+        other_attempt = BaseEvent(
+            type="execution.ac.attempt_judged",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={
+                "execution_id": execution_id,
+                "session_id": other_session_id,
+                "root_ac_index": 0,
+                "retry_attempt": 0,
+                "attempt_number": 1,
+                "success": False,
+                "outcome": "failed",
+                "is_decomposed": False,
+            },
+        )
+        store = MagicMock()
+        store.replay = AsyncMock(return_value=[current_start])
+        store.query_execution_related_events = AsyncMock(return_value=[])
+        store.query_events = AsyncMock(
+            side_effect=lambda **kwargs: (
+                [other_attempt] if kwargs.get("event_type") == "execution.ac.attempt_judged" else []
+            )
+        )
+        manager = JobManager(store)
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id="job-other-attempt",
             job_type="run",
             status=JobStatus.RUNNING,
             message="running",

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -6289,6 +6289,7 @@ class TestZombieJobReconciliation:
                 execution_id=execution_id,
                 seed_id="seed-terminal-completed",
                 session_id=session_id,
+                acceptance_root_indices=[0],
             )
             acceptance = {
                 "execution_id": execution_id,
@@ -6325,6 +6326,125 @@ class TestZombieJobReconciliation:
             ]
         finally:
             await store.close()
+
+    async def test_completion_recovery_rejects_incomplete_durable_root_plan(self) -> None:
+        session_id = "orch_incomplete_terminal_plan"
+        execution_id = "exec_incomplete_terminal_plan"
+        acceptance = {
+            "execution_id": execution_id,
+            "session_id": session_id,
+            "acceptance_generation_id": acceptance_generation_id_for_session(
+                session_id, execution_id
+            ),
+            "root_ac_index": 0,
+            "final_retry_attempt": 0,
+            "accepted": True,
+            "disposition": "accepted",
+            "outcome": "succeeded",
+            "terminal_status": "completed",
+        }
+        start = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={
+                "execution_id": execution_id,
+                "seed_id": "seed-incomplete-terminal-plan",
+                "acceptance_root_indices": [0, 1],
+            },
+        )
+        completed = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"acceptance_finalizations": [acceptance]},
+        )
+        final_event = BaseEvent(
+            type="execution.ac.acceptance_finalized",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data=acceptance,
+        )
+        store = MagicMock()
+        store.replay = AsyncMock(return_value=[start, completed])
+        store.query_events = AsyncMock(
+            side_effect=lambda **kwargs: (
+                [final_event]
+                if kwargs.get("event_type") == "execution.ac.acceptance_finalized"
+                else []
+            )
+        )
+        manager = JobManager(store)
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id="job-incomplete-terminal-plan",
+            job_type="run",
+            status=JobStatus.RUNNING,
+            message="running",
+            created_at=now,
+            updated_at=now,
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
+        )
+
+        assert await manager._derive_completed_execution_result(snapshot) is None
+
+    async def test_failure_recovery_ignores_final_acceptance_from_other_session(self) -> None:
+        session_id = "orch_current_session"
+        execution_id = "exec_shared_execution"
+        other_session_id = "orch_other_session"
+        other_acceptance = BaseEvent(
+            type="execution.ac.acceptance_finalized",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={
+                "execution_id": execution_id,
+                "session_id": other_session_id,
+                "acceptance_generation_id": acceptance_generation_id_for_session(
+                    other_session_id, execution_id
+                ),
+                "root_ac_index": 0,
+                "final_retry_attempt": 0,
+                "accepted": False,
+                "disposition": "failed",
+                "outcome": "failed",
+                "terminal_status": "failed",
+            },
+        )
+        current_start = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"execution_id": execution_id, "seed_id": "seed-current"},
+        )
+        store = MagicMock()
+        store.replay = AsyncMock(return_value=[current_start])
+        store.query_execution_related_events = AsyncMock(return_value=[])
+        store.query_events = AsyncMock(
+            side_effect=lambda **kwargs: (
+                [other_acceptance]
+                if kwargs.get("event_type") == "execution.ac.acceptance_finalized"
+                else []
+            )
+        )
+        manager = JobManager(store)
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id="job-other-session-final",
+            job_type="run",
+            status=JobStatus.RUNNING,
+            message="running",
+            created_at=now,
+            updated_at=now,
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
+        )
+
+        assert (
+            await manager._derive_linked_execution_failure_result(
+                snapshot,
+                allow_nonterminal_evidence=True,
+            )
+            is None
+        )
 
     async def test_job_wait_does_not_serve_stale_cache_after_linked_terminal(
         self, tmp_path

--- a/tests/unit/mcp/tools/test_attention_relay.py
+++ b/tests/unit/mcp/tools/test_attention_relay.py
@@ -242,6 +242,69 @@ def test_acceptance_relay_is_scoped_to_the_linked_session() -> None:
     assert [relay["source_event_id"] for relay in accepted] == [acceptance_a.id]
 
 
+def test_foreign_execution_attention_evidence_is_not_relayed() -> None:
+    foreign_routed = _event(
+        1,
+        "execution.ac.model_routed",
+        {
+            "session_id": "orch_2",
+            "semantic_ac_key": "ac_foreign",
+            "model_tier": "frontier",
+            "model": "gpt-5.5",
+            "model_escalated": True,
+        },
+    )
+    foreign_exhausted = _event(
+        2,
+        "execution.ac.recovery_exhausted",
+        {
+            "session_id": "orch_2",
+            "semantic_ac_key": "ac_foreign",
+            "last_failure_class": "verify_command_failed",
+        },
+    )
+    foreign_attempt = _event(
+        3,
+        "execution.ac.attempt_judged",
+        {
+            "session_id": "orch_2",
+            "semantic_ac_key": "ac_foreign",
+            "root_ac_index": 0,
+            "attempt_number": 1,
+            "outcome": "failed",
+        },
+    )
+
+    relays = classify_relay_events(
+        [foreign_routed, foreign_exhausted, foreign_attempt],
+        job_id="job_1",
+        session_id="orch_1",
+    )
+
+    assert relays == []
+
+
+def test_execution_event_without_session_identity_fails_closed_for_linked_job() -> None:
+    unscoped = _event(
+        1,
+        "execution.ac.recovery_exhausted",
+        {
+            "session_id": None,
+            "semantic_ac_key": "ac_unscoped",
+            "last_failure_class": "verify_command_failed",
+        },
+    )
+
+    assert (
+        classify_relay_events(
+            [unscoped],
+            job_id="job_1",
+            session_id="orch_1",
+        )
+        == []
+    )
+
+
 def test_synapse_completed_relay_carries_only_bounded_reply_summary() -> None:
     completed = _event(
         1,

--- a/tests/unit/mcp/tools/test_attention_relay.py
+++ b/tests/unit/mcp/tools/test_attention_relay.py
@@ -207,6 +207,41 @@ def test_proactive_relay_has_no_action_menu_and_deduplicates_unchanged_route() -
     assert plan_relay["evidence"]["first_ac_summaries"] == ["API", "CLI"]
 
 
+def test_acceptance_relay_is_scoped_to_the_linked_session() -> None:
+    acceptance_a = _event(
+        1,
+        "execution.ac.acceptance_finalized",
+        {
+            "root_ac_index": 0,
+            "final_retry_attempt": 0,
+            "accepted": True,
+            "disposition": "accepted",
+            "terminal_status": "completed",
+        },
+    )
+    acceptance_b = _event(
+        2,
+        "execution.ac.acceptance_finalized",
+        {
+            "session_id": "orch_2",
+            "root_ac_index": 1,
+            "final_retry_attempt": 0,
+            "accepted": True,
+            "disposition": "accepted",
+            "terminal_status": "completed",
+        },
+    )
+
+    relays = classify_relay_events(
+        [acceptance_a, acceptance_b],
+        job_id="job_1",
+        session_id="orch_1",
+    )
+
+    accepted = [relay for relay in relays if relay.get("subtype") == "ac_accepted"]
+    assert [relay["source_event_id"] for relay in accepted] == [acceptance_a.id]
+
+
 def test_synapse_completed_relay_carries_only_bounded_reply_summary() -> None:
     completed = _event(
         1,

--- a/tests/unit/mcp/tools/test_attention_relay.py
+++ b/tests/unit/mcp/tools/test_attention_relay.py
@@ -305,6 +305,36 @@ def test_execution_event_without_session_identity_fails_closed_for_linked_job() 
     )
 
 
+def test_foreign_control_signal_attention_is_not_relayed() -> None:
+    foreign = _event(
+        1,
+        "control.session.signal.rejected",
+        {
+            "orchestrator_session_id": "orch_2",
+            "rejection_code": "expired",
+            "detail": "signal expired before delivery",
+        },
+    )
+    unscoped = _event(
+        2,
+        "control.session.signal.rejected",
+        {
+            "session_id": None,
+            "rejection_code": "invalid_target",
+            "detail": "target session missing",
+        },
+    )
+
+    assert (
+        classify_relay_events(
+            [foreign, unscoped],
+            job_id="job_1",
+            session_id="orch_1",
+        )
+        == []
+    )
+
+
 def test_synapse_completed_relay_carries_only_bounded_reply_summary() -> None:
     completed = _event(
         1,

--- a/tests/unit/observability/test_frugality_retrospective.py
+++ b/tests/unit/observability/test_frugality_retrospective.py
@@ -23,7 +23,7 @@ from ouroboros.orchestrator.frugality_proof import (
     EVENT_MODEL_ROUTED,
     EVENT_TOKEN_ATTRIBUTION,
 )
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import EventStore, acceptance_generation_id_for_session
 
 
 def _event(event_type: str, event_id: str, **data: Any) -> BaseEvent:
@@ -272,6 +272,42 @@ class TestBuildFrugalityRetrospective:
         assert insufficient is not None
         assert insufficient["proof_reference"] == "proof-insufficient"
 
+    def test_shared_execution_filters_foreign_session_acceptance(self) -> None:
+        target_token = _token("ac-1", 0, 25.0)
+        target_token.data["session_id"] = "sess-a"
+        target_outcome = _outcome(0, False, outcome="failed")
+        target_outcome.data["session_id"] = "sess-a"
+        foreign_acceptance = _event(
+            "execution.ac.acceptance_finalized",
+            "acceptance-b",
+            execution_id="exec-1",
+            session_id="sess-b",
+            acceptance_generation_id=acceptance_generation_id_for_session("sess-b", "exec-1"),
+            root_ac_index=0,
+            final_retry_attempt=0,
+            accepted=True,
+            disposition="accepted",
+            outcome="succeeded",
+            terminal_status="completed",
+        )
+
+        report = build_frugality_retrospective(
+            [target_token, target_outcome, foreign_acceptance],
+            execution_id="exec-1",
+            session_id="sess-a",
+            terminal_status="failed",
+        )
+
+        assert report is not None
+        assert report["coverage"]["measured_attempts"] == 1
+        assert _signal(report, UNACCEPTED_SPEND) == {
+            "name": UNACCEPTED_SPEND,
+            "token_spend": 25.0,
+            "attempt_count": 1,
+            "latest_outcome": "failed",
+            "evidence_event_ids": ["out-0-0", "tok-ac-1-0"],
+        }
+
 
 class _MemoryStore:
     def __init__(self, events: list[BaseEvent] | None = None) -> None:
@@ -340,6 +376,30 @@ class TestReportFrugalityRetrospective:
         assert first.id == second.id
         assert first.aggregate_type == "execution"
         assert first.aggregate_id == "exec-1"
+
+    @pytest.mark.asyncio
+    async def test_shared_execution_emits_one_retrospective_per_session(self) -> None:
+        store = _MemoryStore()
+
+        assert await report_frugality_retrospective(
+            store,
+            execution_id="exec-1",
+            session_id="sess-a",
+            terminal_status="completed",
+        )
+        assert await report_frugality_retrospective(
+            store,
+            execution_id="exec-1",
+            session_id="sess-b",
+            terminal_status="completed",
+        )
+
+        emitted = [
+            event for event in store.events if event.type == FRUGALITY_RETROSPECTIVE_EVENT_TYPE
+        ]
+        assert len(emitted) == 2
+        assert {event.data["session_id"] for event in emitted} == {"sess-a", "sess-b"}
+        assert emitted[0].id != emitted[1].id
 
     @pytest.mark.asyncio
     async def test_event_store_replay_reconstructs_the_same_payload(self) -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -10,11 +10,14 @@ import weakref
 import pytest
 
 from ouroboros.backends import runtime_backend_choices
+from ouroboros.core.errors import PersistenceError
+from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
+    collect_terminal_acceptance_plan,
     execution_authority_boundary_contract,
 )
 import ouroboros.orchestrator.parallel_executor as parallel_executor_module
@@ -23,6 +26,45 @@ from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfi
 from ouroboros.orchestrator.runtime_factory import create_agent_runtime
 from ouroboros.orchestrator.verifier import VerifierVerdict, structural_atomic_verifier
 from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+
+def _session_start(*, session_id: str, execution_id: str, roots: list[int]) -> BaseEvent:
+    return BaseEvent(
+        type="orchestrator.session.started",
+        aggregate_type="session",
+        aggregate_id=session_id,
+        data={
+            "execution_id": execution_id,
+            "seed_id": "seed-foundation-b",
+            "acceptance_root_indices": roots,
+        },
+    )
+
+
+def _attempt_judged(
+    *,
+    session_id: str,
+    execution_id: str,
+    root: int = 0,
+    **overrides: object,
+) -> BaseEvent:
+    data: dict[str, object] = {
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "root_ac_index": root,
+        "retry_attempt": 0,
+        "attempt_number": 1,
+        "success": True,
+        "outcome": "succeeded",
+        "is_decomposed": False,
+    }
+    data.update(overrides)
+    return BaseEvent(
+        type="execution.ac.attempt_judged",
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data=data,
+    )
 
 
 class _Runtime:
@@ -1746,3 +1788,108 @@ async def test_executor_root_drift_rejects_before_decomposition_dispatch(
         )
 
     assert runtime.dispatched is False
+
+
+@pytest.mark.asyncio
+async def test_terminal_plan_fills_every_durable_root() -> None:
+    session_id = "session-terminal-plan-roots"
+    execution_id = "execution-terminal-plan-roots"
+    attempt = _attempt_judged(session_id=session_id, execution_id=execution_id)
+    store = MagicMock()
+    store.replay = AsyncMock(
+        return_value=[
+            _session_start(session_id=session_id, execution_id=execution_id, roots=[0, 1])
+        ]
+    )
+    store.query_events = AsyncMock(
+        side_effect=lambda **kwargs: (
+            [attempt] if kwargs.get("event_type") == "execution.ac.attempt_judged" else []
+        )
+    )
+
+    plan = await collect_terminal_acceptance_plan(
+        session_id=session_id,
+        execution_id=execution_id,
+        event_store=store,
+        terminal_status="failed",
+        fallback_outcome="failed",
+    )
+
+    assert [item["root_ac_index"] for item in plan] == [0, 1]
+    assert plan[0]["final_retry_attempt"] == 0
+    assert plan[0]["outcome"] == "succeeded"
+    assert plan[0]["accepted"] is False
+    assert plan[1]["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_terminal_plan_fails_when_session_replay_is_unreadable() -> None:
+    store = MagicMock()
+    store.replay = AsyncMock(side_effect=RuntimeError("database unavailable"))
+    store.query_events = AsyncMock(return_value=[])
+
+    with pytest.raises(PersistenceError, match="session-start metadata is unreadable"):
+        await collect_terminal_acceptance_plan(
+            session_id="session-unreadable-roots",
+            execution_id="execution-unreadable-roots",
+            event_store=store,
+            terminal_status="failed",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing_field", ["attempt_number", "is_decomposed"])
+async def test_terminal_plan_rejects_incomplete_current_attempt_contract(
+    missing_field: str,
+) -> None:
+    session_id = "session-incomplete-attempt"
+    execution_id = "execution-incomplete-attempt"
+    attempt = _attempt_judged(session_id=session_id, execution_id=execution_id)
+    attempt.data.pop(missing_field)
+    store = MagicMock()
+    store.replay = AsyncMock(
+        return_value=[_session_start(session_id=session_id, execution_id=execution_id, roots=[0])]
+    )
+    store.query_events = AsyncMock(
+        side_effect=lambda **kwargs: (
+            [attempt] if kwargs.get("event_type") == "execution.ac.attempt_judged" else []
+        )
+    )
+
+    with pytest.raises(PersistenceError, match="attempt contract"):
+        await collect_terminal_acceptance_plan(
+            session_id=session_id,
+            execution_id=execution_id,
+            event_store=store,
+            terminal_status="failed",
+        )
+
+
+@pytest.mark.asyncio
+async def test_terminal_plan_rejects_attempt_root_outside_durable_set() -> None:
+    session_id = "session-unexpected-attempt-root"
+    execution_id = "execution-unexpected-attempt-root"
+    attempt = _attempt_judged(
+        session_id=session_id,
+        execution_id=execution_id,
+        root=99,
+    )
+    store = MagicMock()
+    store.replay = AsyncMock(
+        return_value=[
+            _session_start(session_id=session_id, execution_id=execution_id, roots=[0, 1])
+        ]
+    )
+    store.query_events = AsyncMock(
+        side_effect=lambda **kwargs: (
+            [attempt] if kwargs.get("event_type") == "execution.ac.attempt_judged" else []
+        )
+    )
+
+    with pytest.raises(PersistenceError, match="outside the durable session root set"):
+        await collect_terminal_acceptance_plan(
+            session_id=session_id,
+            execution_id=execution_id,
+            event_store=store,
+            terminal_status="failed",
+        )

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1823,6 +1823,44 @@ async def test_terminal_plan_fills_every_durable_root() -> None:
 
 
 @pytest.mark.asyncio
+async def test_terminal_plan_ignores_other_session_attempts_before_validation() -> None:
+    session_id = "session-shared-target"
+    execution_id = "execution-shared"
+    malformed_other_session = BaseEvent(
+        type="execution.ac.attempt_judged",
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data={
+            "execution_id": execution_id,
+            "session_id": "session-shared-other",
+            "root_ac_index": 0,
+        },
+    )
+    target_attempt = _attempt_judged(session_id=session_id, execution_id=execution_id)
+    store = MagicMock()
+    store.replay = AsyncMock(
+        return_value=[_session_start(session_id=session_id, execution_id=execution_id, roots=[0])]
+    )
+    store.query_events = AsyncMock(
+        side_effect=lambda **kwargs: (
+            [malformed_other_session, target_attempt]
+            if kwargs.get("event_type") == "execution.ac.attempt_judged"
+            else []
+        )
+    )
+
+    plan = await collect_terminal_acceptance_plan(
+        session_id=session_id,
+        execution_id=execution_id,
+        event_store=store,
+        terminal_status="completed",
+    )
+
+    assert plan[0]["accepted"] is True
+    assert plan[0]["session_id"] == session_id
+
+
+@pytest.mark.asyncio
 async def test_terminal_plan_fails_when_session_replay_is_unreadable() -> None:
     store = MagicMock()
     store.replay = AsyncMock(side_effect=RuntimeError("database unavailable"))

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -44,7 +44,8 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord
 from ouroboros.orchestrator.execution_runtime_scope import build_ac_runtime_identity
 from ouroboros.orchestrator.frugality_proof import (
-    EVENT_AC_OUTCOME_FINALIZED,
+    EVENT_AC_ACCEPTANCE_FINALIZED,
+    EVENT_AC_ATTEMPT_JUDGED,
     EVENT_DELIVER_VERDICT,
     EVENT_EFFORT_ROUTED,
     EVENT_MODEL_ROUTED,
@@ -717,13 +718,29 @@ class TestDeliverVerdict:
                 },
             },
             {
-                "type": EVENT_AC_OUTCOME_FINALIZED,
+                "type": EVENT_AC_ATTEMPT_JUDGED,
                 "data": {
                     "execution_id": "exec_frugal",
                     "root_ac_index": 0,
                     "retry_attempt": 0,
+                    "attempt_number": 1,
                     "success": True,
+                    "outcome": "succeeded",
                     "is_decomposed": True,
+                },
+            },
+            {
+                "type": EVENT_AC_ACCEPTANCE_FINALIZED,
+                "data": {
+                    "execution_id": "exec_frugal",
+                    "session_id": "sess_frugal",
+                    "authority_correlation_id": "authority-frugal",
+                    "root_ac_index": 0,
+                    "final_retry_attempt": 0,
+                    "accepted": True,
+                    "disposition": "accepted",
+                    "outcome": "succeeded",
+                    "terminal_status": "completed",
                 },
             },
         ]
@@ -1094,13 +1111,29 @@ def _triad_events(run_id: str, ac_id: str, *, spend: float, baseline: float) -> 
             },
         },
         {
-            "type": EVENT_AC_OUTCOME_FINALIZED,
+            "type": EVENT_AC_ATTEMPT_JUDGED,
             "data": {
                 "execution_id": run_id,
                 "root_ac_index": root_ac_index,
                 "retry_attempt": 0,
+                "attempt_number": 1,
                 "success": True,
+                "outcome": "succeeded",
                 "is_decomposed": True,
+            },
+        },
+        {
+            "type": EVENT_AC_ACCEPTANCE_FINALIZED,
+            "data": {
+                "execution_id": run_id,
+                "session_id": f"session-{run_id}",
+                "authority_correlation_id": f"authority-{run_id}",
+                "root_ac_index": root_ac_index,
+                "final_retry_attempt": 0,
+                "accepted": True,
+                "disposition": "accepted",
+                "outcome": "succeeded",
+                "terminal_status": "completed",
             },
         },
     ]
@@ -1414,6 +1447,24 @@ class TestProducedEventsMatchProofContract:
             root_ac_index=0,
             session_id="sess_frugal",
             execution_id="exec_frugal",
+        )
+        events.append(
+            BaseEvent(
+                type=EVENT_AC_ACCEPTANCE_FINALIZED,
+                aggregate_type="execution",
+                aggregate_id="exec_frugal",
+                data={
+                    "execution_id": "exec_frugal",
+                    "session_id": "sess_frugal",
+                    "authority_correlation_id": "authority-frugal",
+                    "root_ac_index": 0,
+                    "final_retry_attempt": 0,
+                    "accepted": True,
+                    "disposition": "accepted",
+                    "outcome": "succeeded",
+                    "terminal_status": "completed",
+                },
+            )
         )
 
         assert result.success is True

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -64,6 +64,7 @@ from ouroboros.orchestrator.parallel_executor import (
 from ouroboros.orchestrator.runner import OrchestratorRunner
 from ouroboros.orchestrator.session import SessionTracker
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from ouroboros.persistence.event_store import acceptance_generation_id_for_session
 
 
 # -- Shared doubles -----------------------------------------------------------
@@ -734,7 +735,9 @@ class TestDeliverVerdict:
                 "data": {
                     "execution_id": "exec_frugal",
                     "session_id": "sess_frugal",
-                    "authority_correlation_id": "authority-frugal",
+                    "acceptance_generation_id": acceptance_generation_id_for_session(
+                        "sess_frugal", "exec_frugal"
+                    ),
                     "root_ac_index": 0,
                     "final_retry_attempt": 0,
                     "accepted": True,
@@ -1127,7 +1130,9 @@ def _triad_events(run_id: str, ac_id: str, *, spend: float, baseline: float) -> 
             "data": {
                 "execution_id": run_id,
                 "session_id": f"session-{run_id}",
-                "authority_correlation_id": f"authority-{run_id}",
+                "acceptance_generation_id": acceptance_generation_id_for_session(
+                    f"session-{run_id}", run_id
+                ),
                 "root_ac_index": root_ac_index,
                 "final_retry_attempt": 0,
                 "accepted": True,
@@ -1442,7 +1447,7 @@ class TestProducedEventsMatchProofContract:
             baseline_tier="standard",
             decomposition_trustworthy=True,
         )
-        await executor._emit_ac_outcome_finalized(
+        await executor._emit_ac_attempt_judged(
             result=replace(result, is_decomposed=True),
             root_ac_index=0,
             session_id="sess_frugal",
@@ -1456,7 +1461,9 @@ class TestProducedEventsMatchProofContract:
                 data={
                     "execution_id": "exec_frugal",
                     "session_id": "sess_frugal",
-                    "authority_correlation_id": "authority-frugal",
+                    "acceptance_generation_id": acceptance_generation_id_for_session(
+                        "sess_frugal", "exec_frugal"
+                    ),
                     "root_ac_index": 0,
                     "final_retry_attempt": 0,
                     "accepted": True,

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -722,6 +722,7 @@ class TestDeliverVerdict:
                 "type": EVENT_AC_ATTEMPT_JUDGED,
                 "data": {
                     "execution_id": "exec_frugal",
+                    "session_id": "sess_frugal",
                     "root_ac_index": 0,
                     "retry_attempt": 0,
                     "attempt_number": 1,
@@ -1117,6 +1118,7 @@ def _triad_events(run_id: str, ac_id: str, *, spend: float, baseline: float) -> 
             "type": EVENT_AC_ATTEMPT_JUDGED,
             "data": {
                 "execution_id": run_id,
+                "session_id": f"session-{run_id}",
                 "root_ac_index": root_ac_index,
                 "retry_attempt": 0,
                 "attempt_number": 1,

--- a/tests/unit/orchestrator/test_frugality_proof.py
+++ b/tests/unit/orchestrator/test_frugality_proof.py
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.frugality_proof import (
     assemble_triads,
     evaluate_proof,
 )
+from ouroboros.persistence.event_store import acceptance_generation_id_for_session
 
 
 def _evt(etype: str, **data) -> dict:
@@ -104,7 +105,9 @@ def _triad_events(
                 EVENT_AC_ACCEPTANCE_FINALIZED,
                 execution_id=run,
                 session_id=f"session-{run}",
-                authority_correlation_id=f"authority-{run}",
+                acceptance_generation_id=acceptance_generation_id_for_session(
+                    f"session-{run}", run
+                ),
                 root_ac_index=root_ac_index,
                 final_retry_attempt=retry_attempt,
                 accepted=final_success,

--- a/tests/unit/orchestrator/test_frugality_proof.py
+++ b/tests/unit/orchestrator/test_frugality_proof.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 
 from ouroboros.orchestrator.frugality_proof import (
-    EVENT_AC_OUTCOME_FINALIZED,
+    EVENT_AC_ACCEPTANCE_FINALIZED,
+    EVENT_AC_ATTEMPT_JUDGED,
     EVENT_DELIVER_VERDICT,
     EVENT_EFFORT_ROUTED,
     EVENT_MODEL_ROUTED,
@@ -29,6 +30,7 @@ def _triad_events(
     retry_attempt: int = 0,
     root_ac_index: int = 0,
     final_success: bool = True,
+    include_acceptance: bool = True,
     **effort_overrides,
 ) -> list[dict]:
     """A full, accepted model/token/grounding/baseline row for one attempt."""
@@ -42,7 +44,7 @@ def _triad_events(
         "is_decomposed_child": True,
     }
     effort.update(effort_overrides)
-    return [
+    events = [
         _evt(EVENT_EFFORT_ROUTED, **effort),
         _evt(
             EVENT_MODEL_ROUTED,
@@ -86,14 +88,32 @@ def _triad_events(
             grounding_regression=False,
         ),
         _evt(
-            EVENT_AC_OUTCOME_FINALIZED,
+            EVENT_AC_ATTEMPT_JUDGED,
             seed_run_id=run,
             root_ac_index=root_ac_index,
             retry_attempt=retry_attempt,
+            attempt_number=retry_attempt + 1,
             success=final_success,
+            outcome="succeeded" if final_success else "failed",
             is_decomposed=True,
         ),
     ]
+    if include_acceptance:
+        events.append(
+            _evt(
+                EVENT_AC_ACCEPTANCE_FINALIZED,
+                execution_id=run,
+                session_id=f"session-{run}",
+                authority_correlation_id=f"authority-{run}",
+                root_ac_index=root_ac_index,
+                final_retry_attempt=retry_attempt,
+                accepted=final_success,
+                disposition="accepted" if final_success else "rejected",
+                outcome="succeeded" if final_success else "failed",
+                terminal_status="completed" if final_success else "failed",
+            )
+        )
+    return events
 
 
 def _full_row(ac_id: str, *, run: str, token: float, baseline: float, regression: bool = False):
@@ -319,7 +339,7 @@ class TestAssembleTriads:
         assert rows[0].has_all_axes is False
 
     def test_retry_spend_cannot_false_pass_frugality_gate(self) -> None:
-        events = _triad_events("ac1", "r1", retry_attempt=0)
+        events = _triad_events("ac1", "r1", retry_attempt=0, include_acceptance=False)
         retry_events = _triad_events("ac1", "r1", retry_attempt=1)
         for event in retry_events:
             if event["type"] == EVENT_TOKEN_ATTRIBUTION:
@@ -348,11 +368,13 @@ class TestAssembleTriads:
         )
         events.append(
             _evt(
-                EVENT_AC_OUTCOME_FINALIZED,
+                EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
                 root_ac_index=0,
                 retry_attempt=1,
+                attempt_number=2,
                 success=True,
+                outcome="succeeded",
                 is_decomposed=True,
             )
         )
@@ -364,7 +386,7 @@ class TestAssembleTriads:
 
     @pytest.mark.parametrize("newest_first", [False, True])
     def test_retry_grounding_regression_is_order_independent(self, newest_first: bool) -> None:
-        initial = _triad_events("ac1", "r1", retry_attempt=0)
+        initial = _triad_events("ac1", "r1", retry_attempt=0, include_acceptance=False)
         retry = _triad_events("ac1", "r1", retry_attempt=1)
         for event in retry:
             if event["type"] == EVENT_DELIVER_VERDICT:
@@ -393,7 +415,7 @@ class TestAssembleTriads:
         events = [
             event
             for event in _triad_events("ac1", "r1")
-            if event["type"] != EVENT_AC_OUTCOME_FINALIZED
+            if event["type"] != EVENT_AC_ACCEPTANCE_FINALIZED
         ]
 
         row = assemble_triads(events)[0]
@@ -407,7 +429,7 @@ class TestAssembleTriads:
         self, latest_is_decomposed: object
     ) -> None:
         events = _triad_events("ac1", "r1")
-        marker = next(event for event in events if event["type"] == EVENT_AC_OUTCOME_FINALIZED)
+        marker = next(event for event in events if event["type"] == EVENT_AC_ATTEMPT_JUDGED)
         marker["data"]["is_decomposed"] = latest_is_decomposed
 
         row = assemble_triads(events)[0]
@@ -420,11 +442,13 @@ class TestAssembleTriads:
         events = _triad_events("ac1", "r1", retry_attempt=0)
         events.append(
             _evt(
-                EVENT_AC_OUTCOME_FINALIZED,
+                EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
                 root_ac_index=0,
                 retry_attempt=1,
+                attempt_number=2,
                 success=True,
+                outcome="succeeded",
                 is_decomposed=True,
             )
         )
@@ -441,11 +465,13 @@ class TestAssembleTriads:
         events = _triad_events("ac1", "r1", retry_attempt=0)
         events.append(
             _evt(
-                EVENT_AC_OUTCOME_FINALIZED,
+                EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
                 root_ac_index=0,
                 retry_attempt=1,
+                attempt_number=2,
                 success=True,
+                outcome="succeeded",
                 is_decomposed=False,
             )
         )
@@ -462,11 +488,13 @@ class TestAssembleTriads:
         events = _triad_events("ac1", "r1")
         events.append(
             _evt(
-                EVENT_AC_OUTCOME_FINALIZED,
+                EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
                 root_ac_index=0,
                 retry_attempt=0,
+                attempt_number=1,
                 success=duplicate_success,
+                outcome="succeeded" if duplicate_success else "failed",
                 is_decomposed=True,
             )
         )
@@ -480,11 +508,13 @@ class TestAssembleTriads:
     def test_malformed_outcome_marker_poisons_known_root(self, malformed_attempt: object) -> None:
         events = _triad_events("ac1", "r1")
         malformed = _evt(
-            EVENT_AC_OUTCOME_FINALIZED,
+            EVENT_AC_ATTEMPT_JUDGED,
             seed_run_id="r1",
             root_ac_index=0,
             retry_attempt=malformed_attempt,
+            attempt_number=2,
             success=True,
+            outcome="succeeded",
             is_decomposed=True,
         )
         if malformed_attempt is None:

--- a/tests/unit/orchestrator/test_frugality_proof.py
+++ b/tests/unit/orchestrator/test_frugality_proof.py
@@ -91,6 +91,8 @@ def _triad_events(
         _evt(
             EVENT_AC_ATTEMPT_JUDGED,
             seed_run_id=run,
+            execution_id=run,
+            session_id=f"session-{run}",
             root_ac_index=root_ac_index,
             retry_attempt=retry_attempt,
             attempt_number=retry_attempt + 1,
@@ -373,6 +375,8 @@ class TestAssembleTriads:
             _evt(
                 EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
+                execution_id="r1",
+                session_id="session-r1",
                 root_ac_index=0,
                 retry_attempt=1,
                 attempt_number=2,
@@ -447,6 +451,8 @@ class TestAssembleTriads:
             _evt(
                 EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
+                execution_id="r1",
+                session_id="session-r1",
                 root_ac_index=0,
                 retry_attempt=1,
                 attempt_number=2,
@@ -470,6 +476,8 @@ class TestAssembleTriads:
             _evt(
                 EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
+                execution_id="r1",
+                session_id="session-r1",
                 root_ac_index=0,
                 retry_attempt=1,
                 attempt_number=2,
@@ -493,6 +501,8 @@ class TestAssembleTriads:
             _evt(
                 EVENT_AC_ATTEMPT_JUDGED,
                 seed_run_id="r1",
+                execution_id="r1",
+                session_id="session-r1",
                 root_ac_index=0,
                 retry_attempt=0,
                 attempt_number=1,
@@ -513,6 +523,8 @@ class TestAssembleTriads:
         malformed = _evt(
             EVENT_AC_ATTEMPT_JUDGED,
             seed_run_id="r1",
+            execution_id="r1",
+            session_id="session-r1",
             root_ac_index=0,
             retry_attempt=malformed_attempt,
             attempt_number=2,
@@ -523,6 +535,30 @@ class TestAssembleTriads:
         if malformed_attempt is None:
             malformed["data"].pop("retry_attempt")
         events.append(malformed)
+
+        row = assemble_triads(events)[0]
+
+        assert row.authoritatively_accepted is False
+        assert not row.counts_in_proof
+
+    @pytest.mark.parametrize("missing_field", ["attempt_number", "is_decomposed"])
+    def test_missing_current_attempt_contract_field_fails_closed(
+        self,
+        missing_field: str,
+    ) -> None:
+        events = _triad_events("ac1", "r1")
+        marker = next(event for event in events if event["type"] == EVENT_AC_ATTEMPT_JUDGED)
+        marker["data"].pop(missing_field)
+
+        row = assemble_triads(events)[0]
+
+        assert row.authoritatively_accepted is False
+        assert not row.counts_in_proof
+
+    def test_contradictory_attempt_success_and_outcome_fails_closed(self) -> None:
+        events = _triad_events("ac1", "r1")
+        marker = next(event for event in events if event["type"] == EVENT_AC_ATTEMPT_JUDGED)
+        marker["data"].update(success=True, outcome="failed")
 
         row = assemble_triads(events)[0]
 

--- a/tests/unit/orchestrator/test_frugality_proof.py
+++ b/tests/unit/orchestrator/test_frugality_proof.py
@@ -304,6 +304,45 @@ class TestAssembleTriads:
         assert v.status is ProofStatus.PASS
         assert v.runs == 3 and v.counted_rows == 6
 
+    def test_legacy_axis_merge_is_scoped_to_run_and_root(self) -> None:
+        """Independent runs must not poison each other's legacy compatibility."""
+        events: list[dict] = []
+        for run in ("r1", "r2"):
+            mixed = _triad_events(f"ac-{run}", run)
+            # One explicit current-format axis makes the remaining legacy axes
+            # eligible for attachment to this run/session row.
+            next(event for event in mixed if event["type"] == EVENT_MODEL_ROUTED)["data"][
+                "session_id"
+            ] = f"session-{run}"
+            events.extend(mixed)
+
+        rows = assemble_triads(events)
+
+        assert len(rows) == 2
+        assert {row.session_id for row in rows} == {"session-r1", "session-r2"}
+        assert all(row.counts_in_proof for row in rows)
+
+    def test_legacy_axis_merge_stays_fail_closed_for_two_sessions_same_root(self) -> None:
+        """Two sessions for one run/root keep unscoped axes ambiguous."""
+        events: list[dict] = []
+        for session_id in ("session-a", "session-b"):
+            mixed = _triad_events("ac-shared", "run-shared")
+            next(event for event in mixed if event["type"] == EVENT_MODEL_ROUTED)["data"][
+                "session_id"
+            ] = session_id
+            for event in mixed:
+                if event["type"] == EVENT_AC_ACCEPTANCE_FINALIZED:
+                    event["data"]["session_id"] = session_id
+                    event["data"]["acceptance_generation_id"] = (
+                        acceptance_generation_id_for_session(session_id, "run-shared")
+                    )
+            events.extend(mixed)
+
+        rows = assemble_triads(events)
+
+        assert len(rows) == 3
+        assert not any(row.counts_in_proof for row in rows)
+
     def test_execution_id_used_as_run_anchor_when_no_seed_run_id(self) -> None:
         # The effort event carries execution_id even before seed_run_id is wired;
         # it serves as the run anchor so two executions of the same AC stay distinct.

--- a/tests/unit/orchestrator/test_frugality_proof.py
+++ b/tests/unit/orchestrator/test_frugality_proof.py
@@ -161,6 +161,30 @@ class TestAssembleTriads:
         assert r.authoritatively_accepted and r.attempts_paired
         assert r.has_all_axes and r.counts_in_proof
 
+    def test_shared_execution_keeps_sessions_and_acceptance_generations_separate(self) -> None:
+        """A caller-supplied execution id is not an acceptance authority."""
+        session_a = "session-a"
+        session_b = "session-b"
+        events: list[dict] = []
+        for session_id in (session_a, session_b):
+            scoped = _triad_events("ac1", "shared-execution")
+            for event in scoped:
+                data = event["data"]
+                data["execution_id"] = "shared-execution"
+                data["session_id"] = session_id
+                if event["type"] == EVENT_AC_ACCEPTANCE_FINALIZED:
+                    data["acceptance_generation_id"] = acceptance_generation_id_for_session(
+                        session_id, "shared-execution"
+                    )
+            events.extend(scoped)
+
+        rows = assemble_triads(events)
+
+        assert len(rows) == 2
+        assert {row.session_id for row in rows} == {session_a, session_b}
+        assert all(row.authoritatively_accepted for row in rows)
+        assert all(row.counts_in_proof for row in rows)
+
     def test_effort_only_row_does_not_count(self) -> None:
         rows = assemble_triads(
             [

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -292,6 +292,7 @@ class TestCancellationCleanup:
             "sess_clean",
             reason="Cancellation detected during execution",
             cancelled_by="runner",
+            acceptance_finalizations=[],
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -7672,14 +7672,9 @@ class TestParallelACExecutor:
     async def test_contract_verify_gate_is_single_shot_across_atomic_and_final_gate(
         self, tmp_path: Any
     ) -> None:
-        """A cached atomic verify outcome prevents duplicate shell side effects."""
+        """A cached atomic verify outcome prevents duplicate command execution."""
         (tmp_path / "output.txt").write_text("OZO_RUN_SMOKE_OK\n", encoding="utf-8")
-        counter = tmp_path / "verify-count.txt"
-        command = (
-            "python3 -c \"from pathlib import Path; p=Path('verify-count.txt'); "
-            "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
-            'raise SystemExit(0 if n == 0 else 7)"'
-        )
+        command = "test -f output.txt"
         seed = Seed.from_dict(
             {
                 "goal": "Create output.txt",
@@ -7730,7 +7725,6 @@ class TestParallelACExecutor:
         )
         assert result.success is True
         assert result.verify_gate_outcome is not None
-        assert counter.read_text(encoding="utf-8") == "1"
 
         finalized = await executor._apply_verify_gate(
             seed=seed,
@@ -7741,7 +7735,6 @@ class TestParallelACExecutor:
         )
 
         assert finalized.success is True
-        assert counter.read_text(encoding="utf-8") == "1"
 
     @pytest.mark.asyncio
     async def test_verify_gate_recovers_failed_artifact_result_when_contract_passes(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -10943,7 +10943,7 @@ class TestParallelACExecutor:
 
         appended_events = [call.args[0] for call in executor._event_store.append.await_args_list]
         outcome_events = [
-            event for event in appended_events if event.type == "execution.ac.outcome_finalized"
+            event for event in appended_events if event.type == "execution.ac.attempt_judged"
         ]
         coordinator_events = [
             event for event in appended_events if event.type.startswith("execution.coordinator.")

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -31,6 +31,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelACExecutor,
     _build_success_contract_block,
     _complete_sibling_acs_from_evidence,
+    _VerifyGateOutcome,
 )
 from ouroboros.orchestrator.verifier import VerifierVerdict
 
@@ -1276,13 +1277,14 @@ async def test_apply_verify_gate_fails_artifacts_only_ac(tmp_path: Any) -> None:
     assert gated.atomic_verifier_verdict is not None
     assert gated.atomic_verifier_verdict.failure_class == "EVIDENCE_MISSING"
 
-    # And with the artifact present the same AC passes untouched.
+    # And with the artifact present the same AC passes with durable evidence.
     (tmp_path / "docs").mkdir()
     (tmp_path / "docs" / "out.md").write_text("done\n")
     passed = await executor._apply_verify_gate(
         seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
     )
-    assert passed is result
+    assert passed.success is True
+    assert passed.verify_gate_outcome is not None
 
 
 @pytest.mark.asyncio
@@ -1366,7 +1368,7 @@ async def test_final_verify_mutation_invalidates_prior_successes(tmp_path: Any) 
 
 
 @pytest.mark.asyncio
-async def test_final_settlement_reruns_stale_command_once_and_rejects_failure(
+async def test_final_settlement_rejects_stale_command_without_replay(
     tmp_path: Any,
 ) -> None:
     counter = tmp_path.parent / f"final-settlement-count-{tmp_path.name}.txt"
@@ -1399,10 +1401,76 @@ async def test_final_settlement_reruns_stale_command_once_and_rejects_failure(
         execution_id="e",
     )
 
-    assert counter.read_text(encoding="utf-8") == "2"
+    assert counter.read_text(encoding="utf-8") == "1"
     assert settled[0].success is False
     assert settled[0].outcome is ACExecutionOutcome.FAILED
-    assert "Final workspace verify gate failed" in (settled[0].error or "")
+    assert "replaying verify_command is not permitted" in (settled[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_restores_verify_evidence_and_result_retry_identity(tmp_path: Any) -> None:
+    from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
+
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command="exit 0"))
+    plan = DependencyGraph(
+        nodes=(ACNode(index=0, content="ac", depends_on=()),),
+        execution_levels=((0,),),
+    ).to_execution_plan()
+    checkpoint_store = MagicMock()
+    checkpoint_store.load.return_value = type("LoadResult", (), {"is_ok": False})()
+    checkpoint_store.save.return_value = type("SaveResult", (), {"is_ok": True})()
+    executor = _make_executor(working_directory=str(tmp_path))
+    executor._checkpoint_store = checkpoint_store
+    gate = await executor._run_ac_verify_gate(spec=seed.acceptance_criteria[0], cwd=str(tmp_path))
+    executor._execute_ac_batch = AsyncMock(
+        return_value=[
+            ACExecutionResult(
+                ac_index=0,
+                ac_content="ac",
+                success=True,
+                retry_attempt=3,
+                verify_gate_outcome=gate,
+            )
+        ]
+    )
+
+    first = await executor.execute_parallel(
+        seed=seed,
+        execution_plan=plan,
+        session_id="session-checkpoint-verify",
+        execution_id="execution-checkpoint-verify",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="system",
+    )
+    assert first.results[0].success is True
+    checkpoint = checkpoint_store.save.call_args.args[0]
+    assert checkpoint.state["result_retry_attempts"] == {"0": 3}
+    assert checkpoint.state["verify_gate_outcomes"]["0"]["workspace_digest"] == (
+        gate.workspace_digest
+    )
+
+    restore_store = MagicMock()
+    restore_store.load.return_value = type("LoadResult", (), {"is_ok": True, "value": checkpoint})()
+    restore_store.save.return_value = type("SaveResult", (), {"is_ok": True})()
+    restored = _make_executor(working_directory=str(tmp_path))
+    restored._checkpoint_store = restore_store
+    restored._execute_ac_batch = AsyncMock()
+
+    recovered = await restored.execute_parallel(
+        seed=seed,
+        execution_plan=plan,
+        session_id="session-checkpoint-verify",
+        execution_id="execution-checkpoint-verify",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="system",
+    )
+
+    assert recovered.results[0].success is True
+    assert recovered.results[0].retry_attempt == 3
+    assert isinstance(recovered.results[0].verify_gate_outcome, _VerifyGateOutcome)
+    restored._execute_ac_batch.assert_not_awaited()
 
 
 def test_workspace_digest_includes_empty_directories(tmp_path: Any) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1312,10 +1312,12 @@ async def test_final_workspace_revalidation_does_not_reuse_cached_command_result
         execution_id="e",
     )
 
-    assert counter.read_text(encoding="utf-8") == "2"
+    # Coordinator revalidation must not replay an arbitrary shell command;
+    # external effects are not observable through the workspace digest.
+    assert counter.read_text(encoding="utf-8") == "1"
     assert revalidated[0].success is False
     assert revalidated[0].outcome is ACExecutionOutcome.FAILED
-    assert "Final workspace verify gate failed" in (revalidated[0].error or "")
+    assert "replaying verify_command is not permitted" in (revalidated[0].error or "")
 
 
 @pytest.mark.asyncio
@@ -1357,7 +1359,50 @@ async def test_final_verify_mutation_invalidates_prior_successes(tmp_path: Any) 
         ACExecutionOutcome.FAILED,
         ACExecutionOutcome.FAILED,
     ]
-    assert all("mutated the workspace" in (result.error or "") for result in revalidated)
+    assert all(
+        "replaying verify_command is not permitted" in (result.error or "")
+        for result in revalidated
+    )
+
+
+@pytest.mark.asyncio
+async def test_final_settlement_reruns_stale_command_once_and_rejects_failure(
+    tmp_path: Any,
+) -> None:
+    counter = tmp_path.parent / f"final-settlement-count-{tmp_path.name}.txt"
+    target = tmp_path / "condition.txt"
+    target.write_text("before", encoding="utf-8")
+    command = (
+        'python3 -c "from pathlib import Path; '
+        f"counter=Path({str(counter)!r}); "
+        "n=int(counter.read_text()) if counter.exists() else 0; "
+        "counter.write_text(str(n+1)); "
+        "raise SystemExit(0 if Path('condition.txt').read_text() == 'before' else 7)\""
+    )
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command=command))
+    cached = await executor._run_ac_verify_gate(spec=seed.acceptance_criteria[0], cwd=str(tmp_path))
+    target.write_text("after", encoding="utf-8")
+
+    settled = await executor._settle_verify_gate_results(
+        seed=seed,
+        results=[
+            ACExecutionResult(
+                ac_index=0,
+                ac_content="ac",
+                success=True,
+                outcome=ACExecutionOutcome.SUCCEEDED,
+                verify_gate_outcome=cached,
+            )
+        ],
+        session_id="s",
+        execution_id="e",
+    )
+
+    assert counter.read_text(encoding="utf-8") == "2"
+    assert settled[0].success is False
+    assert settled[0].outcome is ACExecutionOutcome.FAILED
+    assert "Final workspace verify gate failed" in (settled[0].error or "")
 
 
 def test_workspace_digest_includes_empty_directories(tmp_path: Any) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -301,7 +301,7 @@ async def test_batch_emits_outer_outcome_marker_after_verify_failure(tmp_path: A
     assert isinstance(results[0], ACExecutionResult)
     assert results[0].success is False
     emitted = [call.args[0] for call in executor._event_store.append.await_args_list]
-    markers = [event for event in emitted if event.type == "execution.ac.outcome_finalized"]
+    markers = [event for event in emitted if event.type == "execution.ac.attempt_judged"]
     assert len(markers) == 1
     assert markers[0].data == {
         "execution_id": "e",
@@ -309,9 +309,11 @@ async def test_batch_emits_outer_outcome_marker_after_verify_failure(tmp_path: A
         "root_ac_index": 0,
         "ac_index": 0,
         "retry_attempt": 0,
+        "attempt_number": 1,
         "success": False,
         "outcome": "failed",
         "is_decomposed": True,
+        "is_decomposed_child": True,
     }
 
 

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1270,6 +1270,61 @@ async def test_final_workspace_revalidation_does_not_reuse_cached_command_result
 
 
 @pytest.mark.asyncio
+async def test_final_verify_mutation_invalidates_prior_successes(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(
+        AcceptanceCriterionSpec(description="stable", verify_command="exit 0"),
+        AcceptanceCriterionSpec(
+            description="mutating verifier",
+            verify_command=(
+                'python3 -c "from pathlib import Path; '
+                "Path('verify-side-effect.txt').write_text('side effect')\""
+            ),
+        ),
+    )
+    results = [
+        ACExecutionResult(
+            ac_index=0,
+            ac_content="stable",
+            success=True,
+            outcome=ACExecutionOutcome.SUCCEEDED,
+        ),
+        ACExecutionResult(
+            ac_index=1,
+            ac_content="mutating verifier",
+            success=True,
+            outcome=ACExecutionOutcome.SUCCEEDED,
+        ),
+    ]
+
+    revalidated = await executor._revalidate_results_after_coordinator(
+        seed=seed,
+        results=results,
+        session_id="s",
+        execution_id="e",
+    )
+
+    assert [result.outcome for result in revalidated] == [
+        ACExecutionOutcome.FAILED,
+        ACExecutionOutcome.FAILED,
+    ]
+    assert all("mutated the workspace" in (result.error or "") for result in revalidated)
+
+
+def test_workspace_digest_includes_empty_directories(tmp_path: Any) -> None:
+    empty_directory = tmp_path / "expected-artifact-directory"
+    empty_directory.mkdir()
+    before = ParallelACExecutor._workspace_content_digest(str(tmp_path))
+
+    empty_directory.rmdir()
+
+    after = ParallelACExecutor._workspace_content_digest(str(tmp_path))
+    assert before is not None
+    assert after is not None
+    assert before != after
+
+
+@pytest.mark.asyncio
 async def test_final_workspace_revalidation_fails_closed_without_contract(tmp_path: Any) -> None:
     executor = _make_executor(working_directory=str(tmp_path))
     seed = _seed_with_specs("description-only AC")

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1237,6 +1237,57 @@ async def test_apply_verify_gate_fails_artifacts_only_ac(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_final_workspace_revalidation_does_not_reuse_cached_command_result(
+    tmp_path: Any,
+) -> None:
+    counter = tmp_path / "final-verify-count.txt"
+    command = (
+        "python3 -c \"from pathlib import Path; p=Path('final-verify-count.txt'); "
+        "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
+        'raise SystemExit(0 if n == 0 else 7)"'
+    )
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command=command))
+    cached = await executor._run_ac_verify_gate(spec=seed.acceptance_criteria[0], cwd=str(tmp_path))
+    result = ACExecutionResult(
+        ac_index=0,
+        ac_content="ac",
+        success=True,
+        verify_gate_outcome=cached,
+    )
+
+    revalidated = await executor._revalidate_results_after_coordinator(
+        seed=seed,
+        results=[result],
+        session_id="s",
+        execution_id="e",
+    )
+
+    assert counter.read_text(encoding="utf-8") == "2"
+    assert revalidated[0].success is False
+    assert revalidated[0].outcome is ACExecutionOutcome.FAILED
+    assert "Final workspace verify gate failed" in (revalidated[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_final_workspace_revalidation_fails_closed_without_contract(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs("description-only AC")
+    result = ACExecutionResult(ac_index=0, ac_content="description-only AC", success=True)
+
+    revalidated = await executor._revalidate_results_after_coordinator(
+        seed=seed,
+        results=[result],
+        session_id="s",
+        execution_id="e",
+    )
+
+    assert revalidated[0].success is False
+    assert revalidated[0].outcome is ACExecutionOutcome.FAILED
+    assert "no deterministic post-coordinator success contract" in (revalidated[0].error or "")
+
+
+@pytest.mark.asyncio
 async def test_sibling_flip_gated_out_by_artifacts_only_contract(tmp_path: Any) -> None:
     executor = _make_executor(working_directory=str(tmp_path))
     (tmp_path / "present.md").write_text("here\n")

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -120,6 +120,20 @@ async def test_verify_gate_output_assertion_match_and_mismatch(tmp_path: Any) ->
 
 
 @pytest.mark.asyncio
+async def test_verify_gate_rejects_commands_that_mutate_the_workspace(tmp_path: Any) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("keep", encoding="utf-8")
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(description="read-only", verify_command="rm target.txt")
+
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is False
+    assert outcome.workspace_mutated is True
+    assert "mutated the workspace" in (outcome.reason or "")
+
+
+@pytest.mark.asyncio
 async def test_verify_gate_ignores_normalized_exit_code_output_assertion(
     tmp_path: Any,
 ) -> None:
@@ -161,14 +175,8 @@ async def test_apply_verify_gate_flips_success_to_failed(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_apply_verify_gate_reuses_cached_success_outcome(tmp_path: Any) -> None:
-    counter = tmp_path / "verify-count.txt"
-    command = (
-        "python3 -c \"from pathlib import Path; p=Path('verify-count.txt'); "
-        "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
-        'raise SystemExit(0 if n == 0 else 7)"'
-    )
     executor = _make_executor(working_directory=str(tmp_path))
-    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command=command))
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command="exit 0"))
     cached = await executor._run_ac_verify_gate(spec=seed.acceptance_criteria[0], cwd=str(tmp_path))
     result = ACExecutionResult(
         ac_index=0,
@@ -176,14 +184,12 @@ async def test_apply_verify_gate_reuses_cached_success_outcome(tmp_path: Any) ->
         success=True,
         verify_gate_outcome=cached,
     )
-    assert counter.read_text(encoding="utf-8") == "1"
 
     gated = await executor._apply_verify_gate(
         seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
     )
 
     assert gated is result
-    assert counter.read_text(encoding="utf-8") == "1"
 
 
 @pytest.mark.asyncio
@@ -192,17 +198,11 @@ async def test_apply_verify_gate_rechecks_artifacts_without_replaying_cached_com
 ) -> None:
     artifact = tmp_path / "artifact.txt"
     artifact.write_text("ready", encoding="utf-8")
-    counter = tmp_path / "verify-count.txt"
-    command = (
-        "python3 -c \"from pathlib import Path; p=Path('verify-count.txt'); "
-        "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
-        'raise SystemExit(0 if n == 0 else 7)"'
-    )
     executor = _make_executor(working_directory=str(tmp_path))
     seed = _seed_with_specs(
         AcceptanceCriterionSpec(
             description="ac",
-            verify_command=command,
+            verify_command="exit 0",
             expected_artifacts=("artifact.txt",),
         )
     )
@@ -222,7 +222,56 @@ async def test_apply_verify_gate_rechecks_artifacts_without_replaying_cached_com
     assert gated.success is False
     assert gated.verify_gate_outcome is not None
     assert gated.verify_gate_outcome.missing_artifacts == ("artifact.txt",)
-    assert counter.read_text(encoding="utf-8") == "1"
+
+
+@pytest.mark.asyncio
+async def test_final_verify_settlement_invalidates_prior_success_after_mutation(
+    tmp_path: Any,
+) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("keep", encoding="utf-8")
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(
+        AcceptanceCriterionSpec(description="artifact", expected_artifacts=("target.txt",)),
+        AcceptanceCriterionSpec(description="mutator", verify_command="rm target.txt"),
+        "contractless",
+    )
+    first_outcome = await executor._run_ac_verify_gate(
+        spec=seed.acceptance_criteria[0], cwd=str(tmp_path)
+    )
+    mutating_outcome = await executor._run_ac_verify_gate(
+        spec=seed.acceptance_criteria[1], cwd=str(tmp_path)
+    )
+    results = await executor._settle_verify_gate_results(
+        seed=seed,
+        results=[
+            ACExecutionResult(
+                ac_index=0,
+                ac_content="artifact",
+                success=True,
+                outcome=ACExecutionOutcome.SUCCEEDED,
+                verify_gate_outcome=first_outcome,
+            ),
+            ACExecutionResult(
+                ac_index=1,
+                ac_content="mutator",
+                success=True,
+                outcome=ACExecutionOutcome.SUCCEEDED,
+                verify_gate_outcome=mutating_outcome,
+            ),
+            ACExecutionResult(
+                ac_index=2,
+                ac_content="contractless",
+                success=True,
+                outcome=ACExecutionOutcome.SUCCEEDED,
+            ),
+        ],
+        session_id="s",
+        execution_id="e",
+    )
+
+    assert [result.success for result in results] == [False, False, False]
+    assert all(result.outcome is ACExecutionOutcome.FAILED for result in results)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -2289,6 +2289,7 @@ async def test_failure_cleanup_commit_then_cancel_reconciles_owner(tmp_path) -> 
                 session_id=tracker.session_id,
                 execution_id=tracker.execution_id,
                 error=RuntimeError("runtime failed"),
+                seed=_seed(),
             )
 
         durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
@@ -2417,6 +2418,7 @@ async def test_cooperative_cancellation_persists_terminal_before_retiring_author
         *,
         reason: str,
         cancelled_by: str,
+        acceptance_finalizations: list[dict[str, object]] | None = None,
     ) -> Result[None, object]:
         assert runner._has_live_process_local_authority(
             tracker.session_id,
@@ -2426,6 +2428,7 @@ async def test_cooperative_cancellation_persists_terminal_before_retiring_author
         assert heartbeat.is_holder_alive(tracker.session_id)
         assert reason == "CLI requested a careful stop"
         assert cancelled_by == "user"
+        assert acceptance_finalizations == []
         return Result.ok(None)
 
     runner._session_repo.mark_cancelled = mark_cancelled
@@ -3978,6 +3981,8 @@ async def test_public_cancel_interruption_reconciles_committed_terminal_state() 
     contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
     cancelled_tracker = tracker.with_status(SessionStatus.CANCELLED)
     session_repo = MagicMock()
+    session_repo._event_store = MagicMock()
+    session_repo._event_store.query_events = AsyncMock(return_value=[])
     session_repo.mark_cancelled_if_active = AsyncMock(side_effect=asyncio.CancelledError)
     session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(cancelled_tracker))
 
@@ -4100,6 +4105,8 @@ async def test_public_cancel_retry_reclaims_nonterminal_reservation() -> None:
     )
     contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
     session_repo = MagicMock()
+    session_repo._event_store = MagicMock()
+    session_repo._event_store.query_events = AsyncMock(return_value=[])
     session_repo.mark_cancelled_if_active = AsyncMock(side_effect=asyncio.CancelledError)
     session_repo.reconstruct_session = AsyncMock(
         return_value=Result.err(PersistenceError("winner temporarily unreadable"))
@@ -4422,6 +4429,8 @@ async def test_public_terminal_finalizer_cancellation_acknowledges_marker() -> N
     )
     authority = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]["foundation_a_authority"]
     session_repo = MagicMock()
+    session_repo._event_store = MagicMock()
+    session_repo._event_store.query_events = AsyncMock(return_value=[])
     session_repo.mark_cancelled_if_active = AsyncMock(return_value=Result.ok(True))
 
     async def _self_cancelling_finalizer() -> None:

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -55,7 +55,7 @@ from ouroboros.orchestrator.runner import (
 )
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 from ouroboros.persistence.checkpoint import CheckpointStore
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import EventStore, acceptance_generation_id_for_session
 from ouroboros.persistence.uow import UnitOfWork
 
 
@@ -136,7 +136,9 @@ def _seed() -> Seed:
 
 
 def _runner(runtime: _CountingRuntime | None = None) -> OrchestratorRunner:
-    return OrchestratorRunner(runtime or _CountingRuntime(), AsyncMock(), MagicMock())
+    event_store = AsyncMock()
+    event_store.replay = AsyncMock(return_value=[])
+    return OrchestratorRunner(runtime or _CountingRuntime(), event_store, MagicMock())
 
 
 async def _prepare(
@@ -173,6 +175,38 @@ async def _prepare(
 
 def _paused(tracker: SessionTracker) -> SessionTracker:
     return tracker.with_status(SessionStatus.PAUSED)
+
+
+def _terminal_plan(
+    session_id: str,
+    execution_id: str,
+    terminal_status: str,
+    *,
+    root_ac_index: int = 0,
+) -> list[dict[str, object]]:
+    """Synthetic one-root plan for lifecycle-only tests."""
+    outcome = {
+        "completed": "succeeded",
+        "failed": "failed",
+        "cancelled": "cancelled",
+    }[terminal_status]
+    accepted = terminal_status == "completed"
+    disposition = "accepted" if accepted else terminal_status
+    return [
+        {
+            "execution_id": execution_id,
+            "session_id": session_id,
+            "acceptance_generation_id": acceptance_generation_id_for_session(
+                session_id, execution_id
+            ),
+            "root_ac_index": root_ac_index,
+            "final_retry_attempt": 0,
+            "accepted": accepted,
+            "disposition": disposition,
+            "outcome": outcome,
+            "terminal_status": terminal_status,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -381,6 +415,9 @@ async def test_sequential_pause_reconciles_preexisting_terminal_winner(tmp_path)
         cancelled = await runner._session_repo.mark_cancelled(
             tracker.session_id,
             reason="terminal wins before pause",
+            acceptance_finalizations=_terminal_plan(
+                tracker.session_id, tracker.execution_id, "cancelled"
+            ),
         )
         assert cancelled.is_ok and cancelled.value is True
         return await original_mark_paused(*args, **kwargs)
@@ -460,6 +497,9 @@ async def test_parallel_pause_reconciles_preexisting_terminal_winner(tmp_path) -
         cancelled = await runner._session_repo.mark_cancelled(
             tracker.session_id,
             reason="terminal wins before parallel pause",
+            acceptance_finalizations=_terminal_plan(
+                tracker.session_id, tracker.execution_id, "cancelled"
+            ),
         )
         assert cancelled.is_ok and cancelled.value is True
         return await original_mark_paused(*args, **kwargs)
@@ -529,6 +569,9 @@ async def test_resume_pause_reconciles_preexisting_terminal_winner(tmp_path) -> 
         cancelled = await runner._session_repo.mark_cancelled(
             tracker.session_id,
             reason="terminal wins before resumed pause",
+            acceptance_finalizations=_terminal_plan(
+                tracker.session_id, tracker.execution_id, "cancelled"
+            ),
         )
         assert cancelled.is_ok and cancelled.value is True
         return await original_mark_paused(*args, **kwargs)
@@ -891,6 +934,7 @@ async def test_lost_paused_authority_precedes_current_policy_gate(policy_gate: s
         MagicMock(),
         fat_harness_mode=policy_gate == "fat_harness",
     )
+    restarted._event_store.replay = AsyncMock(return_value=[])
     restarted._session_repo.reconstruct_session = AsyncMock(return_value=Result.ok(paused))
     restarted._session_repo.mark_failed_if_active = AsyncMock(return_value=Result.ok(True))
 
@@ -1816,7 +1860,11 @@ async def test_prepare_rejects_reused_terminal_session_id(tmp_path) -> None:
         session_id=session_id,
     )
     assert original.is_ok
-    completed = await original_runner._session_repo.mark_completed(session_id, {"done": True})
+    completed = await original_runner._session_repo.mark_completed(
+        session_id,
+        {"done": True},
+        acceptance_finalizations=_terminal_plan(session_id, original_execution_id, "completed"),
+    )
     assert completed.is_ok
     original_runner._retire_process_local_authority(
         session_id=session_id,
@@ -2202,7 +2250,11 @@ async def test_direct_cancel_of_already_terminal_owner_releases_workspace(tmp_pa
         session_id=session_id,
     )
     assert prepared.is_ok
-    terminal = await runner._session_repo.mark_completed(session_id, {"done": True})
+    terminal = await runner._session_repo.mark_completed(
+        session_id,
+        {"done": True},
+        acceptance_finalizations=_terminal_plan(session_id, execution_id, "completed"),
+    )
     assert terminal.is_ok
 
     try:
@@ -3270,10 +3322,16 @@ async def test_concurrent_conditional_terminal_writes_have_one_durable_winner(tm
             SessionRepository(first_store).mark_failed_if_active(
                 tracker.session_id,
                 "concurrent failure",
+                acceptance_finalizations=_terminal_plan(
+                    tracker.session_id, tracker.execution_id, "failed"
+                ),
             ),
             SessionRepository(second_store).mark_cancelled_if_active(
                 tracker.session_id,
                 "concurrent cancellation",
+                acceptance_finalizations=_terminal_plan(
+                    tracker.session_id, tracker.execution_id, "cancelled"
+                ),
             ),
         )
 
@@ -3507,7 +3565,11 @@ async def test_claimed_owner_completion_racing_cancel_publication_clears_signal(
         reason: str,
         cancelled_by: str,
     ) -> None:
-        completed = await runner._session_repo.mark_completed(session_id, {"done": True})
+        completed = await runner._session_repo.mark_completed(
+            session_id,
+            {"done": True},
+            acceptance_finalizations=_terminal_plan(session_id, tracker.execution_id, "completed"),
+        )
         assert completed.is_ok
         runner._retire_process_local_authority(
             session_id=session_id,
@@ -3941,6 +4003,9 @@ async def test_foreign_owner_terminal_racing_cancel_publication_clears_signal(tm
     completed = await runner._session_repo.mark_completed(
         stale_tracker.session_id,
         {"done": True},
+        acceptance_finalizations=_terminal_plan(
+            stale_tracker.session_id, stale_tracker.execution_id, "completed"
+        ),
     )
     assert completed.is_ok
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -5213,7 +5213,11 @@ class TestCancellationPolling:
         # Return no cancellation at startup, then return a cancellation event
         # at the first periodic message-loop checkpoint.
         cancel_event = create_session_cancelled_event("session_123", "User requested")
-        mock_event_store.query_events = AsyncMock(side_effect=[[], [cancel_event]])
+        # Cancellation now performs two fail-closed telemetry scans before the
+        # terminal CAS and two more during legacy reconciliation.  Only the
+        # session-cancelled poll should report the request; all acceptance
+        # scans are empty for this fixture.
+        mock_event_store.query_events = AsyncMock(side_effect=[[], [cancel_event], [], [], [], []])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
             return Result.ok(
@@ -5309,7 +5313,9 @@ class TestCancellationPolling:
         mock_adapter.execute_task = mock_execute
 
         cancel_event = create_session_cancelled_event("sess_resume_cancelled", "User requested")
-        mock_event_store.query_events = AsyncMock(return_value=[cancel_event])
+        # The periodic cancellation poll sees the request; the subsequent
+        # attempt/outcome scans are intentionally empty for this fixture.
+        mock_event_store.query_events = AsyncMock(side_effect=[[cancel_event], [], []])
 
         running_tracker = SessionTracker.create("exec_resume", "seed_1").with_status(
             SessionStatus.PAUSED

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -878,6 +878,7 @@ class TestOrchestratorRunner:
                 "fat_harness_mode": False,
                 "cause": "store unavailable",
             },
+            acceptance_finalizations=[],
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_runner_cancellation.py
+++ b/tests/unit/orchestrator/test_runner_cancellation.py
@@ -386,6 +386,7 @@ class TestHandleCancellation:
             "sess_1",
             reason="Cancellation detected during execution",
             cancelled_by="runner",
+            acceptance_finalizations=[],
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_runner_execution_guidance.py
+++ b/tests/unit/orchestrator/test_runner_execution_guidance.py
@@ -1,5 +1,6 @@
 """Runner wiring for declared project execution guidance."""
 
+import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from pathlib import Path
@@ -63,6 +64,35 @@ def test_empty_guidance_preserves_prompt_bytes() -> None:
     baseline = build_system_prompt(seed)
 
     assert build_system_prompt(seed, guidance_fragment="") == baseline
+
+
+@pytest.mark.asyncio
+async def test_resume_invocations_serialize_restored_runner_state(tmp_path: Path) -> None:
+    runner, _store = _runner(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    async def fake_resume(session_id: str, seed: Seed) -> str:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        entered.set()
+        await release.wait()
+        active -= 1
+        return session_id
+
+    runner._resume_session_impl = fake_resume  # type: ignore[method-assign]
+    first = asyncio.create_task(runner.resume_session("session-one", _seed()))
+    await entered.wait()
+    second = asyncio.create_task(runner.resume_session("session-two", _seed()))
+    await asyncio.sleep(0)
+    assert max_active == 1
+
+    release.set()
+    assert await first == "session-one"
+    assert await second == "session-two"
 
 
 def test_execution_contract_persists_declared_guidance(tmp_path: Path) -> None:

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -983,6 +983,7 @@ class TestFindOrphanedSessions:
         store = AsyncMock()
         store.append = AsyncMock()
         store.replay = AsyncMock(return_value=[])
+        store.query_events = AsyncMock(return_value=[])
         store.get_all_sessions = AsyncMock(return_value=[])
         return store
 

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -37,7 +37,8 @@ from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import build_ac_runtime_identity
 from ouroboros.orchestrator.frugality_proof import (
-    EVENT_AC_OUTCOME_FINALIZED,
+    EVENT_AC_ACCEPTANCE_FINALIZED,
+    EVENT_AC_ATTEMPT_JUDGED,
     EVENT_SHADOW_REPLAY,
     ProofStatus,
     assemble_triads,
@@ -350,20 +351,38 @@ class _EmitterHarness:
         root_key = (run_id, 0)
         if root_key not in self._finalized_roots:
             self._finalized_roots.add(root_key)
-            self.events.append(
+            self.events.extend([
                 BaseEvent(
-                    type=EVENT_AC_OUTCOME_FINALIZED,
+                    type=EVENT_AC_ATTEMPT_JUDGED,
                     aggregate_type="execution",
                     aggregate_id=run_id,
                     data={
                         "execution_id": run_id,
                         "root_ac_index": 0,
                         "retry_attempt": 0,
+                        "attempt_number": 1,
                         "success": True,
+                        "outcome": "succeeded",
                         "is_decomposed": True,
                     },
-                )
-            )
+                ),
+                BaseEvent(
+                    type=EVENT_AC_ACCEPTANCE_FINALIZED,
+                    aggregate_type="execution",
+                    aggregate_id=run_id,
+                    data={
+                        "execution_id": run_id,
+                        "session_id": session_id,
+                        "authority_correlation_id": f"authority-{run_id}",
+                        "root_ac_index": 0,
+                        "final_retry_attempt": 0,
+                        "accepted": True,
+                        "disposition": "accepted",
+                        "outcome": "succeeded",
+                        "terminal_status": "completed",
+                    },
+                ),
+            ])
 
 
 class TestProofContractClosesWithBaseline:

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -351,38 +351,40 @@ class _EmitterHarness:
         root_key = (run_id, 0)
         if root_key not in self._finalized_roots:
             self._finalized_roots.add(root_key)
-            self.events.extend([
-                BaseEvent(
-                    type=EVENT_AC_ATTEMPT_JUDGED,
-                    aggregate_type="execution",
-                    aggregate_id=run_id,
-                    data={
-                        "execution_id": run_id,
-                        "root_ac_index": 0,
-                        "retry_attempt": 0,
-                        "attempt_number": 1,
-                        "success": True,
-                        "outcome": "succeeded",
-                        "is_decomposed": True,
-                    },
-                ),
-                BaseEvent(
-                    type=EVENT_AC_ACCEPTANCE_FINALIZED,
-                    aggregate_type="execution",
-                    aggregate_id=run_id,
-                    data={
-                        "execution_id": run_id,
-                        "session_id": session_id,
-                        "authority_correlation_id": f"authority-{run_id}",
-                        "root_ac_index": 0,
-                        "final_retry_attempt": 0,
-                        "accepted": True,
-                        "disposition": "accepted",
-                        "outcome": "succeeded",
-                        "terminal_status": "completed",
-                    },
-                ),
-            ])
+            self.events.extend(
+                [
+                    BaseEvent(
+                        type=EVENT_AC_ATTEMPT_JUDGED,
+                        aggregate_type="execution",
+                        aggregate_id=run_id,
+                        data={
+                            "execution_id": run_id,
+                            "root_ac_index": 0,
+                            "retry_attempt": 0,
+                            "attempt_number": 1,
+                            "success": True,
+                            "outcome": "succeeded",
+                            "is_decomposed": True,
+                        },
+                    ),
+                    BaseEvent(
+                        type=EVENT_AC_ACCEPTANCE_FINALIZED,
+                        aggregate_type="execution",
+                        aggregate_id=run_id,
+                        data={
+                            "execution_id": run_id,
+                            "session_id": session_id,
+                            "authority_correlation_id": f"authority-{run_id}",
+                            "root_ac_index": 0,
+                            "final_retry_attempt": 0,
+                            "accepted": True,
+                            "disposition": "accepted",
+                            "outcome": "succeeded",
+                            "terminal_status": "completed",
+                        },
+                    ),
+                ]
+            )
 
 
 class TestProofContractClosesWithBaseline:

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -360,6 +360,7 @@ class _EmitterHarness:
                         aggregate_id=run_id,
                         data={
                             "execution_id": run_id,
+                            "session_id": session_id,
                             "root_ac_index": 0,
                             "retry_attempt": 0,
                             "attempt_number": 1,

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -54,6 +54,7 @@ from ouroboros.orchestrator.shadow_replay import (
     run_shadow_replay,
     shadow_replay_enabled_from_env,
 )
+from ouroboros.persistence.event_store import acceptance_generation_id_for_session
 
 
 # -- Shared doubles -----------------------------------------------------------
@@ -374,7 +375,9 @@ class _EmitterHarness:
                         data={
                             "execution_id": run_id,
                             "session_id": session_id,
-                            "authority_correlation_id": f"authority-{run_id}",
+                            "acceptance_generation_id": acceptance_generation_id_for_session(
+                                session_id, run_id
+                            ),
                             "root_ac_index": 0,
                             "final_retry_attempt": 0,
                             "accepted": True,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -286,6 +286,61 @@ class TestEventStoreAppend:
         assert len(replayed) == 1
         assert replayed[0].data["accepted"] is True
 
+    async def test_terminal_acceptance_plan_is_atomic(self, event_store: EventStore) -> None:
+        """Terminal CAS and all planned root decisions commit together."""
+        payload = self._acceptance_event().data
+        terminal = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-acceptance-plan",
+            data={"acceptance_finalizations": [payload]},
+        )
+
+        assert await event_store.append(terminal) is True
+        assert [event.type for event in await event_store.replay("session", terminal.aggregate_id)] == [
+            "orchestrator.session.completed"
+        ]
+        assert [
+            event.type for event in await event_store.replay("execution", payload["execution_id"])
+        ] == ["execution.ac.acceptance_finalized"]
+
+    async def test_terminal_acceptance_plan_rolls_back_on_conflict(
+        self, event_store: EventStore
+    ) -> None:
+        """A contradictory plan cannot leave a terminal session without its winner."""
+        existing = self._acceptance_event()
+        await event_store.append(existing)
+        conflicting = dict(
+            existing.data,
+            accepted=False,
+            disposition="rejected",
+            outcome="failed",
+            terminal_status="failed",
+        )
+        terminal = BaseEvent(
+            type="orchestrator.session.failed",
+            aggregate_type="session",
+            aggregate_id="sess-acceptance-plan-conflict",
+            data={"acceptance_finalizations": [conflicting]},
+        )
+
+        with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
+            await event_store.append(terminal)
+        assert await event_store.replay("session", terminal.aggregate_id) == []
+
+    async def test_acceptance_digest_includes_additional_payload_fields(
+        self, event_store: EventStore
+    ) -> None:
+        """Extra final-event fields are part of fail-closed idempotence."""
+        event = self._acceptance_event()
+        await event_store.append(event)
+        conflicting = event.model_copy(
+            update={"id": "extra-payload-event-id", "data": {**event.data, "marker": "changed"}}
+        )
+
+        with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
+            await event_store.append(conflicting)
+
     @pytest.mark.parametrize(
         "overrides",
         [

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -234,6 +234,91 @@ class TestEventStoreAppend:
 
         assert await event_store.replay("session", "sess-raw-terminal-path") == []
 
+    @staticmethod
+    def _acceptance_event(**overrides: object) -> BaseEvent:
+        data: dict[str, object] = {
+            "execution_id": "exec-acceptance-guard",
+            "session_id": "sess-acceptance-guard",
+            "authority_correlation_id": "authority-acceptance-guard",
+            "root_ac_index": 0,
+            "final_retry_attempt": 1,
+            "accepted": True,
+            "disposition": "accepted",
+            "outcome": "succeeded",
+            "terminal_status": "completed",
+        }
+        data.update(overrides)
+        return BaseEvent(
+            type="execution.ac.acceptance_finalized",
+            aggregate_type="execution",
+            aggregate_id="exec-acceptance-guard",
+            data=data,
+        )
+
+    async def test_final_acceptance_is_idempotent_and_guarded(
+        self, event_store: EventStore
+    ) -> None:
+        event = self._acceptance_event()
+
+        assert EventStore.is_ac_acceptance_finalized_event(event) is True
+        assert await event_store.append(event) is True
+        assert await event_store.append(event.model_copy(update={"id": "duplicate-event-id"})) is False
+
+        replayed = await event_store.replay("execution", event.aggregate_id)
+        assert [item.type for item in replayed] == ["execution.ac.acceptance_finalized"]
+
+    async def test_conflicting_final_acceptance_fails_closed(self, event_store: EventStore) -> None:
+        await event_store.append(self._acceptance_event())
+        conflicting = self._acceptance_event(
+            id="conflicting-event-id",
+            accepted=False,
+            disposition="rejected",
+            outcome="failed",
+            terminal_status="failed",
+        )
+
+        with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
+            await event_store.append(conflicting)
+
+        replayed = await event_store.replay("execution", conflicting.aggregate_id)
+        assert len(replayed) == 1
+        assert replayed[0].data["accepted"] is True
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"authority_correlation_id": ""},
+            {"root_ac_index": -1},
+            {"accepted": "true"},
+            {"final_retry_attempt": -1},
+            {"terminal_status": ""},
+            {"terminal_status": "paused"},
+            {"disposition": "rejected"},
+        ],
+    )
+    async def test_malformed_final_acceptance_is_rejected(
+        self, event_store: EventStore, overrides: dict[str, object]
+    ) -> None:
+        with pytest.raises(PersistenceError, match="Final acceptance|Accepted final|Rejected final"):
+            await event_store.append(self._acceptance_event(**overrides))
+
+    async def test_final_acceptance_raw_append_paths_are_rejected(
+        self, event_store: EventStore
+    ) -> None:
+        event = self._acceptance_event()
+        benign = BaseEvent(
+            type="execution.progress.updated",
+            aggregate_type="execution",
+            aggregate_id=event.aggregate_id,
+            data={},
+        )
+
+        with pytest.raises(PersistenceError, match="one-winner guard"):
+            await event_store.append_with_rowid(event)
+        with pytest.raises(PersistenceError, match="cannot be appended in a batch"):
+            await event_store.append_batch([benign, event])
+        assert await event_store.replay("execution", event.aggregate_id) == []
+
     async def test_conditional_pause_preserves_existing_terminal_winner(
         self, event_store: EventStore
     ) -> None:

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -262,7 +262,9 @@ class TestEventStoreAppend:
 
         assert EventStore.is_ac_acceptance_finalized_event(event) is True
         assert await event_store.append(event) is True
-        assert await event_store.append(event.model_copy(update={"id": "duplicate-event-id"})) is False
+        assert (
+            await event_store.append(event.model_copy(update={"id": "duplicate-event-id"})) is False
+        )
 
         replayed = await event_store.replay("execution", event.aggregate_id)
         assert [item.type for item in replayed] == ["execution.ac.acceptance_finalized"]
@@ -299,7 +301,9 @@ class TestEventStoreAppend:
     async def test_malformed_final_acceptance_is_rejected(
         self, event_store: EventStore, overrides: dict[str, object]
     ) -> None:
-        with pytest.raises(PersistenceError, match="Final acceptance|Accepted final|Rejected final"):
+        with pytest.raises(
+            PersistenceError, match="Final acceptance|Accepted final|Rejected final"
+        ):
             await event_store.append(self._acceptance_event(**overrides))
 
     async def test_final_acceptance_raw_append_paths_are_rejected(

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -142,17 +142,21 @@ class TestEventStoreAppend:
         *,
         session_id: str,
         execution_id: str,
+        acceptance_root_indices: list[int] | None = None,
     ) -> None:
+        data = {
+            "execution_id": execution_id,
+            "seed_id": "seed-acceptance",
+            "start_time": datetime.now(UTC).isoformat(),
+        }
+        if acceptance_root_indices is not None:
+            data["acceptance_root_indices"] = acceptance_root_indices
         await event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
                 aggregate_type="session",
                 aggregate_id=session_id,
-                data={
-                    "execution_id": execution_id,
-                    "seed_id": "seed-acceptance",
-                    "start_time": datetime.now(UTC).isoformat(),
-                },
+                data=data,
             )
         )
 
@@ -361,6 +365,127 @@ class TestEventStoreAppend:
         assert [
             event.type for event in await event_store.replay("execution", payload["execution_id"])
         ] == ["execution.ac.acceptance_finalized"]
+
+    @pytest.mark.parametrize(
+        "roots",
+        [[], [0], [0, 2], [0, 1, 2]],
+    )
+    async def test_current_terminal_plan_requires_exact_root_set(
+        self,
+        event_store: EventStore,
+        roots: list[int],
+    ) -> None:
+        session_id = "sess-root-set"
+        execution_id = "exec-root-set"
+
+        def payload(root: int) -> dict[str, object]:
+            return self._acceptance_event(
+                execution_id=execution_id,
+                session_id=session_id,
+                acceptance_generation_id=acceptance_generation_id_for_session(
+                    session_id, execution_id
+                ),
+                root_ac_index=root,
+                accepted=False,
+                disposition="failed",
+                outcome="failed",
+                terminal_status="failed",
+            ).data
+
+        await self._seed_session_start(
+            event_store,
+            session_id=session_id,
+            execution_id=execution_id,
+            acceptance_root_indices=[0, 1],
+        )
+        terminal = BaseEvent(
+            type="orchestrator.session.failed",
+            aggregate_type="session",
+            aggregate_id=session_id,
+            data={"acceptance_finalizations": [payload(root) for root in roots]},
+        )
+        with pytest.raises(PersistenceError, match="exactly match"):
+            await event_store.append(terminal)
+
+        assert [event.type for event in await event_store.replay("session", session_id)] == [
+            "orchestrator.session.started"
+        ]
+
+    async def test_current_zero_root_session_requires_explicit_empty_plan(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        session_id = "sess-zero-root-plan"
+        execution_id = "exec-zero-root-plan"
+        await self._seed_session_start(
+            event_store,
+            session_id=session_id,
+            execution_id=execution_id,
+            acceptance_root_indices=[],
+        )
+
+        with pytest.raises(PersistenceError, match="explicit acceptance plan"):
+            await event_store.append(
+                BaseEvent(
+                    type="orchestrator.session.completed",
+                    aggregate_type="session",
+                    aggregate_id=session_id,
+                    data={},
+                )
+            )
+
+        assert (
+            await event_store.append(
+                BaseEvent(
+                    type="orchestrator.session.completed",
+                    aggregate_type="session",
+                    aggregate_id=session_id,
+                    data={"acceptance_finalizations": []},
+                )
+            )
+            is True
+        )
+
+    async def test_current_terminal_plan_accepts_exact_durable_root_set(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        session_id = "sess-exact-root-set"
+        execution_id = "exec-exact-root-set"
+        await self._seed_session_start(
+            event_store,
+            session_id=session_id,
+            execution_id=execution_id,
+            acceptance_root_indices=[0, 1],
+        )
+        plan = [
+            self._acceptance_event(
+                execution_id=execution_id,
+                session_id=session_id,
+                acceptance_generation_id=acceptance_generation_id_for_session(
+                    session_id, execution_id
+                ),
+                root_ac_index=root,
+                accepted=False,
+                disposition="failed",
+                outcome="failed",
+                terminal_status="failed",
+            ).data
+            for root in (0, 1)
+        ]
+
+        assert (
+            await event_store.append(
+                BaseEvent(
+                    type="orchestrator.session.failed",
+                    aggregate_type="session",
+                    aggregate_id=session_id,
+                    data={"acceptance_finalizations": plan},
+                )
+            )
+            is True
+        )
+        assert len(await event_store.replay("execution", execution_id)) == 2
 
     async def test_terminal_acceptance_binds_execution_to_session_start(
         self, event_store: EventStore

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -136,6 +136,26 @@ class TestEventStoreInitialization:
 class TestEventStoreAppend:
     """Test EventStore.append() method."""
 
+    @staticmethod
+    async def _seed_session_start(
+        event_store: EventStore,
+        *,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={
+                    "execution_id": execution_id,
+                    "seed_id": "seed-acceptance",
+                    "start_time": datetime.now(UTC).isoformat(),
+                },
+            )
+        )
+
     async def test_append_stores_event(
         self, event_store: EventStore, sample_event: BaseEvent
     ) -> None:
@@ -274,6 +294,11 @@ class TestEventStoreAppend:
             data={"acceptance_finalizations": [payload, dict(payload)]},
         )
 
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-acceptance-idempotent",
+            execution_id="exec-acceptance-idempotent",
+        )
         assert await event_store.append(terminal) is True
 
         replayed = await event_store.replay("execution", payload["execution_id"])
@@ -295,10 +320,17 @@ class TestEventStoreAppend:
             data={"acceptance_finalizations": [payload.data, conflicting]},
         )
 
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-acceptance-conflict",
+            execution_id="exec-acceptance-conflict",
+        )
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
             await event_store.append(terminal)
 
-        assert await event_store.replay("session", terminal.aggregate_id) == []
+        assert [
+            event.type for event in await event_store.replay("session", terminal.aggregate_id)
+        ] == ["orchestrator.session.started"]
         assert await event_store.replay("execution", payload.aggregate_id) == []
 
     async def test_terminal_acceptance_plan_is_atomic(self, event_store: EventStore) -> None:
@@ -317,13 +349,45 @@ class TestEventStoreAppend:
             data={"acceptance_finalizations": [payload]},
         )
 
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-acceptance-plan",
+            execution_id="exec-acceptance-plan",
+        )
         assert await event_store.append(terminal) is True
-        assert [
+        assert sorted(
             event.type for event in await event_store.replay("session", terminal.aggregate_id)
-        ] == ["orchestrator.session.completed"]
+        ) == sorted(["orchestrator.session.started", "orchestrator.session.completed"])
         assert [
             event.type for event in await event_store.replay("execution", payload["execution_id"])
         ] == ["execution.ac.acceptance_finalized"]
+
+    async def test_terminal_acceptance_binds_execution_to_session_start(
+        self, event_store: EventStore
+    ) -> None:
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-identity-bound",
+            execution_id="exec-real",
+        )
+        payload = self._acceptance_event(
+            execution_id="exec-other",
+            session_id="sess-identity-bound",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-identity-bound", "exec-other"
+            ),
+        ).data
+        terminal = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-identity-bound",
+            data={"acceptance_finalizations": [payload]},
+        )
+
+        with pytest.raises(PersistenceError, match="durable session start"):
+            await event_store.append(terminal)
+
+        assert await event_store.replay("execution", "exec-other") == []
 
     async def test_terminal_acceptance_plan_rolls_back_on_conflict(
         self, event_store: EventStore
@@ -347,9 +411,16 @@ class TestEventStoreAppend:
             data={"acceptance_finalizations": [existing.data, conflicting]},
         )
 
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-acceptance-plan-conflict",
+            execution_id="exec-acceptance-plan-conflict",
+        )
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
             await event_store.append(terminal)
-        assert await event_store.replay("session", terminal.aggregate_id) == []
+        assert [
+            event.type for event in await event_store.replay("session", terminal.aggregate_id)
+        ] == ["orchestrator.session.started"]
 
     async def test_acceptance_digest_includes_additional_payload_fields(
         self, event_store: EventStore
@@ -370,6 +441,11 @@ class TestEventStoreAppend:
             data={"acceptance_finalizations": [event.data, conflicting]},
         )
 
+        await self._seed_session_start(
+            event_store,
+            session_id="sess-acceptance-digest",
+            execution_id="exec-acceptance-digest",
+        )
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
             await event_store.append(terminal)
 
@@ -398,6 +474,11 @@ class TestEventStoreAppend:
                 aggregate_type="session",
                 aggregate_id="sess-acceptance-guard",
                 data={"acceptance_finalizations": [payload]},
+            )
+            await self._seed_session_start(
+                event_store,
+                session_id="sess-acceptance-guard",
+                execution_id="exec-acceptance-guard",
             )
             await event_store.append(terminal)
 

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -10,7 +10,7 @@ from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.execution_runtime_scope import normalize_execution_scope_id
 from ouroboros.orchestrator.session import SessionRepository
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import EventStore, acceptance_generation_id_for_session
 
 
 @pytest.fixture
@@ -239,7 +239,9 @@ class TestEventStoreAppend:
         data: dict[str, object] = {
             "execution_id": "exec-acceptance-guard",
             "session_id": "sess-acceptance-guard",
-            "authority_correlation_id": "authority-acceptance-guard",
+            "acceptance_generation_id": acceptance_generation_id_for_session(
+                "sess-acceptance-guard", "exec-acceptance-guard"
+            ),
             "root_ac_index": 0,
             "final_retry_attempt": 1,
             "accepted": True,
@@ -251,44 +253,63 @@ class TestEventStoreAppend:
         return BaseEvent(
             type="execution.ac.acceptance_finalized",
             aggregate_type="execution",
-            aggregate_id="exec-acceptance-guard",
+            aggregate_id=str(data["execution_id"]),
             data=data,
         )
 
     async def test_final_acceptance_is_idempotent_and_guarded(
         self, event_store: EventStore
     ) -> None:
-        event = self._acceptance_event()
-
-        assert EventStore.is_ac_acceptance_finalized_event(event) is True
-        assert await event_store.append(event) is True
-        assert (
-            await event_store.append(event.model_copy(update={"id": "duplicate-event-id"})) is False
+        payload = self._acceptance_event(
+            execution_id="exec-acceptance-idempotent",
+            session_id="sess-acceptance-idempotent",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-acceptance-idempotent", "exec-acceptance-idempotent"
+            ),
+        ).data
+        terminal = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-acceptance-idempotent",
+            data={"acceptance_finalizations": [payload, dict(payload)]},
         )
 
-        replayed = await event_store.replay("execution", event.aggregate_id)
+        assert await event_store.append(terminal) is True
+
+        replayed = await event_store.replay("execution", payload["execution_id"])
         assert [item.type for item in replayed] == ["execution.ac.acceptance_finalized"]
 
     async def test_conflicting_final_acceptance_fails_closed(self, event_store: EventStore) -> None:
-        await event_store.append(self._acceptance_event())
-        conflicting = self._acceptance_event(
-            id="conflicting-event-id",
-            accepted=False,
-            disposition="rejected",
-            outcome="failed",
-            terminal_status="failed",
+        payload = self._acceptance_event(
+            execution_id="exec-acceptance-conflict",
+            session_id="sess-acceptance-conflict",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-acceptance-conflict", "exec-acceptance-conflict"
+            ),
+        )
+        conflicting = {**payload.data, "marker": "changed"}
+        terminal = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-acceptance-conflict",
+            data={"acceptance_finalizations": [payload.data, conflicting]},
         )
 
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
-            await event_store.append(conflicting)
+            await event_store.append(terminal)
 
-        replayed = await event_store.replay("execution", conflicting.aggregate_id)
-        assert len(replayed) == 1
-        assert replayed[0].data["accepted"] is True
+        assert await event_store.replay("session", terminal.aggregate_id) == []
+        assert await event_store.replay("execution", payload.aggregate_id) == []
 
     async def test_terminal_acceptance_plan_is_atomic(self, event_store: EventStore) -> None:
         """Terminal CAS and all planned root decisions commit together."""
-        payload = self._acceptance_event().data
+        payload = self._acceptance_event(
+            execution_id="exec-acceptance-plan",
+            session_id="sess-acceptance-plan",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-acceptance-plan", "exec-acceptance-plan"
+            ),
+        ).data
         terminal = BaseEvent(
             type="orchestrator.session.completed",
             aggregate_type="session",
@@ -308,20 +329,22 @@ class TestEventStoreAppend:
         self, event_store: EventStore
     ) -> None:
         """A contradictory plan cannot leave a terminal session without its winner."""
-        existing = self._acceptance_event()
-        await event_store.append(existing)
+        existing = self._acceptance_event(
+            execution_id="exec-acceptance-plan-conflict",
+            session_id="sess-acceptance-plan-conflict",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-acceptance-plan-conflict", "exec-acceptance-plan-conflict"
+            ),
+        )
         conflicting = dict(
             existing.data,
-            accepted=False,
-            disposition="rejected",
-            outcome="failed",
-            terminal_status="failed",
+            marker="changed",
         )
         terminal = BaseEvent(
-            type="orchestrator.session.failed",
+            type="orchestrator.session.completed",
             aggregate_type="session",
             aggregate_id="sess-acceptance-plan-conflict",
-            data={"acceptance_finalizations": [conflicting]},
+            data={"acceptance_finalizations": [existing.data, conflicting]},
         )
 
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
@@ -332,19 +355,28 @@ class TestEventStoreAppend:
         self, event_store: EventStore
     ) -> None:
         """Extra final-event fields are part of fail-closed idempotence."""
-        event = self._acceptance_event()
-        await event_store.append(event)
-        conflicting = event.model_copy(
-            update={"id": "extra-payload-event-id", "data": {**event.data, "marker": "changed"}}
+        event = self._acceptance_event(
+            execution_id="exec-acceptance-digest",
+            session_id="sess-acceptance-digest",
+            acceptance_generation_id=acceptance_generation_id_for_session(
+                "sess-acceptance-digest", "exec-acceptance-digest"
+            ),
+        )
+        conflicting = {**event.data, "marker": "changed"}
+        terminal = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-acceptance-digest",
+            data={"acceptance_finalizations": [event.data, conflicting]},
         )
 
         with pytest.raises(PersistenceError, match="Conflicting final acceptance"):
-            await event_store.append(conflicting)
+            await event_store.append(terminal)
 
     @pytest.mark.parametrize(
         "overrides",
         [
-            {"authority_correlation_id": ""},
+            {"acceptance_generation_id": ""},
             {"root_ac_index": -1},
             {"accepted": "true"},
             {"final_retry_attempt": -1},
@@ -357,9 +389,17 @@ class TestEventStoreAppend:
         self, event_store: EventStore, overrides: dict[str, object]
     ) -> None:
         with pytest.raises(
-            PersistenceError, match="Final acceptance|Accepted final|Rejected final"
+            PersistenceError,
+            match="Final acceptance|Accepted final|Rejected final|Terminal acceptance plan",
         ):
-            await event_store.append(self._acceptance_event(**overrides))
+            payload = self._acceptance_event(**overrides).data
+            terminal = BaseEvent(
+                type="orchestrator.session.completed",
+                aggregate_type="session",
+                aggregate_id="sess-acceptance-guard",
+                data={"acceptance_finalizations": [payload]},
+            )
+            await event_store.append(terminal)
 
     async def test_final_acceptance_raw_append_paths_are_rejected(
         self, event_store: EventStore

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -297,9 +297,9 @@ class TestEventStoreAppend:
         )
 
         assert await event_store.append(terminal) is True
-        assert [event.type for event in await event_store.replay("session", terminal.aggregate_id)] == [
-            "orchestrator.session.completed"
-        ]
+        assert [
+            event.type for event in await event_store.replay("session", terminal.aggregate_id)
+        ] == ["orchestrator.session.completed"]
         assert [
             event.type for event in await event_store.replay("execution", payload["execution_id"])
         ] == ["execution.ac.acceptance_finalized"]


### PR DESCRIPTION
## Summary
- separate provisional `execution.ac.attempt_judged` telemetry from Final Gate `execution.ac.acceptance_finalized`
- enforce one durable acceptance per `(authority_correlation_id, root_ac_index)` with idempotent duplicate handling and fail-closed conflicts
- publish final acceptance only after terminal session CAS; keep paused episodes unfinalized
- migrate frugality proof, retrospective, attention relay, and MCP recovery consumers

## Verification
- Foundation B targeted suite: 672 passed
- `ruff check src tests`
- `mypy src/ouroboros`
- `git diff --check`

## Scope
Foundation B only. Dispatch, routing, capsules, cross-run trust, and provider policy remain deferred to the next roadmap slice.