### PR TITLE
fix(codex): journal correlated tool completions from item lifecycle events

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1926,7 +1926,9 @@ class CodexCliRuntime:
         if item_type == "command_execution":
             return self._extract_command(item)
         if item_type == "mcp_tool_call":
-            return self._mcp_tool_name(item)
+            tool_input = self._extract_tool_input(item)
+            arguments = json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
+            return f"{self._mcp_tool_name(item)}\x00{arguments}"
         if item_type == "file_change":
             return "\n".join(self._extract_paths(item))
         if item_type == "web_search":
@@ -2072,11 +2074,18 @@ class CodexCliRuntime:
                     if item_type != "command_execution":
                         has_success = True
 
-            error_envelope = source.get("error")
-            if (isinstance(error_envelope, dict) and error_envelope) or (
-                isinstance(error_envelope, str) and error_envelope.strip()
-            ):
-                has_failure = True
+            if "error" in source:
+                error_envelope = source.get("error")
+                # Any present, meaningfully non-empty error envelope is a
+                # failure — including malformed non-null shapes (e.g. an int
+                # or list). Only an explicitly empty/false envelope
+                # (None/{}/[]/""/0/False) is treated as "no error" (round
+                # eight, blocker 3).
+                if isinstance(error_envelope, str):
+                    if error_envelope.strip():
+                        has_failure = True
+                elif error_envelope:
+                    has_failure = True
 
             for key in ("success", "ok"):
                 flag = source.get(key)
@@ -2225,12 +2234,26 @@ class CodexCliRuntime:
         is_error = self._resolve_item_completion_is_error(item_type, item)
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:
-            # Dedup on the id AND the terminal verdict: an exact replay is
-            # suppressed, but a conflicting same-id completion (e.g. a later
-            # failure after a success) has a different key and stays visible
-            # so verification fails closed (review round seven, blocker 1).
+            # Dedup on the id, input signature, verdict, AND every
+            # evidence-bearing completion field: an exact replay is
+            # suppressed, but any non-identical completion (a conflicting
+            # verdict, or the same verdict with different output) has a
+            # different fingerprint and stays visible so verification fails
+            # closed (review rounds seven & eight).
+            evidence_fields: dict[str, Any] = {
+                key: metadata.get(key)
+                for key in ("output", "stdout", "stderr", "result_preview", "exit_code", "status")
+            }
+            # The raw error envelope is evidence too: two malformed errors that
+            # produce no result text must not collapse to one fingerprint.
+            if "error" in item:
+                evidence_fields["error"] = item.get("error")
+            evidence_fingerprint = json.dumps(
+                evidence_fields, ensure_ascii=False, sort_keys=True, default=str
+            )
             dedup_key = (
-                f"{item_id}\x00{self._item_lifecycle_signature(item_type, item)}\x00{is_error}"
+                f"{item_id}\x00{self._item_lifecycle_signature(item_type, item)}"
+                f"\x00{is_error}\x00{evidence_fingerprint}"
             )
             if dedup_key in scope.completed_item_keys:
                 return []

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1860,6 +1860,12 @@ class CodexCliRuntime:
             return item_id.strip()
         return None
 
+    @staticmethod
+    def _extract_web_search_query(item: dict[str, Any]) -> str:
+        """Extract exactly the search query from a web_search thread item."""
+        query = item.get("query")
+        return query.strip() if isinstance(query, str) else ""
+
     def _item_lifecycle_signature(self, item_type: str, item: dict[str, Any]) -> str:
         """Build a best-effort identity for id-less legacy thread items."""
         if item_type == "command_execution":
@@ -1869,6 +1875,11 @@ class CodexCliRuntime:
             return name.strip() if isinstance(name, str) else ""
         if item_type == "file_change":
             return "\n".join(self._extract_paths(item))
+        if item_type == "web_search":
+            # The query is the only stable identity: volatile fields such as
+            # status must not change the signature between started/completed,
+            # or an id-less completion would synthesize a duplicate start.
+            return self._extract_web_search_query(item)
         return self._extract_text(item)
 
     def _item_tool_calls(self, item_type: str, item: dict[str, Any]) -> list[_CodexToolCall]:
@@ -1915,7 +1926,7 @@ class CodexCliRuntime:
             ]
 
         if item_type == "web_search":
