### PR TITLE
fix(orchestrator): align deliver command evidence matching

### DIFF
--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -204,9 +204,10 @@ async def load_ac_evidence_manifest(
             before TraceGuard sees it.
         admit_accepted_tool_starts: Add AC-scoped ``execution.tool.started``
             events as journal entries after the caller has established accepted
-            leaf + exact typed-evidence match + verifier PASS. Mutation tools are
-            admitted only when the start itself records explicit completion or a
-            correlated ``execution.tool.completed`` event proves success.
+            leaf + exact typed-evidence match + verifier PASS. Mutation tools and
+            Bash commands are admitted only when explicit success is not vetoed
+            by any correlated failure or ambiguity; otherwise an exact successful
+            ``execution.tool.completed`` event is required.
         accepted_retry_attempt: Optional accepted leaf retry attempt. When set,
             tool starts from failed/older attempts are excluded.
         accepted_session_attempt_id: Optional exact implementation-attempt id,
@@ -331,20 +332,20 @@ def _accepted_tool_start_entries(
                 )
                 if len(matching_starts) != 1:
                     continue
-            if not _event_has_explicit_tool_success(
+            start_success = _event_has_explicit_tool_success(
                 event,
                 require_command_verdict=require_command_verdict,
-            ):
-                completion = _correlated_successful_tool_completion(
-                    chronological,
-                    start_index=index,
-                    scope_id=scope_id,
-                    retry_attempt=retry_attempt,
-                    session_attempt_id=session_attempt_id,
-                    require_command_verdict=require_command_verdict,
-                )
-                if completion is None:
-                    continue
+            )
+            completion, completion_veto = _correlated_tool_completion(
+                chronological,
+                start_index=index,
+                scope_id=scope_id,
+                retry_attempt=retry_attempt,
+                session_attempt_id=session_attempt_id,
+                require_command_verdict=require_command_verdict,
+            )
+            if completion_veto or (completion is None and not start_success):
+                continue
         normalized_input = dict(tool_input) if isinstance(tool_input, Mapping) else {}
         payload: dict[str, Any] = {
             "tool_name": normalized_tool_name,
@@ -373,6 +374,9 @@ def _accepted_tool_start_entries(
             relative_path = _event_workspace_relative_path(raw_path, data)
             if relative_path is not None:
                 payload["workspace_relative_path"] = relative_path
+        result_preview = _event_result_preview(event, completion)
+        if result_preview is not None:
+            payload["result_preview"] = result_preview
         entries.append(
             EvidenceEntry(
                 kind=EvidenceKind.TOOL_INVOCATION,
@@ -506,7 +510,7 @@ def _event_matches_accepted_attempt(
     )
 
 
-def _correlated_successful_tool_completion(
+def _correlated_tool_completion(
     events: tuple[BaseEvent, ...],
     *,
     start_index: int,
@@ -514,15 +518,15 @@ def _correlated_successful_tool_completion(
     retry_attempt: int | None,
     session_attempt_id: str | None,
     require_command_verdict: bool,
-) -> BaseEvent | None:
-    """Return one exact successful completion for a guarded tool start, else None."""
+) -> tuple[BaseEvent | None, bool]:
+    """Return an exact completion and whether failure/ambiguity vetoes the start."""
     start = events[start_index]
     start_data = start.data
     if not isinstance(start_data, Mapping):
-        return None
+        return None, True
     start_tool = start_data.get("tool_name")
     if not isinstance(start_tool, str):
-        return None
+        return None, True
     start_call_id = _event_tool_call_id(start)
 
     if start_call_id is not None:
@@ -539,7 +543,7 @@ def _correlated_successful_tool_completion(
             and _event_tool_call_id(candidate) == start_call_id
         )
         if len(matching_starts) != 1:
-            return None
+            return None, True
         matches = tuple(
             candidate
             for candidate in events[start_index + 1 :]
@@ -551,15 +555,23 @@ def _correlated_successful_tool_completion(
                 session_attempt_id=session_attempt_id,
             )
             and _event_tool_call_id(candidate) == start_call_id
-            and isinstance(candidate.data, Mapping)
-            and candidate.data.get("tool_name") == start_tool
         )
-        if len(matches) != 1 or not _event_has_explicit_tool_success(
-            matches[0],
+        if not matches:
+            return None, False
+        if len(matches) != 1:
+            return None, True
+        completion = matches[0]
+        if (
+            not isinstance(completion.data, Mapping)
+            or completion.data.get("tool_name") != start_tool
+        ):
+            return None, True
+        if not _event_has_explicit_tool_success(
+            completion,
             require_command_verdict=require_command_verdict,
         ):
-            return None
-        return matches[0]
+            return None, True
+        return completion, False
 
     # Legacy id-less streams: only the next same-attempt tool event may close
     # the start. Any intervening start or id-bearing completion is ambiguous.
@@ -574,23 +586,43 @@ def _correlated_successful_tool_completion(
         ):
             continue
         if candidate.type == "execution.tool.started":
-            return None
+            return None, True
         if _event_tool_call_id(candidate) is not None:
-            return None
+            return None, True
         candidate_tool = (
             candidate.data.get("tool_name") if isinstance(candidate.data, Mapping) else None
         )
         if candidate_tool != start_tool:
-            return None
-        return (
-            candidate
-            if _event_has_explicit_tool_success(
-                candidate,
-                require_command_verdict=require_command_verdict,
-            )
-            else None
-        )
-    return None
+            return None, True
+        if not _event_has_explicit_tool_success(
+            candidate,
+            require_command_verdict=require_command_verdict,
+        ):
+            return None, True
+        return candidate, False
+    return None, False
+
+
+def _event_result_preview(start: BaseEvent, completion: BaseEvent | None) -> str | None:
+    """Return bounded runtime-produced output for an admitted tool call."""
+    parts: list[str] = []
+    for event in (start, completion):
+        if event is None or not isinstance(event.data, Mapping):
+            continue
+        data = event.data
+        for key in ("result_preview", "output", "stdout", "stderr", "tool_result_text"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                parts.append(value.strip())
+        tool_result = data.get("tool_result")
+        if isinstance(tool_result, Mapping):
+            for key in ("text_content", "content", "output", "stdout", "stderr"):
+                value = tool_result.get(key)
+                if isinstance(value, str) and value.strip():
+                    parts.append(value.strip())
+    if not parts:
+        return None
+    return "\n".join(dict.fromkeys(parts))[-16_000:]
 
 
 def _event_matches_scope(event: BaseEvent, scope_id: str) -> bool:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -291,10 +291,11 @@ def _accepted_tool_start_entries(
     """Project accepted-leaf tool dispatches into claim-independent entries.
 
     The accepted-leaf + exact-match + verifier-PASS preconditions are necessary
-    but not sufficient for file mutation: a failed Edit/Write can still be
-    followed by an overall successful assistant result. Mutation starts therefore
-    require their own explicit success signal or one exact successful completion.
-    Missing, failed, or ambiguous correlation is omitted fail-closed.
+    but not sufficient for file mutation or command success: a failed Edit/Write
+    or Bash call can still be followed by an overall successful assistant result.
+    Mutation and command starts therefore require their own explicit success
+    signal or one exact successful completion. Missing, failed, or ambiguous
+    correlation is omitted fail-closed.
     """
     chronological = tuple(events)
     entries: list[EvidenceEntry] = []
@@ -312,7 +313,7 @@ def _accepted_tool_start_entries(
             continue
         normalized_tool_name = tool_name.strip()
         completion: BaseEvent | None = None
-        if normalized_tool_name in {"Edit", "Write", "NotebookEdit"}:
+        if normalized_tool_name in {"Bash", "Edit", "Write", "NotebookEdit"}:
             call_id = _event_tool_call_id(event)
             if call_id is not None:
                 matching_starts = tuple(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -1261,9 +1261,17 @@ def _event_chronology_key(event: BaseEvent) -> tuple[object, int]:
 
 
 def _event_phase_order(event_type: str) -> int:
-    if event_type in {"tool.call.started", "llm.call.requested"}:
+    if event_type in {
+        "tool.call.started",
+        "llm.call.requested",
+        "execution.tool.started",
+    }:
         return 0
-    if event_type in {"tool.call.returned", "llm.call.returned"}:
+    if event_type in {
+        "tool.call.returned",
+        "llm.call.returned",
+        "execution.tool.completed",
+    }:
         return 1
     return 2
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -314,6 +314,7 @@ def _accepted_tool_start_entries(
         normalized_tool_name = tool_name.strip()
         completion: BaseEvent | None = None
         if normalized_tool_name in {"Bash", "Edit", "Write", "NotebookEdit"}:
+            require_command_verdict = normalized_tool_name == "Bash"
             call_id = _event_tool_call_id(event)
             if call_id is not None:
                 matching_starts = tuple(
@@ -330,13 +331,17 @@ def _accepted_tool_start_entries(
                 )
                 if len(matching_starts) != 1:
                     continue
-            if not _event_has_explicit_tool_success(event):
+            if not _event_has_explicit_tool_success(
+                event,
+                require_command_verdict=require_command_verdict,
+            ):
                 completion = _correlated_successful_tool_completion(
                     chronological,
                     start_index=index,
                     scope_id=scope_id,
                     retry_attempt=retry_attempt,
                     session_attempt_id=session_attempt_id,
+                    require_command_verdict=require_command_verdict,
                 )
                 if completion is None:
                     continue
@@ -407,8 +412,17 @@ def _event_tool_call_id(event: BaseEvent) -> str | None:
     return None
 
 
-def _event_has_explicit_tool_success(event: BaseEvent) -> bool:
-    """Return True only for machine-readable non-error completion evidence."""
+def _event_has_explicit_tool_success(
+    event: BaseEvent,
+    *,
+    require_command_verdict: bool = False,
+) -> bool:
+    """Return True only for machine-readable non-error completion evidence.
+
+    Command execution additionally requires a command-specific result bit or
+    zero exit status. Generic lifecycle completion is sufficient for mutation
+    tools, but cannot prove that a Bash body ran successfully.
+    """
     data = event.data
     if not isinstance(data, Mapping):
         return False
@@ -429,16 +443,18 @@ def _event_has_explicit_tool_success(event: BaseEvent) -> bool:
         if tool_result.get("is_error") is True:
             return False
     is_completion_event = event.type == "execution.tool.completed"
-    success_signal = is_completion_event and (
+    command_success_signal = is_completion_event and (
         data.get("is_error") is False
         or (isinstance(tool_result, Mapping) and tool_result.get("is_error") is False)
     )
+    success_signal = command_success_signal
     if "exit_code" in data:
         exit_code = data["exit_code"]
         if isinstance(exit_code, bool) or not isinstance(exit_code, int):
             return False
         if exit_code != 0:
             return False
+        command_success_signal = True
         success_signal = True
     if isinstance(tool_result, Mapping):
         meta = tool_result.get("meta")
@@ -449,6 +465,7 @@ def _event_has_explicit_tool_success(event: BaseEvent) -> bool:
                     return False
                 if exit_status != 0:
                     return False
+                command_success_signal = True
                 success_signal = True
     subtype = data.get("subtype")
     if isinstance(subtype, str) and subtype.strip().lower() == "success":
@@ -467,7 +484,7 @@ def _event_has_explicit_tool_success(event: BaseEvent) -> bool:
             return False
         if normalized.endswith((".completed", ".succeeded")):
             success_signal = True
-    return success_signal
+    return command_success_signal if require_command_verdict else success_signal
 
 
 def _event_matches_accepted_attempt(
@@ -496,8 +513,9 @@ def _correlated_successful_tool_completion(
     scope_id: str,
     retry_attempt: int | None,
     session_attempt_id: str | None,
+    require_command_verdict: bool,
 ) -> BaseEvent | None:
-    """Return one exact successful completion for a mutation start, else None."""
+    """Return one exact successful completion for a guarded tool start, else None."""
     start = events[start_index]
     start_data = start.data
     if not isinstance(start_data, Mapping):
@@ -536,7 +554,10 @@ def _correlated_successful_tool_completion(
             and isinstance(candidate.data, Mapping)
             and candidate.data.get("tool_name") == start_tool
         )
-        if len(matches) != 1 or not _event_has_explicit_tool_success(matches[0]):
+        if len(matches) != 1 or not _event_has_explicit_tool_success(
+            matches[0],
+            require_command_verdict=require_command_verdict,
+        ):
             return None
         return matches[0]
 
@@ -561,7 +582,14 @@ def _correlated_successful_tool_completion(
         )
         if candidate_tool != start_tool:
             return None
-        return candidate if _event_has_explicit_tool_success(candidate) else None
+        return (
+            candidate
+            if _event_has_explicit_tool_success(
+                candidate,
+                require_command_verdict=require_command_verdict,
+            )
+            else None
+        )
     return None
 
 

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -419,9 +419,7 @@ def _has_non_executing_test_mode(parts: list[str]) -> bool:
         return True
     if runner == "nox" and any(option in {"-l", "--list"} for option in options):
         return True
-    if runner in {"gradle", "gradlew"} and "-m" in options:
-        return True
-    return runner in {"npm", "pnpm", "yarn"} and "--if-present" in options
+    return runner in {"gradle", "gradlew"} and "-m" in options
 
 
 def _unittest_command_invocation(command: str) -> str | None:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -77,18 +77,39 @@ def _shell_command_body(command: str) -> str | None:
         parts = shlex.split(command)
     except ValueError:
         return None
-    if len(parts) < 3:
+    return _shell_command_body_from_argv(tuple(parts))
+
+
+_SHELL_OPTIONS_WITH_ARGUMENT = frozenset({"-O", "+O", "-o", "+o", "--init-file", "--rcfile"})
+
+
+def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
+    """Return a shell ``-c`` body only while parsing the option prefix.
+
+    Once a script operand is encountered, later values are positional
+    arguments even when they happen to be spelled ``-c``. Options that consume
+    a following value remain within the prefix but cannot expose that value as
+    a command body.
+    """
+    if len(argv) < 3:
         return None
-    shell_name = Path(parts[0]).name
+    shell_name = Path(argv[0]).name
     if shell_name not in {"bash", "zsh", "sh"}:
         return None
-    option_index = next(
-        (index for index, part in enumerate(parts[1:], start=1) if part in {"-c", "-lc", "-cl"}),
-        None,
-    )
-    if option_index is None or option_index + 1 >= len(parts):
-        return None
-    return parts[option_index + 1].strip()
+    index = 1
+    while index < len(argv):
+        option = argv[index]
+        if option in {"-c", "-lc", "-cl"}:
+            if index + 1 >= len(argv):
+                return None
+            return argv[index + 1].strip()
+        if option in _SHELL_OPTIONS_WITH_ARGUMENT:
+            index += 2
+            continue
+        if option == "--" or option == "-" or not option.startswith(("-", "+")):
+            return None
+        index += 1
+    return None
 
 
 def _test_invocation_from_shell_body(body: str) -> str | None:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -377,12 +377,16 @@ _GENERIC_NON_EXECUTING_TEST_OPTIONS = frozenset({"-h", "--help", "-V", "--versio
 _PYTEST_NON_EXECUTING_OPTIONS = frozenset(
     {
         "--collect-only",
+        "--collectonly",
         "--co",
         "--fixtures",
         "--fixtures-per-test",
+        "--funcargs",
         "--markers",
         "--setup-only",
         "--setup-plan",
+        "--setuponly",
+        "--setupplan",
     }
 )
 
@@ -454,6 +458,38 @@ _TRAILING_REDIRECT_RE = re.compile(
 )
 
 
+def _top_level_shell_character_positions(command: str, character: str) -> tuple[int, ...]:
+    """Return unquoted occurrences outside shell grouping and substitutions."""
+    positions: list[int] = []
+    quote: str | None = None
+    escaped = False
+    nesting: list[str] = []
+    closing = {"(": ")", "{": "}"}
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            continue
+        if char in closing:
+            nesting.append(closing[char])
+            continue
+        if nesting and char == nesting[-1]:
+            nesting.pop()
+            continue
+        if not nesting and char == character:
+            positions.append(index)
+    return tuple(positions)
+
+
 def _normalized_shell_words_text(command: str) -> str | None:
     """Return a quote-insensitive normalized argv spelling for one shell command.
 
@@ -500,8 +536,18 @@ def _strip_command_output_plumbing(command: str) -> str:
     if not text:
         return text
     # Peel output-only filter pipes from the tail (``... | tail -n 20``).
-    while "|" in text:
-        head, _, tail_segment = text.rpartition("|")
+    while True:
+        pipe_positions = tuple(
+            position
+            for position in _top_level_shell_character_positions(text, "|")
+            if (position == 0 or text[position - 1] != "|")
+            and (position + 1 >= len(text) or text[position + 1] != "|")
+        )
+        if not pipe_positions:
+            break
+        pipe_position = pipe_positions[-1]
+        head = text[:pipe_position]
+        tail_segment = text[pipe_position + 1 :]
         tail_tokens = tail_segment.split()
         if tail_tokens and tail_tokens[0].lower() in _OUTPUT_FILTER_COMMANDS:
             text = head.strip()
@@ -511,7 +557,13 @@ def _strip_command_output_plumbing(command: str) -> str:
     prev: str | None = None
     while prev != text:
         prev = text
-        text = _TRAILING_REDIRECT_RE.sub("", text).strip()
+        match = _TRAILING_REDIRECT_RE.search(text)
+        if match is None:
+            break
+        redirect_positions = _top_level_shell_character_positions(text, ">")
+        if not any(match.start() <= position < match.end() for position in redirect_positions):
+            break
+        text = text[: match.start()].strip()
     return text
 
 

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -73,6 +73,8 @@ def _test_command_invocation_allowing_output_plumbing(command: str) -> str | Non
 
 def _shell_command_body(command: str) -> str | None:
     """Return the ``-c`` body when the command starts with a shell wrapper."""
+    if _has_unquoted_status_masking_control(command):
+        return None
     try:
         parts = shlex.split(command)
     except ValueError:
@@ -120,8 +122,17 @@ def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
                 return None
             return argv[index + 1].strip()
         if option in _SHELL_OPTIONS_WITH_ARGUMENT:
+            if index + 1 >= len(argv):
+                return None
+            option_value = argv[index + 1].strip().lower().replace("_", "").replace("-", "")
+            if option == "-o" and option_value == "noexec":
+                return None
             index += 2
             continue
+        if option.startswith("-o"):
+            option_value = option[2:].strip().lower().replace("_", "").replace("-", "")
+            if option_value == "noexec":
+                return None
         if option == "--" or option == "-" or not option.startswith(("-", "+")):
             return None
         index += 1
@@ -280,7 +291,7 @@ def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
     return False
 
 
-def _has_unquoted_test_status_mask(command: str) -> bool:
+def _has_unquoted_status_masking_control(command: str) -> bool:
     """Return whether shell control syntax can hide a test command's status."""
     quote: str | None = None
     escaped = False
@@ -325,7 +336,7 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     silently back a clean ``tests_passed`` / ``commands_run`` claim via the
     ``startswith`` widening in ``_runtime_message_supports_command_claim``.
     """
-    if _has_unquoted_test_status_mask(command):
+    if _has_unquoted_status_masking_control(command):
         return None
     try:
         parts = shlex.split(command)
@@ -335,6 +346,8 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     if not parts:
         return None
     if any(part in {"|", "||", ";", "&"} for part in parts):
+        return None
+    if _has_non_executing_test_mode(parts):
         return None
 
     if parts[0] in {"pytest", "py.test", "tox", "nox"}:
@@ -358,6 +371,53 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     ):
         return _normalized_evidence_text(" ".join(parts))
     return None
+
+
+_GENERIC_NON_EXECUTING_TEST_OPTIONS = frozenset({"-h", "--help", "-V", "--version", "--dry-run"})
+_PYTEST_NON_EXECUTING_OPTIONS = frozenset(
+    {
+        "--collect-only",
+        "--co",
+        "--fixtures",
+        "--fixtures-per-test",
+        "--markers",
+        "--setup-only",
+        "--setup-plan",
+    }
+)
+
+
+def _has_non_executing_test_mode(parts: list[str]) -> bool:
+    """Return whether a recognized test runner is configured not to run tests."""
+    if any(part in _GENERIC_NON_EXECUTING_TEST_OPTIONS for part in parts[1:]):
+        return True
+
+    runner_parts = parts
+    if len(parts) >= 3 and (
+        parts[:3] == ["uv", "run", "pytest"]
+        or (
+            _is_python_executable(parts[0])
+            and parts[1] == "-m"
+            and parts[2] in {"pytest", "unittest"}
+        )
+    ):
+        runner_parts = parts[2:]
+
+    runner = Path(runner_parts[0]).name if runner_parts else ""
+    options = runner_parts[1:]
+    if runner in {"pytest", "py.test"} and any(
+        option in _PYTEST_NON_EXECUTING_OPTIONS for option in options
+    ):
+        return True
+    if runner == "tox" and any(
+        option in {"-l", "--listenvs", "--showconfig"} for option in options
+    ):
+        return True
+    if runner == "nox" and any(option in {"-l", "--list"} for option in options):
+        return True
+    if runner in {"gradle", "gradlew"} and "-m" in options:
+        return True
+    return runner in {"npm", "pnpm", "yarn"} and "--if-present" in options
 
 
 def _unittest_command_invocation(command: str) -> str | None:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -118,7 +118,7 @@ def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
         ):
             return None
         if option in {"-c", "-lc", "-cl"}:
-            if index + 1 >= len(argv):
+            if index + 1 >= len(argv) or index + 2 != len(argv):
                 return None
             return argv[index + 1].strip()
         if option in _SHELL_OPTIONS_WITH_ARGUMENT:

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -81,6 +81,18 @@ def _shell_command_body(command: str) -> str | None:
 
 
 _SHELL_OPTIONS_WITH_ARGUMENT = frozenset({"-O", "+O", "-o", "+o", "--init-file", "--rcfile"})
+_SHELL_NON_EXECUTING_OPTIONS = frozenset(
+    {
+        "-n",
+        "--noexec",
+        "--version",
+        "--help",
+        "-D",
+        "--dump-strings",
+        "--dump-po-strings",
+        "--pretty-print",
+    }
+)
 
 
 def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
@@ -99,6 +111,10 @@ def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
     index = 1
     while index < len(argv):
         option = argv[index]
+        if option in _SHELL_NON_EXECUTING_OPTIONS or (
+            option.startswith("-") and not option.startswith("--") and "n" in option[1:]
+        ):
+            return None
         if option in {"-c", "-lc", "-cl"}:
             if index + 1 >= len(argv):
                 return None
@@ -264,6 +280,40 @@ def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
     return False
 
 
+def _has_unquoted_test_status_mask(command: str) -> bool:
+    """Return whether shell control syntax can hide a test command's status."""
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote == '"':
+            if char == '"':
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in {"|", ";", "\n", "\r"}:
+            return True
+        if char == "&":
+            previous = command[index - 1] if index > 0 else ""
+            following = command[index + 1] if index + 1 < len(command) else ""
+            if previous == "&" or following == "&":
+                continue
+            if previous not in {">", "<"} and following != ">":
+                return True
+    return False
+
+
 def _test_invocation_from_prefix(command: str) -> str | None:
     """Return a normalized test invocation only when it starts the command text.
 
@@ -275,6 +325,8 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     silently back a clean ``tests_passed`` / ``commands_run`` claim via the
     ``startswith`` widening in ``_runtime_message_supports_command_claim``.
     """
+    if _has_unquoted_test_status_mask(command):
+        return None
     try:
         parts = shlex.split(command)
     except ValueError:
@@ -282,7 +334,7 @@ def _test_invocation_from_prefix(command: str) -> str | None:
     parts = _strip_env_prefix(parts)
     if not parts:
         return None
-    if "|" in parts:
+    if any(part in {"|", "||", ";", "&"} for part in parts):
         return None
 
     if parts[0] in {"pytest", "py.test", "tox", "nox"}:

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -124,6 +124,37 @@ def _text_contains_test_success(text: str) -> bool:
     )
 
 
+def _text_contains_positive_test_execution(text: str) -> bool:
+    """Return True only when runtime output proves at least one test executed."""
+    normalized = text.lower()
+    if re.search(r"\b0\s+passed\b", normalized):
+        return False
+    if re.search(r"\b0\s+tests?\s+(completed|run|executed)\b", normalized):
+        return False
+    if re.search(r"\bno\s+tests?\s+(found|run|executed)\b", normalized):
+        return False
+    if re.search(
+        r"\btask\s+[:\w.-]*test\b[^\n]*(no-source|skipped|up-to-date|from-cache)\b", normalized
+    ):
+        return False
+    return bool(
+        re.search(r"\b[1-9]\d*\s+(passed|passing)\b", normalized)
+        or re.search(r"\bran\s+[1-9]\d*\s+tests?\b", normalized)
+        or re.search(r"\btests?\s+run\s*[:=]\s*[1-9]\d*\b", normalized)
+        or re.search(r"\b[1-9]\d*\s+tests?\s+(completed|run|executed)\b", normalized)
+        or re.search(r"\btests?\s*:\s*[1-9]\d*\s+passed\b", normalized)
+        or re.search(r"\btest\s+result\s*:\s*ok\.[^\n]*\b[1-9]\d*\s+passed\b", normalized)
+        or re.search(r"(?m)^\s*pass\s+\S+", text, flags=re.IGNORECASE)
+        or re.search(r"(?m)^\s*\S+::\S+\s+passed(?:\s|$)", normalized)
+        or re.search(r"(?m)^\s*>\s*task\s+[:\w.-]*test\b", normalized)
+    )
+
+
+def _text_proves_test_execution_success(text: str) -> bool:
+    """Return True when output proves both success and real test execution."""
+    return _text_contains_test_success(text) and _text_contains_positive_test_execution(text)
+
+
 def _message_contains_test_success(message: AgentMessage) -> bool:
     """Return True when one message says a test command passed."""
     parts = [message.content, _runtime_message_test_proof_text(message)]
@@ -134,7 +165,7 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
     exit_code = message.data.get("exit_code")
     if type(exit_code) is int:
         parts.append(f"exit code {exit_code}")
-    return _text_contains_test_success("\n".join(parts))
+    return _text_proves_test_execution_success("\n".join(parts))
 
 
 def _test_chunk_has_structured_failure(chunk: list[AgentMessage]) -> bool:
@@ -423,7 +454,7 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
             continue
         if any(
             not item.is_final
-            and _text_contains_test_success(_runtime_message_test_proof_text(item))
+            and _text_proves_test_execution_success(_runtime_message_test_proof_text(item))
             for item in chunk
         ):
             commands.update(command for command in message_commands if command)

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -215,34 +215,34 @@ def _runtime_message_test_proof_text(message: AgentMessage) -> str:
     is not runtime output for that command. Keep summary matching tied to the
     Bash output/result payloads and tool-result messages that runtimes emit.
     """
-    resultish = (
-        message.type in {"result", "tool_result"} or message.data.get("subtype") == "tool_result"
-    )
+    resultish = _is_tool_result_message(message)
+    carries_runtime_output = resultish or message.tool_name == "Bash"
     parts: list[str] = []
     if resultish:
         parts.append(message.content)
-    for key in ("result_preview", "output", "stdout", "stderr", "tool_result_text"):
-        value = message.data.get(key)
-        if isinstance(value, str):
-            parts.append(value)
-    tool_result = message.data.get("tool_result")
-    if isinstance(tool_result, dict):
-        for key in ("text_content", "content", "output", "stdout", "stderr"):
-            value = tool_result.get(key)
+    if carries_runtime_output:
+        for key in ("result_preview", "output", "stdout", "stderr", "tool_result_text"):
+            value = message.data.get(key)
             if isinstance(value, str):
                 parts.append(value)
-        meta = tool_result.get("meta")
-        exit_status = meta.get("exit_status") if isinstance(meta, dict) else None
-        if type(exit_status) is int:
-            parts.append(f"exit code {exit_status}")
-    elif isinstance(tool_result, str):
-        parts.append(tool_result)
+        tool_result = message.data.get("tool_result")
+        if isinstance(tool_result, dict):
+            for key in ("text_content", "content", "output", "stdout", "stderr"):
+                value = tool_result.get(key)
+                if isinstance(value, str):
+                    parts.append(value)
+            meta = tool_result.get("meta")
+            exit_status = meta.get("exit_status") if isinstance(meta, dict) else None
+            if type(exit_status) is int:
+                parts.append(f"exit code {exit_status}")
+        elif isinstance(tool_result, str):
+            parts.append(tool_result)
     return "\n".join(parts)
 
 
 def _is_tool_result_message(message: AgentMessage) -> bool:
     """Return True for runtime tool-result messages, including named-tool variants."""
-    return message.type in {"result", "tool_result"} or message.data.get("subtype") == "tool_result"
+    return message.type == "tool_result" or message.data.get("subtype") == "tool_result"
 
 
 def _test_claim_file_part(value: str) -> str | None:

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -146,7 +146,7 @@ def _text_contains_positive_test_execution(text: str) -> bool:
         or re.search(r"\btest\s+result\s*:\s*ok\.[^\n]*\b[1-9]\d*\s+passed\b", normalized)
         or re.search(r"(?m)^\s*pass\s+\S+", text, flags=re.IGNORECASE)
         or re.search(r"(?m)^\s*\S+::\S+\s+passed(?:\s|$)", normalized)
-        or re.search(r"(?m)^\s*>\s*task\s+[:\w.-]*test\b", normalized)
+        or re.search(r"(?m)^\s*\S.*\s+>\s+\S.*\s+passed(?:\s|$)", normalized)
     )
 
 
@@ -156,16 +156,8 @@ def _text_proves_test_execution_success(text: str) -> bool:
 
 
 def _message_contains_test_success(message: AgentMessage) -> bool:
-    """Return True when one message says a test command passed."""
-    parts = [message.content, _runtime_message_test_proof_text(message)]
-    for key in ("result_preview", "output", "stdout", "status", "subtype"):
-        value = message.data.get(key)
-        if isinstance(value, str):
-            parts.append(value)
-    exit_code = message.data.get("exit_code")
-    if type(exit_code) is int:
-        parts.append(f"exit code {exit_code}")
-    return _text_proves_test_execution_success("\n".join(parts))
+    """Return True when normalized runtime-result payload proves test success."""
+    return _text_proves_test_execution_success(_runtime_message_test_proof_text(message))
 
 
 def _test_chunk_has_structured_failure(chunk: list[AgentMessage]) -> bool:

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -34,7 +34,11 @@ from ouroboros.orchestrator.codex_cli_runtime import (
     SkillDispatchHandler,
     _CodexItemCorrelationScope,
 )
-from ouroboros.orchestrator.mcp_tools import normalize_runtime_tool_result
+from ouroboros.orchestrator.mcp_tools import (
+    normalize_runtime_tool_definition,
+    normalize_runtime_tool_result,
+    serialize_tool_result,
+)
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
@@ -68,6 +72,54 @@ _MAX_OUROBOROS_DEPTH = 5
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
 _CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
+
+_GEMINI_TOOL_NAME_ALIASES = {
+    "runshell": "Bash",
+    "runshellcommand": "Bash",
+}
+
+
+def _normalize_gemini_tool_name(value: object) -> str:
+    """Map Gemini built-ins into the shared runtime tool vocabulary."""
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    raw_name = value.strip()
+    alias_key = "".join(character for character in raw_name if character.isalnum()).lower()
+    if alias_key in _GEMINI_TOOL_NAME_ALIASES:
+        return _GEMINI_TOOL_NAME_ALIASES[alias_key]
+    return normalize_runtime_tool_definition(raw_name).name
+
+
+def _gemini_tool_result_error_state(event: dict[str, Any]) -> tuple[bool, bool]:
+    """Return normalized error state and whether raw status is untrustworthy."""
+    normalized = event.get("is_error")
+    if not isinstance(normalized, bool):
+        return False, True
+
+    observed: list[bool] = []
+    invalid = False
+    for payload in (event.get("raw"), event.get("metadata")):
+        if not isinstance(payload, dict):
+            continue
+        if "is_error" in payload:
+            raw_is_error = payload["is_error"]
+            if isinstance(raw_is_error, bool):
+                observed.append(raw_is_error)
+            else:
+                invalid = True
+        if "status" in payload:
+            raw_status = payload["status"]
+            if not isinstance(raw_status, str):
+                invalid = True
+            else:
+                status = raw_status.strip().lower()
+                if status in {"error", "failed"}:
+                    observed.append(True)
+                elif status in {"completed", "success", "succeeded"}:
+                    observed.append(False)
+    if any(value != normalized for value in observed):
+        invalid = True
+    return normalized, invalid
 
 
 class GeminiCLIRuntime(CodexCliRuntime):
@@ -357,7 +409,6 @@ class GeminiCLIRuntime(CodexCliRuntime):
         event_type = event.get("type")
         content = event.get("content", "")
         metadata = event.get("metadata", {})
-        is_error = event.get("is_error", False)
 
         # Truncate content using InputValidator for text-bearing events
         # (including the terminal `result` payload, since `response` may be long).
@@ -396,7 +447,7 @@ class GeminiCLIRuntime(CodexCliRuntime):
             ]
 
         if event_type == "tool_use":
-            tool_name = metadata.get("name", "")
+            tool_name = _normalize_gemini_tool_name(metadata.get("name"))
             tool_args = metadata.get("input", {})
             return [
                 AgentMessage(
@@ -409,7 +460,18 @@ class GeminiCLIRuntime(CodexCliRuntime):
             ]
 
         if event_type == "tool_result":
-            tool_name = metadata.get("name", "")
+            tool_name = _normalize_gemini_tool_name(metadata.get("name"))
+            result_is_error, invalid_error_state = _gemini_tool_result_error_state(event)
+            serialized_result = serialize_tool_result(
+                normalize_runtime_tool_result(
+                    content,
+                    is_error=result_is_error,
+                )
+            )
+            message_error_state: bool | str = result_is_error
+            if invalid_error_state:
+                message_error_state = "invalid"
+                serialized_result["is_error"] = "invalid"
             return [
                 AgentMessage(
                     type="tool_result",
@@ -417,11 +479,8 @@ class GeminiCLIRuntime(CodexCliRuntime):
                     tool_name=tool_name,
                     data={
                         "subtype": "tool_result",
-                        "is_error": is_error,
-                        "tool_result": normalize_runtime_tool_result(
-                            content,
-                            is_error=is_error,
-                        ),
+                        "is_error": message_error_state,
+                        "tool_result": serialized_result,
                     },
                     resume_handle=current_handle,
                 )

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -34,6 +34,7 @@ from ouroboros.orchestrator.codex_cli_runtime import (
     SkillDispatchHandler,
     _CodexItemCorrelationScope,
 )
+from ouroboros.orchestrator.mcp_tools import normalize_runtime_tool_result
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
@@ -411,10 +412,17 @@ class GeminiCLIRuntime(CodexCliRuntime):
             tool_name = metadata.get("name", "")
             return [
                 AgentMessage(
-                    type="tool",
+                    type="tool_result",
                     content=content,
                     tool_name=tool_name,
-                    data={"is_error": is_error},
+                    data={
+                        "subtype": "tool_result",
+                        "is_error": is_error,
+                        "tool_result": normalize_runtime_tool_result(
+                            content,
+                            is_error=is_error,
+                        ),
+                    },
                     resume_handle=current_handle,
                 )
             ]

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -39,6 +39,7 @@ import math
 import os
 from pathlib import Path
 import re
+import shlex
 import time
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 from uuid import uuid4
@@ -1262,23 +1263,103 @@ def _matching_journal_entries(
         else:
             if tool_name != "Bash":
                 continue
-            observed = payload.get("command")
-            if not isinstance(observed, str):
-                observed = payload.get("args_preview")
-        if not isinstance(observed, str):
-            continue
-        if field == "commands_run" or field == "tests_passed":
-            # The verifier already treats a concise claim and a runtime shell
-            # wrapper (and safe output plumbing) as the same exact command.
-            # Deliver evidence must use the same aliases or it will reject
-            # claims that the preceding verifier accepted.
-            if set(_normalized_command_claim_aliases(observed)).intersection(
-                _normalized_command_claim_aliases(value)
-            ):
+            observed_commands = _journal_command_values(payload)
+            if any(_commands_are_strictly_equivalent(value, item) for item in observed_commands):
                 matches.append(entry)
-        elif observed.strip() == value:
+            continue
+        if isinstance(observed, str) and observed.strip() == value:
             matches.append(entry)
     return tuple(matches)
+
+
+_JOURNAL_COMMAND_KEYS: tuple[str, ...] = ("command", "cmd", "command_line")
+
+
+def _journal_command_values(payload: Mapping[str, object]) -> tuple[object, ...]:
+    """Extract structured command values from one journal manifest payload.
+
+    Accepted-tool projection keeps the original ``tool_input`` only as bounded
+    JSON in ``args_preview`` for adapters that use ``cmd`` / ``command_line`` or
+    argv-list values. Preserve those structures until signature generation so
+    argument boundaries cannot be flattened into an unsafe string comparison.
+    """
+    values: list[object] = []
+
+    def append_from(container: Mapping[str, object]) -> None:
+        for key in _JOURNAL_COMMAND_KEYS:
+            candidate = container.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                values.append(candidate.strip())
+            elif isinstance(candidate, (list, tuple)) and candidate:
+                values.append(tuple(str(part) for part in candidate))
+
+    append_from(payload)
+    preview = payload.get("args_preview")
+    if isinstance(preview, str) and preview.strip():
+        try:
+            decoded = json.loads(preview)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            # Legacy normalizer rows store the raw command directly.
+            values.append(preview.strip())
+        else:
+            if isinstance(decoded, Mapping):
+                append_from(decoded)
+            elif isinstance(decoded, str) and decoded.strip():
+                values.append(decoded.strip())
+    return tuple(values)
+
+
+def _commands_are_strictly_equivalent(claim: str, observed: object) -> bool:
+    """Compare command evidence using case-sensitive argv signatures.
+
+    Quoting differences that preserve one argv token are equivalent, while case
+    changes and flattened token boundaries are not. Safe shell wrappers and
+    setup-only preambles may expose their single inner command. Output-only
+    plumbing follows the verifier's existing masking guard.
+    """
+    claim_signatures = set(_strict_command_signatures(claim))
+    observed_signatures = set(_strict_command_signatures(observed))
+    return bool(claim_signatures.intersection(observed_signatures))
+
+
+def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
+    if isinstance(command, (list, tuple)):
+        signature = tuple(str(part) for part in command)
+        return (signature,) if signature and all(signature) else ()
+    if not isinstance(command, str) or not command.strip():
+        return ()
+
+    raw = command.strip()
+    candidates: list[tuple[str, bool]] = [(raw, False)]
+    body = _shell_command_body(raw)
+    if body is not None:
+        candidates.append((body, _output_filter_pipeline_is_pipefail_protected(body)))
+        inner = tuple(_segments_after_safe_shell_preamble(body))
+        if len(inner) == 1:
+            candidates.append(
+                (inner[0], _output_filter_pipeline_is_pipefail_protected(body))
+            )
+
+    signatures: list[tuple[str, ...]] = []
+    for candidate, pipefail_protected in candidates:
+        variants = [candidate.strip()]
+        stripped = _strip_command_output_plumbing(candidate)
+        if stripped and stripped != candidate.strip():
+            unsafe_test_filter = (
+                _has_trailing_output_filter_pipeline(candidate)
+                and _looks_like_test_command(stripped)
+                and not pipefail_protected
+            )
+            if not unsafe_test_filter:
+                variants.append(stripped)
+        for variant in variants:
+            try:
+                signature = tuple(shlex.split(variant))
+            except ValueError:
+                continue
+            if signature and signature not in signatures:
+                signatures.append(signature)
+    return tuple(signatures)
 
 
 def _structured_literal(value: str) -> str | None:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1314,6 +1314,12 @@ def _journal_command_values(payload: Mapping[str, object]) -> tuple[object, ...]
                 # command spellings (for example ``true``). Preserve the
                 # preview rather than silently dropping exact evidence.
                 values.append(preview.strip())
+    if len(values) > 1:
+        anchor = values[0]
+        if any(
+            not _commands_are_strictly_equivalent(anchor, candidate) for candidate in values[1:]
+        ):
+            return ()
     return tuple(values)
 
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -211,6 +211,7 @@ from ouroboros.orchestrator.evidence.shell_parsing import (  # noqa: F401
     _segments_after_safe_shell_preamble,
     _segments_after_safe_shell_preamble_with_pipefail,
     _shell_command_body,
+    _shell_command_body_from_argv,
     _single_command_after_safe_shell_preamble,
     _single_exact_command_after_safe_shell_preamble,
     _strip_command_output_plumbing,
@@ -1308,6 +1309,11 @@ def _journal_command_values(payload: Mapping[str, object]) -> tuple[object, ...]
                 append_from(decoded)
             elif isinstance(decoded, str) and decoded.strip():
                 values.append(decoded.strip())
+            else:
+                # JSON scalars and unsupported containers may be legacy raw
+                # command spellings (for example ``true``). Preserve the
+                # preview rather than silently dropping exact evidence.
+                values.append(preview.strip())
     return tuple(values)
 
 
@@ -1373,19 +1379,7 @@ def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
     return tuple(signatures)
 
 
-def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
-    if len(argv) < 3 or Path(argv[0]).name not in {"bash", "zsh", "sh"}:
-        return None
-    option_index = next(
-        (index for index, part in enumerate(argv[1:], start=1) if part in {"-c", "-lc", "-cl"}),
-        None,
-    )
-    if option_index is None or option_index + 1 >= len(argv):
-        return None
-    return argv[option_index + 1].strip()
-
-
-_SHELL_ACTIVE_UNQUOTED = frozenset("$*?[]><;|&`(){}~#!=^\n\r")
+_SHELL_ACTIVE_UNQUOTED = frozenset("$*?[]><;|&`(){}~#!^\n\r")
 _SHELL_ACTIVE_DOUBLE_QUOTED = frozenset("$`")
 _SHELL_RESERVED_WORDS = frozenset(
     {
@@ -1449,7 +1443,9 @@ def _shell_text_is_argv_safe(command: str) -> bool:
         parts = shlex.split(command)
     except ValueError:
         return False
-    return not any(part in _SHELL_RESERVED_WORDS for part in parts)
+    if not parts:
+        return False
+    return parts[0] not in _SHELL_RESERVED_WORDS and not _is_env_assignment(parts[0])
 
 
 def _structured_literal(value: str) -> str | None:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1200,7 +1200,12 @@ def _standard_deliver_facts(
                 if eligible
                 else ()
             )
-            handle = matches[0].handle if len(matches) == 1 else f"missing:{field}:{index}"
+            if len(matches) == 1:
+                handle = matches[0].handle
+            elif len(matches) > 1:
+                handle = f"ambiguous:{field}:{index}"
+            else:
+                handle = f"missing:{field}:{index}"
             statement_value = _structured_literal(match_value)
             if statement_value is None:
                 handle = f"missing:{field}:{index}"
@@ -1260,7 +1265,18 @@ def _matching_journal_entries(
             observed = payload.get("command")
             if not isinstance(observed, str):
                 observed = payload.get("args_preview")
-        if isinstance(observed, str) and observed.strip() == value:
+        if not isinstance(observed, str):
+            continue
+        if field == "commands_run" or field == "tests_passed":
+            # The verifier already treats a concise claim and a runtime shell
+            # wrapper (and safe output plumbing) as the same exact command.
+            # Deliver evidence must use the same aliases or it will reject
+            # claims that the preceding verifier accepted.
+            if set(_normalized_command_claim_aliases(observed)).intersection(
+                _normalized_command_claim_aliases(value)
+            ):
+                matches.append(entry)
+        elif observed.strip() == value:
             matches.append(entry)
     return tuple(matches)
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1263,6 +1263,8 @@ def _matching_journal_entries(
         else:
             if tool_name != "Bash":
                 continue
+            if field == "tests_passed" and not _looks_like_test_command(value):
+                continue
             observed_commands = _journal_command_values(payload)
             if any(_commands_are_strictly_equivalent(value, item) for item in observed_commands):
                 matches.append(entry)
@@ -1325,7 +1327,13 @@ def _commands_are_strictly_equivalent(claim: str, observed: object) -> bool:
 def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
     if isinstance(command, (list, tuple)):
         signature = tuple(str(part) for part in command)
-        return (signature,) if signature and all(signature) else ()
+        if not signature:
+            return ()
+        argv_signatures = [("argv", *signature)]
+        body = _shell_command_body_from_argv(signature)
+        if body is not None:
+            argv_signatures.extend(_strict_command_signatures(body))
+        return tuple(dict.fromkeys(argv_signatures))
     if not isinstance(command, str) or not command.strip():
         return ()
 
@@ -1351,13 +1359,97 @@ def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
             if not unsafe_test_filter:
                 variants.append(stripped)
         for variant in variants:
+            raw_signature = ("raw", variant)
+            if raw_signature not in signatures:
+                signatures.append(raw_signature)
+            if not _shell_text_is_argv_safe(variant):
+                continue
             try:
-                signature = tuple(shlex.split(variant))
+                signature = ("argv", *shlex.split(variant))
             except ValueError:
                 continue
-            if signature and signature not in signatures:
+            if len(signature) > 1 and signature not in signatures:
                 signatures.append(signature)
     return tuple(signatures)
+
+
+def _shell_command_body_from_argv(argv: tuple[str, ...]) -> str | None:
+    if len(argv) < 3 or Path(argv[0]).name not in {"bash", "zsh", "sh"}:
+        return None
+    option_index = next(
+        (index for index, part in enumerate(argv[1:], start=1) if part in {"-c", "-lc", "-cl"}),
+        None,
+    )
+    if option_index is None or option_index + 1 >= len(argv):
+        return None
+    return argv[option_index + 1].strip()
+
+
+_SHELL_ACTIVE_UNQUOTED = frozenset("$*?[]><;|&`(){}~#!=^\n\r")
+_SHELL_ACTIVE_DOUBLE_QUOTED = frozenset("$`")
+_SHELL_RESERVED_WORDS = frozenset(
+    {
+        "case",
+        "coproc",
+        "do",
+        "done",
+        "elif",
+        "else",
+        "esac",
+        "fi",
+        "for",
+        "function",
+        "if",
+        "in",
+        "select",
+        "then",
+        "time",
+        "until",
+        "while",
+    }
+)
+
+
+def _shell_text_is_argv_safe(command: str) -> bool:
+    """Return whether quote removal cannot change this command's shell effects.
+
+    ``shlex.split`` is an argv oracle only when every shell-active token is
+    inert. Single quotes make those tokens literal; double quotes still permit
+    parameter and command substitution. Unsafe strings retain only their exact
+    raw signature, so ``echo $HOME`` cannot equal ``echo '$HOME'`` and quoted
+    redirections/globs cannot equal active ones.
+    """
+    quote: str | None = None
+    escaped = False
+    for char in command:
+        if escaped:
+            escaped = False
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote == '"':
+            if char == '"':
+                quote = None
+            elif char in _SHELL_ACTIVE_DOUBLE_QUOTED:
+                return False
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in _SHELL_ACTIVE_UNQUOTED:
+            return False
+    if quote is not None or escaped:
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    return not any(part in _SHELL_RESERVED_WORDS for part in parts)
 
 
 def _structured_literal(value: str) -> str | None:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1368,7 +1368,11 @@ def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
                 and _looks_like_test_command(stripped)
                 and not pipefail_protected
             )
-            if not unsafe_test_filter:
+            try:
+                stripped_parts = shlex.split(stripped)
+            except ValueError:
+                stripped_parts = []
+            if not unsafe_test_filter and stripped_parts:
                 variants.append(stripped)
         for variant in variants:
             raw_signature = ("raw", variant)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -242,6 +242,7 @@ from ouroboros.orchestrator.evidence.test_detection import (  # noqa: F401
     _test_command_targets_claim,
     _text_contains_test_success,
     _text_contains_unittest_success,
+    _text_proves_test_execution_success,
 )
 from ouroboros.orchestrator.evidence.typed_evidence import (  # noqa: F401
     _add_runtime_command_evidence,
@@ -1264,8 +1265,12 @@ def _matching_journal_entries(
         else:
             if tool_name != "Bash":
                 continue
-            if field == "tests_passed" and not _looks_like_test_command(value):
-                continue
+            if field == "tests_passed":
+                if not _looks_like_test_command(value):
+                    continue
+                result_text = _journal_result_text(payload)
+                if not _text_proves_test_execution_success(result_text):
+                    continue
             observed_commands = _journal_command_values(payload)
             if any(_commands_are_strictly_equivalent(value, item) for item in observed_commands):
                 matches.append(entry)
@@ -1276,6 +1281,22 @@ def _matching_journal_entries(
 
 
 _JOURNAL_COMMAND_KEYS: tuple[str, ...] = ("command", "cmd", "command_line")
+
+
+def _journal_result_text(payload: Mapping[str, object]) -> str:
+    """Return runtime-produced result text attached to one journal entry."""
+    parts: list[str] = []
+    for key in ("result_preview", "output", "stdout", "stderr", "tool_result_text"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value.strip())
+    tool_result = payload.get("tool_result")
+    if isinstance(tool_result, Mapping):
+        for key in ("text_content", "content", "output", "stdout", "stderr"):
+            value = tool_result.get(key)
+            if isinstance(value, str) and value.strip():
+                parts.append(value.strip())
+    return "\n".join(dict.fromkeys(parts))
 
 
 def _journal_command_values(payload: Mapping[str, object]) -> tuple[object, ...]:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1336,9 +1336,7 @@ def _strict_command_signatures(command: object) -> tuple[tuple[str, ...], ...]:
         candidates.append((body, _output_filter_pipeline_is_pipefail_protected(body)))
         inner = tuple(_segments_after_safe_shell_preamble(body))
         if len(inner) == 1:
-            candidates.append(
-                (inner[0], _output_filter_pipeline_is_pipefail_protected(body))
-            )
+            candidates.append((inner[0], _output_filter_pipeline_is_pipefail_protected(body)))
 
     signatures: list[tuple[str, ...]] = []
     for candidate, pipefail_protected in candidates:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -413,6 +413,52 @@ class TestLoadAcEvidenceManifest:
             assert manifest.entries == ()
 
     @pytest.mark.asyncio
+    async def test_same_timestamp_execution_completion_is_ordered_after_start(self) -> None:
+        when = datetime.now(UTC)
+        started = BaseEvent(
+            id="evt_bash_started",
+            type="execution.tool.started",
+            timestamp=when,
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                "ac_id": "ac_1",
+                "execution_id": "exec_1",
+                "tool_name": "Bash",
+                "tool_call_id": "call_bash_1",
+                "tool_input": {"command": "pytest tests/test_app.py"},
+            },
+        )
+        completed = BaseEvent(
+            id="evt_bash_completed",
+            type="execution.tool.completed",
+            timestamp=when,
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                "ac_id": "ac_1",
+                "execution_id": "exec_1",
+                "tool_name": "Bash",
+                "tool_call_id": "call_bash_1",
+                "tool_result": {"is_error": False},
+                "output": "1 passed in 0.01s",
+            },
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            _FakeEventStore([completed, started]),
+            ac_id="ac_1",
+            execution_id="exec_1",
+            admit_accepted_tool_starts=True,
+        )
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == (
+            "evt_bash_started",
+            "evt_bash_completed",
+        )
+
+    @pytest.mark.asyncio
     async def test_bash_start_without_completion_is_not_admitted(self) -> None:
         started = BaseEvent(
             id="evt_bash_started",

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -361,6 +361,83 @@ class TestLoadAcEvidenceManifest:
         assert "accepted_tool_starts_admitted" not in manifest.metadata
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(("completion_error", "admitted"), [(False, True), (True, False)])
+    async def test_bash_start_requires_its_own_successful_completion(
+        self,
+        completion_error: bool,
+        admitted: bool,
+    ) -> None:
+        events = [
+            BaseEvent(
+                id="evt_bash_started",
+                type="execution.tool.started",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    "tool_input": {"command": "pytest tests/test_app.py"},
+                },
+            ),
+            BaseEvent(
+                id="evt_bash_completed",
+                type="execution.tool.completed",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    "tool_result": {"is_error": completion_error},
+                },
+            ),
+        ]
+
+        manifest = await load_ac_evidence_manifest(
+            _FakeEventStore(events),
+            ac_id="ac_1",
+            execution_id="exec_1",
+            admit_accepted_tool_starts=True,
+        )
+
+        if admitted:
+            assert len(manifest.entries) == 1
+            assert manifest.entries[0].source_event_ids == (
+                "evt_bash_started",
+                "evt_bash_completed",
+            )
+        else:
+            assert manifest.entries == ()
+
+    @pytest.mark.asyncio
+    async def test_bash_start_without_completion_is_not_admitted(self) -> None:
+        started = BaseEvent(
+            id="evt_bash_started",
+            type="execution.tool.started",
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                "ac_id": "ac_1",
+                "execution_id": "exec_1",
+                "tool_name": "Bash",
+                "tool_call_id": "call_bash_1",
+                "tool_input": {"command": "pytest tests/test_app.py"},
+            },
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            _FakeEventStore([started]),
+            ac_id="ac_1",
+            execution_id="exec_1",
+            admit_accepted_tool_starts=True,
+        )
+
+        assert manifest.entries == ()
+
+    @pytest.mark.asyncio
     async def test_write_completion_with_different_call_id_is_not_admitted(self, tmp_path) -> None:
         events = [
             BaseEvent(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -438,6 +438,57 @@ class TestLoadAcEvidenceManifest:
         assert manifest.entries == ()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "lifecycle_success",
+        (
+            {"status": "completed"},
+            {"subtype": "success"},
+            {"runtime_event_type": "tool.completed"},
+        ),
+    )
+    async def test_bash_lifecycle_completion_without_command_verdict_is_not_admitted(
+        self,
+        lifecycle_success: dict[str, str],
+    ) -> None:
+        events = [
+            BaseEvent(
+                id="evt_bash_started",
+                type="execution.tool.started",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    "tool_input": {"command": "pytest tests/test_app.py"},
+                },
+            ),
+            BaseEvent(
+                id="evt_bash_completed",
+                type="execution.tool.completed",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    **lifecycle_success,
+                },
+            ),
+        ]
+
+        manifest = await load_ac_evidence_manifest(
+            _FakeEventStore(events),
+            ac_id="ac_1",
+            execution_id="exec_1",
+            admit_accepted_tool_starts=True,
+        )
+
+        assert manifest.entries == ()
+
+    @pytest.mark.asyncio
     async def test_write_completion_with_different_call_id_is_not_admitted(self, tmp_path) -> None:
         events = [
             BaseEvent(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -489,6 +489,48 @@ class TestLoadAcEvidenceManifest:
         assert manifest.entries == ()
 
     @pytest.mark.asyncio
+    async def test_bash_correlated_failure_vetoes_start_side_success(self) -> None:
+        events = [
+            BaseEvent(
+                id="evt_bash_started",
+                type="execution.tool.started",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    "tool_input": {"command": "pytest tests/test_app.py"},
+                    "exit_code": 0,
+                },
+            ),
+            BaseEvent(
+                id="evt_bash_completed",
+                type="execution.tool.completed",
+                aggregate_type="execution",
+                aggregate_id="ac_1",
+                data={
+                    "ac_id": "ac_1",
+                    "execution_id": "exec_1",
+                    "tool_name": "Bash",
+                    "tool_call_id": "call_bash_1",
+                    "tool_result": {"is_error": True},
+                    "exit_code": 1,
+                },
+            ),
+        ]
+
+        manifest = await load_ac_evidence_manifest(
+            _FakeEventStore(events),
+            ac_id="ac_1",
+            execution_id="exec_1",
+            admit_accepted_tool_starts=True,
+        )
+
+        assert manifest.entries == ()
+
+    @pytest.mark.asyncio
     async def test_write_completion_with_different_call_id_is_not_admitted(self, tmp_path) -> None:
         events = [
             BaseEvent(

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -579,6 +579,7 @@ def _tool_completed_event(
     event_id: str,
     tool_name: str,
     tool_call_id: str,
+    output: str | None = None,
 ) -> BaseEvent:
     return BaseEvent(
         id=event_id,
@@ -586,11 +587,16 @@ def _tool_completed_event(
         aggregate_type="execution",
         aggregate_id=identity.ac_id,
         data={
-            **identity.to_metadata(),
-            "execution_id": execution_id,
-            "tool_name": tool_name,
-            "tool_call_id": tool_call_id,
-            "tool_result": {"is_error": False},
+            key: value
+            for key, value in {
+                **identity.to_metadata(),
+                "execution_id": execution_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "tool_result": {"is_error": False},
+                "output": output,
+            }.items()
+            if value is not None
         },
     )
 
@@ -633,6 +639,7 @@ class TestDeliverVerdict:
                 event_id="evt-test-completed",
                 tool_name="Bash",
                 tool_call_id="evt-test",
+                output="1 passed in 0.01s",
             ),
             # Same command from a different failed attempt must not make the
             # accepted attempt ambiguous.

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -627,6 +627,13 @@ class TestDeliverVerdict:
                 tool_input={"command": command},
                 runtime_cwd=str(tmp_path),
             ),
+            _tool_completed_event(
+                identity=identity,
+                execution_id="exec_frugal",
+                event_id="evt-test-completed",
+                tool_name="Bash",
+                tool_call_id="evt-test",
+            ),
             # Same command from a different failed attempt must not make the
             # accepted attempt ambiguous.
             _tool_start_event(

--- a/tests/unit/orchestrator/test_gemini_cli_runtime.py
+++ b/tests/unit/orchestrator/test_gemini_cli_runtime.py
@@ -107,6 +107,42 @@ def test_convert_event_projects_tool_result_as_successful_completion() -> None:
     assert projected.tool_result["text_content"] == "1 passed in 0.01s"
 
 
+def test_convert_event_normalizes_native_shell_tool_name() -> None:
+    runtime = _make_runtime()
+    tool_use = runtime._parse_json_event(
+        '{"type":"tool_use","name":"run_shell","input":{"command":"pytest -q"}}'
+    )
+    tool_result = runtime._parse_json_event(
+        '{"type":"tool_result","name":"run_shell","output":"1 passed"}'
+    )
+
+    assert tool_use is not None
+    assert tool_result is not None
+    started = runtime._convert_event(tool_use, current_handle=None)[0]
+    completed = runtime._convert_event(tool_result, current_handle=None)[0]
+
+    assert started.tool_name == "Bash"
+    assert completed.tool_name == "Bash"
+    assert isinstance(completed.data["tool_result"], dict)
+
+
+def test_convert_event_preserves_malformed_error_status_as_invalid() -> None:
+    runtime = _make_runtime()
+    event = runtime._parse_json_event(
+        '{"type":"tool_result","name":"run_shell","output":"1 passed","is_error":"true"}'
+    )
+
+    assert event is not None
+    message = runtime._convert_event(event, current_handle=None)[0]
+    projected = project_runtime_message(message)
+
+    assert message.data["is_error"] == "invalid"
+    assert message.data["tool_result"]["is_error"] == "invalid"
+    assert projected.runtime_metadata["is_error_invalid"] is True
+    assert projected.tool_result is not None
+    assert projected.tool_result["is_error_invalid"] is True
+
+
 # ---------------------------------------------------------------------------
 # _build_command: headless flags
 # ---------------------------------------------------------------------------

--- a/tests/unit/orchestrator/test_gemini_cli_runtime.py
+++ b/tests/unit/orchestrator/test_gemini_cli_runtime.py
@@ -22,6 +22,7 @@ from ouroboros.orchestrator.gemini_cli_runtime import (
     GeminiCLIRuntime,
 )
 from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
+from ouroboros.orchestrator.runtime_message_projection import project_runtime_message
 
 # ---------------------------------------------------------------------------
 # _convert_event: terminal `result` event
@@ -82,6 +83,28 @@ def test_convert_event_routes_normalizer_response_field_through_result() -> None
     assert len(messages) == 1
     assert messages[0].type == "assistant"
     assert messages[0].content == "final answer text"
+
+
+def test_convert_event_projects_tool_result_as_successful_completion() -> None:
+    runtime = _make_runtime()
+    event = {
+        "type": "tool_result",
+        "content": "1 passed in 0.01s",
+        "metadata": {"name": "Bash"},
+        "is_error": False,
+        "raw": {"type": "tool_result", "name": "Bash"},
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+    projected = project_runtime_message(messages[0])
+
+    assert messages[0].type == "tool_result"
+    assert messages[0].data["subtype"] == "tool_result"
+    assert projected.is_tool_result is True
+    assert projected.tool_name == "Bash"
+    assert projected.tool_result is not None
+    assert projected.tool_result["is_error"] is False
+    assert projected.tool_result["text_content"] == "1 passed in 0.01s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -20,6 +20,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.events.base import BaseEvent
+from ouroboros.harness.journal import EvidenceEntry, EvidenceKind, EvidenceManifest
 from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
@@ -48,10 +49,12 @@ from ouroboros.orchestrator.parallel_executor import (
     _complete_sibling_acs_from_evidence,
     _criterion_satisfied_by_evidence,
     _effective_evidence_schema_for_ac,
+    _matching_journal_entries,
     _message_contains_test_success,
     _runtime_messages_have_masked_test_command_form,
     _runtime_messages_support_command_claim,
     _runtime_messages_support_test_claim,
+    _standard_deliver_facts,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -63,6 +66,61 @@ from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalT
 def test_stall_timeout_default_allows_realistic_test_suites() -> None:
     """The default stall watchdog should not kill long quiet test commands too early."""
     assert STALL_TIMEOUT_SECONDS == 900.0
+
+
+def _journal_entry(*, handle: str, command: str) -> EvidenceEntry:
+    return EvidenceEntry(
+        handle=handle,
+        kind=EvidenceKind.COMMAND_EXECUTED,
+        ok=True,
+        started_at=datetime.now(UTC),
+        ended_at=datetime.now(UTC),
+        payload={"tool_name": "Bash", "command": command},
+        source_event_ids=(f"event-{handle}",),
+    )
+
+
+def test_deliver_matching_uses_verifier_command_aliases() -> None:
+    """A shell-wrapped command has the same backing evidence as its clean claim."""
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_entry(
+                handle="ev_wrapped",
+                command="/bin/zsh -lc 'pytest tests/test_app.py'",
+            ),
+        ),
+    )
+
+    matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value="pytest tests/test_app.py",
+    )
+
+    assert tuple(entry.handle for entry in matches) == ("ev_wrapped",)
+
+
+def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:
+    """Multiple journal matches remain rejected and are not labelled missing."""
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_entry(handle="ev_1", command="pytest tests/test_app.py"),
+            _journal_entry(handle="ev_2", command="pytest tests/test_app.py"),
+        ),
+    )
+
+    facts = _standard_deliver_facts(
+        EvidenceRecord(data={"commands_run": ["pytest tests/test_app.py"]}),
+        manifest,
+        task_cwd=None,
+        verifier_passed=True,
+    )
+
+    assert facts is not None
+    assert len(facts) == 1
+    assert facts[0].evidence_handle == "ambiguous:commands_run:0"
 
 
 class _RateGateStubAdapter:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime
+import json
 import os
 from types import SimpleNamespace
 from typing import Any
@@ -69,13 +70,20 @@ def test_stall_timeout_default_allows_realistic_test_suites() -> None:
 
 
 def _journal_entry(*, handle: str, command: str) -> EvidenceEntry:
+    return _journal_payload_entry(
+        handle=handle,
+        payload={"tool_name": "Bash", "command": command},
+    )
+
+
+def _journal_payload_entry(*, handle: str, payload: dict[str, object]) -> EvidenceEntry:
     return EvidenceEntry(
         handle=handle,
         kind=EvidenceKind.COMMAND_EXECUTED,
         ok=True,
         started_at=datetime.now(UTC),
         ended_at=datetime.now(UTC),
-        payload={"tool_name": "Bash", "command": command},
+        payload=payload,
         source_event_ids=(f"event-{handle}",),
     )
 
@@ -99,6 +107,66 @@ def test_deliver_matching_uses_verifier_command_aliases() -> None:
     )
 
     assert tuple(entry.handle for entry in matches) == ("ev_wrapped",)
+
+
+@pytest.mark.parametrize(
+    ("observed", "claim"),
+    (
+        ("pytest Tests/test_app.py", "pytest tests/test_app.py"),
+        ('python script.py "a b"', "python script.py a b"),
+    ),
+)
+def test_deliver_matching_preserves_case_and_argument_boundaries(
+    observed: str,
+    claim: str,
+) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_distinct", command=observed),),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value=claim,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_input", "claim"),
+    (
+        ({"cmd": "pytest tests/test_a.py"}, "pytest tests/test_a.py"),
+        (
+            {"cmd": ["python", "-m", "unittest", "test_slugify.py"]},
+            "python -m unittest test_slugify.py",
+        ),
+        ({"command_line": "ruff check src"}, "ruff check src"),
+    ),
+)
+def test_deliver_matching_reads_structured_command_shapes_from_args_preview(
+    tool_input: dict[str, object],
+    claim: str,
+) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_payload_entry(
+                handle="ev_structured",
+                payload={
+                    "tool_name": "Bash",
+                    "args_preview": json.dumps(tool_input, separators=(",", ":")),
+                },
+            ),
+        ),
+    )
+
+    matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value=claim,
+    )
+
+    assert tuple(entry.handle for entry in matches) == ("ev_structured",)
 
 
 def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -165,6 +165,8 @@ def test_deliver_matching_allows_inert_quote_spelling_differences() -> None:
             {"cmd": ["/bin/zsh", "-lc", "pytest tests/test_app.py"]},
             "pytest tests/test_app.py",
         ),
+        ({"cmd": ["pytest", "--maxfail=1"]}, "pytest --maxfail=1"),
+        ({"cmd": ["pytest", "-k", "time"]}, "pytest -k time"),
         ({"cmd": ["python", "script.py", ""]}, "python script.py ''"),
         ({"command_line": "ruff check src"}, "ruff check src"),
     ),
@@ -193,6 +195,54 @@ def test_deliver_matching_reads_structured_command_shapes_from_args_preview(
     )
 
     assert tuple(entry.handle for entry in matches) == ("ev_structured",)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"tool_name": "Bash", "command": "bash /dev/null -c 'pytest tests/test_app.py'"},
+        {
+            "tool_name": "Bash",
+            "args_preview": json.dumps(
+                {"cmd": ["bash", "/dev/null", "-c", "pytest tests/test_app.py"]},
+                separators=(",", ":"),
+            ),
+        },
+    ),
+)
+def test_deliver_matching_does_not_extract_shell_body_after_script_operand(
+    payload: dict[str, object],
+) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_payload_entry(handle="ev_script", payload=payload),),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value="pytest tests/test_app.py",
+    )
+
+
+def test_deliver_matching_preserves_legacy_json_scalar_preview() -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_payload_entry(
+                handle="ev_true",
+                payload={"tool_name": "Bash", "args_preview": "true"},
+            ),
+        ),
+    )
+
+    matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value="true",
+    )
+
+    assert tuple(entry.handle for entry in matches) == ("ev_true",)
 
 
 def test_tests_passed_requires_a_successful_test_command() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -114,6 +114,12 @@ def test_deliver_matching_uses_verifier_command_aliases() -> None:
     (
         ("pytest Tests/test_app.py", "pytest tests/test_app.py"),
         ('python script.py "a b"', "python script.py a b"),
+        ("echo $HOME", "echo '$HOME'"),
+        ("echo x > out", "echo x '>' out"),
+        ("echo *.py", "echo '*.py'"),
+        ("echo x; touch out", "echo 'x;' touch out"),
+        ("FOO=bar command", "'FOO=bar' command"),
+        ("if true", "'if' true"),
     ),
 )
 def test_deliver_matching_preserves_case_and_argument_boundaries(
@@ -132,6 +138,21 @@ def test_deliver_matching_preserves_case_and_argument_boundaries(
     )
 
 
+def test_deliver_matching_allows_inert_quote_spelling_differences() -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_quoted", command='python script.py "a b"'),),
+    )
+
+    matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value="python script.py 'a b'",
+    )
+
+    assert tuple(entry.handle for entry in matches) == ("ev_quoted",)
+
+
 @pytest.mark.parametrize(
     ("tool_input", "claim"),
     (
@@ -140,6 +161,11 @@ def test_deliver_matching_preserves_case_and_argument_boundaries(
             {"cmd": ["python", "-m", "unittest", "test_slugify.py"]},
             "python -m unittest test_slugify.py",
         ),
+        (
+            {"cmd": ["/bin/zsh", "-lc", "pytest tests/test_app.py"]},
+            "pytest tests/test_app.py",
+        ),
+        ({"cmd": ["python", "script.py", ""]}, "python script.py ''"),
         ({"command_line": "ruff check src"}, "ruff check src"),
     ),
 )
@@ -167,6 +193,40 @@ def test_deliver_matching_reads_structured_command_shapes_from_args_preview(
     )
 
     assert tuple(entry.handle for entry in matches) == ("ev_structured",)
+
+
+def test_tests_passed_requires_a_successful_test_command() -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_entry(handle="ev_echo", command="echo ready"),
+            _journal_entry(handle="ev_pytest", command="pytest tests/test_app.py"),
+        ),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value="echo ready",
+    )
+    matches = _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value="pytest tests/test_app.py",
+    )
+    assert tuple(entry.handle for entry in matches) == ("ev_pytest",)
+
+    facts = _standard_deliver_facts(
+        EvidenceRecord(data={"commands_run": ["echo ready"], "tests_passed": ["echo ready"]}),
+        manifest,
+        task_cwd=None,
+        verifier_passed=True,
+    )
+    assert facts is not None
+    assert tuple(fact.evidence_handle for fact in facts) == (
+        "ev_echo",
+        "missing:tests_passed:0",
+    )
 
 
 def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -538,6 +538,33 @@ def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:
     assert facts[0].evidence_handle == "ambiguous:commands_run:0"
 
 
+@pytest.mark.parametrize(
+    "observed",
+    (
+        "bash -c 'pytest \"$@\"' ignored tests/test_a.py",
+        ("bash", "-c", 'pytest "$@"', "ignored", "tests/test_a.py"),
+    ),
+)
+def test_shell_wrapper_with_post_body_argv_does_not_expose_inner_alias(
+    observed: object,
+) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_payload_entry(
+                handle="ev_wrapper",
+                payload={"tool_name": "Bash", "cmd": observed},
+            ),
+        ),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value='pytest "$@"',
+    )
+
+
 class _RateGateStubAdapter:
     """Minimal adapter exposing only what the dispatch rate gate inspects."""
 
@@ -1494,7 +1521,11 @@ def test_message_contains_test_success_handles_zero_failure_summaries(
     expected: bool,
 ) -> None:
     """Verifier accepts explicit zero-failure summaries without allowing failures."""
-    message = AgentMessage(type="result", content=content, data={})
+    message = AgentMessage(
+        type="tool_result",
+        content=content,
+        data={"subtype": "tool_result"},
+    )
     assert _message_contains_test_success(message) is expected
 
 
@@ -1600,6 +1631,35 @@ def test_tests_passed_rejects_tool_call_narration_without_runtime_result() -> No
     )
 
 
+def test_atomic_verifier_rejects_intermediate_result_narration_as_test_proof() -> None:
+    command = "pytest tests/test_app.py"
+    executor = ParallelACExecutor(
+        adapter=MagicMock(),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        execution_profile=load_profile("code"),
+        fat_harness_mode=True,
+    )
+
+    verdict = executor._verify_atomic_evidence_against_runtime_messages(
+        messages=(
+            AgentMessage(
+                type="tool",
+                content="Bash command started",
+                tool_name="Bash",
+                data={"tool_input": {"command": command}},
+            ),
+            AgentMessage(type="result", content="1 passed", data={"subtype": "success"}),
+            AgentMessage(type="result", content="Evidence follows", data={}),
+        ),
+        typed_evidence=EvidenceRecord(data={"commands_run": [command], "tests_passed": [command]}),
+        ac_content="Run the focused test.",
+    )
+
+    assert verdict.passed is False
+
+
 def test_tests_passed_rejects_node_id_from_assistant_narration_only() -> None:
     """A broad successful run cannot prove a node-id mentioned only by the agent."""
     started = AgentMessage(
@@ -1698,6 +1758,62 @@ def test_codex_completion_receipts_prove_exact_test_and_file_claims(tmp_path) ->
         )
         == []
     )
+
+
+def test_gemini_native_shell_result_passes_fat_harness_test_verifier() -> None:
+    from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+
+    command = "pytest -q tests/test_example.py"
+    runtime = GeminiCLIRuntime(cli_path="gemini")
+    messages: list[AgentMessage] = []
+    for raw_event in (
+        {"type": "tool_use", "name": "run_shell", "input": {"command": command}},
+        {
+            "type": "tool_result",
+            "name": "run_shell",
+            "output": "1 passed in 0.01s",
+            "is_error": False,
+        },
+    ):
+        event = runtime._parse_json_event(json.dumps(raw_event))
+        assert event is not None
+        messages.extend(runtime._convert_event(event, current_handle=None))
+
+    executor = ParallelACExecutor(
+        adapter=MagicMock(),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        execution_profile=load_profile("code"),
+        fat_harness_mode=True,
+    )
+    verdict = executor._verify_atomic_evidence_against_runtime_messages(
+        messages=tuple(messages),
+        typed_evidence=EvidenceRecord(data={"commands_run": [command], "tests_passed": [command]}),
+        ac_content="Run the focused test.",
+    )
+
+    assert verdict.passed is True
+    assert all(message.tool_name == "Bash" for message in messages)
+    assert isinstance(messages[1].data["tool_result"], dict)
+    malformed_event = runtime._parse_json_event(
+        json.dumps(
+            {
+                "type": "tool_result",
+                "name": "run_shell",
+                "output": "1 passed in 0.01s",
+                "is_error": "true",
+            }
+        )
+    )
+    assert malformed_event is not None
+    malformed_result = runtime._convert_event(malformed_event, current_handle=None)[0]
+    malformed_verdict = executor._verify_atomic_evidence_against_runtime_messages(
+        messages=(messages[0], malformed_result),
+        typed_evidence=EvidenceRecord(data={"commands_run": [command], "tests_passed": [command]}),
+        ac_content="Run the focused test.",
+    )
+    assert malformed_verdict.passed is False
 
 
 @pytest.mark.parametrize(
@@ -5012,9 +5128,9 @@ class TestParallelACExecutor:
                     data={"tool_input": {"command": "python -m pytest test_slugify.py"}},
                 ),
                 AgentMessage(
-                    type="result",
+                    type="tool_result",
                     content="test_slugify.py passed\n1 passed in 0.01s",
-                    data={"subtype": "success"},
+                    data={"subtype": "tool_result"},
                 ),
             ),
         )
@@ -5097,9 +5213,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "pytest test_hello.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="test_hello.py::test_hello passed\n1 passed in 0.01s",
-                        data={"subtype": "success"},
+                        data={"subtype": "tool_result"},
                     ),
                 ),
             ),
@@ -5260,9 +5376,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "pytest tests/test_analysis.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="tests/test_analysis.py passed; 1 passed",
-                        data={"subtype": "success"},
+                        data={"subtype": "tool_result"},
                     ),
                 ),
                 cwd=str(tmp_path),
@@ -5688,9 +5804,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "pytest tests/test_app.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="tests/test_app.py passed\n1 passed in 0.01s",
-                        data={"subtype": "success"},
+                        data={"subtype": "tool_result"},
                     ),
                 ),
             ),
@@ -5751,9 +5867,9 @@ class TestParallelACExecutor:
                     data={"tool_input": {"command": "python -m unittest test_todo.py"}},
                 ),
                 AgentMessage(
-                    type="result",
+                    type="tool_result",
                     content="Ran 6 tests in 0.002s\n\nOK",
-                    data={"subtype": "success", "exit_code": 0},
+                    data={"subtype": "tool_result", "exit_code": 0},
                 ),
             ),
         )
@@ -5830,9 +5946,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "python -m unittest test_todo.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="Ran 6 tests in 0.002s\n\nOK",
-                        data={"subtype": "success", "exit_code": 0},
+                        data={"subtype": "tool_result", "exit_code": 0},
                     ),
                 ),
             ),
@@ -5896,9 +6012,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "python -m unittest test_todo.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="Ran 6 tests in 0.002s\n\nOK",
-                        data={"subtype": "success", "exit_code": 0},
+                        data={"subtype": "tool_result", "exit_code": 0},
                     ),
                 ),
             ),
@@ -6020,12 +6136,12 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "pytest"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content=(
                             "generated.py updated; tests/test_generated.py passed; "
                             "0 failed, 0 errors, 1 passed"
                         ),
-                        data={"subtype": "success"},
+                        data={"subtype": "tool_result"},
                     ),
                 ),
                 cwd=str(tmp_path),
@@ -6091,9 +6207,9 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": "python -m unittest test_todo.py"}},
                     ),
                     AgentMessage(
-                        type="result",
+                        type="tool_result",
                         content="Ran 1 test in 0.001s\n\nOK",
-                        data={"subtype": "success", "exit_code": 0},
+                        data={"subtype": "tool_result", "exit_code": 0},
                     ),
                 ),
                 cwd=str(tmp_path),
@@ -12075,24 +12191,22 @@ class TestParallelACExecutor:
 
             async def execute_task(self, **kwargs: Any):
                 runtime = GeminiCLIRuntime(cli_path="gemini", cwd=self._cwd)
-                events = (
+                raw_events = (
                     {
                         "type": "tool_use",
-                        "content": "",
-                        "metadata": {
-                            "name": "Bash",
-                            "input": {"command": "pytest -q tests/test_example.py"},
-                        },
-                        "is_error": False,
+                        "name": "run_shell",
+                        "input": {"command": "pytest -q tests/test_example.py"},
                     },
                     {
                         "type": "tool_result",
-                        "content": "1 passed in 0.01s",
-                        "metadata": {"name": "Bash"},
+                        "name": "run_shell",
+                        "output": "1 passed in 0.01s",
                         "is_error": False,
                     },
                 )
-                for event in events:
+                for raw_event in raw_events:
+                    event = runtime._parse_json_event(json.dumps(raw_event))
+                    assert event is not None
                     for message in runtime._convert_event(
                         event,
                         current_handle=kwargs["resume_handle"],

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -224,6 +224,23 @@ def test_deliver_matching_reads_structured_command_shapes_from_args_preview(
                 separators=(",", ":"),
             ),
         },
+        {"tool_name": "Bash", "command": "bash -o noexec -c 'pytest tests/test_app.py'"},
+        {
+            "tool_name": "Bash",
+            "args_preview": json.dumps(
+                {"cmd": ["bash", "-o", "noexec", "-c", "pytest tests/test_app.py"]},
+                separators=(",", ":"),
+            ),
+        },
+        {"tool_name": "Bash", "command": "bash -onoexec -c 'pytest tests/test_app.py'"},
+        {
+            "tool_name": "Bash",
+            "command": "bash -c 'pytest tests/test_app.py' || true",
+        },
+        {
+            "tool_name": "Bash",
+            "command": "bash -c 'pytest tests/test_app.py' | cat",
+        },
     ),
 )
 def test_deliver_matching_does_not_extract_shell_body_after_script_operand(
@@ -259,6 +276,36 @@ def test_deliver_matching_preserves_legacy_json_scalar_preview() -> None:
     )
 
     assert tuple(entry.handle for entry in matches) == ("ev_true",)
+
+
+def test_deliver_matching_rejects_conflicting_command_aliases() -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_payload_entry(
+                handle="ev_conflicting",
+                payload={
+                    "tool_name": "Bash",
+                    "command": "echo ready",
+                    "args_preview": json.dumps(
+                        {"cmd": "pytest tests/not-run.py"},
+                        separators=(",", ":"),
+                    ),
+                },
+            ),
+        ),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value="echo ready",
+    )
+    assert not _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value="pytest tests/not-run.py",
+    )
 
 
 def test_tests_passed_requires_a_successful_test_command() -> None:
@@ -322,6 +369,40 @@ def test_tests_passed_rejects_status_masking_shell_chain(command: str) -> None:
 
     assert tuple(entry.handle for entry in command_matches) == ("ev_masked",)
     assert test_matches == ()
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "pytest --version",
+        "pytest --collect-only",
+        "pytest --setup-plan",
+        "python -m unittest --help",
+        "tox --showconfig",
+        "nox --list",
+        "gradle test --dry-run",
+        "npm test --if-present",
+    ),
+)
+def test_tests_passed_rejects_non_executing_runner_modes(command: str) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_no_tests", command=command),),
+    )
+
+    assert tuple(
+        entry.handle
+        for entry in _matching_journal_entries(
+            manifest,
+            field="commands_run",
+            value=command,
+        )
+    ) == ("ev_no_tests",)
+    assert not _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value=command,
+    )
 
 
 def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -442,7 +442,6 @@ def test_tests_passed_rejects_status_masking_shell_chain(command: str) -> None:
         "tox --showconfig",
         "nox --list",
         "gradle test --dry-run",
-        "npm test --if-present",
     ),
 )
 def test_tests_passed_rejects_non_executing_runner_modes(command: str) -> None:
@@ -464,6 +463,29 @@ def test_tests_passed_rejects_non_executing_runner_modes(command: str) -> None:
         field="tests_passed",
         value=command,
     )
+
+
+def test_npm_if_present_accepts_positive_test_execution_output() -> None:
+    command = "npm test --if-present"
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_entry(
+                handle="ev_npm",
+                command=command,
+                result_preview="Tests: 2 passed, 2 total",
+            ),
+        ),
+    )
+
+    assert tuple(
+        entry.handle
+        for entry in _matching_journal_entries(
+            manifest,
+            field="tests_passed",
+            value=command,
+        )
+    ) == ("ev_npm",)
 
 
 def test_tests_passed_requires_positive_execution_output_despite_environment_mode() -> None:
@@ -1561,6 +1583,23 @@ def test_tests_passed_rejects_collect_only_from_environment_configuration() -> N
     )
 
 
+def test_tests_passed_rejects_tool_call_narration_without_runtime_result() -> None:
+    command = "pytest tests/test_app.py"
+    message = AgentMessage(
+        type="tool",
+        content="Running pytest; 1 passed",
+        tool_name="Bash",
+        data={"tool_input": {"command": command}},
+    )
+
+    assert not _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=(message,),
+        task_cwd=None,
+    )
+
+
 def test_tests_passed_rejects_node_id_from_assistant_narration_only() -> None:
     """A broad successful run cannot prove a node-id mentioned only by the agent."""
     started = AgentMessage(
@@ -1949,8 +1988,8 @@ def test_gradle_command_claim_supports_quoted_target_and_tail_pipe() -> None:
     )
 
 
-def test_gradle_tests_passed_claim_supports_class_target_and_build_success() -> None:
-    """Gradle BUILD SUCCESSFUL output can back a class-level tests_passed claim."""
+def test_gradle_tests_passed_claim_supports_class_target_and_case_result() -> None:
+    """A Gradle case result can back a class-level tests_passed claim."""
     command_message = AgentMessage(
         type="tool",
         content="Bash command started",
@@ -1964,13 +2003,14 @@ def test_gradle_tests_passed_claim_supports_class_target_and_build_success() -> 
             }
         },
     )
+    output = "com.example.app.unit.SomeNewTest > createsApp PASSED\nBUILD SUCCESSFUL in 8s"
     result_message = AgentMessage(
         type="tool_result",
-        content="> Task :test\nBUILD SUCCESSFUL in 8s",
+        content=output,
         tool_name=None,
         data={
             "subtype": "tool_result",
-            "output": "> Task :test\nBUILD SUCCESSFUL in 8s",
+            "output": output,
         },
     )
 
@@ -2097,11 +2137,16 @@ def test_atomic_verifier_classifies_dependent_masked_test_evidence_as_form_misma
             ),
             AgentMessage(
                 type="tool_result",
-                content="> Task :test\nBUILD SUCCESSFUL in 8s",
+                content=(
+                    "com.example.app.unit.SomeNewTest > createsApp PASSED\nBUILD SUCCESSFUL in 8s"
+                ),
                 tool_name=None,
                 data={
                     "subtype": "tool_result",
-                    "output": "> Task :test\nBUILD SUCCESSFUL in 8s",
+                    "output": (
+                        "com.example.app.unit.SomeNewTest > createsApp PASSED\n"
+                        "BUILD SUCCESSFUL in 8s"
+                    ),
                 },
             ),
         ),
@@ -2913,6 +2958,7 @@ def test_maven_tests_passed_supports_explicit_false_skip_properties(command: str
 @pytest.mark.parametrize(
     "output",
     (
+        "> Task :test\nBUILD SUCCESSFUL in 1s",
         "> Task :test NO-SOURCE\nBUILD SUCCESSFUL in 1s",
         "> Task :test SKIPPED\nBUILD SUCCESSFUL in 1s",
         "0 tests completed\nBUILD SUCCESSFUL",
@@ -2934,6 +2980,28 @@ def test_gradle_tests_passed_rejects_successful_build_with_no_tests(output: str)
     )
 
     assert not _runtime_messages_support_test_claim(
+        value="./gradlew test",
+        backed_commands=("./gradlew test",),
+        messages=(command_message, result_message),
+        task_cwd=None,
+    )
+
+
+def test_gradle_tests_passed_accepts_individual_test_case_result() -> None:
+    output = "com.example.AppTest > createsApp PASSED\nBUILD SUCCESSFUL in 1s"
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": "./gradlew test"}},
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content=output,
+        data={"subtype": "tool_result", "output": output},
+    )
+
+    assert _runtime_messages_support_test_claim(
         value="./gradlew test",
         backed_commands=("./gradlew test",),
         messages=(command_message, result_message),
@@ -11983,6 +12051,91 @@ class TestParallelACExecutor:
         assert tool_completed.data["runtime_event_type"] == "tool.result"
         assert tool_completed.data["tool_result"]["is_error"] is False
         assert tool_completed.data["tool_result"]["meta"]["exit_status"] == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_projects_gemini_tool_result_to_completed_journal(self) -> None:
+        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+
+        class StubRuntime:
+            _runtime_handle_backend = "gemini_cli"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(self, **kwargs: Any):
+                runtime = GeminiCLIRuntime(cli_path="gemini", cwd=self._cwd)
+                events = (
+                    {
+                        "type": "tool_use",
+                        "content": "",
+                        "metadata": {
+                            "name": "Bash",
+                            "input": {"command": "pytest -q tests/test_example.py"},
+                        },
+                        "is_error": False,
+                    },
+                    {
+                        "type": "tool_result",
+                        "content": "1 passed in 0.01s",
+                        "metadata": {"name": "Bash"},
+                        "is_error": False,
+                    },
+                )
+                for event in events:
+                    for message in runtime._convert_event(
+                        event,
+                        current_handle=kwargs["resume_handle"],
+                    ):
+                        yield message
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                )
+
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=StubRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Run the focused test with Gemini",
+            session_id="sess_gemini",
+            tools=["Bash"],
+            system_prompt="test",
+            seed_goal="Ship the fix",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        appended_events = [call.args[0] for call in event_store.append.await_args_list]
+        tool_started = next(
+            event for event in appended_events if event.type == "execution.tool.started"
+        )
+        tool_completed = next(
+            event for event in appended_events if event.type == "execution.tool.completed"
+        )
+
+        assert result.success is True
+        assert tool_started.data["tool_input"] == {"command": "pytest -q tests/test_example.py"}
+        assert tool_completed.data["tool_name"] == "Bash"
+        assert tool_completed.data["tool_result"]["is_error"] is False
+        assert tool_completed.data["tool_result"]["text_content"] == "1 passed in 0.01s"
 
     def test_message_level_tool_completion_event_type_is_not_terminal(self) -> None:
         """A finished tool must not classify the runtime handle as terminated.

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -69,10 +69,18 @@ def test_stall_timeout_default_allows_realistic_test_suites() -> None:
     assert STALL_TIMEOUT_SECONDS == 900.0
 
 
-def _journal_entry(*, handle: str, command: str) -> EvidenceEntry:
+def _journal_entry(
+    *,
+    handle: str,
+    command: str,
+    result_preview: str | None = None,
+) -> EvidenceEntry:
+    payload: dict[str, object] = {"tool_name": "Bash", "command": command}
+    if result_preview is not None:
+        payload["result_preview"] = result_preview
     return _journal_payload_entry(
         handle=handle,
-        payload={"tool_name": "Bash", "command": command},
+        payload=payload,
     )
 
 
@@ -358,7 +366,11 @@ def test_tests_passed_requires_a_successful_test_command() -> None:
         ac_id="AC-1",
         entries=(
             _journal_entry(handle="ev_echo", command="echo ready"),
-            _journal_entry(handle="ev_pytest", command="pytest tests/test_app.py"),
+            _journal_entry(
+                handle="ev_pytest",
+                command="pytest tests/test_app.py",
+                result_preview="1 passed in 0.01s",
+            ),
         ),
     )
 
@@ -447,6 +459,34 @@ def test_tests_passed_rejects_non_executing_runner_modes(command: str) -> None:
             value=command,
         )
     ) == ("ev_no_tests",)
+    assert not _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value=command,
+    )
+
+
+def test_tests_passed_requires_positive_execution_output_despite_environment_mode() -> None:
+    command = "PYTEST_ADDOPTS=--collect-only pytest tests/test_app.py"
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            _journal_entry(
+                handle="ev_collected",
+                command=command,
+                result_preview="collected 1 item\n\n1 test collected",
+            ),
+        ),
+    )
+
+    assert tuple(
+        entry.handle
+        for entry in _matching_journal_entries(
+            manifest,
+            field="commands_run",
+            value=command,
+        )
+    ) == ("ev_collected",)
     assert not _matching_journal_entries(
         manifest,
         field="tests_passed",
@@ -1413,10 +1453,13 @@ async def test_dispatch_append_failure_does_not_cache_phantom_predecessor() -> N
         ("Tests run: 3, Failures=0, Errors=0, Skipped=0\n[INFO] BUILD SUCCESS", True),
         ("no errors, 3 passed", True),
         ("no tests failed, 3 passed", True),
-        ("exit code 0", True),
+        ("exit code 0", False),
         ("Ran 4 tests in 0.000s\nOK", True),
         ("python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK", True),
-        ("success", True),
+        ("success", False),
+        ("collected 1 item\n1 test collected\nexit code 0", False),
+        ("PASS tests/test_app.py", True),
+        ("tests/test_app.py::test_auth PASSED", True),
         ("FAILED (failures=1)\nRan 4 tests in 0.000s", False),
         ("1 failed, 3 passed", False),
         ("2 errors, 1 passed", False),
@@ -1494,6 +1537,27 @@ def test_tests_passed_respects_correlated_bash_result_status(
             task_cwd=None,
         )
         is expected
+    )
+
+
+def test_tests_passed_rejects_collect_only_from_environment_configuration() -> None:
+    command = "PYTEST_ADDOPTS=--collect-only pytest tests/test_app.py"
+    message = AgentMessage(
+        type="tool",
+        content="run tests",
+        tool_name="Bash",
+        data={
+            "tool_input": {"command": command},
+            "output": "collected 1 item\n\n1 test collected",
+            "exit_code": 0,
+        },
+    )
+
+    assert not _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=(message,),
+        task_cwd=None,
     )
 
 
@@ -2830,9 +2894,12 @@ def test_maven_tests_passed_supports_explicit_false_skip_properties(command: str
     )
     result_message = AgentMessage(
         type="tool_result",
-        content="[INFO] BUILD SUCCESS",
+        content="[INFO] Tests run: 1, Failures: 0, Errors: 0\n[INFO] BUILD SUCCESS",
         tool_name=None,
-        data={"subtype": "tool_result", "output": "[INFO] BUILD SUCCESS"},
+        data={
+            "subtype": "tool_result",
+            "output": "[INFO] Tests run: 1, Failures: 0, Errors: 0\n[INFO] BUILD SUCCESS",
+        },
     )
 
     assert _runtime_messages_support_test_claim(
@@ -4248,9 +4315,12 @@ class TestParallelACExecutor:
                 ),
                 AgentMessage(
                     type="tool",
-                    content="pytest passed",
+                    content="pytest passed\n1 passed in 0.01s",
                     tool_name="Bash",
-                    data={"input": {"command": "pytest"}},
+                    data={
+                        "input": {"command": "pytest"},
+                        "output": "1 passed in 0.01s",
+                    },
                 ),
             ),
         )
@@ -4875,7 +4945,7 @@ class TestParallelACExecutor:
                 ),
                 AgentMessage(
                     type="result",
-                    content="test_slugify.py passed",
+                    content="test_slugify.py passed\n1 passed in 0.01s",
                     data={"subtype": "success"},
                 ),
             ),
@@ -4960,7 +5030,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="test_hello.py::test_hello passed",
+                        content="test_hello.py::test_hello passed\n1 passed in 0.01s",
                         data={"subtype": "success"},
                     ),
                 ),
@@ -5551,7 +5621,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="tests/test_app.py passed",
+                        content="tests/test_app.py passed\n1 passed in 0.01s",
                         data={"subtype": "success"},
                     ),
                 ),
@@ -6311,7 +6381,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="tool_result",
-                        content="tests/test_generated.py passed",
+                        content="tests/test_generated.py passed\n1 passed in 0.01s",
                         data={"subtype": "tool_result", "is_error": False},
                     ),
                 ),
