### PR TITLE
fix(cli): don't require LiteLLM for `ouroboros interview list`

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -703,7 +703,7 @@ class InterviewEngine:
         or passed directly to the constructor.
     """
 
-    llm_adapter: LLMAdapter
+    llm_adapter: LLMAdapter | None = None
     state_dir: Path = field(default_factory=lambda: Path.home() / ".ouroboros" / "data")
     model: str | None = None
     model_is_explicit: bool = field(default=False, init=False)

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -731,6 +731,23 @@ class InterviewEngine:
             self.model = get_llm_model_for_role("interview")
         self.state_dir.mkdir(parents=True, exist_ok=True)
 
+    def _require_llm_adapter(self) -> LLMAdapter:
+        """Return the LLM adapter or raise a clear error.
+
+        Read-only methods (``list_interviews``, ``save_state``, …) do not need
+        an LLM adapter.  Methods that call the LLM (``ask_next_question``,
+        ``_generate_question_candidates``, …) must call this guard first so the
+        error message explains *which* method requires an adapter and why.
+        """
+        if self.llm_adapter is None:
+            raise RuntimeError(
+                "This InterviewEngine method requires an llm_adapter, but none "
+                "was provided. Pass llm_adapter=... when constructing "
+                "InterviewEngine, or use a read-only method such as "
+                "list_interviews() that does not need one."
+            )
+        return self.llm_adapter
+
     def _state_file_path(self, interview_id: str) -> Path:
         """Get the path to the state file for an interview.
 
@@ -913,7 +930,7 @@ class InterviewEngine:
             if candidate is not None:
                 return Result.ok(candidate)
 
-        result = await self.llm_adapter.complete(messages, config)
+        result = await self._require_llm_adapter().complete(messages, config)
 
         if result.is_err:
             log.warning(
@@ -1000,7 +1017,7 @@ class InterviewEngine:
                 *conversation_history,
             ]
             try:
-                result = await self.llm_adapter.complete(messages, config)
+                result = await self._require_llm_adapter().complete(messages, config)
             except Exception as exc:  # noqa: BLE001 - candidate is best-effort
                 log.warning(
                     "interview.question_candidate_failed",

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -1029,9 +1029,7 @@ def list_interviews(
     ] = None,
 ) -> None:
     """List all interview sessions."""
-    llm_adapter = create_llm_adapter(backend="litellm")
     engine = InterviewEngine(
-        llm_adapter=llm_adapter,
         state_dir=state_dir or Path.home() / ".ouroboros" / "data",
     )
 

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -1024,6 +1024,24 @@ class TestInterviewEngineListInterviews:
                 assert interview["rounds"] == 3
 
     @pytest.mark.asyncio
+    async def test_list_interviews_without_llm_adapter(self, tmp_path: Path) -> None:
+        """list_interviews works without an llm_adapter (read-only command).
+
+        Regression test for #1746: `ouroboros interview list` should not
+        require the optional LiteLLM dependency because listing only reads
+        persisted JSON state and never calls the LLM.
+        """
+        engine = InterviewEngine(state_dir=tmp_path)
+
+        state = InterviewState(interview_id="solo", initial_context="ctx")
+        await engine.save_state(state)
+
+        interviews = await engine.list_interviews()
+
+        assert len(interviews) == 1
+        assert interviews[0]["interview_id"] == "solo"
+
+    @pytest.mark.asyncio
     async def test_list_interviews_sorted_by_updated(self, tmp_path: Path) -> None:
         """list_interviews sorts by updated_at descending."""
         mock_adapter = MagicMock()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -306,13 +306,12 @@ class TestShorthandCommands:
 
     def test_init_list_subcommand_still_works(self) -> None:
         """Test backward compat: 'ouroboros init list' still routes to list."""
-        with patch("ouroboros.cli.commands.init.create_llm_adapter"):
-            with patch(
-                "ouroboros.cli.commands.init.InterviewEngine.list_interviews",
-                new=AsyncMock(return_value=[]),
-            ):
-                result = runner.invoke(app, ["init", "list"])
-                assert result.exit_code == 0
+        with patch(
+            "ouroboros.cli.commands.init.InterviewEngine.list_interviews",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = runner.invoke(app, ["init", "list"])
+            assert result.exit_code == 0
 
     def test_monitor_top_level_alias(self) -> None:
         """Test that 'ouroboros monitor' is a shorthand for 'ouroboros tui monitor'."""


### PR DESCRIPTION
## Summary

`ouroboros interview list` unconditionally called `create_llm_adapter(backend="litellm")`, so the command crashed with `ModuleNotFoundError: No module named 'litellm'` on installations without the optional LiteLLM extra — even though listing interviews only reads persisted JSON state and never calls the LLM.

This made a read-only local command unusable for anyone running Ouroboros with Claude Code, Codex CLI, or another non-LiteLLM backend, unless they installed the unrelated LiteLLM dependency.

The fix makes `InterviewEngine.llm_adapter` optional (default `None`) and drops the `create_llm_adapter` call from the CLI list command. The adapter is still required for methods that actually call the LLM (`ask_next_question`, `_generate_question`), which is unchanged — only the list path no longer forces an import that it doesn't need.

## Test plan

- [x] `uv run pytest tests/unit/bigbang/test_interview.py::TestInterviewEngineListInterviews -q` passes (4 tests, including new regression test)
- [x] `uv run pytest tests/unit/cli/test_main.py -k list_subcommand -q` passes
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/` clean

Fixes #1746