### PR TITLE
fix(setup): parse pyproject.toml instead of substring-matching it

### DIFF
--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -426,7 +426,18 @@ def _codex_mcp_entry_from_toml(data: dict[str, object]) -> dict[str, object] | N
 
 
 def _is_source_tree_ouroboros_build() -> bool:
-    """Return whether this module is executing from an Ouroboros source tree."""
+    """Return whether this module is executing from an Ouroboros source tree.
+
+    The project name is read from the parsed document rather than matched as a
+    formatted substring. TOML does not guarantee the spelling ``name = "..."``,
+    so ``name="ouroboros-ai"``, single quotes, or extra whitespace all declare
+    the same project while failing a literal search; conversely the literal can
+    appear in a comment, a ``[tool.*]`` table, or a dependency pin without being
+    the project name. Both directions change which Codex MCP command block
+    setup writes (see ``_render_codex_mcp_section``).
+    """
+    import tomllib
+
     current_file = Path(__file__).resolve()
     for parent in current_file.parents:
         pyproject = parent / "pyproject.toml"
@@ -436,10 +447,15 @@ def _is_source_tree_ouroboros_build() -> bool:
         if not current_file.is_relative_to(source_package):
             continue
         try:
-            pyproject_text = pyproject.read_text(encoding="utf-8")
-        except OSError:
+            parsed = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+            # Unreadable or malformed metadata keeps walking the parents, as
+            # before, instead of aborting setup.
             continue
-        if 'name = "ouroboros-ai"' in pyproject_text and source_package.is_dir():
+        project = parsed.get("project")
+        if not isinstance(project, dict):
+            continue
+        if project.get("name") == "ouroboros-ai" and source_package.is_dir():
             return True
     return False
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4401,3 +4401,97 @@ class TestNonInteractiveAutoSelect:
             available={"codex": "/usr/bin/codex", "hermes": "/usr/bin/hermes"},
         )
         assert selected == "codex"
