### PR TITLE
feat(seed): JSON-array contract for brownfield list fields (#1729, slice 1)

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -66,8 +66,8 @@ Format: name:description:criteria (pipe-separated)
 If the interview mentions existing codebases, extract:
 - **PROJECT_TYPE**: 'greenfield' or 'brownfield'
 - **CONTEXT_REFERENCES**: path:role:summary (pipe-separated, role is 'primary' or 'reference')
-- **EXISTING_PATTERNS**: Key patterns that must be followed (pipe-separated)
-- **EXISTING_DEPENDENCIES**: Key dependencies to reuse (pipe-separated)
+- **EXISTING_PATTERNS**: Key patterns that must be followed (single-line JSON array of strings)
+- **EXISTING_DEPENDENCIES**: Key dependencies to reuse (single-line JSON array of strings)
 
 ## OUTPUT FORMAT
 
@@ -86,8 +86,8 @@ EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
 EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
 PROJECT_TYPE: greenfield|brownfield
 CONTEXT_REFERENCES: <path>:<role>:<summary> | ...
-EXISTING_PATTERNS: <pattern 1> | <pattern 2> | ...
-EXISTING_DEPENDENCIES: <dep 1> | <dep 2> | ...
+EXISTING_PATTERNS: ["<pattern 1>", "<pattern 2>", ...]
+EXISTING_DEPENDENCIES: ["<dep 1>", "<dep 2>", ...]
 ```
 
 Field types should be one of: string, number, boolean, array, object

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -58,8 +58,10 @@ _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.I
 _UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
-def _parse_constraint_values(raw_value: object, *, strict: bool = False) -> tuple[str, ...]:
-    """Parse constraints from a JSON array, a sequence, or a legacy pipe list.
+def _parse_string_array_values(
+    raw_value: object, *, field_label: str, strict: bool = False
+) -> tuple[str, ...]:
+    """Parse a list-valued extraction field from a JSON array, a sequence, or a legacy pipe list.
 
     The extraction format requests a single-line JSON array so literal pipe
     characters inside one constraint survive as data (#1696).
@@ -90,17 +92,17 @@ def _parse_constraint_values(raw_value: object, *, strict: bool = False) -> tupl
             decoded = json.loads(text)
         except json.JSONDecodeError as e:
             raise ValueError(
-                f"CONSTRAINTS must be a single-line JSON array of strings: {e}. Value: {text[:200]}"
+                f"{field_label} must be a single-line JSON array of strings: {e}. Value: {text[:200]}"
             ) from e
         if not isinstance(decoded, list):
             raise ValueError(
-                "CONSTRAINTS must be a JSON array of strings, got "
+                f"{field_label} must be a JSON array of strings, got "
                 f"{type(decoded).__name__}. Value: {text[:200]}"
             )
         non_strings = tuple(type(entry).__name__ for entry in decoded if not isinstance(entry, str))
         if non_strings:
             raise ValueError(
-                "CONSTRAINTS JSON array must contain only strings; got "
+                f"{field_label} JSON array must contain only strings; got "
                 f"{', '.join(non_strings)}. Value: {text[:200]}"
             )
         return tuple(item for item in (entry.strip() for entry in decoded) if item)
@@ -660,8 +662,14 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
         return (
             "PROJECT_TYPE: brownfield\n"
             "CONTEXT_REFERENCES: <path>:<role primary|reference>:<summary> | ...\n"
-            "EXISTING_PATTERNS: <pattern 1> | <pattern 2> | ...\n"
-            "EXISTING_DEPENDENCIES: <dependency 1> | <dependency 2> | ..."
+            'EXISTING_PATTERNS: ["<pattern 1>", "<pattern 2>", ...]\n'
+            'EXISTING_DEPENDENCIES: ["<dependency 1>", "<dependency 2>", ...]\n'
+            "EXISTING_PATTERNS rule: respond with one single-line JSON array of strings. "
+            "Pattern values may contain any characters, including literal | pipes; "
+            "never use a bare pipe as the list separator.\n"
+            "EXISTING_DEPENDENCIES rule: respond with one single-line JSON array of strings. "
+            "Dependency values may contain any characters, including literal | pipes; "
+            "never use a bare pipe as the list separator."
         )
 
     def _build_interview_context(self, state: InterviewState) -> str:
@@ -850,13 +858,18 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
                     f"Response preview: {response[:200]}"
                 )
 
-        # Validate constraints at parse time so malformed JSON-intent output
-        # (e.g. a trailing-comma array) triggers the extraction retry path
-        # instead of being silently pipe-split downstream (#1696).
-        if "constraints" in requirements:
-            requirements["constraints"] = _parse_constraint_values(
-                requirements["constraints"], strict=True
-            )
+        # Validate list-valued fields at parse time so malformed JSON-intent
+        # output triggers the extraction retry path instead of being silently
+        # pipe-split downstream (#1696, #1729).
+        for field_name, field_label in (
+            ("constraints", "CONSTRAINTS"),
+            ("existing_patterns", "EXISTING_PATTERNS"),
+            ("existing_dependencies", "EXISTING_DEPENDENCIES"),
+        ):
+            if field_name in requirements:
+                requirements[field_name] = _parse_string_array_values(
+                    requirements[field_name], field_label=field_label, strict=True
+                )
 
         return requirements
 
@@ -871,7 +884,9 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
             Constructed Seed instance.
         """
         # Parse constraints (JSON array preferred; legacy pipe list supported)
-        constraints = _parse_constraint_values(requirements.get("constraints"))
+        constraints = _parse_string_array_values(
+            requirements.get("constraints"), field_label="CONSTRAINTS"
+        )
 
         # Parse acceptance criteria
         acceptance_criteria: tuple[AcceptanceCriterionSpec | str, ...] = ()
@@ -965,19 +980,15 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
                             )
                         )
 
-            # Parse existing patterns
-            existing_patterns: tuple[str, ...] = ()
-            if "existing_patterns" in requirements and requirements["existing_patterns"]:
-                existing_patterns = tuple(
-                    p.strip() for p in requirements["existing_patterns"].split("|") if p.strip()
-                )
+            # Parse existing patterns (lenient: stored data has no retry path)
+            existing_patterns = _parse_string_array_values(
+                requirements.get("existing_patterns"), field_label="EXISTING_PATTERNS"
+            )
 
-            # Parse existing dependencies
-            existing_deps: tuple[str, ...] = ()
-            if "existing_dependencies" in requirements and requirements["existing_dependencies"]:
-                existing_deps = tuple(
-                    d.strip() for d in requirements["existing_dependencies"].split("|") if d.strip()
-                )
+            # Parse existing dependencies (lenient: stored data has no retry path)
+            existing_deps = _parse_string_array_values(
+                requirements.get("existing_dependencies"), field_label="EXISTING_DEPENDENCIES"
+            )
 
             brownfield_context = BrownfieldContext(
                 project_type="brownfield",

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -21,7 +21,7 @@ from ouroboros.bigbang.interview import (
 )
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
-    _parse_constraint_values,
+    _parse_string_array_values,
     load_seed,
     save_seed_sync,
 )
@@ -554,33 +554,39 @@ class TestSeedGeneratorExtraction:
         )
         for malformed in malformed_cases:
             with pytest.raises(ValueError, match="JSON array"):
-                _parse_constraint_values(malformed, strict=True)
+                _parse_string_array_values(malformed, field_label="CONSTRAINTS", strict=True)
 
     def test_strict_rejects_non_string_json_entries(self) -> None:
         """Strict mode: JSON arrays must contain only strings."""
         for malformed in ("[null]", '[1, "x"]'):
             with pytest.raises(ValueError, match="only strings"):
-                _parse_constraint_values(malformed, strict=True)
+                _parse_string_array_values(malformed, field_label="CONSTRAINTS", strict=True)
 
     def test_lenient_keeps_legacy_bracket_prose_split(self) -> None:
         """Lenient (stored-data) mode: bracket prose keeps the historical split."""
-        assert _parse_constraint_values("[P0] Must work offline | [P1] Fast startup") == (
+        assert _parse_string_array_values(
+            "[P0] Must work offline | [P1] Fast startup", field_label="CONSTRAINTS"
+        ) == (
             "[P0] Must work offline",
             "[P1] Fast startup",
         )
-        assert _parse_constraint_values("[v2.1-rc] Must ship | [2026-01] Later") == (
+        assert _parse_string_array_values(
+            "[v2.1-rc] Must ship | [2026-01] Later", field_label="CONSTRAINTS"
+        ) == (
             "[v2.1-rc] Must ship",
             "[2026-01] Later",
         )
 
     def test_lenient_never_raises_on_malformed_json(self) -> None:
         """Lenient mode: stored data has no retry path, so it pipe-splits instead."""
-        assert _parse_constraint_values('["--lang ko|en",]') == (
+        assert _parse_string_array_values('["--lang ko|en",]', field_label="CONSTRAINTS") == (
             '["--lang ko',
             'en",]',
         )
-        assert _parse_constraint_values("[null]") == ("None",)
-        assert _parse_constraint_values("Python 3.14+ | No external database") == (
+        assert _parse_string_array_values("[null]", field_label="CONSTRAINTS") == ("None",)
+        assert _parse_string_array_values(
+            "Python 3.14+ | No external database", field_label="CONSTRAINTS"
+        ) == (
             "Python 3.14+",
             "No external database",
         )

--- a/tests/unit/bigbang/test_seed_generator_brownfield.py
+++ b/tests/unit/bigbang/test_seed_generator_brownfield.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import tempfile
 from unittest.mock import AsyncMock
 
+import pytest
+
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
 from ouroboros.bigbang.seed_generator import SeedGenerator
 
@@ -76,8 +78,8 @@ class TestBrownfieldParsingRoundTrip:
             "ONTOLOGY_DESCRIPTION: A service\n"
             "PROJECT_TYPE: brownfield\n"
             "CONTEXT_REFERENCES: /repo/api:primary:API layer\n"
-            "EXISTING_PATTERNS: repository pattern | dependency injection\n"
-            "EXISTING_DEPENDENCIES: fastapi | sqlalchemy"
+            'EXISTING_PATTERNS: ["repository pattern", "dependency injection"]\n'
+            'EXISTING_DEPENDENCIES: ["fastapi", "sqlalchemy"]'
         )
         seed = gen._build_seed(requirements, metadata=_metadata())
         bf = seed.brownfield_context
@@ -86,6 +88,66 @@ class TestBrownfieldParsingRoundTrip:
         assert bf.context_references[0].role == "primary"
         assert "repository pattern" in bf.existing_patterns
         assert "fastapi" in bf.existing_dependencies
+
+
+class TestBrownfieldListExtractionContract:
+    """EXISTING_PATTERNS/EXISTING_DEPENDENCIES follow the #1714 JSON-array contract (#1729)."""
+
+    _BASE = (
+        "GOAL: Extend service\n"
+        "ONTOLOGY_NAME: Svc\n"
+        "ONTOLOGY_DESCRIPTION: A service\n"
+        "PROJECT_TYPE: brownfield\n"
+        "CONTEXT_REFERENCES: /repo/api:primary:API layer\n"
+    )
+
+    def test_strict_rejects_pipe_list_existing_patterns(self) -> None:
+        gen = _generator()
+        with pytest.raises(ValueError, match="EXISTING_PATTERNS"):
+            gen._parse_extraction_response(
+                self._BASE
+                + "EXISTING_PATTERNS: repository pattern | dependency injection\n"
+                + 'EXISTING_DEPENDENCIES: ["fastapi"]'
+            )
+
+    def test_strict_rejects_pipe_list_existing_dependencies(self) -> None:
+        gen = _generator()
+        with pytest.raises(ValueError, match="EXISTING_DEPENDENCIES"):
+            gen._parse_extraction_response(
+                self._BASE
+                + 'EXISTING_PATTERNS: ["repository pattern"]\n'
+                + "EXISTING_DEPENDENCIES: fastapi | sqlalchemy"
+            )
+
+    def test_json_arrays_preserve_literal_pipes_end_to_end(self) -> None:
+        gen = _generator()
+        requirements = gen._parse_extraction_response(
+            self._BASE
+            + 'EXISTING_PATTERNS: ["Use Result.ok() | Result.err() unions", "Repository pattern"]\n'
+            + 'EXISTING_DEPENDENCIES: ["typer (CLI | completion extras)", "structlog"]'
+        )
+        seed = gen._build_seed(requirements, metadata=_metadata())
+        bf = seed.brownfield_context
+        assert "Use Result.ok() | Result.err() unions" in bf.existing_patterns
+        assert "Repository pattern" in bf.existing_patterns
+        assert "typer (CLI | completion extras)" in bf.existing_dependencies
+        assert "structlog" in bf.existing_dependencies
+
+    def test_build_seed_keeps_legacy_pipe_lists_for_stored_data(self) -> None:
+        gen = _generator()
+        requirements = {
+            "goal": "Extend service",
+            "ontology_name": "Svc",
+            "ontology_description": "A service",
+            "project_type": "brownfield",
+            "context_references": "/repo/api:primary:API layer",
+            "existing_patterns": "repository pattern | dependency injection",
+            "existing_dependencies": "fastapi | sqlalchemy",
+        }
+        seed = gen._build_seed(requirements, metadata=_metadata())
+        bf = seed.brownfield_context
+        assert bf.existing_patterns == ("repository pattern", "dependency injection")
+        assert bf.existing_dependencies == ("fastapi", "sqlalchemy")
 
 
 def _metadata():


### PR DESCRIPTION
## Summary

First slice of #1729: `EXISTING_PATTERNS` and `EXISTING_DEPENDENCIES` now follow the JSON-array extraction contract merged in #1714 for CONSTRAINTS.

- The brownfield extraction template (initial and retry, both via `_project_type_template`) requests single-line JSON arrays of strings for both fields, with the same rule lines CONSTRAINTS uses.
- `_parse_extraction_response` validates both fields strictly, so malformed output routes through the existing extraction retry instead of being silently pipe-split — previously `EXISTING_PATTERNS: Use Result.ok() | Result.err() unions for fallible calls | Repository pattern` landed in the immutable Seed as three nonsense patterns with no error.
- Seed-build parsing stays lenient and keeps today's pipe split for stored legacy requirements, which have no retry path (same rationale as #1714).
- `_parse_constraint_values` is generalized into the field-labeled `_parse_string_array_values` helper; CONSTRAINTS behavior is unchanged and later slices of #1729 reuse the helper.

Part of #1729 (slice 1 of 4).

## Test plan

- [x] 4 new tests in `tests/unit/bigbang/test_seed_generator_brownfield.py`: strict rejection for both fields (failing before the change), literal-pipe preservation end to end, and the lenient legacy split for stored data
- [x] `uv run pytest tests/ -q` passes — 13153 passed, 12 skipped
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/` clean
