### PR TITLE
fix(orchestrator): make Codex completion evidence consumable by verifiers (#1724, consumer slice)

### DIFF
--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -126,7 +126,7 @@ def _text_contains_test_success(text: str) -> bool:
 
 def _message_contains_test_success(message: AgentMessage) -> bool:
     """Return True when one message says a test command passed."""
-    parts = [message.content]
+    parts = [message.content, _runtime_message_test_proof_text(message)]
     for key in ("result_preview", "output", "stdout", "status", "subtype"):
         value = message.data.get(key)
         if isinstance(value, str):
@@ -208,6 +208,10 @@ def _runtime_message_test_proof_text(message: AgentMessage) -> str:
             value = tool_result.get(key)
             if isinstance(value, str):
                 parts.append(value)
+        meta = tool_result.get("meta")
+        exit_status = meta.get("exit_status") if isinstance(meta, dict) else None
+        if type(exit_status) is int:
+            parts.append(f"exit code {exit_status}")
     elif isinstance(tool_result, str):
         parts.append(tool_result)
     return "\n".join(parts)

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -392,7 +392,7 @@ class ExecutionEventEmitter:
         projected: Any,
     ) -> Any:
         """Create a shared session tool-call event from an AC runtime message."""
-        if projected.tool_name is None:
+        if not projected.is_tool_call or projected.tool_name is None:
             return None
 
         event = create_tool_called_event(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -4334,7 +4334,11 @@ class OrchestratorRunner:
             progress["runtime"] = runtime_handle.to_session_state_dict()
             progress["runtime_backend"] = runtime_handle.backend
             runtime_event_type = runtime_handle.metadata.get("runtime_event_type")
-            if isinstance(runtime_event_type, str) and runtime_event_type:
+            if (
+                "runtime_event_type" not in progress
+                and isinstance(runtime_event_type, str)
+                and runtime_event_type
+            ):
                 progress["runtime_event_type"] = runtime_event_type
             if runtime_handle.backend == "claude" and runtime_handle.native_session_id:
                 progress["agent_session_id"] = runtime_handle.native_session_id
@@ -4390,6 +4394,8 @@ class OrchestratorRunner:
     ):
         """Create an enriched tool-called event from a normalized runtime message."""
         projected = project_runtime_message(message)