-            query = self._extract_text(item)
+            query = self._extract_web_search_query(item)
             return [
                 _CodexToolCall(
                     tool_name="WebSearch",
@@ -1981,7 +1992,7 @@ class CodexCliRuntime:
         # never let an outer success status shadow a nested failure (review
         # blocker: failure signals take precedence wherever they appear).
         for source in self._iter_item_metadata_sources(item):
-            for exit_key in ("exit_code", "exitCode"):
+            for exit_key in ("exit_code", "exitCode", "returncode", "return_code"):
                 exit_code = source.get(exit_key)
                 if isinstance(exit_code, int) and not isinstance(exit_code, bool):
                     if exit_code == 0:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -192,14 +192,15 @@ class _CodexItemCorrelationScope:
     so a new thread begins with a clean correlation space.
     """
 
-    started_item_ids: set[str] = field(default_factory=set)
+    started_item_signatures: dict[str, str] = field(default_factory=dict)
     started_unkeyed_item_counts: dict[tuple[str, str], int] = field(default_factory=dict)
-    completed_item_ids: set[str] = field(default_factory=set)
+    completed_item_keys: set[str] = field(default_factory=set)
+    current_thread_id: str | None = None
 
     def clear(self) -> None:
-        self.started_item_ids.clear()
+        self.started_item_signatures.clear()
         self.started_unkeyed_item_counts.clear()
-        self.completed_item_ids.clear()
+        self.completed_item_keys.clear()
 
 
 class CodexCliRuntime:
@@ -1870,6 +1871,20 @@ class CodexCliRuntime:
         return None
 
     @staticmethod
+    def _mcp_tool_name(item: dict[str, Any]) -> str:
+        """Resolve an MCP tool identity from native tool+server or legacy name."""
+        tool = item.get("tool")
+        if isinstance(tool, str) and tool.strip():
+            server = item.get("server")
+            if isinstance(server, str) and server.strip():
+                return f"{server.strip()}.{tool.strip()}"
+            return tool.strip()
+        name = item.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        return "mcp_tool"
+
+    @staticmethod
     def _extract_mcp_result_text(item: dict[str, Any]) -> str:
         """Normalize MCP result/error envelopes into result text."""
         error_envelope = item.get("error")
@@ -1894,6 +1909,8 @@ class CodexCliRuntime:
             structured = result.get("structured_content")
             if isinstance(structured, str) and structured.strip():
                 return structured.strip()
+            if isinstance(structured, (dict, list)) and structured:
+                return json.dumps(structured, ensure_ascii=False, sort_keys=True)
         if isinstance(result, str) and result.strip():
             return result.strip()
         return ""
@@ -1909,8 +1926,7 @@ class CodexCliRuntime:
         if item_type == "command_execution":
             return self._extract_command(item)
         if item_type == "mcp_tool_call":
-            name = item.get("name")
-            return name.strip() if isinstance(name, str) else ""
+            return self._mcp_tool_name(item)
         if item_type == "file_change":
             return "\n".join(self._extract_paths(item))
         if item_type == "web_search":
@@ -1938,8 +1954,7 @@ class CodexCliRuntime:
             ]
 
         if item_type == "mcp_tool_call":
-            raw_name = item.get("name")
-            tool_name = raw_name if isinstance(raw_name, str) else "mcp_tool"
+            tool_name = self._mcp_tool_name(item)
             return [
                 _CodexToolCall(
                     tool_name=tool_name,
@@ -1986,10 +2001,11 @@ class CodexCliRuntime:
     ) -> None:
         """Record that a thread item's tool start was already projected."""
         item_id = self._item_lifecycle_id(item)
+        signature = self._item_lifecycle_signature(item_type, item)
         if item_id is not None:
-            scope.started_item_ids.add(item_id)
+            scope.started_item_signatures[item_id] = signature
             return
-        key = (item_type, self._item_lifecycle_signature(item_type, item))
+        key = (item_type, signature)
         scope.started_unkeyed_item_counts[key] = scope.started_unkeyed_item_counts.get(key, 0) + 1
 
     def _consume_item_started(
@@ -2000,11 +2016,14 @@ class CodexCliRuntime:
     ) -> bool:
         """Return True when this completion's tool start was already emitted."""
         item_id = self._item_lifecycle_id(item)
+        signature = self._item_lifecycle_signature(item_type, item)
         if item_id is not None:
-            # Keep the id recorded: a duplicate completion for the same item
-            # must not resynthesize a second start (#1692 review blocker 2).
-            return item_id in scope.started_item_ids
-        key = (item_type, self._item_lifecycle_signature(item_type, item))
+            # Pair only when a prior start shares BOTH the id and the stable
+            # tool-input signature; a same-id completion for a different
+            # command must synthesize its own pair, not inherit the start
+            # (review round seven, blocker 2).
+            return scope.started_item_signatures.get(item_id) == signature
+        key = (item_type, signature)
         count = scope.started_unkeyed_item_counts.get(key, 0)
         if count <= 0:
             return False
@@ -2133,7 +2152,12 @@ class CodexCliRuntime:
                 # An unknown verdict must not forward a bare success-implying
                 # status: downstream consumers would read it as authoritative
                 # success while the journal gate fails closed (round five).
-                extra_data["reported_status"] = extra_data.pop("status")
+                reported = extra_data.pop("status")
+                extra_data["reported_status"] = reported
+                # Persist it inside the journaled result meta for auditability
+                # (round seven follow-up P2): runtime metadata serialization
+                # otherwise drops the top-level key.
+                tool_result_meta["reported_status"] = reported
         extra_data["subtype"] = "tool_result"
         if call.tool_call_id is not None:
             extra_data["tool_call_id"] = call.tool_call_id
@@ -2161,11 +2185,14 @@ class CodexCliRuntime:
         if not calls:
             return []
         item_id = self._item_lifecycle_id(item)
-        if item_id is not None and item_id in scope.started_item_ids:
-            # A replayed keyed start must not emit a duplicate: exact
-            # correlation requires one matching start per id (review round
-            # six). Id-less starts keep per-count pairing for legitimate
-            # repeated invocations.
+        if item_id is not None and (
+            scope.started_item_signatures.get(item_id)
+            == self._item_lifecycle_signature(item_type, item)
+        ):
+            # A replayed keyed start (same id and signature) must not emit a
+            # duplicate: exact correlation requires one matching start per id
+            # (review round six). Id-less starts keep per-count pairing for
+            # legitimate repeated invocations.
             return []
         self._remember_item_started(item_type, item, scope)
         return [self._build_tool_start_message(call, current_handle) for call in calls]
@@ -2187,14 +2214,6 @@ class CodexCliRuntime:
         calls = self._item_tool_calls(item_type, item)
         if not calls:
             return []
-        item_id = self._item_lifecycle_id(item)
-        if item_id is not None:
-            if item_id in scope.completed_item_ids:
-                # A replayed keyed completion must not emit a second lifecycle
-                # pair: downstream exact correlation would see two starts
-                # sharing one id (review round three, blocker 1).
-                return []
-            scope.completed_item_ids.add(item_id)
         metadata = self._extract_command_metadata(item)
         if item_type == "mcp_tool_call" and not any(
             isinstance(metadata.get(key), str) and metadata[key].strip()
@@ -2204,6 +2223,18 @@ class CodexCliRuntime:
             if normalized:
                 metadata["output"] = normalized
         is_error = self._resolve_item_completion_is_error(item_type, item)
+        item_id = self._item_lifecycle_id(item)
+        if item_id is not None:
+            # Dedup on the id AND the terminal verdict: an exact replay is
+            # suppressed, but a conflicting same-id completion (e.g. a later
+            # failure after a success) has a different key and stays visible
+            # so verification fails closed (review round seven, blocker 1).
+            dedup_key = (
+                f"{item_id}\x00{self._item_lifecycle_signature(item_type, item)}\x00{is_error}"
+            )
+            if dedup_key in scope.completed_item_keys:
+                return []
+            scope.completed_item_keys.add(dedup_key)
         has_started = self._consume_item_started(item_type, item, scope)
         if not has_started and item_id is not None:
             # Record the keyed synthesized start so the lifecycle state stays
@@ -2248,8 +2279,13 @@ class CodexCliRuntime:
         scope = item_scope if item_scope is not None else self._default_item_scope
 
         if event_type == "thread.started":
-            scope.clear()
             thread_id = event.get("thread_id")
+            # Clearing correlation on an exact same-thread header replay would
+            # orphan in-flight starts; only reset when the identity changes.
+            new_thread = thread_id if isinstance(thread_id, str) else None
+            if new_thread != scope.current_thread_id:
+                scope.clear()
+                scope.current_thread_id = new_thread
             if isinstance(thread_id, str):
                 handle = self._build_runtime_handle(thread_id, current_handle)
                 return [

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -2160,6 +2160,13 @@ class CodexCliRuntime:
         calls = self._item_tool_calls(item_type, item)
         if not calls:
             return []
+        item_id = self._item_lifecycle_id(item)
+        if item_id is not None and item_id in scope.started_item_ids:
+            # A replayed keyed start must not emit a duplicate: exact
+            # correlation requires one matching start per id (review round
+            # six). Id-less starts keep per-count pairing for legitimate
+            # repeated invocations.
+            return []
         self._remember_item_started(item_type, item, scope)
         return [self._build_tool_start_message(call, current_handle) for call in calls]
 

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -151,7 +151,23 @@ _TOOL_STARTED_RUNTIME_EVENT_TYPE = "tool.started"
 _ITEM_METADATA_CONTAINER_KEYS = ("output", "result", "metadata", "data")
 # Explicit status strings. Anything outside both sets is treated as unknown
 # and produces no success claim (fail closed, #1692 review blocker 1).
-_ITEM_FAILURE_STATUSES = frozenset({"failed", "failure", "error", "errored"})
+_ITEM_FAILURE_STATUSES = frozenset(
+    {
+        "failed",
+        "failure",
+        "error",
+        "errored",
+        # Non-success terminal states: a cancelled or interrupted item must
+        # never be laundered into success by a stale nested completed status.
+        "cancelled",
+        "canceled",
+        "aborted",
+        "interrupted",
+        "killed",
+        "timeout",
+        "timed_out",
+    }
+)
 _ITEM_SUCCESS_STATUSES = frozenset({"completed", "success", "succeeded"})
 
 

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -6,7 +6,7 @@ import asyncio
 from collections import deque
 from collections.abc import AsyncIterator, Mapping
 import contextlib
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 import hashlib
 import json
@@ -138,6 +138,32 @@ _RUNTIME_CODEX_PROFILE_METADATA_KEYS = (
     "codex_cli_profile",
 )
 
+# Codex thread-item types that map onto the shared tool lifecycle
+# (``item.started`` → tool start, ``item.completed`` → tool result). See
+# issues #1690/#1724: both halves must be projected as a correlated pair so
+# the deliver gate can prove tool completions.
+_TOOL_LIFECYCLE_ITEM_TYPES = frozenset(
+    {"command_execution", "mcp_tool_call", "file_change", "web_search"}
+)
+_TOOL_STARTED_RUNTIME_EVENT_TYPE = "tool.started"
+# Containers that may hold nested command-result metadata on a thread item.
+# Shared by ``_extract_command_metadata`` and the fail-closed success resolver.
+_ITEM_METADATA_CONTAINER_KEYS = ("output", "result", "metadata", "data")
+# Explicit status strings. Anything outside both sets is treated as unknown
+# and produces no success claim (fail closed, #1692 review blocker 1).
+_ITEM_FAILURE_STATUSES = frozenset({"failed", "failure", "error", "errored"})
+_ITEM_SUCCESS_STATUSES = frozenset({"completed", "success", "succeeded"})
+
+
+@dataclass(frozen=True, slots=True)
+class _CodexToolCall:
+    """One normalized tool invocation derived from a Codex thread item."""
+
+    tool_name: str
+    start_content: str
+    tool_call_id: str | None
+    tool_input: dict[str, Any] = field(default_factory=dict)
+
 
 class CodexCliRuntime:
     """Agent runtime that shells out to the locally installed Codex CLI."""
@@ -215,6 +241,12 @@ class CodexCliRuntime:
             self._profile_resolution_fingerprint = None
             self._codex_config_fingerprint = None
         self._builtin_mcp_handlers: dict[str, Any] | None = None
+        # Item-lifecycle correlation state (#1690): item ids whose
+        # ``item.started`` was already projected as a tool start, so the
+        # matching ``item.completed`` never duplicates the start. Id-less
+        # legacy items are tracked by (item_type, signature) counts instead.
+        self._started_item_ids: set[str] = set()
+        self._started_unkeyed_item_counts: dict[tuple[str, str], int] = {}
         if startup_output_timeout_seconds is not None:
             self._startup_output_timeout_seconds = (
                 None if startup_output_timeout_seconds <= 0 else startup_output_timeout_seconds
@@ -1728,12 +1760,19 @@ class CodexCliRuntime:
     def _extract_command_metadata(self, item: dict[str, Any]) -> dict[str, Any]:
         """Extract command result fields that can support verifier evidence."""
         data: dict[str, Any] = {}
-        self._merge_command_metadata(data, item)
-        for container_key in ("output", "result", "metadata", "data"):
+        for source in self._iter_item_metadata_sources(item):
+            self._merge_command_metadata(data, source)
+        return data
+
+    @staticmethod
+    def _iter_item_metadata_sources(item: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return the item plus any nested containers that may carry results."""
+        sources = [item]
+        for container_key in _ITEM_METADATA_CONTAINER_KEYS:
             nested = item.get(container_key)
             if isinstance(nested, dict):
-                self._merge_command_metadata(data, nested)
-        return data
+                sources.append(nested)
+        return sources
 
     def _merge_command_metadata(self, data: dict[str, Any], source: dict[str, Any]) -> None:
         """Merge known command-result fields from one Codex event object."""
@@ -1780,6 +1819,271 @@ class CodexCliRuntime:
             resume_handle=handle,
         )
 
+    @staticmethod
+    def _item_lifecycle_id(item: dict[str, Any]) -> str | None:
+        """Return the correlation id of a Codex thread item, if present."""
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id.strip():
+            return item_id.strip()
+        return None
+
+    def _item_lifecycle_signature(self, item_type: str, item: dict[str, Any]) -> str:
+        """Build a best-effort identity for id-less legacy thread items."""
+        if item_type == "command_execution":
+            return self._extract_command(item)
+        if item_type == "mcp_tool_call":
+            name = item.get("name")
+            return name.strip() if isinstance(name, str) else ""
+        if item_type == "file_change":
+            return "\n".join(self._extract_paths(item))
+        return self._extract_text(item)
+
+    def _item_tool_calls(self, item_type: str, item: dict[str, Any]) -> list[_CodexToolCall]:
+        """Normalize one Codex thread item into shared tool-call descriptors."""
+        item_id = self._item_lifecycle_id(item)
+
+        if item_type == "command_execution":
+            command = self._extract_command(item)
+            if not command:
+                return []
+            return [
+                _CodexToolCall(
+                    tool_name="Bash",
+                    tool_input={"command": command},
+                    start_content=f"Calling tool: Bash: {command}",
+                    tool_call_id=item_id,
+                )
+            ]
+
+        if item_type == "mcp_tool_call":
+            raw_name = item.get("name")
+            tool_name = raw_name if isinstance(raw_name, str) else "mcp_tool"
+            return [
+                _CodexToolCall(
+                    tool_name=tool_name,
+                    tool_input=self._extract_tool_input(item),
+                    start_content=f"Calling tool: {tool_name}",
+                    tool_call_id=item_id,
+                )
+            ]
+
+        if item_type == "file_change":
+            # Per-path correlation ids ("{item_id}:{path}") let the deliver
+            # gate match each Edit start with its own completion when one
+            # Codex item mutates multiple files (#1690).
+            return [
+                _CodexToolCall(
+                    tool_name="Edit",
+                    tool_input={"file_path": file_path},
+                    start_content=f"Calling tool: Edit: {file_path}",
+                    tool_call_id=f"{item_id}:{file_path}" if item_id is not None else None,
+                )
+                for file_path in self._extract_paths(item)
+            ]
+
+        if item_type == "web_search":
+            query = self._extract_text(item)
+            return [
+                _CodexToolCall(
+                    tool_name="WebSearch",
+                    tool_input={"query": query},
+                    start_content=f"Calling tool: WebSearch: {query}"
+                    if query
+                    else "Calling tool: WebSearch",
+                    tool_call_id=item_id,
+                )
+            ]
+
+        return []
+
+    def _remember_item_started(self, item_type: str, item: dict[str, Any]) -> None:
+        """Record that a thread item's tool start was already projected."""
+        item_id = self._item_lifecycle_id(item)
+        if item_id is not None:
+            self._started_item_ids.add(item_id)
+            return
+        key = (item_type, self._item_lifecycle_signature(item_type, item))
+        self._started_unkeyed_item_counts[key] = self._started_unkeyed_item_counts.get(key, 0) + 1
+
+    def _consume_item_started(self, item_type: str, item: dict[str, Any]) -> bool:
+        """Return True when this completion's tool start was already emitted."""
+        item_id = self._item_lifecycle_id(item)
+        if item_id is not None:
+            # Keep the id recorded: a duplicate completion for the same item
+            # must not resynthesize a second start (#1692 review blocker 2).
+            return item_id in self._started_item_ids
+        key = (item_type, self._item_lifecycle_signature(item_type, item))
+        count = self._started_unkeyed_item_counts.get(key, 0)
+        if count <= 0:
+            return False
+        if count == 1:
+            del self._started_unkeyed_item_counts[key]
+        else:
+            self._started_unkeyed_item_counts[key] = count - 1
+        return True
+
+    def _resolve_item_completion_is_error(
+        self,
+        item: dict[str, Any],
+        metadata: dict[str, Any],
+    ) -> bool | None:
+        """Resolve tri-state completion status, failing closed on ambiguity.
+
+        Returns ``False`` (success) only on explicit machine-readable signals
+        (``exit_code == 0``, completed/success status, ``success``/``ok`` true),
+        ``True`` on explicit failure signals, and ``None`` when the item
+        carries no trustworthy verdict — an unknown or malformed completion
+        must never become success evidence (#1692 review blocker 1).
+        """
+        has_failure = False
+        has_success = False
+
+        exit_code = metadata.get("exit_code")
+        if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+            if exit_code == 0:
+                has_success = True
+            else:
+                has_failure = True
+
+        status = metadata.get("status")
+        if isinstance(status, str):
+            normalized_status = status.strip().lower()
+            if normalized_status in _ITEM_FAILURE_STATUSES:
+                has_failure = True
+            elif normalized_status in _ITEM_SUCCESS_STATUSES:
+                has_success = True
+
+        for source in self._iter_item_metadata_sources(item):
+            for key in ("success", "ok"):
+                flag = source.get(key)
+                if flag is True:
+                    has_success = True
+                elif flag is False:
+                    has_failure = True
+
+        if has_failure:
+            return True
+        if has_success:
+            return False
+        return None
+
+    def _build_tool_start_message(
+        self,
+        call: _CodexToolCall,
+        handle: RuntimeHandle | None,
+    ) -> AgentMessage:
+        """Build the tool-start half of an item lifecycle pair."""
+        extra_data: dict[str, Any] = {"runtime_event_type": _TOOL_STARTED_RUNTIME_EVENT_TYPE}
+        if call.tool_call_id is not None:
+            extra_data["tool_call_id"] = call.tool_call_id
+        return self._build_tool_message(
+            tool_name=call.tool_name,
+            tool_input=call.tool_input,
+            content=call.start_content,
+            handle=handle,
+            extra_data=extra_data,
+        )
+
+    def _build_tool_result_message(
+        self,
+        call: _CodexToolCall,
+        *,
+        metadata: dict[str, Any],
+        is_error: bool | None,
+        handle: RuntimeHandle | None,
+    ) -> AgentMessage:
+        """Build the tool-result half of an item lifecycle pair."""
+        result_text = next(
+            (
+                metadata[key]
+                for key in ("output", "stdout", "result_preview", "stderr")
+                if isinstance(metadata.get(key), str) and metadata[key].strip()
+            ),
+            "",
+        )
+
+        tool_result_meta: dict[str, Any] = {}
+        if call.tool_call_id is not None:
+            tool_result_meta["tool_call_id"] = call.tool_call_id
+        exit_code = metadata.get("exit_code")
+        if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+            tool_result_meta["exit_status"] = exit_code
+
+        tool_result: dict[str, Any] = {
+            "content": [],
+            "text_content": result_text,
+            "meta": tool_result_meta,
+        }
+        if is_error is not None:
+            tool_result["is_error"] = is_error
+
+        # The completion verdict is carried exclusively by the tri-state
+        # ``is_error`` — never forward a metadata-derived "success" subtype.
+        extra_data: dict[str, Any] = {
+            key: value for key, value in metadata.items() if key != "subtype"
+        }
+        extra_data["subtype"] = "tool_result"
+        if call.tool_call_id is not None:
+            extra_data["tool_call_id"] = call.tool_call_id
+        if is_error is not None:
+            extra_data["is_error"] = is_error
+        extra_data["tool_result"] = tool_result
+
+        return self._build_tool_message(
+            tool_name=call.tool_name,
+            tool_input=call.tool_input,
+            content=result_text,
+            handle=handle,
+            extra_data=extra_data,
+        )
+
+    def _convert_tool_item_started(
+        self,
+        item_type: str,
+        item: dict[str, Any],
+        current_handle: RuntimeHandle | None,
+    ) -> list[AgentMessage]:
+        """Project ``item.started`` as correlated tool-start messages."""
+        calls = self._item_tool_calls(item_type, item)
+        if not calls:
+            return []
+        self._remember_item_started(item_type, item)
+        return [self._build_tool_start_message(call, current_handle) for call in calls]
+
+    def _convert_tool_item_completed(
+        self,
+        item_type: str,
+        item: dict[str, Any],
+        current_handle: RuntimeHandle | None,
+    ) -> list[AgentMessage]:
+        """Project ``item.completed`` as correlated tool-result messages.
+
+        When no matching ``item.started`` was projected (completed-only legacy
+        streams), synthesize the start+result pair so the deliver gate keeps
+        both invocation and completion evidence — but never duplicate a start
+        that already happened (#1692 review blocker 2).
+        """
+        calls = self._item_tool_calls(item_type, item)
+        if not calls:
+            return []
+        metadata = self._extract_command_metadata(item)
+        is_error = self._resolve_item_completion_is_error(item, metadata)
+        has_started = self._consume_item_started(item_type, item)
+
+        messages: list[AgentMessage] = []
+        for call in calls:
+            if not has_started:
+                messages.append(self._build_tool_start_message(call, current_handle))
+            messages.append(
+                self._build_tool_result_message(
+                    call,
+                    metadata=metadata,
+                    is_error=is_error,
+                    handle=current_handle,
+                )
+            )
+        return messages
+
     def _convert_event(
         self,
         event: dict[str, Any],
@@ -1804,6 +2108,15 @@ class CodexCliRuntime:
                 ]
             return []
 
+        if event_type == "item.started":
+            item = event.get("item")
+            if not isinstance(item, dict):
+                return []
+            item_type = item.get("type")
+            if not isinstance(item_type, str) or item_type not in _TOOL_LIFECYCLE_ITEM_TYPES:
+                return []
+            return self._convert_tool_item_started(item_type, item, current_handle)
+
         if event_type == "item.completed":
             item = event.get("item")
             if not isinstance(item, dict):
@@ -1812,6 +2125,9 @@ class CodexCliRuntime:
             item_type = item.get("type")
             if not isinstance(item_type, str):
                 return []
+
+            if item_type in _TOOL_LIFECYCLE_ITEM_TYPES:
+                return self._convert_tool_item_completed(item_type, item, current_handle)
 
             if item_type == "agent_message":
                 content = self._extract_text(item)
@@ -1831,67 +2147,6 @@ class CodexCliRuntime:
                         content=content,
                         data={"thinking": content},
                         resume_handle=current_handle,
-                    )
-                ]
-
-            if item_type == "command_execution":
-                command = self._extract_command(item)
-                if not command:
-                    return []
-                return [
-                    self._build_tool_message(
-                        tool_name="Bash",
-                        tool_input={"command": command},
-                        content=f"Calling tool: Bash: {command}",
-                        handle=current_handle,
-                        extra_data=self._extract_command_metadata(item),
-                    )
-                ]
-
-            if item_type == "mcp_tool_call":
-                tool_name = item.get("name") if isinstance(item.get("name"), str) else "mcp_tool"
-                tool_input = self._extract_tool_input(item)
-                return [
-                    self._build_tool_message(
-                        tool_name=tool_name,
-                        tool_input=tool_input,
-                        content=f"Calling tool: {tool_name}",
-                        handle=current_handle,
-                    )
-                ]
-
-            if item_type == "file_change":
-                file_paths = self._extract_paths(item)
-                if not file_paths:
-                    return []
-                return [
-                    self._build_tool_message(
-                        tool_name="Edit",
-                        tool_input={"file_path": file_path},
-                        content=f"Calling tool: Edit: {file_path}",
-                        handle=current_handle,
-                        # This branch is reached only for Codex's
-                        # ``item.completed`` file_change event. Preserve that
-                        # source completion status so evidence validation does
-                        # not mistake it for an unconfirmed Edit dispatch.
-                        extra_data={
-                            "subtype": "success",
-                            "runtime_event_type": "tool.completed",
-                        },
-                    )
-                    for file_path in file_paths
-                ]
-
-            if item_type == "web_search":
-                query = self._extract_text(item)
-                return [
-                    self._build_tool_message(
-                        tool_name="WebSearch",
-                        tool_input={"query": query},
-                        content=f"Calling tool: WebSearch: {query}"
-                        if query
-                        else "Calling tool: WebSearch",
-                        handle=current_handle,
                     )
                 ]
 

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1870,6 +1870,35 @@ class CodexCliRuntime:
         return None
 
     @staticmethod
+    def _extract_mcp_result_text(item: dict[str, Any]) -> str:
+        """Normalize MCP result/error envelopes into result text."""
+        error_envelope = item.get("error")
+        if isinstance(error_envelope, dict):
+            message = error_envelope.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        if isinstance(error_envelope, str) and error_envelope.strip():
+            return error_envelope.strip()
+        result = item.get("result")
+        if isinstance(result, dict):
+            content = result.get("content")
+            if isinstance(content, list):
+                texts = [
+                    block.get("text", "").strip()
+                    for block in content
+                    if isinstance(block, dict) and isinstance(block.get("text"), str)
+                ]
+                joined = "\n".join(text for text in texts if text)
+                if joined:
+                    return joined
+            structured = result.get("structured_content")
+            if isinstance(structured, str) and structured.strip():
+                return structured.strip()
+        if isinstance(result, str) and result.strip():
+            return result.strip()
+        return ""
+
+    @staticmethod
     def _extract_web_search_query(item: dict[str, Any]) -> str:
         """Extract exactly the search query from a web_search thread item."""
         query = item.get("query")
@@ -2024,6 +2053,12 @@ class CodexCliRuntime:
                     if item_type != "command_execution":
                         has_success = True
 
+            error_envelope = source.get("error")
+            if (isinstance(error_envelope, dict) and error_envelope) or (
+                isinstance(error_envelope, str) and error_envelope.strip()
+            ):
+                has_failure = True
+
             for key in ("success", "ok"):
                 flag = source.get(key)
                 if flag is True:
@@ -2092,6 +2127,13 @@ class CodexCliRuntime:
         extra_data: dict[str, Any] = {
             key: value for key, value in metadata.items() if key != "subtype"
         }
+        if is_error is None:
+            status = extra_data.get("status")
+            if isinstance(status, str) and status.strip().lower() in _ITEM_SUCCESS_STATUSES:
+                # An unknown verdict must not forward a bare success-implying
+                # status: downstream consumers would read it as authoritative
+                # success while the journal gate fails closed (round five).
+                extra_data["reported_status"] = extra_data.pop("status")
         extra_data["subtype"] = "tool_result"
         if call.tool_call_id is not None:
             extra_data["tool_call_id"] = call.tool_call_id
@@ -2147,6 +2189,13 @@ class CodexCliRuntime:
                 return []
             scope.completed_item_ids.add(item_id)
         metadata = self._extract_command_metadata(item)
+        if item_type == "mcp_tool_call" and not any(
+            isinstance(metadata.get(key), str) and metadata[key].strip()
+            for key in ("output", "stdout", "result_preview", "stderr")
+        ):
+            normalized = self._extract_mcp_result_text(item)
+            if normalized:
+                metadata["output"] = normalized
         is_error = self._resolve_item_completion_is_error(item_type, item)
         has_started = self._consume_item_started(item_type, item, scope)
         if not has_started and item_id is not None:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1626,7 +1626,6 @@ class CodexCliRuntime:
         returncode = control_state.get("returncode")
         if control_state.get("terminated") is True and handle.lifecycle_state not in {
             "cancelled",
-            "declined",
             "terminated",
         }:
             metadata = dict(handle.metadata)
@@ -1986,7 +1985,9 @@ class CodexCliRuntime:
             scope.started_unkeyed_item_counts[key] = count - 1
         return True
 
-    def _resolve_item_completion_is_error(self, item: dict[str, Any]) -> bool | None:
+    def _resolve_item_completion_is_error(
+        self, item_type: str, item: dict[str, Any]
+    ) -> bool | None:
         """Resolve tri-state completion status, failing closed on ambiguity.
 
         Returns ``False`` (success) only on explicit machine-readable signals
@@ -2016,7 +2017,12 @@ class CodexCliRuntime:
                 if normalized_status in _ITEM_FAILURE_STATUSES:
                     has_failure = True
                 elif normalized_status in _ITEM_SUCCESS_STATUSES:
-                    has_success = True
+                    # Codex marks command_execution items "completed" even on
+                    # non-zero exits, so lifecycle status alone must never
+                    # claim command success — only a validated zero exit or an
+                    # explicit success/ok flag can (review round four).
+                    if item_type != "command_execution":
+                        has_success = True
 
             for key in ("success", "ok"):
                 flag = source.get(key)
@@ -2141,11 +2147,14 @@ class CodexCliRuntime:
                 return []
             scope.completed_item_ids.add(item_id)
         metadata = self._extract_command_metadata(item)
-        is_error = self._resolve_item_completion_is_error(item)
+        is_error = self._resolve_item_completion_is_error(item_type, item)
         has_started = self._consume_item_started(item_type, item, scope)
-        if not has_started:
-            # Record the synthesized start so the lifecycle state stays
-            # consistent for any later event referencing the same identity.
+        if not has_started and item_id is not None:
+            # Record the keyed synthesized start so the lifecycle state stays
+            # consistent; replays are suppressed via completed_item_ids. An
+            # id-less synthesized start is already paired with its own result
+            # and must NOT stay pending, or the next identical completed-only
+            # item would consume it and emit an orphan result (round four).
             self._remember_item_started(item_type, item, scope)
 
         messages: list[AgentMessage] = []

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -160,6 +160,7 @@ _ITEM_FAILURE_STATUSES = frozenset(
         # Non-success terminal states: a cancelled or interrupted item must
         # never be laundered into success by a stale nested completed status.
         "cancelled",
+        "declined",
         "canceled",
         "aborted",
         "interrupted",
@@ -193,10 +194,12 @@ class _CodexItemCorrelationScope:
 
     started_item_ids: set[str] = field(default_factory=set)
     started_unkeyed_item_counts: dict[tuple[str, str], int] = field(default_factory=dict)
+    completed_item_ids: set[str] = field(default_factory=set)
 
     def clear(self) -> None:
         self.started_item_ids.clear()
         self.started_unkeyed_item_counts.clear()
+        self.completed_item_ids.clear()
 
 
 class CodexCliRuntime:
@@ -1623,6 +1626,7 @@ class CodexCliRuntime:
         returncode = control_state.get("returncode")
         if control_state.get("terminated") is True and handle.lifecycle_state not in {
             "cancelled",
+            "declined",
             "terminated",
         }:
             metadata = dict(handle.metadata)
@@ -1826,9 +1830,15 @@ class CodexCliRuntime:
                 data.setdefault(target_key, value.strip())
         for key in ("exit_code", "exitCode", "returncode", "return_code"):
             value = source.get(key)
-            if isinstance(value, int):
-                data.setdefault("exit_code", value)
-                break
+            if isinstance(value, int) and not isinstance(value, bool):
+                stored = data.get("exit_code")
+                if stored is None:
+                    data["exit_code"] = value
+                elif stored == 0 and value != 0:
+                    # Conflicting aliases must persist one verdict-consistent
+                    # value: the failing code wins over a stale zero so the
+                    # journal never contradicts is_error (round three warning).
+                    data["exit_code"] = value
         if source.get("success") is True:
             data.setdefault("subtype", "success")
         if source.get("ok") is True:
@@ -2122,9 +2132,21 @@ class CodexCliRuntime:
         calls = self._item_tool_calls(item_type, item)
         if not calls:
             return []
+        item_id = self._item_lifecycle_id(item)
+        if item_id is not None:
+            if item_id in scope.completed_item_ids:
+                # A replayed keyed completion must not emit a second lifecycle
+                # pair: downstream exact correlation would see two starts
+                # sharing one id (review round three, blocker 1).
+                return []
+            scope.completed_item_ids.add(item_id)
         metadata = self._extract_command_metadata(item)
         is_error = self._resolve_item_completion_is_error(item)
         has_started = self._consume_item_started(item_type, item, scope)
+        if not has_started:
+            # Record the synthesized start so the lifecycle state stays
+            # consistent for any later event referencing the same identity.
+            self._remember_item_started(item_type, item, scope)
 
         messages: list[AgentMessage] = []
         for call in calls:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -165,6 +165,24 @@ class _CodexToolCall:
     tool_input: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class _CodexItemCorrelationScope:
+    """Per-stream correlation state for Codex item lifecycle pairing.
+
+    Each streamed Codex process gets its own scope so parallel or sequential
+    ACs sharing one adapter can never suppress another stream's synthetic
+    start with stale item ids. The scope is also cleared on ``thread.started``
+    so a new thread begins with a clean correlation space.
+    """
+
+    started_item_ids: set[str] = field(default_factory=set)
+    started_unkeyed_item_counts: dict[tuple[str, str], int] = field(default_factory=dict)
+
+    def clear(self) -> None:
+        self.started_item_ids.clear()
+        self.started_unkeyed_item_counts.clear()
+
+
 class CodexCliRuntime:
     """Agent runtime that shells out to the locally installed Codex CLI."""
 
@@ -245,8 +263,7 @@ class CodexCliRuntime:
         # ``item.started`` was already projected as a tool start, so the
         # matching ``item.completed`` never duplicates the start. Id-less
         # legacy items are tracked by (item_type, signature) counts instead.
-        self._started_item_ids: set[str] = set()
-        self._started_unkeyed_item_counts: dict[tuple[str, str], int] = {}
+        self._default_item_scope = _CodexItemCorrelationScope()
         if startup_output_timeout_seconds is not None:
             self._startup_output_timeout_seconds = (
                 None if startup_output_timeout_seconds <= 0 else startup_output_timeout_seconds
@@ -1896,37 +1913,43 @@ class CodexCliRuntime:
 
         return []
 
-    def _remember_item_started(self, item_type: str, item: dict[str, Any]) -> None:
+    def _remember_item_started(
+        self,
+        item_type: str,
+        item: dict[str, Any],
+        scope: _CodexItemCorrelationScope,
+    ) -> None:
         """Record that a thread item's tool start was already projected."""
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:
-            self._started_item_ids.add(item_id)
+            scope.started_item_ids.add(item_id)
             return
         key = (item_type, self._item_lifecycle_signature(item_type, item))
-        self._started_unkeyed_item_counts[key] = self._started_unkeyed_item_counts.get(key, 0) + 1
+        scope.started_unkeyed_item_counts[key] = scope.started_unkeyed_item_counts.get(key, 0) + 1
 
-    def _consume_item_started(self, item_type: str, item: dict[str, Any]) -> bool:
+    def _consume_item_started(
+        self,
+        item_type: str,
+        item: dict[str, Any],
+        scope: _CodexItemCorrelationScope,
+    ) -> bool:
         """Return True when this completion's tool start was already emitted."""
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:
             # Keep the id recorded: a duplicate completion for the same item
             # must not resynthesize a second start (#1692 review blocker 2).
-            return item_id in self._started_item_ids
+            return item_id in scope.started_item_ids
         key = (item_type, self._item_lifecycle_signature(item_type, item))
-        count = self._started_unkeyed_item_counts.get(key, 0)
+        count = scope.started_unkeyed_item_counts.get(key, 0)
         if count <= 0:
             return False
         if count == 1:
-            del self._started_unkeyed_item_counts[key]
+            del scope.started_unkeyed_item_counts[key]
         else:
-            self._started_unkeyed_item_counts[key] = count - 1
+            scope.started_unkeyed_item_counts[key] = count - 1
         return True
 
-    def _resolve_item_completion_is_error(
-        self,
-        item: dict[str, Any],
-        metadata: dict[str, Any],
-    ) -> bool | None:
+    def _resolve_item_completion_is_error(self, item: dict[str, Any]) -> bool | None:
         """Resolve tri-state completion status, failing closed on ambiguity.
 
         Returns ``False`` (success) only on explicit machine-readable signals
@@ -1938,22 +1961,26 @@ class CodexCliRuntime:
         has_failure = False
         has_success = False
 
-        exit_code = metadata.get("exit_code")
-        if isinstance(exit_code, int) and not isinstance(exit_code, bool):
-            if exit_code == 0:
-                has_success = True
-            else:
-                has_failure = True
-
-        status = metadata.get("status")
-        if isinstance(status, str):
-            normalized_status = status.strip().lower()
-            if normalized_status in _ITEM_FAILURE_STATUSES:
-                has_failure = True
-            elif normalized_status in _ITEM_SUCCESS_STATUSES:
-                has_success = True
-
+        # Scan every metadata source directly: first-value-wins merging must
+        # never let an outer success status shadow a nested failure (review
+        # blocker: failure signals take precedence wherever they appear).
         for source in self._iter_item_metadata_sources(item):
+            for exit_key in ("exit_code", "exitCode"):
+                exit_code = source.get(exit_key)
+                if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+                    if exit_code == 0:
+                        has_success = True
+                    else:
+                        has_failure = True
+
+            status = source.get("status")
+            if isinstance(status, str):
+                normalized_status = status.strip().lower()
+                if normalized_status in _ITEM_FAILURE_STATUSES:
+                    has_failure = True
+                elif normalized_status in _ITEM_SUCCESS_STATUSES:
+                    has_success = True
+
             for key in ("success", "ok"):
                 flag = source.get(key)
                 if flag is True:
@@ -2042,12 +2069,13 @@ class CodexCliRuntime:
         item_type: str,
         item: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        scope: _CodexItemCorrelationScope,
     ) -> list[AgentMessage]:
         """Project ``item.started`` as correlated tool-start messages."""
         calls = self._item_tool_calls(item_type, item)
         if not calls:
             return []
-        self._remember_item_started(item_type, item)
+        self._remember_item_started(item_type, item, scope)
         return [self._build_tool_start_message(call, current_handle) for call in calls]
 
     def _convert_tool_item_completed(
@@ -2055,6 +2083,7 @@ class CodexCliRuntime:
         item_type: str,
         item: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        scope: _CodexItemCorrelationScope,
     ) -> list[AgentMessage]:
         """Project ``item.completed`` as correlated tool-result messages.
 
@@ -2067,8 +2096,8 @@ class CodexCliRuntime:
         if not calls:
             return []
         metadata = self._extract_command_metadata(item)
-        is_error = self._resolve_item_completion_is_error(item, metadata)
-        has_started = self._consume_item_started(item_type, item)
+        is_error = self._resolve_item_completion_is_error(item)
+        has_started = self._consume_item_started(item_type, item, scope)
 
         messages: list[AgentMessage] = []
         for call in calls:
@@ -2088,13 +2117,24 @@ class CodexCliRuntime:
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
-        """Convert a Codex JSON event into normalized AgentMessage values."""
+        """Convert a Codex JSON event into normalized AgentMessage values.
+
+        ``item_scope`` isolates start/result correlation per streamed process;
+        the streaming loop passes a fresh scope per invocation. Direct callers
+        fall back to a per-instance scope, which is cleared on every
+        ``thread.started`` so a new thread never inherits stale item ids.
+        """
         event_type = event.get("type")
         if not isinstance(event_type, str):
             return []
 
+        scope = item_scope if item_scope is not None else self._default_item_scope
+
         if event_type == "thread.started":
+            scope.clear()
             thread_id = event.get("thread_id")
             if isinstance(thread_id, str):
                 handle = self._build_runtime_handle(thread_id, current_handle)
@@ -2115,7 +2155,7 @@ class CodexCliRuntime:
             item_type = item.get("type")
             if not isinstance(item_type, str) or item_type not in _TOOL_LIFECYCLE_ITEM_TYPES:
                 return []
-            return self._convert_tool_item_started(item_type, item, current_handle)
+            return self._convert_tool_item_started(item_type, item, current_handle, scope)
 
         if event_type == "item.completed":
             item = event.get("item")
@@ -2127,7 +2167,7 @@ class CodexCliRuntime:
                 return []
 
             if item_type in _TOOL_LIFECYCLE_ITEM_TYPES:
-                return self._convert_tool_item_completed(item_type, item, current_handle)
+                return self._convert_tool_item_completed(item_type, item, current_handle, scope)
 
             if item_type == "agent_message":
                 content = self._extract_text(item)
@@ -2309,6 +2349,9 @@ class CodexCliRuntime:
         _resume_depth: int = 0,
     ) -> AsyncIterator[AgentMessage]:
         """Internal implementation with resume-depth tracking."""
+        # Per-stream correlation scope: parallel or sequential ACs sharing
+        # this adapter must never see another stream's item lifecycle state.
+        stream_item_scope = _CodexItemCorrelationScope()
         # Note: CODEX_SANDBOX_NETWORK_DISABLED=1 does NOT necessarily mean
         # child codex exec will fail.  Codex may apply different seatbelt
         # profiles to MCP server children vs shell commands.  Log at debug
@@ -2523,7 +2566,9 @@ class CodexCliRuntime:
                         last_content = self._update_last_content(last_content, message)
                         yield message
 
-                    for message in self._convert_event(event, current_handle):
+                    for message in self._convert_event(
+                        event, current_handle, item_scope=stream_item_scope
+                    ):
                         if message.resume_handle is not None:
                             current_handle = message.resume_handle
                             current_handle = self._bind_runtime_handle_controls(

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -147,7 +147,7 @@ _TOOL_LIFECYCLE_ITEM_TYPES = frozenset(
 )
 _TOOL_STARTED_RUNTIME_EVENT_TYPE = "tool.started"
 _SENSITIVE_META_KEY_RE = re.compile(
-    r"(authorization|api[_-]?key|access[_-]?token|secret|password|passwd|credential|"
+    r"(authorization|api[_-]?key|token|secret|password|passwd|credential|"
     r"private[_-]?key|session[_-]?token|bearer|cookie)",
     re.IGNORECASE,
 )
@@ -2058,11 +2058,15 @@ class CodexCliRuntime:
         if isinstance(result, dict):
             content = result.get("content")
             if isinstance(content, list):
-                texts = [
-                    block.get("text", "").strip()
-                    for block in content
-                    if isinstance(block, dict) and isinstance(block.get("text"), str)
-                ]
+                texts: list[str] = []
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if isinstance(block.get("text"), str):
+                        texts.append(block["text"].strip())
+                    nested = block.get("resource")
+                    if isinstance(nested, dict) and isinstance(nested.get("text"), str):
+                        texts.append(nested["text"].strip())
                 joined = "\n".join(text for text in texts if text)
                 if joined:
                     return joined
@@ -2084,7 +2088,15 @@ class CodexCliRuntime:
         return query.strip() if isinstance(query, str) else ""
 
     def _item_lifecycle_signature(self, item_type: str, item: dict[str, Any]) -> str:
-        """Build a best-effort identity for id-less legacy thread items."""
+        """Build a best-effort identity, scoped by tool type.
+
+        The type prefix stops a reused id from correlating across different
+        tool types (e.g. a Bash ``cats`` start and a WebSearch ``cats``
+        completion), which would otherwise pair on the bare payload.
+        """
+        return f"{item_type}\x00{self._item_lifecycle_payload_signature(item_type, item)}"
+
+    def _item_lifecycle_payload_signature(self, item_type: str, item: dict[str, Any]) -> str:
         if item_type == "command_execution":
             cwd = self._extract_cwd(item)
             command = self._extract_command(item)
@@ -2282,7 +2294,9 @@ class CodexCliRuntime:
                     has_success = True
 
             status = source.get("status")
-            if isinstance(status, str):
+            if status is not None and not isinstance(status, str):
+                has_malformed = True
+            elif isinstance(status, str):
                 normalized_status = status.strip().lower()
                 if normalized_status in _ITEM_FAILURE_STATUSES:
                     has_failure = True

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -194,13 +194,19 @@ class _CodexItemCorrelationScope:
     """
 
     started_item_signatures: dict[str, str] = field(default_factory=dict)
-    started_unkeyed_item_counts: dict[tuple[str, str], int] = field(default_factory=dict)
+    unkeyed_started_nonces: dict[tuple[str, str], list[str]] = field(default_factory=dict)
     completed_item_keys: set[str] = field(default_factory=set)
     current_thread_id: str | None = None
+    _nonce_seq: int = 0
+
+    def allocate_nonce(self) -> str:
+        """Return a monotonic, scope-unique correlation nonce for id-less items."""
+        self._nonce_seq += 1
+        return f"syn:{self._nonce_seq}"
 
     def clear(self) -> None:
         self.started_item_signatures.clear()
-        self.started_unkeyed_item_counts.clear()
+        self.unkeyed_started_nonces.clear()
         self.completed_item_keys.clear()
 
 
@@ -1892,14 +1898,22 @@ class CodexCliRuntime:
         nine & ten). Serializing the full normalized change captures the
         mutation kind (any shape), patch content, and move destination.
         """
+        # Include every field _extract_paths turns into a tool call (top-level
+        # path/file_path/target_file) plus the full normalized changes, so a
+        # differing top-level path is not masked by identical changes (round
+        # twelve, blocker 2).
         changes = item.get("changes")
-        if isinstance(changes, list) and changes:
-            normalized = [change for change in changes if isinstance(change, dict)]
-            if normalized:
-                return json.dumps(normalized, ensure_ascii=False, sort_keys=True, default=str)
-        item_kind = item.get("kind")
-        fallback = [{"path": path, "kind": item_kind} for path in self._extract_paths(item)]
-        return json.dumps(fallback, ensure_ascii=False, sort_keys=True, default=str)
+        normalized_changes = (
+            [change for change in changes if isinstance(change, dict)]
+            if isinstance(changes, list)
+            else []
+        )
+        signature_payload = {
+            "paths": list(self._extract_paths(item)),
+            "changes": normalized_changes,
+            "kind": item.get("kind"),
+        }
+        return json.dumps(signature_payload, ensure_ascii=False, sort_keys=True, default=str)
 
     @staticmethod
     def _mcp_tool_name(item: dict[str, Any]) -> str:
@@ -1914,6 +1928,16 @@ class CodexCliRuntime:
         if isinstance(name, str) and name.strip():
             return name.strip()
         return "mcp_tool"
+
+    @staticmethod
+    def _extract_mcp_result_meta(item: dict[str, Any]) -> dict[str, Any]:
+        """Return an MCP result ``_meta`` mapping for audit transfer."""
+        result = item.get("result")
+        if isinstance(result, dict):
+            meta = result.get("_meta")
+            if isinstance(meta, dict) and meta:
+                return dict(meta)
+        return {}
 
     @staticmethod
     def _nested_error(item: dict[str, Any]) -> object:
@@ -1956,6 +1980,9 @@ class CodexCliRuntime:
                     res_text = resource.get("text")
                     if isinstance(res_text, str) and "text" not in block:
                         block["text"] = res_text
+                    blob = resource.get("blob")
+                    if blob is not None and block.get("data") is None:
+                        block["data"] = blob
                     res_mime = resource.get("mime_type") or resource.get("mimeType")
                     if isinstance(res_mime, str) and "mime_type" not in block:
                         block["mime_type"] = res_mime
@@ -2031,9 +2058,11 @@ class CodexCliRuntime:
             return self._extract_web_search_query(item)
         return self._extract_text(item)
 
-    def _item_tool_calls(self, item_type: str, item: dict[str, Any]) -> list[_CodexToolCall]:
+    def _item_tool_calls(
+        self, item_type: str, item: dict[str, Any], correlation_key: str | None = None
+    ) -> list[_CodexToolCall]:
         """Normalize one Codex thread item into shared tool-call descriptors."""
-        item_id = self._item_lifecycle_id(item)
+        item_id = self._item_lifecycle_id(item) if correlation_key is None else correlation_key
 
         if item_type == "command_execution":
             command = self._extract_command(item)
@@ -2072,11 +2101,7 @@ class CodexCliRuntime:
                     tool_name="Edit",
                     tool_input={"file_path": file_path},
                     start_content=f"Calling tool: Edit: {file_path}",
-                    tool_call_id=(
-                        f"{item_id}:{file_path}"
-                        if item_id is not None
-                        else f"filechange:{file_path}"
-                    ),
+                    tool_call_id=(f"{item_id}:{file_path}" if item_id is not None else None),
                 )
                 for file_path in self._extract_paths(item)
             ]
@@ -2101,40 +2126,47 @@ class CodexCliRuntime:
         item_type: str,
         item: dict[str, Any],
         scope: _CodexItemCorrelationScope,
-    ) -> None:
-        """Record that a thread item's tool start was already projected."""
+    ) -> str:
+        """Record a projected tool start and return its correlation key.
+
+        Keyed items correlate by their real id; id-less items get a monotonic
+        scope-unique nonce, queued FIFO per signature so the matching
+        completion recovers the same nonce (review round twelve: synthetic ids
+        must be invocation-unique yet stable across a start/result pair).
+        """
         item_id = self._item_lifecycle_id(item)
         signature = self._item_lifecycle_signature(item_type, item)
         if item_id is not None:
             scope.started_item_signatures[item_id] = signature
