### PR TITLE
fix(tui): fail closed on reported tool failures instead of rendering them green

### DIFF
--- a/src/ouroboros/tui/events.py
+++ b/src/ouroboros/tui/events.py
@@ -793,6 +793,41 @@ def _subtask_root_ac_index(data: dict[str, Any]) -> int:
     return ac_index if ac_index is not None else legacy_ac_index or 0
 
 
+def _resolve_tool_completion_success(data: dict[str, Any]) -> bool:
+    """Resolve tool-completion success without laundering a reported failure.
+
+    No producer sets ``success`` on ``execution.tool.completed``:
+    ``ExecutionEventEmitter.emit_atomic_tool_completed`` builds its payload from
+    the runtime identity plus ``serialize_runtime_message_metadata`` output, and
+    neither contributes that key. A plain ``data.get("success", True)`` therefore
+    rendered every failed tool as succeeded — a Codex command exiting 1 arrives
+    carrying ``is_error=True`` and was still displayed as a success.
+
+    ``is_error`` is the authoritative verdict channel, and a malformed claim is
+    treated as failure rather than silently ignored, matching the fail-closed
+    contract the runtime adapters use.
+
+    A completion carrying no verdict at all stays optimistic: the serialized
+    metadata forwards neither ``tool_result`` nor ``reported_status``, so there
+    is no signal to fail closed on, and flipping every signal-less runtime to a
+    failed display would be a louder wrong answer than the one being fixed.
+    Widening the payload is a shared-projection change and is deliberately out
+    of scope here.
+    """
+    raw_success = data.get("success")
+    if isinstance(raw_success, bool):
+        return raw_success
+
+    if data.get("is_error_invalid") is True:
+        return False
+
+    is_error = data.get("is_error")
+    if isinstance(is_error, bool):
+        return not is_error
+
+    return True
+
+
 def create_message_from_event(event: BaseEvent) -> Message | None:
     """Convert an EventStore event to a TUI message.
 
@@ -997,7 +1032,7 @@ def create_message_from_event(event: BaseEvent) -> Message | None:
             tool_detail=data.get("tool_detail", ""),
             call_index=data.get("call_index", 0),
             duration_seconds=data.get("duration_seconds", 0.0),
-            success=data.get("success", True),
+            success=_resolve_tool_completion_success(data),
         )
 
     elif event_type == "execution.agent.thinking":

--- a/src/ouroboros/tui/events.py
+++ b/src/ouroboros/tui/events.py
@@ -807,23 +807,39 @@ def _resolve_tool_completion_success(data: dict[str, Any]) -> bool:
     treated as failure rather than silently ignored, matching the fail-closed
     contract the runtime adapters use.
 
-    A completion carrying no verdict at all stays optimistic: the serialized
-    metadata forwards neither ``tool_result`` nor ``reported_status``, so there
+    Both the top-level and the nested envelopes are supported. ``is_error`` is
+    lifted to the top level only when the message itself carries that key, while
+    ``project_runtime_message`` separately persists the normalized ``tool_result``
+    payload — so an adapter that reports failure only inside ``tool_result``
+    (OpenCode does) has no top-level verdict and would otherwise render green.
+
+    A completion carrying no verdict in either envelope stays optimistic: there
     is no signal to fail closed on, and flipping every signal-less runtime to a
     failed display would be a louder wrong answer than the one being fixed.
-    Widening the payload is a shared-projection change and is deliberately out
-    of scope here.
     """
     raw_success = data.get("success")
     if isinstance(raw_success, bool):
         return raw_success
 
-    if data.get("is_error_invalid") is True:
-        return False
+    tool_result = data.get("tool_result")
+    envelopes: list[dict[str, Any]] = [data]
+    if isinstance(tool_result, dict):
+        envelopes.append(tool_result)
 
