### PR TITLE
Fix Codex completion evidence projection

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -45,6 +45,7 @@ from ouroboros.orchestrator.adapter import (
     SubagentOrchestration,
     TaskResult,
 )
+from ouroboros.orchestrator.mcp_tools import normalize_runtime_tool_result, serialize_tool_result
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.codex_cli_stream import (
     iter_runtime_stream_lines,
@@ -1735,6 +1736,76 @@ class CodexCliRuntime:
                 self._merge_command_metadata(data, nested)
         return data
 
+    @staticmethod
+    def _extract_tool_call_id(item: dict[str, Any]) -> str | None:
+        for key in ("id", "item_id", "call_id"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _command_result_text(metadata: dict[str, Any]) -> str:
+        parts: list[str] = []
+        for key in ("stdout", "output", "result_preview", "stderr"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip() and value.strip() not in parts:
+                parts.append(value.strip())
+        return "\n".join(parts)
+
+    @staticmethod
+    def _completion_failed(
+        metadata: dict[str, Any],
+        *,
+        require_terminal_evidence: bool = False,
+    ) -> bool:
+        if metadata.get("is_error_invalid") is True or metadata.get("is_error") is True:
+            return True
+        status = metadata.get("status")
+        if isinstance(status, str) and status.strip():
+            normalized_status = status.strip().lower()
+            if normalized_status in {"failed", "error"}:
+                return True
+            if normalized_status not in {"completed", "success", "succeeded"}:
+                return True
+        exit_code = metadata.get("exit_code")
+        if exit_code is not None:
+            return not isinstance(exit_code, int) or isinstance(exit_code, bool) or exit_code != 0
+        if isinstance(status, str) and status.strip():
+            return False
+        return require_terminal_evidence
+
+    def _build_tool_completion_message(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        content: str,
+        is_error: bool,
+        handle: RuntimeHandle | None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentMessage:
+        result_metadata = dict(metadata or {})
+        return AgentMessage(
+            type="tool_result",
+            content=content,
+            tool_name=tool_name,
+            data={
+                "subtype": "tool_result",
+                "tool_call_id": tool_call_id,
+                "is_error": is_error,
+                "runtime_event_type": "tool.completed",
+                "tool_result": serialize_tool_result(
+                    normalize_runtime_tool_result(
+                        content,
+                        is_error=is_error,
+                        meta=result_metadata,
+                    )
+                ),
+            },
+            resume_handle=handle,
+        )
+
     def _merge_command_metadata(self, data: dict[str, Any], source: dict[str, Any]) -> None:
         """Merge known command-result fields from one Codex event object."""
         text_key_map = {
@@ -1746,21 +1817,48 @@ class CodexCliRuntime:
             "result_preview": "result_preview",
             "resultPreview": "result_preview",
             "text": "output",
-            "status": "status",
         }
         for key, target_key in text_key_map.items():
             value = source.get(key)
             if isinstance(value, str) and value.strip():
                 data.setdefault(target_key, value.strip())
+        if "status" in source:
+            status = source["status"]
+            if not isinstance(status, str) or not status.strip():
+                data.setdefault("is_error_invalid", True)
+            else:
+                normalized_status = status.strip()
+                existing_status = data.get("status")
+                if existing_status is not None and existing_status != normalized_status:
+                    data.setdefault("is_error_invalid", True)
+                else:
+                    data.setdefault("status", normalized_status)
         for key in ("exit_code", "exitCode", "returncode", "return_code"):
-            value = source.get(key)
-            if isinstance(value, int):
-                data.setdefault("exit_code", value)
-                break
-        if source.get("success") is True:
-            data.setdefault("subtype", "success")
-        if source.get("ok") is True:
-            data.setdefault("subtype", "success")
+            if key not in source:
+                continue
+            value = source[key]
+            if isinstance(value, int) and not isinstance(value, bool):
+                existing_exit_code = data.get("exit_code")
+                if existing_exit_code is not None and existing_exit_code != value:
+                    data.setdefault("is_error_invalid", True)
+                else:
+                    data.setdefault("exit_code", value)
+            else:
+                data.setdefault("is_error_invalid", True)
+            break
+        for key in ("success", "ok", "is_error"):
+            if key not in source:
+                continue
+            value = source[key]
+            if not isinstance(value, bool):
+                data.setdefault("is_error_invalid", True)
+            elif key == "is_error":
+                if value:
+                    data.setdefault("is_error", True)
+            elif value:
+                data.setdefault("subtype", "success")
+            else:
+                data.setdefault("is_error", True)
 
     def _build_tool_message(
         self,
@@ -1838,14 +1936,53 @@ class CodexCliRuntime:
                 command = self._extract_command(item)
                 if not command:
                     return []
+                metadata = self._extract_command_metadata(item)
+                tool_call_id = self._extract_tool_call_id(item)
+                if tool_call_id is None:
+                    return [
+                        self._build_tool_message(
+                            tool_name="Bash",
+                            tool_input={"command": command},
+                            content=f"Calling tool: Bash: {command}",
+                            handle=current_handle,
+                            extra_data=metadata,
+                        )
+                    ]
+                started = self._build_tool_message(
+                    tool_name="Bash",
+                    tool_input={"command": command},
+                    content=f"Calling tool: Bash: {command}",
+                    handle=current_handle,
+                    extra_data={"tool_call_id": tool_call_id},
+                )
+                exit_code = metadata.get("exit_code")
+                if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+                    return [
+                        started,
+                        self._build_tool_completion_message(
+                            tool_name="Bash",
+                            tool_call_id=tool_call_id,
+                            content=self._command_result_text(metadata),
+                            is_error=True,
+                            handle=current_handle,
+                        ),
+                    ]
+                result_metadata = {
+                    key: value
+                    for key, value in metadata.items()
+                    if key in {"output", "stdout", "stderr", "result_preview", "status"}
+                }
+                result_metadata["exit_status"] = exit_code
                 return [
-                    self._build_tool_message(
+                    started,
+                    self._build_tool_completion_message(
                         tool_name="Bash",
-                        tool_input={"command": command},
-                        content=f"Calling tool: Bash: {command}",
+                        tool_call_id=tool_call_id,
+                        content=self._command_result_text(metadata),
+                        is_error=self._completion_failed(metadata),
                         handle=current_handle,
-                        extra_data=self._extract_command_metadata(item),
-                    )
+                        metadata=result_metadata,
+                    ),
                 ]
 
             if item_type == "mcp_tool_call":
@@ -1864,6 +2001,33 @@ class CodexCliRuntime:
                 file_paths = self._extract_paths(item)
                 if not file_paths:
                     return []
+                tool_call_id = self._extract_tool_call_id(item)
+                if tool_call_id is not None:
+                    metadata = self._extract_command_metadata(item)
+                    is_error = self._completion_failed(
+                        metadata,
+                        require_terminal_evidence=True,
+                    )
+                    return [
+                        message
+                        for index, file_path in enumerate(file_paths)
+                        for message in (
+                            self._build_tool_message(
+                                tool_name="Edit",
+                                tool_input={"file_path": file_path},
+                                content=f"Calling tool: Edit: {file_path}",
+                                handle=current_handle,
+                                extra_data={"tool_call_id": f"{tool_call_id}:{index}"},
+                            ),
+                            self._build_tool_completion_message(
+                                tool_name="Edit",
+                                tool_call_id=f"{tool_call_id}:{index}",
+                                content=file_path,
+                                is_error=is_error,
+                                handle=current_handle,
+                            ),
+                        )
+                    ]
                 return [
                     self._build_tool_message(
                         tool_name="Edit",

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -2052,10 +2052,6 @@ class CodexCliRuntime:
                         tool_input={"file_path": file_path},
                         content=f"Calling tool: Edit: {file_path}",
                         handle=current_handle,
-                        # This branch is reached only for Codex's
-                        # ``item.completed`` file_change event. Preserve that
-                        # source completion status so evidence validation does
-                        # not mistake it for an unconfirmed Edit dispatch.
                         extra_data=completion_data,
                     )
                     for file_path in file_paths

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1845,7 +1845,6 @@ class CodexCliRuntime:
                     data.setdefault("exit_code", value)
             else:
                 data.setdefault("is_error_invalid", True)
-            break
         for key in ("success", "ok", "is_error"):
             if key not in source:
                 continue
@@ -1939,6 +1938,10 @@ class CodexCliRuntime:
                 metadata = self._extract_command_metadata(item)
                 tool_call_id = self._extract_tool_call_id(item)
                 if tool_call_id is None:
+                    metadata["is_error"] = self._completion_failed(
+                        metadata,
+                        require_terminal_evidence=True,
+                    )
                     return [
                         self._build_tool_message(
                             tool_name="Bash",
@@ -1973,13 +1976,17 @@ class CodexCliRuntime:
                     if key in {"output", "stdout", "stderr", "result_preview", "status"}
                 }
                 result_metadata["exit_status"] = exit_code
+                is_error = self._completion_failed(
+                    metadata,
+                    require_terminal_evidence=True,
+                )
                 return [
                     started,
                     self._build_tool_completion_message(
                         tool_name="Bash",
                         tool_call_id=tool_call_id,
                         content=self._command_result_text(metadata),
-                        is_error=self._completion_failed(metadata),
+                        is_error=is_error,
                         handle=current_handle,
                         metadata=result_metadata,
                     ),
@@ -2028,6 +2035,17 @@ class CodexCliRuntime:
                             ),
                         )
                     ]
+                metadata = self._extract_command_metadata(item)
+                is_error = self._completion_failed(
+                    metadata,
+                    require_terminal_evidence=True,
+                )
+                completion_data = {
+                    "runtime_event_type": "tool.completed",
+                    "is_error": is_error,
+                }
+                if not is_error:
+                    completion_data["subtype"] = "success"
                 return [
                     self._build_tool_message(
                         tool_name="Edit",
@@ -2038,10 +2056,7 @@ class CodexCliRuntime:
                         # ``item.completed`` file_change event. Preserve that
                         # source completion status so evidence validation does
                         # not mistake it for an unconfirmed Edit dispatch.
-                        extra_data={
-                            "subtype": "success",
-                            "runtime_event_type": "tool.completed",
-                        },
+                        extra_data=completion_data,
                     )
                     for file_path in file_paths
                 ]

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -126,7 +126,7 @@ def _text_contains_test_success(text: str) -> bool:
 
 def _message_contains_test_success(message: AgentMessage) -> bool:
     """Return True when one message says a test command passed."""
-    parts = [message.content]
+    parts = [message.content, _runtime_message_test_proof_text(message)]
     for key in ("result_preview", "output", "stdout", "status", "subtype"):
         value = message.data.get(key)
         if isinstance(value, str):
@@ -208,6 +208,10 @@ def _runtime_message_test_proof_text(message: AgentMessage) -> str:
             value = tool_result.get(key)
             if isinstance(value, str):
                 parts.append(value)
+        meta = tool_result.get("meta")
+        exit_status = meta.get("exit_status") if isinstance(meta, dict) else None
+        if type(exit_status) is int:
+            parts.append(f"exit code {exit_status}")
     elif isinstance(tool_result, str):
         parts.append(tool_result)
     return "\n".join(parts)

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -217,7 +217,7 @@ class ExecutionEventEmitter:
         projected: Any,
     ) -> Any:
         """Create a shared session tool-call event from an AC runtime message."""
-        if projected.tool_name is None:
+        if not projected.is_tool_call or projected.tool_name is None:
             return None
 
         event = create_tool_called_event(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4088,7 +4088,11 @@ class OrchestratorRunner:
             progress["runtime"] = runtime_handle.to_session_state_dict()
             progress["runtime_backend"] = runtime_handle.backend
             runtime_event_type = runtime_handle.metadata.get("runtime_event_type")
-            if isinstance(runtime_event_type, str) and runtime_event_type:
+            if (
+                "runtime_event_type" not in progress
+                and isinstance(runtime_event_type, str)
+                and runtime_event_type
+            ):
                 progress["runtime_event_type"] = runtime_event_type
             if runtime_handle.backend == "claude" and runtime_handle.native_session_id:
                 progress["agent_session_id"] = runtime_handle.native_session_id
@@ -4144,6 +4148,8 @@ class OrchestratorRunner:
     ):
         """Create an enriched tool-called event from a normalized runtime message."""
         projected = project_runtime_message(message)
+        if not projected.is_tool_call:
+            return None
         tool_name = projected.tool_name
         if tool_name is None:
             return None

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -227,7 +227,11 @@ def serialize_runtime_message_metadata(
         metadata["runtime"] = runtime_handle.to_session_state_dict()
         metadata["runtime_backend"] = runtime_handle.backend
         handle_runtime_event_type = runtime_handle.metadata.get("runtime_event_type")
-        if isinstance(handle_runtime_event_type, str) and handle_runtime_event_type:
+        if (
+            "runtime_event_type" not in metadata
+            and isinstance(handle_runtime_event_type, str)
+            and handle_runtime_event_type
+        ):
             metadata["runtime_event_type"] = handle_runtime_event_type
         tool_catalog = runtime_handle_tool_catalog(runtime_handle)
         if tool_catalog is not None:

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -210,6 +210,9 @@ def serialize_runtime_message_metadata(
     from ouroboros.orchestrator.workflow_state import resolve_ac_marker_update
 
     metadata: dict[str, Any] = {}
+    message_runtime_event_type = runtime_event_type(message)
+    if message_runtime_event_type is not None:
+        metadata["runtime_event_type"] = message_runtime_event_type
     if runtime_signal is None or runtime_status is None:
         runtime_signal, runtime_status = derive_runtime_signal(
             message_type=normalized_message_type(message),

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1106,8 +1106,7 @@ class TestCodexCliRuntime:
         assert message.data["status"] == "completed"
         assert message.data["subtype"] == "success"
 
-    def test_convert_file_change_event_emits_each_changed_file(self) -> None:
-        """Multi-file Codex changes should create one proof message per path."""
+    def test_convert_idless_file_change_fails_closed(self) -> None:
         runtime = CodexCliRuntime(cli_path="codex")
 
         messages = runtime._convert_event(
@@ -1129,8 +1128,26 @@ class TestCodexCliRuntime:
             "/tmp/project/hello.py",
             "/tmp/project/test_hello.py",
         ]
-        assert all(message.data["subtype"] == "success" for message in messages)
-        assert all(message.data["runtime_event_type"] == "tool.completed" for message in messages)
+        assert all(message.data["is_error"] is True for message in messages)
+
+    def test_convert_idless_cancelled_command_fails_closed(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "pytest",
+                    "status": "cancelled",
+                    "exit_code": 0,
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        assert messages[0].data["is_error"] is True
 
     def test_convert_file_change_completion_emits_correlated_receipts(self) -> None:
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -882,6 +882,151 @@ class TestCodexCliRuntime:
         assert message.tool_name == "Bash"
         assert message.data["tool_input"]["command"] == "pytest -q"
 
+    def test_convert_command_completion_emits_correlated_tool_receipt(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-42",
+                    "type": "command_execution",
+                    "command": "pytest -q tests/test_example.py",
+                    "stdout": "1 passed in 0.01s",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "is_error": False,
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        started, completed = messages
+        assert started.type == "assistant"
+        assert started.tool_name == "Bash"
+        assert started.data["tool_call_id"] == "cmd-42"
+        assert started.data["tool_input"] == {"command": "pytest -q tests/test_example.py"}
+        assert completed.type == "tool_result"
+        assert completed.tool_name == "Bash"
+        assert completed.data["tool_call_id"] == "cmd-42"
+        assert completed.data["is_error"] is False
+        assert completed.data["tool_result"]["is_error"] is False
+        assert completed.data["tool_result"]["meta"]["exit_status"] == 0
+        assert completed.data["tool_result"]["meta"]["stdout"] == "1 passed in 0.01s"
+
+    def test_convert_command_failure_emits_correlated_failed_receipt(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-failed",
+                    "type": "command_execution",
+                    "command": "pytest -q tests/test_example.py",
+                    "stderr": "1 failed in 0.01s",
+                    "exit_code": 1,
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        completed = messages[1]
+        assert completed.type == "tool_result"
+        assert completed.data["tool_call_id"] == "cmd-failed"
+        assert completed.data["is_error"] is True
+        assert completed.data["tool_result"]["is_error"] is True
+        assert completed.data["tool_result"]["meta"]["exit_status"] == 1
+
+    def test_convert_command_without_terminal_result_fails_closed(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-incomplete",
+                    "type": "command_execution",
+                    "command": "pytest -q tests/test_example.py",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["tool_call_id"] == "cmd-incomplete"
+        assert messages[1].data["is_error"] is True
+
+    def test_convert_command_conflicting_terminal_status_fails_closed(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-conflicted",
+                    "type": "command_execution",
+                    "command": "pytest -q tests/test_example.py",
+                    "exit_code": 0,
+                    "status": "failed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["is_error"] is True
+
+    @pytest.mark.parametrize("item_type", ("command_execution", "file_change"))
+    def test_convert_nested_conflicting_terminal_metadata_fails_closed(
+        self,
+        item_type: str,
+    ) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+        item: dict[str, object] = {
+            "id": f"{item_type}-conflicted",
+            "type": item_type,
+            "status": "completed",
+            "exit_code": 0,
+            "result": {"status": "failed", "exit_code": 1},
+        }
+        if item_type == "command_execution":
+            item["command"] = "pytest -q tests/test_example.py"
+        else:
+            item["path"] = "src/example.py"
+
+        messages = runtime._convert_event(
+            {"type": "item.completed", "item": item},
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["is_error"] is True
+
+    @pytest.mark.parametrize("item_type", ("command_execution", "file_change"))
+    def test_convert_unknown_terminal_status_fails_closed(self, item_type: str) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+        item: dict[str, object] = {
+            "id": f"{item_type}-cancelled",
+            "type": item_type,
+            "status": "cancelled",
+            "exit_code": 0,
+        }
+        if item_type == "command_execution":
+            item["command"] = "pytest -q tests/test_example.py"
+        else:
+            item["path"] = "src/example.py"
+
+        messages = runtime._convert_event(
+            {"type": "item.completed", "item": item},
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["is_error"] is True
+
     def test_convert_command_execution_preserves_output_metadata(self) -> None:
         """Command output must remain available for fat-harness verification."""
         runtime = CodexCliRuntime(cli_path="codex")
@@ -986,6 +1131,94 @@ class TestCodexCliRuntime:
         ]
         assert all(message.data["subtype"] == "success" for message in messages)
         assert all(message.data["runtime_event_type"] == "tool.completed" for message in messages)
+
+    def test_convert_file_change_completion_emits_correlated_receipts(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "change-7",
+                    "type": "file_change",
+                    "status": "completed",
+                    "changes": [
+                        {"path": "src/example.py"},
+                        {"path": "tests/test_example.py"},
+                    ],
+                },
+            },
+            current_handle=None,
+        )
+
+        assert [message.type for message in messages] == [
+            "assistant",
+            "tool_result",
+            "assistant",
+            "tool_result",
+        ]
+        assert [message.data["tool_call_id"] for message in messages] == [
+            "change-7:0",
+            "change-7:0",
+            "change-7:1",
+            "change-7:1",
+        ]
+        assert [message.data["tool_input"]["file_path"] for message in messages[::2]] == [
+            "src/example.py",
+            "tests/test_example.py",
+        ]
+        assert all(message.data["is_error"] is False for message in messages[1::2])
+
+    @pytest.mark.parametrize(
+        "metadata",
+        (
+            {},
+            {"status": "failed"},
+            {"exit_code": True},
+            {"status": "completed", "exit_code": 1},
+        ),
+    )
+    def test_convert_failed_or_malformed_file_change_fails_closed(
+        self,
+        metadata: dict[str, object],
+    ) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "change-failed",
+                    "type": "file_change",
+                    "path": "src/example.py",
+                    **metadata,
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["is_error"] is True
+
+    def test_convert_nested_failed_file_change_exit_code_fails_closed(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "change-nested-failed",
+                    "type": "file_change",
+                    "path": "src/example.py",
+                    "status": "completed",
+                    "result": {"exit_code": 1},
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2
+        assert messages[1].data["is_error"] is True
 
     def test_convert_turn_completed_with_usage_emits_system_usage_message(self) -> None:
         """turn.completed with token usage surfaces a non-final system message."""

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -11462,6 +11462,32 @@ class TestParallelACExecutor:
         assert tool_completed.data["tool_result"]["is_error"] is False
         assert tool_completed.data["tool_result"]["meta"]["exit_status"] == 0
 
+    def test_codex_id_bearing_exit_only_test_completion_proves_file_claim(self) -> None:
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        command = "pytest -q tests/test_example.py"
+        messages = tuple(
+            CodexCliRuntime(cli_path="codex", cwd="/tmp/project")._convert_event(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "cmd-exit-only",
+                        "type": "command_execution",
+                        "command": command,
+                        "exit_code": 0,
+                    },
+                },
+                current_handle=None,
+            )
+        )
+
+        assert _runtime_messages_support_test_claim(
+            value="tests/test_example.py",
+            backed_commands=(command,),
+            messages=messages,
+            task_cwd=None,
+        )
+
     @pytest.mark.asyncio
     async def test_atomic_ac_projects_empty_tool_result_content_into_completion_events(
         self,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1067,6 +1067,80 @@ def test_tests_passed_rejects_node_id_from_assistant_narration_only() -> None:
     )
 
 
+def test_codex_completion_receipts_prove_exact_test_and_file_claims(tmp_path) -> None:
+    from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+    runtime = CodexCliRuntime(cli_path="codex", cwd=tmp_path)
+    command = "pytest -q tests/test_example.py"
+    success_messages = tuple(
+        runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-42",
+                    "type": "command_execution",
+                    "command": command,
+                    "stdout": "1 passed in 0.01s",
+                    "exit_code": 0,
+                },
+            },
+            current_handle=None,
+        )
+        + runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "change-7",
+                    "type": "file_change",
+                    "path": "src/example.py",
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=success_messages,
+        task_cwd=str(tmp_path),
+    )
+    assert _runtime_messages_support_file_claim(
+        "src/example.py",
+        success_messages,
+        task_cwd=str(tmp_path),
+    )
+    failed_messages = tuple(
+        runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-failed",
+                    "type": "command_execution",
+                    "command": command,
+                    "stderr": "1 failed in 0.01s",
+                    "exit_code": 1,
+                },
+            },
+            current_handle=None,
+        )
+    )
+    assert not _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=failed_messages,
+        task_cwd=str(tmp_path),
+    )
+    assert (
+        runtime._convert_event(
+            {"type": "item.completed", "item": {"id": "cmd-empty", "type": "command_execution"}},
+            current_handle=None,
+        )
+        == []
+    )
+
+
 @pytest.mark.parametrize(
     "ac_content",
     (
@@ -11309,6 +11383,84 @@ class TestParallelACExecutor:
         assert tool_completed.data["tool_name"] == "Edit"
         assert tool_completed.data["tool_result"]["text_content"] == "Updated src/app.py"
         assert tool_completed.data["runtime_event_type"] == "tool.completed"
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_projects_codex_completion_receipt_to_journal(self) -> None:
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        class StubRuntime:
+            _runtime_handle_backend = "codex_cli"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(self, **kwargs: Any):
+                runtime = CodexCliRuntime(cli_path="codex", cwd=self._cwd)
+                for message in runtime._convert_event(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "cmd-42",
+                            "type": "command_execution",
+                            "command": "pytest -q tests/test_example.py",
+                            "stdout": "1 passed in 0.01s",
+                            "exit_code": 0,
+                        },
+                    },
+                    current_handle=kwargs["resume_handle"],
+                ):
+                    yield message
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                )
+
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=StubRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Run the focused test",
+            session_id="sess_codex",
+            tools=["Bash"],
+            system_prompt="test",
+            seed_goal="Ship the fix",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        appended_events = [call.args[0] for call in event_store.append.await_args_list]
+        tool_started = next(
+            event for event in appended_events if event.type == "execution.tool.started"
+        )
+        tool_completed = next(
+            event for event in appended_events if event.type == "execution.tool.completed"
+        )
+
+        assert result.success is True
+        assert tool_started.data["tool_call_id"] == "cmd-42"
+        assert tool_started.data["tool_input"] == {"command": "pytest -q tests/test_example.py"}
+        assert tool_completed.data["tool_call_id"] == "cmd-42"
+        assert tool_completed.data["runtime_event_type"] == "tool.completed"
+        assert tool_completed.data["tool_result"]["is_error"] is False
+        assert tool_completed.data["tool_result"]["meta"]["exit_status"] == 0
 
     @pytest.mark.asyncio
     async def test_atomic_ac_projects_empty_tool_result_content_into_completion_events(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1112,6 +1112,42 @@ class TestOrchestratorRunner:
         assert progress_event.data["content_preview"] == "[AC_COMPLETE: 1] Done!"
         assert progress_event.data["progress"]["last_content_preview"] == "[AC_COMPLETE: 1] Done!"
 
+    def test_build_progress_update_keeps_message_runtime_event_type(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        message = AgentMessage(
+            type="assistant",
+            content="Updated src/app.py",
+            data={
+                "subtype": "tool_result",
+                "tool_name": "Edit",
+                "runtime_event_type": "tool.completed",
+            },
+            resume_handle=RuntimeHandle(
+                backend="opencode",
+                native_session_id="oc-session-1",
+                metadata={"runtime_event_type": "tool.started"},
+            ),
+        )
+
+        progress = runner._build_progress_update(message, 3)
+
+        assert progress["runtime_event_type"] == "tool.completed"
+
+    def test_build_tool_called_event_skips_named_tool_results(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        message = AgentMessage(
+            type="assistant",
+            content="Updated src/app.py",
+            tool_name="Edit",
+            data={"subtype": "tool_result"},
+        )
+
+        assert runner._build_tool_called_event("sess_123", message) is None
+
     def test_build_progress_update_extracts_ac_tracking_from_tool_result_payload(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_runtime_message_projection.py
+++ b/tests/unit/orchestrator/test_runtime_message_projection.py
@@ -13,6 +13,23 @@ from ouroboros.orchestrator.runtime_message_projection import project_runtime_me
 class TestRuntimeMessageProjection:
     """Tests for transcript/event projection of runtime messages."""
 
+    def test_message_event_type_precedes_resumed_handle_event_type(self) -> None:
+        message = AgentMessage(
+            type="tool_result",
+            content="completed",
+            tool_name="Bash",
+            data={"runtime_event_type": "tool.completed"},
+            resume_handle=RuntimeHandle(
+                backend="codex",
+                native_session_id="session-1",
+                metadata={"runtime_event_type": "run.completed"},
+            ),
+        )
+
+        projected = project_runtime_message(message)
+
+        assert projected.runtime_metadata["runtime_event_type"] == "tool.completed"
+
     def test_projects_opencode_session_started_metadata_into_standard_signal(self) -> None:
         """Session-start lifecycle updates should stay system-scoped and resumable."""
         message = AgentMessage(


### PR DESCRIPTION
Fixes #1724\n\n## Summary\n- project native Codex completion events into correlated start/result journal receipts\n- preserve command output, exit status, and completion provenance\n- fail closed for missing, malformed, unknown, nonzero, and conflicting terminal metadata\n\n## Verification\n- pytest: parallel executor (276 passed)\n- pytest: Codex runtime + projection (100 passed)\n- ruff check/format and mypy on changed runtime/tests