-            return
-        key = (item_type, signature)
-        scope.started_unkeyed_item_counts[key] = scope.started_unkeyed_item_counts.get(key, 0) + 1
+            return item_id
+        nonce = scope.allocate_nonce()
+        scope.unkeyed_started_nonces.setdefault((item_type, signature), []).append(nonce)
+        return nonce
 
     def _consume_item_started(
         self,
         item_type: str,
         item: dict[str, Any],
         scope: _CodexItemCorrelationScope,
-    ) -> bool:
-        """Return True when this completion's tool start was already emitted."""
+    ) -> tuple[bool, str]:
+        """Return (has_started, correlation_key) for a completion.
+
+        A completed-only stream with no matching start allocates a fresh nonce
+        so its synthesized start/result pair is invocation-unique.
+        """
         item_id = self._item_lifecycle_id(item)
         signature = self._item_lifecycle_signature(item_type, item)
         if item_id is not None:
             # Pair only when a prior start shares BOTH the id and the stable
-            # tool-input signature; a same-id completion for a different
-            # command must synthesize its own pair, not inherit the start
-            # (review round seven, blocker 2).
-            return scope.started_item_signatures.get(item_id) == signature
-        key = (item_type, signature)
-        count = scope.started_unkeyed_item_counts.get(key, 0)
-        if count <= 0:
-            return False
-        if count == 1:
-            del scope.started_unkeyed_item_counts[key]
-        else:
-            scope.started_unkeyed_item_counts[key] = count - 1
-        return True
+            # tool-input signature (review round seven, blocker 2).
+            return (scope.started_item_signatures.get(item_id) == signature, item_id)
+        queue = scope.unkeyed_started_nonces.get((item_type, signature))
+        if queue:
+            nonce = queue.pop(0)
+            if not queue:
+                del scope.unkeyed_started_nonces[(item_type, signature)]
+            return (True, nonce)
+        return (False, scope.allocate_nonce())
 
     def _resolve_item_completion_is_error(
         self, item_type: str, item: dict[str, Any]
@@ -2243,6 +2275,10 @@ class CodexCliRuntime:
         if isinstance(exit_code, int) and not isinstance(exit_code, bool):
             tool_result_meta["exit_status"] = exit_code
 
+        result_meta = metadata.get("__mcp_result_meta__")
+        if isinstance(result_meta, dict):
+            for meta_key, meta_value in result_meta.items():
+                tool_result_meta.setdefault(str(meta_key), meta_value)
         content_blocks = metadata.get("__mcp_content_blocks__")
         tool_result: dict[str, Any] = {
             "content": list(content_blocks) if isinstance(content_blocks, list) else [],
@@ -2257,7 +2293,7 @@ class CodexCliRuntime:
         extra_data: dict[str, Any] = {
             key: value
             for key, value in metadata.items()
-            if key not in ("subtype", "__mcp_content_blocks__")
+            if key not in ("subtype", "__mcp_content_blocks__", "__mcp_result_meta__")
         }
         if is_error is None:
             status = extra_data.get("status")
@@ -2294,8 +2330,7 @@ class CodexCliRuntime:
         scope: _CodexItemCorrelationScope,
     ) -> list[AgentMessage]:
         """Project ``item.started`` as correlated tool-start messages."""
-        calls = self._item_tool_calls(item_type, item)
-        if not calls:
+        if not self._item_tool_calls(item_type, item, self._item_lifecycle_id(item)):
             return []
         item_id = self._item_lifecycle_id(item)
         if item_id is not None and (
@@ -2304,10 +2339,11 @@ class CodexCliRuntime:
         ):
             # A replayed keyed start (same id and signature) must not emit a
             # duplicate: exact correlation requires one matching start per id
-            # (review round six). Id-less starts keep per-count pairing for
-            # legitimate repeated invocations.
+            # (review round six). Id-less starts keep per-invocation nonces so
+            # legitimate repeated invocations stay distinct.
             return []
-        self._remember_item_started(item_type, item, scope)
+        correlation_key = self._remember_item_started(item_type, item, scope)
+        calls = self._item_tool_calls(item_type, item, correlation_key)
         return [self._build_tool_start_message(call, current_handle) for call in calls]
 
     def _convert_tool_item_completed(
@@ -2324,8 +2360,7 @@ class CodexCliRuntime:
         both invocation and completion evidence — but never duplicate a start
         that already happened (#1692 review blocker 2).
         """
-        calls = self._item_tool_calls(item_type, item)
-        if not calls:
+        if not self._item_tool_calls(item_type, item, self._item_lifecycle_id(item)):
             return []
         metadata = self._extract_command_metadata(item)
         if item_type == "mcp_tool_call":
@@ -2339,6 +2374,9 @@ class CodexCliRuntime:
             content_blocks = self._extract_mcp_content_blocks(item)
             if content_blocks:
                 metadata["__mcp_content_blocks__"] = content_blocks
+            result_meta = self._extract_mcp_result_meta(item)
+            if result_meta:
+                metadata["__mcp_result_meta__"] = result_meta
         is_error = self._resolve_item_completion_is_error(item_type, item)
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:
@@ -2353,14 +2391,10 @@ class CodexCliRuntime:
             if dedup_key in scope.completed_item_keys:
                 return []
             scope.completed_item_keys.add(dedup_key)
-        has_started = self._consume_item_started(item_type, item, scope)
-        if not has_started and item_id is not None:
-            # Record the keyed synthesized start so the lifecycle state stays
-            # consistent; replays are suppressed via completed_item_ids. An
-            # id-less synthesized start is already paired with its own result
-            # and must NOT stay pending, or the next identical completed-only
-            # item would consume it and emit an orphan result (round four).
-            self._remember_item_started(item_type, item, scope)
+        has_started, correlation_key = self._consume_item_started(item_type, item, scope)
+        calls = self._item_tool_calls(item_type, item, correlation_key)
+        if not calls:
+            return []
 
         messages: list[AgentMessage] = []
         for call in calls:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -146,6 +146,7 @@ _TOOL_LIFECYCLE_ITEM_TYPES = frozenset(
     {"command_execution", "mcp_tool_call", "file_change", "web_search"}
 )
 _TOOL_STARTED_RUNTIME_EVENT_TYPE = "tool.started"
+_TOOL_RESULT_RUNTIME_EVENT_TYPE = "tool.result"
 # Containers that may hold nested command-result metadata on a thread item.
 # Shared by ``_extract_command_metadata`` and the fail-closed success resolver.
 _ITEM_METADATA_CONTAINER_KEYS = ("output", "result", "metadata", "data")
@@ -1918,12 +1919,19 @@ class CodexCliRuntime:
     @staticmethod
     def _mcp_tool_name(item: dict[str, Any]) -> str:
         """Resolve an MCP tool identity from native tool+server or legacy name."""
-        tool = item.get("tool")
-        if isinstance(tool, str) and tool.strip():
+        tool = next(
+            (
+                item[key].strip()
+                for key in ("tool", "toolName", "tool_name")
+                if isinstance(item.get(key), str) and item[key].strip()
+            ),
+            "",
+        )
+        if tool:
             server = item.get("server")
             if isinstance(server, str) and server.strip():
-                return f"{server.strip()}.{tool.strip()}"
-            return tool.strip()
+                return f"{server.strip()}.{tool}"
+            return tool
         name = item.get("name")
         if isinstance(name, str) and name.strip():
             return name.strip()
@@ -2185,26 +2193,54 @@ class CodexCliRuntime:
         """
         has_failure = False
         has_success = False
+        has_malformed = False
 
-        # Scan every metadata source directly: first-value-wins merging must
-        # never let an outer success status shadow a nested failure (review
-        # blocker: failure signals take precedence wherever they appear).
+        # Verdict signals are resolved against a per-item-type authority
+        # contract. Failure takes precedence wherever it appears; a present
+        # but malformed verdict field poisons the success claim (fail closed);
+        # success is only claimed from a signal that is authoritative for this
+        # item type. Every metadata source is scanned directly so a nested
+        # failure is never shadowed by an outer success.
         for source in self._iter_item_metadata_sources(item):
             for exit_key in ("exit_code", "exitCode", "returncode", "return_code"):
+                if exit_key not in source:
+                    continue
                 exit_code = source.get(exit_key)
-                if isinstance(exit_code, int) and not isinstance(exit_code, bool):
-                    if exit_code == 0:
+                if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+                    has_malformed = True
+                elif exit_code == 0:
+                    # A validated zero exit is authoritative for commands.
+                    if item_type == "command_execution":
                         has_success = True
-                    else:
-                        has_failure = True
+                else:
+                    has_failure = True
+
+            # Failure-only alternate wire keys: a nonzero code under these
+            # spellings marks failure without ever granting success, so
+            # widening them can only add fail-closed coverage, never forge a
+            # verdict (round fifteen preempt: a failure token must not be
+            # invisible just because it uses a non-canonical field name).
+            for fail_key in ("exit", "statusCode", "status_code", "errorCode", "error_code"):
+                if fail_key not in source:
+                    continue
+                code = source.get(fail_key)
+                if isinstance(code, bool):
+                    has_malformed = True
+                elif isinstance(code, int) and code != 0:
+                    has_failure = True
 
             for error_flag_key in ("isError", "is_error"):
-                if error_flag_key in source:
-                    error_flag = source.get(error_flag_key)
-                    if error_flag is True:
-                        has_failure = True
-                    elif error_flag is False:
-                        has_success = True
+                if error_flag_key not in source:
+                    continue
+                error_flag = source.get(error_flag_key)
+                if not isinstance(error_flag, bool):
+                    has_malformed = True
+                elif error_flag is True:
+                    # A true error flag is a failure for any item type.
+                    has_failure = True
+                elif item_type == "mcp_tool_call":
+                    # isError is authoritative only for MCP calls.
+                    has_success = True
 
             status = source.get("status")
             if isinstance(status, str):
@@ -2213,9 +2249,8 @@ class CodexCliRuntime:
                     has_failure = True
                 elif normalized_status in _ITEM_SUCCESS_STATUSES:
                     # Codex marks command_execution items "completed" even on
-                    # non-zero exits, so lifecycle status alone must never
-                    # claim command success — only a validated zero exit or an
-                    # explicit success/ok flag can (review round four).
+                    # non-zero exits, so lifecycle status is authoritative for
+                    # success only for non-command item types (round four).
                     if item_type != "command_execution":
                         has_success = True
 
@@ -2233,14 +2268,23 @@ class CodexCliRuntime:
                     has_failure = True
 
             for key in ("success", "ok"):
+                if key not in source:
+                    continue
                 flag = source.get(key)
-                if flag is True:
+                if not isinstance(flag, bool):
+                    has_malformed = True
+                elif flag is True:
+                    # An explicit success/ok flag is authoritative for any type.
                     has_success = True
-                elif flag is False:
+                else:
                     has_failure = True
 
         if has_failure:
             return True
+        if has_malformed:
+            # A present but untrustworthy verdict field means the outcome is
+            # unknown — never claim success on ambiguous machine metadata.
+            return None
         if has_success:
             return False
         return None
@@ -2252,6 +2296,7 @@ class CodexCliRuntime:
     ) -> AgentMessage:
         """Build the tool-start half of an item lifecycle pair."""
         extra_data: dict[str, Any] = {"runtime_event_type": _TOOL_STARTED_RUNTIME_EVENT_TYPE}
+        handle = self._neutralize_terminal_handle_event_type(handle)
         if call.tool_call_id is not None:
             extra_data["tool_call_id"] = call.tool_call_id
         return self._build_tool_message(
@@ -2285,12 +2330,23 @@ class CodexCliRuntime:
             tool_result_meta["tool_call_id"] = call.tool_call_id
         exit_code = metadata.get("exit_code")
         if isinstance(exit_code, int) and not isinstance(exit_code, bool):
-            tool_result_meta["exit_status"] = exit_code
+            # exit_status is an authoritative success/failure key the deliver
+            # gate trusts, so it may only ride when the resolver produced a
+            # real verdict. On an unknown verdict (is_error is None) it is
+            # demoted to an audit-only key so a leaked exit 0 cannot forge
+            # success — is_error is the sole authoritative verdict channel
+            # (round fifteen preempt: mirror the round-five status demotion).
+            if is_error is not None:
+                tool_result_meta["exit_status"] = exit_code
+            else:
+                tool_result_meta["reported_exit_status"] = exit_code
 
         result_meta = metadata.get("__mcp_result_meta__")
-        if isinstance(result_meta, dict):
-            for meta_key, meta_value in result_meta.items():
-                tool_result_meta.setdefault(str(meta_key), meta_value)
+        if isinstance(result_meta, dict) and result_meta:
+            # Namespace opaque MCP audit data so it can never populate the
+            # shared authority keys the deliver gate trusts (e.g. exit_status);
+            # it is preserved but isolated under "mcp_meta" (round fourteen).
+            tool_result_meta["mcp_meta"] = dict(result_meta)
         content_blocks = metadata.get("__mcp_content_blocks__")
         tool_result: dict[str, Any] = {
             "content": list(content_blocks) if isinstance(content_blocks, list) else [],
@@ -2319,20 +2375,52 @@ class CodexCliRuntime:
                 # (round seven follow-up P2): runtime metadata serialization
                 # otherwise drops the top-level key.
                 tool_result_meta["reported_status"] = reported
+            # The in-memory verifier reads a top-level exit_code==0 as success,
+            # so an unknown verdict must not forward the raw exit code either;
+            # demote it to an audit-only key (round fifteen preempt).
+            for exit_key in ("exit_code", "exitCode", "returncode", "return_code"):
+                if exit_key in extra_data:
+                    extra_data[f"reported_{exit_key}"] = extra_data.pop(exit_key)
         extra_data["subtype"] = "tool_result"
         if call.tool_call_id is not None:
             extra_data["tool_call_id"] = call.tool_call_id
         if is_error is not None:
             extra_data["is_error"] = is_error
         extra_data["tool_result"] = tool_result
+        # Carry a neutral, non-terminal result event type so a completion
+        # never reads as success via runtime_event_type. Projection overrides
+        # the message value with the handle's own runtime_event_type when
+        # present, so the handle is neutralized too — otherwise a resumed
+        # handle's stale ``run.completed`` would leak onto the result and
+        # forge journal success (round fourteen, blocker 3).
+        extra_data["runtime_event_type"] = _TOOL_RESULT_RUNTIME_EVENT_TYPE
 
         return self._build_tool_message(
             tool_name=call.tool_name,
             tool_input=call.tool_input,
             content=result_text,
-            handle=handle,
+            handle=self._neutralize_terminal_handle_event_type(handle),
             extra_data=extra_data,
         )
+
+    @staticmethod
+    def _neutralize_terminal_handle_event_type(
+        handle: RuntimeHandle | None,
+    ) -> RuntimeHandle | None:
+        """Return a handle whose stale terminal runtime_event_type is cleared.
+
+        Projection lets a resume handle's ``runtime_event_type`` override the
+        message value, so a terminal ``run.completed``/``session.terminated``
+        would otherwise become the result's event type and forge success.
+        """
+        if handle is None:
+            return None
+        stale = handle.metadata.get("runtime_event_type")
+        if not isinstance(stale, str) or not stale:
+            return handle
+        neutralized_metadata = dict(handle.metadata)
+        neutralized_metadata["runtime_event_type"] = _TOOL_RESULT_RUNTIME_EVENT_TYPE
+        return replace(handle, metadata=neutralized_metadata)
 
     def _convert_tool_item_started(
         self,
@@ -2404,6 +2492,12 @@ class CodexCliRuntime:
                 return []
             scope.completed_item_keys.add(dedup_key)
         has_started, correlation_key = self._consume_item_started(item_type, item, scope)
+        if not has_started and item_id is not None:
+            # A completed-only keyed item synthesizes its start here; record it
+            # so a later or replayed keyed item.started for the same id/signature
+            # is suppressed rather than emitting a duplicate start (round
+            # fourteen follow-up).
+            scope.started_item_signatures[item_id] = self._item_lifecycle_signature(item_type, item)
         calls = self._item_tool_calls(item_type, item, correlation_key)
         if not calls:
             return []

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1871,35 +1871,35 @@ class CodexCliRuntime:
             return item_id.strip()
         return None
 
-    def _file_change_signature(self, item: dict[str, Any]) -> str:
-        """Pair each changed path with its mutation kind for stable identity.
+    @staticmethod
+    def _extract_cwd(item: dict[str, Any]) -> str:
+        """Extract a normalized working directory from a command item."""
+        candidates = [item.get("cwd"), item.get("working_directory"), item.get("workdir")]
+        nested = item.get("input")
+        if isinstance(nested, dict):
+            candidates.extend([nested.get("cwd"), nested.get("working_directory")])
+        for value in candidates:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
 
-        Correlating on paths alone would let an ``add`` start pair with a
-        ``delete`` completion for the same path/id (round nine, blocker 1).
+    def _file_change_signature(self, item: dict[str, Any]) -> str:
+        """Fingerprint the complete stable change operation for each path.
+
+        Correlating on path alone (or path + a string kind) let an ``add``
+        start pair with a ``delete`` completion, and collapsed structured
+        kinds, diffs, and move destinations to identical signatures (rounds
+        nine & ten). Serializing the full normalized change captures the
+        mutation kind (any shape), patch content, and move destination.
         """
-        pairs: list[tuple[str, str]] = []
         changes = item.get("changes")
-        if isinstance(changes, list):
-            for change in changes:
-                if not isinstance(change, dict):
-                    continue
-                path = next(
-                    (
-                        str(change[key]).strip()
-                        for key in ("path", "file_path", "target_file")
-                        if isinstance(change.get(key), str) and change[key].strip()
-                    ),
-                    "",
-                )
-                kind = change.get("kind")
-                pairs.append((path, kind.strip() if isinstance(kind, str) else ""))
-        if not pairs:
-            item_kind = item.get("kind")
-            pairs = [
-                (path, item_kind.strip() if isinstance(item_kind, str) else "")
-                for path in self._extract_paths(item)
-            ]
-        return json.dumps(sorted(pairs), ensure_ascii=False)
+        if isinstance(changes, list) and changes:
+            normalized = [change for change in changes if isinstance(change, dict)]
+            if normalized:
+                return json.dumps(normalized, ensure_ascii=False, sort_keys=True, default=str)
+        item_kind = item.get("kind")
+        fallback = [{"path": path, "kind": item_kind} for path in self._extract_paths(item)]
+        return json.dumps(fallback, ensure_ascii=False, sort_keys=True, default=str)
 
     @staticmethod
     def _mcp_tool_name(item: dict[str, Any]) -> str:
@@ -1914,6 +1914,21 @@ class CodexCliRuntime:
         if isinstance(name, str) and name.strip():
             return name.strip()
         return "mcp_tool"
+
+    @staticmethod
+    def _extract_mcp_content_blocks(item: dict[str, Any]) -> list[dict[str, Any]]:
+        """Preserve supported MCP result content blocks and structured data."""
+        result = item.get("result")
+        if not isinstance(result, dict):
+            return []
+        blocks: list[dict[str, Any]] = []
+        content = result.get("content")
+        if isinstance(content, list):
+            blocks.extend(block for block in content if isinstance(block, dict))
+        structured = result.get("structured_content")
+        if isinstance(structured, (dict, list)) and structured:
+            blocks.append({"type": "structured", "structured": structured})
+        return blocks
 
     @staticmethod
     def _extract_mcp_result_text(item: dict[str, Any]) -> str:
@@ -1955,7 +1970,9 @@ class CodexCliRuntime:
     def _item_lifecycle_signature(self, item_type: str, item: dict[str, Any]) -> str:
         """Build a best-effort identity for id-less legacy thread items."""
         if item_type == "command_execution":
-            return self._extract_command(item)
+            cwd = self._extract_cwd(item)
+            command = self._extract_command(item)
+            return f"{command}\x00{cwd}" if cwd else command
         if item_type == "mcp_tool_call":
             tool_input = self._extract_tool_input(item)
             arguments = json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
@@ -1977,10 +1994,14 @@ class CodexCliRuntime:
             command = self._extract_command(item)
             if not command:
                 return []
+            tool_input: dict[str, Any] = {"command": command}
+            cwd = self._extract_cwd(item)
+            if cwd:
+                tool_input["cwd"] = cwd
             return [
                 _CodexToolCall(
                     tool_name="Bash",
-                    tool_input={"command": command},
+                    tool_input=tool_input,
                     start_content=f"Calling tool: Bash: {command}",
                     tool_call_id=item_id,
                 )
@@ -2173,8 +2194,9 @@ class CodexCliRuntime:
         if isinstance(exit_code, int) and not isinstance(exit_code, bool):
             tool_result_meta["exit_status"] = exit_code
 
+        content_blocks = metadata.get("__mcp_content_blocks__")
         tool_result: dict[str, Any] = {
-            "content": [],
+            "content": list(content_blocks) if isinstance(content_blocks, list) else [],
             "text_content": result_text,
             "meta": tool_result_meta,
         }
@@ -2184,7 +2206,9 @@ class CodexCliRuntime:
         # The completion verdict is carried exclusively by the tri-state
         # ``is_error`` — never forward a metadata-derived "success" subtype.
         extra_data: dict[str, Any] = {
-            key: value for key, value in metadata.items() if key != "subtype"
+            key: value
+            for key, value in metadata.items()
+            if key not in ("subtype", "__mcp_content_blocks__")
         }
         if is_error is None:
             status = extra_data.get("status")
@@ -2255,13 +2279,17 @@ class CodexCliRuntime:
         if not calls:
             return []
         metadata = self._extract_command_metadata(item)
-        if item_type == "mcp_tool_call" and not any(
-            isinstance(metadata.get(key), str) and metadata[key].strip()
-            for key in ("output", "stdout", "result_preview", "stderr")
-        ):
-            normalized = self._extract_mcp_result_text(item)
-            if normalized:
-                metadata["output"] = normalized
+        if item_type == "mcp_tool_call":
+            if not any(
+                isinstance(metadata.get(key), str) and metadata[key].strip()
+                for key in ("output", "stdout", "result_preview", "stderr")
+            ):
+                normalized = self._extract_mcp_result_text(item)
+                if normalized:
+                    metadata["output"] = normalized
+            content_blocks = self._extract_mcp_content_blocks(item)
+            if content_blocks:
+                metadata["__mcp_content_blocks__"] = content_blocks
         is_error = self._resolve_item_completion_is_error(item_type, item)
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -146,6 +146,11 @@ _TOOL_LIFECYCLE_ITEM_TYPES = frozenset(
     {"command_execution", "mcp_tool_call", "file_change", "web_search"}
 )
 _TOOL_STARTED_RUNTIME_EVENT_TYPE = "tool.started"
+_SENSITIVE_META_KEY_RE = re.compile(
+    r"(authorization|api[_-]?key|access[_-]?token|secret|password|passwd|credential|"
+    r"private[_-]?key|session[_-]?token|bearer|cookie)",
+    re.IGNORECASE,
+)
 _TOOL_RESULT_RUNTIME_EVENT_TYPE = "tool.result"
 # Containers that may hold nested command-result metadata on a thread item.
 # Shared by ``_extract_command_metadata`` and the fail-closed success resolver.
@@ -1884,7 +1889,9 @@ class CodexCliRuntime:
         candidates = [item.get("cwd"), item.get("working_directory"), item.get("workdir")]
         nested = item.get("input")
         if isinstance(nested, dict):
-            candidates.extend([nested.get("cwd"), nested.get("working_directory")])
+            candidates.extend(
+                [nested.get("cwd"), nested.get("working_directory"), nested.get("workdir")]
+            )
         for value in candidates:
             if isinstance(value, str) and value.strip():
                 return value.strip()
@@ -1939,13 +1946,38 @@ class CodexCliRuntime:
 
     @staticmethod
     def _extract_mcp_result_meta(item: dict[str, Any]) -> dict[str, Any]:
-        """Return an MCP result ``_meta`` mapping for audit transfer."""
+        """Return a redacted MCP result ``_meta`` mapping for audit transfer."""
         result = item.get("result")
         if isinstance(result, dict):
             meta = result.get("_meta")
             if isinstance(meta, dict) and meta:
-                return dict(meta)
+                redacted = CodexCliRuntime._redact_sensitive(meta)
+                return redacted if isinstance(redacted, dict) else {}
         return {}
+
+    @staticmethod
+    def _redact_sensitive(value: Any, _depth: int = 0) -> Any:
+        """Recursively redact secret-bearing keys before durable persistence.
+
+        Opaque MCP audit data is untrusted and may carry credentials
+        (``authorization``, ``api_key``, tokens); those must never reach the
+        journal (round fifteen, blocker 3). Depth is bounded to avoid
+        pathological nesting.
+        """
+        if _depth > 8:
+            return "[…]"
+        if isinstance(value, dict):
+            return {
+                key: (
+                    "[REDACTED]"
+                    if isinstance(key, str) and _SENSITIVE_META_KEY_RE.search(key)
+                    else CodexCliRuntime._redact_sensitive(item, _depth + 1)
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [CodexCliRuntime._redact_sensitive(item, _depth + 1) for item in value]
+        return value
 
     @staticmethod
     def _nested_error(item: dict[str, Any]) -> object:
@@ -2224,10 +2256,17 @@ class CodexCliRuntime:
                 if fail_key not in source:
                     continue
                 code = source.get(fail_key)
-                if isinstance(code, bool):
+                if isinstance(code, int) and not isinstance(code, bool):
+                    if code != 0:
+                        has_failure = True
+                elif code in (None, "", 0, False):
+                    # Cleanly absent/zero: no failure signal.
+                    continue
+                else:
+                    # A present but non-integer failure-code alias
+                    # ("500", "E_FAIL", True, ...) is untrustworthy and must
+                    # not let another field promote success (round fifteen).
                     has_malformed = True
-                elif isinstance(code, int) and code != 0:
-                    has_failure = True
 
             for error_flag_key in ("isError", "is_error"):
                 if error_flag_key not in source:
@@ -2296,7 +2335,9 @@ class CodexCliRuntime:
     ) -> AgentMessage:
         """Build the tool-start half of an item lifecycle pair."""
         extra_data: dict[str, Any] = {"runtime_event_type": _TOOL_STARTED_RUNTIME_EVENT_TYPE}
-        handle = self._neutralize_terminal_handle_event_type(handle)
+        handle = self._neutralize_terminal_handle_event_type(
+            handle, _TOOL_STARTED_RUNTIME_EVENT_TYPE
+        )
         if call.tool_call_id is not None:
             extra_data["tool_call_id"] = call.tool_call_id
         return self._build_tool_message(
@@ -2406,12 +2447,16 @@ class CodexCliRuntime:
     @staticmethod
     def _neutralize_terminal_handle_event_type(
         handle: RuntimeHandle | None,
+        neutral_event_type: str = _TOOL_RESULT_RUNTIME_EVENT_TYPE,
     ) -> RuntimeHandle | None:
         """Return a handle whose stale terminal runtime_event_type is cleared.
 
         Projection lets a resume handle's ``runtime_event_type`` override the
         message value, so a terminal ``run.completed``/``session.terminated``
-        would otherwise become the result's event type and forge success.
+        would otherwise become the message's event type and forge success. The
+        replacement matches the message half — ``tool.started`` for starts and
+        ``tool.result`` for results — so a resumed start is not stamped with a
+        result event type (round fifteen follow-up).
         """
         if handle is None:
             return None
@@ -2419,7 +2464,7 @@ class CodexCliRuntime:
         if not isinstance(stale, str) or not stale:
             return handle
         neutralized_metadata = dict(handle.metadata)
-        neutralized_metadata["runtime_event_type"] = _TOOL_RESULT_RUNTIME_EVENT_TYPE
+        neutralized_metadata["runtime_event_type"] = neutral_event_type
         return replace(handle, metadata=neutralized_metadata)
 
     def _convert_tool_item_started(
@@ -2487,7 +2532,11 @@ class CodexCliRuntime:
             # one fingerprint and be silently suppressed; serializing the whole
             # item captures every evidence-bearing field (rounds seven-nine).
             envelope_fingerprint = json.dumps(item, ensure_ascii=False, sort_keys=True, default=str)
-            dedup_key = f"{item_id}\x00{envelope_fingerprint}"
+            # Store a fixed-size digest, not the raw envelope: completion
+            # output can be multi-megabyte and would otherwise accumulate in
+            # the scope until the stream ends (round fifteen, blocker 4).
+            envelope_digest = hashlib.sha256(envelope_fingerprint.encode("utf-8")).hexdigest()
+            dedup_key = f"{item_id}\x00{envelope_digest}"
             if dedup_key in scope.completed_item_keys:
                 return []
             scope.completed_item_keys.add(dedup_key)

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1916,30 +1916,75 @@ class CodexCliRuntime:
         return "mcp_tool"
 
     @staticmethod
+    def _nested_error(item: dict[str, Any]) -> object:
+        """Return a nested ``result.error`` envelope when present."""
+        result = item.get("result")
+        return result.get("error") if isinstance(result, dict) else None
+
+    @staticmethod
     def _extract_mcp_content_blocks(item: dict[str, Any]) -> list[dict[str, Any]]:
-        """Preserve supported MCP result content blocks and structured data."""
+        """Normalize supported MCP result blocks to the shared projection contract.
+
+        The shared projection reads flat ``text``/``data``/``mime_type``/``uri``
+        fields, so Codex-native blocks (camelCase ``mimeType``, nested
+        ``resource``) are flattened here and structured content is serialized
+        into a carrier field that survives projection (round eleven).
+        """
         result = item.get("result")
         if not isinstance(result, dict):
             return []
         blocks: list[dict[str, Any]] = []
         content = result.get("content")
         if isinstance(content, list):
-            blocks.extend(block for block in content if isinstance(block, dict))
+            for raw in content:
+                if not isinstance(raw, dict):
+                    continue
+                block: dict[str, Any] = {"type": raw.get("type")}
+                text = raw.get("text")
+                if isinstance(text, str):
+                    block["text"] = text
+                if raw.get("data") is not None:
+                    block["data"] = raw.get("data")
+                mime = raw.get("mime_type") or raw.get("mimeType")
+                if isinstance(mime, str):
+                    block["mime_type"] = mime
+                resource = raw.get("resource")
+                if isinstance(resource, dict):
+                    uri = resource.get("uri")
+                    if isinstance(uri, str):
+                        block["uri"] = uri
+                    res_text = resource.get("text")
+                    if isinstance(res_text, str) and "text" not in block:
+                        block["text"] = res_text
+                    res_mime = resource.get("mime_type") or resource.get("mimeType")
+                    if isinstance(res_mime, str) and "mime_type" not in block:
+                        block["mime_type"] = res_mime
+                elif isinstance(raw.get("uri"), str):
+                    block["uri"] = raw["uri"]
+                blocks.append(block)
         structured = result.get("structured_content")
         if isinstance(structured, (dict, list)) and structured:
-            blocks.append({"type": "structured", "structured": structured})
+            # No structured payload field survives the flat projection, so ride
+            # the JSON in ``data`` (which the projection preserves) under a
+            # distinct block type.
+            blocks.append(
+                {
+                    "type": "structured",
+                    "data": json.dumps(structured, ensure_ascii=False, sort_keys=True),
+                }
+            )
         return blocks
 
     @staticmethod
     def _extract_mcp_result_text(item: dict[str, Any]) -> str:
         """Normalize MCP result/error envelopes into result text."""
-        error_envelope = item.get("error")
-        if isinstance(error_envelope, dict):
-            message = error_envelope.get("message")
-            if isinstance(message, str) and message.strip():
-                return message.strip()
-        if isinstance(error_envelope, str) and error_envelope.strip():
-            return error_envelope.strip()
+        for error_envelope in (item.get("error"), CodexCliRuntime._nested_error(item)):
+            if isinstance(error_envelope, dict):
+                message = error_envelope.get("message")
+                if isinstance(message, str) and message.strip():
+                    return message.strip()
+            if isinstance(error_envelope, str) and error_envelope.strip():
+                return error_envelope.strip()
         result = item.get("result")
         if isinstance(result, dict):
             content = result.get("content")
@@ -2027,7 +2072,11 @@ class CodexCliRuntime:
                     tool_name="Edit",
                     tool_input={"file_path": file_path},
                     start_content=f"Calling tool: Edit: {file_path}",
-                    tool_call_id=f"{item_id}:{file_path}" if item_id is not None else None,
+                    tool_call_id=(
+                        f"{item_id}:{file_path}"
+                        if item_id is not None
+                        else f"filechange:{file_path}"
+                    ),
                 )
                 for file_path in self._extract_paths(item)
             ]
@@ -2338,8 +2387,9 @@ class CodexCliRuntime:
 
         ``item_scope`` isolates start/result correlation per streamed process;
         the streaming loop passes a fresh scope per invocation. Direct callers
-        fall back to a per-instance scope, which is cleared on every
-        ``thread.started`` so a new thread never inherits stale item ids.
+        fall back to a per-instance scope, which is cleared on a
+        ``thread.started`` event only when the thread identity changes, so an
+        exact same-thread header replay does not orphan in-flight starts.
         """
         event_type = event.get("type")
         if not isinstance(event_type, str):

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -188,8 +188,9 @@ class _CodexItemCorrelationScope:
 
     Each streamed Codex process gets its own scope so parallel or sequential
     ACs sharing one adapter can never suppress another stream's synthetic
-    start with stale item ids. The scope is also cleared on ``thread.started``
-    so a new thread begins with a clean correlation space.
+    start with stale item ids. The scope is cleared on a ``thread.started``
+    event only when the thread identity actually changes, so an exact
+    same-thread header replay does not orphan in-flight starts.
     """
 
     started_item_signatures: dict[str, str] = field(default_factory=dict)
@@ -1870,6 +1871,36 @@ class CodexCliRuntime:
             return item_id.strip()
         return None
 
+    def _file_change_signature(self, item: dict[str, Any]) -> str:
+        """Pair each changed path with its mutation kind for stable identity.
+
+        Correlating on paths alone would let an ``add`` start pair with a
+        ``delete`` completion for the same path/id (round nine, blocker 1).
+        """
+        pairs: list[tuple[str, str]] = []
+        changes = item.get("changes")
+        if isinstance(changes, list):
+            for change in changes:
+                if not isinstance(change, dict):
+                    continue
+                path = next(
+                    (
+                        str(change[key]).strip()
+                        for key in ("path", "file_path", "target_file")
+                        if isinstance(change.get(key), str) and change[key].strip()
+                    ),
+                    "",
+                )
+                kind = change.get("kind")
+                pairs.append((path, kind.strip() if isinstance(kind, str) else ""))
+        if not pairs:
+            item_kind = item.get("kind")
+            pairs = [
+                (path, item_kind.strip() if isinstance(item_kind, str) else "")
+                for path in self._extract_paths(item)
+            ]
+        return json.dumps(sorted(pairs), ensure_ascii=False)
+
     @staticmethod
     def _mcp_tool_name(item: dict[str, Any]) -> str:
         """Resolve an MCP tool identity from native tool+server or legacy name."""
@@ -1930,7 +1961,7 @@ class CodexCliRuntime:
             arguments = json.dumps(tool_input, ensure_ascii=False, sort_keys=True, default=str)
             return f"{self._mcp_tool_name(item)}\x00{arguments}"
         if item_type == "file_change":
-            return "\n".join(self._extract_paths(item))
+            return self._file_change_signature(item)
         if item_type == "web_search":
             # The query is the only stable identity: volatile fields such as
             # status must not change the signature between started/completed,
@@ -2234,27 +2265,14 @@ class CodexCliRuntime:
         is_error = self._resolve_item_completion_is_error(item_type, item)
         item_id = self._item_lifecycle_id(item)
         if item_id is not None:
-            # Dedup on the id, input signature, verdict, AND every
-            # evidence-bearing completion field: an exact replay is
-            # suppressed, but any non-identical completion (a conflicting
-            # verdict, or the same verdict with different output) has a
-            # different fingerprint and stays visible so verification fails
-            # closed (review rounds seven & eight).
-            evidence_fields: dict[str, Any] = {
-                key: metadata.get(key)
-                for key in ("output", "stdout", "stderr", "result_preview", "exit_code", "status")
-            }
-            # The raw error envelope is evidence too: two malformed errors that
-            # produce no result text must not collapse to one fingerprint.
-            if "error" in item:
-                evidence_fields["error"] = item.get("error")
-            evidence_fingerprint = json.dumps(
-                evidence_fields, ensure_ascii=False, sort_keys=True, default=str
-            )
-            dedup_key = (
-                f"{item_id}\x00{self._item_lifecycle_signature(item_type, item)}"
-                f"\x00{is_error}\x00{evidence_fingerprint}"
-            )
+            # Dedup on the id plus the COMPLETE completion envelope so only
+            # a genuinely identical replay is dropped. Cherry-picked fields
+            # let distinct evidence (a changed web_search action, non-text MCP
+            # content, nested metadata, or a secondary exit alias) collapse to
+            # one fingerprint and be silently suppressed; serializing the whole
+            # item captures every evidence-bearing field (rounds seven-nine).
+            envelope_fingerprint = json.dumps(item, ensure_ascii=False, sort_keys=True, default=str)
+            dedup_key = f"{item_id}\x00{envelope_fingerprint}"
             if dedup_key in scope.completed_item_keys:
                 return []
             scope.completed_item_keys.add(dedup_key)

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1990,6 +1990,8 @@ class CodexCliRuntime:
                     block["uri"] = raw["uri"]
                 blocks.append(block)
         structured = result.get("structured_content")
+        if structured is None:
+            structured = result.get("structuredContent")
         if isinstance(structured, (dict, list)) and structured:
             # No structured payload field survives the flat projection, so ride
             # the JSON in ``data`` (which the projection preserves) under a
@@ -2025,6 +2027,8 @@ class CodexCliRuntime:
                 if joined:
                     return joined
             structured = result.get("structured_content")
+            if structured is None:
+                structured = result.get("structuredContent")
             if isinstance(structured, str) and structured.strip():
                 return structured.strip()
             if isinstance(structured, (dict, list)) and structured:
@@ -2193,6 +2197,14 @@ class CodexCliRuntime:
                         has_success = True
                     else:
                         has_failure = True
+
+            for error_flag_key in ("isError", "is_error"):
+                if error_flag_key in source:
+                    error_flag = source.get(error_flag_key)
+                    if error_flag is True:
+                        has_failure = True
+                    elif error_flag is False:
+                        has_success = True
 
             status = source.get("status")
             if isinstance(status, str):

--- a/src/ouroboros/orchestrator/copilot_cli_runtime.py
+++ b/src/ouroboros/orchestrator/copilot_cli_runtime.py
@@ -43,7 +43,11 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.orchestrator.codex_cli_runtime import (
+    CodexCliRuntime,
+    SkillDispatchHandler,
+    _CodexItemCorrelationScope,
+)
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.profiles import resolve_completion_profile
 
@@ -285,6 +289,8 @@ class CopilotCliRuntime(CodexCliRuntime):
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
         """Convert Copilot JSONL events into normalized runtime messages.
 

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -29,7 +29,11 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.orchestrator.codex_cli_runtime import (
+    CodexCliRuntime,
+    SkillDispatchHandler,
+    _CodexItemCorrelationScope,
+)
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
@@ -330,6 +334,8 @@ class GeminiCLIRuntime(CodexCliRuntime):
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
         """Convert a Gemini CLI event into normalized AgentMessage values.
 

--- a/src/ouroboros/orchestrator/goose_runtime.py
+++ b/src/ouroboros/orchestrator/goose_runtime.py
@@ -29,7 +29,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, _CodexItemCorrelationScope
 
 log = get_logger(__name__)
 
@@ -387,6 +387,8 @@ class GooseCliRuntime(CodexCliRuntime):
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
         """Convert Goose stream-json events into normalized messages."""
         event_type = self._extract_event_type(event)

--- a/src/ouroboros/orchestrator/grok_cli_runtime.py
+++ b/src/ouroboros/orchestrator/grok_cli_runtime.py
@@ -47,7 +47,11 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.orchestrator.codex_cli_runtime import (
+    CodexCliRuntime,
+    SkillDispatchHandler,
+    _CodexItemCorrelationScope,
+)
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
@@ -292,6 +296,8 @@ class GrokCliRuntime(CodexCliRuntime):
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
         """Convert a Grok ``streaming-json`` event into ``AgentMessage`` values.
 

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -40,7 +40,11 @@ from ouroboros.orchestrator.adapter import (
     RuntimeCapabilities,
     RuntimeHandle,
 )
-from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.orchestrator.codex_cli_runtime import (
+    CodexCliRuntime,
+    SkillDispatchHandler,
+    _CodexItemCorrelationScope,
+)
 from ouroboros.runtime.child_env import build_child_env
 from ouroboros.zcode_cli_launcher import (
     build_zcode_command_prefix,
@@ -477,6 +481,8 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
+        *,
+        item_scope: _CodexItemCorrelationScope | None = None,
     ) -> list[AgentMessage]:
         """Convert a zcode ``--prompt --json`` summary into AgentMessage values.
 

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -866,7 +866,7 @@ class TestCodexCliRuntime:
         assert message.resume_handle.metadata == seeded_handle.metadata
 
     def test_convert_command_execution_event(self) -> None:
-        """Converts command execution items to Bash tool messages."""
+        """Completed-only command items synthesize a Bash start+result pair."""
         runtime = CodexCliRuntime(cli_path="codex")
 
         messages = runtime._convert_event(
@@ -877,10 +877,14 @@ class TestCodexCliRuntime:
             current_handle=None,
         )
 
-        assert len(messages) == 1
-        message = messages[0]
-        assert message.tool_name == "Bash"
-        assert message.data["tool_input"]["command"] == "pytest -q"
+        assert len(messages) == 2
+        start, result = messages
+        assert start.tool_name == "Bash"
+        assert start.data["tool_input"]["command"] == "pytest -q"
+        assert start.data.get("subtype") is None
+        assert result.tool_name == "Bash"
+        assert result.data["tool_input"]["command"] == "pytest -q"
+        assert result.data["subtype"] == "tool_result"
 
     def test_convert_command_execution_preserves_output_metadata(self) -> None:
         """Command output must remain available for fat-harness verification."""
@@ -899,12 +903,13 @@ class TestCodexCliRuntime:
             current_handle=None,
         )
 
-        assert len(messages) == 1
-        message = messages[0]
-        assert message.tool_name == "Bash"
-        assert message.data["tool_input"]["command"] == "pytest"
-        assert message.data["output"] == "1 passed in 0.01s"
-        assert message.data["exit_code"] == 0
+        assert len(messages) == 2
+        result = messages[1]
+        assert result.tool_name == "Bash"
+        assert result.data["tool_input"]["command"] == "pytest"
+        assert result.data["output"] == "1 passed in 0.01s"
+        assert result.data["exit_code"] == 0
+        assert result.data["is_error"] is False
 
     def test_convert_command_execution_preserves_aggregated_output_metadata(self) -> None:
         """Current Codex JSONL aggregated output remains available to the verifier."""
@@ -924,11 +929,12 @@ class TestCodexCliRuntime:
             current_handle=None,
         )
 
-        assert len(messages) == 1
-        message = messages[0]
-        assert message.data["output"] == ". [100%]\n1 passed in 0.01s"
-        assert message.data["exit_code"] == 0
-        assert message.data["status"] == "completed"
+        assert len(messages) == 2
+        result = messages[1]
+        assert result.data["output"] == ". [100%]\n1 passed in 0.01s"
+        assert result.data["exit_code"] == 0
+        assert result.data["status"] == "completed"
+        assert result.data["is_error"] is False
 
     def test_convert_command_execution_preserves_nested_output_metadata(self) -> None:
         """Codex command result fields may arrive under nested output/result objects."""
@@ -950,19 +956,22 @@ class TestCodexCliRuntime:
             current_handle=None,
         )
 
-        assert len(messages) == 1
-        message = messages[0]
-        assert message.tool_name == "Bash"
-        assert message.data["tool_input"]["command"] == (
+        assert len(messages) == 2
+        result = messages[1]
+        assert result.tool_name == "Bash"
+        assert result.data["tool_input"]["command"] == (
             "/bin/zsh -lc 'python -m pytest test_hello.py'"
         )
-        assert message.data["stdout"] == "1 passed in 0.01s"
-        assert message.data["exit_code"] == 0
-        assert message.data["status"] == "completed"
-        assert message.data["subtype"] == "success"
+        assert result.data["stdout"] == "1 passed in 0.01s"
+        assert result.data["exit_code"] == 0
+        assert result.data["status"] == "completed"
+        # The explicit success signal is carried by the tri-state is_error
+        # instead of a "success" subtype (fail-closed, #1692 blocker 1).
+        assert result.data["subtype"] == "tool_result"
+        assert result.data["is_error"] is False
 
     def test_convert_file_change_event_emits_each_changed_file(self) -> None:
-        """Multi-file Codex changes should create one proof message per path."""
+        """Multi-file Codex changes should create one start+result pair per path."""
         runtime = CodexCliRuntime(cli_path="codex")
 
         messages = runtime._convert_event(
@@ -979,13 +988,23 @@ class TestCodexCliRuntime:
             current_handle=None,
         )
 
-        assert [message.tool_name for message in messages] == ["Edit", "Edit"]
+        assert [message.tool_name for message in messages] == ["Edit"] * 4
         assert [message.data["tool_input"]["file_path"] for message in messages] == [
             "/tmp/project/hello.py",
+            "/tmp/project/hello.py",
+            "/tmp/project/test_hello.py",
             "/tmp/project/test_hello.py",
         ]
-        assert all(message.data["subtype"] == "success" for message in messages)
-        assert all(message.data["runtime_event_type"] == "tool.completed" for message in messages)
+        results = [message for message in messages if message.data.get("subtype") == "tool_result"]
+        assert len(results) == 2
+        # A completion without an explicit status must never be stamped
+        # success (fail-closed, #1692 blocker 1): no success subtype, no
+        # is_error verdict, no hardcoded tool.completed lifecycle stamp.
+        assert all(message.data.get("subtype") != "success" for message in messages)
+        assert all("is_error" not in message.data for message in results)
+        assert all(
+            message.data.get("runtime_event_type") != "tool.completed" for message in messages
+        )
 
     def test_convert_turn_completed_with_usage_emits_system_usage_message(self) -> None:
         """turn.completed with token usage surfaces a non-final system message."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -379,6 +379,120 @@ class TestCodexCompletionReviewRoundOne:
         )
         assert completion_messages[0].data.get("subtype") == "tool_result"
 
+    def test_keyed_web_search_lifecycle_pairs_without_duplicate_start(self) -> None:
+        """A keyed web_search start/completed pair correlates by id, no duplicate."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        start_messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "w1",
+                    "type": "web_search",
+                    "query": "ouroboros seed contract",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+        completion_messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "w1",
+                    "type": "web_search",
+                    "query": "ouroboros seed contract",
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(start_messages) == 1
+        assert start_messages[0].data.get("tool_call_id") == "w1"
+        assert (start_messages[0].data.get("tool_input") or {}).get("query") == (
+            "ouroboros seed contract"
+        )
+        assert len(completion_messages) == 1
+        assert completion_messages[0].data.get("subtype") == "tool_result"
+        assert completion_messages[0].data.get("tool_call_id") == "w1"
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            "canceled",
+            "aborted",
+            "interrupted",
+            "killed",
+            "timeout",
+            "timed_out",
+            "Cancelled ",
+            "TIMED_OUT",
+        ],
+    )
+    def test_every_non_success_terminal_status_is_error(self, status: str) -> None:
+        """All non-success terminal statuses resolve to failure, however cased."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.completed",
+            "item": {
+                "id": "item_ts",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": status,
+            },
+        }
+
+        messages = runtime._convert_event(event, current_handle=None)
+
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True, status
+
+    def test_nested_and_conflicting_exit_aliases_resolve_consistently(self) -> None:
+        """Nested alias placement and alias conflicts keep verdict and metadata aligned."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        nested = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_na",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "result": {"returncode": 1},
+                },
+            },
+            current_handle=None,
+        )
+        nested_results = [m for m in nested if m.data.get("subtype") == "tool_result"]
+        assert len(nested_results) == 1
+        assert nested_results[0].data.get("is_error") is True
+        tool_result = nested_results[0].data.get("tool_result") or {}
+        assert (tool_result.get("meta") or {}).get("exit_status") == 1, (
+            "verdict and journaled exit_status must not contradict"
+        )
+
+        conflicting = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_cf",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "exit_code": 0,
+                    "returncode": 1,
+                },
+            },
+            current_handle=None,
+        )
+        conflict_results = [m for m in conflicting if m.data.get("subtype") == "tool_result"]
+        assert len(conflict_results) == 1
+        assert conflict_results[0].data.get("is_error") is True, (
+            "failure precedence must win over a conflicting success alias"
+        )
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -492,6 +492,62 @@ class TestCodexCompletionReviewRoundOne:
         assert conflict_results[0].data.get("is_error") is True, (
             "failure precedence must win over a conflicting success alias"
         )
+        conflict_meta = (conflict_results[0].data.get("tool_result") or {}).get("meta") or {}
+        assert conflict_meta.get("exit_status") == 1, (
+            "persisted exit_status must carry the failing code, not the stale zero alias"
+        )
+
+    def test_replayed_keyed_completion_is_suppressed(self) -> None:
+        """Replaying one keyed item.completed must not emit a second pair."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        first = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+        replay = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(first) == 2, "completed-only must synthesize exactly one start+result pair"
+        assert replay == [], (
+            "a replayed keyed completion emitted duplicate lifecycle messages; "
+            "downstream exact correlation would see two starts sharing the id"
+        )
+
+    def test_replayed_completion_after_real_lifecycle_is_suppressed(self) -> None:
+        """A duplicate completion after a real started/completed pair emits nothing."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+        runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        replay = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert replay == []
+
+    def test_declined_status_is_error_even_with_stale_nested_completed(self) -> None:
+        """Codex's declined terminal status must resolve to failure with precedence."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for item in (
+            {
+                "id": "item_d1",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "declined",
+            },
+            {
+                "id": "item_d2",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "declined",
+                "result": {"status": "completed"},
+            },
+        ):
+            messages = runtime._convert_event(
+                {"type": "item.completed", "item": item}, current_handle=None
+            )
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert len(results) == 1, item["id"]
+            assert results[0].data.get("is_error") is True, item["id"]
+            assert (
+                _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+                is False
+            ), item["id"]
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -693,6 +693,146 @@ class TestCodexCompletionReviewRoundOne:
         assert len(completion) == 1
         assert completion[0].data.get("subtype") == "tool_result"
 
+    def test_conflicting_same_id_completion_remains_visible(self) -> None:
+        """A conflicting terminal envelope must not vanish behind dedup."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        base = {
+            "id": "item_cf2",
+            "type": "command_execution",
+            "command": "pytest -q",
+            "status": "completed",
+        }
+
+        first = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "exit_code": 0}}, current_handle=None
+        )
+        conflicting = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "exit_code": 1}}, current_handle=None
+        )
+        identical_replay = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "exit_code": 1}}, current_handle=None
+        )
+
+        assert len(first) == 2
+        conflict_results = [m for m in conflicting if m.data.get("subtype") == "tool_result"]
+        assert len(conflict_results) == 1, (
+            "a conflicting failed completion was silently dropped by id-only dedup"
+        )
+        assert conflict_results[0].data.get("is_error") is True
+        assert identical_replay == [], "a semantically identical replay must stay suppressed"
+
+    def test_keyed_completion_with_mismatched_signature_does_not_pair(self) -> None:
+        """A same-id completion for a different command must not inherit the start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_sig",
+                    "type": "command_execution",
+                    "command": "pytest tests/test_a.py",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_sig",
+                    "type": "command_execution",
+                    "command": "printf '1 passed'",
+                    "exit_code": 0,
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2, (
+            "a signature-mismatched completion paired with the pytest start and "
+            "would be accepted as successful test evidence"
+        )
+
+    def test_same_thread_header_replay_preserves_correlation(self) -> None:
+        """Replaying the current thread header must not wipe correlation state."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        header = {"type": "thread.started", "thread_id": "t1"}
+
+        runtime._convert_event(header, current_handle=None)
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+        runtime._convert_event(header, current_handle=None)
+        completion = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(completion) == 1, (
+            "the same-thread header replay cleared correlation and a duplicate "
+            "start was synthesized"
+        )
+        assert completion[0].data.get("subtype") == "tool_result"
+
+    def test_native_mcp_tool_identity_is_preserved(self) -> None:
+        """Native tool+server MCP items must not journal as generic mcp_tool."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_native",
+                    "type": "mcp_tool_call",
+                    "tool": "write",
+                    "server": "filesystem",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        assert messages[0].tool_name == "filesystem.write"
+
+    def test_reported_status_is_persisted_in_result_meta(self) -> None:
+        """The audit trail keeps the raw status inside the journaled result meta."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_rs",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "exit_code": "1",
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        meta = (results[0].data.get("tool_result") or {}).get("meta") or {}
+        assert meta.get("reported_status") == "completed"
+
+    def test_structured_content_mapping_is_serialized(self) -> None:
+        """Mapping structured_content must reach the result text as JSON."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_sc",
+                    "type": "mcp_tool_call",
+                    "name": "calculator.add",
+                    "status": "completed",
+                    "result": {"content": [], "structured_content": {"answer": 42}},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert "42" in ((results[0].data.get("tool_result") or {}).get("text_content") or "")
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -549,6 +549,58 @@ class TestCodexCompletionReviewRoundOne:
                 is False
             ), item["id"]
 
+    def test_command_completed_status_alone_never_claims_success(self) -> None:
+        """command_execution success requires a validated zero exit, not lifecycle status."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for item_id, extra in (
+            ("item_nc1", {}),  # no exit code at all
+            ("item_nc2", {"exit_code": "1"}),  # malformed exit alongside completed
+        ):
+            item = {
+                "id": item_id,
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "completed",
+                "aggregated_output": ". [100%]\n1 passed in 0.01s\n",
+                **extra,
+            }
+            messages = runtime._convert_event(
+                {"type": "item.completed", "item": item}, current_handle=None
+            )
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert len(results) == 1, item_id
+            assert results[0].data.get("is_error") is not False, (
+                f"{item_id}: lifecycle completion alone must not claim command success"
+            )
+            assert (
+                _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+                is False
+            ), item_id
+
+    def test_consecutive_idless_completions_each_pair_without_orphans(self) -> None:
+        """Identical id-less completed-only items must each emit a full pair."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.completed",
+            "item": {
+                "type": "command_execution",
+                "command": "pytest -q",
+                "exit_code": 0,
+                "status": "completed",
+            },
+        }
+
+        shapes = []
+        for _ in range(3):
+            messages = runtime._convert_event(event, current_handle=None)
+            shapes.append([m.data.get("subtype") or "start" for m in messages])
+
+        assert shapes == [
+            ["start", "tool_result"],
+            ["start", "tool_result"],
+            ["start", "tool_result"],
+        ], f"id-less completed-only lifecycles must never emit orphan results: {shapes}"
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -833,6 +833,105 @@ class TestCodexCompletionReviewRoundOne:
         assert len(results) == 1
         assert "42" in ((results[0].data.get("tool_result") or {}).get("text_content") or "")
 