@@ -6386,7 +6456,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="tests/test_generated.py passed",
+                        content="tests/test_generated.py passed\n1 passed in 0.01s",
                         data={"subtype": "success"},
                     ),
                 ),
@@ -6459,7 +6529,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="tests/test_generated.py passed",
+                        content="tests/test_generated.py passed\n1 passed in 0.01s",
                         data={"subtype": "success"},
                     ),
                 ),
@@ -6533,7 +6603,7 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="tests/test_generated.py passed",
+                        content="tests/test_generated.py passed\n1 passed in 0.01s",
                         data={"subtype": "success"},
                     ),
                 ),
@@ -6569,8 +6639,8 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
-    async def test_fat_harness_verifier_accepts_exit_code_only_test_success(self, tmp_path) -> None:
-        """Regression for #978 observation: Codex may omit pytest stdout but keep exit_code=0."""
+    async def test_fat_harness_verifier_rejects_exit_code_only_test_success(self, tmp_path) -> None:
+        """A zero exit without execution output cannot prove that tests ran."""
         hello_file = tmp_path / "hello.py"
         test_file = tmp_path / "test_hello.py"
         hello_file.write_text('def hello():\n    return "hello"\n', encoding="utf-8")
@@ -6639,15 +6709,15 @@ class TestParallelACExecutor:
             start_time=datetime.now(UTC),
         )
 