+        if not projected.is_tool_call:
+            return None
         tool_name = projected.tool_name
         if tool_name is None:
             return None

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -210,6 +210,9 @@ def serialize_runtime_message_metadata(
     from ouroboros.orchestrator.workflow_state import resolve_ac_marker_update
 
     metadata: dict[str, Any] = {}
+    message_runtime_event_type = runtime_event_type(message)
+    if message_runtime_event_type is not None:
+        metadata["runtime_event_type"] = message_runtime_event_type
     if runtime_signal is None or runtime_status is None:
         runtime_signal, runtime_status = derive_runtime_signal(
             message_type=normalized_message_type(message),
@@ -224,7 +227,11 @@ def serialize_runtime_message_metadata(
         metadata["runtime"] = runtime_handle.to_session_state_dict()
         metadata["runtime_backend"] = runtime_handle.backend
         handle_runtime_event_type = runtime_handle.metadata.get("runtime_event_type")
-        if isinstance(handle_runtime_event_type, str) and handle_runtime_event_type:
+        if (
+            "runtime_event_type" not in metadata
+            and isinstance(handle_runtime_event_type, str)
+            and handle_runtime_event_type
+        ):
             metadata["runtime_event_type"] = handle_runtime_event_type
         tool_catalog = runtime_handle_tool_catalog(runtime_handle)
         if tool_catalog is not None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1112,6 +1112,80 @@ def test_tests_passed_rejects_node_id_from_assistant_narration_only() -> None:
     )
 
 
+def test_codex_completion_receipts_prove_exact_test_and_file_claims(tmp_path) -> None:
+    from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+    runtime = CodexCliRuntime(cli_path="codex", cwd=tmp_path)
+    command = "pytest -q tests/test_example.py"
+    success_messages = tuple(
+        runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-42",
+                    "type": "command_execution",
+                    "command": command,
+                    "stdout": "1 passed in 0.01s",
+                    "exit_code": 0,
+                },
+            },
+            current_handle=None,
+        )
+        + runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "change-7",
+                    "type": "file_change",
+                    "path": "src/example.py",
+                    "status": "completed",
+                },
+            },
+            current_handle=None,
+        )
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=success_messages,
+        task_cwd=str(tmp_path),
+    )
+    assert _runtime_messages_support_file_claim(
+        "src/example.py",
+        success_messages,
+        task_cwd=str(tmp_path),
+    )
+    failed_messages = tuple(
+        runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-failed",
+                    "type": "command_execution",
+                    "command": command,
+                    "stderr": "1 failed in 0.01s",
+                    "exit_code": 1,
+                },
+            },
+            current_handle=None,
+        )
+    )
+    assert not _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=failed_messages,
+        task_cwd=str(tmp_path),
+    )
+    assert (
+        runtime._convert_event(
+            {"type": "item.completed", "item": {"id": "cmd-empty", "type": "command_execution"}},
+            current_handle=None,
+        )
+        == []
+    )
+
+
 @pytest.mark.parametrize(
     "ac_content",
     (
@@ -11350,6 +11424,110 @@ class TestParallelACExecutor:
         assert tool_completed.data["tool_name"] == "Edit"
         assert tool_completed.data["tool_result"]["text_content"] == "Updated src/app.py"
         assert tool_completed.data["runtime_event_type"] == "tool.completed"
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_projects_codex_completion_receipt_to_journal(self) -> None:
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        class StubRuntime:
+            _runtime_handle_backend = "codex_cli"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(self, **kwargs: Any):
+                runtime = CodexCliRuntime(cli_path="codex", cwd=self._cwd)
+                for message in runtime._convert_event(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "cmd-42",
+                            "type": "command_execution",
+                            "command": "pytest -q tests/test_example.py",
+                            "stdout": "1 passed in 0.01s",
+                            "exit_code": 0,
+                        },
+                    },
+                    current_handle=kwargs["resume_handle"],
+                ):
+                    yield message
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                )
+
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=StubRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Run the focused test",
+            session_id="sess_codex",
+            tools=["Bash"],
+            system_prompt="test",
+            seed_goal="Ship the fix",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        appended_events = [call.args[0] for call in event_store.append.await_args_list]
+        tool_started = next(
+            event for event in appended_events if event.type == "execution.tool.started"
+        )
+        tool_completed = next(
+            event for event in appended_events if event.type == "execution.tool.completed"
+        )
+
+        assert result.success is True
+        assert tool_started.data["tool_call_id"] == "cmd-42"
+        assert tool_started.data["tool_input"] == {"command": "pytest -q tests/test_example.py"}
+        assert tool_completed.data["tool_call_id"] == "cmd-42"
+        assert tool_completed.data["runtime_event_type"] == "tool.completed"
+        assert tool_completed.data["tool_result"]["is_error"] is False
+        assert tool_completed.data["tool_result"]["meta"]["exit_status"] == 0
+
+    def test_codex_id_bearing_exit_only_test_completion_proves_file_claim(self) -> None:
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        command = "pytest -q tests/test_example.py"
+        messages = tuple(
+            CodexCliRuntime(cli_path="codex", cwd="/tmp/project")._convert_event(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "cmd-exit-only",
+                        "type": "command_execution",
+                        "command": command,
+                        "exit_code": 0,
+                    },
+                },
+                current_handle=None,
+            )
+        )
+
+        assert _runtime_messages_support_test_claim(
+            value="tests/test_example.py",
+            backed_commands=(command,),
+            messages=messages,
+            task_cwd=None,
+        )
 
     @pytest.mark.asyncio
     async def test_atomic_ac_projects_empty_tool_result_content_into_completion_events(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -11499,9 +11499,54 @@ class TestParallelACExecutor:
         assert tool_started.data["tool_call_id"] == "cmd-42"
         assert tool_started.data["tool_input"] == {"command": "pytest -q tests/test_example.py"}
         assert tool_completed.data["tool_call_id"] == "cmd-42"
-        assert tool_completed.data["runtime_event_type"] == "tool.completed"
+        assert tool_completed.data["runtime_event_type"] == "tool.result"
         assert tool_completed.data["tool_result"]["is_error"] is False
         assert tool_completed.data["tool_result"]["meta"]["exit_status"] == 0
+
+    def test_message_level_tool_completion_event_type_is_not_terminal(self) -> None:
+        """A finished tool must not classify the runtime handle as terminated.
+
+        Message-level `runtime_event_type` now takes priority over stale handle
+        metadata, so the adapter's completion vocabulary reaches lifecycle
+        classification directly. `_runtime_handle_lifecycle_state` maps any value
+        containing "completed" (outside the `message.`/`result.`/`turn.` prefixes)
+        onto the terminal `completed` state, so naming a per-tool completion
+        `tool.completed` would end the runtime after its first tool.
+        """
+        from ouroboros.orchestrator.adapter import (
+            _RUNTIME_TERMINAL_STATES,
+            _runtime_handle_lifecycle_state,
+        )
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        runtime = CodexCliRuntime()
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-99",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": 0,
+                    "status": "completed",
+                },
+            },
+            None,
+        )
+
+        event_types = [
+            message.data.get("runtime_event_type")
+            for message in messages
+            if message.data.get("runtime_event_type")
+        ]
+        assert event_types, "completion conversion must stamp a runtime_event_type"
+
+        for event_type in event_types:
+            lifecycle = _runtime_handle_lifecycle_state(event_type, has_session_id=True)
+            assert lifecycle not in _RUNTIME_TERMINAL_STATES, (
+                f"per-tool event type {event_type!r} classifies the runtime as "
+                f"{lifecycle!r}, which is terminal"
+            )
 
     def test_codex_id_bearing_exit_only_test_completion_proves_file_claim(self) -> None:
         from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1113,6 +1113,42 @@ class TestOrchestratorRunner:
         assert progress_event.data["content_preview"] == "[AC_COMPLETE: 1] Done!"
         assert progress_event.data["progress"]["last_content_preview"] == "[AC_COMPLETE: 1] Done!"
 
