### PR TITLE
fix(orchestrator): reject non-finite pause_seconds instead of raising

### DIFF
--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -26,6 +26,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+import math
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -473,17 +474,28 @@ class SessionRepository:
 
     @staticmethod
     def _coerce_positive_seconds(value: object) -> int | None:
-        """Normalize persisted positive-second values from pause metadata."""
+        """Normalize persisted positive-second values from pause metadata.
+
+        Non-finite values are rejected rather than converted, matching
+        ``recoverable_failure._duration_value_to_seconds`` — the sibling parser for
+        this same ``pause_seconds`` key — so persisted ``inf``/``nan`` degrades to
+        "no usable resume metadata" instead of raising out of orphan cleanup.
+        """
         if isinstance(value, bool):
             return None
         if isinstance(value, int | float):
+            if not math.isfinite(value):
+                return None
             seconds = int(value)
             return seconds if seconds > 0 else None
         if isinstance(value, str) and value.strip():
             try:
-                seconds = int(float(value.strip()))
+                parsed = float(value.strip())
             except ValueError:
                 return None
+            if not math.isfinite(parsed):
+                return None
+            seconds = int(parsed)
             return seconds if seconds > 0 else None
         return None
 

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -1397,6 +1397,42 @@ class TestFindOrphanedSessions:
         assert result[0].status == SessionStatus.PAUSED
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("pause_seconds", [float("inf"), float("nan"), "inf", "nan"])
+    async def test_non_finite_pause_seconds_does_not_break_orphan_cleanup(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+        pause_seconds: float | str,
+    ) -> None:
+        """Non-finite pause metadata degrades to "no resume window", never raises."""
+        now = datetime.now(UTC)
+        paused_at = now - timedelta(hours=5)
+        start_event = self._make_start_event(
+            "sess_non_finite_pause",
+            timestamp=paused_at - timedelta(minutes=10),
+        )
+        paused_event = self._make_terminal_event(
+            "sess_non_finite_pause",
+            "orchestrator.session.paused",
+            timestamp=paused_at,
+        )
+        # No resume_after: resolution must fall through to paused_at + pause_seconds.
+        paused_event.data = {
+            "reason": "Usage limit reached",
+            "pause_kind": "usage_limit",
+            "pause_seconds": pause_seconds,
+            "paused_at": paused_at.isoformat(),
+        }
+
+        mock_event_store.get_all_sessions.return_value = [start_event]
+        mock_event_store.replay.return_value = [start_event, paused_event]
+
+        result = await repository.find_orphaned_sessions()
+
+        assert len(result) == 1
+        assert result[0].status == SessionStatus.PAUSED
+
+    @pytest.mark.asyncio
     async def test_snapshot_usage_limit_paused_session_before_resume_after_not_orphaned(
         self,
         repository: SessionRepository,


### PR DESCRIPTION
## Summary

`SessionRepository._coerce_positive_seconds` converted numeric pause metadata with a bare `int(value)`, so a persisted `inf` raised `OverflowError` and `nan` raised `ValueError`. The string branch's `except ValueError` caught `"nan"` but not `"inf"`, leaving the inconsistency visible inside a single function:

| `pause_seconds` | before | after |
|---|---|---|
| `float("inf")` | `OverflowError` | `None` |
| `float("nan")` | `ValueError` | `None` |
| `"inf"` | `OverflowError` | `None` |
| `"nan"` | `None` | `None` |

The caller chain is `_usage_limit_pause_resume_after` → `_usage_limit_pause_cleanup_deferred`, which decides whether a `PAUSED` session is protected from orphan cleanup, so the exception escaped cleanup rather than resolving to "no usable resume metadata".

`recoverable_failure._duration_value_to_seconds` — the sibling parser for this same `pause_seconds` key — is already documented as parsing *"without non-finite arithmetic"* and guards every branch with `math.isfinite`. This aligns the two.

**Conversion order is deliberately unchanged** (`int()` first, then the positivity test), so fractional inputs like `"0.5"` still resolve to `None` rather than `0`.

Severity is low: I did not find a live producer that persists a non-finite `pause_seconds`, so the practical trigger would be hand-edited or legacy state, or a lenient JSON decode (`json.loads` accepts the bare `Infinity`/`NaN` tokens). The argument here is contract consistency with the sibling parser, not a reported outage — see #1774 for the full write-up.

## Test plan

- [x] `uv run pytest tests/ -q` passes — `13840 passed, 6 skipped` on this branch
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/` clean — `Success: no issues found in 476 source files`
- [x] `python3 scripts/check-auto-boundary.py` — `OK (39 files scanned, 0 findings)`
- [x] The new test is parametrized over all four non-finite encodings and drives the public `find_orphaned_sessions` path. On the parent commit **three of the four fail** (`inf`, `nan`, `"inf"`); `"nan"` already passed, which is exactly the inconsistency this fixes.

## Related issues

Fixes #1774