### PR TITLE
fix(decomposition): make verified MECE bounce-only

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,7 +281,8 @@ independently-verifiable units.
 
 **Recursive Decomposition:**
 
-Each AC defaults to **atomic** execution. It is split into
+Each AC defaults to **atomic** execution. Preflight splitting is retired: a split
+may be proposed only after an evidence-backed `TOO_BIG` bounce. It is accepted as
 `MIN_SUB_ACS`–`MAX_SUB_ACS` (2–5) sub-ACs only when it genuinely spans multiple
 units along the profile's axis — splitting is conservative because each sub-AC
 costs a full agent session. Sub-ACs recurse within a bounded depth.

--- a/docs/rfc/decomposition-reliability.md
+++ b/docs/rfc/decomposition-reliability.md
@@ -28,12 +28,13 @@ So this RFC does two things: **delete the dead modules** (repairing fabricated
 fields in code nothing calls is motion, not progress), and **re-aim the
 decomposition discipline at `parallel_executor.py`'s actual split path**.
 
-The live default is now `bounce_only`. Stored `preflight` configuration is
-migrated to that mode, so new production runs cannot perform a decomposition
-provider effect before an evidence-backed `TOO_BIG` bounce. The historical
-`PREFLIGHT` enum remains readable only for durable-record compatibility; both
-live runner and executor constructors reject a direct `preflight` override, and
-the decomposition provider entry itself refuses any call that is not bound to a
+The live default is now `bounce_only`. Stored `preflight` configuration and an
+exact, fingerprint-valid current-format execution contract are migrated once to
+that mode, so new production runs cannot perform a decomposition provider effect
+before an evidence-backed `TOO_BIG` bounce. The historical `PREFLIGHT` enum
+remains readable only for durable-record compatibility; both live runner and
+executor constructors reject a direct `preflight` override, and the
+decomposition provider entry itself refuses any call that is not bound to a
 `TOO_BIG` bounce.
 
 The bounce trace is a typed projection, not a redacted transcript: it contains
@@ -46,8 +47,19 @@ child contract required to execute and replay the split.
 Both `bounce_classified` and `decision_finalized` are required persistence
 boundaries, not best-effort telemetry. Failure to append the bounce prevents the
 decomposition provider call; failure to append the finalized decision prevents
-child dispatch. A forced-atomic/escalated compromise therefore cannot continue
-without its required event.
+child dispatch. Before any resumed effect, the executor strictly replays the
+exact finalized-event population and then permits checkpoints/composite records
+to confirm—but never replace or contradict—the same canonical decision.
+Malformed, truncated, unknown-field, duplicated, or conflicting durable
+decisions fail closed. A historical non-split `PREFLIGHT` record may transition
+once to a new `BOUNCE` record; a finalized live bounce decision is immutable. A
+forced-atomic/escalated compromise therefore cannot continue without its
+required event.
+
+When Routing D is active, its bounded loop offers each failed atomic result to
+this gate before selecting a successor route. A trustworthy `TOO_BIG` split
+transfers the root to the durable composite completion/pause owner; all other
+failures remain atomic and continue through the finite route set.
 
 ## Context
 

--- a/docs/rfc/decomposition-reliability.md
+++ b/docs/rfc/decomposition-reliability.md
@@ -1,6 +1,6 @@
 # RFC — Atomicity & decomposition reliability (re-grounded on the live executor)
 