-    is_error = data.get("is_error")
-    if isinstance(is_error, bool):
-        return not is_error
+    for envelope in envelopes:
+        if envelope.get("is_error_invalid") is True:
+            return False
+
+        if "is_error" not in envelope:
+            continue
+
+        is_error = envelope.get("is_error")
+        if isinstance(is_error, bool):
+            return not is_error
+
+        # A malformed verdict is a claim that could not be validated, so it is
+        # failure rather than an absent signal.
+        return False
 
     return True
 

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -960,3 +960,94 @@ class TestFrugalityTelemetryEvents:
         )
         assert "waste" not in line.lower()
         assert "avoidable" not in line.lower()
+
+
+class TestToolCompletionSuccessFailClosed:
+    """`execution.tool.completed` must not display a reported failure as success.
+
+    No producer sets `success` on this event: `emit_atomic_tool_completed` builds
+    its payload from the runtime identity plus `serialize_runtime_message_metadata`,
+    and neither contributes that key. The previous `data.get("success", True)`
+    therefore rendered every failed tool green.
+    """
+
+    @staticmethod
+    def _completed_event(**data: object) -> BaseEvent:
+        return BaseEvent(
+            type="execution.tool.completed",
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={"ac_id": "ac_1", "tool_name": "Bash", **data},
+        )
+
+    def test_reported_error_renders_as_failure(self) -> None:
+        message = create_message_from_event(self._completed_event(is_error=True))
+        assert message is not None
+        assert message.success is False
+
+    def test_reported_error_false_renders_as_success(self) -> None:
+        message = create_message_from_event(self._completed_event(is_error=False))
+        assert message is not None
+        assert message.success is True
+
+    def test_malformed_error_claim_fails_closed(self) -> None:
+        message = create_message_from_event(self._completed_event(is_error_invalid=True))
+        assert message is not None
+        assert message.success is False
+
+    def test_explicit_success_field_wins(self) -> None:
+        message = create_message_from_event(self._completed_event(success=False, is_error=False))
+        assert message is not None
+        assert message.success is False
+
+    def test_absent_verdict_stays_optimistic(self) -> None:
+        """No verdict channel is forwarded, so there is nothing to fail closed on."""
+        message = create_message_from_event(self._completed_event())
+        assert message is not None
+        assert message.success is True
+
+    @pytest.mark.parametrize(
+        ("exit_code", "expected_success"),
+        [(0, True), (1, False)],
+    )
+    def test_real_codex_completion_reaches_the_display_verdict(
+        self, exit_code: int, expected_success: bool
+    ) -> None:
+        """Drive the real adapter and projection, not a hand-built payload.
+
+        This is the path from #1724: a Codex command exiting non-zero produced
+        `is_error=True` and was still displayed as a success.
+        """
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+        from ouroboros.orchestrator.runtime_message_projection import (
+            serialize_runtime_message_metadata,
+        )
+
+        runtime = CodexCliRuntime()
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "cmd-1",
+                    "type": "command_execution",
+                    "command": "pytest -q",
+                    "exit_code": exit_code,
+                    "status": "completed",
+                },
+            },
+            None,
+        )
+        results = [m for m in messages if m.data.get("subtype") == "tool_result"]
+        assert results, "adapter must emit a tool_result message"
+
+        metadata = serialize_runtime_message_metadata(results[0])
+        event = BaseEvent(
+            type="execution.tool.completed",
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={"ac_id": "ac_1", "tool_name": "Bash", **metadata},
+        )
+
+        message = create_message_from_event(event)
+        assert message is not None
+        assert message.success is expected_success

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -1000,6 +1000,55 @@ class TestToolCompletionSuccessFailClosed:
         assert message is not None
         assert message.success is False
 
