### PR TITLE
feat(bigbang): extract ONTOLOGY_FIELDS as JSON object arrays (#1729 slice 3)

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -50,7 +50,7 @@ Example: "AC: Tasks can be created | verify: python -m pytest tests/test_tasks.p
 The data structure/domain model for this work:
 - **ONTOLOGY_NAME**: A name for the domain model
 - **ONTOLOGY_DESCRIPTION**: What the ontology represents
-- **ONTOLOGY_FIELDS**: Key fields in format: name:type:description (pipe-separated)
+- **ONTOLOGY_FIELDS**: Key fields as a single-line JSON array of objects with "name", "type" (string, number, boolean, array, object), and "description"
 
 Field types should be one of: string, number, boolean, array, object
 
@@ -81,7 +81,7 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
-ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
+ONTOLOGY_FIELDS: [{"name": "<name>", "type": "<string|number|boolean|array|object>", "description": "<description>"}, ...]
 EVALUATION_PRINCIPLES: [{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}, ...]
 EXIT_CONDITIONS: [{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}, ...]
 PROJECT_TYPE: greenfield|brownfield

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -420,6 +420,87 @@ def _parse_exit_conditions(raw_value: object, *, strict: bool = False) -> tuple[
     return tuple(conditions)
 
 
+def _parse_ontology_fields(raw_value: object, *, strict: bool = False) -> tuple[OntologyField, ...]:
+    """Parse ONTOLOGY_FIELDS from JSON object arrays or the legacy pipe list.
+
+    Mirrors the evaluation-principle and exit-condition parsers (#1729): the
+    extraction format requests a single-line JSON array of ``{"name", "type",
+    "description"}`` objects (the model field spelling ``field_type`` is
+    accepted too, and an optional boolean ``required`` is honored) so colons
+    and pipes inside the data survive. Strict mode raises on anything else so
+    the retry path reformats; lenient mode keeps the historical
+    ``name:type:description`` split where the description absorbs any further
+    colons, skips malformed entries, and never raises.
+    """
+    field_label = "ONTOLOGY_FIELDS"
+
+    def _build(entry: object) -> OntologyField | None:
+        if isinstance(entry, OntologyField):
+            return entry
+        if not isinstance(entry, dict):
+            if strict:
+                raise ValueError(
+                    f"{field_label} entries must be JSON objects; got "
+                    f"{type(entry).__name__}: {entry!r}"
+                )
+            return None
+        try:
+            required = entry.get("required", True)
+            if not isinstance(required, bool):
+                raise ValueError(
+                    f"{field_label} entry field 'required' must be a boolean; got {required!r}."
+                )
+            return OntologyField(
+                name=_require_object_string(entry, "name", field_label=field_label),
+                field_type=_require_object_string(
+                    entry, "type", field_label=field_label, aliases=("field_type",)
+                ),
+                description=_require_object_string(entry, "description", field_label=field_label),
+                required=required,
+            )
+        except (ValueError, TypeError, PydanticValidationError):
+            if strict:
+                raise
+            return None
+
+    def _build_all(entries: list | tuple) -> tuple[OntologyField, ...]:
+        return tuple(built for built in (_build(entry) for entry in entries) if built)
+
+    if isinstance(raw_value, list | tuple):
+        return _build_all(raw_value)
+    if not isinstance(raw_value, str):
+        return ()
+    text = raw_value.strip()
+    if not text:
+        if strict:
+            raise ValueError(
+                f"{field_label} must be a single-line JSON array of objects; "
+                "use [] for an intentionally empty list."
+            )
+        return ()
+    decoded = _decode_object_array(text, field_label=field_label, strict=strict)
+    if decoded is not None:
+        return _build_all(decoded)
+
+    fields: list[OntologyField] = []
+    for field_str in text.split("|"):
+        field_str = field_str.strip()
+        if not field_str:
+            continue
+        parts = field_str.split(":")
+        if len(parts) < 3:
+            continue
+        name = parts[0].strip()
+        field_type = parts[1].strip()
+        description = ":".join(parts[2:]).strip()
+        if not name or not field_type or not description:
+            # Stored legacy data has no retry path; skip malformed entries
+            # instead of raising at model construction.
+            continue
+        fields.append(OntologyField(name=name, field_type=field_type, description=description))
+    return tuple(fields)
+
+
 def _parse_acceptance_criteria_contracts(
     raw_value: object,
 ) -> tuple[AcceptanceCriterionSpec | str, ...]:
@@ -946,7 +1027,7 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
-ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
+ONTOLOGY_FIELDS: [{{"name": "<name>", "type": "<string|number|boolean|array|object>", "description": "<description>"}}, ...]
 EVALUATION_PRINCIPLES: [{{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}}, ...]
 EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}}, ...]
 {self._project_type_template(is_brownfield=is_brownfield)}"""
@@ -1053,7 +1134,7 @@ AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> 
 AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
-ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
+ONTOLOGY_FIELDS: [{{"name": "<name>", "type": "<string|number|boolean|array|object>", "description": "<description>"}}, ...]
 EVALUATION_PRINCIPLES: [{{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}}, ...]
 EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}}, ...]
 {self._project_type_template(is_brownfield=is_brownfield)}"""