-> Status: **Draft**
+> Status: **Implemented on the live path**
 > Relates to [discussion #1385](https://github.com/Q00/ouroboros/discussions/1385)
 > (atomicity & AC-decomposition reliability). Sibling mechanism:
 > [spend estimator](https://github.com/Q00/ouroboros/pull/1404) (#1384) — both pre-execution judgments,
@@ -10,10 +10,11 @@
 
 ## Summary
 
-Before fanning out, Ouroboros decides *is this unit atomic (execute it) or not
-(decompose it first)?* — the gate in front of fan-out, where a wrong call is
-asymmetric (under-decompose → rework; over-decompose → wasted motion) and compounds
-recursively. The owner's verification of #1385 produced a finding that
+Ouroboros first attempts each unit atomically. Only an evidence-backed `TOO_BIG`
+bounce may propose a split, and only a Verified-MECE decision may fan out children.
+That recovery gate has asymmetric errors (under-decompose → rework;
+over-decompose → wasted motion) that compound recursively. The owner's verification
+of #1385 produced a finding that
 **re-grounds the entire effort**:
 
 > The module the original analysis dissected — `execution/atomicity.py` +
@@ -26,6 +27,27 @@ recursively. The owner's verification of #1385 produced a finding that
 So this RFC does two things: **delete the dead modules** (repairing fabricated
 fields in code nothing calls is motion, not progress), and **re-aim the
 decomposition discipline at `parallel_executor.py`'s actual split path**.
+
+The live default is now `bounce_only`. Stored `preflight` configuration is
+migrated to that mode, so new production runs cannot perform a decomposition
+provider effect before an evidence-backed `TOO_BIG` bounce. The historical
+`PREFLIGHT` enum remains readable only for durable-record compatibility; both
+live runner and executor constructors reject a direct `preflight` override, and
+the decomposition provider entry itself refuses any call that is not bound to a
+`TOO_BIG` bounce.
+
+The bounce trace is a typed projection, not a redacted transcript: it contains
+only server-derived counts, booleans, and validated failure/retry enums. Classifier
+and semantic-attestation replies likewise contain only closed enums/booleans;
+their prose and claimed evidence cannot enter durable events or authorize child
+dispatch. The only generated prose that survives is the independently attested
+child contract required to execute and replay the split.
+
+Both `bounce_classified` and `decision_finalized` are required persistence
+boundaries, not best-effort telemetry. Failure to append the bounce prevents the
+decomposition provider call; failure to append the finalized decision prevents
+child dispatch. A forced-atomic/escalated compromise therefore cannot continue
+without its required event.
 
 ## Context
 
@@ -142,5 +164,6 @@ re-grounding is that lesson applied.
    split/verdict fields carry **real** inputs (no hardcoded stand-ins).
 4. Evaluation bounces are classified (too-big / bad-spec / environment) and only
    *too-big* drives a decomposition, seeded from the bounce trace.
-5. With no LLM available, the fallback reports "uncertain → decompose conservatively"
-   rather than a confident keyword verdict.
+5. With no LLM available, the fallback records `UNKNOWN` and leaves the failed
+   unit untrusted for escalation or human handoff. It never invents children or
+   emits a confident keyword verdict; verified fan-out has no heuristic fallback.

--- a/docs/rfc/decomposition-reliability.md
+++ b/docs/rfc/decomposition-reliability.md
@@ -47,14 +47,24 @@ child contract required to execute and replay the split.
 Both `bounce_classified` and `decision_finalized` are required persistence
 boundaries, not best-effort telemetry. Failure to append the bounce prevents the
 decomposition provider call; failure to append the finalized decision prevents
-child dispatch. Before any resumed effect, the executor strictly replays the
-exact finalized-event population and then permits checkpoints/composite records
-to confirm—but never replace or contradict—the same canonical decision.
+child dispatch. Before any resumed effect, the executor chronologically replays
+and validates the bounded bounce-event population, then strictly replays the
+exact finalized-event population. A pending durable `TOO_BIG` phase resumes at
+the decomposer/attestation boundary without repeating the atomic parent or
+classifier. Every finalized `BOUNCE` decision must consume an earlier matching
+`TOO_BIG` event for the same node and evidence; a final event without that
+trigger fails closed. Checkpoints and composite completion/pause projections may
+then confirm—but never create, replace, or contradict—the event-owned canonical
+decision.
 Malformed, truncated, unknown-field, duplicated, or conflicting durable
 decisions fail closed. A historical non-split `PREFLIGHT` record may transition
 once to a new `BOUNCE` record; a finalized live bounce decision is immutable. A
 forced-atomic/escalated compromise therefore cannot continue without its
 required event.
+
+A trustworthy live `BOUNCE` split is valid only with `cause=TOO_BIG`. The
+classifier always starts a fresh tool-free runtime session, so an inherited
+conversation cannot supplement the closed server-derived trace.
 
 When Routing D is active, its bounded loop offers each failed atomic result to
 this gate before selecting a successor route. A trustworthy `TOO_BIG` split

--- a/docs/rfc/frugality-proof-producers.md
+++ b/docs/rfc/frugality-proof-producers.md
@@ -165,12 +165,15 @@ currently makes both attestations, so Claude/Codex/Gemini/etc. skip replay and e
 no baseline today. This is intentional fail-closed behavior, not a claim that
 copytree or a normal workspace-write sandbox is sufficient.
 
-Likewise, an LLM-produced string array is not a deterministic MECE proof. The live
-decomposer currently checks JSON type and child count only; until a validator can
-attest non-empty uniqueness plus semantic coverage/exclusivity, production
-decompositions are marked untrustworthy and shadow replay is skipped before any
-extra model call. Test doubles may supply an explicit trusted attestation to verify
-the downstream event/proof machinery, but that does not certify the live producer.
+Likewise, an LLM-produced string array is not a Verified-MECE proof. The live
+`bounce_only` path now requires an exact structured proposal with bounded,
+non-empty, unique child scope claims and verification hints. A fresh independent
+runtime session must attest collective coverage, sibling non-overlap, and simpler
+units; one verifier-guided repair is allowed, after which the decision escalates
+and records its compromise. Only that finalized durable decision may carry
+`trustworthy=true`. Parsing and replay are deterministic and fail closed; the
+semantic attestation does not claim that generated child wording must equal text
+predicted by the Seed.
 
 Host-side `verify_command` execution is also unsupported in shadow mode: such a
 command could name an absolute live path or escape with `cd ../..` outside the

--- a/docs/rfc/routing-d-bounded-escalation.md
+++ b/docs/rfc/routing-d-bounded-escalation.md
@@ -51,21 +51,28 @@ For one route episode:
    cheapest eligible unattempted route.
 3. Rebuild and revalidate the exact admission at the provider boundary.
 4. Execute the route once.
-5. Persist the provisional attempt judgment.
-6. Classify a failed result and persist its `RouteObservation` plus the
-   deterministic escalation decision.
-7. Only after both durable writes succeed, execute exactly the next eligible
+5. Before route escalation, offer a failed atomic result once to the verified
+   bounce gate. Only evidence-backed `TOO_BIG` may leave the atomic route
+   episode and enter the durable composite owner.
+6. Otherwise persist the provisional attempt judgment and the failed result's
+   `RouteObservation` plus deterministic escalation decision.
+7. Only after both route writes succeed, execute exactly the next eligible
    route.
-8. Stop on provisional success, a `BLOCKED` failure, or route exhaustion.
+8. Stop on provisional success, a verified composite transition, a `BLOCKED`
+   failure, or route exhaustion.
 
-Every classified non-`BLOCKED` failure advances exactly one route in Kernel
-order. Routing D never retries the same route, skips an eligible route, loops
-back to an attempted route, or lets legacy retry-count, stall, bounce, or
-alternate-harness recovery preempt its finite route set.
+Every classified non-`BLOCKED` failure that remains atomic advances exactly one
+route in Kernel order. Routing D never retries the same route, skips an eligible
+route, loops back to an attempted route, or lets legacy retry-count, unverified
+bounce, stall, or alternate-harness recovery preempt its finite route set. The
+Verified-MECE transition is the sole exception: it changes the unit itself from
+an atomic route episode to a composite, whose completion/pause owner takes over
+before any successor route is admitted.
 
 | Attempt result | Routing D action |
 | --- | --- |
 | provisional success | persist `attempt_succeeded`; defer acceptance to Final Gate |
+| evidence-backed `TOO_BIG` + trustworthy Verified-MECE split | persist bounce and finalized decision; transfer to composite owner |
 | classified non-`BLOCKED` failure with a successor | persist decision; advance one route |
 | classified `BLOCKED` failure | explicit `BLOCKED`; human handoff |
 | no remaining eligible route | explicit `BLOCKED` with `routes_exhausted`; human handoff |
@@ -105,6 +112,23 @@ If either required write fails, no successor route may execute. The direct
 runner has no root-AC attempt record for its whole-Seed call, so its hard
 boundary is the durable route observation itself; that write must complete
 before a fresh successor session can start.
+
+The atomic-to-composite branch has a different, equally hard order:
+
+```text
+failed atomic result
+    └─► execution.decomposition.bounce_classified
+            └─► decomposition provider / independent attestation
+                    └─► execution.decomposition.decision_finalized
+                            └─► child provider effect
+```
+
+`decision_finalized` is replay authority, not telemetry. Parallel execution
+restores its exact event stream before checkpoints or route projections; a
+checkpoint and composite completion may confirm the same canonical decision but
+cannot replace or contradict it. A historical non-split `PREFLIGHT` decision may
+transition once to a new bounce decision after migration. No finalized live
+bounce decision can mutate.
 
 ## Resume and drift rules
 

--- a/docs/rfc/routing-d-bounded-escalation.md
+++ b/docs/rfc/routing-d-bounded-escalation.md
@@ -124,11 +124,15 @@ failed atomic result
 ```
 
 `decision_finalized` is replay authority, not telemetry. Parallel execution
-restores its exact event stream before checkpoints or route projections; a
-checkpoint and composite completion may confirm the same canonical decision but
-cannot replace or contradict it. A historical non-split `PREFLIGHT` decision may
-transition once to a new bounce decision after migration. No finalized live
-bounce decision can mutate.
+first replays canonical `bounce_classified` events chronologically and then
+restores the exact finalized event stream before checkpoints or route
+projections. A persisted `TOO_BIG` bounce without its final decision resumes the
+decomposer and independent attestation before any atomic or route provider
+effect. Every `BOUNCE` final must consume an earlier matching `TOO_BIG` phase. A
+checkpoint or composite completion/pause may confirm the same event-owned
+canonical decision but cannot mint, replace, or contradict it. A historical
+non-split `PREFLIGHT` decision may transition once to a new bounce decision after
+migration. No finalized live bounce decision can mutate.
 
 ## Resume and drift rules
 

--- a/docs/rfc/routing-d-bounded-escalation.md
+++ b/docs/rfc/routing-d-bounded-escalation.md
@@ -371,13 +371,16 @@ total cap smaller than its producer domain.
 
 ## Parallel and direct scope
 
-Cheapest-first bounded routing applies to top-level atomic ACs. Decomposed
-children remain on legacy child routing until [#1466](https://github.com/Q00/ouroboros/issues/1466)
-provides live Verified-MECE trust. Cheapening untrusted children before that
-slice would let decomposition output expand dispatch authority prematurely.
+Cheapest-first bounded routing applies to top-level atomic ACs. The Verified-MECE
+live path from [#1466](https://github.com/Q00/ouroboros/issues/1466) can now grant a
+finalized child trust signal only after an evidence-backed `TOO_BIG` bounce,
+exact structural validation, fresh-session semantic attestation, and at most one
+repair. Untrusted splits never receive child cheapening.
 
-After #1466, explicitly trusted children can enter the same Admission Kernel and
-bounded escalation loop without changing the authority model.
+Decomposed children still use the legacy child retry path in this slice: they do
+not yet have a complete child-scoped durable route episode and replay owner.
+Verified-MECE establishes the prerequisite trust boundary; it does not silently
+expand Routing D's provider-effect authority.
 
 ## Seed/result and spend semantics
 
@@ -401,7 +404,7 @@ than silently retrying while the host is asked to inspect or intervene.
 
 ## Deferred roadmap
 
-- Verified-MECE child trust and live decomposition: #1466
+- Verified-MECE child trust and live decomposition: #1466 (implemented prerequisite)
 - shared cross-run projection: #1389
 - cross-run advisory memory
 - actual token/spend attribution and guardrails: #1396

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -222,9 +222,9 @@ class ExecutionConfig(BaseModel, frozen=True):
             alt-harness redispatch may fan out to multiple runtimes in parallel,
             first-passing-verification wins (PR-X N-version tournament, opt-in).
         decomposition_mode: Controls where AC decomposition is allowed:
-            ``preflight`` uses the configured preflight decomposition path,
-            ``bounce_only`` only decomposes after an atomic AC bounces, and
-            ``off`` disables decomposition.
+            ``bounce_only`` only decomposes after an evidence-backed too-big
+            bounce, and ``off`` disables decomposition. Legacy ``preflight``
+            configuration is migrated to ``bounce_only`` at load time.
         context_pack: Whether to append a deterministic repo context pack
             (stack, verify commands, layout) to run worker system prompts.
         project_guidance: Allowlist of project guidance ids to resolve from
@@ -240,9 +240,15 @@ class ExecutionConfig(BaseModel, frozen=True):
     ac_retry_attempts: int = Field(default=2, ge=0)
     cross_harness_redispatch: bool = True
     n_version_tournament: bool = False
-    decomposition_mode: Literal["preflight", "bounce_only", "off"] = "preflight"
+    decomposition_mode: Literal["bounce_only", "off"] = "bounce_only"
     context_pack: bool = True
     project_guidance: tuple[str, ...] = ()
+
+    @field_validator("decomposition_mode", mode="before")
+    @classmethod
+    def _migrate_legacy_decomposition_mode(cls, value: object) -> object:
+        """Retire pre-execution splitting without breaking stored config files."""
+        return "bounce_only" if value == "preflight" else value
 
     @field_validator("project_guidance")
     @classmethod

--- a/src/ouroboros/orchestrator/decomposition_policy.py
+++ b/src/ouroboros/orchestrator/decomposition_policy.py
@@ -407,6 +407,13 @@ class DecompositionDecisionRecord:
                 "semantic ESTABLISHED, at least 2 children, and repair_count <= 1"
             )
             raise ValueError(msg)
+        if (
+            self.trustworthy
+            and self.source is DecompositionSource.BOUNCE
+            and self.cause is not BounceCause.TOO_BIG
+        ):
+            msg = "trustworthy BOUNCE splits require a TOO_BIG cause"
+            raise ValueError(msg)
 
     def _meets_trust_invariant(self) -> bool:
         return (

--- a/src/ouroboros/orchestrator/decomposition_policy.py
+++ b/src/ouroboros/orchestrator/decomposition_policy.py
@@ -8,7 +8,7 @@ they are not leaf execution failures.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 import re
@@ -27,8 +27,30 @@ MAX_COVERAGE_CLAIMS = 8
 MAX_COVERAGE_CLAIM_CHARS = 240
 MAX_VERIFICATION_HINT_CHARS = 300
 MAX_RATIONALE_CHARS = 1_000
-MAX_PROPOSAL_REPR_CHARS = 10_000
 MAX_TRACE_SUMMARY_CHARS = 1_000
+MAX_NODE_ID_CHARS = 512
+MAX_REPAIR_COUNT = 1
+
+_TRACE_KEYS = frozenset({"summary", "evidence_refs"})
+_CHILD_KEYS = frozenset({"description", "coverage_claims", "verification_hint"})
+_PROPOSAL_KEYS = frozenset({"children", "covers_parent", "rationale"})
+_DECISION_KEYS = frozenset(
+    {
+        "schema_version",
+        "node_id",
+        "source",
+        "disposition",
+        "cause",
+        "reasons",
+        "evidence_refs",
+        "children",
+        "structural_status",
+        "semantic_status",
+        "repair_count",
+        "trustworthy",
+        "compromise_reason",
+    }
+)
 
 _SECRET_VALUE = "[REDACTED]"
 _SECRET_KEY_PATTERN = (
@@ -131,13 +153,19 @@ class DecompositionTraceSummary:
 
     @classmethod
     def from_dict(cls, data: object) -> DecompositionTraceSummary | None:
-        if not isinstance(data, Mapping):
+        if not _mapping_has_exact_keys(data, _TRACE_KEYS):
             return None
+        assert type(data) is dict
         try:
-            return cls(
+            if type(data["summary"]) is not str:
+                return None
+            parsed = cls(
                 summary=data["summary"],
-                evidence_refs=_read_string_list(data.get("evidence_refs", ())),
+                evidence_refs=_read_bounded_string_list(
+                    data["evidence_refs"], max_count=MAX_EVIDENCE_REF_COUNT
+                ),
             )
+            return parsed if parsed.to_dict() == data else None
         except (KeyError, TypeError, ValueError):
             return None
 
@@ -190,14 +218,20 @@ class DecompositionChild:
 
     @classmethod
     def from_dict(cls, data: object) -> DecompositionChild | None:
-        if not isinstance(data, Mapping):
+        if not _mapping_has_exact_keys(data, _CHILD_KEYS):
             return None
+        assert type(data) is dict
         try:
-            return cls(
+            if type(data["description"]) is not str or type(data["verification_hint"]) is not str:
+                return None
+            parsed = cls(
                 description=data["description"],
-                coverage_claims=_read_string_list(data.get("coverage_claims", ())),
+                coverage_claims=_read_bounded_string_list(
+                    data["coverage_claims"], max_count=MAX_COVERAGE_CLAIMS
+                ),
                 verification_hint=data["verification_hint"],
             )
+            return parsed if parsed.to_dict() == data else None
         except (KeyError, TypeError, ValueError):
             return None
 
@@ -214,12 +248,18 @@ class DecompositionProposal:
         if type(self.covers_parent) is not bool:
             msg = "covers_parent must be a boolean"
             raise ValueError(msg)
+        if self.covers_parent is not True:
+            msg = "covers_parent must be true"
+            raise ValueError(msg)
         if not isinstance(self.rationale, str):
             msg = "rationale must be a string"
             raise ValueError(msg)
         children = _coerce_children(self.children)
         if not MIN_CHILDREN <= len(children) <= MAX_CHILDREN:
             msg = f"children must contain {MIN_CHILDREN}-{MAX_CHILDREN} items"
+            raise ValueError(msg)
+        if not _children_support_trust(children):
+            msg = "proposal children require unique scope claims and verification hints"
             raise ValueError(msg)
         object.__setattr__(self, "children", children)
         object.__setattr__(
@@ -241,11 +281,17 @@ class DecompositionProposal:
 
     @classmethod
     def from_dict(cls, data: object) -> DecompositionProposal | None:
-        if not isinstance(data, Mapping):
+        if not _mapping_has_exact_keys(data, _PROPOSAL_KEYS):
             return None
+        assert type(data) is dict
         try:
             children_raw = data["children"]
-            if not isinstance(children_raw, Sequence) or isinstance(children_raw, str | bytes):
+            if (
+                type(children_raw) is not list
+                or not MIN_CHILDREN <= len(children_raw) <= MAX_CHILDREN
+                or type(data["covers_parent"]) is not bool
+                or type(data["rationale"]) is not str
+            ):
                 return None
             children: list[DecompositionChild] = []
             for raw in children_raw:
@@ -253,11 +299,12 @@ class DecompositionProposal:
                 if child is None:
                     return None
                 children.append(child)
-            return cls(
+            parsed = cls(
                 children=tuple(children),
                 covers_parent=data["covers_parent"],
                 rationale=data["rationale"],
             )
+            return parsed if parsed.to_dict() == data else None
         except (KeyError, TypeError, ValueError):
             return None
 
@@ -288,7 +335,11 @@ class DecompositionDecisionRecord:
         ):
             msg = f"schema_version must be {SCHEMA_VERSION}"
             raise ValueError(msg)
-        if not isinstance(self.node_id, str) or not self.node_id.strip():
+        if (
+            not isinstance(self.node_id, str)
+            or not self.node_id.strip()
+            or len(self.node_id) > MAX_NODE_ID_CHARS
+        ):
             msg = "node_id must be a non-empty string"
             raise ValueError(msg)
         _require_enum(self.source, DecompositionSource, "source")
@@ -300,8 +351,8 @@ class DecompositionDecisionRecord:
         if isinstance(self.repair_count, bool) or not isinstance(self.repair_count, int):
             msg = "repair_count must be an integer"
             raise ValueError(msg)
-        if self.repair_count < 0:
-            msg = "repair_count must be >= 0"
+        if not 0 <= self.repair_count <= MAX_REPAIR_COUNT:
+            msg = f"repair_count must be 0-{MAX_REPAIR_COUNT}"
             raise ValueError(msg)
         if type(self.trustworthy) is not bool:
             msg = "trustworthy must be a boolean"
@@ -386,14 +437,15 @@ class DecompositionDecisionRecord:
 
     @classmethod
     def from_dict(cls, data: object) -> DecompositionDecisionRecord | None:
-        if not isinstance(data, Mapping):
+        if not _mapping_has_exact_keys(data, _DECISION_KEYS):
             return None
+        assert type(data) is dict
         try:
             schema_version = data.get("schema_version")
             if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
                 return None
             children_raw = data["children"]
-            if not isinstance(children_raw, Sequence) or isinstance(children_raw, str | bytes):
+            if type(children_raw) is not list or len(children_raw) > MAX_CHILDREN:
                 return None
             children: list[DecompositionChild] = []
             for raw in children_raw:
@@ -402,16 +454,32 @@ class DecompositionDecisionRecord:
                     return None
                 children.append(child)
             cause_raw = data.get("cause")
-            if cause_raw is not None and not isinstance(cause_raw, str):
+            if cause_raw is not None and type(cause_raw) is not str:
                 return None
-            return cls(
+            if (
+                type(data["node_id"]) is not str
+                or type(data["source"]) is not str
+                or type(data["disposition"]) is not str
+                or type(data["structural_status"]) is not str
+                or type(data["semantic_status"]) is not str
+                or type(data["repair_count"]) is not int
+                or type(data["trustworthy"]) is not bool
+                or (
+                    data["compromise_reason"] is not None
+                    and type(data["compromise_reason"]) is not str
+                )
+            ):
+                return None
+            parsed = cls(
                 schema_version=data["schema_version"],
                 node_id=data["node_id"],
                 source=_parse_enum(DecompositionSource, data["source"]),
                 disposition=_parse_enum(DecompositionDisposition, data["disposition"]),
                 cause=None if cause_raw is None else _parse_enum(BounceCause, cause_raw),
-                reasons=_read_string_list(data["reasons"]),
-                evidence_refs=_read_string_list(data["evidence_refs"]),
+                reasons=_read_bounded_string_list(data["reasons"], max_count=MAX_REASON_COUNT),
+                evidence_refs=_read_bounded_string_list(
+                    data["evidence_refs"], max_count=MAX_EVIDENCE_REF_COUNT
+                ),
                 children=tuple(children),
                 structural_status=_parse_enum(StructuralCheckStatus, data["structural_status"]),
                 semantic_status=_parse_enum(SemanticAttestationStatus, data["semantic_status"]),
@@ -419,6 +487,7 @@ class DecompositionDecisionRecord:
                 trustworthy=data["trustworthy"],
                 compromise_reason=data.get("compromise_reason"),
             )
+            return parsed if parsed.to_dict() == data else None
         except (KeyError, TypeError, ValueError):
             return None
 
@@ -458,12 +527,12 @@ def validate_decomposition_proposal(
     """Return structural validation errors for a proposal payload."""
 
     errors: list[str] = []
-    if isinstance(data, str | bytes) or not isinstance(data, Mapping):
+    if type(data) is not dict:
         return ("proposal must be an object",)
-    if len(repr(data)) > MAX_PROPOSAL_REPR_CHARS:
-        errors.append("proposal payload is too large")
+    if not _mapping_has_exact_keys(data, _PROPOSAL_KEYS):
+        errors.append("proposal must contain exactly the supported fields")
     children_raw = data.get("children")
-    if not isinstance(children_raw, Sequence) or isinstance(children_raw, str | bytes):
+    if type(children_raw) is not list:
         errors.append("children must be a list")
         children_raw = ()
     if not min_children <= len(children_raw) <= max_children:
@@ -482,11 +551,13 @@ def validate_decomposition_proposal(
     coverage_fingerprints: set[str] = set()
     parent_fingerprint = _fingerprint(parent_text)
     for index, child_raw in enumerate(children_raw):
-        if not isinstance(child_raw, Mapping):
+        if type(child_raw) is not dict:
             errors.append(f"child {index} must be an object")
             continue
+        if not _mapping_has_exact_keys(child_raw, _CHILD_KEYS):
+            errors.append(f"child {index} must contain exactly the supported fields")
         description = child_raw.get("description")
-        if not isinstance(description, str) or not _normalize_spaces(description):
+        if type(description) is not str or not _normalize_spaces(description):
             errors.append(f"child {index} description must be a non-empty string")
             continue
         if len(description) > MAX_CHILD_DESCRIPTION_CHARS:
@@ -499,7 +570,7 @@ def validate_decomposition_proposal(
         child_fingerprints.add(child_fingerprint)
 
         claims = child_raw.get("coverage_claims")
-        if not isinstance(claims, Sequence) or isinstance(claims, str | bytes):
+        if type(claims) is not list:
             errors.append(f"child {index} coverage_claims must be a list")
             continue
         if not claims:
@@ -508,7 +579,7 @@ def validate_decomposition_proposal(
             errors.append(f"child {index} has too many coverage claims")
         child_claim_fingerprints: set[str] = set()
         for claim_index, claim in enumerate(claims):
-            if not isinstance(claim, str) or not _normalize_spaces(claim):
+            if type(claim) is not str or not _normalize_spaces(claim):
                 errors.append(f"child {index} claim {claim_index} must be a non-empty string")
                 continue
             if len(claim) > MAX_COVERAGE_CLAIM_CHARS:
@@ -522,7 +593,7 @@ def validate_decomposition_proposal(
             coverage_fingerprints.add(claim_fingerprint)
 
         hint = child_raw.get("verification_hint")
-        if not isinstance(hint, str):
+        if type(hint) is not str:
             errors.append(f"child {index} verification_hint must be a string")
         elif not _normalize_spaces(hint):
             errors.append(f"child {index} verification_hint must be non-empty")
@@ -660,11 +731,27 @@ def _parse_enum(enum_type: type[StrEnum], value: object) -> Any:
 
 
 def _read_string_list(value: object) -> tuple[str, ...]:
-    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+    if type(value) is not list:
         raise ValueError
-    if not all(isinstance(item, str) for item in value):
+    if not all(type(item) is str for item in value):
         raise ValueError
     return tuple(value)
+
+
+def _read_bounded_string_list(value: object, *, max_count: int) -> tuple[str, ...]:
+    if type(value) is not list or len(value) > max_count:
+        raise ValueError
+    return _read_string_list(value)
+
+
+def _mapping_has_exact_keys(value: object, expected: frozenset[str]) -> bool:
+    """Accept only the exact built-in JSON object shape used by durable records."""
+    return (
+        type(value) is dict
+        and len(value) == len(expected)
+        and all(type(key) is str for key in value)
+        and value.keys() == expected
+    )
 
 
 def _bounded_nonblank_text(text: str, *, field_name: str, max_chars: int) -> str:

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -259,8 +259,8 @@ class ExecutionEventEmitter:
         node_identity: ExecutionNodeIdentity,
         decision: DecompositionDecisionRecord,
     ) -> None:
-        """Persist one finalized decomposition decision as best-effort audit data."""
-        await self._safe_emit_event(
+        """Persist the decision before it can authorize children or recovery."""
+        await self._event_store.append(
             BaseEvent(
                 type="execution.decomposition.decision_finalized",
                 aggregate_type="execution",
@@ -289,8 +289,8 @@ class ExecutionEventEmitter:
         evidence_refs: tuple[str, ...],
         trace_summary: str,
     ) -> None:
-        """Persist a bounded cause-matched recovery classification."""
-        await self._safe_emit_event(
+        """Persist the classified bounce before any decomposition provider effect."""
+        await self._event_store.append(
             BaseEvent(
                 type="execution.decomposition.bounce_classified",
                 aggregate_type="execution",

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -375,6 +375,7 @@ from ouroboros.orchestrator.synapse import (
     render_inform_signal_prompt,
 )
 from ouroboros.orchestrator.verifier import (
+    RetryAdmission,
     Verifier,
     VerifierContractError,
     VerifierVerdict,
@@ -504,6 +505,14 @@ _PARALLEL_COMPOSITE_PAUSE_LEAF_KEYS = frozenset(
         "capsule_fingerprint",
     }
 )
+_DECOMPOSITION_ATTESTATION_KEYS = frozenset(
+    {
+        "coverage_established",
+        "non_overlap_established",
+        "simpler_units_established",
+    }
+)
+_BOUNCE_CLASSIFICATION_KEYS = frozenset({"cause", "has_remaining_scope"})
 _PARALLEL_ROUTE_JUDGMENT_KEYS = frozenset(
     {
         "execution_id",
@@ -1720,7 +1729,7 @@ def _structured_literal(value: str) -> str | None:
 
 
 # Decomposition constants
-# Depth >= max_decomposition_depth forces atomic execution as a soft safety net.
+# A bounce at max_decomposition_depth escalates and records the unsplit compromise.
 MIN_SUB_ACS = MIN_DECOMPOSITION_CHILDREN
 MAX_SUB_ACS = MAX_DECOMPOSITION_CHILDREN
 DECOMPOSITION_TIMEOUT_SECONDS = 60.0
@@ -2756,7 +2765,7 @@ class ParallelACExecutor:
         event_store: EventStore,
         console: Console | None = None,
         enable_decomposition: bool = True,
-        decomposition_mode: Literal["preflight", "bounce_only", "off"] = "preflight",
+        decomposition_mode: Literal["bounce_only", "off"] = "bounce_only",
         max_concurrent: int = 3,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
         checkpoint_store: Any | None = None,
@@ -2789,8 +2798,10 @@ class ParallelACExecutor:
             event_store: Event store for progress tracking.
             console: Rich console for output.
             enable_decomposition: Enable Claude to decompose complex ACs.
-            decomposition_mode: Whether decomposition runs before execution,
-                only after a classified bounce, or not at all.
+            decomposition_mode: Whether decomposition runs only after a
+                classified bounce or not at all. Historical ``preflight``
+                records remain readable, but no live constructor can authorize
+                a new pre-execution decomposition effect.
             max_concurrent: Maximum number of concurrent AC executions.
             max_decomposition_depth: Maximum recursive decomposition depth.
             checkpoint_store: Optional CheckpointStore for state recovery (RC3).
@@ -2845,10 +2856,10 @@ class ParallelACExecutor:
         )
         self._event_store = event_store
         self._console = console or Console()
-        if decomposition_mode not in {"preflight", "bounce_only", "off"}:
+        if decomposition_mode not in {"bounce_only", "off"}:
             msg = f"Unsupported decomposition_mode: {decomposition_mode!r}"
             raise ValueError(msg)
-        self._decomposition_mode: Literal["preflight", "bounce_only", "off"] = (
+        self._decomposition_mode: Literal["bounce_only", "off"] = (
             "off" if not enable_decomposition else decomposition_mode
         )
         self._enable_decomposition = self._decomposition_mode != "off"
@@ -5512,7 +5523,6 @@ class ParallelACExecutor:
                 reasons=("decomposition_decision_identity_mismatch",),
             )
         previous = self._decomposition_decisions.get(node_identity.node_id)
-        self._decomposition_decisions[node_identity.node_id] = decision
         if previous != decision:
             await self._event_emitter.emit_decomposition_decision_finalized(
                 execution_id=execution_id,
@@ -5521,6 +5531,7 @@ class ParallelACExecutor:
                 node_identity=node_identity,
                 decision=decision,
             )
+        self._decomposition_decisions[node_identity.node_id] = decision
         return decision
 
     async def _execute_decomposition_children(
@@ -5729,55 +5740,62 @@ class ParallelACExecutor:
         result: ACExecutionResult,
         ac_spec: AcceptanceCriterionSpec | None,
     ) -> DecompositionTraceSummary:
-        """Project one failed attempt into bounded, secret-safe recovery evidence."""
+        """Project one failed attempt into typed counts and enums only."""
+        from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
         verdict = result.atomic_verifier_verdict
-        tool_names = tuple(
-            dict.fromkeys(
-                message.tool_name
-                for message in result.messages
-                if isinstance(message.tool_name, str) and message.tool_name.strip()
-            )
-        )[:8]
-        evidence_fields = (
-            tuple(sorted(str(key) for key in result.typed_evidence.data))[:8]
-            if result.typed_evidence is not None
-            else ()
+        attempted_tool_count = sum(
+            1
+            for message in result.messages
+            if isinstance(message.tool_name, str) and bool(message.tool_name.strip())
         )
-        evidence_refs = tuple(verdict.evidence_used) if verdict is not None else ()
-        verified_artifacts: list[str] = []
-        remaining_artifacts: list[str] = []
+        evidence_field_count = (
+            len(result.typed_evidence.data)
+            if result.typed_evidence is not None and type(result.typed_evidence.data) is dict
+            else 0
+        )
+        verified_artifact_count = 0
+        remaining_artifact_count = 0
         if ac_spec is not None and ac_spec.expected_artifacts:
             cwd = Path(self._task_cwd or self._adapter.working_directory or os.getcwd())
             for artifact in ac_spec.expected_artifacts[:8]:
                 target = Path(artifact)
                 if not target.is_absolute():
                     target = cwd / target
-                (verified_artifacts if target.exists() else remaining_artifacts).append(artifact)
+                if target.exists():
+                    verified_artifact_count += 1
+                else:
+                    remaining_artifact_count += 1
 
-        failure_class = verdict.failure_class if verdict is not None else None
+        try:
+            failure_class = (
+                FailureClass(verdict.failure_class).value
+                if verdict is not None and verdict.failure_class is not None
+                else "UNKNOWN"
+            )
+        except ValueError:
+            failure_class = "UNKNOWN"
         retry_admission = (
             verdict.retry_admission.value
-            if verdict is not None and hasattr(verdict.retry_admission, "value")
-            else (str(verdict.retry_admission) if verdict is not None else None)
+            if verdict is not None and isinstance(verdict.retry_admission, RetryAdmission)
+            else "UNKNOWN"
         )
-        reasons = tuple(verdict.reasons) if verdict is not None else ()
         lines = [
-            "attempted_tools=" + (", ".join(tool_names) if tool_names else "none-recorded"),
-            "evidence_fields="
-            + (", ".join(evidence_fields) if evidence_fields else "none-recorded"),
-            "verified_artifacts="
-            + (", ".join(verified_artifacts) if verified_artifacts else "none-recorded"),
-            "remaining_artifacts="
-            + (", ".join(remaining_artifacts) if remaining_artifacts else "none-recorded"),
-            f"failure_class={failure_class or 'UNKNOWN'}",
-            f"retry_admission={retry_admission or 'UNKNOWN'}",
-            "verifier_reasons=" + ("; ".join(reasons) if reasons else "none-recorded"),
+            f"attempt_message_count={len(result.messages)}",
+            f"attempted_tool_count={attempted_tool_count}",
+            f"typed_evidence_present={result.typed_evidence is not None}",
+            f"evidence_field_count={evidence_field_count}",
+            f"verified_artifact_count={verified_artifact_count}",
+            f"remaining_artifact_count={remaining_artifact_count}",
+            f"failure_class={failure_class}",
+            f"retry_admission={retry_admission}",
+            f"verifier_reason_count={len(verdict.reasons) if verdict is not None else 0}",
             f"failure_detail_present={bool(result.error or result.final_message)}",
         ]
         if ac_spec is not None:
             lines.append(f"verify_command_present={bool(ac_spec.verify_command)}")
             lines.append(f"output_assertion_present={bool(ac_spec.output_assertion)}")
-        return summarize_decomposition_trace("\n".join(lines), evidence_refs=evidence_refs)
+        return summarize_decomposition_trace("\n".join(lines))
 
     async def _dispatch_decomposition_prompt(
         self,
@@ -5829,12 +5847,12 @@ class ParallelACExecutor:
         self,
         *,
         trace: DecompositionTraceSummary,
-    ) -> tuple[BounceCause, str, tuple[str, ...], bool]:
-        """Ask a bounded tool-free classifier only for ambiguous failure causes."""
+    ) -> tuple[BounceCause, bool]:
+        """Ask for typed cause metadata without admitting classifier prose."""
         prompt = (
             "Classify this failed execution attempt for recovery. Use only the bounded "
             "attempt evidence below. Do not infer complexity from task length or wording. "
-            "Return ONLY JSON with cause, reason, evidence_refs, and has_remaining_scope. "
+            "Return ONLY JSON with cause and has_remaining_scope. "
             "cause must be TOO_BIG, BAD_SPEC, ENVIRONMENT, MODEL, or UNKNOWN. TOO_BIG is "
             "allowed only when the trace shows attempted work and distinct parent scope "
             "still remaining.\n\n"
@@ -5851,36 +5869,22 @@ class ParallelACExecutor:
                 raise ValueError
             match = re.search(r"\{.*\}", response, re.DOTALL)
             payload = json.loads(match.group() if match is not None else response)
-            if not isinstance(payload, dict):
+            if not _mapping_has_exact_keys(payload, _BOUNCE_CLASSIFICATION_KEYS):
                 raise ValueError
-            cause = BounceCause(payload.get("cause", BounceCause.UNKNOWN.value))
-            reason = payload.get("reason", "")
-            refs = payload.get("evidence_refs", ())
-            remaining = payload.get("has_remaining_scope", False)
-            if not isinstance(reason, str):
-                reason = ""
-            if not isinstance(refs, list) or not all(isinstance(item, str) for item in refs):
-                refs = []
+            assert isinstance(payload, Mapping)
+            cause = BounceCause(payload["cause"])
+            remaining = payload["has_remaining_scope"]
             if type(remaining) is not bool:
-                remaining = False
-            bounded_refs = DecompositionTraceSummary(
-                summary="",
-                evidence_refs=tuple(refs[:8]),
-            ).evidence_refs
-            return (
-                cause,
-                redact_and_truncate_text(reason, max_chars=240),
-                bounded_refs,
-                remaining,
-            )
+                raise ValueError
+            return cause, remaining
         except (TimeoutError, ValueError, json.JSONDecodeError, TypeError):
-            return BounceCause.UNKNOWN, "Bounce classifier returned no admissible cause.", (), False
+            return BounceCause.UNKNOWN, False
         except Exception as exc:
             log.warning(
                 "parallel_executor.bounce_classifier.error",
-                error=redact_and_truncate_text(str(exc), max_chars=240),
+                error_type=type(exc).__name__,
             )
-            return BounceCause.UNKNOWN, "Bounce classifier failed operationally.", (), False
+            return BounceCause.UNKNOWN, False
 
     async def _classify_bounce_result(
         self,
@@ -5912,19 +5916,13 @@ class ParallelACExecutor:
         if failure not in {None, FailureClass.SCOPE_CREEP, FailureClass.STALL}:
             return deterministic
 
-        (
-            proposed_cause,
-            reason,
-            proposed_refs,
-            has_remaining_scope,
-        ) = await self._request_bounce_classification(trace=trace)
-        refs = tuple(dict.fromkeys((*trace.evidence_refs, *proposed_refs)))
+        proposed_cause, has_remaining_scope = await self._request_bounce_classification(trace=trace)
         return classify_bounce(
             failure,
             admission,
             proposed_cause=proposed_cause,
-            proposed_reasons=(reason,),
-            evidence_refs=refs,
+            proposed_reasons=(),
+            evidence_refs=trace.evidence_refs,
             has_attempt_evidence=bool(
                 result.messages or result.typed_evidence or trace.evidence_refs
             ),
@@ -5954,7 +5952,11 @@ class ParallelACExecutor:
         investment_spec: InvestmentSpec | None = None,
     ) -> tuple[ACExecutionResult | None, DecompositionDecisionRecord | None]:
         """Run cause-matched bounce recovery before alternate-harness fallback."""
-        if self._decomposition_mode != "bounce_only" or result.success:
+        if (
+            self._decomposition_mode != "bounce_only"
+            or result.success
+            or _has_usage_limit_pause(result)
+        ):
             return None, None
         previous = self._decomposition_decisions.get(node_identity.node_id)
         if previous is not None and previous.source is DecompositionSource.BOUNCE:
@@ -6090,9 +6092,9 @@ class ParallelACExecutor:
         """Execute a single AC via the sole recursive AC execution entry point.
 
         Flow:
-        1. Ask Claude to analyze if AC needs decomposition
-        2. If decomposable → get Sub-ACs → execute in parallel
-        3. If atomic → execute directly
+        1. Execute the AC atomically.
+        2. Classify an evidence-backed failure.
+        3. Only a ``TOO_BIG`` bounce may enter verified decomposition.
 
         Args:
             ac_index: 0-based AC index.
@@ -6121,8 +6123,8 @@ class ParallelACExecutor:
                 This is separate from ``ac_spec`` so the parent's success contract
                 is not copied into child prompts.
             decomposition_trustworthy: Explicit deterministic trust for this unit's
-                decomposition. Defaults fail closed; current live decomposition has
-                no trusted producer.
+                decomposition. Defaults fail closed; only the verified-MECE producer
+                may authorize trusted-child routing.
 
         Returns:
             ACExecutionResult for this AC.
@@ -6161,64 +6163,12 @@ class ParallelACExecutor:
                 raise RuntimeError(
                     "durable atomic route state contradicts the decomposition decision"
                 )
-            # The provider boundary already emitted a RouteCandidate only
-            # after this root passed decomposition as atomic.  Re-running the
-            # preflight provider on resume/successor dispatch would repeat an
-            # effect before replay authorization and could switch call sites.
-            node_decision = DecompositionDecisionRecord(
-                node_id=node_identity.node_id,
-                source=DecompositionSource.PREFLIGHT,
-                disposition=DecompositionDisposition.ATOMIC,
-                reasons=("durable_route_history_proves_atomic",),
-            )
-            self._decomposition_decisions[node_identity.node_id] = node_decision
-
-        # Compatibility mode keeps preflight ordering, but every result is now a
-        # persisted explicit decision and only a trusted SPLIT may lower children.
-        if (
-            not durable_route_proves_atomic
-            and self._decomposition_mode == "preflight"
-            and depth < self._max_decomposition_depth
-        ):
-            display_label = (
-                f"AC {node_identity.display_path}"
-                if node_identity.depth == 0
-                else f"Sub-AC {node_identity.display_path}"
-            )
-            self._console.print(f"  [dim]{display_label}: Analyzing complexity...[/dim]")
-            self._flush_console()
-            if node_decision is None:
-                raw_decision = await self._try_decompose_ac(
-                    ac_content=ac_content,
-                    ac_index=ac_index,
-                    seed_goal=seed_goal,
-                    tools=tools,
-                    system_prompt=system_prompt,
-                    node_identity=node_identity,
-                    session_id=session_id,
-                    execution_id=execution_context_id,
-                    retry_attempt=retry_attempt,
-                    depth=depth,
-                    ac_spec=ac_spec,
-                    source=DecompositionSource.PREFLIGHT,
-                )
-                node_decision = self._coerce_decomposition_decision(
-                    raw_decision,
-                    node_identity=node_identity,
-                    source=DecompositionSource.PREFLIGHT,
-                )
-                node_decision = await self._finalize_decomposition_decision(
-                    decision=node_decision,
-                    node_identity=node_identity,
-                    execution_id=execution_context_id,
-                    session_id=session_id,
-                )
 
         if (
             node_decision is not None
             and node_decision.disposition is DecompositionDisposition.SPLIT
             and len(node_decision.children) >= MIN_SUB_ACS
-            and (self._decomposition_mode == "preflight" or node_decision.trustworthy is True)
+            and node_decision.trustworthy is True
         ):
             if depth >= self._max_decomposition_depth:
                 raise RuntimeError("durable decomposition exceeds the replayable depth boundary")
@@ -6242,35 +6192,16 @@ class ParallelACExecutor:
                 investment_spec=investment_spec,
             )
 
-        if (
-            self._decomposition_mode == "preflight"
-            and depth >= self._max_decomposition_depth
-            and node_decision is None
-        ):
-            node_decision = await self._finalize_decomposition_decision(
-                decision=DecompositionDecisionRecord(
-                    node_id=node_identity.node_id,
-                    source=DecompositionSource.PREFLIGHT,
-                    disposition=DecompositionDisposition.ESCALATED,
-                    reasons=("decomposition_depth_cap",),
-                    compromise_reason="depth_cap_forced_atomic",
-                ),
-                node_identity=node_identity,
-                execution_id=execution_context_id,
-                session_id=session_id,
-            )
-
-        # Depth-limit canary: execution is forced atomic once the soft recursion
-        # safety net is reached, so downstream stages can detect decomposition pressure.
-        decomposition_depth_warning = (
-            self._decomposition_mode == "preflight" and depth >= self._max_decomposition_depth
-        )
+        decomposition_depth_warning = False
 
         def _finalize_node_result(result: ACExecutionResult) -> ACExecutionResult:
-            updates: dict[str, Any] = {"decomposition_decision": node_decision}
-            if decomposition_depth_warning:
-                updates["decomposition_depth_warning"] = True
-            return replace(result, **updates)
+            return replace(
+                result,
+                decomposition_decision=node_decision,
+                decomposition_depth_warning=(
+                    result.decomposition_depth_warning or decomposition_depth_warning
+                ),
+            )
 
         # Stall recovery belongs to atomic leaves only. Once this method decides
         # to execute atomically, it can retry the leaf without re-running the
@@ -6722,29 +6653,6 @@ class ParallelACExecutor:
         )
 
     @staticmethod
-    def _parse_legacy_decomposition(
-        response_text: str,
-        *,
-        min_sub_acs: int,
-        max_sub_acs: int,
-    ) -> list[str] | None:
-        """Parse a legacy string-array response without granting it trust."""
-        match = re.search(r"\[.*\]", response_text, re.DOTALL)
-        if match is None:
-            return None
-        try:
-            parsed = json.loads(match.group())
-        except json.JSONDecodeError:
-            return None
-        if (
-            isinstance(parsed, list)
-            and all(isinstance(item, str) and item.strip() for item in parsed)
-            and min_sub_acs <= len(parsed) <= max_sub_acs
-        ):
-            return [item.strip() for item in parsed]
-        return None
-
-    @staticmethod
     def _parse_structured_decomposition(
         response_text: str,
         *,
@@ -6785,7 +6693,7 @@ class ParallelACExecutor:
         trace_summary: str,
         system_prompt: str,
     ) -> tuple[bool, tuple[str, ...]]:
-        """Run one independent bounded semantic attestation for a proposed split."""
+        """Run one independent typed semantic attestation for a proposed split."""
         profile_clause = ""
         if self._execution_profile is not None:
             profile_clause = (
@@ -6797,8 +6705,8 @@ class ParallelACExecutor:
             "Independently attest this proposed decomposition. Do not modify files and do "
             "not accept the proposal merely because it declares coverage. Return ONLY JSON "
             "with boolean coverage_established, non_overlap_established, "
-            "simpler_units_established, and a reasons string array. All three booleans must "
-            "be true to establish the split.\n\n"
+            "and simpler_units_established. All three booleans must be true to establish "
+            "the split. Do not add explanatory fields.\n\n"
             f"{profile_clause}"
             f"Parent criterion:\n{parent_text}\n\n"
             f"Bounded attempt trace:\n{trace_summary or 'none'}\n\n"
@@ -6817,32 +6725,38 @@ class ParallelACExecutor:
                 raise ValueError
             match = re.search(r"\{.*\}", response, re.DOTALL)
             payload = json.loads(match.group() if match is not None else response)
-            if not isinstance(payload, dict):
+            if not _mapping_has_exact_keys(payload, _DECOMPOSITION_ATTESTATION_KEYS):
                 raise ValueError
+            assert isinstance(payload, Mapping)
             checks = (
                 payload.get("coverage_established"),
                 payload.get("non_overlap_established"),
                 payload.get("simpler_units_established"),
             )
-            reasons_raw = payload.get("reasons", ())
-            reasons = (
-                tuple(
-                    redact_and_truncate_text(item, max_chars=240)
-                    for item in reasons_raw[:7]
-                    if isinstance(item, str) and item.strip()
-                )
-                if isinstance(reasons_raw, list)
-                else ()
-            )
+            if any(type(value) is not bool for value in checks):
+                raise ValueError
             if all(value is True for value in checks):
-                return True, ("semantic_attestation_established", *reasons)
-            return False, ("semantic_attestation_not_established", *reasons)
+                return True, ("semantic_attestation_established",)
+            failed_checks = tuple(
+                reason
+                for value, reason in zip(
+                    checks,
+                    (
+                        "coverage_not_established",
+                        "non_overlap_not_established",
+                        "simpler_units_not_established",
+                    ),
+                    strict=True,
+                )
+                if value is False
+            )
+            return False, ("semantic_attestation_not_established", *failed_checks)
         except (TimeoutError, ValueError, json.JSONDecodeError, TypeError):
             return False, ("semantic_attestation_unparseable",)
         except Exception as exc:
             log.warning(
                 "parallel_executor.decomposition.attestation_error",
-                error=redact_and_truncate_text(str(exc), max_chars=240),
+                error_type=type(exc).__name__,
             )
             return False, ("semantic_attestation_runtime_error",)
 
@@ -6909,12 +6823,14 @@ class ParallelACExecutor:
         retry_attempt: int = 0,
         depth: int = 0,
         ac_spec: AcceptanceCriterionSpec | None = None,
-        source: DecompositionSource = DecompositionSource.PREFLIGHT,
+        source: DecompositionSource = DecompositionSource.BOUNCE,
         cause: BounceCause | None = None,
         trace_summary: str = "",
         evidence_refs: tuple[str, ...] = (),
     ) -> DecompositionDecisionRecord:
         """Decompose an AC and return a versioned, fail-closed decision."""
+        if source is not DecompositionSource.BOUNCE or cause is not BounceCause.TOO_BIG:
+            raise RuntimeError("live decomposition requires an evidence-backed TOO_BIG bounce")
         del tools, system_prompt, retry_attempt, ac_spec
         ac_label = (
             f"AC #{node_identity.display_path}"
@@ -7002,139 +6918,94 @@ Respond with either ATOMIC or the structured JSON object only.
                 return DecompositionDecisionRecord(
                     node_id=decision_identity.node_id,
                     source=source,
-                    disposition=(
-                        DecompositionDisposition.ATOMIC
-                        if source is DecompositionSource.PREFLIGHT
-                        else DecompositionDisposition.ESCALATED
-                    ),
+                    disposition=DecompositionDisposition.ESCALATED,
                     cause=cause,
                     reasons=("explicit_atomic",),
                     evidence_refs=evidence_refs,
-                    compromise_reason=(
-                        None
-                        if source is DecompositionSource.PREFLIGHT
-                        else "too_big_classifier_disagreed_with_decomposer"
-                    ),
+                    compromise_reason="too_big_classifier_disagreed_with_decomposer",
                 )
 
-            if "{" in response_text:
-                proposal, proposal_reasons = await self._verify_generic_decomposition(
-                    response_text=response_text,
-                    parent_text=ac_content,
-                    trace_summary=bounded_trace,
-                    system_prompt=decomposition_system_prompt,
-                    min_sub_acs=min_sub_acs,
-                    max_sub_acs=max_sub_acs,
-                )
-                if proposal is not None:
-                    return DecompositionDecisionRecord(
-                        node_id=decision_identity.node_id,
-                        source=source,
-                        disposition=DecompositionDisposition.SPLIT,
-                        cause=cause,
-                        reasons=proposal_reasons,
-                        evidence_refs=evidence_refs,
-                        children=proposal.children,
-                        structural_status=StructuralCheckStatus.PASSED,
-                        semantic_status=SemanticAttestationStatus.ESTABLISHED,
-                        trustworthy=True,
-                    )
-
-                repair_prompt = self._build_generic_decomposition_repair_prompt(
-                    parent_text=ac_content,
-                    trace_summary=bounded_trace,
-                    reasons=proposal_reasons,
-                    min_sub_acs=min_sub_acs,
-                    max_sub_acs=max_sub_acs,
-                )
-                repaired_text = await _invoke_execution_authority_entry(
-                    self,
-                    _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
-                    prompt=repair_prompt,
-                    system_prompt=decomposition_system_prompt,
-                )
-                repaired_proposal, repaired_reasons = await self._verify_generic_decomposition(
-                    response_text=repaired_text,
-                    parent_text=ac_content,
-                    trace_summary=bounded_trace,
-                    system_prompt=decomposition_system_prompt,
-                    min_sub_acs=min_sub_acs,
-                    max_sub_acs=max_sub_acs,
-                )
-                if repaired_proposal is not None:
-                    return DecompositionDecisionRecord(
-                        node_id=decision_identity.node_id,
-                        source=source,
-                        disposition=DecompositionDisposition.SPLIT,
-                        cause=cause,
-                        reasons=repaired_reasons,
-                        evidence_refs=evidence_refs,
-                        children=repaired_proposal.children,
-                        structural_status=StructuralCheckStatus.PASSED,
-                        semantic_status=SemanticAttestationStatus.ESTABLISHED,
-                        repair_count=1,
-                        trustworthy=True,
-                    )
-
-                final_reasons = repaired_reasons or proposal_reasons
-                semantic_failure = any(
-                    reason.startswith("semantic_attestation") for reason in final_reasons
-                )
-                return DecompositionDecisionRecord(
-                    node_id=decision_identity.node_id,
-                    source=source,
-                    disposition=DecompositionDisposition.ESCALATED,
-                    cause=cause,
-                    reasons=final_reasons,
-                    evidence_refs=evidence_refs,
-                    structural_status=(
-                        StructuralCheckStatus.PASSED
-                        if semantic_failure
-                        else StructuralCheckStatus.FAILED
-                    ),
-                    semantic_status=(
-                        SemanticAttestationStatus.NOT_ESTABLISHED
-                        if semantic_failure
-                        else SemanticAttestationStatus.NOT_RUN
-                    ),
-                    repair_count=1,
-                    compromise_reason="generic_decomposition_repair_failed",
-                )
-
-            sub_acs = self._parse_legacy_decomposition(
-                response_text,
+            proposal, proposal_reasons = await self._verify_generic_decomposition(
+                response_text=response_text,
+                parent_text=ac_content,
+                trace_summary=bounded_trace,
+                system_prompt=decomposition_system_prompt,
                 min_sub_acs=min_sub_acs,
                 max_sub_acs=max_sub_acs,
             )
-            if sub_acs is not None:
-                log.warning(
-                    "parallel_executor.decomposition.legacy_array_untrusted",
-                    ac_index=ac_index,
-                    sub_ac_count=len(sub_acs),
-                    **profile_metadata,
-                )
-                return legacy_unverified_split_decision(
+            if proposal is not None:
+                return DecompositionDecisionRecord(
                     node_id=decision_identity.node_id,
                     source=source,
-                    child_descriptions=sub_acs,
+                    disposition=DecompositionDisposition.SPLIT,
                     cause=cause,
-                    reasons=("legacy_array_without_attestation",),
+                    reasons=proposal_reasons,
                     evidence_refs=evidence_refs,
+                    children=proposal.children,
+                    structural_status=StructuralCheckStatus.PASSED,
+                    semantic_status=SemanticAttestationStatus.ESTABLISHED,
+                    trustworthy=True,
                 )
 
-            log.warning(
-                "parallel_executor.decomposition.unparseable_unknown",
-                ac_index=ac_index,
-                response_preview=redact_and_truncate_text(response_text, max_chars=100),
-                **profile_metadata,
+            repair_prompt = self._build_generic_decomposition_repair_prompt(
+                parent_text=ac_content,
+                trace_summary=bounded_trace,
+                reasons=proposal_reasons,
+                min_sub_acs=min_sub_acs,
+                max_sub_acs=max_sub_acs,
+            )
+            repaired_text = await _invoke_execution_authority_entry(
+                self,
+                _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
+                prompt=repair_prompt,
+                system_prompt=decomposition_system_prompt,
+            )
+            repaired_proposal, repaired_reasons = await self._verify_generic_decomposition(
+                response_text=repaired_text,
+                parent_text=ac_content,
+                trace_summary=bounded_trace,
+                system_prompt=decomposition_system_prompt,
+                min_sub_acs=min_sub_acs,
+                max_sub_acs=max_sub_acs,
+            )
+            if repaired_proposal is not None:
+                return DecompositionDecisionRecord(
+                    node_id=decision_identity.node_id,
+                    source=source,
+                    disposition=DecompositionDisposition.SPLIT,
+                    cause=cause,
+                    reasons=repaired_reasons,
+                    evidence_refs=evidence_refs,
+                    children=repaired_proposal.children,
+                    structural_status=StructuralCheckStatus.PASSED,
+                    semantic_status=SemanticAttestationStatus.ESTABLISHED,
+                    repair_count=1,
+                    trustworthy=True,
+                )
+
+            final_reasons = repaired_reasons or proposal_reasons
+            semantic_failure = any(
+                reason.startswith("semantic_attestation") for reason in final_reasons
             )
             return DecompositionDecisionRecord(
                 node_id=decision_identity.node_id,
                 source=source,
-                disposition=DecompositionDisposition.UNKNOWN,
+                disposition=DecompositionDisposition.ESCALATED,
                 cause=cause,
-                reasons=("unparseable_decomposition_response",),
+                reasons=final_reasons,
                 evidence_refs=evidence_refs,
+                structural_status=(
+                    StructuralCheckStatus.PASSED
+                    if semantic_failure
+                    else StructuralCheckStatus.FAILED
+                ),
+                semantic_status=(
+                    SemanticAttestationStatus.NOT_ESTABLISHED
+                    if semantic_failure
+                    else SemanticAttestationStatus.NOT_RUN
+                ),
+                repair_count=1,
+                compromise_reason="generic_decomposition_repair_failed",
             )
         except TimeoutError:
             log.warning(
@@ -7155,7 +7026,7 @@ Respond with either ATOMIC or the structured JSON object only.
             log.warning(
                 "parallel_executor.decomposition.error",
                 ac_index=ac_index,
-                error=redact_and_truncate_text(str(exc), max_chars=240),
+                error_type=type(exc).__name__,
                 **profile_metadata,
             )
             return DecompositionDecisionRecord(
@@ -10769,8 +10640,8 @@ Respond with either ATOMIC or the structured JSON object only.
                         )
                         continue
                     # Routing D has no child/aggregate replay owner in this
-                    # slice.  Once preflight or bounce execution proves this
-                    # root is composite, finish its established legacy
+                    # slice. Once a verified bounce decision proves this root
+                    # is composite, finish its established legacy
                     # verify/retry policy rather than interpreting a missing
                     # top-level RouteCandidate as a bounded outcome.
                     legacy_result = await self._continue_decomposed_legacy_recovery(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -412,6 +412,72 @@ def _composite_completion_event_sentinel(root_ac_count: int) -> int:
     return root_ac_count + 1
 
 
+def _decomposition_decision_event_sentinel(root_ac_count: int) -> int:
+    """Return the max-plus-one durable decision population for one Seed.
+
+    A historical PREFLIGHT atomic decision may transition once to the live
+    BOUNCE decision after migration. No other finalized decision can change.
+    """
+
+    if type(root_ac_count) is not int or root_ac_count < 0:
+        raise ValueError("decomposition decision root population is invalid")
+    node_population = root_ac_count * (MAX_DECOMPOSITION_REPLAY_NODES + 1)
+    return node_population * 2 + 1
+
+
+_DECOMPOSITION_DECISION_RECORD_KEYS = frozenset(
+    {
+        "schema_version",
+        "node_id",
+        "source",
+        "disposition",
+        "cause",
+        "reasons",
+        "evidence_refs",
+        "children",
+        "structural_status",
+        "semantic_status",
+        "repair_count",
+        "trustworthy",
+        "compromise_reason",
+    }
+)
+_DECOMPOSITION_DECISION_EVENT_KEYS = frozenset(
+    {
+        "identity_model",
+        "schema_version",
+        "node_id",
+        "parent_node_id",
+        "legacy_node_id",
+        "legacy_parent_node_id",
+        "legacy_node_aliases",
+        "legacy_parent_node_aliases",
+        "root_ac_index",
+        "root_ac_number",
+        "path",
+        "display_path",
+        "depth",
+        "ordinal",
+        "node_kind",
+        "execution_id",
+        "session_id",
+        "mode",
+        "child_count",
+        "source",
+        "disposition",
+        "cause",
+        "reasons",
+        "evidence_refs",
+        "children",
+        "structural_status",
+        "semantic_status",
+        "repair_count",
+        "trustworthy",
+        "compromise_reason",
+    }
+)
+
+
 _PARALLEL_ROUTE_PAUSE_KEYS = frozenset(
     {
         "schema_version",
@@ -3953,6 +4019,15 @@ class ParallelACExecutor:
         resume_from_level = 0
         recoverable_route_pause = False
 
+        # ``decision_finalized`` is the mandatory persistence boundary. Restore
+        # it before checkpoints, route projections, or any provider entrance so
+        # a crash after finalization cannot redispatch the parent/decomposer.
+        await self._restore_finalized_decomposition_decisions(
+            seed=seed,
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+
         # RC3: Attempt to recover from checkpoint
         if self._checkpoint_store:
             try:
@@ -4031,14 +4106,10 @@ class ParallelACExecutor:
                         saved_contexts = cp.state.get("level_contexts", [])
                         if saved_contexts:
                             level_contexts = deserialize_level_contexts(saved_contexts)
-                        raw_decisions = cp.state.get("decomposition_decisions", {})
-                        if isinstance(raw_decisions, Mapping):
-                            for raw_node_id, raw_record in raw_decisions.items():
-                                if not isinstance(raw_node_id, str):
-                                    continue
-                                restored = DecompositionDecisionRecord.from_dict(raw_record)
-                                if restored is not None and restored.node_id == raw_node_id:
-                                    self._decomposition_decisions[raw_node_id] = restored
+                        self._restore_checkpoint_decomposition_decisions(
+                            checkpoint_state.get("decomposition_decisions", {}),
+                            root_ac_count=total_acs,
+                        )
                         log.info(
                             "parallel_executor.recovery.resuming",
                             from_level=resume_from_level,
@@ -4132,6 +4203,11 @@ class ParallelACExecutor:
                             session_id=session_id,
                             execution_id=execution_id,
                         )
+            except RuntimeError:
+                # A matching checkpoint is durable execution authority.  Once
+                # recognized, malformed state must stop before provider entry;
+                # treating it as a cache miss would redispatch completed work.
+                raise
             except Exception as e:
                 log.warning(
                     "parallel_executor.recovery.failed",
@@ -5523,16 +5599,174 @@ class ParallelACExecutor:
                 reasons=("decomposition_decision_identity_mismatch",),
             )
         previous = self._decomposition_decisions.get(node_identity.node_id)
-        if previous != decision:
-            await self._event_emitter.emit_decomposition_decision_finalized(
-                execution_id=execution_id,
-                session_id=session_id,
-                mode=self._decomposition_mode,
-                node_identity=node_identity,
-                decision=decision,
+        if (
+            previous is not None
+            and previous != decision
+            and not self._is_valid_decision_transition(
+                previous,
+                decision,
             )
+        ):
+            raise RuntimeError("a finalized decomposition decision cannot change")
+        if previous == decision:
+            return decision
+        await self._event_emitter.emit_decomposition_decision_finalized(
+            execution_id=execution_id,
+            session_id=session_id,
+            mode=self._decomposition_mode,
+            node_identity=node_identity,
+            decision=decision,
+        )
         self._decomposition_decisions[node_identity.node_id] = decision
         return decision
+
+    @staticmethod
+    def _is_valid_decision_transition(
+        previous: DecompositionDecisionRecord,
+        current: DecompositionDecisionRecord,
+    ) -> bool:
+        """Admit only the one historical-to-live migration transition."""
+
+        return bool(
+            previous.node_id == current.node_id
+            and previous.source is DecompositionSource.PREFLIGHT
+            and previous.disposition is not DecompositionDisposition.SPLIT
+            and current.source is DecompositionSource.BOUNCE
+        )
+
+    def _publish_replayed_decomposition_decision(
+        self,
+        decision: DecompositionDecisionRecord,
+    ) -> None:
+        """Publish one replayed decision without permitting source conflicts."""
+
+        previous = self._decomposition_decisions.get(decision.node_id)
+        if previous is not None and previous != decision:
+            raise RuntimeError("durable decomposition decisions conflict")
+        self._decomposition_decisions[decision.node_id] = decision
+
+    async def _restore_finalized_decomposition_decisions(
+        self,
+        *,
+        seed: Seed,
+        execution_id: str,
+        session_id: str,
+    ) -> None:
+        """Replay the mandatory decision event before any resumed effect.
+
+        Checkpoints and composite projections are caches of this authority, not
+        substitutes for it.  Historical PREFLIGHT decisions remain consumable,
+        while the live constructor still exposes no preflight producer path.
+        """
+
+        event_limit = _decomposition_decision_event_sentinel(len(seed.acceptance_criteria))
+        raw_events = await self._event_store.query_execution_related_events(
+            execution_id,
+            event_type="execution.decomposition.decision_finalized",
+            limit=event_limit,
+        )
+        try:
+            events = list(raw_events)
+        except TypeError as exc:
+            raise RuntimeError(
+                "decomposition decision replay returned a non-iterable page"
+            ) from exc
+        if len(events) >= event_limit:
+            raise RuntimeError("decomposition decision replay exceeds the admitted node population")
+        seen: dict[str, DecompositionDecisionRecord] = {}
+        for event in sorted(events, key=lambda item: (item.timestamp, item.id)):
+            if event.type != "execution.decomposition.decision_finalized":
+                continue
+            data = event.data
+            if not _mapping_has_exact_keys(data, _DECOMPOSITION_DECISION_EVENT_KEYS):
+                raise RuntimeError("decomposition decision replay has an invalid event envelope")
+            if data.get("session_id") != session_id:
+                continue
+            raw_path = data.get("path")
+            root_ac_index = data.get("root_ac_index")
+            if (
+                data.get("execution_id") != execution_id
+                or data.get("identity_model") != "execution_node_v1"
+                or type(root_ac_index) is not int
+                or not 0 <= root_ac_index < len(seed.acceptance_criteria)
+                or type(raw_path) is not list
+                or not raw_path
+                or len(raw_path) > self._max_decomposition_depth + 1
+                or any(type(ordinal) is not int or ordinal < 0 for ordinal in raw_path)
+                or raw_path[0] != root_ac_index
+                or any(ordinal >= MAX_DECOMPOSITION_CHILDREN for ordinal in raw_path[1:])
+            ):
+                raise RuntimeError("decomposition decision replay has invalid execution identity")
+            node_identity = ExecutionNodeIdentity.root(
+                execution_context_id=execution_id or session_id,
+                ac_index=root_ac_index,
+            )
+            for ordinal in raw_path[1:]:
+                node_identity = node_identity.child(ordinal)
+            raw_decision = {key: data[key] for key in _DECOMPOSITION_DECISION_RECORD_KEYS}
+            decision = DecompositionDecisionRecord.from_dict(raw_decision)
+            mode = data.get("mode")
+            expected_source = (
+                DecompositionSource.PREFLIGHT
+                if mode == "preflight"
+                else DecompositionSource.BOUNCE
+                if mode == "bounce_only"
+                else None
+            )
+            if (
+                decision is None
+                or decision.node_id != node_identity.node_id
+                or decision.source is not expected_source
+                or data.get("child_count") != len(decision.children)
+                or (
+                    decision.disposition is DecompositionDisposition.SPLIT
+                    and node_identity.depth >= self._max_decomposition_depth
+                )
+            ):
+                raise RuntimeError("decomposition decision replay has invalid decision authority")
+            expected_payload = {
+                **node_identity.to_event_metadata(),
+                **decision.to_dict(),
+                "execution_id": execution_id,
+                "session_id": session_id,
+                "mode": mode,
+                "child_count": len(decision.children),
+            }
+            if data != expected_payload:
+                raise RuntimeError("decomposition decision replay is not canonical")
+            previous = seen.get(decision.node_id)
+            if previous is not None:
+                if not self._is_valid_decision_transition(previous, decision):
+                    raise RuntimeError("decomposition decision replay has an invalid transition")
+                self._decomposition_decisions[decision.node_id] = decision
+            else:
+                self._publish_replayed_decomposition_decision(decision)
+            seen[decision.node_id] = decision
+
+    def _restore_checkpoint_decomposition_decisions(
+        self,
+        raw_decisions: object,
+        *,
+        root_ac_count: int,
+    ) -> None:
+        """Strictly merge the checkpoint cache into event-owned replay state."""
+
+        if type(raw_decisions) is not dict:
+            raise RuntimeError("checkpoint decomposition decisions are malformed")
+        max_population = root_ac_count * (MAX_DECOMPOSITION_REPLAY_NODES + 1)
+        if len(raw_decisions) > max_population:
+            raise RuntimeError("checkpoint decomposition decisions exceed their bound")
+        for raw_node_id, raw_record in raw_decisions.items():
+            if type(raw_node_id) is not str:
+                raise RuntimeError("checkpoint decomposition decision id is malformed")
+            restored = DecompositionDecisionRecord.from_dict(raw_record)
+            if (
+                restored is None
+                or restored.node_id != raw_node_id
+                or restored.to_dict() != raw_record
+            ):
+                raise RuntimeError("checkpoint decomposition decision is non-canonical")
+            self._publish_replayed_decomposition_decision(restored)
 
     async def _execute_decomposition_children(
         self,
@@ -10623,6 +10857,71 @@ Respond with either ATOMIC or the structured JSON object only.
                 if not isinstance(value, ACExecutionResult):
                     self._parallel_route_resumes.pop(ac_idx, None)
                     continue
+                if (
+                    not value.is_decomposed
+                    and not value.success
+                    and not _has_usage_limit_pause(value)
+                    and value.outcome
+                    not in {ACExecutionOutcome.BLOCKED, ACExecutionOutcome.INVALID}
+                ):
+                    # A classified TOO_BIG result changes the root from an
+                    # atomic route episode into a verified composite.  Own that
+                    # transition here, before route escalation can skip the sole
+                    # live decomposition path.  Once finalized, the composite
+                    # branch below owns child replay and no top-level successor
+                    # route is admitted for this result.
+                    criterion = seed.acceptance_criteria[ac_idx]
+                    semantic_ac_key = (
+                        criterion.semantic_ac_key
+                        if isinstance(criterion, AcceptanceCriterionSpec)
+                        and criterion.semantic_ac_key is not None
+                        else derive_semantic_ac_key(criterion)
+                    )
+                    node_identity = ExecutionNodeIdentity.root(
+                        execution_context_id=execution_id or session_id,
+                        ac_index=ac_idx,
+                    )
+                    (
+                        bounce_result,
+                        bounce_decision,
+                    ) = await self._maybe_recover_with_bounce_decomposition(
+                        result=value,
+                        ac_index=ac_idx,
+                        ac_content=ac_text(criterion),
+                        session_id=session_id,
+                        tools=tools,
+                        tool_catalog=tool_catalog,
+                        system_prompt=system_prompt,
+                        seed_goal=seed.goal,
+                        depth=0,
+                        execution_id=execution_id,
+                        level_contexts=level_contexts,
+                        retry_attempt=ac_retry_attempts[ac_idx],
+                        execution_counters=execution_counters,
+                        node_identity=node_identity,
+                        ac_spec=(
+                            criterion if isinstance(criterion, AcceptanceCriterionSpec) else None
+                        ),
+                        start_time=datetime.now(UTC),
+                        semantic_ac_key=semantic_ac_key,
+                        investment_spec=(
+                            criterion.investment
+                            if isinstance(criterion, AcceptanceCriterionSpec)
+                            else None
+                        ),
+                    )
+                    if bounce_decision is not None:
+                        value = replace(
+                            value,
+                            decomposition_decision=bounce_decision,
+                            decomposition_depth_warning=(
+                                value.decomposition_depth_warning
+                                or bounce_decision.compromise_reason == "depth_cap_forced_atomic"
+                            ),
+                        )
+                    if bounce_result is not None:
+                        value = bounce_result
+                    results[positions[ac_idx]] = value
                 if value.is_decomposed:
                     if (
                         recoverable_pause_seen
@@ -11145,7 +11444,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 decomposition_decision=decision,
             )
             composite_results[root_ac_index] = restored
-            self._decomposition_decisions[decision.node_id] = decision
+            self._publish_replayed_decomposition_decision(decision)
         partial_states: dict[int, tuple[_PartialCompositeResumeState, ...]] = {}
         prior_frame_states: dict[tuple[int, str], _PartialCompositeResumeState] = {}
         prior_paths: dict[int, tuple[_PartialCompositeResumeState, ...]] = {}
@@ -11336,7 +11635,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     raise RuntimeError("partial composite replay conflicts with completion")
                 continue
             for state in states:
-                self._decomposition_decisions[state.decision.node_id] = state.decision
+                self._publish_replayed_decomposition_decision(state.decision)
                 self._partial_composite_resumes[state.decision.node_id] = state
         grouped: dict[int, list[tuple[RouteObservation, object, bool, object]]] = {
             ac_idx: [] for ac_idx in root_ac_indices

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -122,6 +122,10 @@ from ouroboros.orchestrator.decomposition_params import (
     params_from_profile,
 )
 from ouroboros.orchestrator.decomposition_policy import (
+    MAX_EVIDENCE_REF_CHARS,
+    MAX_EVIDENCE_REF_COUNT,
+    MAX_REASON_CHARS,
+    MAX_TRACE_SUMMARY_CHARS,
     BounceCause,
     DecompositionDecisionRecord,
     DecompositionDisposition,
@@ -476,6 +480,33 @@ _DECOMPOSITION_DECISION_EVENT_KEYS = frozenset(
         "compromise_reason",
     }
 )
+_BOUNCE_CLASSIFIED_EVENT_KEYS = frozenset(
+    {
+        "identity_model",
+        "schema_version",
+        "node_id",
+        "parent_node_id",
+        "legacy_node_id",
+        "legacy_parent_node_id",
+        "legacy_node_aliases",
+        "legacy_parent_node_aliases",
+        "root_ac_index",
+        "root_ac_number",
+        "path",
+        "display_path",
+        "depth",
+        "ordinal",
+        "node_kind",
+        "execution_id",
+        "session_id",
+        "cause",
+        "rationale",
+        "failure_class",
+        "retry_admission",
+        "evidence_refs",
+        "trace_summary",
+    }
+)
 
 
 _PARALLEL_ROUTE_PAUSE_KEYS = frozenset(
@@ -613,6 +644,19 @@ class _PartialCompositeResumeState:
     paused_runtime_scope_id: str | None
     paused_dispatch_id: str | None
     paused_capsule_fingerprint: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _DurableBounceReplayState:
+    """Validated TOO_BIG phase persisted before decomposition provider effects."""
+
+    cause: BounceCause
+    rationale: str
+    failure_class: str | None
+    retry_admission: str | None
+    evidence_refs: tuple[str, ...]
+    trace_summary: str
+    event_key: tuple[datetime, str] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -3022,6 +3066,8 @@ class ParallelACExecutor:
         )
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
+        self._event_owned_decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
+        self._pending_bounce_decompositions: dict[str, _DurableBounceReplayState] = {}
         self._partial_composite_resumes: dict[str, _PartialCompositeResumeState] = {}
         self._parallel_route_resumes: dict[int, _ParallelRouteResumeState] = {}
         self._execution_counters_lock = asyncio.Lock()
@@ -4019,9 +4065,14 @@ class ParallelACExecutor:
         resume_from_level = 0
         recoverable_route_pause = False
 
-        # ``decision_finalized`` is the mandatory persistence boundary. Restore
-        # it before checkpoints, route projections, or any provider entrance so
-        # a crash after finalization cannot redispatch the parent/decomposer.
+        # Restore the durable bounce phase before its consuming finalized event.
+        # Both precede checkpoints, route projections, and every provider entry.
+        if self._decomposition_mode == "bounce_only":
+            await self._restore_bounce_classifications(
+                seed=seed,
+                execution_id=execution_id,
+                session_id=session_id,
+            )
         await self._restore_finalized_decomposition_decisions(
             seed=seed,
             execution_id=execution_id,
@@ -5589,7 +5640,7 @@ class ParallelACExecutor:
         execution_id: str,
         session_id: str,
     ) -> DecompositionDecisionRecord:
-        """Cache and emit a finalized node decision once per distinct value."""
+        """Persist event-owned authority, then publish its runtime projection."""
         if decision.node_id != node_identity.node_id:
             decision = DecompositionDecisionRecord(
                 node_id=node_identity.node_id,
@@ -5598,7 +5649,10 @@ class ParallelACExecutor:
                 cause=decision.cause,
                 reasons=("decomposition_decision_identity_mismatch",),
             )
-        previous = self._decomposition_decisions.get(node_identity.node_id)
+        previous = self._event_owned_decomposition_decisions.get(node_identity.node_id)
+        cached = self._decomposition_decisions.get(node_identity.node_id)
+        if cached is not None and cached != previous:
+            raise RuntimeError("decomposition cache lacks matching finalized-event authority")
         if (
             previous is not None
             and previous != decision
@@ -5609,7 +5663,9 @@ class ParallelACExecutor:
         ):
             raise RuntimeError("a finalized decomposition decision cannot change")
         if previous == decision:
+            self._decomposition_decisions[node_identity.node_id] = decision
             return decision
+        self._require_pending_bounce_for_finalized_decision(decision)
         await self._event_emitter.emit_decomposition_decision_finalized(
             execution_id=execution_id,
             session_id=session_id,
@@ -5617,6 +5673,9 @@ class ParallelACExecutor:
             node_identity=node_identity,
             decision=decision,
         )
+        if decision.source is DecompositionSource.BOUNCE:
+            self._pending_bounce_decompositions.pop(decision.node_id)
+        self._event_owned_decomposition_decisions[node_identity.node_id] = decision
         self._decomposition_decisions[node_identity.node_id] = decision
         return decision
 
@@ -5634,16 +5693,168 @@ class ParallelACExecutor:
             and current.source is DecompositionSource.BOUNCE
         )
 
-    def _publish_replayed_decomposition_decision(
+    def _require_pending_bounce_for_finalized_decision(
+        self,
+        decision: DecompositionDecisionRecord,
+        *,
+        finalized_event_key: tuple[datetime, str] | None = None,
+    ) -> None:
+        """Bind every BOUNCE decision to its earlier durable TOO_BIG trigger."""
+
+        if decision.source is not DecompositionSource.BOUNCE:
+            return
+        pending = self._pending_bounce_decompositions.get(decision.node_id)
+        if (
+            decision.cause is not BounceCause.TOO_BIG
+            or pending is None
+            or pending.cause is not BounceCause.TOO_BIG
+            or decision.evidence_refs != pending.evidence_refs
+            or (
+                finalized_event_key is not None
+                and pending.event_key is not None
+                and pending.event_key >= finalized_event_key
+            )
+        ):
+            raise RuntimeError("BOUNCE decision lacks matching prior TOO_BIG authority")
+
+    def _publish_event_owned_decomposition_decision(
         self,
         decision: DecompositionDecisionRecord,
     ) -> None:
-        """Publish one replayed decision without permitting source conflicts."""
+        """Publish authority restored from a canonical finalized event."""
 
-        previous = self._decomposition_decisions.get(decision.node_id)
+        previous = self._event_owned_decomposition_decisions.get(decision.node_id)
+        cached = self._decomposition_decisions.get(decision.node_id)
         if previous is not None and previous != decision:
             raise RuntimeError("durable decomposition decisions conflict")
+        if cached is not None and cached != decision:
+            raise RuntimeError("decomposition cache conflicts with finalized-event authority")
+        self._event_owned_decomposition_decisions[decision.node_id] = decision
         self._decomposition_decisions[decision.node_id] = decision
+
+    def _confirm_replayed_decomposition_decision(
+        self,
+        decision: DecompositionDecisionRecord,
+    ) -> None:
+        """Confirm a cache projection without allowing it to mint authority."""
+
+        authority = self._event_owned_decomposition_decisions.get(decision.node_id)
+        if authority is None:
+            raise RuntimeError("decomposition cache lacks finalized-event authority")
+        if authority != decision:
+            raise RuntimeError("decomposition cache conflicts with finalized-event authority")
+        self._decomposition_decisions[decision.node_id] = authority
+
+    async def _restore_bounce_classifications(
+        self,
+        *,
+        seed: Seed,
+        execution_id: str,
+        session_id: str,
+    ) -> None:
+        """Restore canonical durable TOO_BIG phases before any resumed effect."""
+
+        async for event in replay_execution_events_chronologically(
+            self._event_store,
+            execution_id=execution_id,
+            event_type="execution.decomposition.bounce_classified",
+            page_size=_PARALLEL_PAUSE_REPLAY_PAGE_SIZE,
+        ):
+            if event.type != "execution.decomposition.bounce_classified":
+                continue
+            data = event.data
+            if not _mapping_has_exact_keys(data, _BOUNCE_CLASSIFIED_EVENT_KEYS):
+                raise RuntimeError("bounce classification replay has an invalid event envelope")
+            if data.get("session_id") != session_id:
+                continue
+            raw_path = data.get("path")
+            root_ac_index = data.get("root_ac_index")
+            if (
+                data.get("execution_id") != execution_id
+                or data.get("identity_model") != "execution_node_v1"
+                or type(root_ac_index) is not int
+                or not 0 <= root_ac_index < len(seed.acceptance_criteria)
+                or type(raw_path) is not list
+                or not raw_path
+                or len(raw_path) > self._max_decomposition_depth + 1
+                or any(type(ordinal) is not int or ordinal < 0 for ordinal in raw_path)
+                or raw_path[0] != root_ac_index
+                or any(ordinal >= MAX_DECOMPOSITION_CHILDREN for ordinal in raw_path[1:])
+            ):
+                raise RuntimeError("bounce classification replay has invalid execution identity")
+            node_identity = ExecutionNodeIdentity.root(
+                execution_context_id=execution_id or session_id,
+                ac_index=root_ac_index,
+            )
+            for ordinal in raw_path[1:]:
+                node_identity = node_identity.child(ordinal)
+            try:
+                cause = BounceCause(data.get("cause"))
+                raw_evidence_refs = data.get("evidence_refs")
+                if type(raw_evidence_refs) is not list:
+                    raise ValueError
+                trace = DecompositionTraceSummary(
+                    summary=data.get("trace_summary"),
+                    evidence_refs=tuple(raw_evidence_refs),
+                )
+            except (TypeError, ValueError):
+                raise RuntimeError(
+                    "bounce classification replay has malformed bounded evidence"
+                ) from None
+            rationale = data.get("rationale")
+            failure_class = data.get("failure_class")
+            retry_admission = data.get("retry_admission")
+            if (
+                type(rationale) is not str
+                or not rationale
+                or rationale != redact_and_truncate_text(rationale, max_chars=MAX_REASON_CHARS)
+                or trace.summary != data.get("trace_summary")
+                or list(trace.evidence_refs) != raw_evidence_refs
+                or len(trace.evidence_refs) > MAX_EVIDENCE_REF_COUNT
+                or any(len(ref) > MAX_EVIDENCE_REF_CHARS for ref in trace.evidence_refs)
+                or len(trace.summary) > MAX_TRACE_SUMMARY_CHARS
+                or (
+                    failure_class is not None
+                    and (type(failure_class) is not str or len(failure_class) > MAX_REASON_CHARS)
+                )
+                or (
+                    retry_admission is not None
+                    and (
+                        type(retry_admission) is not str or len(retry_admission) > MAX_REASON_CHARS
+                    )
+                )
+            ):
+                raise RuntimeError(
+                    "bounce classification replay has non-canonical bounded evidence"
+                )
+            expected_payload = {
+                **node_identity.to_event_metadata(),
+                "execution_id": execution_id,
+                "session_id": session_id,
+                "cause": cause.value,
+                "rationale": rationale,
+                "failure_class": failure_class,
+                "retry_admission": retry_admission,
+                "evidence_refs": list(trace.evidence_refs),
+                "trace_summary": trace.summary,
+            }
+            if data != expected_payload:
+                raise RuntimeError("bounce classification replay is not canonical")
+            if cause is not BounceCause.TOO_BIG:
+                continue
+            if node_identity.node_id in self._pending_bounce_decompositions:
+                raise RuntimeError(
+                    "bounce classification replay duplicated a pending TOO_BIG phase"
+                )
+            self._pending_bounce_decompositions[node_identity.node_id] = _DurableBounceReplayState(
+                cause=cause,
+                rationale=rationale,
+                failure_class=failure_class,
+                retry_admission=retry_admission,
+                evidence_refs=trace.evidence_refs,
+                trace_summary=trace.summary,
+                event_key=(event.timestamp, event.id),
+            )
 
     async def _restore_finalized_decomposition_decisions(
         self,
@@ -5738,9 +5949,17 @@ class ParallelACExecutor:
             if previous is not None:
                 if not self._is_valid_decision_transition(previous, decision):
                     raise RuntimeError("decomposition decision replay has an invalid transition")
+            self._require_pending_bounce_for_finalized_decision(
+                decision,
+                finalized_event_key=(event.timestamp, event.id),
+            )
+            if decision.source is DecompositionSource.BOUNCE:
+                self._pending_bounce_decompositions.pop(decision.node_id)
+            if previous is not None:
+                self._event_owned_decomposition_decisions[decision.node_id] = decision
                 self._decomposition_decisions[decision.node_id] = decision
             else:
-                self._publish_replayed_decomposition_decision(decision)
+                self._publish_event_owned_decomposition_decision(decision)
             seen[decision.node_id] = decision
 
     def _restore_checkpoint_decomposition_decisions(
@@ -5766,7 +5985,10 @@ class ParallelACExecutor:
                 or restored.to_dict() != raw_record
             ):
                 raise RuntimeError("checkpoint decomposition decision is non-canonical")
-            self._publish_replayed_decomposition_decision(restored)
+            try:
+                self._confirm_replayed_decomposition_decision(restored)
+            except RuntimeError as exc:
+                raise RuntimeError(f"checkpoint {exc}") from exc
 
     async def _execute_decomposition_children(
         self,
@@ -6098,6 +6320,7 @@ class ParallelACExecutor:
                 _FOUNDATION_A_ENTRY_DISPATCH_DECOMPOSITION_PROMPT,
                 prompt=prompt,
                 system_prompt="You are a conservative execution-recovery classifier.",
+                independent_session=True,
             )
             if len(response) > 10_000:
                 raise ValueError
@@ -6192,7 +6415,9 @@ class ParallelACExecutor:
             or _has_usage_limit_pause(result)
         ):
             return None, None
-        previous = self._decomposition_decisions.get(node_identity.node_id)
+        previous = self._event_owned_decomposition_decisions.get(node_identity.node_id)
+        if self._decomposition_decisions.get(node_identity.node_id) != previous:
+            raise RuntimeError("decomposition cache lacks matching finalized-event authority")
         if previous is not None and previous.source is DecompositionSource.BOUNCE:
             return None, previous
 
@@ -6218,6 +6443,69 @@ class ParallelACExecutor:
         if not classification.allows_decomposition:
             return None, None
 
+        if node_identity.node_id in self._pending_bounce_decompositions:
+            raise RuntimeError("a node cannot own two pending TOO_BIG bounce phases")
+        pending = _DurableBounceReplayState(
+            cause=classification.cause,
+            rationale=classification.rationale,
+            failure_class=verdict.failure_class if verdict is not None else None,
+            retry_admission=retry_admission,
+            evidence_refs=classification.evidence_refs,
+            trace_summary=trace.summary,
+            event_key=None,
+        )
+        self._pending_bounce_decompositions[node_identity.node_id] = pending
+        return await self._continue_bounce_decomposition(
+            pending=pending,
+            ac_index=ac_index,
+            ac_content=ac_content,
+            session_id=session_id,
+            tools=tools,
+            tool_catalog=tool_catalog,
+            system_prompt=system_prompt,
+            seed_goal=seed_goal,
+            depth=depth,
+            execution_id=execution_id,
+            level_contexts=level_contexts,
+            retry_attempt=retry_attempt,
+            execution_counters=execution_counters,
+            node_identity=node_identity,
+            ac_spec=ac_spec,
+            start_time=start_time,
+            semantic_ac_key=semantic_ac_key,
+            investment_spec=investment_spec,
+        )
+
+    async def _continue_bounce_decomposition(
+        self,
+        *,
+        pending: _DurableBounceReplayState,
+        ac_index: int,
+        ac_content: str,
+        session_id: str,
+        tools: list[str],
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+        system_prompt: str,
+        seed_goal: str,
+        depth: int,
+        execution_id: str,
+        level_contexts: list[LevelContext] | None,
+        retry_attempt: int,
+        execution_counters: dict[str, int] | None,
+        node_identity: ExecutionNodeIdentity,
+        ac_spec: AcceptanceCriterionSpec | None,
+        start_time: datetime,
+        semantic_ac_key: str,
+        investment_spec: InvestmentSpec | None = None,
+    ) -> tuple[ACExecutionResult | None, DecompositionDecisionRecord]:
+        """Resume the post-classification phase without repeating the parent attempt."""
+
+        if (
+            pending.cause is not BounceCause.TOO_BIG
+            or self._pending_bounce_decompositions.get(node_identity.node_id) != pending
+        ):
+            raise RuntimeError("decomposition requires the node's durable TOO_BIG phase")
+
         if depth >= self._max_decomposition_depth:
             decision = await self._finalize_decomposition_decision(
                 decision=DecompositionDecisionRecord(
@@ -6225,8 +6513,8 @@ class ParallelACExecutor:
                     source=DecompositionSource.BOUNCE,
                     disposition=DecompositionDisposition.ESCALATED,
                     cause=BounceCause.TOO_BIG,
-                    reasons=("decomposition_depth_cap", classification.rationale),
-                    evidence_refs=classification.evidence_refs,
+                    reasons=("decomposition_depth_cap", pending.rationale),
+                    evidence_refs=pending.evidence_refs,
                     compromise_reason="depth_cap_forced_atomic",
                 ),
                 node_identity=node_identity,
@@ -6249,8 +6537,8 @@ class ParallelACExecutor:
             ac_spec=ac_spec,
             source=DecompositionSource.BOUNCE,
             cause=BounceCause.TOO_BIG,
-            trace_summary=trace.summary,
-            evidence_refs=classification.evidence_refs,
+            trace_summary=pending.trace_summary,
+            evidence_refs=pending.evidence_refs,
         )
         decision = self._coerce_decomposition_decision(
             decision,
@@ -6385,7 +6673,47 @@ class ParallelACExecutor:
             depth=depth,
         )
 
-        node_decision = self._decomposition_decisions.get(node_identity.node_id)
+        cached_decision = self._decomposition_decisions.get(node_identity.node_id)
+        node_decision = self._event_owned_decomposition_decisions.get(node_identity.node_id)
+        if cached_decision != node_decision:
+            raise RuntimeError("decomposition cache lacks matching finalized-event authority")
+        pending_bounce = self._pending_bounce_decompositions.get(node_identity.node_id)
+        if pending_bounce is not None:
+            recovered, node_decision = await self._continue_bounce_decomposition(
+                pending=pending_bounce,
+                ac_index=ac_index,
+                ac_content=ac_content,
+                session_id=session_id,
+                tools=tools,
+                tool_catalog=tool_catalog,
+                system_prompt=system_prompt,
+                seed_goal=seed_goal,
+                depth=depth,
+                execution_id=execution_id,
+                level_contexts=level_contexts,
+                retry_attempt=retry_attempt,
+                execution_counters=execution_counters,
+                node_identity=node_identity,
+                ac_spec=ac_spec,
+                start_time=start_time,
+                semantic_ac_key=semantic_ac_key,
+                investment_spec=investment_spec,
+            )
+            if recovered is not None:
+                return recovered
+            return ACExecutionResult(
+                ac_index=ac_index,
+                ac_content=ac_content,
+                success=False,
+                error="Durable TOO_BIG recovery completed without an admissible split.",
+                final_message="Durable TOO_BIG recovery completed without an admissible split.",
+                retry_attempt=retry_attempt,
+                outcome=ACExecutionOutcome.FAILED,
+                decomposition_decision=node_decision,
+                decomposition_depth_warning=(
+                    node_decision.compromise_reason == "depth_cap_forced_atomic"
+                ),
+            )
         durable_route_proves_atomic = (
             expected_route_candidate is not None or expected_resume_dispatch_id is not None
         ) and not is_sub_ac
@@ -11444,7 +11772,10 @@ Respond with either ATOMIC or the structured JSON object only.
                 decomposition_decision=decision,
             )
             composite_results[root_ac_index] = restored
-            self._publish_replayed_decomposition_decision(decision)
+            try:
+                self._confirm_replayed_decomposition_decision(decision)
+            except RuntimeError as exc:
+                raise RuntimeError(f"composite completion {exc}") from exc
         partial_states: dict[int, tuple[_PartialCompositeResumeState, ...]] = {}
         prior_frame_states: dict[tuple[int, str], _PartialCompositeResumeState] = {}
         prior_paths: dict[int, tuple[_PartialCompositeResumeState, ...]] = {}
@@ -11635,7 +11966,10 @@ Respond with either ATOMIC or the structured JSON object only.
                     raise RuntimeError("partial composite replay conflicts with completion")
                 continue
             for state in states:
-                self._publish_replayed_decomposition_decision(state.decision)
+                try:
+                    self._confirm_replayed_decomposition_decision(state.decision)
+                except RuntimeError as exc:
+                    raise RuntimeError(f"partial composite {exc}") from exc
                 self._partial_composite_resumes[state.decision.node_id] = state
         grouped: dict[int, list[tuple[RouteObservation, object, bool, object]]] = {
             ac_idx: [] for ac_idx in root_ac_indices

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -3846,6 +3846,25 @@ class OrchestratorRunner:
             and valid_runtime_effect_capabilities_contract(value.get("runtime_effect_capabilities"))
         )
 
+    @staticmethod
+    def _valid_legacy_preflight_execution_semantics_contract(value: object) -> bool:
+        """Recognize only the retired current-schema preflight snapshot.
+
+        The migration changes one authority bit (``preflight`` to
+        ``bounce_only``); every other effect-bearing field must already satisfy
+        the exact current schema.  This helper never feeds a live constructor.
+        """
+
+        if (
+            not isinstance(value, Mapping)
+            or value.get("decomposition_mode") != "preflight"
+            or value.get("enable_decomposition") is not True
+        ):
+            return False
+        migrated = dict(value)
+        migrated["decomposition_mode"] = "bounce_only"
+        return OrchestratorRunner._valid_execution_semantics_contract(migrated)
+
     def _execution_semantics_snapshot(
         self,
         execution_contract: Mapping[str, Any] | None,
@@ -6032,6 +6051,33 @@ class OrchestratorRunner:
                 },
             )
 
+        migrate_preflight_contract = self._valid_legacy_preflight_execution_semantics_contract(
+            raw_execution_semantics
+        )
+        if migrate_preflight_contract:
+            persisted_legacy_fingerprint = raw_proof.get("execution_semantics_fingerprint")
+            if not isinstance(
+                persisted_legacy_fingerprint, str
+            ) or persisted_legacy_fingerprint != self._execution_semantics_fingerprint(
+                raw_execution_semantics
+            ):
+                raise OrchestratorError(
+                    message="Cannot resume with an invalid legacy preflight contract",
+                    details={"invalid": "execution_semantics_fingerprint"},
+                )
+            migrated_contract = deepcopy(dict(raw_contract))
+            migrated_semantics = migrated_contract["execution_semantics"]
+            migrated_proof = migrated_contract["frugality_proof"]
+            assert isinstance(migrated_semantics, dict)
+            assert isinstance(migrated_proof, dict)
+            migrated_semantics["decomposition_mode"] = "bounce_only"
+            migrated_proof["execution_semantics_fingerprint"] = (
+                self._execution_semantics_fingerprint(migrated_semantics)
+            )
+            raw_contract = migrated_contract
+            raw_proof = migrated_proof
+            raw_execution_semantics = migrated_semantics
+
         # Version 2 predates effort/Route B fields; version 3 predates the
         # independent requested-tier field; version 4 predates the complete
         # executor-semantics snapshot. Only those exact shapes migrate.
@@ -6492,6 +6538,9 @@ class OrchestratorRunner:
             if authority_generation is None:
                 replacement["foundation_a_authority"] = dict(raw_contract["foundation_a_authority"])
             self._execution_contract = replacement
+            return True
+        if migrate_preflight_contract:
+            self._execution_contract = dict(raw_contract)
             return True
         # Preserve the exact persisted proof identity alongside the restored
         # router. Recomputing it from a resumed throwaway worktree would make the

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -862,7 +862,7 @@ class OrchestratorRunner:
         mcp_tool_prefix: str = "",
         debug: bool = False,
         enable_decomposition: bool = True,
-        decomposition_mode: Literal["preflight", "bounce_only", "off"] | None = None,
+        decomposition_mode: Literal["bounce_only", "off"] | None = None,
         inherited_runtime_handle: RuntimeHandle | None = None,
         inherited_tools: list[str] | None = None,
         task_cwd: str | None = None,
@@ -892,6 +892,8 @@ class OrchestratorRunner:
             decomposition_mode: Optional decomposition mode override. When omitted,
                 the runner uses ``execution.decomposition_mode`` from config.
                 ``enable_decomposition=False`` forces the effective mode to ``off``.
+                Legacy config files are migrated while loading; direct preflight
+                overrides are rejected instead of authorizing a provider effect.
             inherited_runtime_handle: Optional parent Claude runtime handle for
                         delegated child executions that should fork a session.
             inherited_tools: Optional effective tool set inherited from a
@@ -1023,14 +1025,16 @@ class OrchestratorRunner:
         self._cross_harness_redispatch_enabled = get_cross_harness_redispatch_enabled()
         self._context_pack_enabled = get_context_pack_enabled()
         self._project_guidance_ids = tuple(_execution_config.project_guidance)
-        self._decomposition_mode: Literal["preflight", "bounce_only", "off"] = (
-            "off"
-            if not enable_decomposition
-            else (
-                _execution_config.decomposition_mode
-                if decomposition_mode is None
-                else decomposition_mode
-            )
+        configured_decomposition_mode = (
+            _execution_config.decomposition_mode
+            if decomposition_mode is None
+            else decomposition_mode
+        )
+        if configured_decomposition_mode not in {"bounce_only", "off"}:
+            msg = f"Unsupported decomposition_mode: {configured_decomposition_mode!r}"
+            raise ValueError(msg)
+        self._decomposition_mode: Literal["bounce_only", "off"] = (
+            "off" if not enable_decomposition else configured_decomposition_mode
         )
         if not _model_routing_disabled:
             from ouroboros.orchestrator.model_routing import build_model_router
@@ -3832,7 +3836,7 @@ class OrchestratorRunner:
             and 1 <= effective_workers <= max_workers
             and effective_workers == expected_effective_workers
             and isinstance(mode, str)
-            and mode in {"preflight", "bounce_only", "off"}
+            and mode in {"bounce_only", "off"}
             and (value.get("enable_decomposition") is True or mode == "off")
             and isinstance(backend, str)
             and bool(backend)

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -307,8 +307,14 @@ class TestExecutionConfig:
         assert config.retrospective_interval == 3
         assert config.tui_autolaunch is False
         assert config.auto_evaluate is True
-        assert config.decomposition_mode == "preflight"
+        assert config.decomposition_mode == "bounce_only"
         assert config.context_pack is True
+
+    def test_execution_config_migrates_legacy_preflight_to_bounce_only(self) -> None:
+        """Stored preflight settings cannot re-enable pre-execution splitting."""
+        config = ExecutionConfig(decomposition_mode="preflight")  # type: ignore[arg-type]
+
+        assert config.decomposition_mode == "bounce_only"
 
     def test_execution_config_rejects_invalid_decomposition_mode(self) -> None:
         """ExecutionConfig only accepts known decomposition modes."""

--- a/tests/unit/orchestrator/test_decomposition_live_path.py
+++ b/tests/unit/orchestrator/test_decomposition_live_path.py
@@ -1,0 +1,119 @@
+"""Architecture guards for the sole live decomposition path (issue #1466)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_FORBIDDEN_MODULES = frozenset(
+    {
+        "ouroboros.execution.atomicity",
+        "ouroboros.execution.decomposition",
+    }
+)
+
+
+def _source_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "src"
+
+
+def _imported_modules(
+    node: ast.Import | ast.ImportFrom, *, package: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Resolve every spelling of an import to its absolute module candidates."""
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+
+    if node.level:
+        parent_count = node.level - 1
+        if parent_count > len(package):
+            return ()
+        base = package[: len(package) - parent_count]
+    else:
+        base = ()
+    if node.module:
+        base = (*base, *node.module.split("."))
+    module = ".".join(base)
+    imported: list[str] = []
+    if module:
+        imported.append(module)
+    for alias in node.names:
+        if alias.name == "*":
+            imported.append(f"{module}.*" if module else "*")
+        else:
+            imported.append(f"{module}.{alias.name}" if module else alias.name)
+    return tuple(imported)
+
+
+def _references_forbidden_module(module: str) -> bool:
+    return any(
+        module == forbidden
+        or module.startswith(f"{forbidden}.")
+        or (module.endswith(".*") and forbidden.startswith(f"{module[:-2]}."))
+        for forbidden in _FORBIDDEN_MODULES
+    )
+
+
+def _forbidden_imports(source: str, *, module_name: str) -> tuple[str, ...]:
+    tree = ast.parse(source)
+    package = tuple(module_name.split(".")[:-1])
+    return tuple(
+        imported
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import | ast.ImportFrom)
+        for imported in _imported_modules(node, package=package)
+        if _references_forbidden_module(imported)
+    )
+
+
+def test_dead_decomposition_modules_and_wiring_cannot_return() -> None:
+    """Only orchestrator.parallel_executor may own live decomposition."""
+    source_root = _source_root()
+    execution_root = source_root / "ouroboros" / "execution"
+
+    assert not (execution_root / "atomicity.py").exists()
+    assert not (execution_root / "decomposition.py").exists()
+
+    forbidden_importers: list[str] = []
+    forbidden_wiring: list[str] = []
+    for source_file in source_root.rglob("*.py"):
+        source = source_file.read_text(encoding="utf-8")
+        relative_module = source_file.relative_to(source_root).with_suffix("")
+        module_name = ".".join(relative_module.parts)
+        if _forbidden_imports(source, module_name=module_name):
+            forbidden_importers.append(str(source_file.relative_to(source_root)))
+        if "run_cycle_with_decomposition" in source:
+            forbidden_wiring.append(str(source_file.relative_to(source_root)))
+
+    assert forbidden_importers == []
+    assert forbidden_wiring == []
+
+
+def test_dead_module_guard_covers_every_import_form() -> None:
+    """The architecture guard cannot be bypassed by another Python import spelling."""
+    source = """
+import ouroboros.execution.atomicity
+import ouroboros.execution.decomposition.helpers
+from ouroboros.execution.atomicity import AtomicityChecker
+from ouroboros.execution import decomposition
+from . import atomicity
+from .decomposition import Decomposer
+from ouroboros.execution import *
+"""
+
+    forbidden = _forbidden_imports(
+        source,
+        module_name="ouroboros.execution.double_diamond",
+    )
+
+    assert forbidden == (
+        "ouroboros.execution.atomicity",
+        "ouroboros.execution.decomposition.helpers",
+        "ouroboros.execution.atomicity",
+        "ouroboros.execution.atomicity.AtomicityChecker",
+        "ouroboros.execution.decomposition",
+        "ouroboros.execution.atomicity",
+        "ouroboros.execution.decomposition",
+        "ouroboros.execution.decomposition.Decomposer",
+        "ouroboros.execution.*",
+    )

--- a/tests/unit/orchestrator/test_decomposition_policy.py
+++ b/tests/unit/orchestrator/test_decomposition_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from types import MappingProxyType
 
 import pytest
 
@@ -121,6 +122,41 @@ class TestEnumsAndSerialization:
         record["trustworthy"] = "true"
         assert DecompositionDecisionRecord.from_dict(record) is None
 
+    def test_unknown_durable_decision_field_fails_closed(self) -> None:
+        record = DecompositionDecisionRecord(
+            node_id="n1",
+            source=DecompositionSource.BOUNCE,
+            disposition=DecompositionDisposition.UNKNOWN,
+        ).to_dict()
+        record["acceptance_authority"] = "trusted"
+
+        assert DecompositionDecisionRecord.from_dict(record) is None
+
+    def test_durable_decision_requires_canonical_json_containers(self) -> None:
+        record = DecompositionDecisionRecord(
+            node_id="n1",
+            source=DecompositionSource.BOUNCE,
+            disposition=DecompositionDisposition.UNKNOWN,
+        ).to_dict()
+
+        assert DecompositionDecisionRecord.from_dict(MappingProxyType(record)) is None
+        record["reasons"] = ()
+        assert DecompositionDecisionRecord.from_dict(record) is None
+
+    @pytest.mark.parametrize("mutation", ["oversized_reason", "normalized_node_id"])
+    def test_non_canonical_durable_decision_fails_closed(self, mutation: str) -> None:
+        record = DecompositionDecisionRecord(
+            node_id="n1",
+            source=DecompositionSource.BOUNCE,
+            disposition=DecompositionDisposition.UNKNOWN,
+        ).to_dict()
+        if mutation == "oversized_reason":
+            record["reasons"] = ["r" * 241]
+        else:
+            record["node_id"] = " n1 "
+
+        assert DecompositionDecisionRecord.from_dict(record) is None
+
     def test_records_are_frozen(self) -> None:
         record = DecompositionDecisionRecord(
             node_id="n1",
@@ -133,7 +169,7 @@ class TestEnumsAndSerialization:
 
 class TestTrustInvariant:
     def test_trust_requires_split_statuses_children_and_low_repair_count(self) -> None:
-        with pytest.raises(ValueError, match="trustworthy split"):
+        with pytest.raises(ValueError, match="repair_count"):
             DecompositionDecisionRecord(
                 node_id="n1",
                 source=DecompositionSource.PREFLIGHT,
@@ -143,6 +179,24 @@ class TestTrustInvariant:
                 semantic_status=SemanticAttestationStatus.ESTABLISHED,
                 repair_count=2,
                 trustworthy=True,
+            )
+
+    @pytest.mark.parametrize("repair_count", [-1, 2, 10_000])
+    def test_every_decision_bounds_repair_count(self, repair_count: int) -> None:
+        with pytest.raises(ValueError, match="repair_count"):
+            DecompositionDecisionRecord(
+                node_id="n1",
+                source=DecompositionSource.BOUNCE,
+                disposition=DecompositionDisposition.ESCALATED,
+                repair_count=repair_count,
+            )
+
+    def test_durable_decision_bounds_node_identity(self) -> None:
+        with pytest.raises(ValueError, match="node_id"):
+            DecompositionDecisionRecord(
+                node_id="n" * 513,
+                source=DecompositionSource.BOUNCE,
+                disposition=DecompositionDisposition.UNKNOWN,
             )
 
     def test_trusted_split_accepts_repair_count_one(self) -> None:
@@ -218,6 +272,29 @@ class TestProposalValidation:
         assert decision.structural_status is StructuralCheckStatus.PASSED
         assert decision.semantic_status is SemanticAttestationStatus.NOT_RUN
         assert decision.trustworthy is False
+
+    def test_proposal_requires_canonical_json_containers(self) -> None:
+        payload = _proposal_payload()
+
+        assert parse_decomposition_proposal(MappingProxyType(payload)) is None
+        payload["children"] = tuple(payload["children"])  # type: ignore[arg-type]
+        assert parse_decomposition_proposal(payload) is None
+
+    @pytest.mark.parametrize("mutation", ["uncovered_parent", "empty_verification"])
+    def test_proposal_value_object_cannot_bypass_structural_requirements(
+        self, mutation: str
+    ) -> None:
+        payload = _proposal_payload()
+        if mutation == "uncovered_parent":
+            payload["covers_parent"] = False
+        else:
+            children = payload["children"]
+            assert isinstance(children, list)
+            child = children[0]
+            assert isinstance(child, dict)
+            child["verification_hint"] = ""
+
+        assert DecompositionProposal.from_dict(payload) is None
 
     def test_rejects_duplicate_normalized_children(self) -> None:
         payload = _proposal_payload()
@@ -304,6 +381,20 @@ class TestProposalValidation:
         first = children[0]
         assert isinstance(first, dict)
         first["description"] = "x" * 501
+        assert parse_decomposition_proposal(payload) is None
+
+    @pytest.mark.parametrize("target", ["proposal", "child"])
+    def test_rejects_unknown_proposal_semantics(self, target: str) -> None:
+        payload = _proposal_payload()
+        if target == "proposal":
+            payload["mece_verified"] = True
+        else:
+            children = payload["children"]
+            assert isinstance(children, list)
+            first = children[0]
+            assert isinstance(first, dict)
+            first["exclusive"] = True
+
         assert parse_decomposition_proposal(payload) is None
 
 

--- a/tests/unit/orchestrator/test_decomposition_policy.py
+++ b/tests/unit/orchestrator/test_decomposition_policy.py
@@ -168,6 +168,31 @@ class TestEnumsAndSerialization:
 
 
 class TestTrustInvariant:
+    def test_trustworthy_bounce_split_requires_too_big_cause_on_construct_and_parse(self) -> None:
+        with pytest.raises(ValueError, match="TOO_BIG"):
+            DecompositionDecisionRecord(
+                node_id="n1",
+                source=DecompositionSource.BOUNCE,
+                disposition=DecompositionDisposition.SPLIT,
+                cause=BounceCause.ENVIRONMENT,
+                children=_children(),
+                structural_status=StructuralCheckStatus.PASSED,
+                semantic_status=SemanticAttestationStatus.ESTABLISHED,
+                trustworthy=True,
+            )
+
+        payload = DecompositionDecisionRecord(
+            node_id="n1",
+            source=DecompositionSource.PREFLIGHT,
+            disposition=DecompositionDisposition.SPLIT,
+            children=_children(),
+            structural_status=StructuralCheckStatus.PASSED,
+            semantic_status=SemanticAttestationStatus.ESTABLISHED,
+            trustworthy=True,
+        ).to_dict()
+        payload.update(source="bounce", cause="ENVIRONMENT")
+        assert DecompositionDecisionRecord.from_dict(payload) is None
+
     def test_trust_requires_split_statuses_children_and_low_repair_count(self) -> None:
         with pytest.raises(ValueError, match="repair_count"):
             DecompositionDecisionRecord(

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1687,12 +1687,7 @@ async def test_dynamic_runtime_does_not_reopen_captured_executor_entry_roots(
         trace=parallel_executor_module.DecompositionTraceSummary(summary="bounded evidence"),
     )
 
-    assert result == (
-        parallel_executor_module.BounceCause.UNKNOWN,
-        "Bounce classifier returned no admissible cause.",
-        (),
-        False,
-    )
+    assert result == (parallel_executor_module.BounceCause.UNKNOWN, False)
     assert injected is False
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -32,7 +32,15 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict, LevelCoordinator
 from ouroboros.orchestrator.decomposition_limits import MAX_DECOMPOSITION_DEPTH
-from ouroboros.orchestrator.decomposition_policy import DecompositionDisposition
+from ouroboros.orchestrator.decomposition_policy import (
+    BounceCause,
+    DecompositionChild,
+    DecompositionDecisionRecord,
+    DecompositionDisposition,
+    DecompositionSource,
+    SemanticAttestationStatus,
+    StructuralCheckStatus,
+)
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
@@ -66,6 +74,29 @@ from ouroboros.orchestrator.parallel_executor import (
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
 from ouroboros.orchestrator.verifier import VerifierVerdict
 from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
+
+
+def _trusted_preflight_split(
+    node_id: str,
+    *descriptions: str,
+) -> DecompositionDecisionRecord:
+    """Build a verified historical preflight decision for replay-only tests."""
+    return DecompositionDecisionRecord(
+        node_id=node_id,
+        source=DecompositionSource.PREFLIGHT,
+        disposition=DecompositionDisposition.SPLIT,
+        children=tuple(
+            DecompositionChild(
+                description=description,
+                coverage_claims=(f"scope-{index}",),
+                verification_hint=f"verify scope {index}",
+            )
+            for index, description in enumerate(descriptions)
+        ),
+        structural_status=StructuralCheckStatus.PASSED,
+        semantic_status=SemanticAttestationStatus.ESTABLISHED,
+        trustworthy=True,
+    )
 
 
 def test_stall_timeout_default_allows_realistic_test_suites() -> None:
@@ -9156,6 +9187,8 @@ class TestParallelACExecutor:
                 seed_goal="Ship OpenCode support",
                 tools=["Read", "Edit"],
                 system_prompt="system",
+                source=DecompositionSource.BOUNCE,
+                cause=BounceCause.TOO_BIG,
             )
 
         assert result.disposition is DecompositionDisposition.UNKNOWN
@@ -9173,9 +9206,13 @@ class TestParallelACExecutor:
             enable_decomposition=True,
         )
         executor._emit_subtask_event = AsyncMock()
-        executor._try_decompose_ac = AsyncMock(
-            side_effect=[["Extract parser", "Wire parser"], None, None]
+        root = ExecutionNodeIdentity.root(execution_context_id="exec_decompose", ac_index=1)
+        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
+            root.node_id,
+            "Extract parser",
+            "Wire parser",
         )
+        executor._try_decompose_ac = AsyncMock()
 
         async def fake_execute_atomic_ac(**kwargs: Any) -> ACExecutionResult:
             return ACExecutionResult(
@@ -9222,7 +9259,7 @@ class TestParallelACExecutor:
             (100, "Extract parser", 1),
             (101, "Wire parser", 1),
         ]
-        assert executor._try_decompose_ac.await_count == 3
+        executor._try_decompose_ac.assert_not_awaited()
         assert execute_atomic_ac.await_count == 2
 
     @pytest.mark.asyncio
@@ -9235,9 +9272,13 @@ class TestParallelACExecutor:
             enable_decomposition=True,
         )
         executor._emit_subtask_event = AsyncMock()
-        executor._try_decompose_ac = AsyncMock(
-            side_effect=[["Extract parser", "Wire parser"], None, None]
+        root = ExecutionNodeIdentity.root(execution_context_id="exec_sub_ac_runtime", ac_index=1)
+        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
+            root.node_id,
+            "Extract parser",
+            "Wire parser",
         )
+        executor._try_decompose_ac = AsyncMock()
 
         async def fake_execute_atomic_ac(**kwargs: Any) -> ACExecutionResult:
             return ACExecutionResult(
@@ -9491,9 +9532,15 @@ class TestParallelACExecutor:
             enable_decomposition=True,
         )
         executor._emit_subtask_event = AsyncMock()
-        executor._try_decompose_ac = AsyncMock(
-            side_effect=[["Retry leaf", "Stable leaf"], None, None]
+        root = ExecutionNodeIdentity.root(
+            execution_context_id="exec_atomic_retry_scope", ac_index=1
         )
+        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
+            root.node_id,
+            "Retry leaf",
+            "Stable leaf",
+        )
+        executor._try_decompose_ac = AsyncMock()
 
         async def fake_execute_atomic_ac(**kwargs: Any) -> ACExecutionResult:
             ac_index = int(kwargs["ac_index"])
@@ -9535,7 +9582,7 @@ class TestParallelACExecutor:
         assert result.success is True
         assert result.is_decomposed is True
         assert [sub_result.retry_attempt for sub_result in result.sub_results] == [1, 0]
-        assert executor._try_decompose_ac.await_count == 3
+        executor._try_decompose_ac.assert_not_awaited()
         assert [
             (
                 int(call.kwargs["ac_index"]),
@@ -12753,20 +12800,12 @@ async def test_try_decompose_ac_replaces_goose_chunks_with_final_result() -> Non
         enable_decomposition=True,
     )
 
-    result = await executor._try_decompose_ac(
-        ac_content="Investigate and test sub-AC behavior.",
-        ac_index=0,
-        seed_goal="Verify Goose final result handling",
-        tools=[],
+    response = await executor._dispatch_decomposition_prompt(
+        prompt="Investigate and test sub-AC behavior.",
         system_prompt="system",
     )
 
-    assert result.disposition is DecompositionDisposition.SPLIT
-    assert [child.description for child in result.children] == [
-        "Sub-AC 1: inspect",
-        "Sub-AC 2: test",
-    ]
-    assert result.trustworthy is False
+    assert response == '["Sub-AC 1: inspect", "Sub-AC 2: test"]'
 
 
 @pytest.mark.asyncio
@@ -12800,21 +12839,16 @@ async def test_try_decompose_ac_accumulates_goose_stream_chunks() -> None:
         enable_decomposition=True,
     )
 
-    result = await executor._try_decompose_ac(
-        ac_content="Investigate, test, and document sub-AC behavior.",
-        ac_index=0,
-        seed_goal="Verify Goose sub-AC support",
-        tools=[],
+    response = await executor._dispatch_decomposition_prompt(
+        prompt="Investigate, test, and document sub-AC behavior.",
         system_prompt="system",
     )
 
-    assert result.disposition is DecompositionDisposition.SPLIT
-    assert [child.description for child in result.children] == [
-        "Sub-AC 1: inspect the implementation",
-        "Sub-AC 2: write a focused regression test",
-        "Sub-AC 3: document the result",
-    ]
-    assert result.trustworthy is False
+    assert response == (
+        '["Sub-AC 1: inspect the implementation", '
+        '"Sub-AC 2: write a focused regression test", '
+        '"Sub-AC 3: document the result"]'
+    )
 
 
 @pytest.mark.asyncio
@@ -12852,20 +12886,12 @@ async def test_try_decompose_ac_announces_same_empty_tools_allowlist_it_dispatch
         enable_decomposition=True,
     )
 
-    result = await executor._try_decompose_ac(
-        ac_content="Investigate and test sub-AC behavior.",
-        ac_index=0,
-        seed_goal="Verify decomposition tool handling",
-        tools=["Read"],
+    response = await executor._dispatch_decomposition_prompt(
+        prompt="Investigate and test sub-AC behavior.",
         system_prompt="system",
     )
 
-    assert result.disposition is DecompositionDisposition.SPLIT
-    assert [child.description for child in result.children] == [
-        "Sub-AC 1: inspect",
-        "Sub-AC 2: test",
-    ]
-    assert result.trustworthy is False
+    assert response == '["Sub-AC 1: inspect", "Sub-AC 2: test"]'
     assert runtime.dispatched_tools == []
     console.print.assert_called_once()
     notice = console.print.call_args.args[0]

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -9207,10 +9207,12 @@ class TestParallelACExecutor:
         )
         executor._emit_subtask_event = AsyncMock()
         root = ExecutionNodeIdentity.root(execution_context_id="exec_decompose", ac_index=1)
-        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
-            root.node_id,
-            "Extract parser",
-            "Wire parser",
+        executor._publish_event_owned_decomposition_decision(
+            _trusted_preflight_split(
+                root.node_id,
+                "Extract parser",
+                "Wire parser",
+            )
         )
         executor._try_decompose_ac = AsyncMock()
 
@@ -9273,10 +9275,12 @@ class TestParallelACExecutor:
         )
         executor._emit_subtask_event = AsyncMock()
         root = ExecutionNodeIdentity.root(execution_context_id="exec_sub_ac_runtime", ac_index=1)
-        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
-            root.node_id,
-            "Extract parser",
-            "Wire parser",
+        executor._publish_event_owned_decomposition_decision(
+            _trusted_preflight_split(
+                root.node_id,
+                "Extract parser",
+                "Wire parser",
+            )
         )
         executor._try_decompose_ac = AsyncMock()
 
@@ -9535,10 +9539,12 @@ class TestParallelACExecutor:
         root = ExecutionNodeIdentity.root(
             execution_context_id="exec_atomic_retry_scope", ac_index=1
         )
-        executor._decomposition_decisions[root.node_id] = _trusted_preflight_split(
-            root.node_id,
-            "Retry leaf",
-            "Stable leaf",
+        executor._publish_event_owned_decomposition_decision(
+            _trusted_preflight_split(
+                root.node_id,
+                "Retry leaf",
+                "Stable leaf",
+            )
         )
         executor._try_decompose_ac = AsyncMock()
 

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -8,10 +8,12 @@ import pytest
 
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.decomposition_policy import (
+    BounceCause,
     DecompositionDecisionRecord,
     DecompositionDisposition,
     DecompositionSource,
 )
+from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import (
     MAX_DECOMPOSITION_DEPTH,
     ACExecutionResult,
@@ -34,8 +36,8 @@ class _AtomicDecompositionRuntime:
 
 
 @pytest.mark.asyncio
-async def test_try_decompose_ac_treats_atomic_response_as_terminal() -> None:
-    """Claude's explicit ATOMIC verdict should suppress further decomposition."""
+async def test_too_big_decomposer_atomic_response_escalates_with_compromise() -> None:
+    """A decomposer disagreement cannot silently turn a TOO_BIG bounce atomic."""
     executor = ParallelACExecutor(
         adapter=_AtomicDecompositionRuntime(),
         event_store=AsyncMock(),
@@ -50,12 +52,15 @@ async def test_try_decompose_ac_treats_atomic_response_as_terminal() -> None:
         seed_goal="Preserve ATOMIC termination",
         tools=["Read"],
         system_prompt="system",
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
     )
 
-    assert result.disposition is DecompositionDisposition.ATOMIC
-    assert result.source is DecompositionSource.PREFLIGHT
+    assert result.disposition is DecompositionDisposition.ESCALATED
+    assert result.source is DecompositionSource.BOUNCE
     assert result.children == ()
     assert result.reasons == ("explicit_atomic",)
+    assert result.compromise_reason == "too_big_classifier_disagreed_with_decomposer"
 
 
 @pytest.mark.asyncio
@@ -64,10 +69,10 @@ async def test_try_decompose_ac_treats_atomic_response_as_terminal() -> None:
     range(MAX_DECOMPOSITION_DEPTH),
     ids=lambda depth: f"depth_{depth}",
 )
-async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
+async def test_historical_atomic_judgment_replays_without_preflight_at_any_depth(
     depth: int,
 ) -> None:
-    """Nested AC execution should stop recursing once decomposition returns ATOMIC."""
+    """Historical records remain readable but cannot trigger a provider judgment."""
     executor = ProcessLocalTestExecutor(
         adapter=MagicMock(),
         event_store=AsyncMock(),
@@ -76,14 +81,17 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
         max_decomposition_depth=MAX_DECOMPOSITION_DEPTH,
     )
     executor._emit_subtask_event = AsyncMock()
-    executor._try_decompose_ac = AsyncMock(
-        return_value=DecompositionDecisionRecord(
-            node_id=f"exec_atomic_depth_{depth}:ac:{depth + 1}",
-            source=DecompositionSource.PREFLIGHT,
-            disposition=DecompositionDisposition.ATOMIC,
-            reasons=("explicit_atomic",),
-        )
+    node = ExecutionNodeIdentity.root(
+        execution_context_id=f"exec_atomic_depth_{depth}",
+        ac_index=depth + 1,
     )
+    executor._decomposition_decisions[node.node_id] = DecompositionDecisionRecord(
+        node_id=node.node_id,
+        source=DecompositionSource.PREFLIGHT,
+        disposition=DecompositionDisposition.ATOMIC,
+        reasons=("explicit_atomic",),
+    )
+    executor._try_decompose_ac = AsyncMock()
     execute_atomic_ac = AsyncMock(
         return_value=ACExecutionResult(
             ac_index=depth + 1,
@@ -106,12 +114,13 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
         seed_goal="Preserve ATOMIC termination",
         depth=depth,
         execution_id=f"exec_atomic_depth_{depth}",
+        node_identity=node,
     )
 
     assert result.success is True
     assert result.is_decomposed is False
     assert result.depth == depth
-    executor._try_decompose_ac.assert_awaited_once()
+    executor._try_decompose_ac.assert_not_awaited()
     execute_atomic_ac.assert_awaited_once()
     assert [call["depth"] for call in executor._test_single_ac_calls] == [depth]
 
@@ -156,10 +165,12 @@ async def test_try_decompose_ac_uses_profile_axis_when_profile_is_configured() -
         seed_goal="Produce a sourced design memo",
         tools=["Read"],
         system_prompt="legacy system prompt",
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
     )
 
-    assert result.disposition is DecompositionDisposition.ATOMIC
-    assert result.source is DecompositionSource.PREFLIGHT
+    assert result.disposition is DecompositionDisposition.ESCALATED
+    assert result.source is DecompositionSource.BOUNCE
     assert result.children == ()
     assert result.reasons == ("explicit_atomic",)
     assert runtime.prompt is not None
@@ -209,20 +220,18 @@ suggested_model_tier: medium
         seed_goal="Produce a sourced memo",
         tools=["Read"],
         system_prompt="legacy system prompt",
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
     )
 
-    assert result.disposition is DecompositionDisposition.SPLIT
-    assert result.source is DecompositionSource.PREFLIGHT
-    assert [child.description for child in result.children] == [
-        "Sub-AC 1: a",
-        "Sub-AC 2: b",
-        "Sub-AC 3: c",
-    ]
+    assert result.disposition is DecompositionDisposition.ESCALATED
+    assert result.source is DecompositionSource.BOUNCE
+    assert result.children == ()
     assert result.trustworthy is False
-    assert result.reasons == ("legacy_array_without_attestation",)
+    assert result.repair_count == 1
     assert runtime.prompt is not None
-    assert "2-3 sub-ACs" in runtime.prompt
-    assert "2-5 sub-ACs" not in runtime.prompt
+    assert "Return 2-3 children" in runtime.prompt
+    assert "Return 2-5 children" not in runtime.prompt
 
 
 class _FixedResponseRuntime:
@@ -245,46 +254,32 @@ class _FixedResponseRuntime:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("response", "expected_disposition", "expected_children", "expected_reasons"),
+    ("response", "expected_repair_count"),
     [
-        # Explicit atomic verdict the response STARTS WITH → atomic.
-        ("ATOMIC", DecompositionDisposition.ATOMIC, [], ("explicit_atomic",)),
-        (
-            "ATOMIC — this is one focused task",
-            DecompositionDisposition.ATOMIC,
-            [],
-            ("explicit_atomic",),
-        ),
+        ("ATOMIC", 0),
+        ("ATOMIC — this is one focused task", 0),
         # A real split that happens to contain the word "ATOMIC" in a negation
         # must NOT be mis-read as atomic (the substring-match bug).
         (
             'NOT ATOMIC, decompose into: ["Sub-AC 1: build it", "Sub-AC 2: test it"]',
-            DecompositionDisposition.SPLIT,
-            ["Sub-AC 1: build it", "Sub-AC 2: test it"],
-            ("legacy_array_without_attestation",),
+            1,
         ),
         # A valid array whose elements merely mention "atomic" must still split.
         (
             '["update the atomic counter module", "add a regression test"]',
-            DecompositionDisposition.SPLIT,
-            ["update the atomic counter module", "add a regression test"],
-            ("legacy_array_without_attestation",),
+            1,
         ),
         # Unparseable / no verdict → fail closed as an explicit UNKNOWN decision.
         (
             "I think this could go either way, hard to say.",
-            DecompositionDisposition.UNKNOWN,
-            [],
-            ("unparseable_decomposition_response",),
+            1,
         ),
     ],
     ids=["bare_atomic", "atomic_prefix", "not_atomic_split", "array_mentions_atomic", "garbage"],
 )
 async def test_try_decompose_ac_parses_verdict_array_before_atomic_substring(
     response: str,
-    expected_disposition: DecompositionDisposition,
-    expected_children: list[str],
-    expected_reasons: tuple[str, ...],
+    expected_repair_count: int,
 ) -> None:
     """JSON array is parsed before the ATOMIC verdict, and only a leading ATOMIC
     counts — so negated/atomic-mentioning splits are not mis-classified, and
@@ -302,9 +297,12 @@ async def test_try_decompose_ac_parses_verdict_array_before_atomic_substring(
         seed_goal="goal",
         tools=["Read"],
         system_prompt="system",
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
     )
 
-    assert result.disposition is expected_disposition
-    assert result.source is DecompositionSource.PREFLIGHT
-    assert [child.description for child in result.children] == expected_children
-    assert result.reasons == expected_reasons
+    assert result.disposition is DecompositionDisposition.ESCALATED
+    assert result.source is DecompositionSource.BOUNCE
+    assert result.children == ()
+    assert result.trustworthy is False
+    assert result.repair_count == expected_repair_count

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -85,11 +85,13 @@ async def test_historical_atomic_judgment_replays_without_preflight_at_any_depth
         execution_context_id=f"exec_atomic_depth_{depth}",
         ac_index=depth + 1,
     )
-    executor._decomposition_decisions[node.node_id] = DecompositionDecisionRecord(
-        node_id=node.node_id,
-        source=DecompositionSource.PREFLIGHT,
-        disposition=DecompositionDisposition.ATOMIC,
-        reasons=("explicit_atomic",),
+    executor._publish_event_owned_decomposition_decision(
+        DecompositionDecisionRecord(
+            node_id=node.node_id,
+            source=DecompositionSource.PREFLIGHT,
+            disposition=DecompositionDisposition.ATOMIC,
+            reasons=("explicit_atomic",),
+        )
     )
     executor._try_decompose_ac = AsyncMock()
     execute_atomic_ac = AsyncMock(

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.decomposition_policy import (
     DecompositionChild,
     DecompositionDecisionRecord,
     DecompositionDisposition,
+    DecompositionProposal,
     DecompositionSource,
     DecompositionTraceSummary,
     SemanticAttestationStatus,
@@ -75,10 +76,30 @@ def _executor(*, max_depth: int = 2) -> ProcessLocalTestExecutor:
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=AsyncMock(),
         console=MagicMock(),
-        decomposition_mode="bounce_only",
         max_decomposition_depth=max_depth,
         cross_harness_redispatch=False,
     )
+
+
+def test_default_executor_decomposition_mode_is_bounce_only() -> None:
+    """The live low-level default cannot run a pre-execution decomposition."""
+    executor = _executor()
+
+    assert executor._decomposition_mode == "bounce_only"
+
+
+def test_executor_rejects_direct_preflight_override_before_provider_effect() -> None:
+    runtime = MagicMock()
+
+    with pytest.raises(ValueError, match="Unsupported decomposition_mode"):
+        ParallelACExecutor(
+            adapter=runtime,
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            decomposition_mode="preflight",  # type: ignore[arg-type]
+        )
+
+    runtime.execute_task.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -102,6 +123,42 @@ async def test_successful_first_attempt_never_calls_decomposer() -> None:
     )
 
     assert result.success is True
+    executor._try_decompose_ac.assert_not_awaited()
+    executor._request_bounce_classification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_usage_limit_pause_never_calls_bounce_classifier_or_decomposer() -> None:
+    executor = _executor()
+    executor._execute_atomic_ac = AsyncMock(
+        return_value=ACExecutionResult(
+            ac_index=0,
+            ac_content="Parent work",
+            success=False,
+            messages=(
+                AgentMessage(
+                    type="result",
+                    content="Usage limit reached. Please try again in 5 hours.",
+                    data={"subtype": "error", "error_type": "CodexCliError"},
+                ),
+            ),
+        )
+    )
+    executor._try_decompose_ac = AsyncMock()
+    executor._request_bounce_classification = AsyncMock()
+
+    result = await executor._execute_single_ac(
+        ac_index=0,
+        ac_content="Parent work",
+        session_id="session-quota",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal="goal",
+        execution_id="exec-quota",
+    )
+
+    assert result.success is False
     executor._try_decompose_ac.assert_not_awaited()
     executor._request_bounce_classification.assert_not_awaited()
 
@@ -180,9 +237,7 @@ async def test_abandoned_stall_runs_bounce_recovery_without_losing_semantic_key(
             depth=kwargs["depth"],
         )
     )
-    executor._request_bounce_classification = AsyncMock(
-        return_value=(BounceCause.UNKNOWN, "No decomposition evidence.", (), False)
-    )
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.UNKNOWN, False))
 
     result = await executor._execute_single_ac(
         ac_index=0,
@@ -207,9 +262,7 @@ async def test_evidence_backed_too_big_bounce_dispatches_trusted_children(
 ) -> None:
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-too-big", ac_index=0)
-    executor._request_bounce_classification = AsyncMock(
-        return_value=(BounceCause.TOO_BIG, "Distinct parent scope remains.", ("remaining:1",), True)
-    )
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
     executor._try_decompose_ac = AsyncMock(return_value=_trusted_split(node.node_id))
     executor._maybe_redispatch_alt_harness = AsyncMock()
 
@@ -263,12 +316,60 @@ async def test_evidence_backed_too_big_bounce_dispatches_trusted_children(
 
 
 @pytest.mark.asyncio
+async def test_bounce_persistence_failure_prevents_decomposition_provider_effect() -> None:
+    executor = _executor()
+    executor._execute_atomic_ac = AsyncMock(return_value=_failed_result())
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
+    executor._try_decompose_ac = AsyncMock()
+    executor._event_store.append.side_effect = RuntimeError("event store unavailable")
+
+    with pytest.raises(RuntimeError, match="event store unavailable"):
+        await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Parent work",
+            session_id="session-bounce-persist",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="goal",
+            execution_id="exec-bounce-persist",
+        )
+
+    executor._try_decompose_ac.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_decision_persistence_failure_prevents_child_dispatch() -> None:
+    executor = _executor()
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-decision-persist", ac_index=0)
+    executor._execute_atomic_ac = AsyncMock(return_value=_failed_result())
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
+    executor._try_decompose_ac = AsyncMock(return_value=_trusted_split(node.node_id))
+    executor._event_store.append.side_effect = [None, RuntimeError("decision append failed")]
+    executor._execute_decomposition_children = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="decision append failed"):
+        await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Parent work",
+            session_id="session-decision-persist",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="goal",
+            execution_id="exec-decision-persist",
+            node_identity=node,
+        )
+
+    executor._execute_decomposition_children.assert_not_awaited()
+    assert node.node_id not in executor._decomposition_decisions
+
+
+@pytest.mark.asyncio
 async def test_too_big_at_depth_cap_records_escalated_compromise() -> None:
     executor = _executor(max_depth=0)
     executor._execute_atomic_ac = AsyncMock(return_value=_failed_result())
-    executor._request_bounce_classification = AsyncMock(
-        return_value=(BounceCause.TOO_BIG, "Distinct parent scope remains.", (), True)
-    )
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
     executor._try_decompose_ac = AsyncMock()
 
     result = await executor._execute_single_ac(
@@ -495,7 +596,10 @@ def test_trace_summary_is_bounded_and_does_not_copy_tool_inputs() -> None:
     assert "hunter2" not in trace.summary
     assert "abc123" not in trace.summary
     assert "secret-value" not in trace.summary
-    assert "Read, Bash" in trace.summary
+    assert "attempt_message_count=2" in trace.summary
+    assert "attempted_tool_count=2" in trace.summary
+    assert "verifier_reason_count=1" in trace.summary
+    assert trace.evidence_refs == ()
 
 
 class _SequenceRuntime:
@@ -520,15 +624,14 @@ class _SequenceRuntime:
 
 
 @pytest.mark.asyncio
-async def test_classifier_output_is_bounded_and_redacted_before_use() -> None:
+async def test_classifier_rejects_oversized_output_instead_of_normalizing_authority() -> None:
     runtime = _SequenceRuntime(
         [
             json.dumps(
                 {
                     "cause": "TOO_BIG",
-                    "reason": "token=secret-value " + ("x" * 500),
-                    "evidence_refs": [f"ref-{index}: password=hunter2" for index in range(20)],
                     "has_remaining_scope": True,
+                    "explanation": "token=secret-value " + ("x" * 500),
                 }
             )
         ]
@@ -541,16 +644,53 @@ async def test_classifier_output_is_bounded_and_redacted_before_use() -> None:
         cross_harness_redispatch=False,
     )
 
-    cause, reason, refs, remaining = await executor._request_bounce_classification(
+    cause, remaining = await executor._request_bounce_classification(
         trace=DecompositionTraceSummary(summary="attempted_tools=Read")
     )
 
-    assert cause is BounceCause.TOO_BIG
-    assert remaining is True
-    assert len(reason) <= 240
-    assert "secret-value" not in reason
-    assert len(refs) == 8
-    assert all("hunter2" not in ref for ref in refs)
+    assert cause is BounceCause.UNKNOWN
+    assert remaining is False
+
+
+@pytest.mark.asyncio
+async def test_classifier_admits_only_closed_cause_and_scope_metadata() -> None:
+    runtime = _SequenceRuntime([json.dumps({"cause": "TOO_BIG", "has_remaining_scope": True})])
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+
+    result = await executor._request_bounce_classification(
+        trace=DecompositionTraceSummary(summary="attempted_tool_count=1")
+    )
+
+    assert result == (BounceCause.TOO_BIG, True)
+
+
+@pytest.mark.asyncio
+async def test_classifier_requires_exact_bounded_schema() -> None:
+    payload = {
+        "cause": "TOO_BIG",
+        "has_remaining_scope": True,
+        "decompose_now": True,
+    }
+    runtime = _SequenceRuntime([json.dumps(payload)])
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+
+    result = await executor._request_bounce_classification(
+        trace=DecompositionTraceSummary(summary="attempted_tools=Read")
+    )
+
+    assert result == (BounceCause.UNKNOWN, False)
 
 
 @pytest.mark.asyncio
@@ -570,9 +710,7 @@ async def test_classifier_cannot_self_author_attempt_evidence() -> None:
         ),
     )
     trace = executor._build_decomposition_trace_summary(result=result, ac_spec=None)
-    executor._request_bounce_classification = AsyncMock(
-        return_value=(BounceCause.TOO_BIG, "Scope remains.", ("invented:ref",), True)
-    )
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
 
     classification = await executor._classify_bounce_result(result=result, trace=trace)
 
@@ -608,19 +746,41 @@ def _attestation(*, established: bool) -> str:
             "coverage_established": established,
             "non_overlap_established": established,
             "simpler_units_established": established,
-            "reasons": [] if established else ["siblings overlap"],
         }
     )
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "source",
-    [DecompositionSource.BOUNCE, DecompositionSource.PREFLIGHT],
-)
-async def test_generic_structured_proposal_requires_independent_attestation(
-    source: DecompositionSource,
-) -> None:
+@pytest.mark.parametrize("mutation", ["unknown_field", "non_boolean"])
+async def test_semantic_attestation_rejects_non_strict_payloads(mutation: str) -> None:
+    payload = json.loads(_attestation(established=True))
+    if mutation == "unknown_field":
+        payload["authorizes_child_dispatch"] = True
+    else:
+        payload["non_overlap_established"] = 1
+    runtime = _SequenceRuntime([json.dumps(payload)])
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        cross_harness_redispatch=False,
+    )
+    proposal = DecompositionProposal.from_dict(json.loads(_generic_proposal()))
+    assert proposal is not None
+
+    established, reasons = await executor._attest_decomposition_proposal(
+        parent_text="Produce output and verify integration",
+        proposal=proposal,
+        trace_summary="remaining_artifacts=report.json",
+        system_prompt="system",
+    )
+
+    assert established is False
+    assert reasons == ("semantic_attestation_unparseable",)
+
+
+@pytest.mark.asyncio
+async def test_generic_structured_proposal_requires_independent_attestation() -> None:
     runtime = _SequenceRuntime([_generic_proposal(), _attestation(established=True)])
     inherited_handle = RuntimeHandle(backend="claude", native_session_id="proposal-session")
     executor = ParallelACExecutor(
@@ -638,8 +798,8 @@ async def test_generic_structured_proposal_requires_independent_attestation(
         seed_goal="goal",
         tools=[],
         system_prompt="system",
-        source=source,
-        cause=BounceCause.TOO_BIG if source is DecompositionSource.BOUNCE else None,
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
         trace_summary="attempted_tools=Read; remaining_artifacts=report.json",
     )
 
@@ -648,6 +808,30 @@ async def test_generic_structured_proposal_requires_independent_attestation(
     assert result.semantic_status is SemanticAttestationStatus.ESTABLISHED
     assert len(runtime.prompts) == 2
     assert runtime.resume_handles == [inherited_handle, None]
+
+
+@pytest.mark.asyncio
+async def test_live_decomposer_rejects_preflight_invocation_before_provider_effect() -> None:
+    runtime = _SequenceRuntime([_generic_proposal()])
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+
+    with pytest.raises(RuntimeError, match="TOO_BIG bounce"):
+        await executor._try_decompose_ac(
+            ac_content="Produce output and verify integration",
+            ac_index=0,
+            seed_goal="goal",
+            tools=[],
+            system_prompt="system",
+            source=DecompositionSource.PREFLIGHT,
+        )
+
+    assert runtime.prompts == []
 
 
 @pytest.mark.asyncio
@@ -682,7 +866,7 @@ async def test_failed_semantic_attestation_repairs_once_then_admits() -> None:
     assert result.disposition is DecompositionDisposition.SPLIT
     assert result.trustworthy is True
     assert result.repair_count == 1
-    assert "siblings overlap" in runtime.prompts[2]
+    assert "non_overlap_not_established" in runtime.prompts[2]
     assert len(runtime.prompts) == 4
 
 

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 import json
 from types import SimpleNamespace
 from typing import Any
@@ -73,6 +74,72 @@ def _trusted_split(node_id: str) -> DecompositionDecisionRecord:
         semantic_status=SemanticAttestationStatus.ESTABLISHED,
         trustworthy=True,
     )
+
+
+_BOUNCE_EVENT_TIME = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _bounce_event(
+    node: ExecutionNodeIdentity,
+    *,
+    execution_id: str,
+    session_id: str,
+    evidence_refs: tuple[str, ...] = (),
+) -> BaseEvent:
+    return BaseEvent(
+        type="execution.decomposition.bounce_classified",
+        timestamp=_BOUNCE_EVENT_TIME,
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data={
+            **node.to_event_metadata(),
+            "execution_id": execution_id,
+            "session_id": session_id,
+            "cause": "TOO_BIG",
+            "rationale": "Attempt evidence shows distinct parent scope remains.",
+            "failure_class": "SCOPE_CREEP",
+            "retry_admission": "REDISPATCH",
+            "evidence_refs": list(evidence_refs),
+            "trace_summary": "attempted_tool_count=1\nremaining_artifact_count=1",
+        },
+    )
+
+
+def _finalized_event(
+    node: ExecutionNodeIdentity,
+    decision: DecompositionDecisionRecord,
+    *,
+    execution_id: str,
+    session_id: str,
+) -> BaseEvent:
+    return BaseEvent(
+        type="execution.decomposition.decision_finalized",
+        timestamp=_BOUNCE_EVENT_TIME + timedelta(seconds=1),
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data={
+            **node.to_event_metadata(),
+            **decision.to_dict(),
+            "execution_id": execution_id,
+            "session_id": session_id,
+            "mode": "bounce_only",
+            "child_count": len(decision.children),
+        },
+    )
+
+
+def _replay_store(*events: BaseEvent) -> AsyncMock:
+    store = AsyncMock()
+
+    async def query_events(
+        _execution_id: str,
+        event_type: str | None = None,
+        **_kwargs: Any,
+    ) -> list[BaseEvent]:
+        return [event for event in events if event.type == event_type]
+
+    store.query_execution_related_events.side_effect = query_events
+    return store
 
 
 def _executor(*, max_depth: int = 2) -> ProcessLocalTestExecutor:
@@ -408,7 +475,7 @@ async def test_too_big_at_depth_cap_records_escalated_compromise() -> None:
 async def test_restored_trusted_bounce_decision_dispatches_without_reclassification() -> None:
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-restored", ac_index=0)
-    executor._decomposition_decisions[node.node_id] = _trusted_split(node.node_id)
+    executor._publish_event_owned_decomposition_decision(_trusted_split(node.node_id))
     execute_atomic_ac = AsyncMock(
         side_effect=lambda **kwargs: ACExecutionResult(
             ac_index=kwargs["ac_index"],
@@ -441,6 +508,98 @@ async def test_restored_trusted_bounce_decision_dispatches_without_reclassificat
 
 
 @pytest.mark.asyncio
+async def test_cache_only_trusted_split_fails_before_parent_or_child_provider_entry() -> None:
+    executor = _executor()
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-cache-only", ac_index=0)
+    executor._decomposition_decisions[node.node_id] = _trusted_split(node.node_id)
+    execute_atomic = AsyncMock()
+    execute_children = AsyncMock()
+    executor._execute_atomic_ac = execute_atomic
+    executor._execute_decomposition_children = execute_children
+
+    with pytest.raises(RuntimeError, match="finalized-event authority"):
+        await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Parent work",
+            session_id="session-cache-only",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="goal",
+            execution_id="exec-cache-only",
+            node_identity=node,
+        )
+
+    execute_atomic.assert_not_awaited()
+    execute_children.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pending_too_big_replay_resumes_decomposer_before_atomic_parent() -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-pending", ac_index=0)
+    bounce_event = _bounce_event(
+        node,
+        execution_id="exec-pending",
+        session_id="session-pending",
+    )
+    executor = ProcessLocalTestExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=_replay_store(bounce_event),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+    seed = Seed(
+        goal="Resume pending bounce",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Replay", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+    await executor._restore_bounce_classifications(
+        seed=seed,
+        execution_id="exec-pending",
+        session_id="session-pending",
+    )
+    decision = _trusted_split(node.node_id)
+    try_decompose = AsyncMock(return_value=decision)
+    execute_atomic = AsyncMock(side_effect=AssertionError("parent reran"))
+    classify = AsyncMock(side_effect=AssertionError("classifier reran"))
+    execute_children = AsyncMock(
+        return_value=ACExecutionResult(
+            ac_index=0,
+            ac_content="Parent work",
+            success=True,
+            is_decomposed=True,
+            decomposition_decision=decision,
+        )
+    )
+    executor._try_decompose_ac = try_decompose
+    executor._execute_atomic_ac = execute_atomic
+    executor._request_bounce_classification = classify
+    executor._execute_decomposition_children = execute_children
+
+    result = await executor._execute_single_ac(
+        ac_index=0,
+        ac_content="Parent work",
+        session_id="session-pending",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal=seed.goal,
+        execution_id="exec-pending",
+        node_identity=node,
+    )
+
+    assert result.success and result.is_decomposed
+    try_decompose.assert_awaited_once()
+    execute_atomic.assert_not_awaited()
+    classify.assert_not_awaited()
+    assert executor._pending_bounce_decompositions == {}
+    assert executor._event_owned_decomposition_decisions[node.node_id] == decision
+
+
+@pytest.mark.asyncio
 async def test_checkpoint_persists_and_restores_decision_by_stable_node_id() -> None:
     node = ExecutionNodeIdentity.root(execution_context_id="exec-checkpoint", ac_index=0)
     decision = _trusted_split(node.node_id)
@@ -458,15 +617,25 @@ async def test_checkpoint_persists_and_restores_decision_by_stable_node_id() -> 
     store = MagicMock()
     store.load.return_value = SimpleNamespace(is_ok=False)
     store.save.return_value = SimpleNamespace(is_ok=True)
+    bounce_event = _bounce_event(
+        node,
+        execution_id="exec-checkpoint",
+        session_id="session-checkpoint",
+    )
+    finalized_event = _finalized_event(
+        node,
+        decision,
+        execution_id="exec-checkpoint",
+        session_id="session-checkpoint",
+    )
     executor = ParallelACExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
-        event_store=AsyncMock(),
+        event_store=_replay_store(bounce_event, finalized_event),
         console=MagicMock(),
         decomposition_mode="bounce_only",
         checkpoint_store=store,
         cross_harness_redispatch=False,
     )
-    executor._decomposition_decisions[node.node_id] = decision
     executor._run_batch_with_verify_and_retry = AsyncMock(
         return_value=[ACExecutionResult(ac_index=0, ac_content="Parent work", success=True)]
     )
@@ -487,7 +656,7 @@ async def test_checkpoint_persists_and_restores_decision_by_stable_node_id() -> 
     restore_store.load.return_value = SimpleNamespace(is_ok=True, value=checkpoint)
     restored_executor = ParallelACExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
-        event_store=AsyncMock(),
+        event_store=_replay_store(bounce_event, finalized_event),
         console=MagicMock(),
         decomposition_mode="bounce_only",
         checkpoint_store=restore_store,
@@ -523,24 +692,19 @@ async def test_finalized_event_restores_decision_before_batch_execution() -> Non
         nodes=(ACNode(index=0, content="Parent work"),),
         stages=(ExecutionStage(index=0, ac_indices=(0,)),),
     )
-    producer_store = AsyncMock()
-    producer = ParallelACExecutor(
-        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
-        event_store=producer_store,
-        console=MagicMock(),
-        decomposition_mode="bounce_only",
-        cross_harness_redispatch=False,
-    )
-    await producer._finalize_decomposition_decision(
-        decision=decision,
-        node_identity=node,
+    bounce_event = _bounce_event(
+        node,
         execution_id="exec-event-replay",
         session_id="session-event-replay",
     )
-    finalized_event = producer_store.append.await_args.args[0]
+    finalized_event = _finalized_event(
+        node,
+        decision,
+        execution_id="exec-event-replay",
+        session_id="session-event-replay",
+    )
 
-    replay_store = AsyncMock()
-    replay_store.query_execution_related_events.return_value = [finalized_event]
+    replay_store = _replay_store(bounce_event, finalized_event)
     replay = ParallelACExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=replay_store,
@@ -674,6 +838,39 @@ async def test_historical_preflight_event_replays_without_new_preflight_effect()
 
 
 @pytest.mark.asyncio
+async def test_bounce_finalized_event_without_prior_too_big_fails_replay() -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-orphan-final", ac_index=0)
+    decision = _trusted_split(node.node_id)
+    replay = _executor()
+    replay._event_store = _replay_store(
+        _finalized_event(
+            node,
+            decision,
+            execution_id="exec-orphan-final",
+            session_id="session-orphan-final",
+        )
+    )
+    replay._event_emitter = replay._event_emitter.__class__(
+        replay._event_store,
+        safe_emit_event=replay._safe_emit_event,
+    )
+    seed = Seed(
+        goal="Reject orphan final",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Replay", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+
+    with pytest.raises(RuntimeError, match="prior TOO_BIG"):
+        await replay._restore_finalized_decomposition_decisions(
+            seed=seed,
+            execution_id="exec-orphan-final",
+            session_id="session-orphan-final",
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("malformed_kind", ["unknown", "truncated", "container"])
 async def test_checkpoint_malformed_decomposition_decisions_fail_before_execution(
     malformed_kind: str,
@@ -737,6 +934,57 @@ async def test_checkpoint_malformed_decomposition_decisions_fail_before_executio
     executor._run_batch_with_verify_and_retry.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_valid_cache_only_checkpoint_fails_before_execution() -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-cache-checkpoint", ac_index=0)
+    decision = _trusted_split(node.node_id)
+    seed = Seed(
+        goal="Reject cache-only checkpoint",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Checkpoint", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+    plan = StagedExecutionPlan(
+        nodes=(ACNode(index=0, content="Parent work"),),
+        stages=(ExecutionStage(index=0, ac_indices=(0,)),),
+    )
+    checkpoint = CheckpointData.create(
+        getattr(seed, "id", "session-cache-checkpoint"),
+        "parallel_execution",
+        {
+            "session_id": "session-cache-checkpoint",
+            "execution_id": "exec-cache-checkpoint",
+            "workspace_identity": canonical_workspace_authority("/tmp/project"),
+            "completed_levels": 0,
+            "decomposition_decisions": {node.node_id: decision.to_dict()},
+        },
+    )
+    checkpoint_store = MagicMock()
+    checkpoint_store.load.return_value = SimpleNamespace(is_ok=True, value=checkpoint)
+    executor = ParallelACExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=_replay_store(),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        checkpoint_store=checkpoint_store,
+        cross_harness_redispatch=False,
+    )
+    executor._run_batch_with_verify_and_retry = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="checkpoint.*finalized-event authority"):
+        await executor.execute_parallel(
+            seed,
+            session_id="session-cache-checkpoint",
+            execution_id="exec-cache-checkpoint",
+            tools=[],
+            system_prompt="system",
+            execution_plan=plan,
+        )
+
+    executor._run_batch_with_verify_and_retry.assert_not_awaited()
+
+
 def test_mismatched_decision_identity_fails_closed() -> None:
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-identity", ac_index=0)
@@ -756,7 +1004,13 @@ def test_mismatched_decision_identity_fails_closed() -> None:
 
 @pytest.mark.asyncio
 async def test_finalized_decision_event_is_idempotent_for_equal_record() -> None:
-    store = AsyncMock()
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-event", ac_index=0)
+    bounce_event = _bounce_event(
+        node,
+        execution_id="exec-event",
+        session_id="session-event",
+    )
+    store = _replay_store(bounce_event)
     executor = ParallelACExecutor(
         adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
         event_store=store,
@@ -764,8 +1018,18 @@ async def test_finalized_decision_event_is_idempotent_for_equal_record() -> None
         decomposition_mode="bounce_only",
         cross_harness_redispatch=False,
     )
-    node = ExecutionNodeIdentity.root(execution_context_id="exec-event", ac_index=0)
     decision = _trusted_split(node.node_id)
+    await executor._restore_bounce_classifications(
+        seed=Seed(
+            goal="Finalize once",
+            constraints=(),
+            acceptance_criteria=("Parent work",),
+            ontology_schema=OntologySchema(name="Finalize", description="Test schema"),
+            metadata=SeedMetadata(ambiguity_score=0.05),
+        ),
+        execution_id="exec-event",
+        session_id="session-event",
+    )
 
     await executor._finalize_decomposition_decision(
         decision=decision,
@@ -901,6 +1165,31 @@ async def test_classifier_admits_only_closed_cause_and_scope_metadata() -> None:
     )
 
     assert result == (BounceCause.TOO_BIG, True)
+
+
+@pytest.mark.asyncio
+async def test_classifier_uses_fresh_session_when_executor_inherits_runtime_handle() -> None:
+    runtime = _SequenceRuntime([json.dumps({"cause": "TOO_BIG", "has_remaining_scope": True})])
+    inherited = RuntimeHandle(
+        backend="claude",
+        native_session_id="parent-conversation",
+        cwd="/tmp/project",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        inherited_runtime_handle=inherited,
+        cross_harness_redispatch=False,
+    )
+
+    result = await executor._request_bounce_classification(
+        trace=DecompositionTraceSummary(summary="attempted_tool_count=1")
+    )
+
+    assert result == (BounceCause.TOO_BIG, True)
+    assert runtime.resume_handles == [None]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
+++ b/tests/unit/orchestrator/test_parallel_executor_bounce_only.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 from types import SimpleNamespace
 from typing import Any
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.decomposition_policy import (
     BounceCause,
@@ -23,6 +25,7 @@ from ouroboros.orchestrator.decomposition_policy import (
     StructuralCheckStatus,
 )
 from ouroboros.orchestrator.dependency_analyzer import ACNode, ExecutionStage, StagedExecutionPlan
+from ouroboros.orchestrator.execution_authority import canonical_workspace_authority
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import (
     ACExecutionOutcome,
@@ -30,6 +33,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelACExecutor,
 )
 from ouroboros.orchestrator.verifier import RetryAdmission, VerifierVerdict
+from ouroboros.persistence.checkpoint import CheckpointData
 from tests.unit.orchestrator.parallel_executor_test_support import ProcessLocalTestExecutor
 
 
@@ -504,6 +508,235 @@ async def test_checkpoint_persists_and_restores_decision_by_stable_node_id() -> 
     restored_executor._run_batch_with_verify_and_retry.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_finalized_event_restores_decision_before_batch_execution() -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-event-replay", ac_index=0)
+    decision = _trusted_split(node.node_id)
+    seed = Seed(
+        goal="Replay finalized decision",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Replay", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+    plan = StagedExecutionPlan(
+        nodes=(ACNode(index=0, content="Parent work"),),
+        stages=(ExecutionStage(index=0, ac_indices=(0,)),),
+    )
+    producer_store = AsyncMock()
+    producer = ParallelACExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=producer_store,
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+    await producer._finalize_decomposition_decision(
+        decision=decision,
+        node_identity=node,
+        execution_id="exec-event-replay",
+        session_id="session-event-replay",
+    )
+    finalized_event = producer_store.append.await_args.args[0]
+
+    replay_store = AsyncMock()
+    replay_store.query_execution_related_events.return_value = [finalized_event]
+    replay = ParallelACExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=replay_store,
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+    try_decompose = AsyncMock()
+    execute_atomic = AsyncMock(side_effect=AssertionError("atomic parent was redispatched"))
+    execute_children = AsyncMock(
+        return_value=ACExecutionResult(
+            ac_index=0,
+            ac_content="Parent work",
+            success=True,
+            is_decomposed=True,
+            decomposition_decision=decision,
+        )
+    )
+    replay._try_decompose_ac = try_decompose
+    replay._execute_atomic_ac = execute_atomic
+    replay._execute_decomposition_children = execute_children
+
+    async def assert_decision_restored(**_kwargs: Any) -> list[ACExecutionResult]:
+        assert replay._decomposition_decisions == {node.node_id: decision}
+        result = await replay._execute_single_ac(
+            ac_index=0,
+            ac_content="Parent work",
+            session_id="session-event-replay",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal=seed.goal,
+            execution_id="exec-event-replay",
+            node_identity=node,
+        )
+        return [result]
+
+    replay._run_batch_with_verify_and_retry = assert_decision_restored  # type: ignore[method-assign]
+    await replay.execute_parallel(
+        seed,
+        session_id="session-event-replay",
+        execution_id="exec-event-replay",
+        tools=[],
+        system_prompt="system",
+        execution_plan=plan,
+    )
+
+    replay_store.query_execution_related_events.assert_any_await(
+        "exec-event-replay",
+        event_type="execution.decomposition.decision_finalized",
+        limit=1563,
+    )
+    try_decompose.assert_not_awaited()
+    execute_atomic.assert_not_awaited()
+    execute_children.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_historical_preflight_event_replays_without_new_preflight_effect() -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-preflight-replay", ac_index=0)
+    decision = replace(
+        _trusted_split(node.node_id),
+        source=DecompositionSource.PREFLIGHT,
+        cause=None,
+    )
+    event = BaseEvent(
+        type="execution.decomposition.decision_finalized",
+        aggregate_type="execution",
+        aggregate_id="exec-preflight-replay",
+        data={
+            **node.to_event_metadata(),
+            **decision.to_dict(),
+            "execution_id": "exec-preflight-replay",
+            "session_id": "session-preflight-replay",
+            "mode": "preflight",
+            "child_count": len(decision.children),
+        },
+    )
+    store = AsyncMock()
+    store.query_execution_related_events.return_value = [event]
+    replay = ProcessLocalTestExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=store,
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        cross_harness_redispatch=False,
+    )
+    seed = Seed(
+        goal="Replay historical preflight",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Replay", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+    await replay._restore_finalized_decomposition_decisions(
+        seed=seed,
+        execution_id="exec-preflight-replay",
+        session_id="session-preflight-replay",
+    )
+    try_decompose = AsyncMock()
+    execute_atomic = AsyncMock(side_effect=AssertionError("historical parent was redispatched"))
+    execute_children = AsyncMock(
+        return_value=ACExecutionResult(
+            ac_index=0,
+            ac_content="Parent work",
+            success=True,
+            is_decomposed=True,
+            decomposition_decision=decision,
+        )
+    )
+    replay._try_decompose_ac = try_decompose
+    replay._execute_atomic_ac = execute_atomic
+    replay._execute_decomposition_children = execute_children
+
+    result = await replay._execute_single_ac(
+        ac_index=0,
+        ac_content="Parent work",
+        session_id="session-preflight-replay",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="system",
+        seed_goal=seed.goal,
+        execution_id="exec-preflight-replay",
+        node_identity=node,
+    )
+
+    assert result.is_decomposed
+    try_decompose.assert_not_awaited()
+    execute_atomic.assert_not_awaited()
+    execute_children.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed_kind", ["unknown", "truncated", "container"])
+async def test_checkpoint_malformed_decomposition_decisions_fail_before_execution(
+    malformed_kind: str,
+) -> None:
+    node = ExecutionNodeIdentity.root(execution_context_id="exec-corrupt", ac_index=0)
+    decision_data = _trusted_split(node.node_id).to_dict()
+    if malformed_kind == "unknown":
+        decision_data["unknown"] = True
+        raw_decisions: object = {node.node_id: decision_data}
+    elif malformed_kind == "truncated":
+        del decision_data["source"]
+        raw_decisions = {node.node_id: decision_data}
+    else:
+        raw_decisions = [decision_data]
+    seed = Seed(
+        goal="Reject malformed checkpoint",
+        constraints=(),
+        acceptance_criteria=("Parent work",),
+        ontology_schema=OntologySchema(name="Checkpoint", description="Test schema"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+    plan = StagedExecutionPlan(
+        nodes=(ACNode(index=0, content="Parent work"),),
+        stages=(ExecutionStage(index=0, ac_indices=(0,)),),
+    )
+    checkpoint = CheckpointData.create(
+        getattr(seed, "id", "session-corrupt"),
+        "parallel_execution",
+        {
+            "session_id": "session-corrupt",
+            "execution_id": "exec-corrupt",
+            "workspace_identity": canonical_workspace_authority("/tmp/project"),
+            "completed_levels": 0,
+            "decomposition_decisions": raw_decisions,
+        },
+    )
+    checkpoint_store = MagicMock()
+    checkpoint_store.load.return_value = SimpleNamespace(is_ok=True, value=checkpoint)
+    event_store = AsyncMock()
+    event_store.query_execution_related_events.return_value = []
+    executor = ParallelACExecutor(
+        adapter=MagicMock(working_directory="/tmp/project", runtime_backend="claude"),
+        event_store=event_store,
+        console=MagicMock(),
+        decomposition_mode="bounce_only",
+        checkpoint_store=checkpoint_store,
+        cross_harness_redispatch=False,
+    )
+    executor._run_batch_with_verify_and_retry = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="checkpoint decomposition"):
+        await executor.execute_parallel(
+            seed,
+            session_id="session-corrupt",
+            execution_id="exec-corrupt",
+            tools=[],
+            system_prompt="system",
+            execution_plan=plan,
+        )
+
+    executor._run_batch_with_verify_and_retry.assert_not_awaited()
+
+
 def test_mismatched_decision_identity_fails_closed() -> None:
     executor = _executor()
     node = ExecutionNodeIdentity.root(execution_context_id="exec-identity", ac_index=0)
@@ -546,30 +779,30 @@ async def test_finalized_decision_event_is_idempotent_for_equal_record() -> None
         execution_id="exec-event",
         session_id="session-event",
     )
-    await executor._finalize_decomposition_decision(
-        decision=DecompositionDecisionRecord(
-            node_id=node.node_id,
-            source=DecompositionSource.BOUNCE,
-            disposition=DecompositionDisposition.ESCALATED,
-            cause=BounceCause.TOO_BIG,
-            reasons=("repair failed",),
-            compromise_reason="generic_decomposition_repair_failed",
-        ),
-        node_identity=node,
-        execution_id="exec-event",
-        session_id="session-event",
-    )
+    with pytest.raises(RuntimeError, match="finalized decomposition decision cannot change"):
+        await executor._finalize_decomposition_decision(
+            decision=DecompositionDecisionRecord(
+                node_id=node.node_id,
+                source=DecompositionSource.BOUNCE,
+                disposition=DecompositionDisposition.ESCALATED,
+                cause=BounceCause.TOO_BIG,
+                reasons=("repair failed",),
+                compromise_reason="generic_decomposition_repair_failed",
+            ),
+            node_identity=node,
+            execution_id="exec-event",
+            session_id="session-event",
+        )
 
     events = [
         call.args[0]
         for call in store.append.await_args_list
         if call.args[0].type == "execution.decomposition.decision_finalized"
     ]
-    assert len(events) == 2
+    assert len(events) == 1
     assert events[0].data["mode"] == "bounce_only"
     assert events[0].data["child_count"] == 2
     assert events[0].data["trustworthy"] is True
-    assert events[1].data["compromise_reason"] == "generic_decomposition_repair_failed"
 
 
 def test_trace_summary_is_bounded_and_does_not_copy_tool_inputs() -> None:

--- a/tests/unit/orchestrator/test_route_escalation_live.py
+++ b/tests/unit/orchestrator/test_route_escalation_live.py
@@ -30,10 +30,12 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.decomposition_limits import MAX_DECOMPOSITION_DEPTH
 from ouroboros.orchestrator.decomposition_policy import (
+    DecompositionChild,
     DecompositionDecisionRecord,
     DecompositionDisposition,
     DecompositionSource,
-    legacy_unverified_split_decision,
+    SemanticAttestationStatus,
+    StructuralCheckStatus,
 )
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
@@ -335,10 +337,21 @@ def _split_decision(
     identity = node_identity or ExecutionNodeIdentity.root(
         execution_context_id=execution_id, ac_index=root_ac_index
     )
-    return legacy_unverified_split_decision(
+    return DecompositionDecisionRecord(
         node_id=identity.node_id,
         source=DecompositionSource.PREFLIGHT,
-        child_descriptions=child_descriptions,
+        disposition=DecompositionDisposition.SPLIT,
+        children=tuple(
+            DecompositionChild(
+                description=description,
+                coverage_claims=(f"scope-{index}",),
+                verification_hint=f"verify scope {index}",
+            )
+            for index, description in enumerate(child_descriptions)
+        ),
+        structural_status=StructuralCheckStatus.PASSED,
+        semantic_status=SemanticAttestationStatus.ESTABLISHED,
+        trustworthy=True,
     )
 
 
@@ -1214,6 +1227,12 @@ async def test_partial_composite_resume_reuses_only_exact_paused_child_boundary(
                 data={"subtype": "success" if resume_succeeds else "error"},
                 resume_handle=handle,
             )
+        elif call_number == 4 and not resume_succeeds:
+            assert kwargs.get("resume_handle") is None
+            yield AgentMessage(
+                type="result",
+                content=('{"cause":"BAD_SPEC","has_remaining_scope":false}'),
+            )
         else:  # pragma: no cover - the assertion below is the primary guard
             raise AssertionError("a completed child was redispatched")
 
@@ -1299,7 +1318,7 @@ async def test_partial_composite_resume_reuses_only_exact_paused_child_boundary(
         execution_counters=None,
     )
 
-    assert len(provider_resume_handles) == 3
+    assert len(provider_resume_handles) == (3 if resume_succeeds else 4)
     restored = resumed[0]
     assert isinstance(restored, ACExecutionResult)
     assert restored.success is resume_succeeds
@@ -2994,7 +3013,7 @@ async def test_parallel_pause_rejects_effort_drift_from_durable_successor() -> N
 
 
 @pytest.mark.asyncio
-async def test_durable_route_override_bypasses_preflight_decomposition_effect() -> None:
+async def test_durable_route_override_creates_no_preflight_decomposition_state() -> None:
     executor, _store, _events = _executor(enable_decomposition=True)
     candidate = _candidate(executor, "compat:claude:frugal")
 
@@ -3016,9 +3035,7 @@ async def test_durable_route_override_bypasses_preflight_decomposition_effect() 
 
     assert result.success is False
     assert "execute_task" in (result.error or "")
-    decision = next(iter(executor._decomposition_decisions.values()))
-    assert decision.disposition.value == "ATOMIC"
-    assert decision.reasons == ("durable_route_history_proves_atomic",)
+    assert executor._decomposition_decisions == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_route_escalation_live.py
+++ b/tests/unit/orchestrator/test_route_escalation_live.py
@@ -30,6 +30,7 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.decomposition_limits import MAX_DECOMPOSITION_DEPTH
 from ouroboros.orchestrator.decomposition_policy import (
+    BounceCause,
     DecompositionChild,
     DecompositionDecisionRecord,
     DecompositionDisposition,
@@ -62,7 +63,7 @@ from ouroboros.orchestrator.route_escalation import (
     advance_route,
 )
 from ouroboros.orchestrator.route_policy import RouteRequirements
-from ouroboros.orchestrator.verifier import VerifierVerdict
+from ouroboros.orchestrator.verifier import RetryAdmission, VerifierVerdict
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -545,6 +546,98 @@ async def test_live_loop_walks_each_route_once_then_succeeds() -> None:
     assert [event.data["route_id"] for event in judgments] == calls
     assert [event.data["route_attempt_index"] for event in judgments] == [0, 1, 2]
     assert all(event.data["route_episode_id"] == _episode_id(_seed()) for event in judgments)
+
+
+@pytest.mark.asyncio
+async def test_live_bounded_route_too_big_transitions_to_verified_composite() -> None:
+    """Routing D must not make the sole live bounce path unreachable."""
+
+    executor, _store, events = _executor(enable_decomposition=True)
+    node = ExecutionNodeIdentity.root(execution_context_id="execution-1", ac_index=0)
+    decision = replace(
+        _split_decision(node_identity=node),
+        source=DecompositionSource.BOUNCE,
+        cause=BounceCause.TOO_BIG,
+    )
+    route_calls = 0
+
+    async def failed_atomic_batch(**_kwargs: Any) -> list[ACExecutionResult]:
+        nonlocal route_calls
+        route_calls += 1
+        return [
+            ACExecutionResult(
+                ac_index=0,
+                ac_content="ship it",
+                success=False,
+                error="The parent has multiple unfinished scopes.",
+                messages=(AgentMessage(type="tool", content="attempted", tool_name="Read"),),
+                outcome=ACExecutionOutcome.FAILED,
+                atomic_verifier_verdict=VerifierVerdict(
+                    passed=False,
+                    reasons=("unfinished independent scopes",),
+                    failure_class=FailureClass.SCOPE_CREEP.value,
+                    retry_admission=RetryAdmission.REDISPATCH,
+                ),
+                route_candidate=_candidate(executor, "compat:claude:frugal"),
+            )
+        ]
+
+    child_results = (
+        ACExecutionResult(
+            ac_index=0,
+            ac_content=decision.children[0].description,
+            success=True,
+            final_message="first complete",
+            depth=1,
+        ),
+        ACExecutionResult(
+            ac_index=1,
+            ac_content=decision.children[1].description,
+            success=True,
+            final_message="second complete",
+            depth=1,
+        ),
+    )
+    composite = ACExecutionResult(
+        ac_index=0,
+        ac_content="ship it",
+        success=True,
+        final_message="composite complete",
+        is_decomposed=True,
+        sub_results=child_results,
+        decomposition_decision=decision,
+    )
+    executor._execute_ac_batch = failed_atomic_batch  # type: ignore[method-assign]
+    executor._request_bounce_classification = AsyncMock(return_value=(BounceCause.TOO_BIG, True))
+    executor._try_decompose_ac = AsyncMock(return_value=decision)  # type: ignore[method-assign]
+    executor._execute_decomposition_children = AsyncMock(  # type: ignore[method-assign]
+        return_value=composite
+    )
+
+    results = await executor._run_batch_with_bounded_route_escalation(
+        seed=_seed(),
+        batch_executable=[0],
+        session_id="session-1",
+        execution_id="execution-1",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="sys",
+        level_contexts=[],
+        ac_retry_attempts={0: 0},
+        execution_counters=None,
+    )
+
+    assert route_calls == 1
+    assert isinstance(results[0], ACExecutionResult)
+    assert results[0].success and results[0].is_decomposed
+    executor._request_bounce_classification.assert_awaited_once()
+    executor._try_decompose_ac.assert_awaited_once()  # type: ignore[attr-defined]
+    executor._execute_decomposition_children.assert_awaited_once()  # type: ignore[attr-defined]
+    event_types = [event.type for event in events]
+    assert "execution.decomposition.bounce_classified" in event_types
+    assert "execution.decomposition.decision_finalized" in event_types
+    assert "execution.ac.composite_completed" in event_types
+    assert "execution.ac.route_observed" not in event_types
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_route_escalation_live.py
+++ b/tests/unit/orchestrator/test_route_escalation_live.py
@@ -1341,7 +1341,7 @@ async def test_partial_composite_resume_reuses_only_exact_paused_child_boundary(
         execution_context_id="execution-1",
         ac_index=0,
     )
-    executor._decomposition_decisions[root_identity.node_id] = decision
+    executor._publish_event_owned_decomposition_decision(decision)
 
     first = await executor._run_batch_with_bounded_route_escalation(
         seed=seed,
@@ -1398,6 +1398,7 @@ async def test_partial_composite_resume_reuses_only_exact_paused_child_boundary(
         event_log=events,
         adapter_override=executor._adapter,
     )
+    resumed_executor._publish_event_owned_decomposition_decision(decision)
     resumed = await resumed_executor._run_batch_with_bounded_route_escalation(
         seed=seed,
         batch_executable=[0],
@@ -1487,17 +1488,15 @@ async def test_nested_partial_composite_resume_reuses_exact_depth_two_leaf_bound
         node_identity=root.child(1),
         child_descriptions=("nested completed", "nested paused"),
     )
-    executor._decomposition_decisions.update(
-        {
-            root.node_id: root_decision,
-            root.child(0).node_id: DecompositionDecisionRecord(
-                node_id=root.child(0).node_id,
-                source=DecompositionSource.PREFLIGHT,
-                disposition=DecompositionDisposition.ATOMIC,
-            ),
-            root.child(1).node_id: nested_decision,
-        }
+    executor._publish_event_owned_decomposition_decision(root_decision)
+    executor._publish_event_owned_decomposition_decision(
+        DecompositionDecisionRecord(
+            node_id=root.child(0).node_id,
+            source=DecompositionSource.PREFLIGHT,
+            disposition=DecompositionDisposition.ATOMIC,
+        )
     )
+    executor._publish_event_owned_decomposition_decision(nested_decision)
 
     first = await executor._run_batch_with_bounded_route_escalation(
         seed=seed,
@@ -1542,6 +1541,8 @@ async def test_nested_partial_composite_resume_reuses_exact_depth_two_leaf_bound
         event_log=events,
         adapter_override=executor._adapter,
     )
+    resumed_executor._publish_event_owned_decomposition_decision(root_decision)
+    resumed_executor._publish_event_owned_decomposition_decision(nested_decision)
     resumed = await resumed_executor._run_batch_with_bounded_route_escalation(
         seed=seed,
         batch_executable=[0],
@@ -2244,6 +2245,7 @@ async def test_parallel_pause_resume_preserves_completed_composite_without_effec
     executor._adapter.working_directory = str(tmp_path)  # type: ignore[attr-defined]
     seed = _multi_seed()
     cheap = _candidate(executor, "compat:claude:frugal")
+    decomposition_decision = _split_decision()
     touched = tmp_path / "composite.py"
     touched.write_text("def completed_effect():\n    return True\n")
     child_message = AgentMessage(
@@ -2279,7 +2281,7 @@ async def test_parallel_pause_resume_preserves_completed_composite_without_effec
                     ),
                 ),
                 outcome=ACExecutionOutcome.SUCCEEDED,
-                decomposition_decision=_split_decision(),
+                decomposition_decision=decomposition_decision,
             ),
             ACExecutionResult(
                 ac_index=1,
@@ -2340,6 +2342,7 @@ async def test_parallel_pause_resume_preserves_completed_composite_without_effec
     executor._try_decompose_ac = AsyncMock(  # type: ignore[method-assign]
         side_effect=AssertionError("completed composite decomposition replayed")
     )
+    executor._publish_event_owned_decomposition_decision(decomposition_decision)
     resumed = await executor._run_batch_with_bounded_route_escalation(
         seed=seed,
         batch_executable=[0, 1],
@@ -2739,10 +2742,98 @@ async def test_partial_composite_replay_rejects_non_strict_or_conflicting_state(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("projection", ["completion", "partial"])
+async def test_composite_projection_without_finalized_event_cannot_mint_authority(
+    projection: str,
+) -> None:
+    executor, store, events = _executor(enable_decomposition=True)
+    seed = _seed()
+    decision = _split_decision()
+    if projection == "completion":
+        result = ACExecutionResult(
+            ac_index=0,
+            ac_content="ship it",
+            success=True,
+            final_message="composite complete",
+            is_decomposed=True,
+            sub_results=(
+                ACExecutionResult(ac_index=100, ac_content="first child", success=True, depth=1),
+                ACExecutionResult(ac_index=101, ac_content="second child", success=True, depth=1),
+            ),
+            decomposition_decision=decision,
+        )
+        await executor._persist_composite_completion(
+            seed=seed,
+            result=result,
+            root_ac_index=0,
+            session_id="session-1",
+            execution_id="execution-1",
+        )
+    else:
+        root = ExecutionNodeIdentity.root(execution_context_id="execution-1", ac_index=0)
+        paused = AgentMessage(
+            type="result",
+            content="Usage limit reached. Please try again in 5 hours.",
+            data={"subtype": "error", "error_type": "CodexCliError"},
+        )
+        result = ACExecutionResult(
+            ac_index=0,
+            ac_content="ship it",
+            success=False,
+            is_decomposed=True,
+            sub_results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content="first child",
+                    success=False,
+                    messages=(paused,),
+                    final_message=paused.content,
+                    runtime_handle=RuntimeHandle(
+                        backend="claude",
+                        native_session_id="cache-only-child",
+                        cwd="/tmp/project",
+                        metadata={
+                            "node_id": root.child(0).node_id,
+                            "session_scope_id": "execution-1-cache-only-child",
+                            "ac_dispatch_id": "e" * 32,
+                            "ac_capsule_fingerprint": "sha256:" + "e" * 64,
+                        },
+                    ),
+                    depth=1,
+                ),
+            ),
+            decomposition_decision=decision,
+        )
+        await executor._persist_partial_composite_pause(
+            seed=seed,
+            result=result,
+            root_ac_index=0,
+            session_id="session-1",
+            execution_id="execution-1",
+        )
+
+    async def query(*_args: Any, **kwargs: Any) -> list[BaseEvent]:
+        return [event for event in events if event.type == kwargs.get("event_type")]
+
+    store.query_execution_related_events.side_effect = query
+    with pytest.raises(RuntimeError, match=f"{projection}.*finalized-event authority"):
+        await executor._load_bounded_route_resume_state(
+            seed=seed,
+            execution_id="execution-1",
+            session_id="session-1",
+            root_ac_indices=(0,),
+        )
+
+    assert executor._decomposition_decisions == {}
+    assert executor._partial_composite_resumes == {}
+
+
+@pytest.mark.asyncio
 async def test_partial_composite_replay_folds_newest_first_advancing_history() -> None:
     executor, store, events = _executor(enable_decomposition=True)
     seed = _seed()
     decision = _split_decision()
+    executor._publish_event_owned_decomposition_decision(decision)
     root = ExecutionNodeIdentity.root(execution_context_id="execution-1", ac_index=0)
     paused_message = AgentMessage(
         type="result",
@@ -2883,6 +2974,7 @@ async def test_valid_4097_composite_pauses_replay_without_a_total_cap(tmp_path: 
         working_directory=str(tmp_path),
         process_local_resume_nonce="d" * 32,
     )
+    replay._publish_event_owned_decomposition_decision(decision)
     try:
         await replay._load_bounded_route_resume_state(
             seed=seed,
@@ -3726,6 +3818,10 @@ async def test_valid_4097_composite_completion_population_replays_all_roots(
         working_directory=str(tmp_path),
         process_local_resume_nonce="a" * 32,
     )
+    for root_ac_index in range(root_count):
+        replay._publish_event_owned_decomposition_decision(
+            _split_decision(root_ac_index=root_ac_index)
+        )
     try:
         (
             _histories,

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -743,6 +743,17 @@ def test_current_execution_semantics_requires_complete_exact_population(field: s
         _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
 
 
+def test_current_execution_semantics_rejects_retired_preflight_authority() -> None:
+    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted["execution_semantics"]["decomposition_mode"] = "preflight"
+    persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
+        OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
+    )
+
+    with pytest.raises(OrchestratorError, match="invalid execution contract"):
+        _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+
 @pytest.mark.parametrize(
     "field",
     [

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -743,14 +743,31 @@ def test_current_execution_semantics_requires_complete_exact_population(field: s
         _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
 
 
-def test_current_execution_semantics_rejects_retired_preflight_authority() -> None:
+def test_current_execution_semantics_migrates_retired_preflight_authority_once() -> None:
     persisted = copy.deepcopy(_runner()._build_execution_contract())
     persisted["execution_semantics"]["decomposition_mode"] = "preflight"
     persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
         OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
     )
 
-    with pytest.raises(OrchestratorError, match="invalid execution contract"):
+    resumed = _runner()
+    changed = resumed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
+
+    assert changed is True
+    assert resumed._execution_contract is not None
+    migrated = resumed._execution_contract
+    assert migrated["execution_semantics"]["decomposition_mode"] == "bounce_only"
+    assert migrated["frugality_proof"]["execution_semantics_fingerprint"] == (
+        OrchestratorRunner._execution_semantics_fingerprint(migrated["execution_semantics"])
+    )
+    assert resumed._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: migrated}) is False
+
+
+def test_legacy_preflight_migration_rejects_unsealed_semantics() -> None:
+    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted["execution_semantics"]["decomposition_mode"] = "preflight"
+
+    with pytest.raises(OrchestratorError, match="invalid legacy preflight contract"):
         _runner()._restore_execution_contract({EXECUTION_CONTRACT_PROGRESS_KEY: persisted})
 
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -6471,6 +6471,88 @@ class TestOrchestratorRunner:
         assert captured_init["decomposition_mode"] == "bounce_only"
 
     @pytest.mark.asyncio
+    async def test_legacy_preflight_resume_reaches_executor_as_bounce_only(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """An old durable run migrates before the resumed executor is built."""
+
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        legacy_contract = copy.deepcopy(runner._build_execution_contract(seed=sample_seed))
+        legacy_contract["execution_semantics"]["decomposition_mode"] = "preflight"
+        legacy_contract["frugality_proof"]["execution_semantics_fingerprint"] = (
+            runner._execution_semantics_fingerprint(legacy_contract["execution_semantics"])
+        )
+        changed, migrated_contract = runner._restore_execution_contract_snapshot(
+            {EXECUTION_CONTRACT_PROGRESS_KEY: legacy_contract},
+            seed=sample_seed,
+        )
+        assert changed is True
+
+        tracker = SessionTracker.create("exec_preflight_resume", sample_seed.metadata.seed_id)
+        dependency_graph = DependencyGraph(
+            nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
+            execution_levels=((0,),),
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=True,
+                    final_message="done",
+                ),
+            ),
+            success_count=1,
+            failure_count=0,
+            total_messages=1,
+        )
+        captured_init: dict[str, Any] = {}
+
+        class _FakeParallelExecutor:
+            def __init__(self, **kwargs: Any) -> None:
+                captured_init.update(kwargs)
+
+            async def execute_parallel(self, **_kwargs: Any) -> ParallelExecutionResult:
+                return parallel_result
+
+        with (
+            patch(
+                "ouroboros.orchestrator.dependency_analyzer.DependencyAnalyzer.analyze",
+                AsyncMock(return_value=Result.ok(dependency_graph)),
+            ),
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor",
+                _FakeParallelExecutor,
+            ),
+        ):
+            result = await runner._execute_parallel(
+                seed=sample_seed,
+                exec_id=tracker.execution_id,
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+                execution_contract=migrated_contract,
+            )
+
+        assert result.is_ok
+        assert captured_init["decomposition_mode"] == "bounce_only"
+        assert migrated_contract["execution_semantics"]["decomposition_mode"] == "bounce_only"
+
+    @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(
         self,
         mock_adapter: MagicMock,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -502,6 +502,7 @@ class TestExecutionEventEmitter:
         self,
     ) -> None:
         from ouroboros.orchestrator.decomposition_policy import (
+            BounceCause,
             DecompositionDecisionRecord,
             DecompositionDisposition,
             DecompositionSource,
@@ -510,29 +511,33 @@ class TestExecutionEventEmitter:
         from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 
         safe_emit = AsyncMock(return_value=True)
-        emitter = ExecutionEventEmitter(AsyncMock(), safe_emit_event=safe_emit)
+        event_store = AsyncMock()
+        emitter = ExecutionEventEmitter(event_store, safe_emit_event=safe_emit)
         node = ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0)
         decision = DecompositionDecisionRecord(
             node_id=node.node_id,
-            source=DecompositionSource.PREFLIGHT,
-            disposition=DecompositionDisposition.ATOMIC,
-            reasons=("small enough",),
+            source=DecompositionSource.BOUNCE,
+            disposition=DecompositionDisposition.ESCALATED,
+            cause=BounceCause.TOO_BIG,
+            reasons=("decomposition_depth_cap",),
+            compromise_reason="depth_cap_forced_atomic",
         )
 
         await emitter.emit_decomposition_decision_finalized(
             execution_id="exec_1",
             session_id="sess_1",
-            mode="preflight",
+            mode="bounce_only",
             node_identity=node,
             decision=decision,
         )
 
-        event = safe_emit.await_args.args[0]
+        event = event_store.append.await_args.args[0]
+        safe_emit.assert_not_awaited()
         assert event.type == "execution.decomposition.decision_finalized"
         assert event.aggregate_id == "exec_1"
         assert event.data["node_id"] == node.node_id
-        assert event.data["mode"] == "preflight"
-        assert event.data["disposition"] == "ATOMIC"
+        assert event.data["mode"] == "bounce_only"
+        assert event.data["disposition"] == "ESCALATED"
         assert event.data["child_count"] == 0
 
     @pytest.mark.asyncio
@@ -541,7 +546,8 @@ class TestExecutionEventEmitter:
         from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 
         safe_emit = AsyncMock(return_value=True)
-        emitter = ExecutionEventEmitter(AsyncMock(), safe_emit_event=safe_emit)
+        event_store = AsyncMock()
+        emitter = ExecutionEventEmitter(event_store, safe_emit_event=safe_emit)
         node = ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0)
 
         await emitter.emit_bounce_classified(
@@ -549,22 +555,23 @@ class TestExecutionEventEmitter:
             session_id="sess_1",
             node_identity=node,
             cause="TOO_BIG",
-            rationale="leaf exceeded scope",
-            failure_class="blocked",
-            retry_admission="redispatch",
-            evidence_refs=("event:1",),
-            trace_summary="bounded summary",
+            rationale="Attempt evidence shows distinct parent scope remains.",
+            failure_class="SCOPE_CREEP",
+            retry_admission="REDISPATCH",
+            evidence_refs=(),
+            trace_summary="attempted_tool_count=1\nremaining_artifact_count=1",
         )
 
-        event = safe_emit.await_args.args[0]
+        event = event_store.append.await_args.args[0]
+        safe_emit.assert_not_awaited()
         assert event.type == "execution.decomposition.bounce_classified"
         assert event.aggregate_id == "exec_1"
         assert event.data["node_id"] == node.node_id
         assert event.data["cause"] == "TOO_BIG"
-        assert event.data["failure_class"] == "blocked"
-        assert event.data["retry_admission"] == "redispatch"
-        assert event.data["evidence_refs"] == ["event:1"]
-        assert event.data["trace_summary"] == "bounded summary"
+        assert event.data["failure_class"] == "SCOPE_CREEP"
+        assert event.data["retry_admission"] == "REDISPATCH"
+        assert event.data["evidence_refs"] == []
+        assert event.data["trace_summary"] == ("attempted_tool_count=1\nremaining_artifact_count=1")
 
 
 class TestOrchestratorRunner:
@@ -647,8 +654,15 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             enable_decomposition=False,
-            decomposition_mode="preflight",
+            decomposition_mode="off",
         )
+        with pytest.raises(ValueError, match="Unsupported decomposition_mode"):
+            OrchestratorRunner(
+                mock_adapter,
+                mock_event_store,
+                mock_console,
+                decomposition_mode="preflight",  # type: ignore[arg-type]
+            )
 
         assert runner._decomposition_mode == "bounce_only"
         assert disabled_runner._decomposition_mode == "off"
@@ -6454,7 +6468,7 @@ class TestOrchestratorRunner:
         assert profile.profile == sample_seed.task_type == "code"
         assert profile.axis == "testable_unit"
         assert captured_init["fat_harness_mode"] is True
-        assert captured_init["decomposition_mode"] == "preflight"
+        assert captured_init["decomposition_mode"] == "bounce_only"
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -7823,6 +7823,7 @@ class TestOrchestratorRunnerWithMCP:
         store = AsyncMock()
         store.append = AsyncMock()
         store.replay = AsyncMock(return_value=[])
+        store.query_execution_related_events = AsyncMock(return_value=[])
         return store
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

- retire live preflight decomposition and permit a split only after an evidence-backed `TOO_BIG` bounce
- require exact-schema structural validation plus an independent fresh-session semantic attestation, with one repair and then explicit escalation
- make bounce/decision persistence mandatory before the next provider or child effect, while preserving historical durable replay
- pin the already-removed dead decomposition modules and every Python import spelling with an AST architecture guard

Implements the approved design in #1406 and closes #1466.

## Structural contract

- Stored `preflight` config migrates to `bounce_only`; direct runner/executor overrides and the provider entry reject live preflight authority.
- Bounce input contains only server-derived counts, booleans, and validated enums. Classifier and attestation replies contain only closed enums/booleans; model prose and self-claimed evidence cannot enter durable events.
- Proposals accept canonical JSON `dict`/`list` shapes only, reject unknown fields, bound every population/string, require unique child scope claims and verification hints, and fail closed on non-canonical durable records.
- Only a structurally valid proposal with all three independent attestations (`coverage`, `non_overlap`, `simpler_units`) may finalize `trustworthy=true` and dispatch children.
- A failed proposal/attestation gets exactly one verifier-guided repair. Failure, disagreement, timeout, and depth exhaustion remain untrusted and emit an explicit finalized compromise.
- `execution.decomposition.bounce_classified` must persist before the decomposition provider call; `decision_finalized` must persist before cache publication or child dispatch.
- Historical `PREFLIGHT` records remain parseable for replay, but cannot mint a new live preflight effect.

## Deterministic vs semantic boundary

Deterministic guarantees cover trigger authority, exact schemas, bounds, retry count, persistence order, replay identity, and child-dispatch gating. Semantic MECE is independently attested from the actual parent and bounded attempt trace; it does not claim generated child wording must equal text predicted in the Seed.

## Dead-path cleanup

`src/ouroboros/execution/atomicity.py`, `src/ouroboros/execution/decomposition.py`, and `run_cycle_with_decomposition` are already absent from the current base. The new architecture test pins their absence and resolves absolute imports, `from package import module`, relative imports, submodules, and wildcard imports so the dead path cannot silently return.

## Verification

- `UV_OFFLINE=1 uv run pytest -q` — **14193 passed, 12 skipped**
- focused decomposition/config/authority/routing tests — **356 passed**
- runner plus focused regression set — **612 passed, 1 skipped**
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy src` — passed (476 source files)
- MyPy for the changed decomposition policy/architecture/bounce tests — passed
- `git diff --check` — passed

Closes #1466