+    def test_nested_tool_result_error_renders_as_failure(self) -> None:
+        """OpenCode reports failure only inside `tool_result`, with no top-level key."""
+        message = create_message_from_event(
+            self._completed_event(tool_result={"is_error": True, "text_content": "failed"})
+        )
+        assert message is not None
+        assert message.success is False
+
+    def test_nested_tool_result_success_renders_as_success(self) -> None:
+        message = create_message_from_event(
+            self._completed_event(tool_result={"is_error": False, "text_content": "ok"})
+        )
+        assert message is not None
+        assert message.success is True
+
+    def test_nested_malformed_error_claim_fails_closed(self) -> None:
+        message = create_message_from_event(self._completed_event(tool_result={"is_error": "boom"}))
+        assert message is not None
+        assert message.success is False
+
+    def test_top_level_verdict_wins_over_nested(self) -> None:
+        message = create_message_from_event(
+            self._completed_event(is_error=True, tool_result={"is_error": False})
+        )
+        assert message is not None
+        assert message.success is False
+
+    def test_nested_error_reaches_display_through_production_metadata(self) -> None:
+        """Drive the real projection path, not a hand-built event payload."""
+        from ouroboros.orchestrator.adapter import AgentMessage
+        from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
+
+        agent_message = AgentMessage(
+            type="tool_result",
+            content="failed to patch",
+            data={
+                "subtype": "tool_result",
+                "tool_name": "Edit",
+                "tool_result": {"is_error": True, "text_content": "failed to patch"},
+            },
+        )
+        metadata = ExecutionEventEmitter.runtime_event_metadata(agent_message)
+        assert "is_error" not in metadata, "this envelope must carry no top-level verdict"
+        assert metadata["tool_result"]["is_error"] is True
+
+        message = create_message_from_event(self._completed_event(**metadata))
+        assert message is not None
+        assert message.success is False
+
     def test_absent_verdict_stays_optimistic(self) -> None:
         """No verdict channel is forwarded, so there is nothing to fail closed on."""
         message = create_message_from_event(self._completed_event())


### PR DESCRIPTION
## Summary

`execution.tool.completed` was converted to a TUI message with `success=data.get("success", True)` — but **no producer ever sets `success`**. `ExecutionEventEmitter.emit_atomic_tool_completed` (`execution_event_emitter.py:986`, the only producer of this event type) builds its payload from the runtime identity plus `serialize_runtime_message_metadata` output, and neither contributes that key. The default always won, so every failed tool displayed as a success.

## Reproduced against the real path

Not a hand-built payload — the actual adapter and projection:

```
Codex command_execution, exit_code=1
  -> event data carries is_error=True
  -> create_message_from_event(...) -> ToolCallCompleted(success=True)
```

## Fix

Resolution order in `_resolve_tool_completion_success`:

1. explicit boolean `success` wins, if a producer ever sets one
2. `is_error_invalid` (a malformed `is_error` claim) → **failure**, rather than silently ignored
3. `is_error` boolean → `not is_error`
4. otherwise → optimistic

`is_error` is the authoritative verdict channel, and step 2 matches the fail-closed contract the runtime adapters already use.

### Why step 4 is not fail-closed

Deliberate, and worth stating plainly. The serialized metadata forwards neither `tool_result` nor `reported_status` — verified, not assumed — so a verdict-less completion carries no signal to fail closed on. Flipping every signal-less runtime to a failed display would be a louder wrong answer than the one being fixed.

Widening that payload so the unknown case is representable is a **shared projection change**, which lands inside the RFC #1681 gate boundary. Out of scope here by that rule.

## Scope

Cross-runtime and pre-existing — **not** caused by #1732. But Codex previously emitted no completion events at all (`started: 158 / completed: 0`, #1724), so for that runtime the adapter fix turns "nothing shown" into "failures shown as successes". That is why it is worth fixing now rather than later.

Kept out of #1732 and #1740, both of which are Codex-scoped, because this changes display behaviour for every runtime.

## Verification

- 7 new regression tests; **confirmed failing before the fix** by reverting the one-line call site — 3 of the 7 fail (`reported_error_renders_as_failure`, `malformed_error_claim_fails_closed`, and the real-Codex `exit_code=1` case), the other 4 pin behaviour that must not change
- Two of the tests drive the real `CodexCliRuntime` conversion + `serialize_runtime_message_metadata` end to end, parameterized over exit 0 and exit 1
- `tests/unit/tui` — 217 passed
- `ruff check` / `ruff format --check` clean across `src/` and `tests/`; `mypy` clean

## Related

- #1741 — `tool_calls_count` double-counting, the other cross-runtime defect found in the same review, filed rather than bundled
- #1740 — Codex completion consumer slice
- #1732 — Codex adapter half (merged)