+    def test_build_progress_update_keeps_message_runtime_event_type(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        message = AgentMessage(
+            type="assistant",
+            content="Updated src/app.py",
+            data={
+                "subtype": "tool_result",
+                "tool_name": "Edit",
+                "runtime_event_type": "tool.completed",
+            },
+            resume_handle=RuntimeHandle(
+                backend="opencode",
+                native_session_id="oc-session-1",
+                metadata={"runtime_event_type": "tool.started"},
+            ),
+        )
+
+        progress = runner._build_progress_update(message, 3)
+
+        assert progress["runtime_event_type"] == "tool.completed"
+
+    def test_build_tool_called_event_skips_named_tool_results(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        message = AgentMessage(
+            type="assistant",
+            content="Updated src/app.py",
+            tool_name="Edit",
+            data={"subtype": "tool_result"},
+        )
+
+        assert runner._build_tool_called_event("sess_123", message) is None
+
     def test_build_progress_update_extracts_ac_tracking_from_tool_result_payload(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_runtime_message_projection.py
+++ b/tests/unit/orchestrator/test_runtime_message_projection.py
@@ -13,6 +13,23 @@ from ouroboros.orchestrator.runtime_message_projection import project_runtime_me
 class TestRuntimeMessageProjection:
     """Tests for transcript/event projection of runtime messages."""
 
+    def test_message_event_type_precedes_resumed_handle_event_type(self) -> None:
+        message = AgentMessage(
+            type="tool_result",
+            content="completed",
+            tool_name="Bash",
+            data={"runtime_event_type": "tool.completed"},
+            resume_handle=RuntimeHandle(
+                backend="codex",
+                native_session_id="session-1",
+                metadata={"runtime_event_type": "run.completed"},
+            ),
+        )
+
+        projected = project_runtime_message(message)
+
+        assert projected.runtime_metadata["runtime_event_type"] == "tool.completed"
+
     def test_projects_opencode_session_started_metadata_into_standard_signal(self) -> None:
         """Session-start lifecycle updates should stay system-scoped and resumable."""
         message = AgentMessage(


### PR DESCRIPTION
## Summary

Consumer-side half of the #1724 fix. Carries forward @berkshirehathaways' work from #1731, rebased onto the adapter half merged as #1732.

#1732 made the Codex adapter emit correlated tool start/result pairs. This PR makes the consumers actually able to use them — without it, the new evidence exists but never reaches the verifier.

| File | Change |
|---|---|
| `evidence/test_detection.py` | Read the runtime tool_result proof text and `meta.exit_status`, so a validated zero exit can support a `tests_passed` claim |
| `execution_event_emitter.py` | Gate `build_session_tool_called_event` on `projected.is_tool_call`, so a tool_result is not re-emitted as a second tool-called event |
| `runner.py` | Same guard in `_build_tool_called_event`; stop stale handle metadata from overriding the message's own `runtime_event_type` |
| `runtime_message_projection.py` | Message-level `runtime_event_type` takes priority over handle metadata |

21 source lines across 4 files. No adapter changes — `codex_cli_runtime.py` is untouched.

## Why this is a separate PR from #1731

#1731 fixed both halves. Its adapter half is superseded by #1732 (which resolved the two blockers @Q00 raised when closing #1692: fail-closed tri-state terminal validation, and no duplicate start when a real `item.started` was observed). Its consumer half had no blocking findings against it and is preserved here verbatim, with authorship intact.

Per the gate boundary now written into RFC #1681: the adapter's own conversion contract is outside the gate, while shared consumer semantics are sequenced deliberately. This is that sequencing.

## One expectation changed, and why it is not cosmetic

#1731 stamped completions as `runtime_event_type="tool.completed"`; the merged adapter uses `"tool.result"`.

This slice makes message-level `runtime_event_type` take priority over handle metadata — which means the adapter's vocabulary now reaches lifecycle classification directly. `_runtime_handle_lifecycle_state` (`adapter.py:416`) maps any value containing `"completed"` outside the `message.`/`result.`/`turn.` prefixes onto the terminal `completed` state, and `completed` is in `_RUNTIME_TERMINAL_STATES`:

```
tool.completed -> lifecycle=completed  terminal=True
tool.result    -> lifecycle=running    terminal=False
```

Under the original naming, **the first finished tool would have marked the whole runtime handle terminal.** The combination was the hazard: #1731's adapter naming was harmless until #1731's own consumer patch made it load-bearing.

Updating the assertion alone would leave the trap armed for the next adapter, so the invariant is pinned instead (`test_message_level_tool_completion_event_type_is_not_terminal`): drive the real `CodexCliRuntime` conversion and assert that no emitted per-tool event type classifies the runtime as terminal.

## Verification

- `tests/unit/orchestrator` + `tests/unit/harness` — 3669 passed, 1 skipped
- Focused: projection + runner + parallel executor — 443 passed, 1 skipped
- `ruff check src/ tests/` clean; `ruff format --check` clean (206 files)
- `mypy` clean on all four changed source files
- Lifecycle mapping verified empirically, not by reading

## Known gaps deliberately not bundled

Both are pre-existing, cross-runtime, and tracked separately rather than smuggled into a Codex-scoped change:

1. **Inflated tool counts.** `workflow_state.py:704` passes `projected.tool_name` for tool *and* tool_result; `process_message` at `:682` increments `tool_calls_count` on any `tool_name`. Every runtime already double-counts. This PR removes the duplicate *event*, not the counter.
2. **Failed tools render green.** `emit_atomic_tool_completed` never sets `success`; `tui/events.py:1000` defaults a missing `success` to `True`. Separate PR.

## Closing conditions

#1690 and #1724 stay open until a real Codex run shows `execution.tool.completed > 0` and the false `FABRICATION_SUSPECTED` rejections stop. Unit tests cannot demonstrate that.

Supersedes the consumer half of #1731. Thanks @berkshirehathaways — original commits carried forward with authorship preserved.