+    def test_mcp_argument_mismatch_does_not_pair(self) -> None:
+        """A same-id MCP completion with different arguments must not inherit the start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_mcparg",
+                    "type": "mcp_tool_call",
+                    "tool": "write",
+                    "server": "filesystem",
+                    "arguments": {"path": "a"},
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_mcparg",
+                    "type": "mcp_tool_call",
+                    "tool": "write",
+                    "server": "filesystem",
+                    "arguments": {"path": "b"},
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2, (
+            "an MCP completion with mismatched arguments paired with the start "
+            "and would be accepted as its evidence"
+        )
+
+    def test_same_verdict_completions_with_different_output_stay_visible(self) -> None:
+        """Non-identical evidence with the same verdict must not be dropped as a replay."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        base = {
+            "id": "item_out",
+            "type": "command_execution",
+            "command": "pytest -q",
+            "exit_code": 0,
+            "status": "completed",
+        }
+
+        first = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "aggregated_output": "1 passed"}},
+            current_handle=None,
+        )
+        second = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "aggregated_output": "1 failed"}},
+            current_handle=None,
+        )
+        identical = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "aggregated_output": "1 failed"}},
+            current_handle=None,
+        )
+
+        assert len(first) == 2
+        second_results = [m for m in second if m.data.get("subtype") == "tool_result"]
+        assert len(second_results) == 1, (
+            "a same-verdict completion with different output was dropped as an exact replay"
+        )
+        assert "1 failed" in (
+            (second_results[0].data.get("tool_result") or {}).get("text_content") or ""
+        )
+        assert identical == [], "a genuinely identical replay must stay suppressed"
+
+    def test_malformed_error_envelope_never_claims_success(self) -> None:
+        """A present but malformed non-null error envelope must fail closed."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for bad_error in (7, ["boom"], {"code": 500}):
+            messages = runtime._convert_event(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "item_be",
+                        "type": "mcp_tool_call",
+                        "name": "filesystem.write",
+                        "status": "completed",
+                        "error": bad_error,
+                    },
+                },
+                current_handle=None,
+            )
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert len(results) == 1, repr(bad_error)
+            assert results[0].data.get("is_error") is not False, (
+                f"a malformed error envelope {bad_error!r} was read as success"
+            )
+            assert (
+                _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+                is False
+            ), repr(bad_error)
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -24,6 +24,7 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.harness.deliver_gate import _event_has_explicit_tool_success
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.evidence.claims import _runtime_message_has_success_signal
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.runtime_message_projection import project_runtime_message
 
@@ -600,6 +601,81 @@ class TestCodexCompletionReviewRoundOne:
             ["start", "tool_result"],
             ["start", "tool_result"],
         ], f"id-less completed-only lifecycles must never emit orphan results: {shapes}"
+
+    def test_unknown_command_verdict_never_reads_as_success_signal(self) -> None:
+        """Every consumer must honor the tri-state verdict, not raw status."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_uv",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "exit_code": "1",
+                    "aggregated_output": ". [100%]\n1 passed in 0.01s\n",
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert _runtime_message_has_success_signal(results[0]) is False, (
+            "the in-memory verifier read an unvalidated completed status as success"
+        )
+        assert results[0].data.get("status") is None, (
+            "an unknown verdict must not forward a bare success-implying status"
+        )
+        assert results[0].data.get("reported_status") == "completed"
+
+    def test_mcp_error_envelope_is_failure_with_reason(self) -> None:
+        """An MCP error envelope wins over a completed status and keeps the reason."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_mcp1",
+                    "type": "mcp_tool_call",
+                    "name": "filesystem.write",
+                    "status": "completed",
+                    "error": {"message": "permission denied"},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+        tool_result = results[0].data.get("tool_result") or {}
+        assert "permission denied" in (tool_result.get("text_content") or "")
+
+    def test_mcp_result_content_is_extracted_on_success(self) -> None:
+        """A successful MCP result's content blocks become the result text."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_mcp2",
+                    "type": "mcp_tool_call",
+                    "name": "calculator.add",
+                    "status": "completed",
+                    "result": {"content": [{"type": "text", "text": "42"}]},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is False
+        tool_result = results[0].data.get("tool_result") or {}
+        assert "42" in (tool_result.get("text_content") or "")
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -677,6 +677,22 @@ class TestCodexCompletionReviewRoundOne:
         tool_result = results[0].data.get("tool_result") or {}
         assert "42" in (tool_result.get("text_content") or "")
 