@@ -1181,6 +1262,10 @@ EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria"
             requirements["exit_conditions"] = _parse_exit_conditions(
                 requirements["exit_conditions"], strict=True
             )
+        if "ontology_fields" in requirements:
+            requirements["ontology_fields"] = _parse_ontology_fields(
+                requirements["ontology_fields"], strict=True
+            )
 
         return requirements
 
@@ -1206,22 +1291,9 @@ EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria"
                 requirements["acceptance_criteria"]
             )
 
-        # Parse ontology fields
-        ontology_fields: list[OntologyField] = []
-        if "ontology_fields" in requirements and requirements["ontology_fields"]:
-            for field_str in requirements["ontology_fields"].split("|"):
-                field_str = field_str.strip()
-                if not field_str:
-                    continue
-                parts = field_str.split(":")
-                if len(parts) >= 3:
-                    ontology_fields.append(
-                        OntologyField(
-                            name=parts[0].strip(),
-                            field_type=parts[1].strip(),
-                            description=":".join(parts[2:]).strip(),
-                        )
-                    )
+        # Parse ontology fields (JSON object arrays preferred; legacy
+        # colon/pipe lists supported for stored requirements)
+        ontology_fields = _parse_ontology_fields(requirements.get("ontology_fields"))
 
         # Build ontology schema
         ontology_schema = OntologySchema(

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -23,6 +23,7 @@ from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
     _parse_evaluation_principles,
     _parse_exit_conditions,
+    _parse_ontology_fields,
     _parse_string_array_values,
     load_seed,
     save_seed_sync,
@@ -62,7 +63,10 @@ def create_valid_extraction_response(
     acceptance_criteria: str = "Tasks can be created | Tasks can be listed | Tasks can be deleted",
     ontology_name: str = "TaskManager",
     ontology_description: str = "Task management domain model",
-    ontology_fields: str = "tasks:array:List of task objects | projects:array:List of project objects",
+    ontology_fields: str = (
+        '[{"name": "tasks", "type": "array", "description": "List of task objects"},'
+        ' {"name": "projects", "type": "array", "description": "List of project objects"}]'
+    ),
     evaluation_principles: str = (
         '[{"name": "completeness", "description": "All requirements implemented",'
         ' "weight": 0.4},'
@@ -811,7 +815,10 @@ class TestSeedGeneratorExtraction:
         extraction_response = create_valid_extraction_response(
             ontology_name="TaskManager",
             ontology_description="Domain model for task management",
-            ontology_fields="tasks:array:List of tasks | status:string:Task status",
+            ontology_fields=(
+                '[{"name": "tasks", "type": "array", "description": "List of tasks"},'
+                ' {"name": "status", "type": "string", "description": "Task status"}]'
+            ),
         )
         mock_adapter.complete = AsyncMock(
             return_value=Result.ok(create_mock_completion_response(extraction_response))
@@ -1561,6 +1568,93 @@ class TestObjectArrayExtractionContract:
             '[{"name": "x", "description": "d", "weight": -1e999}]', strict=True
         )
         assert json_neg_strict[0].weight == 0.0
+
+    def test_ontology_strict_parses_json_object_arrays(self) -> None:
+        fields = _parse_ontology_fields(
+            '[{"name": "ratio", "type": "string",'
+            ' "description": "A 1:1 request:response mapping | primary"}]',
+            strict=True,
+        )
+        assert fields == (
+            OntologyField(
+                name="ratio",
+                field_type="string",
+                description="A 1:1 request:response mapping | primary",
+            ),
+        )
+        aliased = _parse_ontology_fields(
+            '[{"name": "n", "field_type": "number", "description": "d", "required": false}]',
+            strict=True,
+        )
+        assert aliased[0].field_type == "number"
+        assert aliased[0].required is False
+
+    def test_ontology_strict_rejects_legacy_and_malformed(self) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_ontology_fields("tasks:array:List of tasks", strict=True)
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_ontology_fields("", strict=True)
+        assert _parse_ontology_fields("[]", strict=True) == ()
+        malformed = (
+            '["not an object"]',
+            '[{"type": "string", "description": "missing name"}]',
+            '[{"name": "x", "description": "no type"}]',
+            '[{"name": "x", "type": " ", "description": "blank type"}]',
+            '[{"name": "x", "type": "string", "description": "d", "required": "yes"}]',
+        )
+        for case in malformed:
+            with pytest.raises(ValueError, match="ONTOLOGY_FIELDS"):
+                _parse_ontology_fields(case, strict=True)
+
+    def test_ontology_lenient_keeps_legacy_split_and_never_raises(self) -> None:
+        legacy = _parse_ontology_fields(
+            "tasks:array:List of tasks | status:string:Status: open or closed | :string:d | x::d"
+        )
+        assert legacy == (
+            OntologyField(name="tasks", field_type="array", description="List of tasks"),
+            OntologyField(name="status", field_type="string", description="Status: open or closed"),
+        )
+        stored_json = _parse_ontology_fields(
+            '[{"name": "a", "type": "string", "description": "d | note"},'
+            ' {"name": "bad", "required": "yes"}, 42]'
+        )
+        assert len(stored_json) == 1
+        assert stored_json[0].description == "d | note"
+        assert _parse_ontology_fields('[{"name": "x",]') == ()
+        assert _parse_ontology_fields(None) == ()
+        model = OntologyField(name="m", field_type="string", description="d")
+        assert _parse_ontology_fields((model,)) == (model,)
+
+    @pytest.mark.asyncio
+    async def test_ontology_json_fields_reach_seed_and_legacy_retries(self) -> None:
+        malformed = create_valid_extraction_response(ontology_fields="tasks:array:List of tasks")
+        reformatted = create_valid_extraction_response(
+            ontology_fields=(
+                '[{"name": "tasks", "type": "array",'
+                ' "description": "Tasks with a 1:1 owner mapping | primary"}]'
+            )
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(malformed)),
+                Result.ok(create_mock_completion_response(reformatted)),
+            ]
+        )
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        assert mock_adapter.complete.await_count == 2
+        fields = result.value.ontology_schema.fields
+        assert fields[0].description == "Tasks with a 1:1 owner mapping | primary"
 
     def test_lenient_null_weight_defaults_without_raising(self) -> None:
         principles = _parse_evaluation_principles(


### PR DESCRIPTION
## Summary

Slice 3 of #1729: ONTOLOGY_FIELDS moves to a single-line JSON object array at extraction time, extending the exact contract merged for CONSTRAINTS (#1714), the brownfield lists (#1730), and evaluation principles / exit conditions (#1762).

Today a field description like `Ratio of open:closed tasks` breaks the colon split, and a pipe anywhere silently truncates the entry. With this change:

| Lane | Behavior |
|---|---|
| Extraction (strict) | Must be a valid JSON array of `{"name", "type", "description"}` objects; anything else — legacy pipe lines, blank values, non-objects, missing or blank fields — raises so the existing reformat-retry path asks the LLM to resend. `[]` is the explicit empty spelling. |
| Stored requirements (lenient) | Bracket-led valid JSON arrays parse to models; everything else keeps the historical `name:type:description` split with the description absorbing further colons; malformed or blank-segment entries are skipped instead of raising (the legacy loop previously raised a model ValidationError on e.g. `x::d`); pre-parsed model tuples pass through; never raises. |

Details:
- The model field spelling `field_type` is accepted alongside the prompt's `type`, and an optional boolean `required` is honored (a non-boolean value poisons the strict claim rather than being ignored).
- Reuses the shared decode/validation helpers hardened in #1762's review rounds (bounded integer decoding, non-finite token markers, blank-field strict rejection), so those edge classes are covered here from the start.
- The extraction prompt, the reformat template, and the seed-architect agent template request the new format.

## Sequencing vs #1729

Same shape as the previous slices: adapter-local to `bigbang/` parsing plus its prompt templates, no shared schema or consumer changes. Slice 4 (CONTEXT_REFERENCES) stays separate and will follow once this lands. Happy to hold if you'd rather sequence differently.

## Test plan

- [x] 4 new regression tests: strict parsing with delimiters inside data plus the `field_type`/`required` handling, strict rejection of legacy/blank/malformed values, lenient legacy-split preservation and never-raise fallbacks (including blank segments the old loop raised on), and the end-to-end extraction retry
- [x] `uv run pytest tests/unit/bigbang -q` — 704 passed
- [x] `uv run pytest tests/ -q -n 4` — 14198 passed, 12 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ouroboros` — clean

Refs #1729 (slice 3 of 4; #1730 was slice 1, #1762 slice 2)
