### PR TITLE
fix(core): interview artifacts are owner-only from the moment they exist

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -12,9 +12,11 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import structlog
 import yaml
 
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
+from ouroboros.core.owner_only import write_owner_only
 from ouroboros.core.requirement_candidate import RequirementDistillation
 from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.mcp.errors import MCPServerError
@@ -35,6 +37,8 @@ from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers.base import CompletionConfig, LLMAdapter, Message, MessageRole
 from ouroboros.resilience.lateral import ThinkingPersona
+
+log = structlog.get_logger(__name__)
 
 _SAFE_SEED_ID_FILENAME_CHARS = frozenset(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
@@ -1108,16 +1112,32 @@ def load_seed(path: str | Path) -> Seed:
 
 
 def save_seed(seed: Seed, *, seeds_dir: Path | None = None) -> str:
-    """Persist an auto-generated Seed in the standard seed directory."""
+    """Persist an auto-generated Seed in the standard seed directory.
+
+    An auto-generated Seed carries the same requirement content as one written
+    by the interview path — including answers confirmed from a data lookup —
+    so it takes the same owner-only primitive. Reached through Auto
+    rather than through ``ouroboros.bigbang``, this writer was the one Seed
+    path still landing at the umask default, typically ``0644``.
+
+    The directory keeps its own permissions: ``seeds_dir`` may be a shared
+    project directory the caller chose, and narrowing it is not this package's
+    to do.
+    """
     directory = seeds_dir or (Path.home() / ".ouroboros" / "seeds")
     directory.mkdir(parents=True, exist_ok=True)
     seed_id = _safe_seed_id_for_filename(seed.metadata.seed_id)
     path = directory / f"{seed_id}{_SEED_FILENAME_SUFFIX}"
     _require_path_inside_directory(path, directory)
-    path.write_text(
+    if not write_owner_only(
+        path,
         yaml.dump(seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False),
-        encoding="utf-8",
-    )
+    ):
+        # Reported like every other migrated artifact writer: the
+        # file exists but the directory flush was unconfirmed, so a crash may
+        # still lose it — the caller's success return stays, the risk is
+        # visible in the log.
+        log.warning("auto.seed_save_durability_uncertain", path=str(path))
     return str(path)
 
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -14,6 +14,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.auto.recovery_plan import AutoRecoveryPlan
+from ouroboros.core.owner_only import write_owner_only
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1540,15 +1541,29 @@ class AutoStore:
         return self.root / f"{safe}.json"
 
     def save(self, state: AutoPipelineState) -> Path:
-        """Persist ``state`` atomically and return the written path."""
+        """Persist ``state`` atomically, owner-only, and return the path.
+
+        Auto pipeline state carries the interview answers the user gave, and
+        it lives for as long as the session record does. It is the same
+        artifact class the interview transcript and the Seed belong to, so it
+        takes the same primitive — writing it through ``write_text`` left it
+        at the umask default, typically ``0644``, for its whole lifetime.
+
+        The directory is deliberately NOT re-permissioned: ``root`` may be
+        supplied by the caller, and narrowing a directory this package does
+        not own is not its to do.
+        """
         state._validate_loaded()
         self.root.mkdir(parents=True, exist_ok=True)
         path = self.path_for(state.auto_session_id)
-        tmp_path = path.with_suffix(".json.tmp")
-        tmp_path.write_text(
-            json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-        tmp_path.replace(path)
+        # Written straight to the target: write_owner_only is temp-file +
+        # atomic rename + fsync, so the prior state survives a failed write
+        # and a second staging step would only add an unflushed rename.
+        durable = write_owner_only(path, json.dumps(state.to_dict(), ensure_ascii=False, indent=2))
+        if not durable:
+            logging.getLogger(__name__).warning(
+                "auto.state_save_durability_unconfirmed path=%s", path
+            )
         return path
 
     def load(self, auto_session_id: str) -> AutoPipelineState:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -8,12 +8,8 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-import errno
 import functools
-import os
 from pathlib import Path
-import stat
-import tempfile
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -22,6 +18,7 @@ import structlog
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.file_lock import file_lock as _file_lock
+from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.requirement_candidate import (
     RequirementDistillation,
     compute_requirement_input_fingerprint,
@@ -103,72 +100,6 @@ _TOOLLESS_INTERVIEW_BASE_PROMPT = """## Role Boundaries
 - Prefer scope, non-goal, success criteria, ownership, risk, and verification questions.
 - For brownfield work, focus on intent and decisions rather than discovering what exists.
 """
-
-
-def _fsync_parent_directory(file_path: Path) -> bool:
-    if os.name != "posix":
-        return True
-
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
-    try:
-        directory_fd = os.open(file_path.parent, flags)
-    except OSError as error:
-        return error.errno in (errno.EINVAL, errno.ENOTSUP)
-    durability_confirmed = True
-    try:
-        try:
-            os.fsync(directory_fd)
-        except OSError as error:
-            if error.errno not in (errno.EINVAL, errno.ENOTSUP):
-                durability_confirmed = False
-    finally:
-        try:
-            os.close(directory_fd)
-        except OSError:
-            durability_confirmed = False
-    return durability_confirmed
-
-
-def _atomic_write_text(file_path: Path, content: str) -> bool:
-    try:
-        existing_mode = stat.S_IMODE(file_path.stat().st_mode)
-    except FileNotFoundError:
-        existing_mode = None
-
-    fd, tmp_name = tempfile.mkstemp(
-        prefix=f".{file_path.name}.",
-        suffix=".tmp",
-        dir=str(file_path.parent),
-    )
-    raw_fd: int | None = fd
-    tmp_path = Path(tmp_name)
-    try:
-        if existing_mode is not None:
-            if os.name == "posix":
-                os.fchmod(fd, existing_mode)
-            else:
-                tmp_path.chmod(existing_mode)
-
-        handle = os.fdopen(fd, "w", encoding="utf-8")
-        raw_fd = None
-        with handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp_path, file_path)
-        return _fsync_parent_directory(file_path)
-    finally:
-        if raw_fd is not None:
-            try:
-                os.close(raw_fd)
-            except OSError:
-                pass
-        try:
-            tmp_path.unlink()
-        except OSError:
-            pass
 
 
 class InterviewPerspective(StrEnum):
@@ -729,7 +660,7 @@ class InterviewEngine:
         self.model_is_explicit = self.model is not None
         if self.model is None:
             self.model = get_llm_model_for_role("interview")
-        self.state_dir.mkdir(parents=True, exist_ok=True)
+        secure_directory(self.state_dir)
 
     def _state_file_path(self, interview_id: str) -> Path:
         """Get the path to the state file for an interview.
@@ -1109,7 +1040,7 @@ class InterviewEngine:
 
             def _sync_write() -> bool:
                 with _file_lock(file_path, exclusive=True):
-                    return _atomic_write_text(file_path, content)
+                    return write_owner_only(file_path, content)
 
             durability_confirmed = await asyncio.to_thread(_sync_write)
 

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -39,7 +39,6 @@ from ouroboros.bigbang.interview import (
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
     InterviewState,
-    _atomic_write_text,
     initial_context_summary_missing,
     prompt_safe_initial_context,
 )
@@ -52,6 +51,7 @@ from ouroboros.bigbang.question_classifier import (
 )
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
+from ouroboros.core.owner_only import write_owner_only
 from ouroboros.core.pm_snapshot import refresh_pm_snapshot_worktrees
 from ouroboros.core.types import Result
 from ouroboros.providers.base import (
@@ -1186,7 +1186,7 @@ class PMInterviewEngine:
             ensure_ascii=False,
             indent=2,
         )
-        durability_confirmed = _atomic_write_text(filepath, json_content)
+        durability_confirmed = write_owner_only(filepath, json_content)
 
         if not durability_confirmed:
             log.warning(

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -36,6 +36,7 @@ from ouroboros.bigbang.requirement_distillation import (
 )
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
+from ouroboros.core.owner_only import write_owner_only
 from ouroboros.core.seed import (
     AcceptanceCriterionSpec,
     BrownfieldContext,
@@ -1047,7 +1048,14 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
                 sort_keys=False,
             )
 
-            file_path.write_text(content, encoding="utf-8")
+            if not write_owner_only(file_path, content):
+                # Reported like every other artifact writer: the file exists
+                # but the directory flush was unconfirmed.
+                log.warning(
+                    "seed.save_durability_uncertain",
+                    seed_id=seed.metadata.seed_id,
+                    file_path=str(file_path),
+                )
 
             log.info(
                 "seed.saved",
@@ -1155,7 +1163,12 @@ def save_seed_sync(seed: Seed, file_path: Path) -> Result[Path, ValidationError]
             sort_keys=False,
         )
 
-        file_path.write_text(content, encoding="utf-8")
+        if not write_owner_only(file_path, content):
+            log.warning(
+                "seed.save_durability_uncertain",
+                seed_id=seed.metadata.seed_id,
+                file_path=str(file_path),
+            )
 
         log.info(
             "seed.saved.sync",

--- a/src/ouroboros/cli/commands/pm.py
+++ b/src/ouroboros/cli/commands/pm.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from rich.prompt import Confirm, Prompt
+import structlog
 import typer
 
 from ouroboros.bigbang.interview import InterviewRound
@@ -26,6 +27,7 @@ from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
 from ouroboros.config import get_clarification_model, get_llm_backend
+from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.types import Result
 from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.pm.handoff import build_pm_dev_handoff_command
@@ -42,6 +44,8 @@ app = typer.Typer(
     no_args_is_help=False,
     invoke_without_command=True,
 )
+
+log = structlog.get_logger()
 
 
 def _create_pm_litellm_adapter() -> Any:
@@ -341,7 +345,7 @@ def _save_cli_pm_meta(session_id: str, engine: Any) -> None:
     import json
 
     data_dir = Path.home() / ".ouroboros" / "data"
-    data_dir.mkdir(parents=True, exist_ok=True)
+    secure_directory(data_dir)
     meta_path = data_dir / f"pm_meta_{session_id}.json"
 
     # Build pending_reframe from the engine's reframe map (mirrors MCP _save_pm_meta)
@@ -369,7 +373,17 @@ def _save_cli_pm_meta(session_id: str, engine: Any) -> None:
         "classifications": [c.output_type.value for c in getattr(engine, "classifications", [])],
     }
 
-    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+    durability_confirmed = write_owner_only(
+        meta_path,
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    if not durability_confirmed:
+        log.warning(
+            "pm.meta_save_durability_unconfirmed",
+            session_id=session_id,
+            path=str(meta_path),
+        )
 
 
 def _make_message_callback(debug: bool):

--- a/src/ouroboros/core/owner_only.py
+++ b/src/ouroboros/core/owner_only.py
@@ -1,0 +1,257 @@
+"""Owner-only writes for files that hold interview and data content.
+
+Interview transcripts, Seeds, and fan-out records all carry whatever a data
+lookup returned and whatever the user confirmed about it. They are written
+under the process umask by default, which on a typical `022` leaves them
+world-readable for their whole lifetime — indefinitely, in the case of
+interview state and Seeds.
+
+The protection cannot be an instruction to the writer to be careful: every
+call site would have to remember, and one that forgets is invisible. It is a
+function, applied at every site that persists this class of content, that
+creates the file with mode `0600` rather than fixing the mode afterwards — so
+the content never exists at the umask default even briefly.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import errno
+import logging
+import os
+from pathlib import Path
+import stat
+from uuid import uuid4
+
+#: Files: readable and writable by the owner only.
+OWNER_ONLY_FILE = 0o600
+#: Directories: additionally traversable by the owner only.
+OWNER_ONLY_DIR = 0o700
+#: How much of the target name a temporary may borrow. Bounds the temporary
+#: at 70 characters however long the target is.
+_TMP_NAME_PREFIX_CHARS = 32
+
+_log = logging.getLogger(__name__)
+
+
+def _posix() -> bool:
+    """Whether the platform can represent the owner-only mode.
+
+    A function rather than an inline ``os.name`` check so tests can probe
+    the non-POSIX branch without patching the global ``os.name`` — which
+    pathlib also reads, turning every ``Path()`` into a ``WindowsPath``.
+    """
+    return os.name == "posix"
+
+
+#: Emitted once per process on a platform where the mode cannot be enforced.
+_degradation_warned = False
+
+
+def package_owned_directory(path: Path) -> bool:
+    """Whether ``path`` lies inside the package namespace ``~/.ouroboros``.
+
+    Ownership of a DIRECTORY is decided by provenance, not by which module
+    happens to call mkdir. The interview state directory, the
+    fan-out registry, and the plugin state directory all default under the
+    package namespace but are caller-suppliable, and a probe showed an
+    explicitly supplied 0755 directory being narrowed to 0700 — revoking
+    access this package had no business revoking. Inside ``~/.ouroboros``
+    the directories are this package's to repair (a 0755 one inherited
+    from an older version included); outside it they are the caller's.
+    """
+    try:
+        resolved = Path(path).expanduser().resolve()
+        namespace = (Path.home() / ".ouroboros").resolve()
+    except OSError:
+        return False
+    return resolved == namespace or namespace in resolved.parents
+
+
+def fsync_parent_directory(file_path: Path) -> bool:
+    """Flush the directory entry so the rename itself survives a crash.
+
+    Public because durability has to be RETRYABLE: a record whose
+    content reached disk but whose directory entry was not confirmed is
+    already readable and already terminal, so the recovery that helps is
+    flushing again — not rewriting content that is not the problem.
+
+    Returns whether durability could be confirmed. A filesystem that cannot
+    fsync a directory (``EINVAL``/``ENOTSUP``) is reported as confirmed: it
+    never owed the guarantee, so treating it as a failure would make every
+    write on that filesystem look suspect.
+    """
+    if not _posix():
+        return True
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        directory_fd = os.open(file_path.parent, flags)
+    except OSError as error:
+        return error.errno in (errno.EINVAL, errno.ENOTSUP)
+    durability_confirmed = True
+    try:
+        try:
+            os.fsync(directory_fd)
+        except OSError as error:
+            if error.errno not in (errno.EINVAL, errno.ENOTSUP):
+                durability_confirmed = False
+    finally:
+        try:
+            os.close(directory_fd)
+        except OSError:
+            durability_confirmed = False
+    return durability_confirmed
+
+
+def write_owner_only(path: Path, text: str, *, encoding: str = "utf-8") -> bool:
+    """Write ``text`` to ``path`` as a durable owner-only file.
+
+    The content is written to a NEW file created at ``0600`` and then renamed
+    over the target, so the mode is established at creation and never depends
+    on repairing an existing file's permissions. That matters because the
+    repair can fail — a filesystem without chmod, an EPERM on a file owned by
+    someone else — and the earlier version suppressed that failure and wrote
+    anyway, leaving the new secret at the old ``0644``. Here a
+    failure to establish the mode is a failure to write: nothing sensitive
+    reaches disk at a wider mode, ever.
+
+    The replacement is atomic, so a reader never observes a partial file, and
+    the temporary lives beside the target so the rename stays within one
+    filesystem. Contents and directory entry are both fsync'd, and the return
+    value reports whether that durability could be confirmed — callers that
+    persist state a user would notice losing should log when it could not.
+
+    Establishing the mode at creation is also what keeps an *existing*
+    world-readable file from staying that way. Preserving the previous mode,
+    the usual behaviour for an atomic-write helper, would carry a `0644` file
+    written by an older version forward forever.
+
+    Directories are not touched: a caller may write into a directory that is
+    not this package's to re-permission. Call :func:`secure_directory` only
+    for directories this package creates and owns.
+    """
+    target = Path(path)
+    if not _posix():
+        # The owner-only guarantee is scoped to POSIX. `os.open`
+        # with 0o600 on native Windows only sets the CRT read/write flags —
+        # access stays governed by the inherited ACL, and `st_mode` reflects
+        # the flags, so the mode check below would be vacuous there. Round 71
+        # made this path refuse outright; the review pointed out that native
+        # Windows is an advertised (experimental) platform and refusing every
+        # Interview/Seed/PM/Auto write makes it unusable. So the write
+        # proceeds atomically under the directory's inherited ACL, the
+        # degradation is stated loudly once per process instead of being
+        # discovered, and no surface may advertise owner-only permissions on
+        # this platform. An owner-only DACL implementation can restore the
+        # guarantee later; a mode check that cannot fail must not stand in
+        # for it meanwhile.
+        global _degradation_warned
+        if not _degradation_warned:
+            _degradation_warned = True
+            _log.warning(
+                "owner-only file permissions cannot be established on this "
+                "platform; %s is written under the directory's inherited ACL",
+                target,
+            )
+        return _write_atomic_unscoped(target, text, encoding=encoding)
+    # The temporary must not be longer than the filesystem allows just because
+    # the target is near the limit. Embedding the WHOLE target name
+    # added a fixed 38 characters, so a caller that had carefully bounded its
+    # filename to the 255-byte limit — the Auto Seed writer does exactly that —
+    # got ENAMETOOLONG from the temporary instead. Only a bounded prefix is
+    # kept, for debuggability; uniqueness comes from the uuid, and the
+    # `.NAME.tmp-` shape is what leftover sweeps match on.
+    tmp_path = target.with_name(f".{target.name[:_TMP_NAME_PREFIX_CHARS]}.tmp-{uuid4().hex}")
+    # Held only until a file object takes ownership of it. If wrapping the
+    # descriptor fails, nothing else will ever close it, so the cleanup path
+    # has to.
+    raw_fd: int | None = None
+    try:
+        raw_fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, OWNER_ONLY_FILE)
+        # Checked BEFORE a single byte is written. This check exists
+        # for the filesystem that ignores or widens the requested mode, and
+        # verifying it after the write meant that on exactly that filesystem
+        # the content had already existed group- or world-readable — the
+        # window the check was added to close. fstat on the descriptor, not
+        # stat on the path, so nothing can be swapped underneath it.
+        if stat.S_IMODE(os.fstat(raw_fd).st_mode) != OWNER_ONLY_FILE:
+            raise OSError(f"cannot create {target} with owner-only permissions on this filesystem")
+        handle = os.fdopen(raw_fd, "w", encoding=encoding)
+        raw_fd = None
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+    except BaseException:
+        if raw_fd is not None:
+            with suppress(OSError):
+                os.close(raw_fd)
+        with suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+    return fsync_parent_directory(target)
+
+
+def _write_atomic_unscoped(target: Path, text: str, *, encoding: str) -> bool:
+    """The atomic half of :func:`write_owner_only`, without the mode contract.
+
+    Used only where the platform cannot represent the contract (native
+    Windows). Same temporary shape, same replace, same cleanup — only the
+    permission establishment and its verification are absent, because there
+    is nothing true they could verify there.
+    """
+    tmp_path = target.with_name(f".{target.name[:_TMP_NAME_PREFIX_CHARS]}.tmp-{uuid4().hex}")
+    raw_fd: int | None = None
+    try:
+        raw_fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, OWNER_ONLY_FILE)
+        handle = os.fdopen(raw_fd, "w", encoding=encoding)
+        raw_fd = None
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+    except BaseException:
+        if raw_fd is not None:
+            with suppress(OSError):
+                os.close(raw_fd)
+        with suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+    return fsync_parent_directory(target)
+
+
+def secure_directory(path: Path) -> None:
+    """Create ``path`` if needed and make it owner-only.
+
+    Call this ONLY for directories this package creates and owns — the
+    interview state directory and the fan-out registry directory. A Seed is
+    written wherever the caller asks, which may be a shared project
+    directory, and narrowing that from 0755 to 0700 would be this package
+    changing something that is not its own. The Seed file itself is
+    still owner-only through :func:`write_owner_only`.
+
+    ``mkdir``'s mode argument is ignored when the directory already exists, so
+    an inherited `0755` state directory keeps its permissions unless it is
+    chmod'd explicitly. Failure is suppressed: a directory we do not own is
+    not ours to re-permission, and refusing to run there would be worse than
+    proceeding with the file mode we do control.
+
+    Ownership is checked HERE rather than trusted to the caller:
+    every one of these directories is caller-suppliable, and a supplied
+    ``0755`` directory outside the package namespace was being narrowed to
+    ``0700`` — revoking collaborator access this package had no business
+    revoking. Outside ``~/.ouroboros`` the directory is created if missing
+    and otherwise left exactly as found; the files written into it are still
+    owner-only through :func:`write_owner_only`.
+    """
+    if not package_owned_directory(path):
+        path.mkdir(parents=True, exist_ok=True)
+        return
+    path.mkdir(parents=True, exist_ok=True, mode=OWNER_ONLY_DIR)
+    with suppress(OSError):
+        os.chmod(path, OWNER_ONLY_DIR)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -51,6 +51,7 @@ from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.initial_context import resolve_initial_context_input
+from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.types import Result
 from ouroboros.interview_adapters import (
     InterviewTurnContext,
@@ -1211,10 +1212,22 @@ async def _plugin_save_state(state_dir: Path, state: InterviewState) -> Result[P
         state.mark_updated()
         content = state.model_dump_json(indent=2)
 
-        def _sync_write() -> None:
-            file_path.write_text(content, encoding="utf-8")
+        def _sync_write() -> bool:
+            # The plugin transport persists the same transcript the stdio one
+            # does, so it uses the same owner-only writer. This fourth site was
+            # still on write_text and produced 0644 under a 022 umask.
+            secure_directory(file_path.parent)
+            return write_owner_only(file_path, content)
 
-        await asyncio.to_thread(_sync_write)
+        durability_confirmed = await asyncio.to_thread(_sync_write)
+        if not durability_confirmed:
+            # The stdio writer logs this state; discarding it here reported a
+            # durability the filesystem never confirmed.
+            log.warning(
+                "plugin.state_save_durability_uncertain",
+                interview_id=state.interview_id,
+                file_path=str(file_path),
+            )
         return Result.ok(file_path)
     except (OSError, ValueError) as e:
         return Result.err(f"Failed to save interview state: {e}")

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -40,6 +40,7 @@ from ouroboros.bigbang.pm_document import save_pm_document
 from ouroboros.bigbang.pm_interview import PM_UNCERTAINTY_GUIDANCE, PMInterviewEngine
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.initial_context import resolve_initial_context_input
+from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.pm_snapshot import refresh_pm_snapshot_worktrees
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -185,8 +186,21 @@ def _save_pm_meta(
         meta.update(extra)
 
     path = _meta_path(session_id, data_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+    if data_dir is None:
+        secure_directory(path.parent)
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    durability_confirmed = write_owner_only(
+        path,
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    if not durability_confirmed:
+        log.warning(
+            "pm_handler.meta_save_durability_unconfirmed",
+            session_id=session_id,
+            path=str(path),
+        )
     log.debug("pm_handler.meta_saved", session_id=session_id, path=str(path))
 
 

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -49,6 +49,7 @@ from ouroboros.backends.capabilities import (
     SubagentDispatchMode,
     resolve_subagent_dispatch,
 )
+from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.assignment import AssignmentMessage
@@ -2717,11 +2718,22 @@ class FanoutRegistry:
             synthesizer_input=synthesizer_input,
         )
         try:
-            self._dir.mkdir(parents=True, exist_ok=True)
-            self._path(resolved_id).write_text(
+            # A fan-out record carries the producer's ``synthesizer_input``
+            # verbatim — the code-investigation request, the persona panel
+            # entries — so it is the same artifact class as the transcript it
+            # was derived from and takes the same writer. Registration stays
+            # best-effort: an unconfirmed durability flush is logged like every
+            # other migrated writer, and the caller still gets its id.
+            secure_directory(self._dir)
+            if not write_owner_only(
+                self._path(resolved_id),
                 json.dumps(record.to_dict(), ensure_ascii=False),
-                encoding="utf-8",
-            )
+            ):
+                log.warning(
+                    "fanout.registry.durability_unconfirmed",
+                    fanout_id=resolved_id,
+                    kind=kind,
+                )
         except OSError as exc:
             log.warning(
                 "fanout.registry.persist_failed",

--- a/tests/unit/bigbang/test_interview_async_io.py
+++ b/tests/unit/bigbang/test_interview_async_io.py
@@ -13,7 +13,6 @@ import errno
 import os
 from pathlib import Path
 import stat
-import tempfile
 from typing import IO
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -110,7 +109,7 @@ class TestSaveStateUsesThread:
         saved_path.write_text("original\n", encoding="utf-8")
 
         with (
-            patch("tempfile.mkstemp", wraps=tempfile.mkstemp) as mock_mkstemp,
+            patch("os.open", wraps=os.open) as mock_open,
             patch("os.fsync") as mock_fsync,
             patch("os.replace", side_effect=OSError("boom")),
         ):
@@ -118,8 +117,9 @@ class TestSaveStateUsesThread:
 
         assert result.is_err
         assert saved_path.read_text(encoding="utf-8") == "original\n"
-        assert mock_mkstemp.call_count == 1
-        assert mock_mkstemp.call_args.kwargs["dir"] == str(saved_path.parent)
+        temp_creations = [call for call in mock_open.call_args_list if call.args[1] & os.O_EXCL]
+        assert len(temp_creations) == 1
+        assert Path(temp_creations[0].args[0]).parent == saved_path.parent
         mock_fsync.assert_called_once()
         assert {path.name for path in saved_path.parent.iterdir()} == {
             saved_path.name,
@@ -132,16 +132,17 @@ class TestSaveStateUsesThread:
         state = _make_state()
         created_fds: list[int] = []
         created_paths: list[Path] = []
-        real_mkstemp = tempfile.mkstemp
+        real_open = os.open
 
-        def _recording_mkstemp(*args, **kwargs):
-            fd, name = real_mkstemp(*args, **kwargs)
-            created_fds.append(fd)
-            created_paths.append(Path(name))
-            return fd, name
+        def _recording_open(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_EXCL:
+                created_fds.append(fd)
+                created_paths.append(Path(path))
+            return fd
 
         with (
-            patch("tempfile.mkstemp", side_effect=_recording_mkstemp),
+            patch("os.open", side_effect=_recording_open),
             patch("os.fdopen", side_effect=RuntimeError("fdopen failed")),
             pytest.raises(RuntimeError, match="fdopen failed"),
         ):
@@ -175,18 +176,24 @@ class TestSaveStateUsesThread:
         }
 
     @pytest.mark.asyncio
-    async def test_save_state_preserves_existing_mode(self, tmp_path) -> None:
+    async def test_save_state_narrows_an_existing_readable_mode(self, tmp_path) -> None:
+        """A transcript left readable by an older version is narrowed, not kept.
+
+        The mode is deliberately NOT preserved here. Preserving it is the usual
+        contract for an atomic write, and it is exactly what would carry a
+        group- or world-readable transcript forward forever. The transcript
+        holds confirmed data answers and lives indefinitely.
+        """
         engine = _make_engine(tmp_path)
         state = _make_state()
         saved_path = engine._state_file_path(state.interview_id)
         saved_path.write_text("original\n", encoding="utf-8")
         saved_path.chmod(0o640)
-        expected_mode = stat.S_IMODE(saved_path.stat().st_mode)
 
         result = await engine.save_state(state)
 
         assert result.is_ok
-        assert stat.S_IMODE(saved_path.stat().st_mode) == expected_mode
+        assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
 
     @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
     @pytest.mark.asyncio

--- a/tests/unit/bigbang/test_pm_seed_save.py
+++ b/tests/unit/bigbang/test_pm_seed_save.py
@@ -11,7 +11,6 @@ import json
 import os
 from pathlib import Path
 import stat
-import tempfile
 from typing import IO
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -131,7 +130,7 @@ class TestPMSeedSaveJSON:
         saved_path.write_text("original\n", encoding="utf-8")
 
         with (
-            patch("tempfile.mkstemp", wraps=tempfile.mkstemp) as mock_mkstemp,
+            patch("os.open", wraps=os.open) as mock_open,
             patch("os.fsync") as mock_fsync,
             patch("os.replace", side_effect=OSError("boom")),
         ):
@@ -139,8 +138,9 @@ class TestPMSeedSaveJSON:
                 engine.save_pm_seed(seed, output_dir=seeds_dir)
 
         assert saved_path.read_text(encoding="utf-8") == "original\n"
-        assert mock_mkstemp.call_count == 1
-        assert mock_mkstemp.call_args.kwargs["dir"] == str(seeds_dir)
+        temp_creations = [call for call in mock_open.call_args_list if call.args[1] & os.O_EXCL]
+        assert len(temp_creations) == 1
+        assert Path(temp_creations[0].args[0]).parent == seeds_dir
         mock_fsync.assert_called_once()
         assert {path.name for path in seeds_dir.iterdir()} == {saved_path.name}
 
@@ -150,16 +150,17 @@ class TestPMSeedSaveJSON:
         seeds_dir = tmp_path / "seeds"
         created_fds: list[int] = []
         created_paths: list[Path] = []
-        real_mkstemp = tempfile.mkstemp
+        real_open = os.open
 
-        def _recording_mkstemp(*args, **kwargs):
-            fd, name = real_mkstemp(*args, **kwargs)
-            created_fds.append(fd)
-            created_paths.append(Path(name))
-            return fd, name
+        def _recording_open(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_EXCL:
+                created_fds.append(fd)
+                created_paths.append(Path(path))
+            return fd
 
         with (
-            patch("tempfile.mkstemp", side_effect=_recording_mkstemp),
+            patch("os.open", side_effect=_recording_open),
             patch("os.fdopen", side_effect=RuntimeError("fdopen failed")),
             pytest.raises(RuntimeError, match="fdopen failed"),
         ):
@@ -190,7 +191,13 @@ class TestPMSeedSaveJSON:
         assert saved_path.read_text(encoding="utf-8") == "original\n"
         assert {path.name for path in seeds_dir.iterdir()} == {saved_path.name}
 
-    def test_preserves_existing_file_mode(self, tmp_path: Path) -> None:
+    def test_narrows_an_existing_readable_file_mode(self, tmp_path: Path) -> None:
+        """A PM Seed left readable by an older version is narrowed, not kept.
+
+        The mode is deliberately NOT preserved: the Seed carries whatever the
+        PM confirmed during the interview, and preserving the previous mode
+        would keep an older version's group-readable file readable forever.
+        """
         engine = _make_engine(tmp_path)
         seed = _make_seed()
         seeds_dir = tmp_path / "seeds"
@@ -198,12 +205,11 @@ class TestPMSeedSaveJSON:
         saved_path = seeds_dir / f"{seed.pm_id}.json"
         saved_path.write_text("original\n", encoding="utf-8")
         saved_path.chmod(0o640)
-        expected_mode = stat.S_IMODE(saved_path.stat().st_mode)
 
         result = engine.save_pm_seed(seed, output_dir=seeds_dir)
 
         assert result == saved_path
-        assert stat.S_IMODE(saved_path.stat().st_mode) == expected_mode
+        assert stat.S_IMODE(saved_path.stat().st_mode) == 0o600
 
     @pytest.mark.skipif(os.name != "posix", reason="directory fsync is POSIX-only")
     def test_fsyncs_file_and_parent_directory(self, tmp_path: Path) -> None:

--- a/tests/unit/cli/test_pm_runtime_adapter.py
+++ b/tests/unit/cli/test_pm_runtime_adapter.py
@@ -3,14 +3,100 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
+import stat
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
 import typer
 
-from ouroboros.cli.commands.pm import _run_pm_interview, pm_command
+from ouroboros.cli.commands.pm import _run_pm_interview, _save_cli_pm_meta, pm_command
 from ouroboros.core.types import Result
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _make_pm_meta_engine() -> SimpleNamespace:
+    return SimpleNamespace(
+        _reframe_map={},
+        deferred_items=[],
+        decide_later_items=[],
+        codebase_context="",
+        _selected_brownfield_repos=[],
+        classifications=[],
+    )
+
+
+def test_save_cli_pm_meta_is_owner_only_under_umask_022(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI pm_meta lives in the package-owned data dir and is always 0600."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    previous_umask = os.umask(0o022)
+    try:
+        _save_cli_pm_meta("sess-owner", _make_pm_meta_engine())
+    finally:
+        os.umask(previous_umask)
+
+    data_dir = tmp_path / ".ouroboros" / "data"
+    meta_path = data_dir / "pm_meta_sess-owner.json"
+    assert _mode(data_dir) == 0o700
+    assert _mode(meta_path) == 0o600
+
+
+def test_save_cli_pm_meta_failure_propagates_without_leftover_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI pm_meta persistence keeps the owner-only writer's failure contract."""
+    import ouroboros.cli.commands.pm as pm
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+
+    def _fail_write(*_args: object, **_kwargs: object) -> bool:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(pm, "write_owner_only", _fail_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        _save_cli_pm_meta("sess-fail", _make_pm_meta_engine())
+
+    assert not (tmp_path / ".ouroboros" / "data" / "pm_meta_sess-fail.json").exists()
+
+
+def test_save_cli_pm_meta_logs_unconfirmed_durability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI helper returns None, so unconfirmed durability is logged."""
+    import ouroboros.cli.commands.pm as pm
+
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    monkeypatch.setattr(pm, "write_owner_only", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        pm.log,
+        "warning",
+        lambda event, **kwargs: warnings.append((event, kwargs)),
+    )
+
+    _save_cli_pm_meta("sess-uncertain", _make_pm_meta_engine())
+
+    assert warnings == [
+        (
+            "pm.meta_save_durability_unconfirmed",
+            {
+                "session_id": "sess-uncertain",
+                "path": str(tmp_path / ".ouroboros" / "data" / "pm_meta_sess-uncertain.json"),
+            },
+        )
+    ]
 
 
 def test_run_pm_interview_uses_factory_for_interview_adapter_on_resume() -> None:

--- a/tests/unit/core/test_owner_only.py
+++ b/tests/unit/core/test_owner_only.py
@@ -538,3 +538,54 @@ def test_native_windows_degrades_loudly_instead_of_refusing(
     assert len(degradations) == 1, "the degradation must be stated exactly once per process"
     # Atomic on that platform too: no temporary survives.
     assert [path.name for path in tmp_path.iterdir()] == ["secret.json"]
+
+
+def test_fanout_registry_register_is_owner_only(tmp_path: Path) -> None:
+    """A fan-out record carries the producer's request verbatim.
+
+    ``synthesizer_input`` is the code-investigation request or the persona
+    panel entries the transcript produced, so the record is the same artifact
+    class and takes the same writer. This site was still on ``write_text`` and
+    produced 0644 under a 022 umask.
+    """
+    from ouroboros.mcp.tools.subagent import FANOUT_KIND_CODE_INVESTIGATION, FanoutRegistry
+
+    registry = FanoutRegistry(tmp_path / "fanout")
+    fanout_id = registry.register(
+        kind=FANOUT_KIND_CODE_INVESTIGATION,
+        session_id="sess-mode",
+        correlation_key="context.lane_id",
+        expected_keys=["code_facts"],
+        synthesizer_input={"request": {"question": "which module owns auth?"}},
+    )
+    saved = tmp_path / "fanout" / f"{fanout_id}.json"
+
+    assert _mode(saved) == 0o600
+    assert registry.load(fanout_id) is not None
+
+
+def test_fanout_registry_narrows_a_record_left_at_0644(tmp_path: Path) -> None:
+    """A record written before this change is narrowed on the next write."""
+    from ouroboros.mcp.tools.subagent import FANOUT_KIND_CODE_INVESTIGATION, FanoutRegistry
+
+    registry = FanoutRegistry(tmp_path / "fanout")
+    fanout_id = registry.register(
+        kind=FANOUT_KIND_CODE_INVESTIGATION,
+        session_id="sess-narrow",
+        correlation_key="context.lane_id",
+        expected_keys=["code_facts"],
+        synthesizer_input={},
+    )
+    saved = tmp_path / "fanout" / f"{fanout_id}.json"
+    saved.chmod(0o644)
+
+    registry.register(
+        kind=FANOUT_KIND_CODE_INVESTIGATION,
+        session_id="sess-narrow",
+        correlation_key="context.lane_id",
+        expected_keys=["code_facts"],
+        synthesizer_input={},
+        fanout_id=fanout_id,
+    )
+
+    assert _mode(saved) == 0o600

--- a/tests/unit/core/test_owner_only.py
+++ b/tests/unit/core/test_owner_only.py
@@ -1,0 +1,540 @@
+"""Every file that holds interview or data content is owner-only.
+
+The protection cannot be an instruction to each writer to remember: a call
+site that forgets is invisible. These tests pin the property at each site that
+persists this class of content, including the case that mattered — a state
+directory inherited at 0755 from an earlier version.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import stat
+from typing import Any
+
+import pytest
+
+from ouroboros.core.owner_only import secure_directory, write_owner_only
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_write_owner_only_never_exists_at_the_umask_default(tmp_path: Path) -> None:
+    target = tmp_path / "secret.json"
+    write_owner_only(target, '{"answer": "confirmed"}')
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == '{"answer": "confirmed"}'
+
+
+def test_secure_directory_repairs_an_inherited_open_namespace_directory(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Inside ~/.ouroboros the directory is ours — an inherited 0755 is repaired."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+    directory = tmp_path / ".ouroboros" / "data"
+    directory.mkdir(parents=True, mode=0o755)
+    os.chmod(directory, 0o755)
+    secure_directory(directory)
+    assert _mode(directory) == 0o700
+
+
+def test_secure_directory_leaves_a_caller_supplied_directory_alone(tmp_path: Path) -> None:
+    """Outside the namespace the directory is the caller's.
+
+    An explicitly supplied 0755 state directory was being narrowed to 0700,
+    revoking collaborator access this package had no business revoking.
+    Ownership follows the path's provenance, not which module calls mkdir.
+    """
+    directory = tmp_path / "shared-state"
+    directory.mkdir(mode=0o755)
+    os.chmod(directory, 0o755)
+    secure_directory(directory)
+    assert _mode(directory) == 0o755
+
+
+def test_interview_state_is_owner_only(tmp_path: Path) -> None:
+    """The transcript holds confirmed data answers and lives indefinitely.
+
+    The FILE is owner-only wherever it lands; a caller-supplied state
+    directory keeps its own permissions — this is the reviewer's
+    probe: InterviewEngine(state_dir=<existing 0755 dir>).
+    """
+    from ouroboros.bigbang.interview import InterviewEngine, InterviewState
+
+    state_dir = tmp_path / "data"
+    state_dir.mkdir(mode=0o755)
+    os.chmod(state_dir, 0o755)
+
+    engine: Any = InterviewEngine.__new__(InterviewEngine)
+    engine.state_dir = state_dir
+    state = InterviewState(interview_id="iv_owner_only", initial_context="ctx")
+    asyncio.run(engine.save_state(state))
+
+    saved = state_dir / "interview_iv_owner_only.json"
+    assert _mode(saved) == 0o600
+    assert _mode(state_dir) == 0o755
+
+
+def test_overwriting_an_existing_open_file_upgrades_it(tmp_path: Path) -> None:
+    """The creation mode is ignored for a file that already exists.
+
+    A Seed or transcript left at 0644 by an earlier version must not keep that
+    mode just because the write reuses the inode.
+    """
+    target = tmp_path / "existing.yaml"
+    target.write_text("old", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    write_owner_only(target, "new")
+
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_writing_does_not_re_permission_the_callers_directory(tmp_path: Path) -> None:
+    """A Seed goes wherever the caller asks — often a shared project directory.
+
+    Narrowing that directory would be this package changing something that is
+    not its own. Only the file it writes is its business.
+    """
+    project = tmp_path / "project"
+    project.mkdir(mode=0o755)
+    os.chmod(project, 0o755)
+
+    write_owner_only(project / "seed.yaml", "seed: {}")
+
+    assert _mode(project) == 0o755
+    assert _mode(project / "seed.yaml") == 0o600
+
+
+def test_seed_save_leaves_the_target_directory_alone(tmp_path: Path) -> None:
+    """The Seed writer must not chmod a caller-controlled parent."""
+    from ouroboros.bigbang.seed_generator import save_seed_sync
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    os.chmod(shared, 0o755)
+    seed_path = shared / "seed.yaml"
+
+    seed = Seed(
+        metadata=SeedMetadata(),
+        goal="ship the lane",
+        task_type="code",
+        constraints=("Python 3.14+",),
+        acceptance_criteria=("The lane answers",),
+        ontology_schema=OntologySchema(name="lane", description="lane domain"),
+        evaluation_principles=(
+            EvaluationPrinciple(name="completeness", description="all done", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(name="done", description="criteria pass", criteria="100% satisfied"),
+        ),
+    )
+    result = save_seed_sync(seed, seed_path)
+    assert result.is_ok, result.error if result.is_err else None
+
+    assert _mode(shared) == 0o755
+    assert _mode(seed_path) == 0o600
+
+
+def test_the_mode_is_established_not_repaired(tmp_path: Path) -> None:
+    """Content reaches disk only through a file created owner-only.
+
+    The earlier version chmod'd an existing file and suppressed failure, so a
+    filesystem or ownership that refused the repair got the new secret at the
+    old mode. Establishing the mode at creation removes the failure branch
+    entirely, and the replacement is atomic so no reader sees a partial file.
+    """
+    target = tmp_path / "seed.yaml"
+    target.write_text("old", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    write_owner_only(target, "SECRET")
+
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == "SECRET"
+    # No temporary is left behind on success.
+    assert [entry.name for entry in tmp_path.iterdir() if entry.name.startswith(".")] == []
+
+
+def test_a_failed_write_leaves_nothing_behind(tmp_path: Path, monkeypatch: Any) -> None:
+    """A write that cannot complete must not deposit the content anywhere."""
+    import ouroboros.core.owner_only as owner_only
+
+    target = tmp_path / "seed.yaml"
+    original_write = os.fdopen
+
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        handle = original_write(*args, **kwargs)
+        handle.close()
+        raise OSError("disk full")
+
+    monkeypatch.setattr(owner_only.os, "fdopen", _explode)
+    try:
+        owner_only.write_owner_only(target, "SECRET")
+    except OSError:
+        pass
+    else:  # pragma: no cover - the monkeypatch always raises
+        raise AssertionError("expected the write to fail")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_every_transport_that_persists_a_transcript_is_owner_only(tmp_path: Path) -> None:
+    """The plugin interview path writes the same transcript the stdio one does.
+
+    Round-62 found it still on ``write_text``: a fourth persistence site behind
+    three that had been converted. The class is "files carrying interview,
+    PM, Seed, or fan-out content", and every member of it goes through the
+    owner-only writer.
+    """
+    import asyncio
+
+    from ouroboros.bigbang.interview import InterviewState
+    from ouroboros.mcp.tools.authoring_handlers import _plugin_save_state
+
+    state_dir = tmp_path / "data"
+    state_dir.mkdir(mode=0o755)
+    os.chmod(state_dir, 0o755)
+
+    state = InterviewState(interview_id="iv_plugin", initial_context="ctx")
+    result = asyncio.run(_plugin_save_state(state_dir, state))
+    assert result.is_ok, result.error if result.is_err else None
+
+    saved = Path(result.value)
+    assert _mode(saved) == 0o600
+    # The directory is caller-supplied (outside ~/.ouroboros), so its
+    # permissions are its own; the FILE carries the guarantee.
+    assert _mode(saved.parent) == 0o755
+
+
+def test_owner_only_write_reports_durability(tmp_path: Path) -> None:
+    """The owner-only write is also the durable write.
+
+    Round-64 merged two independently-added guarantees: main gained an atomic
+    write that fsyncs and reports durability, this branch gained owner-only
+    creation. Resolving the conflict either way would have dropped one of
+    them silently, so the write returns the durability signal it replaced.
+    """
+    target = tmp_path / "state.json"
+    assert write_owner_only(target, "{}") is True
+    assert _mode(target) == 0o600
+
+
+def test_owner_only_write_does_not_inherit_an_existing_open_mode(tmp_path: Path) -> None:
+    """The mode is established at creation, never carried over from the target.
+
+    An atomic-write helper conventionally preserves the previous mode. That is
+    exactly what would keep a 0644 transcript written by an older version
+    world-readable forever.
+    """
+    target = tmp_path / "legacy.json"
+    target.write_text("{}", encoding="utf-8")
+    os.chmod(target, 0o644)
+    assert _mode(target) == 0o644
+
+    write_owner_only(target, '{"round": 64}')
+
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == '{"round": 64}'
+
+
+def test_durability_is_reported_not_swallowed(tmp_path: Path, monkeypatch: Any) -> None:
+    """A directory fsync that genuinely fails is surfaced, not suppressed.
+
+    The caller logs on an unconfirmed write; if the failure were swallowed the
+    log would claim a durability the filesystem never gave.
+    """
+    import errno as _errno
+
+    from ouroboros.core import owner_only
+
+    real_fsync = os.fsync
+    target = tmp_path / "state.json"
+
+    def _fail_directory_fsync(fd: int) -> None:
+        if os.path.isdir(f"/dev/fd/{fd}") or stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(_errno.EIO, "directory fsync failed")
+        real_fsync(fd)
+
+    monkeypatch.setattr(owner_only.os, "fsync", _fail_directory_fsync)
+
+    assert write_owner_only(target, "{}") is False
+    # The content is still written and still owner-only — only the durability
+    # claim is withheld.
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == "{}"
+
+
+def test_no_descriptor_leaks_when_the_file_object_cannot_be_created(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The raw descriptor is closed when nothing takes ownership of it.
+
+    Between ``os.open`` and ``os.fdopen`` the descriptor belongs to no file
+    object, so a failure there leaks it — a long-lived server would exhaust
+    its descriptors one failed transcript write at a time.
+    """
+    from ouroboros.core import owner_only
+
+    opened: list[int] = []
+    real_open = os.open
+
+    def _recording_open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        fd = real_open(path, flags, *args, **kwargs)
+        if flags & os.O_EXCL:
+            opened.append(fd)
+        return fd
+
+    def _failing_fdopen(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("fdopen failed")
+
+    monkeypatch.setattr(owner_only.os, "open", _recording_open)
+    monkeypatch.setattr(owner_only.os, "fdopen", _failing_fdopen)
+
+    target = tmp_path / "state.json"
+    try:
+        write_owner_only(target, "{}")
+    except RuntimeError:
+        pass
+    else:  # pragma: no cover - the write must not succeed here
+        raise AssertionError("expected the fdopen failure to propagate")
+
+    assert opened, "the temporary was never created"
+    with pytest.raises(OSError):
+        os.fstat(opened[0])
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_auto_pipeline_state_is_owner_only(tmp_path: Path) -> None:
+    """Auto state holds the confirmed interview answers, including [from-data].
+
+    Reached through Auto rather than through the interview engine, this
+    writer was one of two still landing at the umask default.
+    """
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+    store = AutoStore(tmp_path / "data")
+    state = AutoPipelineState(goal="ship the thing", cwd=str(tmp_path))
+
+    path = store.save(state)
+
+    assert _mode(path) == 0o600
+    # Round-trips: narrowing the mode must not cost readability to its owner.
+    assert store.load(state.auto_session_id).auto_session_id == state.auto_session_id
+
+
+def test_auto_pipeline_state_narrows_an_inherited_open_file(tmp_path: Path) -> None:
+    """A state file left at 0644 by an earlier version is narrowed on save."""
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+    store = AutoStore(tmp_path / "data")
+    state = AutoPipelineState(goal="ship the thing", cwd=str(tmp_path))
+    path = store.save(state)
+    os.chmod(path, 0o644)
+    assert _mode(path) == 0o644
+
+    store.save(state)
+
+    assert _mode(path) == 0o600
+
+
+def test_auto_state_directory_is_not_re_permissioned(tmp_path: Path) -> None:
+    """`root` may be a directory the caller owns — narrowing it is not ours."""
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+    root = tmp_path / "caller-owned"
+    root.mkdir(mode=0o755)
+    os.chmod(root, 0o755)
+
+    AutoStore(root).save(AutoPipelineState(goal="ship the thing", cwd=str(tmp_path)))
+
+    assert _mode(root) == 0o755
+
+
+def _minimal_seed() -> Any:
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("The CLI exits non-zero on bad input",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+def test_auto_generated_seed_is_owner_only(tmp_path: Path) -> None:
+    """The Auto Seed writer was the one Seed path still at the umask default.
+
+    An auto-generated Seed carries the same requirement content as one written
+    through the interview path, including answers confirmed from a data
+    lookup.
+    """
+    from ouroboros.auto.adapters import save_seed
+
+    written = Path(save_seed(_minimal_seed(), seeds_dir=tmp_path / "seeds"))
+
+    assert _mode(written) == 0o600
+    assert written.read_text(encoding="utf-8")
+
+
+def test_auto_generated_seed_narrows_an_inherited_open_file(tmp_path: Path) -> None:
+    from ouroboros.auto.adapters import save_seed
+
+    seeds_dir = tmp_path / "seeds"
+    # The SAME Seed, so the rewrite lands on the same path — a fresh Seed
+    # would get a fresh seed_id and write a different file.
+    seed = _minimal_seed()
+    written = Path(save_seed(seed, seeds_dir=seeds_dir))
+    os.chmod(written, 0o644)
+    assert _mode(written) == 0o644
+
+    assert Path(save_seed(seed, seeds_dir=seeds_dir)) == written
+
+    assert _mode(written) == 0o600
+
+
+def test_auto_seed_directory_keeps_its_own_permissions(tmp_path: Path) -> None:
+    """`seeds_dir` may be a shared project directory the caller chose."""
+    from ouroboros.auto.adapters import save_seed
+
+    seeds_dir = tmp_path / "project-seeds"
+    seeds_dir.mkdir(mode=0o755)
+    os.chmod(seeds_dir, 0o755)
+
+    save_seed(_minimal_seed(), seeds_dir=seeds_dir)
+
+    assert _mode(seeds_dir) == 0o755
+
+
+def test_owner_only_write_survives_a_target_at_the_filename_limit(tmp_path: Path) -> None:
+    """A caller that bounded its filename must not be broken by the temporary.
+
+    The temporary used to embed the whole target name, adding a fixed 38
+    characters, so a name sized to the 255-byte limit — which the Auto Seed
+    writer produces deliberately — failed with ENAMETOOLONG before anything
+    was written.
+    """
+    name = "s" * (255 - len(".yaml")) + ".yaml"
+    target = tmp_path / name
+
+    assert write_owner_only(target, "goal: ship\n") is True
+
+    assert _mode(target) == 0o600
+    assert target.read_text(encoding="utf-8") == "goal: ship\n"
+    # And nothing was left behind.
+    assert [path.name for path in tmp_path.iterdir()] == [name]
+
+
+def test_no_bytes_are_written_when_the_filesystem_widens_the_mode(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The widened-mode check must run BEFORE the content exists.
+
+    This check exists for the filesystem that ignores or widens the requested
+    0600. Verifying it after the write meant that on exactly that filesystem
+    the content had already existed group- or world-readable — the window the
+    check was added to close.
+    """
+    from ouroboros.core import owner_only
+
+    real_open = os.open
+    widened: list[Path] = []
+
+    def _widening_open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        fd = real_open(path, flags, *args, **kwargs)
+        if flags & os.O_EXCL:
+            os.fchmod(fd, 0o644)  # the filesystem "ignores" the requested mode
+            widened.append(Path(path))
+        return fd
+
+    written: list[str] = []
+    real_fdopen = os.fdopen
+
+    def _recording_fdopen(fd: int, *args: Any, **kwargs: Any) -> Any:
+        written.append("fdopen")
+        return real_fdopen(fd, *args, **kwargs)
+
+    monkeypatch.setattr(owner_only.os, "open", _widening_open)
+    monkeypatch.setattr(owner_only.os, "fdopen", _recording_fdopen)
+
+    target = tmp_path / "secret.json"
+    with pytest.raises(OSError, match="owner-only"):
+        write_owner_only(target, '{"answer": "confirmed"}')
+
+    # The failure happened before anything could be wrapped for writing.
+    assert written == [], "content was written into a widened temporary"
+    assert not target.exists()
+    assert widened, "the probe never created a temporary"
+    assert list(tmp_path.iterdir()) == [], "a widened temporary was left behind"
+
+
+def test_native_windows_degrades_loudly_instead_of_refusing(
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: Any,
+) -> None:
+    """The guarantee is scoped to POSIX; Windows still writes, and says so.
+
+    Round 71 made this path refuse outright; round 72 pointed out native
+    Windows is an advertised (experimental) platform and refusing every
+    Interview/Seed/PM/Auto write makes it unusable. The write proceeds
+    atomically under the inherited ACL, the degradation is stated once per
+    process rather than discovered, and the vacuous mode check does not run —
+    a check that cannot fail must not stand in for a guarantee.
+    """
+    import logging
+
+    from ouroboros.core import owner_only
+
+    monkeypatch.setattr(owner_only, "_posix", lambda: False)
+    monkeypatch.setattr(owner_only, "_degradation_warned", False)
+
+    target = tmp_path / "secret.json"
+    with caplog.at_level(logging.WARNING, logger="ouroboros.core.owner_only"):
+        assert write_owner_only(target, '{"answer": "confirmed"}') is True
+        write_owner_only(target, '{"answer": "again"}')
+
+    assert target.read_text(encoding="utf-8") == '{"answer": "again"}'
+    degradations = [r for r in caplog.records if "inherited ACL" in r.getMessage()]
+    assert len(degradations) == 1, "the degradation must be stated exactly once per process"
+    # Atomic on that platform too: no temporary survives.
+    assert [path.name for path in tmp_path.iterdir()] == ["secret.json"]

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import stat
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -61,6 +62,10 @@ def _make_engine_stub(
         deferred_items=list(deferred or []),
         decide_later_items=list(decide_later or []),
     )
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
 
 
 def _make_state(
@@ -298,6 +303,71 @@ class TestPrdMetaFileLocation:
         assert nested_dir.exists()
         meta = _load_pm_meta("sess-nested", data_dir=nested_dir)
         assert meta is not None
+
+    def test_save_meta_is_owner_only_and_preserves_supplied_directory_mode(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Caller-supplied pm_meta directories keep their mode; meta files do not."""
+        previous_umask = os.umask(0o022)
+        try:
+            data_dir = tmp_path / "shared-data"
+            data_dir.mkdir(mode=0o755)
+            os.chmod(data_dir, 0o755)
+
+            _save_pm_meta("sess-owner", _make_engine_stub(), data_dir=data_dir)
+        finally:
+            os.umask(previous_umask)
+
+        assert _mode(data_dir) == 0o755
+        assert _mode(_meta_path("sess-owner", data_dir)) == 0o600
+
+    def test_save_meta_write_failure_propagates_without_leftover_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """PM meta persistence keeps the owner-only writer's failure contract."""
+        import ouroboros.mcp.tools.pm_handler as pmh
+
+        def _fail_write(*_args: object, **_kwargs: object) -> bool:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(pmh, "write_owner_only", _fail_write)
+
+        with pytest.raises(OSError, match="disk full"):
+            _save_pm_meta("sess-fail", _make_engine_stub(), data_dir=tmp_path)
+
+        assert not _meta_path("sess-fail", tmp_path).exists()
+
+    def test_save_meta_logs_unconfirmed_durability(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The helper returns None, so an unconfirmed durable write is logged."""
+        import ouroboros.mcp.tools.pm_handler as pmh
+
+        warnings: list[tuple[str, dict[str, object]]] = []
+
+        monkeypatch.setattr(pmh, "write_owner_only", lambda *_args, **_kwargs: False)
+        monkeypatch.setattr(
+            pmh.log,
+            "warning",
+            lambda event, **kwargs: warnings.append((event, kwargs)),
+        )
+
+        _save_pm_meta("sess-uncertain", _make_engine_stub(), data_dir=tmp_path)
+
+        assert warnings == [
+            (
+                "pm_handler.meta_save_durability_unconfirmed",
+                {
+                    "session_id": "sess-uncertain",
+                    "path": str(_meta_path("sess-uncertain", tmp_path)),
+                },
+            )
+        ]
 
     def test_meta_file_has_expected_fields(self, tmp_path: Path) -> None:
         """pm_meta JSON contains all required fields."""


### PR DESCRIPTION
Closes #1756.

First of three slices carved out of the closed combined PR #1749. This one is
independent of the other two: it is about file modes only, and touches neither
the advisory lane (#1754) nor interview provenance (#1755).

## Purpose

An interview transcript holds what the user typed, verbatim. A Seed holds what
was distilled from it. Auto pipeline state holds the same answers for as long
as the session record exists. All three are written at the umask default —
typically `0644` — and stay world-readable for their whole lifetime.

## What changed

`core/owner_only.py` is one primitive: create at `0600`, temp file plus
`os.replace`, fsync the parent directory, return whether durability was
confirmed. Five writers now call it.

| Writer | Was |
|---|---|
| `InterviewEngine.save_state` | `_atomic_write_text`, mode preserved |
| `_plugin_save_state` | `write_text`, no atomicity |
| `SeedGenerator.save_seed` / `save_seed_sync` | `write_text` |
| `PMInterviewEngine.save_pm_seed` | `_atomic_write_text` |
| `auto/adapters.py`, `auto/state.py` | `write_text` |

`interview.py`'s local `_atomic_write_text` is removed. It was careful about
atomicity and about *preserving* an existing mode, but a file it creates starts
at the umask default and preservation then keeps it there.
`cli/commands/setup.py` keeps its own same-named helper — those config files are
meant to be readable.

An existing `0644` file is narrowed on the next write rather than preserved.
Preserving it would mean the fix never reaches anyone already installed.

Directories are deliberately left alone. `seeds_dir` and Auto's `root` may be
caller-supplied and shared, and narrowing a directory this package does not own
is not its call. `state_dir`, which Ouroboros does own, is created secured.

## Success criteria

- Every writer above produces `0600`, including the plugin transport and both
  Auto paths.
- A file that already exists at `0644` is narrowed on the next write.
- A failed `os.replace` leaves the previous file intact with its content
  unchanged; an unconfirmed directory flush is logged and the caller's success
  return is unchanged.
- Caller-supplied directories keep their own permissions.
- `tests/unit`: 13,281 passed. Three failures are pre-existing and unrelated —
  two build a wheel via `uv build`, which cannot reach the network in this
  environment, and one asserts on orphaned-session cleanup; all three fail
  identically with this branch's changes stashed.

Two existing tests pinned the old contract and are updated rather than deleted:
mode preservation becomes mode narrowing, while the atomicity and fd-hygiene
assertions around them are kept and now cover the new writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## R-run comparison

| Metric | Baseline (sha) | This PR (sha) | Ratio |
|---|---|---|---|
| Rounds completed in 600 s | N/A | N/A | n/a |
| Per-round wall-clock (s/round) | N/A | N/A | n/a |
| Terminal reason | N/A | N/A | n/a |
| EventStore event count | N/A | N/A | n/a |

Budget compliance: [x] N/A (storage-only auto persistence change; no R-run behavior change)