### PR TITLE
feat(bigbang): extract EVALUATION_PRINCIPLES and EXIT_CONDITIONS as JSON object arrays (#1729 slice 2)

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -56,11 +56,11 @@ Field types should be one of: string, number, boolean, array, object
 
 ### 5. EVALUATION_PRINCIPLES
 Principles for evaluating output quality.
-Format: name:description:weight (pipe-separated, weight 0.0-1.0)
+Format: single-line JSON array of objects with "name", "description", and "weight" (0.0-1.0) so colons and pipes inside the text survive as data
 
 ### 6. EXIT_CONDITIONS
 Conditions that indicate the workflow should terminate.
-Format: name:description:criteria (pipe-separated)
+Format: single-line JSON array of objects with "name", "description", and "criteria"
 
 ### 7. BROWNFIELD CONTEXT (if applicable)
 If the interview mentions existing codebases, extract:
@@ -82,8 +82,8 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
-EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
-EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
+EVALUATION_PRINCIPLES: [{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}, ...]
+EXIT_CONDITIONS: [{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}, ...]
 PROJECT_TYPE: greenfield|brownfield
 CONTEXT_REFERENCES: <path>:<role>:<summary> | ...
 EXISTING_PATTERNS: ["<pattern 1>", "<pattern 2>", ...]

--- a/src/ouroboros/bigbang/requirement_distillation.py
+++ b/src/ouroboros/bigbang/requirement_distillation.py
@@ -272,11 +272,18 @@ def apply_requirement_distillation(
         "ontology_description": "Only user-authorized interview requirements.",
         "ontology_fields": "",
         "evaluation_principles": (
-            "confirmed_requirements:Evaluate only promoted user-authorized requirements:1.0"
+            EvaluationPrinciple(
+                name="confirmed_requirements",
+                description="Evaluate only promoted user-authorized requirements",
+                weight=1.0,
+            ),
         ),
         "exit_conditions": (
-            "confirmed_requirements_met:All promoted requirements are satisfied:"
-            "Every promoted acceptance criterion passes"
+            ExitCondition(
+                name="confirmed_requirements_met",
+                description="All promoted requirements are satisfied",
+                evaluation_criteria="Every promoted acceptance criterion passes",
+            ),
         ),
         "project_type": "greenfield",
     }

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import re
 from typing import Any
 
+from pydantic import ValidationError as PydanticValidationError
 import structlog
 import yaml
 
@@ -150,6 +151,10 @@ def _clamp_weight(raw_weight: object, *, field_label: str, strict: bool) -> floa
     of falling back to 1.0 on anything unparseable.
     """
     if raw_weight is None:
+        if strict:
+            raise ValueError(
+                f"{field_label} entry field 'weight' must be omitted or a number; got null."
+            )
         return 1.0
     if isinstance(raw_weight, bool) or not isinstance(raw_weight, int | float):
         if strict:
@@ -237,9 +242,13 @@ def _parse_evaluation_principles(
             return EvaluationPrinciple(
                 name=_require_object_string(entry, "name", field_label=field_label),
                 description=_require_object_string(entry, "description", field_label=field_label),
-                weight=_clamp_weight(entry.get("weight"), field_label=field_label, strict=strict),
+                weight=(
+                    _clamp_weight(entry["weight"], field_label=field_label, strict=strict)
+                    if "weight" in entry
+                    else 1.0
+                ),
             )
-        except ValueError:
+        except (ValueError, TypeError, PydanticValidationError):
             if strict:
                 raise
             return None
@@ -253,6 +262,8 @@ def _parse_evaluation_principles(
         return ()
     text = raw_value.strip()
     if not text:
+        if strict:
+            raise ValueError(f"{field_label} must be an explicit JSON array; got a blank value.")
         return ()
     decoded = _decode_object_array(text, field_label=field_label, strict=strict)
     if decoded is not None:
@@ -266,10 +277,14 @@ def _parse_evaluation_principles(
         parts = principle_str.split(":")
         if len(parts) < 2:
             continue
+        name = parts[0].strip()
+        description = parts[1].strip()
+        if not name or not description:
+            continue
         principles.append(
             EvaluationPrinciple(
-                name=parts[0].strip(),
-                description=parts[1].strip(),
+                name=name,
+                description=description,
                 weight=_clamp_weight(
                     parts[2].strip() if len(parts) >= 3 else None,
                     field_label=field_label,
@@ -312,7 +327,7 @@ def _parse_exit_conditions(raw_value: object, *, strict: bool = False) -> tuple[
                     aliases=("evaluation_criteria",),
                 ),
             )
-        except ValueError:
+        except (ValueError, TypeError, PydanticValidationError):
             if strict:
                 raise
             return None
@@ -326,6 +341,8 @@ def _parse_exit_conditions(raw_value: object, *, strict: bool = False) -> tuple[
         return ()
     text = raw_value.strip()
     if not text:
+        if strict:
+            raise ValueError(f"{field_label} must be an explicit JSON array; got a blank value.")
         return ()
     decoded = _decode_object_array(text, field_label=field_label, strict=strict)
     if decoded is not None:
@@ -339,11 +356,16 @@ def _parse_exit_conditions(raw_value: object, *, strict: bool = False) -> tuple[
         parts = condition_str.split(":")
         if len(parts) < 3:
             continue
+        name = parts[0].strip()
+        description = parts[1].strip()
+        criteria = ":".join(parts[2:]).strip()
+        if not name or not description or not criteria:
+            continue
         conditions.append(
             ExitCondition(
-                name=parts[0].strip(),
-                description=parts[1].strip(),
-                evaluation_criteria=":".join(parts[2:]).strip(),
+                name=name,
+                description=description,
+                evaluation_criteria=criteria,
             )
         )
     return tuple(conditions)

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -81,6 +81,14 @@ def _parse_string_array_values(
             array of strings.
     """
     if isinstance(raw_value, list | tuple):
+        if strict:
+            non_strings = tuple(
+                type(entry).__name__ for entry in raw_value if not isinstance(entry, str)
+            )
+            if non_strings:
+                raise ValueError(
+                    f"{field_label} array must contain only strings; got {', '.join(non_strings)}."
+                )
         return tuple(item for item in (str(entry).strip() for entry in raw_value) if item)
     if not isinstance(raw_value, str):
         return ()
@@ -115,6 +123,216 @@ def _parse_string_array_values(
             if isinstance(decoded, list):
                 return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
     return tuple(item.strip() for item in text.split("|") if item.strip())
+
+
+def _require_object_string(
+    entry: dict, key: str, *, field_label: str, aliases: tuple[str, ...] = ()
+) -> str:
+    """Return a required non-empty string value from an extraction object entry."""
+    for candidate in (key, *aliases):
+        if candidate in entry:
+            value = entry[candidate]
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            raise ValueError(
+                f"{field_label} entry field {candidate!r} must be a non-empty string; "
+                f"got {value!r}."
+            )
+    raise ValueError(f"{field_label} entry is missing required field {key!r}: {entry!r}")
+
+
+def _clamp_weight(raw_weight: object, *, field_label: str, strict: bool) -> float:
+    """Resolve an optional principle weight, clamped to [0.0, 1.0].
+
+    Strict mode requires a JSON number (bools rejected) so malformed weights
+    trigger the extraction retry; lenient mode keeps the historical behavior
+    of falling back to 1.0 on anything unparseable.
+    """
+    if raw_weight is None:
+        return 1.0
+    if isinstance(raw_weight, bool) or not isinstance(raw_weight, int | float):
+        if strict:
+            raise ValueError(
+                f"{field_label} entry field 'weight' must be a number; got {raw_weight!r}."
+            )
+        try:
+            return min(1.0, max(0.0, float(str(raw_weight).strip())))
+        except ValueError:
+            return 1.0
+    return min(1.0, max(0.0, float(raw_weight)))
+
+
+def _decode_object_array(text: str, *, field_label: str, strict: bool) -> list | None:
+    """Decode an extraction field into a JSON list, honoring the strict boundary.
+
+    Strict mode raises unless the text is a valid JSON array — the retry path
+    asks the LLM to reformat (#1729). Lenient mode returns the decoded list
+    only for valid bracket-led JSON arrays and ``None`` otherwise so callers
+    fall back to the historical colon/pipe split.
+    """
+    if strict:
+        try:
+            decoded = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"{field_label} must be a single-line JSON array of objects: {e}. "
+                f"Value: {text[:200]}"
+            ) from e
+        if not isinstance(decoded, list):
+            raise ValueError(
+                f"{field_label} must be a JSON array of objects, got "
+                f"{type(decoded).__name__}. Value: {text[:200]}"
+            )
+        return decoded
+    if not text.startswith("["):
+        return None
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, list) else None
+
+
+def _parse_evaluation_principles(
+    raw_value: object, *, strict: bool = False
+) -> tuple[EvaluationPrinciple, ...]:
+    """Parse EVALUATION_PRINCIPLES from JSON object arrays or the legacy pipe list.
+
+    The extraction format requests a single-line JSON array of
+    ``{"name", "description", "weight"}`` objects so colons and pipes inside
+    the data survive (#1729 slice 2). Strict mode (extraction time) raises on
+    anything else so the retry path can reformat; lenient mode (stored legacy
+    requirements) keeps the historical ``name:description:weight`` pipe split
+    and never raises.
+    """
+    field_label = "EVALUATION_PRINCIPLES"
+
+    def _build(entry: object) -> EvaluationPrinciple | None:
+        if isinstance(entry, EvaluationPrinciple):
+            return entry
+        if not isinstance(entry, dict):
+            if strict:
+                raise ValueError(
+                    f"{field_label} entries must be JSON objects; got "
+                    f"{type(entry).__name__}: {entry!r}"
+                )
+            return None
+        try:
+            return EvaluationPrinciple(
+                name=_require_object_string(entry, "name", field_label=field_label),
+                description=_require_object_string(entry, "description", field_label=field_label),
+                weight=_clamp_weight(entry.get("weight"), field_label=field_label, strict=strict),
+            )
+        except ValueError:
+            if strict:
+                raise
+            return None
+
+    def _build_all(entries: list | tuple) -> tuple[EvaluationPrinciple, ...]:
+        return tuple(built for built in (_build(entry) for entry in entries) if built)
+
+    if isinstance(raw_value, list | tuple):
+        return _build_all(raw_value)
+    if not isinstance(raw_value, str):
+        return ()
+    text = raw_value.strip()
+    if not text:
+        return ()
+    decoded = _decode_object_array(text, field_label=field_label, strict=strict)
+    if decoded is not None:
+        return _build_all(decoded)
+
+    principles: list[EvaluationPrinciple] = []
+    for principle_str in text.split("|"):
+        principle_str = principle_str.strip()
+        if not principle_str:
+            continue
+        parts = principle_str.split(":")
+        if len(parts) < 2:
+            continue
+        weight = 1.0
+        if len(parts) >= 3:
+            try:
+                weight = float(parts[2].strip())
+            except ValueError:
+                weight = 1.0
+        principles.append(
+            EvaluationPrinciple(
+                name=parts[0].strip(),
+                description=parts[1].strip(),
+                weight=min(1.0, max(0.0, weight)),
+            )
+        )
+    return tuple(principles)
+
+
+def _parse_exit_conditions(raw_value: object, *, strict: bool = False) -> tuple[ExitCondition, ...]:
+    """Parse EXIT_CONDITIONS from JSON object arrays or the legacy pipe list.
+
+    Mirrors :func:`_parse_evaluation_principles`: strict extraction demands a
+    JSON array of ``{"name", "description", "criteria"}`` objects (the
+    ``evaluation_criteria`` spelling is accepted too); lenient parsing keeps
+    the historical ``name:description:criteria`` split where the criteria
+    segment absorbs any further colons, and never raises.
+    """
+    field_label = "EXIT_CONDITIONS"
+
+    def _build(entry: object) -> ExitCondition | None:
+        if isinstance(entry, ExitCondition):
+            return entry
+        if not isinstance(entry, dict):
+            if strict:
+                raise ValueError(
+                    f"{field_label} entries must be JSON objects; got "
+                    f"{type(entry).__name__}: {entry!r}"
+                )
+            return None
+        try:
+            return ExitCondition(
+                name=_require_object_string(entry, "name", field_label=field_label),
+                description=_require_object_string(entry, "description", field_label=field_label),
+                evaluation_criteria=_require_object_string(
+                    entry,
+                    "criteria",
+                    field_label=field_label,
+                    aliases=("evaluation_criteria",),
+                ),
+            )
+        except ValueError:
+            if strict:
+                raise
+            return None
+
+    def _build_all(entries: list | tuple) -> tuple[ExitCondition, ...]:
+        return tuple(built for built in (_build(entry) for entry in entries) if built)
+
+    if isinstance(raw_value, list | tuple):
+        return _build_all(raw_value)
+    if not isinstance(raw_value, str):
+        return ()
+    text = raw_value.strip()
+    if not text:
+        return ()
+    decoded = _decode_object_array(text, field_label=field_label, strict=strict)
+    if decoded is not None:
+        return _build_all(decoded)
+
+    conditions: list[ExitCondition] = []
+    for condition_str in text.split("|"):
+        condition_str = condition_str.strip()
+        if not condition_str:
+            continue
+        parts = condition_str.split(":")
+        if len(parts) < 3:
+            continue
+        conditions.append(
+            ExitCondition(
+                name=parts[0].strip(),
+                description=parts[1].strip(),
+                evaluation_criteria=":".join(parts[2:]).strip(),
+            )
+        )
+    return tuple(conditions)
 
 
 def _parse_acceptance_criteria_contracts(
@@ -644,8 +862,8 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
-EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
-EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
+EVALUATION_PRINCIPLES: [{{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}}, ...]
+EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}}, ...]
 {self._project_type_template(is_brownfield=is_brownfield)}"""
 
     @staticmethod
@@ -751,8 +969,8 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
-EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
-EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
+EVALUATION_PRINCIPLES: [{{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}}, ...]
+EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}}, ...]
 {self._project_type_template(is_brownfield=is_brownfield)}"""
 
     _KNOWN_PREFIXES = (
@@ -870,6 +1088,14 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
                 requirements[field_name] = _parse_string_array_values(
                     requirements[field_name], field_label=field_label, strict=True
                 )
+        if "evaluation_principles" in requirements:
+            requirements["evaluation_principles"] = _parse_evaluation_principles(
+                requirements["evaluation_principles"], strict=True
+            )
+        if "exit_conditions" in requirements:
+            requirements["exit_conditions"] = _parse_exit_conditions(
+                requirements["exit_conditions"], strict=True
+            )
 
         return requirements
 
@@ -919,45 +1145,12 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
             fields=tuple(ontology_fields),
         )
 
