### PR TITLE
fix(orchestrator): scope dependency-analysis CLI paths to matching executables

### DIFF
--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -133,6 +133,10 @@ class ClaudeWorkerTransport:
         # command builder just appends the flags. Empty ⇒ no ``--add-dir`` at all.
         self._add_dirs = _resolve_add_dirs(context_reference_dirs, cwd=cwd)
 
+    @property
+    def cli_path(self) -> str:
+        return self._cli_path
+
     @staticmethod
     def _permission_args(permission_mode: str | None) -> list[str]:
         normalized = (permission_mode or "").strip().lower()

--- a/src/ouroboros/orchestrator/codex_mcp_runtime.py
+++ b/src/ouroboros/orchestrator/codex_mcp_runtime.py
@@ -126,6 +126,10 @@ class CodexMcpWorkerTransport:
         # across turns so codex-reply reaches the SAME (process-bound) server.
         self._pool: dict[str, MCPSessionActor] = {}
 
+    @property
+    def cli_path(self) -> str:
+        return self._cli_path
+
     def _server_config(self) -> MCPServerConfig:
         # Strip ouroboros MCP env vars so the spawned codex server cannot recurse
         # back into the ouroboros MCP server (#185 child-env discipline).

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -38,7 +38,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
-from ouroboros.backends import backend_supports_tool_envelope
+from ouroboros.backends import backend_supports_tool_envelope, get_backend_capability
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.errors import ConfigError, OuroborosError, PersistenceError
@@ -4009,9 +4009,28 @@ class OrchestratorRunner:
             if isinstance(llm_backend, str) and llm_backend
             else (self._adapter.runtime_backend)
         )
-        cli_path = getattr(self._adapter, "cli_path", None)
-        resolved_cli_path = cli_path if isinstance(cli_path, str) and cli_path else None
         try:
+            resolved_backend = resolve_llm_backend(backend)
+            cli_path = getattr(self._adapter, "cli_path", None)
+            runtime_backend = self._adapter.runtime_backend
+            runtime_capability = (
+                get_backend_capability(runtime_backend)
+                if isinstance(runtime_backend, str)
+                else None
+            )
+            llm_capability = get_backend_capability(resolved_backend)
+            resolved_cli_path = (
+                cli_path
+                if (
+                    isinstance(cli_path, str)
+                    and cli_path
+                    and runtime_capability is not None
+                    and runtime_capability.cli_name is not None
+                    and llm_capability is not None
+                    and runtime_capability.cli_name == llm_capability.cli_name
+                )
+                else None
+            )
             # ``allowed_tools=[]`` paired with ``max_turns=1``: see issue #781.
             llm_adapter = create_llm_adapter(
                 backend=backend,
@@ -4019,9 +4038,7 @@ class OrchestratorRunner:
                 cli_path=resolved_cli_path,
                 cwd=self._effective_cwd(),
                 max_turns=1,
-                allowed_tools=(
-                    [] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
-                ),
+                allowed_tools=([] if backend_supports_tool_envelope(resolved_backend) else None),
             )
         except (RuntimeError, ImportError, ConnectionError, OSError, ValueError) as exc:
             log.warning(

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -75,6 +75,9 @@ class LeaderDrivenWorkerTransport(Protocol):
         """Canonical backend id stamped into the emitted ``RuntimeHandle``."""
         ...
 
+    @property
+    def cli_path(self) -> str | None: ...
+
     async def spawn(
         self,
         *,
@@ -157,6 +160,10 @@ class LeaderDrivenWorkerRuntime:
     @property
     def llm_backend(self) -> str | None:
         return self._llm_backend
+
+    @property
+    def cli_path(self) -> str | None:
+        return self._transport.cli_path
 
     @property
     def working_directory(self) -> str | None:

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -104,6 +104,11 @@ class TestRuntimeWiring:
 
         assert rt.working_directory == str(tmp_path)
 
+    def test_exposes_effective_cli_path(self) -> None:
+        rt = build_claude_worker_runtime(cli_path="/tmp/claude", cwd="/tmp")
+
+        assert rt.cli_path == "/tmp/claude"
+
     def test_declares_native_model_override(self) -> None:
         # The transport routes a per-call model to ``claude --model``, so the
         # worker enforces a model-tier override natively (RFC #1405 sibling).

--- a/tests/unit/orchestrator/test_codex_mcp_runtime.py
+++ b/tests/unit/orchestrator/test_codex_mcp_runtime.py
@@ -90,6 +90,11 @@ class TestRuntimeWiring:
 
         assert rt.working_directory == str(tmp_path)
 
+    def test_exposes_effective_cli_path(self) -> None:
+        rt = build_codex_mcp_worker_runtime(cli_path="/tmp/codex", cwd="/tmp")
+
+        assert rt.cli_path == "/tmp/codex"
+
     def test_resume_controls_are_declared_ignored(self) -> None:
         """codex-reply cannot retarget either model or reasoning effort."""
         rt = build_codex_mcp_worker_runtime(cwd="/tmp")

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -4105,6 +4105,66 @@ class TestOrchestratorRunner:
             allowed_tools=[],
         )
 
+    def test_build_dependency_analyzer_drops_runtime_cli_path_for_different_llm_backend(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        mock_adapter.runtime_backend = "codex"
+        mock_adapter.llm_backend = "claude_code"
+        mock_adapter.cli_path = "/tmp/real-codex"
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with patch("ouroboros.orchestrator.runner.create_llm_adapter") as mock_create_llm_adapter:
+            runner._build_dependency_analyzer()
+
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "claude_code"
+        assert mock_create_llm_adapter.call_args.kwargs["cli_path"] is None
+
+    def test_build_dependency_analyzer_drops_runtime_cli_path_for_runtime_only_backend(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        mock_adapter.runtime_backend = "grok"
+        mock_adapter.llm_backend = "claude_code"
+        mock_adapter.cli_path = "/tmp/real-grok"
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with patch("ouroboros.orchestrator.runner.create_llm_adapter") as mock_create_llm_adapter:
+            runner._build_dependency_analyzer()
+
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "claude_code"
+        assert mock_create_llm_adapter.call_args.kwargs["cli_path"] is None
+
+    @pytest.mark.parametrize(
+        ("runtime_backend", "llm_backend", "cli_path"),
+        [
+            ("codex_mcp", "codex", "/tmp/real-codex"),
+            ("claude_mcp", "claude_code", "/tmp/real-claude"),
+        ],
+    )
+    def test_build_dependency_analyzer_reuses_cli_path_for_same_cli_worker_transport(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        runtime_backend: str,
+        llm_backend: str,
+        cli_path: str,
+    ) -> None:
+        mock_adapter.runtime_backend = runtime_backend
+        mock_adapter.llm_backend = llm_backend
+        mock_adapter.cli_path = cli_path
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with patch("ouroboros.orchestrator.runner.create_llm_adapter") as mock_create_llm_adapter:
+            runner._build_dependency_analyzer()
+
+        assert mock_create_llm_adapter.call_args.kwargs["cli_path"] == cli_path
+
     def test_build_dependency_analyzer_uses_public_llm_backend_property(
         self,
         mock_adapter: MagicMock,
@@ -4249,6 +4309,23 @@ class TestOrchestratorRunner:
             side_effect=RuntimeError("CLI not found"),
         ):
             analyzer = runner._build_dependency_analyzer()
+
+        assert isinstance(analyzer, DependencyAnalyzer)
+
+    def test_build_dependency_analyzer_falls_back_for_invalid_llm_backend(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
+
+        mock_adapter.runtime_backend = "codex"
+        mock_adapter.llm_backend = "not-a-backend"
+        mock_adapter.cli_path = "/tmp/real-codex"
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        analyzer = runner._build_dependency_analyzer()
 
         assert isinstance(analyzer, DependencyAnalyzer)
 

--- a/tests/unit/orchestrator/test_worker_runtime.py
+++ b/tests/unit/orchestrator/test_worker_runtime.py
@@ -26,6 +26,7 @@ class _FakeTransport:
     """Records calls and returns canned turns."""
 
     backend_name = "fake_worker"
+    cli_path = "/usr/bin/fake-worker"
 
     def __init__(self, *, spawn_turn: WorkerTurn, resume_turn: WorkerTurn | None = None) -> None:
         self._spawn_turn = spawn_turn
@@ -340,6 +341,7 @@ class TestErrors:
     async def test_transport_exception_becomes_error_result(self) -> None:
         class _Boom:
             backend_name = "boom"
+            cli_path = "/usr/bin/boom"
 
             async def spawn(self, **kwargs) -> WorkerTurn:
                 raise RuntimeError("transport exploded")


### PR DESCRIPTION
## Summary
- Forward a runtime CLI path only when its backend capability owns the same executable as the analysis LLM.
- Retain configured paths for aliases and Codex/Claude worker transports.
- Safely drop unrelated runtime paths and preserve invalid-LLM structured fallback.

Closes #1723

## Verification
- /private/tmp/ouroboros-uv-bin/uv run pytest -q tests/unit/orchestrator/test_runner.py: 150 passed, 1 skipped
- /private/tmp/ouroboros-uv-bin/uv run ruff check and ruff format --check on changed files
- Manual runtime construction: Codex-to-Claude, Grok-to-Claude, invalid LLM fallback, and worker transports