### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -140,11 +140,11 @@ Claude Code 세션 안에서 `ooo setup` 실행.
 **pip / uv / pipx**:
 ```bash
 pip install ouroboros-ai                # 기본
-pip install ouroboros-ai[claude]        # + Claude Code 의존성
-pip install ouroboros-ai[litellm]       # + LiteLLM 멀티 프로바이더; Python 3.12-3.13
-pip install ouroboros-ai[mcp]           # + MCP 서버/클라이언트 지원
-pip install ouroboros-ai[tui]           # + Textual 터미널 UI
-pip install ouroboros-ai[all]           # 전부; Python 3.12-3.13
+pip install 'ouroboros-ai[claude]'        # + Claude Code 의존성
+pip install 'ouroboros-ai[litellm]'       # + LiteLLM 멀티 프로바이더; Python 3.12-3.13
+pip install 'ouroboros-ai[mcp]'           # + MCP 서버/클라이언트 지원
+pip install 'ouroboros-ai[tui]'           # + Textual 터미널 UI
+pip install 'ouroboros-ai[all]'           # 전부; Python 3.12-3.13
 ouroboros setup                         # 런타임 설정
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ Then run `ooo setup` inside a Claude Code session.
 **pip / uv / pipx**:
 ```bash
 pip install ouroboros-ai                # base
-pip install ouroboros-ai[claude]        # + Claude Code deps; pair with [mcp] for the MCP server
-pip install ouroboros-ai[litellm]       # + LiteLLM multi-provider; Python 3.12-3.13
-pip install ouroboros-ai[mcp]           # + MCP server/client support
-pip install ouroboros-ai[tui]           # + Textual terminal UI
-pip install ouroboros-ai[all]           # everything (claude + litellm + mcp + tui); Python 3.12-3.13
+pip install 'ouroboros-ai[claude]'        # + Claude Code deps; pair with [mcp] for the MCP server
+pip install 'ouroboros-ai[litellm]'       # + LiteLLM multi-provider; Python 3.12-3.13
+pip install 'ouroboros-ai[mcp]'           # + MCP server/client support
+pip install 'ouroboros-ai[tui]'           # + Textual terminal UI
+pip install 'ouroboros-ai[all]'           # everything (claude + litellm + mcp + tui); Python 3.12-3.13
 ouroboros setup                         # configure runtime
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,11 +83,11 @@ claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@o
 **pip / uv / pipx**：
 ```bash
 pip install ouroboros-ai                # 基础
-pip install ouroboros-ai[claude]        # + Claude Code 依赖
-pip install ouroboros-ai[litellm]       # + LiteLLM 多 provider；Python 3.12-3.13
-pip install ouroboros-ai[mcp]           # + MCP server / client 支持
-pip install ouroboros-ai[tui]           # + Textual 终端 UI
-pip install ouroboros-ai[all]           # 全部 (claude + litellm + mcp + tui + dashboard)；Python 3.12-3.13
+pip install 'ouroboros-ai[claude]'        # + Claude Code 依赖
+pip install 'ouroboros-ai[litellm]'       # + LiteLLM 多 provider；Python 3.12-3.13
+pip install 'ouroboros-ai[mcp]'           # + MCP server / client 支持
+pip install 'ouroboros-ai[tui]'           # + Textual 终端 UI
+pip install 'ouroboros-ai[all]'           # 全部 (claude + litellm + mcp + tui + dashboard)；Python 3.12-3.13
 ouroboros setup                         # 配置运行时
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,11 +110,11 @@ No Python, pip, or API key configuration needed -- Claude Code handles the runti
 
 ```bash
 pip install ouroboros-ai              # Base package (core engine)
-pip install ouroboros-ai[claude]      # + Claude Code runtime deps; pair with [mcp] for the MCP server
-pip install ouroboros-ai[litellm]     # + LiteLLM multi-provider support; Python 3.12-3.13
-pip install ouroboros-ai[mcp]         # + MCP server/client runtime support
-pip install ouroboros-ai[tui]         # + Textual terminal UI
-pip install ouroboros-ai[all]         # Everything (claude + litellm + mcp + tui); Python 3.12-3.13
+pip install 'ouroboros-ai[claude]'      # + Claude Code runtime deps; pair with [mcp] for the MCP server
+pip install 'ouroboros-ai[litellm]'     # + LiteLLM multi-provider support; Python 3.12-3.13
+pip install 'ouroboros-ai[mcp]'         # + MCP server/client runtime support
+pip install 'ouroboros-ai[tui]'         # + Textual terminal UI
+pip install 'ouroboros-ai[all]'         # Everything (claude + litellm + mcp + tui); Python 3.12-3.13
 
 ouroboros --version                   # verify CLI
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,7 @@ Use WSL 2 for the supported Windows path, then run the Linux install commands fr
 | Standalone CLI (`ouroboros`) | Python >= 3.12, API key (Anthropic or OpenAI) |
 | Codex CLI backend | Python >= 3.12, `npm install -g @openai/codex`, OpenAI API key with access to GPT-5.4 |
 | OpenCode backend | Python >= 3.12, `opencode` on PATH, provider configured in OpenCode |
-| Kiro CLI backend | Python >= 3.12, `kiro-cli` on PATH (signed in to Kiro), `pip install ouroboros-ai[mcp,claude]` (shares the Claude extras for the Agent SDK types; `[mcp]` for the MCP server). Then `ouroboros setup --runtime kiro` to register the Ouroboros MCP server in `~/.kiro/settings/mcp.json` |
+| Kiro CLI backend | Python >= 3.12, `kiro-cli` on PATH (signed in to Kiro), `pip install 'ouroboros-ai[mcp,claude]'` (shares the Claude extras for the Agent SDK types; `[mcp]` for the MCP server). Then `ouroboros setup --runtime kiro` to register the Ouroboros MCP server in `~/.kiro/settings/mcp.json` |
 | GitHub Copilot CLI backend | Python >= 3.12, `copilot` on PATH, `gh` on PATH (`gh auth login`), `pip install 'ouroboros-ai[mcp]'` (or `pipx`/`uv tool` install). Then `ouroboros setup --runtime copilot` to live-discover available models, pick a default, and register the Ouroboros MCP server in `~/.copilot/mcp-config.json` |
 | Pi CLI backend | Python >= 3.12, `pi` on PATH or `orchestrator.pi_cli_path` configured. Use `runtime_backend: pi` for workflow execution. Use `llm.backend: pi` only when authoring/evaluation flows can accept Pi's adapter-level JSON extraction and schema validation rather than native `--output-schema` enforcement |
 
@@ -354,7 +354,7 @@ Ouroboros delegates code execution to a pluggable runtime backend. Three ship ou
 | | Claude Code | Codex CLI | OpenCode |
 |---|---|---|---|
 | **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing | Multi-provider flexibility; open-source tooling |
-| **Install** | `pip install ouroboros-ai[mcp,claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` | `pip install ouroboros-ai` + `opencode` on PATH |
+| **Install** | `pip install 'ouroboros-ai[mcp,claude]'` | `pip install ouroboros-ai` + `npm install -g @openai/codex` | `pip install ouroboros-ai` + `opencode` on PATH |
 | **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills | `ooo` after `ouroboros setup --runtime opencode` |
 | **Config value** | `claude` | `codex` | `opencode` |
 


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.ko.md`
- `README.md`
- `README.zh-CN.md`
- `docs/getting-started.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`