### PR TITLE
fix(pm): keep launch outcomes out of acceptance criteria

### DIFF
--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -99,6 +99,11 @@ turn uncertain, stakeholder-dependent, or unknown answers into confirmed
 requirements. Put tentative claims in assumptions and unresolved choices in
 decide_later_items.
 
+A PRD is a contract between the PM and the developers: success_criteria are the
+behavior and policy the PM must observe in the delivered feature to accept it as
+built. Post-launch outcomes mentioned in the transcript are the PM's follow-up
+work, not contract terms — record them under assumptions or decide_later_items.
+
 Respond ONLY with valid JSON in this exact format:
 {
     "product_name": "Short product/feature name",

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -79,6 +79,12 @@ class TestPMSuccessCriteriaBoundary:
         assert "Post-launch outcomes" in prefix
         assert "no place in this contract" in prefix
 
+    def test_extraction_routes_post_launch_outcomes_outside_success_criteria(self) -> None:
+        prompt = " ".join(_EXTRACTION_SYSTEM_PROMPT.split())
+        assert "contract between the PM and the developers" in prompt
+        assert "accept it as built" in prompt
+        assert "record them under assumptions or decide_later_items" in prompt
+
 
 class TestPMSteeringPromptBudget:
     """Regression: steering is charged against the prompt budget, not stacked on top.


### PR DESCRIPTION
## Summary
- align extraction-stage success criteria with the existing PM/developer acceptance contract
- route post-launch outcomes to assumptions or decide_later_items
- add the requested extraction prompt-contract regression beside the existing boundary tests

Closes #1665

## Verification
- pytest -q tests/unit/bigbang/test_pm_interview.py: 94 passed
- ruff check and ruff format --check changed files
- direct extraction-prompt import assertion