### PR TITLE
fix(hooks): honor Codex UserPromptSubmit JSON contract

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -8,8 +8,8 @@ IMPORTANT: If MCP is not configured (ooo setup not run),
 ALL ooo commands (except setup/help) redirect to setup first.
 
 Hook: UserPromptSubmit
-Input: User prompt text via stdin (piped by Claude Code)
-Output: Modified prompt with skill suggestion appended
+Input: JSON hook payload via stdin, with raw prompt text supported as a fallback
+Output: Structured hook context when a skill is suggested; otherwise no output
 """
 
 import json
@@ -275,53 +275,80 @@ def detect_keywords(text: str) -> dict:
     return {"detected": False, "keyword": None, "suggested_skill": None}
 
 
-def main() -> None:
-    # Read user prompt from stdin
+def _extract_prompt_and_host(hook_input: str) -> tuple[str, str]:
+    """Extract a prompt and identify the hook host from its wire envelope."""
+
     try:
-        user_input = sys.stdin.read().strip()
+        payload = json.loads(hook_input)
+    except (ValueError, RecursionError):
+        return hook_input, "claude"
+
+    if (
+        isinstance(payload, dict)
+        and payload.get("hook_event_name") == "UserPromptSubmit"
+        and isinstance(payload.get("session_id"), str)
+        and isinstance(payload.get("prompt"), str)
+    ):
+        host = "codex" if isinstance(payload.get("turn_id"), str) else "claude"
+        return payload["prompt"], host
+    return hook_input, "claude"
+
+
+def _emit_context(context: str) -> None:
+    """Emit a schema-valid UserPromptSubmit response."""
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> None:
+    # Read the hook payload from stdin. Older integrations may still pipe raw text.
+    try:
+        hook_input = sys.stdin.read().strip()
     except Exception:
-        user_input = ""
+        hook_input = ""
+
+    user_input, host = _extract_prompt_and_host(hook_input)
 
     result = detect_keywords(user_input)
 
-    # First-time user: append welcome suggestion to their first message
+    # First-time user: add welcome context to their first message.
     if not result["detected"] and is_first_time():
         skill_name = "welcome"
-        print(f"""{user_input}
-
-<skill-suggestion>
+        _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS (use AskUserQuestion to let user choose):
 - /ouroboros:{skill_name} - First time using Ouroboros! Starting welcome experience.
 IMPORTANT: Auto-triggering welcome experience now. Use AskUserQuestion to confirm or skip.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         return
 
     if result["detected"]:
         skill = result["suggested_skill"]
         keyword = result["keyword"]
 
-        # Gate check: if MCP not configured and skill requires it, redirect to setup
-        if skill not in SETUP_BYPASS_SKILLS and not is_mcp_configured():
-            print(f"""{user_input}
-
-<skill-suggestion>
+        # Codex hook envelopes do not expose the parent session's profile/config
+        # layers, so a child hook process cannot reconstruct its effective MCP state.
+        needs_setup = host != "codex" and not is_mcp_configured()
+        if skill not in SETUP_BYPASS_SKILLS and needs_setup:
+            _emit_context("""<skill-suggestion>
 🎯 REQUIRED SKILL:
 - /ouroboros:setup - Ouroboros setup required. Run "ooo setup" first to register the MCP server.
-</skill-suggestion>
-""")
+</skill-suggestion>""")
         else:
             skill_name = skill.replace("/ouroboros:", "")
-            print(f"""{user_input}
-
-<skill-suggestion>
+            _emit_context(f"""<skill-suggestion>
 🎯 MATCHED SKILLS:
 - /ouroboros:{skill_name} - Detected "{keyword}"
-</skill-suggestion>
-""")
-    else:
-        # Pass through unchanged when no keyword detected
-        print(user_input)
+</skill-suggestion>""")
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -1,6 +1,7 @@
 """Tests for keyword-detector.py — setup gate and routing behavior."""
 
 import importlib.util
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -325,3 +326,119 @@ class TestMainGate:
         out = capsys.readouterr().out
         assert "/ouroboros:setup" not in out
         assert "/ouroboros:resume-session" in out
+
+
+class TestHookProtocol:
+    """UserPromptSubmit input and output follow the shared hook JSON protocol."""
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_json_payload_detection_uses_only_prompt_field(self, _first, capsys):
+        payload = {
+            "session_id": "ooo status",
+            "turn_id": "turn-1",
+            "prompt": "hello world",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        assert capsys.readouterr().out == ""
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_codex_payload_match_emits_structured_context_without_setup_probe(
+        self,
+        _first,
+        capsys,
+    ):
+        payload = {
+            "session_id": "test-session",
+            "turn_id": "test-turn",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch.object(_mod, "is_mcp_configured") as configured,
+        ):
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        configured.assert_not_called()
+        output = json.loads(capsys.readouterr().out)
+        assert output == {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    "<skill-suggestion>\n🎯 MATCHED SKILLS:\n"
+                    '- /ouroboros:status - Detected "ooo status"\n'
+                    "</skill-suggestion>"
+                ),
+            }
+        }
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_claude_payload_retains_setup_gate(self, _first, _mcp, capsys):
+        payload = {
+            "session_id": "test-session",
+            "prompt": "ooo status",
+            "hook_event_name": "UserPromptSubmit",
+        }
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = json.dumps(payload)
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:setup" in context
+        assert "/ouroboros:status" not in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_text_fallback_remains_supported(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "ooo qa"
+            main()
+
+        output = json.loads(capsys.readouterr().out)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:qa" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_raw_json_object_text_without_hook_marker_remains_prompt(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = '{"command": "ooo status"}'
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context
+
+    @patch.object(_mod, "is_mcp_configured", return_value=True)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_hook_shaped_json_without_session_id_remains_prompt(self, _first, _mcp, capsys):
+        raw_prompt = json.dumps(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "explain this payload",
+                "command": "ooo status",
+            }
+        )
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = raw_prompt
+            main()
+
+        context = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+        assert "/ouroboros:status" in context
+
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_recursive_json_failure_falls_back_without_crashing(self, _first, capsys):
+        raw_prompt = "[" * 10_000 + "]" * 10_000
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch.object(_mod.json, "loads", side_effect=RecursionError),
+        ):
+            mock_stdin.read.return_value = raw_prompt
+            main()
+
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

- parse genuine UserPromptSubmit JSON envelopes before keyword matching
- emit schema-valid `hookSpecificOutput.additionalContext` without echoing the original prompt
- keep raw-text and raw-JSON prompt fallback behavior
- identify Codex envelopes through the documented `turn_id` field and avoid reconstructing parent profile/config state in the hook child

This intentionally replaces #1712 with the issue-scoped two-file change. CODEX_HOME, setup, model catalog, doctor, and uninstall lifecycle changes are out of scope.

Closes #1694.

## Verification

- `47 passed` in `tests/unit/scripts/test_keyword_detector.py`
- `241 passed` in `tests/unit/scripts`
- Ruff lint and format checks pass
- direct Codex JSON-envelope smoke output is schema-valid