### PR TITLE
fix(orchestrator): recognize artifact verification evidence

### DIFF
--- a/src/ouroboros/orchestrator/evidence/ac_classification.py
+++ b/src/ouroboros/orchestrator/evidence/ac_classification.py
@@ -100,6 +100,17 @@ _VALIDATION_ONLY_TEST_SIGNAL_RE = re.compile(
     r"test_[\w.-]+\.py|python\s+-m\s+unittest)\b",
     re.IGNORECASE,
 )
+_WORKSPACE_ISOLATION_VALIDATION_RE = re.compile(
+    r"("
+    r"\bno\s+(?:files?|paths?)\s+other\s+than\b"
+    r"|"
+    r"\bonly\s+(?:the\s+)?(?:target|requested|specified)\s+files?\b"
+    r".{0,80}\b(?:changed|created|modified|edited|touched)\b"
+    r"|"
+    r"\bgit\s+status\b.{0,80}\bonly\b"
+    r")",
+    re.IGNORECASE,
+)
 
 
 def _has_mixed_code_and_documentation_work(ac_content: str) -> bool:
@@ -252,6 +263,23 @@ def _is_validation_only_ac(ac_content: str) -> bool:
     )
 
 
+def _is_workspace_isolation_validation_ac(ac_content: str) -> bool:
+    """Return True when an AC only verifies no collateral file changes."""
+    normalized = " ".join(ac_content.split())
+    if not normalized:
+        return False
+    if not _WORKSPACE_ISOLATION_VALIDATION_RE.search(normalized):
+        return False
+    if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
+        return False
+    stripped = _NO_MUTATION_VALIDATION_RE.sub("", normalized)
+    return not (
+        _CODE_MUTATION_ACTION_RE.search(stripped)
+        and _CODE_WORK_SIGNAL_RE.search(stripped)
+        and not re.search(r"\bother\s+than\b|\bonly\b", stripped, re.IGNORECASE)
+    )
+
+
 def _drop_required_evidence_field(schema: EvidenceSchema, field: str) -> EvidenceSchema:
     """Return a schema copy with ``field`` removed from required and rejected_if."""
     required = tuple(name for name in schema.required if name != field)