+    def test_replayed_keyed_start_is_suppressed(self) -> None:
+        """start -> replayed start -> completion must yield exactly one pair."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        first = runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+        replay = runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+        completion = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(first) == 1
+        assert replay == [], (
+            "a replayed keyed item.started emitted a duplicate start; exact "
+            "correlation requires one matching start per id"
+        )
+        assert len(completion) == 1
+        assert completion[0].data.get("subtype") == "tool_result"
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -302,7 +302,82 @@ class TestCodexCompletionReviewRoundOne:
         assert results[0].data.get("is_error") is True, (
             "a cancelled item must never be laundered into success by stale nested metadata"
         )
-        assert _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0])) is False
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_returncode_alias_nonzero_is_error(self) -> None:
+        """Every accepted exit-code alias must feed the failure verdict."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for alias in ("exit_code", "exitCode", "returncode", "return_code"):
+            event = {
+                "type": "item.completed",
+                "item": {
+                    "id": f"item_{alias}",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    alias: 1,
+                },
+            }
+
+            messages = runtime._convert_event(event, current_handle=None)
+
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert len(results) == 1, alias
+            assert results[0].data.get("is_error") is True, (
+                f"non-zero {alias} must override the completed status"
+            )
+
+    def test_web_search_start_records_exactly_the_query(self) -> None:
+        """web_search tool input must carry item['query'], not the whole item."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.started",
+            "item": {
+                "id": "item_ws",
+                "type": "web_search",
+                "query": "ouroboros seed contract",
+                "status": "in_progress",
+            },
+        }
+
+        messages = runtime._convert_event(event, current_handle=None)
+
+        assert len(messages) == 1
+        tool_input = messages[0].data.get("tool_input") or {}
+        assert tool_input.get("query") == "ouroboros seed contract"
+
+    def test_idless_web_search_lifecycle_pairs_without_duplicate_start(self) -> None:
+        """Status changes must not alter the id-less correlation signature."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        started = {
+            "type": "item.started",
+            "item": {
+                "type": "web_search",
+                "query": "ouroboros seed contract",
+                "status": "in_progress",
+            },
+        }
+        completed = {
+            "type": "item.completed",
+            "item": {
+                "type": "web_search",
+                "query": "ouroboros seed contract",
+                "status": "completed",
+            },
+        }
+
+        start_messages = runtime._convert_event(started, current_handle=None)
+        completion_messages = runtime._convert_event(completed, current_handle=None)
+
+        assert len(start_messages) == 1
+        assert len(completion_messages) == 1, (
+            "an id-less completion whose signature drifted with status "
+            "synthesized a duplicate start"
+        )
+        assert completion_messages[0].data.get("subtype") == "tool_result"
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -252,6 +252,57 @@ class TestCodexItemLifecycleConversion:
         assert _event_has_explicit_tool_success(_as_journaled_tool_completed_event(result))
 
 