-        assert result.success is True
+        assert result.success is False
         assert result.atomic_verifier_verdict is not None
-        assert result.atomic_verifier_verdict.passed is True
+        assert result.atomic_verifier_verdict.passed is False
         evidence_event = next(
             event
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
-        assert evidence_event.data["verifier_passed"] is True
+        assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
     async def test_fat_harness_verifier_accepts_unittest_command_summary_claim(
@@ -11959,7 +12029,7 @@ class TestParallelACExecutor:
                 f"{lifecycle!r}, which is terminal"
             )
 
-    def test_codex_id_bearing_exit_only_test_completion_proves_file_claim(self) -> None:
+    def test_codex_id_bearing_exit_only_test_completion_does_not_prove_file_claim(self) -> None:
         from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 
         command = "pytest -q tests/test_example.py"
@@ -11978,7 +12048,7 @@ class TestParallelACExecutor:
             )
         )
 
-        assert _runtime_messages_support_test_claim(
+        assert not _runtime_messages_support_test_claim(
             value="tests/test_example.py",
             backed_commands=(command,),
             messages=messages,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -154,6 +154,51 @@ def test_deliver_matching_allows_inert_quote_spelling_differences() -> None:
 
 
 @pytest.mark.parametrize(
+    ("observed", "malformed_claim"),
+    (
+        (
+            "pytest tests/test_app.py --basetemp='cache > out'",
+            "pytest tests/test_app.py --basetemp='cache",
+        ),
+        (
+            "pytest tests/test_app.py -k 'unit|integration'",
+            "pytest tests/test_app.py -k 'unit",
+        ),
+    ),
+)
+def test_deliver_matching_does_not_strip_quoted_shell_metacharacters(
+    observed: str,
+    malformed_claim: str,
+) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_quoted_meta", command=observed),),
+    )
+
+    assert not _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value=malformed_claim,
+    )
+
+
+def test_deliver_matching_keeps_equivalent_quoted_metacharacter_argument() -> None:
+    observed = "pytest tests/test_app.py --basetemp='cache > out'"
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_quoted_meta", command=observed),),
+    )
+
+    matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value='pytest tests/test_app.py --basetemp="cache > out"',
+    )
+
+    assert tuple(entry.handle for entry in matches) == ("ev_quoted_meta",)
+
+
+@pytest.mark.parametrize(
     ("tool_input", "claim"),
     (
         ({"cmd": "pytest tests/test_a.py"}, "pytest tests/test_a.py"),
@@ -376,7 +421,11 @@ def test_tests_passed_rejects_status_masking_shell_chain(command: str) -> None:
     (
         "pytest --version",
         "pytest --collect-only",
+        "pytest --collectonly",
+        "pytest --funcargs",
         "pytest --setup-plan",
+        "pytest --setuponly",
+        "pytest --setupplan",
         "python -m unittest --help",
         "tox --showconfig",
         "nox --list",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -208,6 +208,22 @@ def test_deliver_matching_reads_structured_command_shapes_from_args_preview(
                 separators=(",", ":"),
             ),
         },
+        {"tool_name": "Bash", "command": "bash -n -c 'pytest tests/test_app.py'"},
+        {
+            "tool_name": "Bash",
+            "args_preview": json.dumps(
+                {"cmd": ["bash", "-n", "-c", "pytest tests/test_app.py"]},
+                separators=(",", ":"),
+            ),
+        },
+        {"tool_name": "Bash", "command": "bash --version -c 'pytest tests/test_app.py'"},
+        {
+            "tool_name": "Bash",
+            "args_preview": json.dumps(
+                {"cmd": ["bash", "--version", "-c", "pytest tests/test_app.py"]},
+                separators=(",", ":"),
+            ),
+        },
     ),
 )
 def test_deliver_matching_does_not_extract_shell_body_after_script_operand(
@@ -277,6 +293,35 @@ def test_tests_passed_requires_a_successful_test_command() -> None:
         "ev_echo",
         "missing:tests_passed:0",
     )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "pytest tests/does_not_exist.py >/dev/null 2>&1 || true",