-        # Parse evaluation principles
-        evaluation_principles: list[EvaluationPrinciple] = []
-        if "evaluation_principles" in requirements and requirements["evaluation_principles"]:
-            for principle_str in requirements["evaluation_principles"].split("|"):
-                principle_str = principle_str.strip()
-                if not principle_str:
-                    continue
-                parts = principle_str.split(":")
-                if len(parts) >= 2:
-                    weight = 1.0
-                    if len(parts) >= 3:
-                        try:
-                            weight = float(parts[2].strip())
-                        except ValueError:
-                            weight = 1.0
-                    evaluation_principles.append(
-                        EvaluationPrinciple(
-                            name=parts[0].strip(),
-                            description=parts[1].strip(),
-                            weight=min(1.0, max(0.0, weight)),
-                        )
-                    )
-
-        # Parse exit conditions
-        exit_conditions: list[ExitCondition] = []
-        if "exit_conditions" in requirements and requirements["exit_conditions"]:
-            for condition_str in requirements["exit_conditions"].split("|"):
-                condition_str = condition_str.strip()
-                if not condition_str:
-                    continue
-                parts = condition_str.split(":")
-                if len(parts) >= 3:
-                    exit_conditions.append(
-                        ExitCondition(
-                            name=parts[0].strip(),
-                            description=parts[1].strip(),
-                            evaluation_criteria=":".join(parts[2:]).strip(),
-                        )
-                    )
+        # Parse evaluation principles and exit conditions (JSON object arrays
+        # preferred; legacy colon/pipe lists supported for stored requirements)
+        evaluation_principles = _parse_evaluation_principles(
+            requirements.get("evaluation_principles")
+        )
+        exit_conditions = _parse_exit_conditions(requirements.get("exit_conditions"))
 
         # Parse brownfield context
         brownfield_context = BrownfieldContext()

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -99,7 +99,9 @@ def _parse_string_array_values(
         return ()
     if strict:
         try:
-            decoded = json.loads(text)
+            decoded = json.loads(
+                text, parse_int=_bounded_json_int, parse_constant=_JsonNonFiniteToken
+            )
         except json.JSONDecodeError as e:
             raise ValueError(
                 f"{field_label} must be a single-line JSON array of strings: {e}. Value: {text[:200]}"
@@ -125,6 +127,39 @@ def _parse_string_array_values(
             if isinstance(decoded, list):
                 return tuple(item for item in (str(entry).strip() for entry in decoded) if item)
     return tuple(item.strip() for item in text.split("|") if item.strip())
+
+
+class _JsonNonFiniteToken:
+    """Marks a non-standard JSON constant (NaN/Infinity) seen during decoding.
+
+    These tokens are not JSON numbers, so strict extraction must retry them
+    while lenient parsing falls back to the default weight — unlike genuine
+    numeric overflow, which saturates by sign (review round three).
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __repr__(self) -> str:
+        return self.token
+
+
+_JSON_INT_SATURATION_DIGITS = 400
+
+
+def _bounded_json_int(text: str) -> int | float:
+    """Decode a JSON integer, saturating past a fixed digit bound.
+
+    CPython raises a plain ``ValueError`` (not ``JSONDecodeError``) when an
+    integer literal exceeds its conversion digit limit, which would escape the
+    lenient never-raises contract and turn a syntactically valid number into a
+    strict retry. Anything beyond the bound saturates to a signed infinity so
+    the weight clamp resolves it deterministically in both modes.
+    """
+    digits = text.lstrip("+-")
+    if len(digits) > _JSON_INT_SATURATION_DIGITS:
+        return float("-inf") if text.lstrip().startswith("-") else float("inf")
+    return int(text)
 
 
 def _require_object_string(
@@ -165,21 +200,33 @@ def _clamp_weight(raw_weight: object, *, field_label: str, strict: bool) -> floa
             numeric = float(str(raw_weight).strip())
         except (ValueError, OverflowError):
             return 1.0
-        return min(1.0, max(0.0, numeric)) if math.isfinite(numeric) else 1.0
+        if math.isnan(numeric):
+            return 1.0
+        if math.isinf(numeric):
+            # Saturate overflow by sign so a negative overflow keeps the
+            # historical 0.0 clamp (review round three).
+            return 1.0 if numeric > 0 else 0.0
+        return min(1.0, max(0.0, numeric))
     if isinstance(raw_weight, int):
         # Clamp in integer space: arbitrary-precision JSON integers would
         # overflow float() (an OverflowError the retry path does not catch),
         # and the clamp result is what any out-of-range number gets anyway.
         return float(min(max(raw_weight, 0), 1))
     if not math.isfinite(raw_weight):
-        # Python's json.loads accepts the non-standard NaN/Infinity tokens;
-        # they are not JSON numbers, so strict extraction retries and lenient
-        # parsing keeps the historical 1.0 fallback.
-        if strict:
-            raise ValueError(
-                f"{field_label} entry field 'weight' must be a finite number; got {raw_weight!r}."
-            )
-        return 1.0
+        # A NaN float cannot come from a JSON number (the non-standard tokens
+        # decode to _JsonNonFiniteToken and are handled above), so it only
+        # appears in pre-decoded input: strict retries it, lenient defaults.
+        if math.isnan(raw_weight):
+            if strict:
+                raise ValueError(
+                    f"{field_label} entry field 'weight' must be a finite number; "
+                    f"got {raw_weight!r}."
+                )
+            return 1.0
+        # Genuine numeric overflow (e.g. 1e999 or an integer past the decode
+        # bound) is a valid JSON number and follows the clamp contract in both
+        # modes, saturating by sign (review round three).
+        return 1.0 if raw_weight > 0 else 0.0
     return min(1.0, max(0.0, raw_weight))
 
 
@@ -193,7 +240,9 @@ def _decode_object_array(text: str, *, field_label: str, strict: bool) -> list |
     """
     if strict:
         try:
-            decoded = json.loads(text)
+            decoded = json.loads(
+                text, parse_int=_bounded_json_int, parse_constant=_JsonNonFiniteToken
+            )
         except json.JSONDecodeError as e:
             raise ValueError(
                 f"{field_label} must be a single-line JSON array of objects: {e}. "
@@ -208,8 +257,8 @@ def _decode_object_array(text: str, *, field_label: str, strict: bool) -> list |
     if not text.startswith("["):
         return None
     try:
-        decoded = json.loads(text)
-    except json.JSONDecodeError:
+        decoded = json.loads(text, parse_int=_bounded_json_int, parse_constant=_JsonNonFiniteToken)
+    except (json.JSONDecodeError, ValueError):
         return None
     return decoded if isinstance(decoded, list) else None
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -13,6 +13,7 @@ The SeedGenerator:
 
 from dataclasses import dataclass, field
 import json
+import math
 from pathlib import Path
 import re
 from typing import Any
@@ -156,10 +157,25 @@ def _clamp_weight(raw_weight: object, *, field_label: str, strict: bool) -> floa
                 f"{field_label} entry field 'weight' must be a number; got {raw_weight!r}."
             )
         try:
-            return min(1.0, max(0.0, float(str(raw_weight).strip())))
-        except ValueError:
+            numeric = float(str(raw_weight).strip())
+        except (ValueError, OverflowError):
             return 1.0
-    return min(1.0, max(0.0, float(raw_weight)))
+        return min(1.0, max(0.0, numeric)) if math.isfinite(numeric) else 1.0
+    if isinstance(raw_weight, int):
+        # Clamp in integer space: arbitrary-precision JSON integers would
+        # overflow float() (an OverflowError the retry path does not catch),
+        # and the clamp result is what any out-of-range number gets anyway.
+        return float(min(max(raw_weight, 0), 1))
+    if not math.isfinite(raw_weight):
+        # Python's json.loads accepts the non-standard NaN/Infinity tokens;
+        # they are not JSON numbers, so strict extraction retries and lenient
+        # parsing keeps the historical 1.0 fallback.
+        if strict:
+            raise ValueError(
+                f"{field_label} entry field 'weight' must be a finite number; got {raw_weight!r}."
+            )
+        return 1.0
+    return min(1.0, max(0.0, raw_weight))
 
 
 def _decode_object_array(text: str, *, field_label: str, strict: bool) -> list | None:
@@ -250,17 +266,15 @@ def _parse_evaluation_principles(
         parts = principle_str.split(":")
         if len(parts) < 2:
             continue
-        weight = 1.0
-        if len(parts) >= 3:
-            try:
-                weight = float(parts[2].strip())
-            except ValueError:
-                weight = 1.0
         principles.append(
             EvaluationPrinciple(
                 name=parts[0].strip(),
                 description=parts[1].strip(),
-                weight=min(1.0, max(0.0, weight)),
+                weight=_clamp_weight(
+                    parts[2].strip() if len(parts) >= 3 else None,
+                    field_label=field_label,
+                    strict=False,
+                ),
             )
         )
     return tuple(principles)

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1453,6 +1453,28 @@ class TestObjectArrayExtractionContract:
         )
         assert [p.weight for p in principles] == [1.0, 1.0, 0.0]
 
+    def test_strict_rejects_blank_object_array_fields(self) -> None:
+        with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
+            _parse_evaluation_principles("", strict=True)
+        with pytest.raises(ValueError, match="EXIT_CONDITIONS"):
+            _parse_exit_conditions("   ", strict=True)
+
+        assert _parse_evaluation_principles("[]", strict=True) == ()
+        assert _parse_exit_conditions("[]", strict=True) == ()
+
+    def test_strict_distinguishes_omitted_weight_from_explicit_null(self) -> None:
+        omitted = _parse_evaluation_principles(
+            '[{"name": "a", "description": "omitted weight"}]',
+            strict=True,
+        )
+        assert omitted[0].weight == 1.0
+
+        with pytest.raises(ValueError, match="weight"):
+            _parse_evaluation_principles(
+                '[{"name": "a", "description": "null weight", "weight": null}]',
+                strict=True,
+            )
+
     def test_strict_rejects_legacy_pipe_lines(self) -> None:
         with pytest.raises(ValueError, match="JSON array"):
             _parse_evaluation_principles(
@@ -1473,6 +1495,7 @@ class TestObjectArrayExtractionContract:
             '[{"name": "x", "description": ""}]',
             '[{"name": "x", "description": "d", "weight": "high"}]',
             '[{"name": "x", "description": "d", "weight": true}]',
+            '[{"name": "x", "description": "d", "weight": null}]',
         )
         for malformed in malformed_principles:
             with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
@@ -1504,6 +1527,29 @@ class TestObjectArrayExtractionContract:
                 name="all_met",
                 description="All pass",
                 evaluation_criteria="100% satisfied:with margin",
+            ),
+        )
+
+    def test_lenient_skips_malformed_legacy_principle_entries_without_raising(self) -> None:
+        assert _parse_evaluation_principles(
+            ":description:0.5 | complete::0.4 | valid:Description:0.25"
+        ) == (EvaluationPrinciple(name="valid", description="Description", weight=0.25),)
+
+    def test_lenient_null_weight_defaults_without_raising(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "x", "description": "d", "weight": null}]'
+        )
+        assert principles[0].weight == 1.0
+        assert _parse_exit_conditions("done:desc:   ") == ()
+
+    def test_lenient_skips_malformed_legacy_exit_condition_entries_without_raising(self) -> None:
+        assert _parse_exit_conditions(
+            "done::criteria | :description:criteria | valid:Description:criteria"
+        ) == (
+            ExitCondition(
+                name="valid",
+                description="Description",
+                evaluation_criteria="criteria",
             ),
         )
 