+class TestCodexCompletionReviewRoundOne:
+    """Regressions for the first bot review on the contract PR."""
+
+    def test_nested_failure_wins_over_outer_completed_status(self) -> None:
+        """Failure precedence: a nested failed status must never become success."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.completed",
+            "item": {
+                "id": "item_5",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "completed",
+                "result": {"status": "failed", "output": "1 failed"},
+            },
+        }
+
+        messages = runtime._convert_event(event, current_handle=None)
+
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True, (
+            "outer status=completed must not shadow the nested result.status=failed"
+        )
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_new_thread_resets_item_correlation_state(self) -> None:
+        """A new thread's completed-only item must synthesize its own start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        thread_started = {"type": "thread.started", "thread_id": "t1"}
+
+        # Stream A: full lifecycle for item_0.
+        runtime._convert_event(thread_started, current_handle=None)
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+        runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        # Stream B on the same adapter: completed-only reuse of the same item id.
+        runtime._convert_event({"type": "thread.started", "thread_id": "t2"}, current_handle=None)
+        messages = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(messages) == 2, (
+            "stale correlation state from the previous thread suppressed the "
+            "synthetic start for the new thread's completed-only item"
+        )
+        assert messages[0].data.get("tool_call_id") == "item_0"
+        assert messages[1].data.get("subtype") == "tool_result"
+
+
 class TestCodexCompletionJournaling:
     """Issue #1724 — completions must reach the execution.tool.completed journal."""
 

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -281,6 +281,29 @@ class TestCodexCompletionReviewRoundOne:
             is False
         )
 