+
+
+class TestSourceTreeDetection:
+    """Tests for `_is_source_tree_ouroboros_build`.
+
+    Every other case in this file mocks this function out, so its real
+    behaviour had no direct coverage. It gates which Codex MCP command block
+    setup writes, so a misread of `pyproject.toml` silently downgrades a dev
+    install back to the published release.
+    """
+
+    @staticmethod
+    def _build_tree(root: Path, pyproject_body: str) -> Path:
+        """Lay out a fake source tree and return the fake `setup.py` path."""
+        (root / "pyproject.toml").write_text(pyproject_body, encoding="utf-8")
+        module_dir = root / "src" / "ouroboros" / "cli" / "commands"
+        module_dir.mkdir(parents=True)
+        module_path = module_dir / "setup.py"
+        module_path.write_text("", encoding="utf-8")
+        return module_path
+
+    def _detect(self, monkeypatch: pytest.MonkeyPatch, root: Path, body: str) -> bool:
+        module_path = self._build_tree(root, body)
+        monkeypatch.setattr(setup_cmd, "__file__", str(module_path))
+        return setup_cmd._is_source_tree_ouroboros_build()
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param('[project]\nname = "ouroboros-ai"\n', id="canonical"),
+            pytest.param('[project]\nname="ouroboros-ai"\n', id="no-spaces"),
+            pytest.param("[project]\nname = 'ouroboros-ai'\n", id="single-quotes"),
+            pytest.param('[project]\nname  =   "ouroboros-ai"\n', id="extra-whitespace"),
+            pytest.param('[project]\nname = """ouroboros-ai"""\n', id="multi-line-string"),
+        ],
+    )
+    def test_valid_spellings_of_the_name_are_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str
+    ) -> None:
+        """TOML does not guarantee one spelling; all of these declare the same name."""
+        assert self._detect(monkeypatch, tmp_path, body) is True
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(
+                '[project]\nname = "something-else"\n# name = "ouroboros-ai"\n',
+                id="only-in-comment",
+            ),
+            pytest.param(
+                '[project]\nname = "something-else"\n\n[tool.whatever]\nname = "ouroboros-ai"\n',
+                id="only-in-tool-table",
+            ),
+            pytest.param(
+                '[project]\nname = "downstream"\ndependencies = ["ouroboros-ai==0.1"]\n',
+                id="only-in-dependency-pin",
+            ),
+        ],
+    )
+    def test_the_literal_outside_project_name_is_not_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str
+    ) -> None:
+        """A consumer project that merely depends on Ouroboros is not a source tree."""
+        assert self._detect(monkeypatch, tmp_path, body) is False
+
+    def test_malformed_toml_continues_the_walk_instead_of_raising(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Preserves the pre-existing control flow for unreadable metadata."""
+        assert self._detect(monkeypatch, tmp_path, "[project\nname = broken") is False
+
+    def test_missing_project_table_is_not_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        assert (
+            self._detect(monkeypatch, tmp_path, '[tool.poetry]\nname = "ouroboros-ai"\n') is False
+        )
+
+    def test_module_outside_the_source_package_is_not_detected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An installed wheel sitting next to a pyproject.toml is not a source tree."""
+        self._build_tree(tmp_path, '[project]\nname = "ouroboros-ai"\n')
+        elsewhere = tmp_path / "site-packages" / "ouroboros" / "cli" / "commands"
+        elsewhere.mkdir(parents=True)
+        installed = elsewhere / "setup.py"
+        installed.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(setup_cmd, "__file__", str(installed))
+        assert setup_cmd._is_source_tree_ouroboros_build() is False
+
+    def test_real_repository_checkout_is_detected(self) -> None:
+        """Guards the fixtures: the actual checkout running these tests must pass."""
+        assert setup_cmd._is_source_tree_ouroboros_build() is True


### PR DESCRIPTION
## Summary

`_is_source_tree_ouroboros_build()` decided whether Ouroboros runs from a source tree by searching `pyproject.toml` for the literal `name = "ouroboros-ai"`. It now reads `project.name` from the parsed document.

Closes #1779.

## Evidence

Replaying the old predicate over the eight fixtures added in this PR, six came out wrong:

| Fixture | Expected | Old predicate |
|---|---|---|
| `name = "ouroboros-ai"` | detected | detected |
| `name="ouroboros-ai"` | detected | **missed** |
| `name = 'ouroboros-ai'` | detected | **missed** |
| `name  =   "ouroboros-ai"` | detected | **missed** |
| `name = """ouroboros-ai"""` | detected | **missed** |
| literal only in a `#` comment | not detected | **false positive** |
| literal only in a `[tool.*]` table | not detected | **false positive** |
| dependency pin `ouroboros-ai==0.1` | not detected | not detected |

The last row never matched the literal either; it is kept as a regression guard for the parsed version, not as a claim about the old bug.

## Why it matters

The verdict gates three call sites and, through `_is_dev_ouroboros_build()`, decides which Codex MCP command block setup writes. Quoting the existing comment on `_render_codex_mcp_section`, getting it wrong "silently downgrades the MCP server back to the latest PyPI release and hides main-branch fixes under test".

## Implementation notes

- `tomllib` was already imported and used in this same file (line 721, with `TOMLDecodeError` handling), so this follows the existing local-import style rather than adding a dependency or a new pattern.
- Control flow is unchanged: malformed, unreadable, or non-UTF-8 metadata continues the parent walk instead of raising. `UnicodeDecodeError` is now caught explicitly — it is a `ValueError`, not an `OSError`, so the previous `except OSError` would have let it escape.
- The `project` table is type-checked before `.get("name")`, so a `project = "string"` document cannot raise.

## Test plan

- [x] `TestSourceTreeDetection` added — 12 cases. Every other case in `test_setup.py` mocks this function out, so its real behaviour had no direct coverage until now.
- [x] Includes an installed-wheel layout (module outside `src/ouroboros` next to a valid `pyproject.toml`) → not detected.
- [x] Includes `test_real_repository_checkout_is_detected`, which asserts the actual checkout running the suite is detected. Without it the fixtures could drift into passing vacuously.
- [x] `uv run pytest tests/unit/cli/test_setup.py -q` → 177 passed
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy src/ouroboros/cli/commands/setup.py` → Success

## R-run comparison

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (PR does not touch `src/ouroboros/auto/`)

## Context

Found during a 2026-07-28 sweep for code that reimplements a format owned by another tool. `main` otherwise delegates consistently — YAML to PyYAML, TOML reads to `tomllib`, shell to `shlex`, git to the `git` CLI — which made this substring probe an outlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)