### PR TITLE
fix(release): harden version synchronization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,19 +44,39 @@ jobs:
             exit 1
           fi
           python scripts/sync-plugin-version.py --require-canonical --version "$VERSION"
-          PACKAGE_VERSION="$(uv run hatch version)"
-          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
-            echo "Package version $PACKAGE_VERSION does not match release tag $VERSION" >&2
-            exit 1
-          fi
 
       - name: Build package
         run: |
           uv build
 
       - name: Check package
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           uv publish --dry-run dist/*
+          VERSION="${REF_NAME#v}"
+          PACKAGE_VERSION="$(python - <<'PY'
+          from pathlib import Path
+          import zipfile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {len(wheels)}")
+          with zipfile.ZipFile(wheels[0]) as archive:
+              metadata_files = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+              if len(metadata_files) != 1:
+                  raise SystemExit(f"expected exactly one METADATA file, found {len(metadata_files)}")
+              metadata = archive.read(metadata_files[0]).decode("utf-8")
+          versions = [line.removeprefix("Version: ") for line in metadata.splitlines() if line.startswith("Version: ")]
+          if len(versions) != 1:
+              raise SystemExit(f"expected exactly one package version, found {len(versions)}")
+          print(versions[0])
+          PY
+          )"
+          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+            echo "Package version $PACKAGE_VERSION does not match release tag $VERSION" >&2
+            exit 1
+          fi
 
       - name: Detect pre-release
         id: prerelease
@@ -176,20 +196,37 @@ jobs:
           uv sync --dev
           uv pip check
 
-      - name: Validate package version
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Validate built package version
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
           VERSION="${REF_NAME#v}"
-          PACKAGE_VERSION="$(uv run hatch version)"
+          PACKAGE_VERSION="$(python - <<'PY'
+          from pathlib import Path
+          import zipfile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {len(wheels)}")
+          with zipfile.ZipFile(wheels[0]) as archive:
+              metadata_files = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+              if len(metadata_files) != 1:
+                  raise SystemExit(f"expected exactly one METADATA file, found {len(metadata_files)}")
+              metadata = archive.read(metadata_files[0]).decode("utf-8")
+          versions = [line.removeprefix("Version: ") for line in metadata.splitlines() if line.startswith("Version: ")]
+          if len(versions) != 1:
+              raise SystemExit(f"expected exactly one package version, found {len(versions)}")
+          print(versions[0])
+          PY
+          )"
           if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
             echo "Package version $PACKAGE_VERSION does not match release tag $VERSION" >&2
             exit 1
           fi
-
-      - name: Build package
-        run: |
-          uv build
 
       - name: Publish to PyPI
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,13 @@ jobs:
           uv sync --dev
           uv pip check
 
+      - name: Validate release metadata
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${REF_NAME#v}"
+          python scripts/sync-plugin-version.py --version "$VERSION"
+
       - name: Build package
         run: |
           uv build
@@ -68,6 +75,7 @@ jobs:
 
   build-tui:
     name: Build TUI (${{ matrix.target }})
+    needs: release
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           VERSION="${REF_NAME#v}"
+          if [[ "$VERSION" == *.dev* ]]; then
+            echo "Development versions cannot be published from release tags: $VERSION" >&2
+            exit 1
+          fi
           python scripts/sync-plugin-version.py --version "$VERSION"
 
       - name: Build package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             echo "Development versions cannot be published from release tags: $VERSION" >&2
             exit 1
           fi
-          python scripts/sync-plugin-version.py --version "$VERSION"
+          python scripts/sync-plugin-version.py --require-canonical --version "$VERSION"
 
       - name: Build package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
             exit 1
           fi
           python scripts/sync-plugin-version.py --require-canonical --version "$VERSION"
+          PACKAGE_VERSION="$(uv run hatch version)"
+          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+            echo "Package version $PACKAGE_VERSION does not match release tag $VERSION" >&2
+            exit 1
+          fi
 
       - name: Build package
         run: |
@@ -170,6 +175,17 @@ jobs:
         run: |
           uv sync --dev
           uv pip check
+
+      - name: Validate package version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${REF_NAME#v}"
+          PACKAGE_VERSION="$(uv run hatch version)"
+          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+            echo "Package version $PACKAGE_VERSION does not match release tag $VERSION" >&2
+            exit 1
+          fi
 
       - name: Build package
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Before creating a release tag, synchronize every version-bearing plugin artifact
 
 ```bash
 python scripts/sync-plugin-version.py --write --version 0.50.7
-python scripts/sync-plugin-version.py --version 0.50.7
+python scripts/sync-plugin-version.py --require-canonical --version 0.50.7
 git diff --check
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to Ouroboros! This guide covers ever
 - [Development Environment](#development-environment)
 - [Code Style Guide](#code-style-guide)
 - [Commit Message Convention](#commit-message-convention)
+- [Release Maintenance](#release-maintenance)
 - [Project Structure](#project-structure)
 - [Key Patterns](#key-patterns)
 - [Documentation Coverage](#documentation-coverage)
@@ -139,6 +140,18 @@ the PR description.
 - Reference the related issue (e.g., `Closes #123`)
 - Ensure all tests pass and linting is clean
 - Wait for code review and address feedback
+
+### Release Maintenance
+
+Before creating a release tag, synchronize every version-bearing plugin artifact in the release commit:
+
+```bash
+python scripts/sync-plugin-version.py --write --version 0.50.7
+python scripts/sync-plugin-version.py --version 0.50.7
+git diff --check
+```
+
+Commit the metadata changes before creating `v0.50.7`. The tag-triggered release workflow repeats the read-only check and refuses to build when the tag version and tracked metadata differ.
 
 ---
 

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -345,6 +345,7 @@ def update_version_marker(
     version: str,
     *,
     expected_current: bytes | None = None,
+    expected_generation: _PathGeneration | None = None,
 ) -> _PathGeneration | None:
     """Update <!-- ooo:VERSION:X.Y.Z --> marker in a text file."""
     original = expected_current if expected_current is not None else path.read_bytes()
@@ -358,7 +359,12 @@ def update_version_marker(
     content = original.replace(old_marker_bytes, new_marker_bytes, 1)
     if original == content:
         return None
-    owned_generation = _atomic_write_bytes(path, content, expected_current=original)
+    owned_generation = _atomic_write_bytes(
+        path,
+        content,
+        expected_current=original,
+        expected_generation=expected_generation,
+    )
 
     try:
         updated = path.read_bytes()
@@ -378,6 +384,7 @@ def update_json(
     *,
     nested_key: str | None = None,
     expected_current: bytes | None = None,
+    expected_generation: _PathGeneration | None = None,
 ) -> _PathGeneration | None:
     """Update version in a JSON file. Returns the owned generation if changed."""
     original = expected_current if expected_current is not None else path.read_bytes()
@@ -403,7 +410,12 @@ def update_json(
         return None
 
     content = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
-    return _atomic_write_bytes(path, content, expected_current=original)
+    return _atomic_write_bytes(
+        path,
+        content,
+        expected_current=original,
+        expected_generation=expected_generation,
+    )
 
 
 def _run() -> None:
@@ -434,10 +446,12 @@ def _run() -> None:
         (MARKETPLACE_JSON, "plugins.0"),
     ]
     originals: dict[Path, bytes] = {}
+    original_generations: dict[Path, _PathGeneration] = {}
     setup_markers: dict[Path, tuple[str, str]] = {}
     for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
         if not path.exists():
             sys.exit(f"Error: required setup skill not found: {path.relative_to(ROOT)}")
+        original_generations[path] = _path_generation(path)
         original = path.read_bytes()
         originals[path] = original
         text = original.decode("utf-8")
@@ -454,6 +468,7 @@ def _run() -> None:
             sys.exit(f"Error: required plugin metadata not found: {path.relative_to(ROOT)}")
 
         try:
+            original_generations[path] = _path_generation(path)
             original = path.read_bytes()
             originals[path] = original
             data = _parse_json_bytes(original)
@@ -505,6 +520,7 @@ def _run() -> None:
                     version,
                     nested_key=nested,
                     expected_current=originals[path],
+                    expected_generation=original_generations[path],
                 )
                 if owned_generation is None:
                     sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
@@ -524,6 +540,7 @@ def _run() -> None:
                     path,
                     version,
                     expected_current=originals[path],
+                    expected_generation=original_generations[path],
                 )
                 if owned_generation is None:
                     sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -33,6 +33,7 @@ BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.m
 VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([0-9A-Za-z.]+) -->")
 VERSION_MARKER_ENVELOPE_RE = re.compile(r"<!-- ooo:VERSION:(.*?) -->", re.DOTALL)
 _MAX_CONFLICT_RESTORE_EXCHANGES = 8
+_QUARANTINE_DIR_NAME = "ouroboros-sync-plugin-version-quarantine"
 _PathGeneration = tuple[int, int, int, int, int, int, int, int, int, int, str]
 
 
@@ -240,6 +241,78 @@ def _path_generation(path: Path) -> _PathGeneration:
     )
 
 
+def _git_directory() -> Path | None:
+    marker = ROOT / ".git"
+    if marker.is_dir():
+        git_dir = marker
+    else:
+        try:
+            value = marker.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeError):
+            return None
+        prefix = "gitdir:"
+        if not value.startswith(prefix):
+            return None
+        git_dir = Path(value.removeprefix(prefix).strip())
+        if not git_dir.is_absolute():
+            git_dir = marker.parent / git_dir
+    try:
+        common_value = (git_dir / "commondir").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError):
+        return git_dir
+    common_dir = Path(common_value)
+    return common_dir if common_dir.is_absolute() else (git_dir / common_dir).resolve()
+
+
+def _quarantine_directory(path: Path) -> Path:
+    """Return a writable quarantine directory on the target filesystem."""
+    target_device = path.parent.stat().st_dev
+    git_dir = _git_directory()
+    candidates: list[Path] = []
+    if git_dir is not None:
+        candidates.append(git_dir / _QUARANTINE_DIR_NAME)
+    candidates.extend(
+        [
+            ROOT / f".{_QUARANTINE_DIR_NAME}",
+            path.parent / f".{_QUARANTINE_DIR_NAME}",
+        ]
+    )
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            if candidate.parent.stat().st_dev != target_device:
+                continue
+            candidate.mkdir(parents=True, exist_ok=True)
+            if candidate.stat().st_dev == target_device:
+                return candidate
+        except OSError:
+            continue
+    raise RuntimeError(f"could not create same-filesystem write quarantine for {path}")
+
+
+def _quarantine_displaced_path(temp_path: Path, path: Path) -> Path:
+    """Move a displaced inode to durable storage instead of unlinking it."""
+    # Quarantines persist because an uncooperative pre-exchange descriptor has
+    # no observable point at which it is safe to delete the displaced inode.
+    quarantine_dir = _quarantine_directory(path)
+    fd, quarantine_name = tempfile.mkstemp(
+        prefix=f"{path.name}.",
+        suffix=".displaced",
+        dir=quarantine_dir,
+    )
+    os.close(fd)
+    quarantine_path = Path(quarantine_name)
+    try:
+        os.replace(temp_path, quarantine_path)
+    except BaseException:
+        quarantine_path.unlink(missing_ok=True)
+        raise
+    return quarantine_path
+
+
 def _restore_latest_exchanged_content(
     temp_path: Path,
     path: Path,
@@ -271,6 +344,7 @@ def _atomic_write_bytes(
     temp_path = Path(temp_name)
     preserve_temp = False
     replaced_target = False
+    quarantine_path: Path | None = None
     try:
         with os.fdopen(fd, "wb") as temp_file:
             temp_file.write(content)
@@ -309,14 +383,20 @@ def _atomic_write_bytes(
                     f"write conflict for {path}: file changed since preflight; "
                     f"preserved exchanged content at {temp_path}"
                 )
+            preserve_temp = True
+            quarantine_path = _quarantine_displaced_path(temp_path, path)
         else:
             os.replace(temp_path, path)
             replaced_target = True
-        directory_fd = os.open(path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        directories = [path.parent]
+        if quarantine_path is not None and quarantine_path.parent != path.parent:
+            directories.append(quarantine_path.parent)
+        for directory in directories:
+            directory_fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
         return staged_generation
     except BaseException as exc:
         if replaced_target and not isinstance(exc, _OwnedWriteError):

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -171,22 +171,34 @@ def _load_json(path: Path) -> object:
 
 
 def _exchange_paths(source: Path, destination: Path) -> bool:
-    """Atomically exchange two Linux pathnames when renameat2 is available."""
-    if not sys.platform.startswith("linux"):
+    """Atomically exchange two pathnames when the host filesystem supports it."""
+    if sys.platform.startswith("linux"):
+        function_name = "renameat2"
+        at_fdcwd = -100
+    elif sys.platform == "darwin":
+        function_name = "renameatx_np"
+        at_fdcwd = -2
+    else:
         return False
     try:
-        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+        exchange = getattr(ctypes.CDLL(None, use_errno=True), function_name)
     except AttributeError:
         return False
-    renameat2.argtypes = [
+    exchange.argtypes = [
         ctypes.c_int,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_char_p,
         ctypes.c_uint,
     ]
-    renameat2.restype = ctypes.c_int
-    result = renameat2(-100, os.fsencode(source), -100, os.fsencode(destination), 2)
+    exchange.restype = ctypes.c_int
+    result = exchange(
+        at_fdcwd,
+        os.fsencode(source),
+        at_fdcwd,
+        os.fsencode(destination),
+        0x00000002,
+    )
     if result == 0:
         return True
     error = ctypes.get_errno()
@@ -212,10 +224,13 @@ def _atomic_write_bytes(
             temp_file.flush()
             os.fchmod(temp_file.fileno(), mode)
             os.fsync(temp_file.fileno())
-        exchanged = (
-            expected_current is not None and path.exists() and _exchange_paths(temp_path, path)
-        )
-        if exchanged:
+        if expected_current is not None:
+            if not path.exists():
+                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+            if not _exchange_paths(temp_path, path):
+                raise RuntimeError(
+                    f"write conflict for {path}: atomic path exchange is unavailable"
+                )
             if temp_path.read_bytes() != expected_current:
                 try:
                     restored = _exchange_paths(temp_path, path)
@@ -230,8 +245,6 @@ def _atomic_write_bytes(
                     )
                 raise RuntimeError(f"write conflict for {path}: file changed since preflight")
         else:
-            if expected_current is not None and path.read_bytes() != expected_current:
-                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
             os.replace(temp_path, path)
         directory_fd = os.open(path.parent, os.O_RDONLY)
         try:
@@ -377,8 +390,10 @@ def _run() -> None:
             if not isinstance(old, str):
                 raise TypeError("version must be a string")
             target["version"] = version
-            expected_writes[path] = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode(
-                "utf-8"
+            expected_writes[path] = (
+                original
+                if old == version
+                else (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
             )
         except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError) as exc:
             sys.exit(f"Error: could not validate {path.relative_to(ROOT)}: {exc}")
@@ -427,6 +442,13 @@ def _run() -> None:
             else:
                 print(f"  DRIFT {path.relative_to(ROOT)} ({old_marker} != {version})")
                 changed = True
+
+        if write:
+            for path, expected in expected_writes.items():
+                if path.read_bytes() != expected:
+                    raise RuntimeError(
+                        f"post-write conflict for {path}: final content differs from preflight plan"
+                    )
     except BaseException as primary_error:
         if not write:
             raise

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -288,8 +288,10 @@ def _atomic_write_bytes(
                         f"write conflict for {path}: could not restore exchanged target; "
                         f"preserved displaced content at {temp_path}"
                     )
-                preserve_temp = False
-                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+                raise RuntimeError(
+                    f"write conflict for {path}: file changed since preflight; "
+                    f"preserved exchanged content at {temp_path}"
+                )
         else:
             os.replace(temp_path, path)
         directory_fd = os.open(path.parent, os.O_RDONLY)
@@ -489,12 +491,13 @@ def _run() -> None:
                 print(f"  DRIFT {path.relative_to(ROOT)} ({old_marker} != {version})")
                 changed = True
 
-        if write:
-            for path, expected in expected_writes.items():
-                if path.read_bytes() != expected:
-                    raise RuntimeError(
-                        f"post-write conflict for {path}: final content differs from preflight plan"
-                    )
+        final_expectations = expected_writes if write else originals
+        for path, expected in final_expectations.items():
+            if path.read_bytes() != expected:
+                phase = "post-write" if write else "validation"
+                raise RuntimeError(
+                    f"{phase} conflict for {path}: final content differs from preflight plan"
+                )
     except BaseException as primary_error:
         if not write:
             raise

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -102,13 +102,20 @@ def normalize_version(v: str) -> str:
     # Match semver + optional pre-release (a/alpha/b/beta/rc + number)
     # and an optional hatch-vcs development suffix.
     match = re.fullmatch(
-        r"(?P<public>[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|alpha|b|beta|rc)[0-9]*)?)"
+        r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)"
+        r"(?:(?P<label>a|alpha|b|beta|rc)(?P<pre>[0-9]*))?"
         r"(?:\.dev[0-9]+)?",
         v,
     )
     if match is None:
         raise ValueError(f"unsupported version: {v}")
-    return match.group("public")
+    public = ".".join(str(int(match.group(name))) for name in ("major", "minor", "patch"))
+    label = match.group("label")
+    if label is None:
+        return public
+    canonical_label = {"alpha": "a", "beta": "b"}.get(label, label)
+    prerelease = int(match.group("pre") or "0")
+    return f"{public}{canonical_label}{prerelease}"
 
 
 def _read_version_marker(text: str, path: Path) -> str:
@@ -138,11 +145,20 @@ def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]
     return result
 
 
-def _load_json(path: Path) -> object:
+def _reject_json_constant(value: str) -> object:
+    raise ValueError(f"non-RFC JSON constant: {value}")
+
+
+def _parse_json_bytes(content: bytes) -> object:
     return json.loads(
-        path.read_bytes().decode("utf-8"),
+        content.decode("utf-8"),
         object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_json_constant,
     )
+
+
+def _load_json(path: Path) -> object:
+    return _parse_json_bytes(path.read_bytes())
 
 
 def _atomic_write_bytes(
@@ -211,10 +227,7 @@ def update_json(
 ) -> bool:
     """Update version in a JSON file. Returns True if changed."""
     original = expected_current if expected_current is not None else path.read_bytes()
-    data = json.loads(
-        original.decode("utf-8"),
-        object_pairs_hook=_reject_duplicate_keys,
-    )
+    data = _parse_json_bytes(original)
     if not isinstance(data, dict):
         raise TypeError("top-level JSON value must be an object")
 
@@ -287,10 +300,7 @@ def _run() -> None:
         try:
             original = path.read_bytes()
             originals[path] = original
-            data = json.loads(
-                original.decode("utf-8"),
-                object_pairs_hook=_reject_duplicate_keys,
-            )
+            data = _parse_json_bytes(original)
             if not isinstance(data, dict):
                 raise TypeError("top-level JSON value must be an object")
             target: object = data

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -33,6 +33,7 @@ BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.m
 VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([0-9A-Za-z.]+) -->")
 VERSION_MARKER_ENVELOPE_RE = re.compile(r"<!-- ooo:VERSION:(.*?) -->", re.DOTALL)
 _MAX_CONFLICT_RESTORE_EXCHANGES = 8
+_PathGeneration = tuple[int, int, int, int, int, int, int, int, int, int]
 
 
 def get_version() -> str:
@@ -208,18 +209,37 @@ def _exchange_paths(source: Path, destination: Path) -> bool:
     raise OSError(error, os.strerror(error), destination)
 
 
+def _path_generation(path: Path) -> _PathGeneration:
+    """Return the pathname identity and mutable inode generation fields."""
+    metadata = path.stat(follow_symlinks=False)
+    # Path exchange itself updates ctime on APFS, so ctime cannot distinguish
+    # an external writer from the ownership transfer being validated here.
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        int(getattr(metadata, "st_flags", 0)),
+        int(getattr(metadata, "st_gen", 0)),
+    )
+
+
 def _restore_latest_exchanged_content(
     temp_path: Path,
     path: Path,
     *,
-    expected_displaced: bytes,
+    expected_displaced: _PathGeneration,
 ) -> bool:
     """Restore the newest observed external edit without deleting a later writer."""
     for _ in range(_MAX_CONFLICT_RESTORE_EXCHANGES):
-        candidate = temp_path.read_bytes()
+        candidate = _path_generation(temp_path)
         if not _exchange_paths(temp_path, path):
             return False
-        displaced = temp_path.read_bytes()
+        displaced = _path_generation(temp_path)
         if displaced == expected_displaced:
             return True
         expected_displaced = candidate
@@ -246,6 +266,7 @@ def _atomic_write_bytes(
         if expected_current is not None:
             if not path.exists():
                 raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+            staged_generation = _path_generation(temp_path)
             if not _exchange_paths(temp_path, path):
                 raise RuntimeError(
                     f"write conflict for {path}: atomic path exchange is unavailable"
@@ -256,7 +277,7 @@ def _atomic_write_bytes(
                     restored = _restore_latest_exchanged_content(
                         temp_path,
                         path,
-                        expected_displaced=content,
+                        expected_displaced=staged_generation,
                     )
                 except BaseException:
                     raise

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -6,20 +6,30 @@ Usage:
     python scripts/sync-plugin-version.py --write  # actually update files
 
 Called by CI (dev-publish.yml) before build to keep plugin metadata in sync.
+
+Each target is replaced atomically. Catchable failures roll back files already
+replaced, but an uncatchable process or machine crash can leave a mixed version
+across targets; ordinary files cannot provide a durable multi-file transaction.
 """
 
+import fcntl
+import hashlib
 import json
+import os
 from pathlib import Path
 import re
+import stat
 import subprocess
 import sys
+import tempfile
 
 ROOT = Path(__file__).resolve().parent.parent
 PLUGIN_JSON = ROOT / ".claude-plugin" / "plugin.json"
 MARKETPLACE_JSON = ROOT / ".claude-plugin" / "marketplace.json"
 SETUP_SKILL_MD = ROOT / "skills" / "setup" / "SKILL.md"
 BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
-VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([\d\w.]+) -->")
+VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([0-9A-Za-z.]+) -->")
+VERSION_MARKER_ENVELOPE_RE = re.compile(r"<!-- ooo:VERSION:(.*?) -->", re.DOTALL)
 
 
 def get_version() -> str:
@@ -92,7 +102,8 @@ def normalize_version(v: str) -> str:
     # Match semver + optional pre-release (a/alpha/b/beta/rc + number)
     # and an optional hatch-vcs development suffix.
     match = re.fullmatch(
-        r"(?P<public>\d+\.\d+\.\d+(?:(?:a|alpha|b|beta|rc)\d*)?)(?:\.dev\d+)?",
+        r"(?P<public>[0-9]+\.[0-9]+\.[0-9]+(?:(?:a|alpha|b|beta|rc)[0-9]*)?)"
+        r"(?:\.dev[0-9]+)?",
         v,
     )
     if match is None:
@@ -100,27 +111,112 @@ def normalize_version(v: str) -> str:
     return match.group("public")
 
 
-def update_version_marker(path: Path, version: str) -> bool:
-    """Update <!-- ooo:VERSION:X.Y.Z --> marker in a text file."""
-    text = path.read_text()
-    matches = list(VERSION_MARKER_RE.finditer(text))
-    if len(matches) != 1:
+def _read_version_marker(text: str, path: Path) -> str:
+    """Return one well-formed marker value, rejecting malformed duplicates."""
+    if text.count("<!-- ooo:VERSION:") != 1:
         raise ValueError(f"expected exactly one version marker in {path}")
+    envelopes = list(VERSION_MARKER_ENVELOPE_RE.finditer(text))
+    matches = list(VERSION_MARKER_RE.finditer(text))
+    if len(envelopes) != 1 or len(matches) != 1 or envelopes[0].span() != matches[0].span():
+        raise ValueError(f"expected exactly one version marker in {path}")
+    marker_value = matches[0].group(1)
+    try:
+        normalized_marker = normalize_version(marker_value)
+    except ValueError as exc:
+        raise ValueError(f"expected exactly one version marker in {path}") from exc
+    if normalized_marker != marker_value:
+        raise ValueError(f"expected exactly one version marker in {path}")
+    return marker_value
 
-    new_text = VERSION_MARKER_RE.sub(f"<!-- ooo:VERSION:{version} -->", text)
-    if text == new_text:
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(
+        path.read_bytes().decode("utf-8"),
+        object_pairs_hook=_reject_duplicate_keys,
+    )
+
+
+def _atomic_write_bytes(
+    path: Path,
+    content: bytes,
+    *,
+    expected_current: bytes | None = None,
+) -> None:
+    """Durably replace one target without exposing a partial file."""
+    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            os.fchmod(temp_file.fileno(), mode)
+            os.fsync(temp_file.fileno())
+        if expected_current is not None and path.read_bytes() != expected_current:
+            raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def update_version_marker(
+    path: Path,
+    version: str,
+    *,
+    expected_current: bytes | None = None,
+) -> bool:
+    """Update <!-- ooo:VERSION:X.Y.Z --> marker in a text file."""
+    original = expected_current if expected_current is not None else path.read_bytes()
+    text = original.decode("utf-8")
+    _read_version_marker(text, path)
+
+    old_marker = VERSION_MARKER_RE.search(text)
+    assert old_marker is not None
+    old_marker_bytes = old_marker.group(0).encode("ascii")
+    new_marker_bytes = f"<!-- ooo:VERSION:{version} -->".encode("ascii")
+    content = original.replace(old_marker_bytes, new_marker_bytes, 1)
+    if original == content:
         return False
-    path.write_text(new_text)
+    _atomic_write_bytes(path, content, expected_current=original)
 
-    updated_matches = list(VERSION_MARKER_RE.finditer(path.read_text()))
+    updated = path.read_bytes()
+    if updated != content:
+        raise RuntimeError(f"failed to verify version marker update in {path}")
+    updated_matches = list(VERSION_MARKER_RE.finditer(updated.decode("utf-8")))
     if len(updated_matches) != 1 or updated_matches[0].group(1) != version:
         raise RuntimeError(f"failed to verify version marker update in {path}")
     return True
 
 
-def update_json(path: Path, version: str, *, nested_key: str | None = None) -> bool:
+def update_json(
+    path: Path,
+    version: str,
+    *,
+    nested_key: str | None = None,
+    expected_current: bytes | None = None,
+) -> bool:
     """Update version in a JSON file. Returns True if changed."""
-    data = json.loads(path.read_text())
+    original = expected_current if expected_current is not None else path.read_bytes()
+    data = json.loads(
+        original.decode("utf-8"),
+        object_pairs_hook=_reject_duplicate_keys,
+    )
+    if not isinstance(data, dict):
+        raise TypeError("top-level JSON value must be an object")
 
     if nested_key:
         # marketplace.json: plugins[0].version
@@ -139,11 +235,12 @@ def update_json(path: Path, version: str, *, nested_key: str | None = None) -> b
     if old == version:
         return False
 
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    content = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    _atomic_write_bytes(path, content, expected_current=original)
     return True
 
 
-def main() -> None:
+def _run() -> None:
     write = "--write" in sys.argv
 
     # Allow explicit version override (e.g. --version 0.26.0b6)
@@ -167,24 +264,33 @@ def main() -> None:
         (PLUGIN_JSON, None),
         (MARKETPLACE_JSON, "plugins.0"),
     ]
-
+    originals: dict[Path, bytes] = {}
     setup_markers: dict[Path, tuple[str, str]] = {}
     for path in (SETUP_SKILL_MD, BUNDLED_SETUP_SKILL_MD):
         if not path.exists():
             sys.exit(f"Error: required setup skill not found: {path.relative_to(ROOT)}")
-        text = path.read_text()
-        marker_matches = list(VERSION_MARKER_RE.finditer(text))
-        if len(marker_matches) != 1:
+        original = path.read_bytes()
+        originals[path] = original
+        text = original.decode("utf-8")
+        try:
+            old_marker = _read_version_marker(text, path)
+        except ValueError:
             sys.exit(f"Error: expected exactly one version marker in {path.relative_to(ROOT)}")
-        setup_markers[path] = (text, marker_matches[0].group(1))
+        setup_markers[path] = (text, old_marker)
 
     json_targets: list[tuple[Path, str | None, object, str]] = []
+    expected_writes: dict[Path, bytes] = {}
     for path, nested in targets:
         if not path.exists():
             sys.exit(f"Error: required plugin metadata not found: {path.relative_to(ROOT)}")
 
         try:
-            data = json.loads(path.read_text())
+            original = path.read_bytes()
+            originals[path] = original
+            data = json.loads(
+                original.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_keys,
+            )
             if not isinstance(data, dict):
                 raise TypeError("top-level JSON value must be an object")
             target: object = data
@@ -198,47 +304,107 @@ def main() -> None:
                         if not isinstance(target, dict):
                             raise TypeError("named path component requires an object")
                         target = target[key]
-                if not isinstance(target, dict):
-                    raise TypeError("version target must be an object")
+            if not isinstance(target, dict):
+                raise TypeError("version target must be an object")
             old = target.get("version")
             if not isinstance(old, str):
                 raise TypeError("version must be a string")
+            target["version"] = version
+            expected_writes[path] = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode(
+                "utf-8"
+            )
         except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError) as exc:
             sys.exit(f"Error: could not validate {path.relative_to(ROOT)}: {exc}")
         json_targets.append((path, nested, data, old))
 
     changed = False
-    for path, nested, _data, old in json_targets:
-        if not path.exists():
-            print(f"  SKIP  {path.relative_to(ROOT)} (not found)")
-            continue
-
-        if old == version:
-            print(f"  OK    {path.relative_to(ROOT)} ({old})")
-        elif write:
-            update_json(path, version, nested_key=nested)
-            print(f"  WRITE {path.relative_to(ROOT)} ({old} -> {version})")
-            changed = True
-        else:
-            print(f"  DRIFT {path.relative_to(ROOT)} ({old} != {version})")
-            changed = True
-
     for path, (_text, old_marker) in setup_markers.items():
-        if old_marker == version:
-            print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
-        elif write:
-            updated = update_version_marker(path, version)
-            if not updated:
-                sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
-            print(f"  WRITE {path.relative_to(ROOT)} ({old_marker} -> {version})")
-            changed = True
-        else:
-            print(f"  DRIFT {path.relative_to(ROOT)} ({old_marker} != {version})")
-            changed = True
+        expected_writes[path] = originals[path].replace(
+            f"<!-- ooo:VERSION:{old_marker} -->".encode("ascii"),
+            f"<!-- ooo:VERSION:{version} -->".encode("ascii"),
+            1,
+        )
+    attempted: list[Path] = []
+    try:
+        for path, nested, _data, old in json_targets:
+            if old == version:
+                print(f"  OK    {path.relative_to(ROOT)} ({old})")
+            elif write:
+                attempted.append(path)
+                update_json(
+                    path,
+                    version,
+                    nested_key=nested,
+                    expected_current=originals[path],
+                )
+                print(f"  WRITE {path.relative_to(ROOT)} ({old} -> {version})")
+                changed = True
+            else:
+                print(f"  DRIFT {path.relative_to(ROOT)} ({old} != {version})")
+                changed = True
+
+        for path, (_text, old_marker) in setup_markers.items():
+            if old_marker == version:
+                print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
+            elif write:
+                attempted.append(path)
+                updated = update_version_marker(
+                    path,
+                    version,
+                    expected_current=originals[path],
+                )
+                if not updated:
+                    sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
+                print(f"  WRITE {path.relative_to(ROOT)} ({old_marker} -> {version})")
+                changed = True
+            else:
+                print(f"  DRIFT {path.relative_to(ROOT)} ({old_marker} != {version})")
+                changed = True
+    except BaseException as primary_error:
+        if not write:
+            raise
+        rollback_failures: list[BaseException] = []
+        for path in attempted:
+            try:
+                current = path.read_bytes()
+                if current == originals[path]:
+                    continue
+                if current != expected_writes[path]:
+                    raise RuntimeError(
+                        f"rollback conflict for {path}: file changed after version sync write"
+                    )
+                _atomic_write_bytes(
+                    path,
+                    originals[path],
+                    expected_current=expected_writes[path],
+                )
+            except BaseException as rollback_error:
+                failure = RuntimeError(f"failed to roll back {path}: {rollback_error}")
+                failure.__cause__ = rollback_error
+                rollback_failures.append(failure)
+        if rollback_failures:
+            raise BaseExceptionGroup(
+                "version synchronization failed and rollback was incomplete",
+                [primary_error, *rollback_failures],
+            ) from None
+        raise
 
     if changed and not write:
         print("\nRun with --write to update files.")
         sys.exit(1)
+
+
+def _lock_path() -> Path:
+    root_key = hashlib.sha256(str(ROOT.resolve()).encode("utf-8")).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"ouroboros-sync-plugin-version-{root_key}.lock"
+
+
+def main() -> None:
+    """Serialize invocations; the OS releases this lock if the process crashes."""
+    lock_path = _lock_path()
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        _run()
 
 
 if __name__ == "__main__":

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -33,7 +33,7 @@ BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.m
 VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([0-9A-Za-z.]+) -->")
 VERSION_MARKER_ENVELOPE_RE = re.compile(r"<!-- ooo:VERSION:(.*?) -->", re.DOTALL)
 _MAX_CONFLICT_RESTORE_EXCHANGES = 8
-_PathGeneration = tuple[int, int, int, int, int, int, int, int, int, int]
+_PathGeneration = tuple[int, int, int, int, int, int, int, int, int, int, str]
 
 
 def get_version() -> str:
@@ -214,6 +214,7 @@ def _path_generation(path: Path) -> _PathGeneration:
     metadata = path.stat(follow_symlinks=False)
     # Path exchange itself updates ctime on APFS, so ctime cannot distinguish
     # an external writer from the ownership transfer being validated here.
+    content_digest = hashlib.sha256(path.read_bytes()).hexdigest()
     return (
         metadata.st_dev,
         metadata.st_ino,
@@ -225,6 +226,7 @@ def _path_generation(path: Path) -> _PathGeneration:
         metadata.st_mtime_ns,
         int(getattr(metadata, "st_flags", 0)),
         int(getattr(metadata, "st_gen", 0)),
+        content_digest,
     )
 
 

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -32,6 +32,7 @@ SETUP_SKILL_MD = ROOT / "skills" / "setup" / "SKILL.md"
 BUNDLED_SETUP_SKILL_MD = ROOT / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
 VERSION_MARKER_RE = re.compile(r"<!-- ooo:VERSION:([0-9A-Za-z.]+) -->")
 VERSION_MARKER_ENVELOPE_RE = re.compile(r"<!-- ooo:VERSION:(.*?) -->", re.DOTALL)
+_MAX_CONFLICT_RESTORE_EXCHANGES = 8
 
 
 def get_version() -> str:
@@ -207,6 +208,24 @@ def _exchange_paths(source: Path, destination: Path) -> bool:
     raise OSError(error, os.strerror(error), destination)
 
 
+def _restore_latest_exchanged_content(
+    temp_path: Path,
+    path: Path,
+    *,
+    expected_displaced: bytes,
+) -> bool:
+    """Restore the newest observed external edit without deleting a later writer."""
+    for _ in range(_MAX_CONFLICT_RESTORE_EXCHANGES):
+        candidate = temp_path.read_bytes()
+        if not _exchange_paths(temp_path, path):
+            return False
+        displaced = temp_path.read_bytes()
+        if displaced == expected_displaced:
+            return True
+        expected_displaced = candidate
+    return False
+
+
 def _atomic_write_bytes(
     path: Path,
     content: bytes,
@@ -232,17 +251,21 @@ def _atomic_write_bytes(
                     f"write conflict for {path}: atomic path exchange is unavailable"
                 )
             if temp_path.read_bytes() != expected_current:
+                preserve_temp = True
                 try:
-                    restored = _exchange_paths(temp_path, path)
+                    restored = _restore_latest_exchanged_content(
+                        temp_path,
+                        path,
+                        expected_displaced=content,
+                    )
                 except BaseException:
-                    preserve_temp = True
                     raise
                 if not restored:
-                    preserve_temp = True
                     raise RuntimeError(
                         f"write conflict for {path}: could not restore exchanged target; "
-                        f"preserved original at {temp_path}"
+                        f"preserved displaced content at {temp_path}"
                     )
+                preserve_temp = False
                 raise RuntimeError(f"write conflict for {path}: file changed since preflight")
         else:
             os.replace(temp_path, path)

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -324,7 +324,20 @@ def _atomic_write_bytes(
         raise
     finally:
         if not preserve_temp:
-            temp_path.unlink(missing_ok=True)
+            active_error = sys.exception()
+            try:
+                temp_path.unlink(missing_ok=True)
+            except BaseException as cleanup_error:
+                if active_error is not None:
+                    active_error.add_note(
+                        f"also failed to remove temporary file {temp_path}: {cleanup_error}"
+                    )
+                elif replaced_target:
+                    raise _OwnedWriteError(
+                        path, staged_generation, cleanup_error
+                    ) from cleanup_error
+                else:
+                    raise
 
 
 def update_version_marker(

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -12,6 +12,8 @@ replaced, but an uncatchable process or machine crash can leave a mixed version
 across targets; ordinary files cannot provide a durable multi-file transaction.
 """
 
+import ctypes
+import errno
 import fcntl
 import hashlib
 import json
@@ -118,6 +120,13 @@ def normalize_version(v: str) -> str:
     return f"{public}{canonical_label}{prerelease}"
 
 
+def require_canonical_version(v: str) -> str:
+    normalized = normalize_version(v)
+    if normalized != v:
+        raise ValueError(f"release version must be canonical: {v} (canonical: {normalized})")
+    return normalized
+
+
 def _read_version_marker(text: str, path: Path) -> str:
     """Return one well-formed marker value, rejecting malformed duplicates."""
     if text.count("<!-- ooo:VERSION:") != 1:
@@ -161,6 +170,31 @@ def _load_json(path: Path) -> object:
     return _parse_json_bytes(path.read_bytes())
 
 
+def _exchange_paths(source: Path, destination: Path) -> bool:
+    """Atomically exchange two Linux pathnames when renameat2 is available."""
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+    except AttributeError:
+        return False
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    result = renameat2(-100, os.fsencode(source), -100, os.fsencode(destination), 2)
+    if result == 0:
+        return True
+    error = ctypes.get_errno()
+    if error in {errno.ENOSYS, errno.EINVAL, errno.EOPNOTSUPP, errno.EXDEV}:
+        return False
+    raise OSError(error, os.strerror(error), destination)
+
+
 def _atomic_write_bytes(
     path: Path,
     content: bytes,
@@ -171,22 +205,42 @@ def _atomic_write_bytes(
     mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
     fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     temp_path = Path(temp_name)
+    preserve_temp = False
     try:
         with os.fdopen(fd, "wb") as temp_file:
             temp_file.write(content)
             temp_file.flush()
             os.fchmod(temp_file.fileno(), mode)
             os.fsync(temp_file.fileno())
-        if expected_current is not None and path.read_bytes() != expected_current:
-            raise RuntimeError(f"write conflict for {path}: file changed since preflight")
-        os.replace(temp_path, path)
+        exchanged = (
+            expected_current is not None and path.exists() and _exchange_paths(temp_path, path)
+        )
+        if exchanged:
+            if temp_path.read_bytes() != expected_current:
+                try:
+                    restored = _exchange_paths(temp_path, path)
+                except BaseException:
+                    preserve_temp = True
+                    raise
+                if not restored:
+                    preserve_temp = True
+                    raise RuntimeError(
+                        f"write conflict for {path}: could not restore exchanged target; "
+                        f"preserved original at {temp_path}"
+                    )
+                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+        else:
+            if expected_current is not None and path.read_bytes() != expected_current:
+                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+            os.replace(temp_path, path)
         directory_fd = os.open(path.parent, os.O_RDONLY)
         try:
             os.fsync(directory_fd)
         finally:
             os.close(directory_fd)
     finally:
-        temp_path.unlink(missing_ok=True)
+        if not preserve_temp:
+            temp_path.unlink(missing_ok=True)
 
 
 def update_version_marker(
@@ -265,7 +319,10 @@ def _run() -> None:
 
     raw_version = explicit_version or get_version()
     try:
-        version = normalize_version(raw_version)
+        if "--require-canonical" in sys.argv:
+            version = require_canonical_version(raw_version)
+        else:
+            version = normalize_version(raw_version)
     except ValueError as exc:
         sys.exit(f"Error: {exc}")
 

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -36,6 +36,16 @@ _MAX_CONFLICT_RESTORE_EXCHANGES = 8
 _PathGeneration = tuple[int, int, int, int, int, int, int, int, int, int, str]
 
 
+class _OwnedWriteError(RuntimeError):
+    """Error raised after this process owns a completed pathname replacement."""
+
+    def __init__(self, path: Path, generation: _PathGeneration, error: BaseException) -> None:
+        super().__init__(str(error))
+        self.path = path
+        self.generation = generation
+        self.__cause__ = error
+
+
 def get_version() -> str:
     """Get version from hatch-vcs (same source as the Python package)."""
     # Try hatch first
@@ -260,6 +270,7 @@ def _atomic_write_bytes(
     fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     temp_path = Path(temp_name)
     preserve_temp = False
+    replaced_target = False
     try:
         with os.fdopen(fd, "wb") as temp_file:
             temp_file.write(content)
@@ -274,10 +285,12 @@ def _atomic_write_bytes(
                 raise RuntimeError(
                     f"write conflict for {path}: atomic path exchange is unavailable"
                 )
+            replaced_target = True
             displaced_generation = _path_generation(temp_path)
             if temp_path.read_bytes() != expected_current or (
                 expected_generation is not None and displaced_generation != expected_generation
             ):
+                replaced_target = False
                 preserve_temp = True
                 try:
                     restored = _restore_latest_exchanged_content(
@@ -298,12 +311,17 @@ def _atomic_write_bytes(
                 )
         else:
             os.replace(temp_path, path)
+            replaced_target = True
         directory_fd = os.open(path.parent, os.O_RDONLY)
         try:
             os.fsync(directory_fd)
         finally:
             os.close(directory_fd)
         return staged_generation
+    except BaseException as exc:
+        if replaced_target and not isinstance(exc, _OwnedWriteError):
+            raise _OwnedWriteError(path, staged_generation, exc) from exc
+        raise
     finally:
         if not preserve_temp:
             temp_path.unlink(missing_ok=True)
@@ -329,12 +347,15 @@ def update_version_marker(
         return None
     owned_generation = _atomic_write_bytes(path, content, expected_current=original)
 
-    updated = path.read_bytes()
-    if updated != content:
-        raise RuntimeError(f"failed to verify version marker update in {path}")
-    updated_matches = list(VERSION_MARKER_RE.finditer(updated.decode("utf-8")))
-    if len(updated_matches) != 1 or updated_matches[0].group(1) != version:
-        raise RuntimeError(f"failed to verify version marker update in {path}")
+    try:
+        updated = path.read_bytes()
+        if updated != content:
+            raise RuntimeError(f"failed to verify version marker update in {path}")
+        updated_matches = list(VERSION_MARKER_RE.finditer(updated.decode("utf-8")))
+        if len(updated_matches) != 1 or updated_matches[0].group(1) != version:
+            raise RuntimeError(f"failed to verify version marker update in {path}")
+    except BaseException as exc:
+        raise _OwnedWriteError(path, owned_generation, exc) from exc
     return owned_generation
 
 
@@ -510,6 +531,8 @@ def _run() -> None:
     except BaseException as primary_error:
         if not write:
             raise
+        if isinstance(primary_error, _OwnedWriteError):
+            owned_writes[primary_error.path] = primary_error.generation
         rollback_failures: list[BaseException] = []
         for path in attempted:
             try:

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -253,7 +253,8 @@ def _atomic_write_bytes(
     content: bytes,
     *,
     expected_current: bytes | None = None,
-) -> None:
+    expected_generation: _PathGeneration | None = None,
+) -> _PathGeneration:
     """Durably replace one target without exposing a partial file."""
     mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
     fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
@@ -265,15 +266,18 @@ def _atomic_write_bytes(
             temp_file.flush()
             os.fchmod(temp_file.fileno(), mode)
             os.fsync(temp_file.fileno())
+        staged_generation = _path_generation(temp_path)
         if expected_current is not None:
             if not path.exists():
                 raise RuntimeError(f"write conflict for {path}: file changed since preflight")
-            staged_generation = _path_generation(temp_path)
             if not _exchange_paths(temp_path, path):
                 raise RuntimeError(
                     f"write conflict for {path}: atomic path exchange is unavailable"
                 )
-            if temp_path.read_bytes() != expected_current:
+            displaced_generation = _path_generation(temp_path)
+            if temp_path.read_bytes() != expected_current or (
+                expected_generation is not None and displaced_generation != expected_generation
+            ):
                 preserve_temp = True
                 try:
                     restored = _restore_latest_exchanged_content(
@@ -288,8 +292,10 @@ def _atomic_write_bytes(
                         f"write conflict for {path}: could not restore exchanged target; "
                         f"preserved displaced content at {temp_path}"
                     )
-                preserve_temp = False
-                raise RuntimeError(f"write conflict for {path}: file changed since preflight")
+                raise RuntimeError(
+                    f"write conflict for {path}: file changed since preflight; "
+                    f"preserved displaced content at {temp_path}"
+                )
         else:
             os.replace(temp_path, path)
         directory_fd = os.open(path.parent, os.O_RDONLY)
@@ -297,6 +303,7 @@ def _atomic_write_bytes(
             os.fsync(directory_fd)
         finally:
             os.close(directory_fd)
+        return staged_generation
     finally:
         if not preserve_temp:
             temp_path.unlink(missing_ok=True)
@@ -307,7 +314,7 @@ def update_version_marker(
     version: str,
     *,
     expected_current: bytes | None = None,
-) -> bool:
+) -> _PathGeneration | None:
     """Update <!-- ooo:VERSION:X.Y.Z --> marker in a text file."""
     original = expected_current if expected_current is not None else path.read_bytes()
     text = original.decode("utf-8")
@@ -319,8 +326,8 @@ def update_version_marker(
     new_marker_bytes = f"<!-- ooo:VERSION:{version} -->".encode("ascii")
     content = original.replace(old_marker_bytes, new_marker_bytes, 1)
     if original == content:
-        return False
-    _atomic_write_bytes(path, content, expected_current=original)
+        return None
+    owned_generation = _atomic_write_bytes(path, content, expected_current=original)
 
     updated = path.read_bytes()
     if updated != content:
@@ -328,7 +335,7 @@ def update_version_marker(
     updated_matches = list(VERSION_MARKER_RE.finditer(updated.decode("utf-8")))
     if len(updated_matches) != 1 or updated_matches[0].group(1) != version:
         raise RuntimeError(f"failed to verify version marker update in {path}")
-    return True
+    return owned_generation
 
 
 def update_json(
@@ -337,8 +344,8 @@ def update_json(
     *,
     nested_key: str | None = None,
     expected_current: bytes | None = None,
-) -> bool:
-    """Update version in a JSON file. Returns True if changed."""
+) -> _PathGeneration | None:
+    """Update version in a JSON file. Returns the owned generation if changed."""
     original = expected_current if expected_current is not None else path.read_bytes()
     data = _parse_json_bytes(original)
     if not isinstance(data, dict):
@@ -359,11 +366,10 @@ def update_json(
         data["version"] = version
 
     if old == version:
-        return False
+        return None
 
     content = (json.dumps(data, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
-    _atomic_write_bytes(path, content, expected_current=original)
-    return True
+    return _atomic_write_bytes(path, content, expected_current=original)
 
 
 def _run() -> None:
@@ -453,18 +459,22 @@ def _run() -> None:
             1,
         )
     attempted: list[Path] = []
+    owned_writes: dict[Path, _PathGeneration] = {}
     try:
         for path, nested, _data, old in json_targets:
             if old == version:
                 print(f"  OK    {path.relative_to(ROOT)} ({old})")
             elif write:
                 attempted.append(path)
-                update_json(
+                owned_generation = update_json(
                     path,
                     version,
                     nested_key=nested,
                     expected_current=originals[path],
                 )
+                if owned_generation is None:
+                    sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
+                owned_writes[path] = owned_generation
                 print(f"  WRITE {path.relative_to(ROOT)} ({old} -> {version})")
                 changed = True
             else:
@@ -476,13 +486,14 @@ def _run() -> None:
                 print(f"  OK    {path.relative_to(ROOT)} ({old_marker})")
             elif write:
                 attempted.append(path)
-                updated = update_version_marker(
+                owned_generation = update_version_marker(
                     path,
                     version,
                     expected_current=originals[path],
                 )
-                if not updated:
+                if owned_generation is None:
                     sys.exit(f"Error: failed to update {path.relative_to(ROOT)}")
+                owned_writes[path] = owned_generation
                 print(f"  WRITE {path.relative_to(ROOT)} ({old_marker} -> {version})")
                 changed = True
             else:
@@ -508,10 +519,16 @@ def _run() -> None:
                     raise RuntimeError(
                         f"rollback conflict for {path}: file changed after version sync write"
                     )
+                if _path_generation(path) != owned_writes.get(path):
+                    raise RuntimeError(
+                        f"rollback conflict for {path}: file generation changed after "
+                        "version sync write"
+                    )
                 _atomic_write_bytes(
                     path,
                     originals[path],
                     expected_current=expected_writes[path],
+                    expected_generation=owned_writes[path],
                 )
             except BaseException as rollback_error:
                 failure = RuntimeError(f"failed to roll back {path}: {rollback_error}")

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -106,11 +106,15 @@ def test_main_write_updates_both_setup_skill_markers(
     assert bundled_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nbundled\n"
 
 
-def test_update_version_marker_preserves_unrelated_bytes_with_bom_and_crlf(tmp_path: Path) -> None:
+def test_update_version_marker_preserves_unrelated_bytes_with_bom_and_crlf(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     marker = b"<!-- ooo:VERSION:1.2.3 -->"
     target = tmp_path / "SKILL.md"
     original = b"\xef\xbb\xbfheading\r\n" + marker + "\r\nbody café\r\n".encode()
     target.write_bytes(original)
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
 
     assert sync_plugin_version.update_version_marker(target, "1.2.4") is not None
 
@@ -829,6 +833,56 @@ def test_atomic_exchange_preserves_open_descriptor_write_displaced_to_temp(
     assert late_external in reachable_bytes
 
 
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_exchange_quarantines_late_open_descriptor_write_on_success(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    late_external = b'{"version":"1.2.3","note":"late fd during cleanup"}\n'
+    target.write_bytes(original)
+    expected_generation = sync_plugin_version._path_generation(target)
+    displaced_fd = os.open(target, os.O_WRONLY)
+    real_quarantine = sync_plugin_version._quarantine_displaced_path
+    quarantined_path: Path | None = None
+
+    def write_before_quarantine(temp_path: Path, path: Path) -> Path:
+        nonlocal quarantined_path
+        os.lseek(displaced_fd, 0, os.SEEK_SET)
+        os.write(displaced_fd, late_external)
+        os.ftruncate(displaced_fd, len(late_external))
+        os.fsync(displaced_fd)
+        quarantined_path = real_quarantine(temp_path, path)
+        return quarantined_path
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "_quarantine_displaced_path",
+        write_before_quarantine,
+    )
+
+    try:
+        owned_generation = sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
+            expected_current=original,
+            expected_generation=expected_generation,
+        )
+    finally:
+        os.close(displaced_fd)
+
+    assert target.read_bytes() == content
+    assert sync_plugin_version._path_generation(target) == owned_generation
+    assert quarantined_path is not None
+    assert quarantined_path.read_bytes() == late_external
+
+
 def test_atomic_write_fails_closed_when_exchange_is_unavailable(
     tmp_path: Path,
     monkeypatch,
@@ -854,7 +908,7 @@ def test_atomic_write_fails_closed_when_exchange_is_unavailable(
     not (sys.platform.startswith("linux") or sys.platform == "darwin"),
     reason="atomic pathname exchange is unavailable on this platform",
 )
-def test_atomic_write_cleanup_failure_does_not_mask_active_owned_write_error(
+def test_atomic_write_quarantines_displaced_inode_before_directory_sync_failure(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -863,20 +917,22 @@ def test_atomic_write_cleanup_failure_does_not_mask_active_owned_write_error(
     content = b'{"version":"1.2.4"}\n'
     target.write_bytes(original)
     real_open = sync_plugin_version.os.open
-    real_unlink = Path.unlink
+    real_quarantine = sync_plugin_version._quarantine_displaced_path
+    quarantined_path: Path | None = None
 
     def fail_directory_open(path, flags, *args, **kwargs):
         if Path(path) == tmp_path:
             raise OSError("injected directory open failure")
         return real_open(path, flags, *args, **kwargs)
 
-    def fail_displaced_temp_unlink(path: Path, *, missing_ok: bool = False) -> None:
-        if path != target and path.parent == tmp_path and path.read_bytes() == original:
-            raise OSError("injected displaced temp unlink failure")
-        real_unlink(path, missing_ok=missing_ok)
+    def capture_quarantine(temp_path: Path, path: Path) -> Path:
+        nonlocal quarantined_path
+        quarantined_path = real_quarantine(temp_path, path)
+        return quarantined_path
 
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
     monkeypatch.setattr(sync_plugin_version.os, "open", fail_directory_open)
-    monkeypatch.setattr(Path, "unlink", fail_displaced_temp_unlink)
+    monkeypatch.setattr(sync_plugin_version, "_quarantine_displaced_path", capture_quarantine)
 
     with pytest.raises(sync_plugin_version._OwnedWriteError) as raised:
         sync_plugin_version._atomic_write_bytes(
@@ -888,8 +944,9 @@ def test_atomic_write_cleanup_failure_does_not_mask_active_owned_write_error(
     assert "directory open failure" in str(raised.value)
     assert isinstance(raised.value.__cause__, OSError)
     assert "directory open failure" in str(raised.value.__cause__)
-    assert any("displaced temp unlink failure" in note for note in raised.value.__notes__)
     assert target.read_bytes() == content
+    assert quarantined_path is not None
+    assert quarantined_path.read_bytes() == original
 
 
 def test_main_write_rolls_back_when_later_write_fails(
@@ -1147,7 +1204,7 @@ def test_main_write_rolls_back_owned_exchange_when_parent_dir_open_fails(
     not (sys.platform.startswith("linux") or sys.platform == "darwin"),
     reason="atomic pathname exchange is unavailable on this platform",
 )
-def test_main_write_rolls_back_owned_exchange_when_displaced_temp_unlink_fails(
+def test_main_write_rolls_back_owned_exchange_when_displaced_quarantine_fails(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -1176,36 +1233,35 @@ def test_main_write_rolls_back_owned_exchange_when_displaced_temp_unlink_fails(
         "argv",
         ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
     )
-    real_unlink = Path.unlink
-    cleanup_failure_injected = False
+    real_quarantine = sync_plugin_version._quarantine_displaced_path
+    quarantine_failure_injected = False
     foreign_generation = None
 
-    def fail_marketplace_displaced_temp_unlink(
-        path: Path,
-        *,
-        missing_ok: bool = False,
-    ) -> None:
-        nonlocal cleanup_failure_injected, foreign_generation
+    def fail_marketplace_displaced_quarantine(temp_path: Path, path: Path) -> Path:
+        nonlocal quarantine_failure_injected, foreign_generation
         if (
-            not cleanup_failure_injected
-            and path.parent == marketplace_json.parent
-            and path.name.startswith(f".{marketplace_json.name}.")
-            and path.read_bytes() == originals[marketplace_json]
+            not quarantine_failure_injected
+            and path == marketplace_json
+            and temp_path.read_bytes() == originals[marketplace_json]
         ):
             replacement = tmp_path / "source-skill-same-bytes-foreign-generation"
             replacement.write_bytes(originals[source_skill])
             os.replace(replacement, source_skill)
             foreign_generation = sync_plugin_version._path_generation(source_skill)
-            cleanup_failure_injected = True
-            raise OSError("injected displaced temp unlink failure")
-        real_unlink(path, missing_ok=missing_ok)
+            quarantine_failure_injected = True
+            raise OSError("injected displaced quarantine failure")
+        return real_quarantine(temp_path, path)
 
-    monkeypatch.setattr(Path, "unlink", fail_marketplace_displaced_temp_unlink)
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "_quarantine_displaced_path",
+        fail_marketplace_displaced_quarantine,
+    )
 
-    with pytest.raises(sync_plugin_version._OwnedWriteError, match="displaced temp unlink failure"):
+    with pytest.raises(sync_plugin_version._OwnedWriteError, match="displaced quarantine failure"):
         sync_plugin_version.main()
 
-    assert cleanup_failure_injected
+    assert quarantine_failure_injected
     assert foreign_generation is not None
     assert source_skill.read_bytes() == originals[source_skill]
     assert sync_plugin_version._path_generation(source_skill) == foreign_generation

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -579,6 +579,51 @@ def test_atomic_write_rejects_target_changed_since_preflight(tmp_path: Path) -> 
     not (sys.platform.startswith("linux") or sys.platform == "darwin"),
     reason="atomic pathname exchange is unavailable on this platform",
 )
+def test_atomic_exchange_preserves_same_bytes_new_inode_replacement_at_commit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    target.write_bytes(original)
+    expected_generation = sync_plugin_version._path_generation(target)
+    real_exchange = sync_plugin_version._exchange_paths
+    injected = False
+    replacement_generation = None
+
+    def inject_same_bytes_replacement(source: Path, destination: Path) -> bool:
+        nonlocal injected, replacement_generation
+        if not injected:
+            injected = True
+            replacement = tmp_path / "same-bytes-replacement"
+            replacement.write_bytes(original)
+            os.replace(replacement, destination)
+            replacement_generation = sync_plugin_version._path_generation(destination)
+        return real_exchange(source, destination)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_same_bytes_replacement)
+
+    with pytest.raises(RuntimeError, match="write conflict") as raised:
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
+            expected_current=original,
+            expected_generation=expected_generation,
+        )
+
+    assert "preserved exchanged content at" in str(raised.value)
+    assert replacement_generation is not None
+    assert target.read_bytes() == original
+    assert sync_plugin_version._path_generation(target) == replacement_generation
+    reachable_bytes = [path.read_bytes() for path in tmp_path.iterdir()]
+    assert content in reachable_bytes
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
 def test_atomic_exchange_restores_edit_arriving_at_commit(
     tmp_path: Path,
     monkeypatch,
@@ -888,6 +933,7 @@ def test_main_write_rolls_back_when_later_write_fails(
         *,
         nested_key=None,
         expected_current=None,
+        expected_generation=None,
     ) -> bool:
         nonlocal calls
         calls += 1
@@ -898,6 +944,7 @@ def test_main_write_rolls_back_when_later_write_fails(
             version,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
 
     monkeypatch.setattr(sync_plugin_version, "update_json", fail_second_json_write)
@@ -944,6 +991,7 @@ def test_main_write_does_not_clobber_external_edit_during_rollback(
         *,
         nested_key=None,
         expected_current=None,
+        expected_generation=None,
     ) -> bool:
         nonlocal calls
         calls += 1
@@ -955,6 +1003,7 @@ def test_main_write_does_not_clobber_external_edit_during_rollback(
             version,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
 
     monkeypatch.setattr(sync_plugin_version, "update_json", fail_after_external_edit)
@@ -1000,6 +1049,7 @@ def test_main_write_does_not_roll_back_same_bytes_new_inode_aba(
         *,
         nested_key=None,
         expected_current=None,
+        expected_generation=None,
     ):
         nonlocal calls
         calls += 1
@@ -1008,6 +1058,7 @@ def test_main_write_does_not_roll_back_same_bytes_new_inode_aba(
             version,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
         if calls == 1:
             same_bytes = plugin_json.read_bytes()
@@ -1195,6 +1246,7 @@ def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkey
         *,
         nested_key=None,
         expected_current=None,
+        expected_generation=None,
     ) -> bool:
         nonlocal edited
         if not edited:
@@ -1205,6 +1257,7 @@ def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkey
             version,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
 
     monkeypatch.setattr(sync_plugin_version, "update_json", edit_after_preflight)
@@ -1251,12 +1304,14 @@ def test_main_write_revalidates_targets_that_were_already_current(
         *,
         nested_key=None,
         expected_current=None,
+        expected_generation=None,
     ) -> bool:
         updated = original_update_json(
             path,
             version,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
         plugin_json.write_bytes(external_plugin)
         return updated
@@ -1451,7 +1506,14 @@ module.SETUP_SKILL_MD = root / "skills/setup/SKILL.md"
 module.BUNDLED_SETUP_SKILL_MD = root / ".claude-plugin/skills/setup/SKILL.md"
 if mode == "hold":
     original = module.update_json
-    def hold_first_write(path, value, *, nested_key=None, expected_current=None):
+    def hold_first_write(
+        path,
+        value,
+        *,
+        nested_key=None,
+        expected_current=None,
+        expected_generation=None,
+    ):
         if not (root / "ready").exists():
             (root / "ready").touch()
             while not (root / "release").exists():
@@ -1461,6 +1523,7 @@ if mode == "hold":
             value,
             nested_key=nested_key,
             expected_current=expected_current,
+            expected_generation=expected_generation,
         )
     module.update_json = hold_first_write
 module.sys.argv = ["sync-plugin-version.py", "--write", "--version", version]

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -989,6 +989,67 @@ def test_main_write_does_not_roll_back_same_bytes_new_inode_aba(
     assert any("file generation changed" in str(exc) for exc in raised.value.exceptions)
 
 
+def test_main_write_rolls_back_owned_exchange_when_parent_dir_open_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    originals = {
+        path: path.read_bytes()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    real_open = sync_plugin_version.os.open
+    directory_opens = 0
+    failure_injected = False
+    foreign_generation = None
+
+    def fail_second_plugin_metadata_directory_open(path, flags, *args, **kwargs):
+        nonlocal directory_opens, failure_injected, foreign_generation
+        if Path(path) == plugin_json.parent:
+            directory_opens += 1
+            if directory_opens == 2:
+                replacement = tmp_path / "source-skill-same-bytes-foreign-generation"
+                replacement.write_bytes(originals[source_skill])
+                os.replace(replacement, source_skill)
+                foreign_generation = sync_plugin_version._path_generation(source_skill)
+                failure_injected = True
+                raise OSError("injected parent directory open failure")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(sync_plugin_version.os, "open", fail_second_plugin_metadata_directory_open)
+
+    with pytest.raises(sync_plugin_version._OwnedWriteError, match="parent directory open failure"):
+        sync_plugin_version.main()
+
+    assert failure_injected
+    assert foreign_generation is not None
+    assert source_skill.read_bytes() == originals[source_skill]
+    assert sync_plugin_version._path_generation(source_skill) == foreign_generation
+    assert bundled_skill.read_bytes() == originals[bundled_skill]
+    assert plugin_json.read_bytes() == originals[plugin_json]
+    assert marketplace_json.read_bytes() == originals[marketplace_json]
+
+
 def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkeypatch) -> None:
     source_skill = tmp_path / "skills/setup/SKILL.md"
     bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -1332,14 +1332,17 @@ def test_release_workflow_checks_tag_metadata_before_build() -> None:
 
     validation = workflow.index("python scripts/sync-plugin-version.py")
     build = workflow.index("uv build")
+    package_identity = workflow.index("PACKAGE_VERSION=", build)
     tui_job = workflow[workflow.index("  build-tui:") : workflow.index("  attach-tui-binaries:")]
 
     assert "${REF_NAME#v}" in workflow
     assert '[[ "$VERSION" == *.dev* ]]' in workflow
     assert "--require-canonical" in workflow
-    assert 'PACKAGE_VERSION="$(uv run hatch version)"' in workflow
+    assert "zipfile.ZipFile" in workflow
     assert '[[ "$PACKAGE_VERSION" != "$VERSION" ]]' in workflow
     assert validation < build
+    assert build < package_identity
+    assert workflow.count("zipfile.ZipFile") == 2
     assert "needs: release" in tui_job
 
 

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -646,6 +646,44 @@ def test_atomic_exchange_preserves_newer_edit_arriving_during_restore(
     assert list(tmp_path.iterdir()) == [target]
 
 
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_exchange_preserves_same_bytes_edit_arriving_during_restore(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    first_external = b'{"version":"1.2.3","note":"first"}\n'
+    target.write_bytes(original)
+    real_exchange = sync_plugin_version._exchange_paths
+    exchange_count = 0
+
+    def inject_edits(source: Path, destination: Path) -> bool:
+        nonlocal exchange_count
+        exchange_count += 1
+        if exchange_count == 1:
+            destination.write_bytes(first_external)
+        elif exchange_count == 2:
+            destination.write_bytes(content)
+        return real_exchange(source, destination)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_edits)
+
+    with pytest.raises(RuntimeError, match="write conflict"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == content
+    assert list(tmp_path.iterdir()) == [target]
+
+
 def test_atomic_write_fails_closed_when_exchange_is_unavailable(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -34,6 +34,9 @@ def test_git_describe_fallback_preserves_exact_tag_version() -> None:
         ("1.2.3b4", "1.2.3b4"),
         ("1.2.3rc2", "1.2.3rc2"),
         ("1.2.3b4.dev1", "1.2.3b4"),
+        ("1.2.3alpha1", "1.2.3a1"),
+        ("1.2.3beta02", "1.2.3b2"),
+        ("01.02.003", "1.2.3"),
     ],
 )
 def test_plugin_metadata_version_normalizes_supported_versions(
@@ -223,6 +226,15 @@ def test_update_json_rejects_duplicate_object_keys(tmp_path: Path) -> None:
         sync_plugin_version.update_json(target, "1.2.4")
 
     assert target.read_bytes() == original
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_load_json_rejects_non_rfc_constants(tmp_path: Path, constant: str) -> None:
+    path = tmp_path / "plugin.json"
+    path.write_text(f'{{"version":"1.2.3","invalid":{constant}}}\n')
+
+    with pytest.raises(ValueError, match="non-RFC JSON constant"):
+        sync_plugin_version._load_json(path)
 
 
 def test_main_write_preflight_rejects_duplicate_json_keys_before_mutation(

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -639,6 +640,52 @@ def test_atomic_exchange_preserves_newer_edit_arriving_during_restore(
         sync_plugin_version._atomic_write_bytes(
             target,
             b'{"version":"1.2.4"}\n',
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == newer_external
+    assert list(tmp_path.iterdir()) == [target]
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_exchange_preserves_timestamp_restored_same_size_edit_during_restore(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    first_external = b'{"version":"1.2.5"}\n'
+    newer_external = b'{"version":"9.9.9"}\n'
+    assert len(content) == len(newer_external)
+    target.write_bytes(original)
+    real_exchange = sync_plugin_version._exchange_paths
+    exchange_count = 0
+
+    def inject_edits(source: Path, destination: Path) -> bool:
+        nonlocal exchange_count
+        exchange_count += 1
+        if exchange_count == 1:
+            destination.write_bytes(first_external)
+        elif exchange_count == 2:
+            before = destination.stat()
+            destination.write_bytes(newer_external)
+            os.utime(
+                destination,
+                ns=(before.st_atime_ns, before.st_mtime_ns),
+                follow_symlinks=False,
+            )
+        return real_exchange(source, destination)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_edits)
+
+    with pytest.raises(RuntimeError, match="write conflict"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
             expected_current=original,
         )
 

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -55,6 +55,17 @@ def test_plugin_metadata_version_rejects_unsupported_versions(version: str) -> N
         sync_plugin_version.normalize_version(version)
 
 
+@pytest.mark.parametrize("version", ["01.2.3", "1.2.3alpha1", "1.2.3b01", "1.2.3.dev1"])
+def test_release_version_rejects_noncanonical_aliases(version: str) -> None:
+    with pytest.raises(ValueError, match="release version must be canonical"):
+        sync_plugin_version.require_canonical_version(version)
+
+
+@pytest.mark.parametrize("version", ["1.2.3", "1.2.3a1", "1.2.3b2", "1.2.3rc3"])
+def test_release_version_accepts_canonical_versions(version: str) -> None:
+    assert sync_plugin_version.require_canonical_version(version) == version
+
+
 def test_main_write_updates_both_setup_skill_markers(
     tmp_path: Path,
     monkeypatch,
@@ -563,6 +574,37 @@ def test_atomic_write_rejects_target_changed_since_preflight(tmp_path: Path) -> 
     assert target.read_bytes() == external
 
 
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="rename exchange is Linux-only")
+def test_atomic_exchange_restores_edit_arriving_at_commit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    external = b'{"version":"1.2.3","note":"external"}\n'
+    target.write_bytes(original)
+    real_exchange = sync_plugin_version._exchange_paths
+    injected = False
+
+    def inject_before_exchange(source: Path, destination: Path) -> bool:
+        nonlocal injected
+        if not injected:
+            injected = True
+            destination.write_bytes(external)
+        return real_exchange(source, destination)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_before_exchange)
+
+    with pytest.raises(RuntimeError, match="write conflict"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            b'{"version":"1.2.4"}\n',
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == external
+
+
 def test_main_write_rolls_back_when_later_write_fails(
     tmp_path: Path,
     monkeypatch,
@@ -924,6 +966,7 @@ def test_release_workflow_checks_tag_metadata_before_build() -> None:
 
     assert "${REF_NAME#v}" in workflow
     assert '[[ "$VERSION" == *.dev* ]]' in workflow
+    assert "--require-canonical" in workflow
     assert validation < build
     assert "needs: release" in tui_job
 

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -608,6 +608,44 @@ def test_atomic_exchange_restores_edit_arriving_at_commit(
     assert target.read_bytes() == external
 
 
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_exchange_preserves_newer_edit_arriving_during_restore(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    first_external = b'{"version":"1.2.3","note":"first"}\n'
+    newer_external = b'{"version":"1.2.3","note":"newer"}\n'
+    target.write_bytes(original)
+    real_exchange = sync_plugin_version._exchange_paths
+    exchange_count = 0
+
+    def inject_edits(source: Path, destination: Path) -> bool:
+        nonlocal exchange_count
+        exchange_count += 1
+        if exchange_count == 1:
+            destination.write_bytes(first_external)
+        elif exchange_count == 2:
+            destination.write_bytes(newer_external)
+        return real_exchange(source, destination)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_edits)
+
+    with pytest.raises(RuntimeError, match="write conflict"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            b'{"version":"1.2.4"}\n',
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == newer_external
+    assert list(tmp_path.iterdir()) == [target]
+
+
 def test_atomic_write_fails_closed_when_exchange_is_unavailable(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -805,6 +805,48 @@ def test_atomic_write_fails_closed_when_exchange_is_unavailable(
     assert list(tmp_path.iterdir()) == [target]
 
 
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_write_cleanup_failure_does_not_mask_active_owned_write_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    target.write_bytes(original)
+    real_open = sync_plugin_version.os.open
+    real_unlink = Path.unlink
+
+    def fail_directory_open(path, flags, *args, **kwargs):
+        if Path(path) == tmp_path:
+            raise OSError("injected directory open failure")
+        return real_open(path, flags, *args, **kwargs)
+
+    def fail_displaced_temp_unlink(path: Path, *, missing_ok: bool = False) -> None:
+        if path != target and path.parent == tmp_path and path.read_bytes() == original:
+            raise OSError("injected displaced temp unlink failure")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(sync_plugin_version.os, "open", fail_directory_open)
+    monkeypatch.setattr(Path, "unlink", fail_displaced_temp_unlink)
+
+    with pytest.raises(sync_plugin_version._OwnedWriteError) as raised:
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
+            expected_current=original,
+        )
+
+    assert "directory open failure" in str(raised.value)
+    assert isinstance(raised.value.__cause__, OSError)
+    assert "directory open failure" in str(raised.value.__cause__)
+    assert any("displaced temp unlink failure" in note for note in raised.value.__notes__)
+    assert target.read_bytes() == content
+
+
 def test_main_write_rolls_back_when_later_write_fails(
     tmp_path: Path,
     monkeypatch,
@@ -1042,6 +1084,77 @@ def test_main_write_rolls_back_owned_exchange_when_parent_dir_open_fails(
         sync_plugin_version.main()
 
     assert failure_injected
+    assert foreign_generation is not None
+    assert source_skill.read_bytes() == originals[source_skill]
+    assert sync_plugin_version._path_generation(source_skill) == foreign_generation
+    assert bundled_skill.read_bytes() == originals[bundled_skill]
+    assert plugin_json.read_bytes() == originals[plugin_json]
+    assert marketplace_json.read_bytes() == originals[marketplace_json]
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_main_write_rolls_back_owned_exchange_when_displaced_temp_unlink_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    originals = {
+        path: path.read_bytes()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    real_unlink = Path.unlink
+    cleanup_failure_injected = False
+    foreign_generation = None
+
+    def fail_marketplace_displaced_temp_unlink(
+        path: Path,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        nonlocal cleanup_failure_injected, foreign_generation
+        if (
+            not cleanup_failure_injected
+            and path.parent == marketplace_json.parent
+            and path.name.startswith(f".{marketplace_json.name}.")
+            and path.read_bytes() == originals[marketplace_json]
+        ):
+            replacement = tmp_path / "source-skill-same-bytes-foreign-generation"
+            replacement.write_bytes(originals[source_skill])
+            os.replace(replacement, source_skill)
+            foreign_generation = sync_plugin_version._path_generation(source_skill)
+            cleanup_failure_injected = True
+            raise OSError("injected displaced temp unlink failure")
+        real_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_marketplace_displaced_temp_unlink)
+
+    with pytest.raises(sync_plugin_version._OwnedWriteError, match="displaced temp unlink failure"):
+        sync_plugin_version.main()
+
+    assert cleanup_failure_injected
     assert foreign_generation is not None
     assert source_skill.read_bytes() == originals[source_skill]
     assert sync_plugin_version._path_generation(source_skill) == foreign_generation

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -112,7 +112,7 @@ def test_update_version_marker_preserves_unrelated_bytes_with_bom_and_crlf(tmp_p
     original = b"\xef\xbb\xbfheading\r\n" + marker + "\r\nbody café\r\n".encode()
     target.write_bytes(original)
 
-    assert sync_plugin_version.update_version_marker(target, "1.2.4") is True
+    assert sync_plugin_version.update_version_marker(target, "1.2.4") is not None
 
     assert target.read_bytes() == original.replace(marker, b"<!-- ooo:VERSION:1.2.4 -->")
 
@@ -644,7 +644,7 @@ def test_atomic_exchange_preserves_newer_edit_arriving_during_restore(
         )
 
     assert target.read_bytes() == newer_external
-    assert list(tmp_path.iterdir()) == [target]
+    assert [path for path in tmp_path.iterdir() if path != target]
 
 
 @pytest.mark.skipif(
@@ -690,7 +690,7 @@ def test_atomic_exchange_preserves_timestamp_restored_same_size_edit_during_rest
         )
 
     assert target.read_bytes() == newer_external
-    assert list(tmp_path.iterdir()) == [target]
+    assert [path for path in tmp_path.iterdir() if path != target]
 
 
 @pytest.mark.skipif(
@@ -728,7 +728,57 @@ def test_atomic_exchange_preserves_same_bytes_edit_arriving_during_restore(
         )
 
     assert target.read_bytes() == content
-    assert list(tmp_path.iterdir()) == [target]
+    assert [path for path in tmp_path.iterdir() if path != target]
+
+
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
+def test_atomic_exchange_preserves_open_descriptor_write_displaced_to_temp(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    content = b'{"version":"1.2.4"}\n'
+    first_external = b'{"version":"1.2.3","note":"first"}\n'
+    late_external = b'{"version":"1.2.4","note":"late fd"}\n'
+    target.write_bytes(original)
+    real_exchange = sync_plugin_version._exchange_paths
+    exchange_count = 0
+    displaced_fd: int | None = None
+
+    def inject_open_descriptor_writer(source: Path, destination: Path) -> bool:
+        nonlocal exchange_count, displaced_fd
+        exchange_count += 1
+        if exchange_count == 1:
+            destination.write_bytes(first_external)
+        result = real_exchange(source, destination)
+        if exchange_count == 1:
+            displaced_fd = os.open(destination, os.O_WRONLY)
+        elif exchange_count == 2:
+            assert displaced_fd is not None
+            os.write(displaced_fd, late_external)
+            os.ftruncate(displaced_fd, len(late_external))
+            os.fsync(displaced_fd)
+            os.close(displaced_fd)
+            displaced_fd = None
+        return result
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_open_descriptor_writer)
+
+    with pytest.raises(RuntimeError, match="preserved displaced content"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            content,
+            expected_current=original,
+        )
+
+    preserved = [path for path in tmp_path.iterdir() if path != target]
+    reachable_bytes = [target.read_bytes(), *(path.read_bytes() for path in preserved)]
+    assert preserved
+    assert late_external in reachable_bytes
 
 
 def test_atomic_write_fails_closed_when_exchange_is_unavailable(
@@ -869,6 +919,71 @@ def test_main_write_does_not_clobber_external_edit_during_rollback(
 
     assert plugin_json.read_bytes() == external
     assert any("rollback conflict" in str(exc) for exc in raised.value.exceptions)
+
+
+def test_main_write_does_not_roll_back_same_bytes_new_inode_aba(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    original_update_json = sync_plugin_version.update_json
+    calls = 0
+
+    def replace_first_write_with_same_bytes_new_inode_before_bookkeeping_then_fail(
+        path: Path,
+        version: str,
+        *,
+        nested_key=None,
+        expected_current=None,
+    ):
+        nonlocal calls
+        calls += 1
+        result = original_update_json(
+            path,
+            version,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+        if calls == 1:
+            same_bytes = plugin_json.read_bytes()
+            replacement = tmp_path / "same-bytes-replacement"
+            replacement.write_bytes(same_bytes)
+            os.replace(replacement, plugin_json)
+        if calls == 2:
+            raise OSError("injected later write failure")
+        return result
+
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "update_json",
+        replace_first_write_with_same_bytes_new_inode_before_bookkeeping_then_fail,
+    )
+
+    with pytest.raises(BaseExceptionGroup, match="rollback was incomplete") as raised:
+        sync_plugin_version.main()
+
+    assert __import__("json").loads(plugin_json.read_text())["version"] == "1.2.4"
+    assert any("file generation changed" in str(exc) for exc in raised.value.exceptions)
 
 
 def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkeypatch) -> None:
@@ -1018,7 +1133,8 @@ def test_main_write_rolls_back_only_successfully_replaced_targets(
         content: bytes,
         *,
         expected_current: bytes | None = None,
-    ) -> None:
+        expected_generation=None,
+    ):
         if b"1.2.4" in content and path == marketplace_json:
             raise OSError("primary marketplace failure")
         if b"1.2.3" in content:
@@ -1027,7 +1143,12 @@ def test_main_write_rolls_back_only_successfully_replaced_targets(
                 raise OSError("plugin rollback failure")
             if path == source_skill:
                 raise OSError("source rollback failure")
-        original_atomic_write(path, content, expected_current=expected_current)
+        return original_atomic_write(
+            path,
+            content,
+            expected_current=expected_current,
+            expected_generation=expected_generation,
+        )
 
     monkeypatch.setattr(
         sync_plugin_version,
@@ -1210,7 +1331,7 @@ def test_main_write_rolls_back_when_marker_update_reports_no_change(
     monkeypatch.setattr(
         sync_plugin_version,
         "update_version_marker",
-        lambda *_args, **_kwargs: False,
+        lambda *_args, **_kwargs: None,
     )
 
     with pytest.raises(SystemExit, match="failed to update"):

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -923,6 +923,7 @@ def test_release_workflow_checks_tag_metadata_before_build() -> None:
     tui_job = workflow[workflow.index("  build-tui:") : workflow.index("  attach-tui-binaries:")]
 
     assert "${REF_NAME#v}" in workflow
+    assert '[[ "$VERSION" == *.dev* ]]' in workflow
     assert validation < build
     assert "needs: release" in tui_job
 

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -644,14 +644,16 @@ def test_atomic_exchange_preserves_newer_edit_arriving_during_restore(
         )
 
     assert target.read_bytes() == newer_external
-    assert list(tmp_path.iterdir()) == [target]
+    preserved = [path.read_bytes() for path in tmp_path.iterdir()]
+    assert first_external in preserved
+    assert newer_external in preserved
 
 
 @pytest.mark.skipif(
     not (sys.platform.startswith("linux") or sys.platform == "darwin"),
     reason="atomic pathname exchange is unavailable on this platform",
 )
-def test_atomic_exchange_preserves_timestamp_restored_same_size_edit_during_restore(
+def test_atomic_exchange_preserves_timestamp_restored_same_bytes_edit_during_restore(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -659,8 +661,7 @@ def test_atomic_exchange_preserves_timestamp_restored_same_size_edit_during_rest
     original = b'{"version":"1.2.3"}\n'
     content = b'{"version":"1.2.4"}\n'
     first_external = b'{"version":"1.2.5"}\n'
-    newer_external = b'{"version":"9.9.9"}\n'
-    assert len(content) == len(newer_external)
+    newer_external = content
     target.write_bytes(original)
     real_exchange = sync_plugin_version._exchange_paths
     exchange_count = 0
@@ -682,15 +683,17 @@ def test_atomic_exchange_preserves_timestamp_restored_same_size_edit_during_rest
 
     monkeypatch.setattr(sync_plugin_version, "_exchange_paths", inject_edits)
 
-    with pytest.raises(RuntimeError, match="write conflict"):
+    with pytest.raises(RuntimeError, match="write conflict") as raised:
         sync_plugin_version._atomic_write_bytes(
             target,
             content,
             expected_current=original,
         )
 
-    assert target.read_bytes() == newer_external
-    assert list(tmp_path.iterdir()) == [target]
+    assert "preserved exchanged content at" in str(raised.value)
+    preserved = [path.read_bytes() for path in tmp_path.iterdir()]
+    assert first_external in preserved
+    assert newer_external in preserved
 
 
 @pytest.mark.skipif(
@@ -728,7 +731,9 @@ def test_atomic_exchange_preserves_same_bytes_edit_arriving_during_restore(
         )
 
     assert target.read_bytes() == content
-    assert list(tmp_path.iterdir()) == [target]
+    preserved = [path.read_bytes() for path in tmp_path.iterdir()]
+    assert first_external in preserved
+    assert content in preserved
 
 
 def test_atomic_write_fails_closed_when_exchange_is_unavailable(
@@ -982,6 +987,47 @@ def test_main_write_revalidates_targets_that_were_already_current(
     assert marketplace_json.read_bytes() == original_marketplace
 
 
+def test_main_read_only_revalidates_targets_after_preflight(tmp_path: Path, monkeypatch) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.4 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.4 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.4"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.4"}]}\n')
+    external_plugin = b'{"version":"external"}\n'
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--require-canonical", "--version", "1.2.4"],
+    )
+    original_print = print
+    mutated = False
+
+    def mutate_after_preflight(*args, **kwargs) -> None:
+        nonlocal mutated
+        original_print(*args, **kwargs)
+        if not mutated and args and str(args[0]).startswith("  OK"):
+            mutated = True
+            plugin_json.write_bytes(external_plugin)
+
+    monkeypatch.setattr(sync_plugin_version, "print", mutate_after_preflight, raising=False)
+
+    with pytest.raises(RuntimeError, match="validation conflict"):
+        sync_plugin_version.main()
+
+    assert plugin_json.read_bytes() == external_plugin
+
+
 def test_main_write_rolls_back_only_successfully_replaced_targets(
     tmp_path: Path,
     monkeypatch,
@@ -1172,6 +1218,8 @@ def test_release_workflow_checks_tag_metadata_before_build() -> None:
     assert "${REF_NAME#v}" in workflow
     assert '[[ "$VERSION" == *.dev* ]]' in workflow
     assert "--require-canonical" in workflow
+    assert 'PACKAGE_VERSION="$(uv run hatch version)"' in workflow
+    assert '[[ "$PACKAGE_VERSION" != "$VERSION" ]]' in workflow
     assert validation < build
     assert "needs: release" in tui_job
 

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
+import sys
+import time
 
 import pytest
 
@@ -40,7 +43,10 @@ def test_plugin_metadata_version_normalizes_supported_versions(
     assert sync_plugin_version.normalize_version(version) == expected
 
 
-@pytest.mark.parametrize("version", ["not-a-version", "1.2", "1.2.3garbage"])
+@pytest.mark.parametrize(
+    "version",
+    ["not-a-version", "1.2", "1.2.3garbage", "١.٢.٣", "1.2.3\n"],
+)
 def test_plugin_metadata_version_rejects_unsupported_versions(version: str) -> None:
     with pytest.raises(ValueError, match="unsupported version"):
         sync_plugin_version.normalize_version(version)
@@ -83,6 +89,17 @@ def test_main_write_updates_both_setup_skill_markers(
     assert "WRITE .claude-plugin/skills/setup/SKILL.md (0.39.1 -> 1.2.4)" in captured.out
     assert source_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nsource\n"
     assert bundled_skill.read_text() == "<!-- ooo:VERSION:1.2.4 -->\nbundled\n"
+
+
+def test_update_version_marker_preserves_unrelated_bytes_with_bom_and_crlf(tmp_path: Path) -> None:
+    marker = b"<!-- ooo:VERSION:1.2.3 -->"
+    target = tmp_path / "SKILL.md"
+    original = b"\xef\xbb\xbfheading\r\n" + marker + "\r\nbody café\r\n".encode()
+    target.write_bytes(original)
+
+    assert sync_plugin_version.update_version_marker(target, "1.2.4") is True
+
+    assert target.read_bytes() == original.replace(marker, b"<!-- ooo:VERSION:1.2.4 -->")
 
 
 def test_main_write_fails_when_required_setup_skill_is_missing(
@@ -195,6 +212,50 @@ def test_main_write_preflights_json_targets_before_mutation(
         assert plugin_json.read_text() == original_plugin_json
     else:
         raise AssertionError("invalid marketplace JSON must fail before mutation")
+
+
+def test_update_json_rejects_duplicate_object_keys(tmp_path: Path) -> None:
+    target = tmp_path / "plugin.json"
+    original = b'{"version": "1.2.3", "version": "9.9.9"}\n'
+    target.write_bytes(original)
+
+    with pytest.raises(ValueError, match="duplicate JSON object key: version"):
+        sync_plugin_version.update_json(target, "1.2.4")
+
+    assert target.read_bytes() == original
+
+
+def test_main_write_preflight_rejects_duplicate_json_keys_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_bytes(b"<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_bytes(b"<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_bytes(b'{"version":"1.2.3"}\n')
+    marketplace_json.write_bytes(b'{"plugins":[{"version":"1.2.3","version":"9.9.9"}]}\n')
+    originals = {path: path.read_bytes() for path in (source_skill, bundled_skill, plugin_json)}
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    with pytest.raises(SystemExit, match="duplicate JSON object key: version"):
+        sync_plugin_version.main()
+
+    assert {path: path.read_bytes() for path in originals} == originals
 
 
 @pytest.mark.parametrize("missing_target", ["plugin", "marketplace"])
@@ -334,3 +395,565 @@ def test_main_write_rejects_unsupported_source_version_before_mutation(
 
     for path, original in originals.items():
         assert path.read_text() == original
+
+
+@pytest.mark.parametrize("marker_version", ["stale.version", "abc", "1..2", "1.2.3.4"])
+def test_main_write_rejects_malformed_single_marker_value_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+    marker_version: str,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text(f"<!-- ooo:VERSION:{marker_version} -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+    originals = {
+        path: path.read_bytes()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    with pytest.raises(SystemExit, match="expected exactly one version marker"):
+        sync_plugin_version.main()
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "source_text",
+    [
+        "<!-- ooo:VERSION:stale-version -->\n<!-- ooo:VERSION:1.2.3 -->\nsource\n",
+        "<!-- ooo:VERSION:stale\nversion -->\n<!-- ooo:VERSION:1.2.3 -->\nsource\n",
+        "<!-- ooo:VERSION:1.2.3 -->\n<!-- ooo:VERSION:stale\nversion-->\nsource\n",
+        "<!-- ooo:VERSION:1.2.3 -->\n<!-- ooo:VERSION:stale\nversion\nsource\n",
+    ],
+)
+def test_main_write_rejects_malformed_duplicate_marker_before_mutation(
+    tmp_path: Path,
+    monkeypatch,
+    source_text: str,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text(source_text)
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+    originals = {
+        path: path.read_text()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    with pytest.raises(SystemExit, match="expected exactly one version marker"):
+        sync_plugin_version.main()
+
+    for path, original in originals.items():
+        assert path.read_text() == original
+
+
+def test_atomic_write_keeps_target_intact_when_temp_fsync_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version": "1.2.3"}\n'
+    target.write_bytes(original)
+
+    def fail_fsync(_fd: int) -> None:
+        raise OSError("injected fsync failure")
+
+    monkeypatch.setattr(sync_plugin_version.os, "fsync", fail_fsync)
+
+    with pytest.raises(OSError, match="injected fsync failure"):
+        sync_plugin_version._atomic_write_bytes(target, b'{"version": "1.2.4"}\n')
+
+    assert target.read_bytes() == original
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_atomic_write_applies_mode_to_open_temp_before_file_fsync(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    target.write_bytes(b"old")
+    target.chmod(0o640)
+    calls: list[tuple[str, int]] = []
+    real_fchmod = sync_plugin_version.os.fchmod
+    real_fsync = sync_plugin_version.os.fsync
+
+    def record_fchmod(fd: int, mode: int) -> None:
+        calls.append(("fchmod", mode))
+        real_fchmod(fd, mode)
+
+    def record_fsync(fd: int) -> None:
+        calls.append(("fsync", fd))
+        real_fsync(fd)
+
+    monkeypatch.setattr(sync_plugin_version.os, "fchmod", record_fchmod)
+    monkeypatch.setattr(sync_plugin_version.os, "fsync", record_fsync)
+
+    sync_plugin_version._atomic_write_bytes(target, b"new")
+
+    assert calls[0] == ("fchmod", 0o640)
+    assert calls[1][0] == "fsync"
+
+
+def test_atomic_write_rejects_target_changed_since_preflight(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    external = b'{"version":"1.2.3","note":"external"}\n'
+    target.write_bytes(external)
+
+    with pytest.raises(RuntimeError, match="write conflict"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            b'{"version":"1.2.4"}\n',
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == external
+
+
+def test_main_write_rolls_back_when_later_write_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+    originals = {
+        path: path.read_bytes()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    original_update_json = sync_plugin_version.update_json
+    calls = 0
+
+    def fail_second_json_write(
+        path: Path,
+        version: str,
+        *,
+        nested_key=None,
+        expected_current=None,
+    ) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected later write failure")
+        return original_update_json(
+            path,
+            version,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+
+    monkeypatch.setattr(sync_plugin_version, "update_json", fail_second_json_write)
+
+    with pytest.raises(OSError, match="injected later write failure"):
+        sync_plugin_version.main()
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original
+
+
+def test_main_write_does_not_clobber_external_edit_during_rollback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    original_update_json = sync_plugin_version.update_json
+    calls = 0
+    external = b'{"version":"external"}\n'
+
+    def fail_after_external_edit(
+        path: Path,
+        version: str,
+        *,
+        nested_key=None,
+        expected_current=None,
+    ) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            plugin_json.write_bytes(external)
+            raise OSError("injected later write failure")
+        return original_update_json(
+            path,
+            version,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+
+    monkeypatch.setattr(sync_plugin_version, "update_json", fail_after_external_edit)
+
+    with pytest.raises(BaseExceptionGroup, match="rollback was incomplete") as raised:
+        sync_plugin_version.main()
+
+    assert plugin_json.read_bytes() == external
+    assert any("rollback conflict" in str(exc) for exc in raised.value.exceptions)
+
+
+def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkeypatch) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    original_update_json = sync_plugin_version.update_json
+    external = b'{"version":{"external":"must-survive"}}\n'
+    edited = False
+
+    def edit_after_preflight(
+        path: Path,
+        version: str,
+        *,
+        nested_key=None,
+        expected_current=None,
+    ) -> bool:
+        nonlocal edited
+        if not edited:
+            edited = True
+            plugin_json.write_bytes(external)
+        return original_update_json(
+            path,
+            version,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+
+    monkeypatch.setattr(sync_plugin_version, "update_json", edit_after_preflight)
+
+    with pytest.raises(BaseExceptionGroup, match="rollback was incomplete") as raised:
+        sync_plugin_version.main()
+
+    assert plugin_json.read_bytes() == external
+    assert any("write conflict" in str(exc) for exc in raised.value.exceptions)
+
+
+def test_main_write_rolls_back_only_successfully_replaced_targets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    original_atomic_write = sync_plugin_version._atomic_write_bytes
+    rollback_attempts: list[Path] = []
+
+    def fail_primary_and_two_rollbacks(
+        path: Path,
+        content: bytes,
+        *,
+        expected_current: bytes | None = None,
+    ) -> None:
+        if b"1.2.4" in content and path == marketplace_json:
+            raise OSError("primary marketplace failure")
+        if b"1.2.3" in content:
+            rollback_attempts.append(path)
+            if path == plugin_json:
+                raise OSError("plugin rollback failure")
+            if path == source_skill:
+                raise OSError("source rollback failure")
+        original_atomic_write(path, content, expected_current=expected_current)
+
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "_atomic_write_bytes",
+        fail_primary_and_two_rollbacks,
+    )
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        sync_plugin_version.main()
+
+    assert [str(exc) for exc in raised.value.exceptions] == [
+        "primary marketplace failure",
+        f"failed to roll back {plugin_json}: plugin rollback failure",
+    ]
+    assert rollback_attempts == [plugin_json]
+
+
+def test_main_write_ignores_untrusted_legacy_transaction_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    forged = tmp_path / ".sync-plugin-version.transaction.json"
+    forged.write_text('{"originals":{".claude-plugin/plugin.json":"Zm9yZ2Vk"}}\n')
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+
+    sync_plugin_version.main()
+
+    assert forged.read_text() == '{"originals":{".claude-plugin/plugin.json":"Zm9yZ2Vk"}}\n'
+    assert __import__("json").loads(plugin_json.read_text())["version"] == "1.2.4"
+    assert __import__("json").loads(marketplace_json.read_text())["plugins"][0]["version"] == (
+        "1.2.4"
+    )
+
+
+def test_concurrent_invocations_are_serialized_by_os_lock(tmp_path: Path) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.3"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    ready = tmp_path / "ready"
+    release = tmp_path / "release"
+    runner = """
+import importlib.util
+from pathlib import Path
+import sys
+import time
+script, root, version, mode = Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3], sys.argv[4]
+spec = importlib.util.spec_from_file_location("sync_plugin_version_process", script)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.ROOT = root
+module.PLUGIN_JSON = root / ".claude-plugin/plugin.json"
+module.MARKETPLACE_JSON = root / ".claude-plugin/marketplace.json"
+module.SETUP_SKILL_MD = root / "skills/setup/SKILL.md"
+module.BUNDLED_SETUP_SKILL_MD = root / ".claude-plugin/skills/setup/SKILL.md"
+if mode == "hold":
+    original = module.update_json
+    def hold_first_write(path, value, *, nested_key=None, expected_current=None):
+        if not (root / "ready").exists():
+            (root / "ready").touch()
+            while not (root / "release").exists():
+                time.sleep(0.01)
+        return original(
+            path,
+            value,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+    module.update_json = hold_first_write
+module.sys.argv = ["sync-plugin-version.py", "--write", "--version", version]
+module.main()
+"""
+    first = subprocess.Popen(
+        [sys.executable, "-c", runner, str(_SCRIPT_PATH), str(tmp_path), "1.2.4", "hold"]
+    )
+    deadline = time.monotonic() + 5
+    while not ready.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ready.exists()
+    second = subprocess.Popen(
+        [sys.executable, "-c", runner, str(_SCRIPT_PATH), str(tmp_path), "1.2.5", "normal"]
+    )
+    time.sleep(0.25)
+    try:
+        assert second.poll() is None
+    finally:
+        release.touch()
+        first.wait(timeout=5)
+        second.wait(timeout=5)
+
+    assert first.returncode == second.returncode == 0
+    assert __import__("json").loads(plugin_json.read_text())["version"] == "1.2.5"
+    assert __import__("json").loads(marketplace_json.read_text())["plugins"][0]["version"] == (
+        "1.2.5"
+    )
+    assert b"VERSION:1.2.5" in source_skill.read_bytes()
+    assert b"VERSION:1.2.5" in bundled_skill.read_bytes()
+
+
+def test_lock_file_is_outside_checkout(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+
+    lock_path = sync_plugin_version._lock_path()
+
+    assert lock_path.parent != tmp_path
+
+
+def test_release_workflow_checks_tag_metadata_before_build() -> None:
+    workflow = (_SCRIPT_PATH.parents[1] / ".github/workflows/release.yml").read_text()
+
+    validation = workflow.index("python scripts/sync-plugin-version.py")
+    build = workflow.index("uv build")
+    tui_job = workflow[workflow.index("  build-tui:") : workflow.index("  attach-tui-binaries:")]
+
+    assert "${REF_NAME#v}" in workflow
+    assert validation < build
+    assert "needs: release" in tui_job
+
+
+def test_main_write_rolls_back_when_marker_update_reports_no_change(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills" / "setup" / "SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin" / "skills" / "setup" / "SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin" / "plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin" / "marketplace.json"
+
+    source_skill.parent.mkdir(parents=True, exist_ok=True)
+    bundled_skill.parent.mkdir(parents=True, exist_ok=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.3 -->\nbundled\n")
+    plugin_json.write_text('{"version": "1.2.3"}\n')
+    marketplace_json.write_text('{"plugins": [{"version": "1.2.3"}]}\n')
+    originals = {
+        path: path.read_bytes()
+        for path in (source_skill, bundled_skill, plugin_json, marketplace_json)
+    }
+
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "update_version_marker",
+        lambda *_args, **_kwargs: False,
+    )
+
+    with pytest.raises(SystemExit, match="failed to update"):
+        sync_plugin_version.main()
+
+    for path, original in originals.items():
+        assert path.read_bytes() == original

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -574,7 +574,10 @@ def test_atomic_write_rejects_target_changed_since_preflight(tmp_path: Path) -> 
     assert target.read_bytes() == external
 
 
-@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="rename exchange is Linux-only")
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") or sys.platform == "darwin"),
+    reason="atomic pathname exchange is unavailable on this platform",
+)
 def test_atomic_exchange_restores_edit_arriving_at_commit(
     tmp_path: Path,
     monkeypatch,
@@ -603,6 +606,27 @@ def test_atomic_exchange_restores_edit_arriving_at_commit(
         )
 
     assert target.read_bytes() == external
+
+
+def test_atomic_write_fails_closed_when_exchange_is_unavailable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "target.json"
+    original = b'{"version":"1.2.3"}\n'
+    target.write_bytes(original)
+
+    monkeypatch.setattr(sync_plugin_version, "_exchange_paths", lambda *_args: False)
+
+    with pytest.raises(RuntimeError, match="atomic path exchange is unavailable"):
+        sync_plugin_version._atomic_write_bytes(
+            target,
+            b'{"version":"1.2.4"}\n',
+            expected_current=original,
+        )
+
+    assert target.read_bytes() == original
+    assert list(tmp_path.iterdir()) == [target]
 
 
 def test_main_write_rolls_back_when_later_write_fails(
@@ -775,6 +799,64 @@ def test_main_write_rejects_external_edit_after_preflight(tmp_path: Path, monkey
 
     assert plugin_json.read_bytes() == external
     assert any("write conflict" in str(exc) for exc in raised.value.exceptions)
+
+
+def test_main_write_revalidates_targets_that_were_already_current(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source_skill = tmp_path / "skills/setup/SKILL.md"
+    bundled_skill = tmp_path / ".claude-plugin/skills/setup/SKILL.md"
+    plugin_json = tmp_path / ".claude-plugin/plugin.json"
+    marketplace_json = tmp_path / ".claude-plugin/marketplace.json"
+    source_skill.parent.mkdir(parents=True)
+    bundled_skill.parent.mkdir(parents=True)
+    plugin_json.parent.mkdir(parents=True, exist_ok=True)
+    source_skill.write_text("<!-- ooo:VERSION:1.2.4 -->\nsource\n")
+    bundled_skill.write_text("<!-- ooo:VERSION:1.2.4 -->\nbundled\n")
+    plugin_json.write_text('{"version":"1.2.4"}\n')
+    marketplace_json.write_text('{"plugins":[{"version":"1.2.3"}]}\n')
+    original_marketplace = marketplace_json.read_bytes()
+    external_plugin = b'{"version":"external"}\n'
+    monkeypatch.setattr(sync_plugin_version, "ROOT", tmp_path)
+    monkeypatch.setattr(sync_plugin_version, "PLUGIN_JSON", plugin_json)
+    monkeypatch.setattr(sync_plugin_version, "MARKETPLACE_JSON", marketplace_json)
+    monkeypatch.setattr(sync_plugin_version, "SETUP_SKILL_MD", source_skill)
+    monkeypatch.setattr(sync_plugin_version, "BUNDLED_SETUP_SKILL_MD", bundled_skill)
+    monkeypatch.setattr(
+        sync_plugin_version.sys,
+        "argv",
+        ["sync-plugin-version.py", "--write", "--version", "1.2.4"],
+    )
+    original_update_json = sync_plugin_version.update_json
+
+    def mutate_current_target_after_write(
+        path: Path,
+        version: str,
+        *,
+        nested_key=None,
+        expected_current=None,
+    ) -> bool:
+        updated = original_update_json(
+            path,
+            version,
+            nested_key=nested_key,
+            expected_current=expected_current,
+        )
+        plugin_json.write_bytes(external_plugin)
+        return updated
+
+    monkeypatch.setattr(
+        sync_plugin_version,
+        "update_json",
+        mutate_current_target_after_write,
+    )
+
+    with pytest.raises(RuntimeError, match="post-write conflict"):
+        sync_plugin_version.main()
+
+    assert plugin_json.read_bytes() == external_plugin
+    assert marketplace_json.read_bytes() == original_marketplace
 
 
 def test_main_write_rolls_back_only_successfully_replaced_targets(


### PR DESCRIPTION
## Summary
- validate all version-bearing release artifacts before mutation
- reject malformed markers, unsupported versions, duplicate JSON keys, and post-preflight conflicts
- use atomic per-file replacement with rollback for recoverable multi-file failures
- fail tag releases closed when metadata does not match the tag version
- document the required pre-tag synchronization procedure

## Verification
- `pytest -q tests/unit/scripts` repeated 3 times: 259 passed each run
- Ruff check and format check repeated 3 times
- mypy repeated 3 times
- `git diff --check` repeated 3 times
- release workflow YAML parsed successfully

Follow-up to #1719.