@@ -1588,6 +1634,73 @@ class TestObjectArrayExtractionContract:
         assert mock_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field_name", "field_value"),
+        (
+            ("evaluation_principles", ""),
+            ("exit_conditions", "   "),
+        ),
+    )
+    async def test_blank_object_array_field_triggers_extraction_retry(
+        self, field_name: str, field_value: str
+    ) -> None:
+        malformed = create_valid_extraction_response(**{field_name: field_value})
+        reformatted = create_valid_extraction_response(
+            evaluation_principles="[]",
+            exit_conditions="[]",
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles == ()
+        assert result.value.exit_conditions == ()
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_null_weight_triggers_extraction_retry(self) -> None:
+        malformed = create_valid_extraction_response(
+            evaluation_principles='[{"name": "x", "description": "d", "weight": null}]'
+        )
+        reformatted = create_valid_extraction_response(
+            evaluation_principles='[{"name": "x", "description": "d"}]'
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles[0].weight == 1.0
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_oversized_weight_does_not_crash_seed_generation(self) -> None:
         response = create_valid_extraction_response(
             evaluation_principles=(f'[{{"name": "x", "description": "d", "weight": {"9" * 400}}}]')
@@ -1608,66 +1721,6 @@ class TestObjectArrayExtractionContract:
 
         assert result.is_ok
         assert result.value.evaluation_principles[0].weight == 1.0
-
-    def test_strict_blank_field_requires_explicit_empty_array(self) -> None:
-        for blank in ("", "   "):
-            with pytest.raises(ValueError, match="JSON array"):
-                _parse_evaluation_principles(blank, strict=True)
-            with pytest.raises(ValueError, match="JSON array"):
-                _parse_exit_conditions(blank, strict=True)
-        assert _parse_evaluation_principles("[]", strict=True) == ()
-        assert _parse_exit_conditions("[]", strict=True) == ()
-
-    def test_strict_rejects_explicit_null_weight(self) -> None:
-        with pytest.raises(ValueError, match="weight"):
-            _parse_evaluation_principles(
-                '[{"name": "x", "description": "d", "weight": null}]', strict=True
-            )
-
-    def test_lenient_null_weight_and_blank_fields_never_raise(self) -> None:
-        principles = _parse_evaluation_principles(
-            '[{"name": "x", "description": "d", "weight": null}]'
-        )
-        assert principles[0].weight == 1.0
-        assert _parse_evaluation_principles(":description:0.5") == ()
-        assert _parse_evaluation_principles("name: | :d") == ()
-        assert _parse_exit_conditions("done::criteria") == ()
-        assert _parse_exit_conditions(":d:criteria") == ()
-        assert _parse_exit_conditions("done:desc:  ") == ()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("field_kwargs",),
-        (
-            ({"evaluation_principles": ""},),
-            ({"exit_conditions": "   "},),
-            ({"evaluation_principles": '[{"name": "x", "description": "d", "weight": null}]'},),
-        ),
-    )
-    async def test_blank_or_null_object_fields_trigger_extraction_retry(
-        self, field_kwargs: dict[str, str]
-    ) -> None:
-        malformed = create_valid_extraction_response(**field_kwargs)
-        reformatted = create_valid_extraction_response()
-        mock_adapter = AsyncMock()
-        mock_adapter.complete = AsyncMock(
-            side_effect=[
-                Result.ok(create_mock_completion_response(malformed)),
-                Result.ok(create_mock_completion_response(reformatted)),
-            ]
-        )
-        state = create_interview_state_with_rounds()
-        low_ambiguity = create_low_ambiguity_score()
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            generator = SeedGenerator(
-                llm_adapter=mock_adapter,
-                output_dir=Path(tmp_dir) / "seeds",
-            )
-            result = await generator.generate(state, low_ambiguity)
-
-        assert result.is_ok
-        assert mock_adapter.complete.await_count == 2
 
     def test_strict_string_array_rejects_predecoded_non_strings(self) -> None:
         with pytest.raises(ValueError, match="only strings"):

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1532,6 +1532,83 @@ class TestObjectArrayExtractionContract:
         condition = ExitCondition(name="c", description="d", evaluation_criteria="e")
         assert _parse_exit_conditions([condition]) == (condition,)
 
+    def test_strict_rejects_nonfinite_weights(self) -> None:
+        for token in ("NaN", "Infinity", "-Infinity"):
+            with pytest.raises(ValueError, match="finite"):
+                _parse_evaluation_principles(
+                    f'[{{"name": "x", "description": "d", "weight": {token}}}]',
+                    strict=True,
+                )
+
+    def test_oversized_integer_weights_clamp_without_crashing(self) -> None:
+        huge = "9" * 400
+        principles = _parse_evaluation_principles(
+            f'[{{"name": "x", "description": "d", "weight": {huge}}}]', strict=True
+        )
+        assert principles[0].weight == 1.0
+        principles = _parse_evaluation_principles(
+            f'[{{"name": "x", "description": "d", "weight": -{huge}}}]', strict=True
+        )
+        assert principles[0].weight == 0.0
+
+    def test_lenient_nonfinite_and_oversized_weights_never_raise(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "a", "description": "d", "weight": NaN},'
+            ' {"name": "b", "description": "d", "weight": Infinity},'
+            f' {{"name": "c", "description": "d", "weight": {"9" * 400}}}]'
+        )
+        assert [p.weight for p in principles] == [1.0, 1.0, 1.0]
+        legacy = _parse_evaluation_principles("a:d:inf | b:d:nan | c:d:1e999")
+        assert [p.weight for p in legacy] == [1.0, 1.0, 1.0]
+
+    @pytest.mark.asyncio
+    async def test_nonfinite_weight_triggers_extraction_retry_not_crash(self) -> None:
+        malformed = create_valid_extraction_response(
+            evaluation_principles='[{"name": "x", "description": "d", "weight": NaN}]'
+        )
+        reformatted = create_valid_extraction_response()
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_oversized_weight_does_not_crash_seed_generation(self) -> None:
+        response = create_valid_extraction_response(
+            evaluation_principles=(f'[{{"name": "x", "description": "d", "weight": {"9" * 400}}}]')
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(response))
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles[0].weight == 1.0
+
     def test_strict_string_array_rejects_predecoded_non_strings(self) -> None:
         with pytest.raises(ValueError, match="only strings"):
             _parse_string_array_values([1, "x"], field_label="CONSTRAINTS", strict=True)

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1535,6 +1535,33 @@ class TestObjectArrayExtractionContract:
             ":description:0.5 | complete::0.4 | valid:Description:0.25"
         ) == (EvaluationPrinciple(name="valid", description="Description", weight=0.25),)
 