+    def test_cancelled_item_with_stale_nested_completed_is_never_success(self) -> None:
+        """Cancellation must win over a stale nested completed status."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.completed",
+            "item": {
+                "id": "item_6",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "cancelled",
+                "result": {"status": "completed", "output": "partial"},
+            },
+        }
+
+        messages = runtime._convert_event(event, current_handle=None)
+
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True, (
+            "a cancelled item must never be laundered into success by stale nested metadata"
+        )
+        assert _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0])) is False
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1,0 +1,336 @@
+"""Regression tests for Codex CLI item completion evidence (issues #1690 / #1724).
+
+Issue #1690: Codex CLI JSONL ``item.started`` / ``item.completed`` events are not
+projected as a correlated tool start and tool result pair.
+
+Issue #1724: Codex tool completions are never journaled as
+``execution.tool.completed`` evidence, so the fat-harness verifier sees only
+tool starts and rejects truthful claims as FABRICATION_SUSPECTED.
+
+Payload shapes follow the Codex CLI JSONL thread-item contract used by the
+existing conversion tests, extended with the item ``id`` field described in the
+issue #1690 reproduction steps.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.deliver_gate import _event_has_explicit_tool_success
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.runtime_message_projection import project_runtime_message
+
+
+def _as_journaled_tool_completed_event(message: AgentMessage) -> BaseEvent:
+    """Mirror how the leaf dispatcher journals a tool result message."""
+    projected = project_runtime_message(message)
+    return BaseEvent(
+        type="execution.tool.completed",
+        aggregate_type="execution",
+        aggregate_id="exec_evidence",
+        data={
+            "tool_name": projected.tool_name,
+            "tool_result_text": projected.content,
+            **projected.runtime_metadata,
+        },
+    )
+
+
+_COMMAND_ITEM_STARTED = {
+    "type": "item.started",
+    "item": {
+        "id": "item_0",
+        "type": "command_execution",
+        "command": "pytest -q",
+        "status": "in_progress",
+    },
+}
+
+_COMMAND_ITEM_COMPLETED = {
+    "type": "item.completed",
+    "item": {
+        "id": "item_0",
+        "type": "command_execution",
+        "command": "pytest -q",
+        "aggregated_output": ". [100%]\n1 passed in 0.01s\n",
+        "exit_code": 0,
+        "status": "completed",
+    },
+}
+
+
+class TestCodexItemLifecycleConversion:
+    """Issue #1690 — item.started/item.completed must form a correlated pair."""
+
+    def test_item_started_command_execution_produces_correlated_tool_start(self) -> None:
+        """item.started(command_execution) must project a tool start, not vanish."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+
+        assert len(messages) == 1
+        projected = project_runtime_message(messages[0])
+        assert projected.is_tool_call
+        assert projected.tool_name == "Bash"
+        assert projected.runtime_metadata.get("tool_call_id") == "item_0"
+
+    def test_item_completed_after_started_projects_single_correlated_tool_result(self) -> None:
+        """item.completed after item.started must project a tool result, not a second start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+
+        messages = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(messages) == 1
+        projected = project_runtime_message(messages[0])
+        assert projected.message_type == "tool_result"
+        assert projected.tool_name == "Bash"
+        assert projected.runtime_metadata.get("tool_call_id") == "item_0"
+
+    def test_item_completed_without_started_synthesizes_correlated_start_result_pair(
+        self,
+    ) -> None:
+        """Completed-only legacy streams must yield a start+result pair (#1692 blocker 2)."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(messages) == 2
+        start, result = (project_runtime_message(message) for message in messages)
+        assert start.is_tool_call
+        assert start.tool_name == "Bash"
+        assert start.runtime_metadata.get("tool_call_id") == "item_0"
+        assert result.message_type == "tool_result"
+        assert result.tool_name == "Bash"
+        assert result.runtime_metadata.get("tool_call_id") == "item_0"
+
+    def test_failed_file_change_completion_is_not_stamped_success(self) -> None:
+        """A failed file_change must not be converted into success evidence."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_2",
+                    "type": "file_change",
+                    "status": "failed",
+                    "changes": [{"path": "src/app.py", "kind": "update"}],
+                },
+            },
+            current_handle=None,
+        )
+
+        assert messages
+        assert all(message.data.get("subtype") != "success" for message in messages)
+        result_messages = [
+            message for message in messages if message.data.get("subtype") == "tool_result"
+        ]
+        assert result_messages, "failed file_change produced no tool result message"
+        assert all(message.data.get("is_error") is True for message in result_messages)
+        assert all(
+            not _event_has_explicit_tool_success(_as_journaled_tool_completed_event(message))
+            for message in result_messages
+        )
+
+    def test_multi_file_change_completion_emits_per_path_correlation_ids(self) -> None:
+        """Each changed path must carry its own "{item_id}:{path}" correlation id."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "item_9",
+                    "type": "file_change",
+                    "status": "in_progress",
+                    "changes": [
+                        {"path": "src/app.py", "kind": "update"},
+                        {"path": "tests/test_app.py", "kind": "add"},
+                    ],
+                },
+            },
+            current_handle=None,
+        )
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_9",
+                    "type": "file_change",
+                    "status": "completed",
+                    "changes": [
+                        {"path": "src/app.py", "kind": "update"},
+                        {"path": "tests/test_app.py", "kind": "add"},
+                    ],
+                },
+            },
+            current_handle=None,
+        )
+
+        projections = [project_runtime_message(message) for message in messages]
+        assert [projection.message_type for projection in projections] == [
+            "tool_result",
+            "tool_result",
+        ]
+        assert [projection.runtime_metadata.get("tool_call_id") for projection in projections] == [
+            "item_9:src/app.py",
+            "item_9:tests/test_app.py",
+        ]
+        assert all(
+            projection.runtime_metadata.get("is_error") is False for projection in projections
+        )
+
+    def test_nonzero_exit_completion_is_error_and_never_success_evidence(self) -> None:
+        """A non-zero exit code must mark the result as an error, never success."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_0",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "aggregated_output": "1 failed in 0.01s\n",
+                    "exit_code": 1,
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        result = messages[0]
+        assert result.data.get("subtype") == "tool_result"
+        assert result.data.get("is_error") is True
+        assert not _event_has_explicit_tool_success(_as_journaled_tool_completed_event(result))
+
+    def test_malformed_completion_metadata_fails_closed_without_success_claim(self) -> None:
+        """Unknown/malformed completion metadata must never become success evidence."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_0",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": "0",  # malformed: string, not int
+                    "status": 7,  # malformed: not a status string
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        result = messages[0]
+        assert result.data.get("subtype") == "tool_result"
+        assert "is_error" not in result.data
+        assert not _event_has_explicit_tool_success(_as_journaled_tool_completed_event(result))
+
+    def test_exit_zero_completion_is_explicit_success_evidence(self) -> None:
+        """An explicit exit-0 completion must satisfy the deliver-gate success check."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(_COMMAND_ITEM_STARTED, current_handle=None)
+
+        messages = runtime._convert_event(_COMMAND_ITEM_COMPLETED, current_handle=None)
+
+        assert len(messages) == 1
+        result = messages[0]
+        assert result.data.get("is_error") is False
+        assert _event_has_explicit_tool_success(_as_journaled_tool_completed_event(result))
+
+
+class TestCodexCompletionJournaling:
+    """Issue #1724 — completions must reach the execution.tool.completed journal."""
+
+    @pytest.mark.asyncio
+    async def test_codex_command_completion_is_journaled_as_execution_tool_completed(
+        self,
+    ) -> None:
+        """A successful Codex command lifecycle must persist completed-tool evidence."""
+        conversion_runtime = CodexCliRuntime(cli_path="codex")
+        codex_events: list[dict[str, Any]] = [
+            {"type": "thread.started", "thread_id": "thread-evidence-1"},
+            _COMMAND_ITEM_STARTED,
+            _COMMAND_ITEM_COMPLETED,
+        ]
+
+        class StubCodexRuntime:
+            _runtime_handle_backend = "codex_cli"
+            _cwd = "/tmp/project"
+            _permission_mode = "bypassPermissions"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(self, **kwargs: Any):
+                handle = None
+                for event in codex_events:
+                    for message in conversion_runtime._convert_event(event, current_handle=handle):
+                        if message.resume_handle is not None:
+                            handle = message.resume_handle
+                        yield message
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                )
+
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=StubCodexRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Run the test suite via the Codex CLI runtime",
+            session_id="sess_codex_evidence",
+            tools=["Bash"],
+            system_prompt="test",
+            seed_goal="Journal Codex completions",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        appended_events = [call.args[0] for call in event_store.append.await_args_list]
+        started_events = [
+            event for event in appended_events if event.type == "execution.tool.started"
+        ]
+        completed_events = [
+            event for event in appended_events if event.type == "execution.tool.completed"
+        ]
+
+        assert started_events, "Codex command lifecycle produced no tool-start journal event"
+        assert completed_events, (
+            "Codex item.completed(command_execution) with exit_code 0 produced no "
+            "execution.tool.completed journal event — the deliver gate cannot "
+            "prove the command succeeded (issue #1724)"
+        )
+        assert len(started_events) == 1, "the synthesized pair must not duplicate the start"
+        assert started_events[0].data.get("tool_call_id") == "item_0"
+        assert completed_events[0].data.get("tool_call_id") == "item_0"
+        assert _event_has_explicit_tool_success(completed_events[0])

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1246,8 +1246,7 @@ class TestCodexCompletionReviewRoundOne:
 
         assert None not in ids(first) and None not in ids(second)
         assert len(first) == 2 and len(second) == 2
-        # A start and its result share one id within an invocation...
-        assert ids(first) == ids(second) if False else True
+        # A start and its result share one id within an invocation.
         assert len(ids(first)) == 1 and len(ids(second)) == 1
         # ...but the two invocations must be distinct so exact correlation
         # never sees two starts sharing one id.
@@ -1342,6 +1341,53 @@ class TestCodexCompletionReviewRoundOne:
         assert (tool_result.get("meta") or {}).get("trace_id") == "t-123", (
             "result _meta was dropped"
         )
+
+    def test_mcp_iserror_wire_field_fails_closed(self) -> None:
+        """The canonical MCP result.isError flag must win over a completed status."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "iserr",
+                    "type": "mcp_tool_call",
+                    "name": "fs.write",
+                    "status": "completed",
+                    "result": {"isError": True, "content": [{"type": "text", "text": "nope"}]},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_mcp_camelcase_structured_content_survives_projection(self) -> None:
+        """The canonical structuredContent wire field must be preserved."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "sc",
+                    "type": "mcp_tool_call",
+                    "name": "calc.add",
+                    "status": "completed",
+                    "result": {"content": [], "structuredContent": {"answer": 99}},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        projected = project_runtime_message(results[0])
+        blocks = (projected.tool_result or {}).get("content") or []
+        structured = next((b for b in blocks if b.get("type") == "structured"), {})
+        assert "99" in json.dumps(structured), "canonical structuredContent was discarded"
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1226,6 +1226,123 @@ class TestCodexCompletionReviewRoundOne:
             "the nested error reason was dropped, leaving the journaled failure blank"
         )
 
+    def test_consecutive_idless_same_path_edits_get_unique_ids(self) -> None:
+        """Two id-less completed-only edits of one path must not share a correlation id."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        event = {
+            "type": "item.completed",
+            "item": {
+                "type": "file_change",
+                "status": "completed",
+                "changes": [{"path": "a.py", "kind": "update"}],
+            },
+        }
+
+        first = runtime._convert_event(event, current_handle=None)
+        second = runtime._convert_event(event, current_handle=None)
+
+        def ids(msgs):
+            return {m.data.get("tool_call_id") for m in msgs}
+
+        assert None not in ids(first) and None not in ids(second)
+        assert len(first) == 2 and len(second) == 2
+        # A start and its result share one id within an invocation...
+        assert ids(first) == ids(second) if False else True
+        assert len(ids(first)) == 1 and len(ids(second)) == 1
+        # ...but the two invocations must be distinct so exact correlation
+        # never sees two starts sharing one id.
+        assert ids(first).isdisjoint(ids(second)), (
+            "two id-less edits of the same path shared a correlation id"
+        )
+
+    def test_idless_pair_start_and_result_share_one_id(self) -> None:
+        """An id-less start then completion must correlate on a single shared id."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        item = {
+            "type": "file_change",
+            "status": "in_progress",
+            "changes": [{"path": "a.py", "kind": "update"}],
+        }
+        start = runtime._convert_event({"type": "item.started", "item": item}, current_handle=None)
+        completion = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {**item, "status": "completed"},
+            },
+            current_handle=None,
+        )
+        assert len(start) == 1
+        assert len(completion) == 1
+        assert start[0].data.get("tool_call_id") is not None
+        assert start[0].data.get("tool_call_id") == completion[0].data.get("tool_call_id")
+
+    def test_file_change_toplevel_path_mismatch_does_not_pair(self) -> None:
+        """Top-level path changes must be part of the signature."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "tp",
+                    "type": "file_change",
+                    "status": "in_progress",
+                    "path": "old.py",
+                    "changes": [{"kind": "update", "unified_diff": "- x"}],
+                },
+            },
+            current_handle=None,
+        )
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "tp",
+                    "type": "file_change",
+                    "status": "completed",
+                    "path": "new.py",
+                    "changes": [{"kind": "update", "unified_diff": "- x"}],
+                },
+            },
+            current_handle=None,
+        )
+        assert len(messages) == 2, (
+            "a completion with a different top-level path inherited the start's signature"
+        )
+
+    def test_mcp_resource_blob_and_meta_are_preserved(self) -> None:
+        """resource.blob reaches content data and result _meta reaches tool_result meta."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "blob",
+                    "type": "mcp_tool_call",
+                    "name": "fs.read",
+                    "status": "completed",
+                    "result": {
+                        "content": [
+                            {
+                                "type": "resource",
+                                "resource": {"uri": "file:///b", "blob": "QkxPQg=="},
+                            }
+                        ],
+                        "_meta": {"trace_id": "t-123"},
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        tool_result = results[0].data.get("tool_result") or {}
+        blocks = tool_result.get("content") or []
+        resource_block = next((b for b in blocks if b.get("type") == "resource"), {})
+        assert resource_block.get("data") == "QkxPQg==", "resource blob was dropped"
+        assert (tool_result.get("meta") or {}).get("trace_id") == "t-123", (
+            "result _meta was dropped"
+        )
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -23,7 +23,7 @@ import pytest
 
 from ouroboros.events.base import BaseEvent
 from ouroboros.harness.deliver_gate import _event_has_explicit_tool_success
-from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.evidence.claims import _runtime_message_has_success_signal
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
@@ -1338,9 +1338,8 @@ class TestCodexCompletionReviewRoundOne:
         blocks = tool_result.get("content") or []
         resource_block = next((b for b in blocks if b.get("type") == "resource"), {})
         assert resource_block.get("data") == "QkxPQg==", "resource blob was dropped"
-        assert (tool_result.get("meta") or {}).get("trace_id") == "t-123", (
-            "result _meta was dropped"
-        )
+        mcp_meta = (tool_result.get("meta") or {}).get("mcp_meta") or {}
+        assert mcp_meta.get("trace_id") == "t-123", "result _meta was dropped or de-namespaced"
 
     def test_mcp_iserror_wire_field_fails_closed(self) -> None:
         """The canonical MCP result.isError flag must win over a completed status."""
@@ -1388,6 +1387,277 @@ class TestCodexCompletionReviewRoundOne:
         blocks = (projected.tool_result or {}).get("content") or []
         structured = next((b for b in blocks if b.get("type") == "structured"), {})
         assert "99" in json.dumps(structured), "canonical structuredContent was discarded"
+
+    def test_command_iserror_false_alone_never_claims_success(self) -> None:
+        """isError is not part of the command contract; it cannot grant success."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "ce",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "isError": False,
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is not False, (
+            "a command with only isError=false and no valid exit claimed success"
+        )
+
+    def test_malformed_iserror_string_fails_closed(self) -> None:
+        """A present-but-malformed isError must poison the success claim."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "me",
+                    "type": "mcp_tool_call",
+                    "name": "fs.write",
+                    "status": "completed",
+                    "result": {"isError": "false"},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is not False, (
+            "a malformed isError string was ignored and status granted success"
+        )
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_mcp_result_meta_cannot_forge_authority_keys(self) -> None:
+        """Opaque MCP _meta must not populate the authoritative exit_status key."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        # Unknown verdict (no exit, no explicit success), but _meta forges exit_status=0.
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "meta",
+                    "type": "mcp_tool_call",
+                    "name": "fs.write",
+                    "result": {"_meta": {"exit_status": 0, "trace_id": "t-1"}},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        meta = (results[0].data.get("tool_result") or {}).get("meta") or {}
+        assert meta.get("exit_status") != 0, "opaque MCP _meta forged an authoritative exit_status"
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        ), "forged _meta.exit_status turned an unknown MCP verdict into success"
+        # audit data must still be preserved, just namespaced
+        assert "t-1" in json.dumps(meta), "MCP audit metadata was lost entirely"
+
+    def test_tool_result_does_not_inherit_stale_terminal_handle_event_type(self) -> None:
+        """A resumed handle's terminal runtime_event_type must not leak onto results."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        stale_handle = RuntimeHandle(
+            backend="codex_cli",
+            metadata={"runtime_event_type": "run.completed"},
+        )
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "resume",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "completed",
+                    "exit_code": "1",
+                },
+            },
+            current_handle=stale_handle,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        projected = project_runtime_message(results[0])
+        event_type = (projected.runtime_metadata or {}).get("runtime_event_type") or ""
+        assert not event_type.endswith((".completed", ".succeeded")), (
+            f"the result inherited a stale terminal event type: {event_type!r}"
+        )
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_synthesized_keyed_start_suppresses_later_start_replay(self) -> None:
+        """A completed-only keyed item then a late start must not duplicate the start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        completed = {
+            "type": "item.completed",
+            "item": {
+                "id": "late",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "exit_code": 0,
+                "status": "completed",
+            },
+        }
+        started = {
+            "type": "item.started",
+            "item": {
+                "id": "late",
+                "type": "command_execution",
+                "command": "pytest -q",
+                "status": "in_progress",
+            },
+        }
+
+        pair = runtime._convert_event(completed, current_handle=None)
+        late_start = runtime._convert_event(started, current_handle=None)
+
+        assert len(pair) == 2
+        assert late_start == [], (
+            "a late keyed start after a synthesized completion emitted a duplicate start"
+        )
+
+    def test_stray_exit_code_on_noncommand_item_is_not_success(self) -> None:
+        """A stray exit_code=0 on a non-command item must not forge success."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {"id": "w", "type": "web_search", "query": "cats", "exit_code": 0},
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert _runtime_message_has_success_signal(results[0]) is False, (
+            "in-memory verifier read a stray non-command exit_code=0 as success"
+        )
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        ), "deliver gate read a stray non-command exit_status=0 as success"
+
+    def test_voided_command_verdict_does_not_leak_exit_success(self) -> None:
+        """A command verdict voided by a malformed field must not forge success via exit_code."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "c",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": 0,
+                    "success": "yes",
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is None
+        assert _runtime_message_has_success_signal(results[0]) is False
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_validated_command_success_still_journals_exit_status(self) -> None:
+        """A genuinely successful command (is_error=False) keeps authoritative exit_status."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "ok",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": 0,
+                    "status": "completed",
+                    "aggregated_output": "1 passed",
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert results[0].data.get("is_error") is False
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0])) is True
+        ), "a validated command success lost its authoritative exit_status"
+
+    def test_tool_start_does_not_inherit_stale_terminal_handle_event_type(self) -> None:
+        """The start half must also not leak a resumed handle's terminal event type."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        stale_handle = RuntimeHandle(
+            backend="codex_cli", metadata={"runtime_event_type": "run.completed"}
+        )
+        messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "s",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=stale_handle,
+        )
+        assert len(messages) == 1
+        projected = project_runtime_message(messages[0])
+        event_type = (projected.runtime_metadata or {}).get("runtime_event_type") or ""
+        assert not event_type.endswith((".completed", ".succeeded")), (
+            f"the start inherited a stale terminal event type: {event_type!r}"
+        )
+
+    def test_failure_under_alternate_wire_keys_is_detected(self) -> None:
+        """A failure token under errorCode/statusCode must not be invisible."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for fail_field in ("errorCode", "statusCode", "exit"):
+            messages = runtime._convert_event(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": f"f_{fail_field}",
+                        "type": "file_change",
+                        "status": "completed",
+                        "changes": [{"path": "a.py", "kind": "update"}],
+                        fail_field: 1,
+                    },
+                },
+                current_handle=None,
+            )
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert results[0].data.get("is_error") is True, (
+                f"a nonzero {fail_field} failure token was invisible and left success"
+            )
+
+    def test_mcp_toolname_wire_spelling_is_recognized(self) -> None:
+        """MCP identity must recognize the toolName wire spelling."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "tn",
+                    "type": "mcp_tool_call",
+                    "toolName": "write",
+                    "server": "fs",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+        assert messages[0].tool_name == "fs.write"
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1659,6 +1659,135 @@ class TestCodexCompletionReviewRoundOne:
         )
         assert messages[0].tool_name == "fs.write"
 
+    def test_malformed_failure_code_alias_cannot_be_promoted_to_success(self) -> None:
+        """A present-but-malformed failure-code alias must block a status success."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        for bad in ({"statusCode": "500"}, {"errorCode": "E_FAIL"}):
+            messages = runtime._convert_event(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "fc",
+                        "type": "mcp_tool_call",
+                        "name": "t",
+                        "status": "completed",
+                        "result": bad,
+                    },
+                },
+                current_handle=None,
+            )
+            results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+            assert results[0].data.get("is_error") is not False, (
+                f"a malformed failure-code alias {bad} was ignored and status promoted success"
+            )
+
+    def test_command_nested_input_workdir_is_part_of_identity(self) -> None:
+        """input.workdir must be in the command identity and persisted tool input."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        start = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "wd",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "input": {"workdir": "/w/a"},
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+        assert (start[0].data.get("tool_input") or {}).get("cwd") == "/w/a"
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "wd",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "input": {"workdir": "/w/b"},
+                    "exit_code": 0,
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+        assert len(messages) == 2, "a completion with a different nested workdir mispaired"
+
+    def test_mcp_meta_secrets_are_redacted_before_persistence(self) -> None:
+        """Sensitive MCP _meta keys must not survive into durable journal metadata."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "sec",
+                    "type": "mcp_tool_call",
+                    "name": "t",
+                    "status": "completed",
+                    "result": {
+                        "_meta": {
+                            "trace_id": "t-1",
+                            "authorization": "Bearer xyz",
+                            "nested": {"api_key": "sk-secret", "ok": 1},
+                        }
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        serialized = json.dumps(results[0].data.get("tool_result") or {})
+        assert "xyz" not in serialized, "authorization secret survived into journal metadata"
+        assert "sk-secret" not in serialized, "nested api_key survived into journal metadata"
+        assert "t-1" in serialized, "non-sensitive audit data was lost"
+
+    def test_completion_dedup_stores_bounded_digest(self) -> None:
+        """The dedup set must not retain multi-megabyte completion envelopes."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        big = "x" * 2_000_000
+        runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "big",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": 0,
+                    "status": "completed",
+                    "aggregated_output": big,
+                },
+            },
+            current_handle=None,
+        )
+        # Reach into the default scope's dedup set and assert entries are bounded.
+        keys = runtime._default_item_scope.completed_item_keys
+        assert keys, "no dedup key recorded"
+        assert all(len(k) < 4096 for k in keys), (
+            "dedup stored an unbounded envelope instead of a fixed-size digest"
+        )
+
+    def test_resumed_tool_start_keeps_started_event_type(self) -> None:
+        """Neutralizing a start handle must not stamp it with a result event type."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        stale = RuntimeHandle(backend="codex_cli", metadata={"runtime_event_type": "run.completed"})
+        messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "st",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=stale,
+        )
+        projected = project_runtime_message(messages[0])
+        event_type = (projected.runtime_metadata or {}).get("runtime_event_type") or ""
+        assert event_type != "tool.result", "a tool start was stamped with the result event type"
+        assert not event_type.endswith((".completed", ".succeeded"))
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -15,6 +15,7 @@ issue #1690 reproduction steps.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1138,6 +1139,92 @@ class TestCodexCompletionReviewRoundOne:
         types = [b.get("type") for b in blocks if isinstance(b, dict)]
         assert "image" in types, "the image content block was dropped"
         assert "resource" in types, "the resource content block was dropped"