+        "pytest tests/does_not_exist.py||true",
+        "pytest tests/does_not_exist.py; true",
+    ),
+)
+def test_tests_passed_rejects_status_masking_shell_chain(command: str) -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(_journal_entry(handle="ev_masked", command=command),),
+    )
+
+    command_matches = _matching_journal_entries(
+        manifest,
+        field="commands_run",
+        value=command,
+    )
+    test_matches = _matching_journal_entries(
+        manifest,
+        field="tests_passed",
+        value=command,
+    )
+
+    assert tuple(entry.handle for entry in command_matches) == ("ev_masked",)
+    assert test_matches == ()
 
 
 def test_standard_deliver_facts_distinguishes_ambiguous_matches() -> None:


### PR DESCRIPTION
## Summary

Refs #1469.

The handoff investigation is reproducible, but its root-cause wording overstates two points: the repository has read-side rejection consumers (attention relay and benchmark capture), and the local verdicts include `files_touched` in addition to `commands_run`/`tests_passed`.

This PR fixes the concrete live-path mismatch and the trust-boundary gaps found during review:

- Match journal commands case-sensitively with argv boundaries intact across safe shell wrappers and structured `command`, `cmd`, argv-list, and `command_line` forms. Wrappers with post-`-c` positional argv do not expose a lossy inner alias.
- Preserve fail-closed behavior for absent, conflicting, ambiguous, unsuccessful, malformed-provider, or non-executing evidence; ambiguity is labeled `ambiguous:<field>:<index>`.
- Require runtime output proving that at least one test executed before `tests_passed` can bind a journal handle. Tool/final narration, collection-only modes, generic success, exit-code-only evidence, and count-free Gradle task banners do not qualify.
- Correlate Bash starts with authoritative completions, including failure vetoes, canonical Gemini shell/result normalization, serialized result payloads, and deterministic start-before-completion replay for equal timestamps.
- Retain valid execution forms such as `npm test --if-present` when positive output proves tests ran.

The PR does not enable deliver-rejection enforcement; persisted verdicts remain observe-only for live AC success. It intentionally tightens the shared fat-harness verifier: exit-code-only or otherwise non-executing test evidence can now reject an AC that previously passed without proof that tests ran.

## Verification

- 673 related harness, journal, routing, orchestrator, frugality, Gemini, Codex completion, and runtime-projection tests passed locally.
- Ruff lint and formatting passed for all changed files.
- mypy passed for the changed source modules.
- `git diff --check` passed.

## Reproduced local measurements

From `~/.ouroboros/ouroboros.db` (through 2026-07-25): 424 completed ACs, 115 gated ACs, 309 ungated ACs, 143 verdict events, 143 rejected, 0 accepted, mean unsupported claim rate 0.6818076923. Rejection reasons mention `commands_run` in 137/143 events, `tests_passed` in 137/143, and `files_touched` in 64/143.