+    def test_weights_beyond_interpreter_digit_limit_never_raise(self) -> None:
+        huge = "9" * 5000
+        lenient = _parse_evaluation_principles(
+            f'[{{"name": "x", "description": "d", "weight": {huge}}}]'
+        )
+        assert lenient[0].weight == 1.0
+        strict = _parse_evaluation_principles(
+            f'[{{"name": "x", "description": "d", "weight": {huge}}}]', strict=True
+        )
+        assert strict[0].weight == 1.0
+        negative = _parse_evaluation_principles(
+            f'[{{"name": "x", "description": "d", "weight": -{huge}}}]', strict=True
+        )
+        assert negative[0].weight == 0.0
+
+    def test_overflowed_negative_weights_keep_their_sign(self) -> None:
+        legacy = _parse_evaluation_principles("x:d:-1e999 | y:d:1e999")
+        assert [p.weight for p in legacy] == [0.0, 1.0]
+        json_neg = _parse_evaluation_principles(
+            '[{"name": "x", "description": "d", "weight": -1e999}]'
+        )
+        assert json_neg[0].weight == 0.0
+        json_neg_strict = _parse_evaluation_principles(
+            '[{"name": "x", "description": "d", "weight": -1e999}]', strict=True
+        )
+        assert json_neg_strict[0].weight == 0.0
+
     def test_lenient_null_weight_defaults_without_raising(self) -> None:
         principles = _parse_evaluation_principles(
             '[{"name": "x", "description": "d", "weight": null}]'
@@ -1580,7 +1607,7 @@ class TestObjectArrayExtractionContract:
 
     def test_strict_rejects_nonfinite_weights(self) -> None:
         for token in ("NaN", "Infinity", "-Infinity"):
-            with pytest.raises(ValueError, match="finite"):
+            with pytest.raises(ValueError, match="weight"):
                 _parse_evaluation_principles(
                     f'[{{"name": "x", "description": "d", "weight": {token}}}]',
                     strict=True,

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -21,6 +21,8 @@ from ouroboros.bigbang.interview import (
 )
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
+    _parse_evaluation_principles,
+    _parse_exit_conditions,
     _parse_string_array_values,
     load_seed,
     save_seed_sync,
@@ -61,8 +63,15 @@ def create_valid_extraction_response(
     ontology_name: str = "TaskManager",
     ontology_description: str = "Task management domain model",
     ontology_fields: str = "tasks:array:List of task objects | projects:array:List of project objects",
-    evaluation_principles: str = "completeness:All requirements implemented:0.4 | quality:Code meets standards:0.3",
-    exit_conditions: str = "all_criteria_met:All acceptance criteria pass:100% criteria satisfied",
+    evaluation_principles: str = (
+        '[{"name": "completeness", "description": "All requirements implemented",'
+        ' "weight": 0.4},'
+        ' {"name": "quality", "description": "Code meets standards", "weight": 0.3}]'
+    ),
+    exit_conditions: str = (
+        '[{"name": "all_criteria_met", "description": "All acceptance criteria pass",'
+        ' "criteria": "100% criteria satisfied"}]'
+    ),
 ) -> str:
     """Create a valid LLM extraction response string."""
     return f"""GOAL: {goal}
@@ -828,7 +837,11 @@ class TestSeedGeneratorExtraction:
         low_ambiguity = create_low_ambiguity_score()
 
         extraction_response = create_valid_extraction_response(
-            evaluation_principles="completeness:All requirements met:0.5 | quality:High quality:0.3"
+            evaluation_principles=(
+                '[{"name": "completeness", "description": "All requirements met",'
+                ' "weight": 0.5},'
+                ' {"name": "quality", "description": "High quality", "weight": 0.3}]'
+            )
         )
         mock_adapter.complete = AsyncMock(
             return_value=Result.ok(create_mock_completion_response(extraction_response))
@@ -855,7 +868,10 @@ class TestSeedGeneratorExtraction:
         low_ambiguity = create_low_ambiguity_score()
 
         extraction_response = create_valid_extraction_response(
-            exit_conditions="done:All done:100% pass | timeout:Max time:10 iterations"
+            exit_conditions=(
+                '[{"name": "done", "description": "All done", "criteria": "100% pass"},'
+                ' {"name": "timeout", "description": "Max time", "criteria": "10 iterations"}]'
+            )
         )
         mock_adapter.complete = AsyncMock(
             return_value=Result.ok(create_mock_completion_response(extraction_response))
@@ -1383,3 +1399,204 @@ class TestAcceptanceCriteriaGranularityContract:
         assert "sub-step of a sibling" in system_prompt.lower()
         assert "heredoc" in system_prompt.lower()
         assert "python -c" in system_prompt
+
+
+class TestObjectArrayExtractionContract:
+    """#1729 slice 2: EVALUATION_PRINCIPLES / EXIT_CONDITIONS as JSON object arrays.
+
+    Extraction (strict) demands single-line JSON arrays of objects so colons
+    and pipes inside names, descriptions, and criteria survive as data; stored
+    legacy requirements (lenient) keep the historical colon/pipe split and
+    never raise.
+    """
+
+    def test_strict_parses_json_object_arrays_with_delimiters_in_data(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "ratio", "description": "Keep a 1:1 request:response mapping | no drops",'
+            ' "weight": 0.4}]',
+            strict=True,
+        )
+        assert principles == (
+            EvaluationPrinciple(
+                name="ratio",
+                description="Keep a 1:1 request:response mapping | no drops",
+                weight=0.4,
+            ),
+        )
+        conditions = _parse_exit_conditions(
+            '[{"name": "done", "description": "All pass",'
+            ' "criteria": "pytest exit 0: all green | no skips"}]',
+            strict=True,
+        )
+        assert conditions == (
+            ExitCondition(
+                name="done",
+                description="All pass",
+                evaluation_criteria="pytest exit 0: all green | no skips",
+            ),
+        )
+
+    def test_strict_accepts_evaluation_criteria_key_alias(self) -> None:
+        conditions = _parse_exit_conditions(
+            '[{"name": "done", "description": "All pass",'
+            ' "evaluation_criteria": "coverage >= 80%"}]',
+            strict=True,
+        )
+        assert conditions[0].evaluation_criteria == "coverage >= 80%"
+
+    def test_strict_defaults_and_clamps_weight(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "a", "description": "no weight"},'
+            ' {"name": "b", "description": "too big", "weight": 1.5},'
+            ' {"name": "c", "description": "negative", "weight": -0.5}]',
+            strict=True,
+        )
+        assert [p.weight for p in principles] == [1.0, 1.0, 0.0]
+
+    def test_strict_rejects_legacy_pipe_lines(self) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_evaluation_principles(
+                "completeness:All requirements implemented:0.4 | quality:Meets standards:0.3",
+                strict=True,
+            )
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_exit_conditions(
+                "all_criteria_met:All acceptance criteria pass:100% criteria satisfied",
+                strict=True,
+            )
+
+    def test_strict_rejects_malformed_entries(self) -> None:
+        malformed_principles = (
+            '["not an object"]',
+            '[{"description": "missing name"}]',
+            '[{"name": "  ", "description": "blank name"}]',
+            '[{"name": "x", "description": ""}]',
+            '[{"name": "x", "description": "d", "weight": "high"}]',
+            '[{"name": "x", "description": "d", "weight": true}]',
+        )
+        for malformed in malformed_principles:
+            with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
+                _parse_evaluation_principles(malformed, strict=True)
+        malformed_conditions = (
+            "[42]",
+            '[{"name": "x", "description": "d"}]',
+            '[{"name": "x", "description": "d", "criteria": "   "}]',
+        )
+        for malformed in malformed_conditions:
+            with pytest.raises(ValueError, match="EXIT_CONDITIONS"):
+                _parse_exit_conditions(malformed, strict=True)
+
+    def test_lenient_keeps_legacy_colon_pipe_split(self) -> None:
+        principles = _parse_evaluation_principles(
+            "completeness:All requirements implemented:0.4 | quality:Meets standards:bad | solo"
+        )
+        assert principles == (
+            EvaluationPrinciple(
+                name="completeness", description="All requirements implemented", weight=0.4
+            ),
+            EvaluationPrinciple(name="quality", description="Meets standards", weight=1.0),
+        )
+        conditions = _parse_exit_conditions(
+            "all_met:All pass:100% satisfied:with margin | too:short"
+        )
+        assert conditions == (
+            ExitCondition(
+                name="all_met",
+                description="All pass",
+                evaluation_criteria="100% satisfied:with margin",
+            ),
+        )
+
+    def test_lenient_parses_stored_json_object_arrays(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "ratio", "description": "1:1 mapping | no drops", "weight": 0.4}]'
+        )
+        assert principles[0].description == "1:1 mapping | no drops"
+
+    def test_lenient_never_raises(self) -> None:
+        # Bracket-led malformed JSON falls back to the historical colon/pipe
+        # split (slice-1-consistent junk tolerance) instead of raising.
+        fallback = _parse_evaluation_principles('[{"name": "x",]')
+        assert isinstance(fallback, tuple)
+        assert _parse_exit_conditions("[1, 2]") == ()
+        assert _parse_evaluation_principles("[not json | at all") == ()
+        assert _parse_evaluation_principles(None) == ()
+        assert _parse_exit_conditions("") == ()
+
+    def test_predecoded_sequences_pass_through(self) -> None:
+        model = EvaluationPrinciple(name="a", description="b", weight=0.5)
+        assert _parse_evaluation_principles((model,)) == (model,)
+        assert _parse_evaluation_principles(
+            [{"name": "a", "description": "b", "weight": 0.5}], strict=True
+        ) == (model,)
+        condition = ExitCondition(name="c", description="d", evaluation_criteria="e")
+        assert _parse_exit_conditions([condition]) == (condition,)
+
+    def test_strict_string_array_rejects_predecoded_non_strings(self) -> None:
+        with pytest.raises(ValueError, match="only strings"):
+            _parse_string_array_values([1, "x"], field_label="CONSTRAINTS", strict=True)
+        assert _parse_string_array_values([1, "x"], field_label="CONSTRAINTS") == ("1", "x")
+
+    @pytest.mark.asyncio
+    async def test_extraction_json_object_arrays_reach_seed(self) -> None:
+        response = create_valid_extraction_response(
+            evaluation_principles=(
+                '[{"name": "ratio", "description": "Keep a 1:1 mapping | no drops", "weight": 0.4}]'
+            ),
+            exit_conditions=(
+                '[{"name": "done", "description": "All pass",'
+                ' "criteria": "pytest exit 0: all green"}]'
+            ),
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(response))
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles == (
+            EvaluationPrinciple(
+                name="ratio", description="Keep a 1:1 mapping | no drops", weight=0.4
+            ),
+        )
+        assert result.value.exit_conditions == (
+            ExitCondition(
+                name="done", description="All pass", evaluation_criteria="pytest exit 0: all green"
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_object_array_triggers_extraction_retry(self) -> None:
+        malformed = create_valid_extraction_response(
+            evaluation_principles="completeness:All requirements implemented:0.4"
+        )
+        reformatted = create_valid_extraction_response()
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
+        assert result.value.evaluation_principles[0].name == "completeness"

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1453,6 +1453,28 @@ class TestObjectArrayExtractionContract:
         )
         assert [p.weight for p in principles] == [1.0, 1.0, 0.0]
 
+    def test_strict_rejects_blank_object_array_fields(self) -> None:
+        with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
+            _parse_evaluation_principles("", strict=True)
+        with pytest.raises(ValueError, match="EXIT_CONDITIONS"):
+            _parse_exit_conditions("   ", strict=True)
+
+        assert _parse_evaluation_principles("[]", strict=True) == ()
+        assert _parse_exit_conditions("[]", strict=True) == ()
+
+    def test_strict_distinguishes_omitted_weight_from_explicit_null(self) -> None:
+        omitted = _parse_evaluation_principles(
+            '[{"name": "a", "description": "omitted weight"}]',
+            strict=True,
+        )
+        assert omitted[0].weight == 1.0
+
+        with pytest.raises(ValueError, match="weight"):
+            _parse_evaluation_principles(
+                '[{"name": "a", "description": "null weight", "weight": null}]',
+                strict=True,
+            )
+
     def test_strict_rejects_legacy_pipe_lines(self) -> None:
         with pytest.raises(ValueError, match="JSON array"):
             _parse_evaluation_principles(
@@ -1473,6 +1495,7 @@ class TestObjectArrayExtractionContract:
             '[{"name": "x", "description": ""}]',
             '[{"name": "x", "description": "d", "weight": "high"}]',
             '[{"name": "x", "description": "d", "weight": true}]',
+            '[{"name": "x", "description": "d", "weight": null}]',
         )
         for malformed in malformed_principles:
             with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
@@ -1504,6 +1527,22 @@ class TestObjectArrayExtractionContract:
                 name="all_met",
                 description="All pass",
                 evaluation_criteria="100% satisfied:with margin",
+            ),
+        )
+
+    def test_lenient_skips_malformed_legacy_principle_entries_without_raising(self) -> None:
+        assert _parse_evaluation_principles(
+            ":description:0.5 | complete::0.4 | valid:Description:0.25"
+        ) == (EvaluationPrinciple(name="valid", description="Description", weight=0.25),)
+
+    def test_lenient_skips_malformed_legacy_exit_condition_entries_without_raising(self) -> None:
+        assert _parse_exit_conditions(
+            "done::criteria | :description:criteria | valid:Description:criteria"
+        ) == (
+            ExitCondition(
+                name="valid",
+                description="Description",
+                evaluation_criteria="criteria",
             ),
         )
 
@@ -1585,6 +1624,73 @@ class TestObjectArrayExtractionContract:
             result = await generator.generate(state, low_ambiguity)
 
         assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field_name", "field_value"),
+        (
+            ("evaluation_principles", ""),
+            ("exit_conditions", "   "),
+        ),
+    )
+    async def test_blank_object_array_field_triggers_extraction_retry(
+        self, field_name: str, field_value: str
+    ) -> None:
+        malformed = create_valid_extraction_response(**{field_name: field_value})
+        reformatted = create_valid_extraction_response(
+            evaluation_principles="[]",
+            exit_conditions="[]",
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles == ()
+        assert result.value.exit_conditions == ()
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_null_weight_triggers_extraction_retry(self) -> None:
+        malformed = create_valid_extraction_response(
+            evaluation_principles='[{"name": "x", "description": "d", "weight": null}]'
+        )
+        reformatted = create_valid_extraction_response(
+            evaluation_principles='[{"name": "x", "description": "d"}]'
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert result.value.evaluation_principles[0].weight == 1.0
         assert mock_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1453,28 +1453,6 @@ class TestObjectArrayExtractionContract:
         )
         assert [p.weight for p in principles] == [1.0, 1.0, 0.0]
 
-    def test_strict_rejects_blank_object_array_fields(self) -> None:
-        with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
-            _parse_evaluation_principles("", strict=True)
-        with pytest.raises(ValueError, match="EXIT_CONDITIONS"):
-            _parse_exit_conditions("   ", strict=True)
-
-        assert _parse_evaluation_principles("[]", strict=True) == ()
-        assert _parse_exit_conditions("[]", strict=True) == ()
-
-    def test_strict_distinguishes_omitted_weight_from_explicit_null(self) -> None:
-        omitted = _parse_evaluation_principles(
-            '[{"name": "a", "description": "omitted weight"}]',
-            strict=True,
-        )
-        assert omitted[0].weight == 1.0
-
-        with pytest.raises(ValueError, match="weight"):
-            _parse_evaluation_principles(
-                '[{"name": "a", "description": "null weight", "weight": null}]',
-                strict=True,
-            )
-
     def test_strict_rejects_legacy_pipe_lines(self) -> None:
         with pytest.raises(ValueError, match="JSON array"):
             _parse_evaluation_principles(
@@ -1495,7 +1473,6 @@ class TestObjectArrayExtractionContract:
             '[{"name": "x", "description": ""}]',
             '[{"name": "x", "description": "d", "weight": "high"}]',
             '[{"name": "x", "description": "d", "weight": true}]',
-            '[{"name": "x", "description": "d", "weight": null}]',
         )
         for malformed in malformed_principles:
             with pytest.raises(ValueError, match="EVALUATION_PRINCIPLES"):
@@ -1527,22 +1504,6 @@ class TestObjectArrayExtractionContract:
                 name="all_met",
                 description="All pass",
                 evaluation_criteria="100% satisfied:with margin",
-            ),
-        )
-
-    def test_lenient_skips_malformed_legacy_principle_entries_without_raising(self) -> None:
-        assert _parse_evaluation_principles(
-            ":description:0.5 | complete::0.4 | valid:Description:0.25"
-        ) == (EvaluationPrinciple(name="valid", description="Description", weight=0.25),)
-
-    def test_lenient_skips_malformed_legacy_exit_condition_entries_without_raising(self) -> None:
-        assert _parse_exit_conditions(
-            "done::criteria | :description:criteria | valid:Description:criteria"
-        ) == (
-            ExitCondition(
-                name="valid",
-                description="Description",
-                evaluation_criteria="criteria",
             ),
         )
 
@@ -1627,73 +1588,6 @@ class TestObjectArrayExtractionContract:
         assert mock_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("field_name", "field_value"),
-        (
-            ("evaluation_principles", ""),
-            ("exit_conditions", "   "),
-        ),
-    )
-    async def test_blank_object_array_field_triggers_extraction_retry(
-        self, field_name: str, field_value: str
-    ) -> None:
-        malformed = create_valid_extraction_response(**{field_name: field_value})
-        reformatted = create_valid_extraction_response(
-            evaluation_principles="[]",
-            exit_conditions="[]",
-        )
-        mock_adapter = AsyncMock()
-        mock_adapter.complete = AsyncMock(
-            side_effect=[
-                Result.ok(create_mock_completion_response(malformed)),
-                Result.ok(create_mock_completion_response(reformatted)),
-            ]
-        )
-        state = create_interview_state_with_rounds()
-        low_ambiguity = create_low_ambiguity_score()
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            generator = SeedGenerator(
-                llm_adapter=mock_adapter,
-                output_dir=Path(tmp_dir) / "seeds",
-            )
-            result = await generator.generate(state, low_ambiguity)
-
-        assert result.is_ok
-        assert result.value.evaluation_principles == ()
-        assert result.value.exit_conditions == ()
-        assert mock_adapter.complete.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_null_weight_triggers_extraction_retry(self) -> None:
-        malformed = create_valid_extraction_response(
-            evaluation_principles='[{"name": "x", "description": "d", "weight": null}]'
-        )
-        reformatted = create_valid_extraction_response(
-            evaluation_principles='[{"name": "x", "description": "d"}]'
-        )
-        mock_adapter = AsyncMock()
-        mock_adapter.complete = AsyncMock(
-            side_effect=[
-                Result.ok(create_mock_completion_response(malformed)),
-                Result.ok(create_mock_completion_response(reformatted)),
-            ]
-        )
-        state = create_interview_state_with_rounds()
-        low_ambiguity = create_low_ambiguity_score()
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            generator = SeedGenerator(
-                llm_adapter=mock_adapter,
-                output_dir=Path(tmp_dir) / "seeds",
-            )
-            result = await generator.generate(state, low_ambiguity)
-
-        assert result.is_ok
-        assert result.value.evaluation_principles[0].weight == 1.0
-        assert mock_adapter.complete.await_count == 2
-
-    @pytest.mark.asyncio
     async def test_oversized_weight_does_not_crash_seed_generation(self) -> None:
         response = create_valid_extraction_response(
             evaluation_principles=(f'[{{"name": "x", "description": "d", "weight": {"9" * 400}}}]')
@@ -1714,6 +1608,66 @@ class TestObjectArrayExtractionContract:
 
         assert result.is_ok
         assert result.value.evaluation_principles[0].weight == 1.0
+
+    def test_strict_blank_field_requires_explicit_empty_array(self) -> None:
+        for blank in ("", "   "):
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_evaluation_principles(blank, strict=True)
+            with pytest.raises(ValueError, match="JSON array"):
+                _parse_exit_conditions(blank, strict=True)
+        assert _parse_evaluation_principles("[]", strict=True) == ()
+        assert _parse_exit_conditions("[]", strict=True) == ()
+
+    def test_strict_rejects_explicit_null_weight(self) -> None:
+        with pytest.raises(ValueError, match="weight"):
+            _parse_evaluation_principles(
+                '[{"name": "x", "description": "d", "weight": null}]', strict=True
+            )
+
+    def test_lenient_null_weight_and_blank_fields_never_raise(self) -> None:
+        principles = _parse_evaluation_principles(
+            '[{"name": "x", "description": "d", "weight": null}]'
+        )
+        assert principles[0].weight == 1.0
+        assert _parse_evaluation_principles(":description:0.5") == ()
+        assert _parse_evaluation_principles("name: | :d") == ()
+        assert _parse_exit_conditions("done::criteria") == ()
+        assert _parse_exit_conditions(":d:criteria") == ()
+        assert _parse_exit_conditions("done:desc:  ") == ()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field_kwargs",),
+        (
+            ({"evaluation_principles": ""},),
+            ({"exit_conditions": "   "},),
+            ({"evaluation_principles": '[{"name": "x", "description": "d", "weight": null}]'},),
+        ),
+    )
+    async def test_blank_or_null_object_fields_trigger_extraction_retry(
+        self, field_kwargs: dict[str, str]
+    ) -> None:
+        malformed = create_valid_extraction_response(**field_kwargs)
+        reformatted = create_valid_extraction_response()
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
 
     def test_strict_string_array_rejects_predecoded_non_strings(self) -> None:
         with pytest.raises(ValueError, match="only strings"):


### PR DESCRIPTION
## Summary

Slice 2 of #1729: EVALUATION_PRINCIPLES and EXIT_CONDITIONS move to single-line JSON object arrays at extraction time, following the same strict-extraction / lenient-legacy contract merged in #1714 and #1730.

Today a description like `Keep a 1:1 request:response mapping` breaks the colon split, and a pipe inside any field silently truncates the entry. With this change:

| Lane | Behavior |
|---|---|
| Extraction (strict) | Must be a valid JSON array of `{"name", "description", "weight"/"criteria"}` objects; anything else raises so the existing reformat-retry path asks the LLM to resend. No fallback surface. |
| Stored requirements (lenient) | Bracket-led valid JSON arrays parse to models; everything else keeps the historical `name:description:...` pipe split; pre-parsed model tuples pass through; never raises. |

Details:
- `criteria` (prompt spelling) and `evaluation_criteria` (model field name) are both accepted for exit conditions.
- Weight must be a JSON number in strict mode (bools rejected, malformed triggers retry) and is clamped to [0.0, 1.0] exactly as the legacy path always did.
- The extraction prompt, the reformat template, and the seed-architect agent template now request the object-array format, and the internal requirement-distillation producer emits model tuples instead of legacy colon strings — no in-repo producer emits the legacy format anymore.
- Also closes the low-priority follow-up from the #1730 review: strict string-array parsing now rejects pre-decoded non-string entries instead of coercing them.

## Sequencing vs #1729 needs-design

The bot labeled #1729 needs-design for the multi-PR rollout. Slice 1 (#1730) has since merged, and this slice extends that same merged parser boundary to the next two fields without touching shared schemas or consumers outside `bigbang/`. Slices 3 (ONTOLOGY_FIELDS) and 4 (CONTEXT_REFERENCES) stay separate and sequential. If you'd rather settle the rollout design on #1729 first, happy to hold this PR — nothing else depends on it.

## Test plan

- [x] 13 new regression tests covering the strict/lenient boundary for both fields: delimiters inside data, criteria key alias, weight defaulting/clamping, malformed-entry rejection (non-objects, missing/blank fields, string/bool weights), legacy colon/pipe split preservation (including the criteria segment absorbing further colons), never-raise lenient fallback, pre-decoded pass-through, and the extraction retry integration
- [x] `uv run pytest tests/unit/bigbang -q` — 685 passed
- [x] `uv run pytest tests/ -q -n 4` — 13628 passed, 12 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ouroboros` — clean

Refs #1729 (slice 2 of 4; #1730 was slice 1)