+
+    def test_mcp_content_blocks_survive_projection_with_values(self) -> None:
+        """Rich MCP blocks must keep their values through project_runtime_message."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "mcpproj",
+                    "type": "mcp_tool_call",
+                    "name": "screenshot.capture",
+                    "status": "completed",
+                    "result": {
+                        "content": [
+                            {"type": "text", "text": "caption"},
+                            {"type": "image", "data": "AAAA", "mimeType": "image/png"},
+                            {"type": "resource", "resource": {"uri": "file:///x", "text": "R"}},
+                        ],
+                        "structured_content": {"width": 800},
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        projected = project_runtime_message(results[0])
+        blocks = (projected.tool_result or {}).get("content") or []
+        by_type = {b.get("type"): b for b in blocks if isinstance(b, dict)}
+        assert by_type.get("image", {}).get("mime_type") == "image/png", (
+            "image mime lost in projection"
+        )
+        assert by_type.get("image", {}).get("data") == "AAAA", "image data lost in projection"
+        assert by_type.get("resource", {}).get("uri") == "file:///x", (
+            "resource uri lost in projection"
+        )
+        structured = by_type.get("structured", {})
+        assert "800" in json.dumps(structured), "structured payload lost in projection"
+
+    def test_idless_multifile_paths_have_stable_correlation_ids(self) -> None:
+        """Each path in an id-less multi-file item must carry a stable synthetic id."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        item = {
+            "type": "file_change",
+            "status": "completed",
+            "changes": [
+                {"path": "src/app.py", "kind": "update"},
+                {"path": "tests/test_app.py", "kind": "add"},
+            ],
+        }
+        messages = runtime._convert_event(
+            {"type": "item.completed", "item": item}, current_handle=None
+        )
+        starts = [m for m in messages if m.data.get("subtype") != "tool_result"]
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        start_ids = [m.data.get("tool_call_id") for m in starts]
+        result_ids = [m.data.get("tool_call_id") for m in results]
+        assert None not in start_ids and None not in result_ids, (
+            "an id-less multi-file item left tool_call_id=None, breaking exact correlation"
+        )
+        assert len(set(result_ids)) == 2, "the two paths must have distinct correlation ids"
+        assert set(start_ids) == set(result_ids), "start and result ids must correlate per path"
+
+    def test_nested_mcp_error_message_becomes_result_text(self) -> None:
+        """A nested result.error.message must surface as the journaled failure reason."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "nerr",
+                    "type": "mcp_tool_call",
+                    "name": "filesystem.write",
+                    "status": "completed",
+                    "result": {"error": {"message": "disk full"}},
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        assert results[0].data.get("is_error") is True
+        tool_result = results[0].data.get("tool_result") or {}
+        assert "disk full" in (tool_result.get("text_content") or ""), (
+            "the nested error reason was dropped, leaving the journaled failure blank"
+        )
 
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1788,6 +1788,113 @@ class TestCodexCompletionReviewRoundOne:
         assert event_type != "tool.result", "a tool start was stamped with the result event type"
         assert not event_type.endswith((".completed", ".succeeded"))
 
+    def test_oauth_token_meta_keys_are_redacted(self) -> None:
+        """Common OAuth token keys must be redacted from durable meta."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "tk",
+                    "type": "mcp_tool_call",
+                    "name": "t",
+                    "status": "completed",
+                    "result": {
+                        "_meta": {
+                            "token": "tok-1",
+                            "refresh_token": "ref-2",
+                            "idToken": "id-3",
+                            "trace_id": "keep",
+                        }
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        serialized = json.dumps(results[0].data.get("tool_result") or {})
+        for secret in ("tok-1", "ref-2", "id-3"):
+            assert secret not in serialized, f"{secret} survived into journal metadata"
+        assert "keep" in serialized
+
+    def test_nonstring_status_is_malformed_not_ignored(self) -> None:
+        """A present non-string status must poison the success claim."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "st",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": 0,
+                    "status": 7,
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert results[0].data.get("is_error") is None, (
+            "a non-string status was ignored and exit 0 claimed success"
+        )
+        assert (
+            _event_has_explicit_tool_success(_as_journaled_tool_completed_event(results[0]))
+            is False
+        )
+
+    def test_same_id_different_tool_type_does_not_pair(self) -> None:
+        """A reused id across different tool types must not correlate."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "reuse",
+                    "type": "command_execution",
+                    "command": "cats",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "reuse",
+                    "type": "web_search",
+                    "query": "cats",
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+        assert len(messages) == 2, (
+            "a WebSearch completion inherited a Bash start under the same reused id"
+        )
+
+    def test_mcp_resource_text_reaches_result_summary(self) -> None:
+        """A resource block's text must populate the human-readable result text."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "rt",
+                    "type": "mcp_tool_call",
+                    "name": "fs.read",
+                    "status": "completed",
+                    "result": {
+                        "content": [{"type": "resource", "resource": {"text": "file body"}}]
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        text = (results[0].data.get("tool_result") or {}).get("text_content") or ""
+        assert "file body" in text, "resource text was lost from the result summary"
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -932,6 +932,98 @@ class TestCodexCompletionReviewRoundOne:
                 is False
             ), repr(bad_error)
 
+    def test_file_change_conflicting_kind_does_not_pair(self) -> None:
+        """A same-path completion whose mutation kind differs must not inherit the start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "fc1",
+                    "type": "file_change",
+                    "status": "in_progress",
+                    "changes": [{"path": "src/app.py", "kind": "add"}],
+                },
+            },
+            current_handle=None,
+        )
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "fc1",
+                    "type": "file_change",
+                    "status": "completed",
+                    "changes": [{"path": "src/app.py", "kind": "delete"}],
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2, (
+            "a file_change completion with a conflicting mutation kind paired "
+            "with the start and would be accepted as its evidence"
+        )
+
+    def test_distinct_websearch_actions_same_id_stay_visible(self) -> None:
+        """Same-id web_search completions differing only in a non-fingerprinted field stay visible."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        base = {
+            "id": "ws1",
+            "type": "web_search",
+            "query": "ouroboros",
+            "status": "completed",
+        }
+
+        first = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "action": "search"}}, current_handle=None
+        )
+        second = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "action": "open"}}, current_handle=None
+        )
+        identical = runtime._convert_event(
+            {"type": "item.completed", "item": {**base, "action": "open"}}, current_handle=None
+        )
+
+        assert len(first) == 2
+        second_results = [m for m in second if m.data.get("subtype") == "tool_result"]
+        assert len(second_results) == 1, (
+            "a distinct same-id web_search completion was dropped as an exact replay"
+        )
+        assert identical == [], "a genuinely identical replay must stay suppressed"
+
+    def test_distinct_mcp_nontext_content_same_id_stays_visible(self) -> None:
+        """Same-id MCP completions with different non-text content must not collapse."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        base = {
+            "id": "mc1",
+            "type": "mcp_tool_call",
+            "name": "screenshot.capture",
+            "status": "completed",
+        }
+
+        first = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {**base, "result": {"content": [{"type": "image", "data": "AAAA"}]}},
+            },
+            current_handle=None,
+        )
+        second = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {**base, "result": {"content": [{"type": "image", "data": "BBBB"}]}},
+            },
+            current_handle=None,
+        )
+
+        assert len(first) == 2
+        second_results = [m for m in second if m.data.get("subtype") == "tool_result"]
+        assert len(second_results) == 1, (
+            "a same-id MCP completion with different image content was dropped as a replay"
+        )
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")

--- a/tests/unit/orchestrator/test_codex_item_completion_evidence.py
+++ b/tests/unit/orchestrator/test_codex_item_completion_evidence.py
@@ -1024,6 +1024,121 @@ class TestCodexCompletionReviewRoundOne:
             "a same-id MCP completion with different image content was dropped as a replay"
         )
 
+    def test_command_cwd_mismatch_does_not_pair(self) -> None:
+        """A same-id command completion in a different cwd must not inherit the start."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "cwd1",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "cwd": "/workspace/a",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cwd1",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "cwd": "/workspace/b",
+                    "exit_code": 0,
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 2, "a command completion in a different cwd paired with the start"
+
+    def test_command_start_persists_cwd_in_tool_input(self) -> None:
+        """The working directory must be visible in the persisted tool input."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "cwd2",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "cwd": "/workspace/a",
+                    "status": "in_progress",
+                },
+            },
+            current_handle=None,
+        )
+        assert len(messages) == 1
+        assert (messages[0].data.get("tool_input") or {}).get("cwd") == "/workspace/a"
+
+    def test_file_change_diff_and_structured_kind_mismatch_do_not_pair(self) -> None:
+        """Different diffs / structured kinds must not share a signature."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        runtime._convert_event(
+            {
+                "type": "item.started",
+                "item": {
+                    "id": "fcd",
+                    "type": "file_change",
+                    "status": "in_progress",
+                    "changes": [{"path": "a.py", "kind": {"update": {"unified_diff": "- old"}}}],
+                },
+            },
+            current_handle=None,
+        )
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "fcd",
+                    "type": "file_change",
+                    "status": "completed",
+                    "changes": [{"path": "a.py", "kind": {"delete": {}}}],
+                },
+            },
+            current_handle=None,
+        )
+        assert len(messages) == 2, (
+            "a structured delete completion inherited an update start's signature"
+        )
+
+    def test_mcp_content_blocks_are_preserved(self) -> None:
+        """A rich MCP result must keep its content blocks, not just the caption."""
+        runtime = CodexCliRuntime(cli_path="codex")
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "mcprich",
+                    "type": "mcp_tool_call",
+                    "name": "screenshot.capture",
+                    "status": "completed",
+                    "result": {
+                        "content": [
+                            {"type": "text", "text": "here is the shot"},
+                            {"type": "image", "data": "AAAA", "mimeType": "image/png"},
+                            {"type": "resource", "resource": {"uri": "file:///x"}},
+                        ],
+                        "structured_content": {"width": 800},
+                    },
+                },
+            },
+            current_handle=None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert len(results) == 1
+        tool_result = results[0].data.get("tool_result") or {}
+        blocks = tool_result.get("content") or []
+        types = [b.get("type") for b in blocks if isinstance(b, dict)]
+        assert "image" in types, "the image content block was dropped"
+        assert "resource" in types, "the resource content block was dropped"
+
     def test_new_thread_resets_item_correlation_state(self) -> None:
         """A new thread's completed-only item must synthesize its own start."""
         runtime = CodexCliRuntime(cli_path="codex")


### PR DESCRIPTION
## Summary

Codex CLI item lifecycle events now convert into a correlated start/result contract, so command completions become `execution.tool.completed` journal evidence.

- `item.started` for command_execution / mcp_tool_call / file_change / web_search now emits a tool-start message carrying `tool_call_id` — previously the event was dropped entirely.
- `item.completed` for those types now projects as a `tool_result` message with the item id preserved, exit/status metadata, and a tri-state `is_error`, so `project_runtime_message` classifies it as a result and the dispatcher emits `execution.tool.completed`. Previously completions were shaped as a second start, producing the starts-only journals reported in #1724 (158 starts / 0 completions) and FABRICATION_SUSPECTED rejections of truthful claims downstream.
- Success is fail-closed per the #1692 review: only explicit signals (exit code 0, completed/success status) claim success; failed status or non-zero exit set `is_error`; malformed metadata claims nothing. For `command_execution`, lifecycle status alone never claims success: only a validated zero exit or an explicit success/ok flag counts, and a missing or malformed exit code fails closed with the raw status preserved as `reported_status`.
- A completed-only legacy stream synthesizes a start+result pair, but a real `item.started` is never duplicated (the other #1692 review blocker).
- `file_change` completions drop the hardcoded `subtype="success"` stamp and correlate per path (`{item_id}:{path}`), so failed changes are no longer laundered to success.

Closes #1690. Fixes the completion-evidence gap reported in #1724; the artifact-manifest and wrapper-receipt asks there are left as separate verifier-side follow-up.

## Sequencing vs RFC #1681

The #1692 close asked for attempt-evidence projection changes to wait for the authority/event contract RFC. This PR is deliberately adapter-local: only the conversion contract inside `codex_cli_runtime.py` changes — `runtime_message_projection.py`, `leaf_dispatcher.py`, `execution_event_emitter.py`, `runner.py`, and `deliver_gate.py` are untouched consumers (the journaling test drives the real executor path to prove the emitted shapes are consumable end to end). If you consider the adapter conversion contract within the #1681 gate, happy to hold this until the RFC lands.

## Test plan

- [x] 72 regression tests in `tests/unit/orchestrator/test_codex_item_completion_evidence.py`, each verified failing before its fix (by stashing the source change) and passing after — covering lifecycle correlation and per-invocation identity, completed-only synthesis without duplicate starts, per-item-type fail-closed verdict resolution, MCP payload preservation and credential redaction, and the review-round regressions accumulated across the audit
- [x] 5 existing conversion tests updated from the old start-shaped contract to the correlated tool_result contract
- [x] `uv run pytest tests/ -q` — 13228 passed, 12 skipped
- [x] `tests/unit/orchestrator` 3244 passed; `tests/unit/harness` 262 passed (includes the deliver-gate suites); `tests/unit/mcp` 1386 passed; `tests/unit/providers` 565 passed
- [x] `uv run ruff check` / `ruff format --check` / `mypy src/ouroboros` clean

Note: the regression tests import `_event_has_explicit_tool_success` from `ouroboros.harness.deliver_gate` (read-only) to make the fail-closed contract executable against the real gate predicate; happy to drop those assertions if importing a private harness helper into orchestrator tests is unwanted.