@@ -296,7 +324,10 @@ def _effective_evidence_schema_for_ac(
     unaffected — those are not gate delegations.
     """
     schema = profile.evidence_schema
-    if _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
+    if _is_workspace_isolation_validation_ac(ac_content):
+        schema = _drop_required_evidence_field(schema, "files_touched")
+        schema = _drop_required_evidence_field(schema, "tests_passed")
+    elif _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
         schema = _drop_required_evidence_field(schema, "files_touched")
     elif _is_documentation_only_ac(ac_content) and "tests_passed" in schema.required:
         schema = _drop_required_evidence_field(schema, "tests_passed")

--- a/src/ouroboros/orchestrator/evidence/claims.py
+++ b/src/ouroboros/orchestrator/evidence/claims.py
@@ -414,10 +414,18 @@ def _bash_command_mutates_file_reference(message: AgentMessage, normalized_refer
     normalized_command = command.strip().lower()
     if not normalized_command:
         return False
-    if not _file_reference_pattern(normalized_reference).search(normalized_command):
+    reference_in_command = _file_reference_pattern(normalized_reference).search(
+        normalized_command
+    ) or re.search(
+        rf"(^|[/\\'\"]){re.escape(normalized_reference)}(?=$|[/\\'\"])",
+        normalized_command,
+    )
+    if not reference_in_command:
         return False
     quoted_reference = rf"['\"]?{re.escape(normalized_reference)}['\"]?"
     if re.search(rf"(^|[\s;&|])(?:\d?>|&>|>>|\d>>)\s*{quoted_reference}", normalized_command):
+        return True
+    if re.search(r"\.(write_text|write_bytes)\s*\(", normalized_command):
         return True
     return bool(
         re.search(

--- a/src/ouroboros/orchestrator/evidence/shell_parsing.py
+++ b/src/ouroboros/orchestrator/evidence/shell_parsing.py
@@ -616,6 +616,28 @@ def _is_pipefail_parts(parts: list[str]) -> bool:
     return parts == ["set", "-o", "pipefail"]
 
 
+def _normalized_python_c_payload_alias(command: str) -> str | None:
+    """Return a stable alias for direct ``python -c`` payload equivalence."""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    parts = _strip_env_prefix(parts)
+    if len(parts) < 3 or not _is_python_executable(parts[0]):
+        return None
+    try:
+        option_index = parts.index("-c")
+    except ValueError:
+        return None
+    if option_index + 1 >= len(parts):
+        return None
+    payload = parts[option_index + 1]
+    normalized_payload = re.sub(r"[;\s]+", " ", payload.lower()).strip()
+    if not normalized_payload:
+        return None
+    return f"python -c {normalized_payload}"
+
+
 def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     """Return normalized command forms that a concise evidence claim may use.
 
@@ -634,10 +656,12 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
             aliases.append(candidate)
 
     append_alias(_normalized_shell_words_text(command))
+    append_alias(_normalized_python_c_payload_alias(command))
     shell_body = _shell_command_body(command)
     normalized_shell_body = _normalized_evidence_text(shell_body) if shell_body else None
     append_alias(normalized_shell_body)
     append_alias(_normalized_shell_words_text(shell_body) if shell_body else None)
+    append_alias(_normalized_python_c_payload_alias(shell_body) if shell_body else None)
     test_invocation = _test_command_invocation(command)
     append_alias(test_invocation)
     # A recorded command may append output plumbing (``... 2>&1 | tail -20``)

--- a/src/ouroboros/orchestrator/evidence/test_detection.py
+++ b/src/ouroboros/orchestrator/evidence/test_detection.py
@@ -160,6 +160,30 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
     return _text_proves_test_execution_success(_runtime_message_test_proof_text(message))
 
 
+def _text_contains_verification_success(text: str) -> bool:
+    """Return True for explicit ad-hoc verification command success output."""
+    normalized = text.lower()
+    if re.search(r"\b(equality|equal|matches|match|verified)\s*[:=]\s*false\b", normalized):
+        return False
+    if re.search(r"\b(no_trailing_newline|no trailing newline)\s*[:=]\s*false\b", normalized):
+        return False
+    return bool(
+        re.search(r"\b(equality|equal|matches|match|verified)\s*[:=]\s*true\b", normalized)
+        or re.search(r"\bverification\s+(passed|succeeded|successful)\b", normalized)
+    )
+
+
+def _looks_like_ad_hoc_verification_command(command: str) -> bool:
+    """Return True for shell commands that perform a self-contained assertion."""
+    normalized = command.lower()
+    if "python" not in normalized or " -c " not in normalized:
+        return False
+    return bool(
+        ("read_bytes" in normalized or "read_text" in normalized)
+        and ("==" in normalized or "assert " in normalized)
+    )
+
+
 def _test_chunk_has_structured_failure(chunk: list[AgentMessage]) -> bool:
     """Return whether a Bash/result chunk carries failure or malformed status.
 
@@ -378,7 +402,13 @@ def _runtime_messages_support_test_claim(
         matching_commands = tuple(
             candidate
             for candidate in candidate_commands
-            if _looks_like_test_command(candidate)
+            if (
+                _looks_like_test_command(candidate)
+                or (
+                    candidate == value.strip()
+                    and _looks_like_ad_hoc_verification_command(candidate)
+                )
+            )
             and _runtime_message_supports_command_claim(candidate, message)
         )
         if not matching_commands:
@@ -398,9 +428,16 @@ def _runtime_messages_support_test_claim(
             )
         ):
             continue
+        chunk_test_proof_text = "\n".join(_runtime_message_test_proof_text(item) for item in chunk)
+        if any(
+            command == value.strip()
+            and _looks_like_ad_hoc_verification_command(command)
+            and _text_contains_verification_success(chunk_test_proof_text)
+            for command in matching_commands
+        ):
+            return True
         if not any(_message_contains_test_success(item) for item in chunk):
             continue
-        chunk_test_proof_text = "\n".join(_runtime_message_test_proof_text(item) for item in chunk)
         if any(
             _test_command_targets_claim(
                 command=command,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1614,6 +1614,155 @@ def test_tests_passed_rejects_collect_only_from_environment_configuration() -> N
     )
 
 
+def test_file_claim_supports_successful_pathlib_write_bytes(tmp_path) -> None:
+    """ZCode Bash evidence can prove a file touched through pathlib write_bytes."""
+    target = tmp_path / "ozo_gui_smoke.txt"
+    target.write_bytes(b"OZO")
+    command = f"python3 -c \"from pathlib import Path; Path('{target}').write_bytes(b'OZO')\""
+    started = AgentMessage(
+        type="tool",
+        content="run byte writer",
+        tool_name="Bash",
+        data={
+            "tool_call_id": "bash_write_1",
+            "tool_input": {"command": command},
+        },
+    )
+    completed = AgentMessage(
+        type="tool_result",
+        content="ok",
+        tool_name="Bash",
+        data={
+            "subtype": "tool_result",
+            "tool_call_id": "bash_write_1",
+            "is_error": False,
+            "output": "ok",
+        },
+    )
+
+    assert _runtime_messages_support_file_claim(
+        "ozo_gui_smoke.txt",
+        (started, completed),
+        task_cwd=str(tmp_path),
+    )
+
+
+def test_tests_passed_accepts_successful_ad_hoc_python_verifier() -> None:
+    """A transcript-backed Python equality verifier can support tests_passed."""
+    command = (
+        'python3 -c "from pathlib import Path; '
+        "expected = b'OZO'; observed = Path('ozo_gui_smoke.txt').read_bytes(); "
+        "print('equality:', observed == expected)\""
+    )
+    started = AgentMessage(
+        type="tool",
+        content="run byte verifier",
+        tool_name="Bash",
+        data={
+            "tool_call_id": "bash_verify_1",
+            "tool_input": {"command": command},
+        },
+    )
+    completed = AgentMessage(
+        type="tool_result",
+        content="equality: True",
+        data={
+            "subtype": "tool_result",
+            "tool_call_id": "bash_verify_1",
+            "is_error": False,
+            "output": "equality: True",
+        },
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=(started, completed),
+        task_cwd=None,
+    )
+
+
+def test_python_c_command_claim_matches_multiline_runtime_payload() -> None:
+    """ZCode may cite a multiline python -c command as a semicolon command."""
+    runtime_command = (
+        'python3 -c "\n'
+        "from pathlib import Path\n"
+        "target = Path('ozo_gui_smoke.txt')\n"
+        "expected = b'OZO'\n"
+        "target.write_bytes(expected)\n"
+        "observed = target.read_bytes()\n"
+        "print('equality:', observed == expected)\n"
+        '"'
+    )
+    claim = (
+        "python3 -c \"from pathlib import Path; target = Path('ozo_gui_smoke.txt'); "
+        "expected = b'OZO'; target.write_bytes(expected); observed = target.read_bytes(); "
+        "print('equality:', observed == expected)\""
+    )
+    started = AgentMessage(
+        type="tool",
+        content="run byte verifier",
+        tool_name="Bash",
+        data={
+            "tool_call_id": "bash_verify_multiline",
+            "tool_input": {"command": runtime_command},
+        },
+    )
+    completed = AgentMessage(
+        type="tool_result",
+        content="equality: True",
+        data={
+            "subtype": "tool_result",
+            "tool_call_id": "bash_verify_multiline",
+            "is_error": False,
+            "output": "equality: True",
+        },
+    )
+
+    assert _runtime_messages_support_command_claim(claim, (started,))
+    assert _runtime_messages_support_test_claim(
+        value=claim,
+        backed_commands=(claim,),
+        messages=(started, completed),
+        task_cwd=None,
+    )
+
+
+def test_tests_passed_rejects_failed_ad_hoc_python_verifier() -> None:
+    """The ad-hoc verifier path still fails closed on negative equality output."""
+    command = (
+        'python3 -c "from pathlib import Path; '
+        "expected = b'OZO'; observed = Path('ozo_gui_smoke.txt').read_bytes(); "
+        "print('equality:', observed == expected)\""
+    )
+    started = AgentMessage(
+        type="tool",
+        content="run byte verifier",
+        tool_name="Bash",
+        data={
+            "tool_call_id": "bash_verify_2",
+            "tool_input": {"command": command},
+        },
+    )
+    completed = AgentMessage(
+        type="tool_result",
+        content="equality: False",
+        data={
+            "subtype": "tool_result",
+            "tool_call_id": "bash_verify_2",
+            "is_error": False,
+            "output": "equality: False",
+        },
+    )
+
+    assert not _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=(started, completed),
+        task_cwd=None,
+    )
+
+
 def test_tests_passed_rejects_tool_call_narration_without_runtime_result() -> None:
     command = "pytest tests/test_app.py"
     message = AgentMessage(
@@ -1832,6 +1981,22 @@ def test_validation_only_ac_drops_files_touched_requirement(ac_content: str) -> 
     """Validation-only ACs prove command/test evidence without requiring file mutation."""
     schema = _effective_evidence_schema_for_ac(load_profile("code"), ac_content)
     assert schema.required == ("commands_run", "tests_passed")
+
+
+@pytest.mark.parametrize(
+    "ac_content",
+    (
+        "No files other than the target file are created or modified in the project tree.",
+        "Only the requested file is changed.",
+        "git status shows only the target file.",
+    ),
+)
+def test_workspace_isolation_validation_ac_requires_only_commands_run(
+    ac_content: str,
+) -> None:
+    """No-collateral-change ACs are verification ACs, not code/test mutation ACs."""
+    schema = _effective_evidence_schema_for_ac(load_profile("code"), ac_content)
+    assert schema.required == ("commands_run",)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Recognize artifact file writes performed through `pathlib.Path.write_text()` / `write_bytes()` as transcript-backed file evidence.
- Normalize direct `python -c` verifier payloads so multiline runtime commands and concise evidence claims can match.
- Accept explicit successful ad-hoc artifact verification output such as `equality: True` / `verified: True` as `tests_passed` evidence, while failing closed on negative output.
- Treat workspace-isolation acceptance criteria such as "only the target file changed" as validation ACs that do not require unrelated file/test mutation evidence.

## Verification

- Rebased/applied cleanly on `Q00/ouroboros` `origin/main@14af5553866af58a856e1829fa866619482cfb70` in isolated worktree `/private/tmp/ozo-ba050383-pubgate-20260727`.
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 python -m pytest tests/unit/orchestrator/test_parallel_executor.py -q`
  - `349 passed in 15.33s`
  - repeat: `349 passed in 7.34s`
- `uv run --python 3.13 ruff check src/ouroboros/orchestrator/evidence/ac_classification.py src/ouroboros/orchestrator/evidence/claims.py src/ouroboros/orchestrator/evidence/shell_parsing.py src/ouroboros/orchestrator/evidence/test_detection.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run --python 3.13 ruff format --check src/ouroboros/orchestrator/evidence/ac_classification.py src/ouroboros/orchestrator/evidence/claims.py src/ouroboros/orchestrator/evidence/shell_parsing.py src/ouroboros/orchestrator/evidence/test_detection.py tests/unit/orchestrator/test_parallel_executor.py`
- `git diff --check`
- Direct production verifier probe using `_verify_atomic_evidence_against_runtime_messages`:
  - `Path('ozo_gui_smoke.txt').write_bytes(b'OZO')` plus Python `read_bytes()` equality verifier returned `pass_verdict True`.
  - The same typed evidence with `equality: False` returned `fail_verdict False FABRICATION_SUSPECTED`.
- Ouroboros QA on the publication-gate evidence: `qa-4ac023e8` PASS `0.83`.

Evidence memo: `/private/tmp/ozo-session140-ba050383-publication-gate-evidence.md`

## Scope Notes

This PR claims the evidence-recognition behavior above. It does not claim a full live ZCode GUI workflow, external LLM runtime behavior, or any behavior related to PR #1648/#1649.
