### PR TITLE
refactor(evidence): back both command normalizers with one implementation

### DIFF
--- a/src/ouroboros/orchestrator/evidence/common.py
+++ b/src/ouroboros/orchestrator/evidence/common.py
@@ -234,13 +234,30 @@ def _normalized_evidence_text(text: str) -> str:
 
 
 def _normalize_command(command: str) -> str:
-    """Normalize Bash commands for stable audit output."""
+    """Collapse a Bash command's whitespace for stable audit output.
+
+    Case is preserved. That is worth stating because the neighbouring
+    :func:`_normalized_evidence_text` does fold case, so the two are easy to
+    confuse when skimming this module.
+    """
     return " ".join(command.split())
 
 
 def _normalize_exact_command(command: str) -> str:
-    """Normalize command whitespace while preserving case-sensitive exactness."""
-    return " ".join(command.split())
+    """Alias of :func:`_normalize_command` for command-proof call sites.
+
+    Introduced by ``69bc1ad7a`` ("Preserve exact command case and tool-result
+    boundaries") so that evidence sites asserting a command actually ran read
+    as explicitly case-sensitive: *"Exact command proof must be case-sensitive
+    and tied to the Bash command's own runtime output chunk."*
+
+    The two names stay because that call-site vocabulary is deliberate, but
+    they delegate to one implementation. Previously each carried its own copy
+    of the body under a contract that they must never diverge, with nothing
+    enforcing it — and a whitespace fix applied to only one would have made the
+    proof path and the audit path disagree about what "the same command" means.
+    """
+    return _normalize_command(command)
 
 
 def _truncate_text(text: str, limit: int = _MAX_LEAF_RESULT_CHARS) -> str:

--- a/tests/unit/orchestrator/evidence/test_common_normalizers.py
+++ b/tests/unit/orchestrator/evidence/test_common_normalizers.py
@@ -1,0 +1,66 @@
+"""Regression tests for the evidence whitespace normalizers.
+
+`_normalize_command` and `_normalize_exact_command` are two names for one
+behaviour. The second exists so that command-proof call sites read as
+explicitly case-sensitive (see `69bc1ad7a`). They used to carry separate copies
+of the body under an unenforced contract that they must never diverge; a
+whitespace fix applied to only one would have made the proof path and the audit
+path disagree about what "the same command" means.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.evidence.common import (
+    _normalize_command,
+    _normalize_exact_command,
+    _normalized_evidence_text,
+)
+
+COMMANDS = [
+    pytest.param("uv run pytest", id="already-normal"),
+    pytest.param("uv   run    pytest", id="runs-of-spaces"),
+    pytest.param("uv\trun\tpytest", id="tabs"),
+    pytest.param("uv run \\\n  pytest -q", id="line-continuation"),
+    pytest.param("  uv run pytest  ", id="surrounding-whitespace"),
+    pytest.param("UV Run PyTest", id="mixed-case"),
+    pytest.param("./Scripts/Check-Auto-Boundary.py", id="mixed-case-path"),
+    pytest.param("", id="empty"),
+    pytest.param("   ", id="whitespace-only"),
+    pytest.param("echo '  spaced  literal  '", id="quoted-inner-spaces"),
+    pytest.param("printf '한글 인자'", id="non-ascii"),
+]
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+def test_both_names_agree(command: str) -> None:
+    """The alias must never drift from the implementation it documents."""
+    assert _normalize_exact_command(command) == _normalize_command(command)
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+def test_case_is_preserved(command: str) -> None:
+    """Command proof is case-sensitive; neither normalizer may fold case."""
+    assert _normalize_command(command) == " ".join(command.split())
+    assert _normalize_exact_command(command) == " ".join(command.split())
+
+
+def test_mixed_case_survives_normalization() -> None:
+    """The property the `exact` name advertises, pinned explicitly."""
+    assert _normalize_exact_command("UV Run PyTest") == "UV Run PyTest"
+
+
+def test_evidence_text_normalizer_still_folds_case() -> None:
+    """Guard the contrast: the text normalizer is the one that lowercases.
+
+    If this ever stops being true, the docstring on `_normalize_command`
+    explaining why case-preservation is worth mentioning becomes stale.
+    """
+    assert _normalized_evidence_text("UV Run PyTest") == "uv run pytest"
+
+
+def test_normalization_is_idempotent() -> None:
+    for command in ("uv   run\tpytest", "  Mixed   Case  "):
+        once = _normalize_command(command)
+        assert _normalize_command(once) == once


### PR DESCRIPTION
## Summary

`_normalize_command` and `_normalize_exact_command` in `evidence/common.py` had character-for-character identical bodies. Both names stay; they now share one implementation.

Closes #1781.

## The duplication was intentional — that shaped the fix

Blame points at `69bc1ad7a` "Preserve exact command case and tool-result boundaries", which added `_normalize_exact_command` and swapped every proof call site to it. From that commit:

> Responds to the latest bot review by making exact-command helpers **visibly case-preserving** …
> Constraint: Exact command proof must be case-sensitive and tied to the Bash command's own runtime output chunk.

`_normalize_command` never lowercased. The second name is a deliberate readability device added in response to a review, so deleting it would reverse a considered decision. This PR keeps both names and every call site's vocabulary.

## What was actually broken

Two independent bodies held a contract that they must never diverge, with nothing enforcing it.

- `_normalize_command` — 1 call site (`evidence/formatting.py`, audit output)
- `_normalize_exact_command` — 6 call sites (`evidence/typed_evidence.py`, `evidence/shell_parsing.py`); both re-exported through `parallel_executor.py`

A whitespace fix applied to only one — say, to cope with a quoted argument containing a run of spaces — would leave the proof path and the audit path disagreeing about what "the same command" means, inside the module whose job is deciding whether a claimed command really ran.

The docstrings made it worse. `_normalize_exact_command` advertised "preserving case-sensitive exactness" as a distinguishing property while `_normalize_command` said nothing about case, so a reader comparing them reasonably inferred the plain one folds case — especially since `_normalized_evidence_text`, three lines above in the same file, genuinely does call `.lower()`.

## Changes

- `_normalize_exact_command` delegates to `_normalize_command`. Drift is now impossible by construction.
- Both docstrings state what is true: the plain one preserves case, and the alias records *why* the second name exists, quoting the constraint from `69bc1ad7a`.
- New `tests/unit/orchestrator/evidence/test_common_normalizers.py`.

## No behaviour change

Both functions return `" ".join(command.split())` for every input, before and after. Verified directly against the pre-change expression across mixed case, tabs, runs of spaces, quoted inner spaces, non-ASCII, empty, and whitespace-only inputs — 0 differences.

## Test plan

- [x] 25 new cases pin the two functions against each other and against `" ".join(split())`
- [x] `test_evidence_text_normalizer_still_folds_case` guards the contrast the new docstring depends on, so it cannot go stale unnoticed
- [x] `uv run pytest tests/unit/orchestrator/ -k "evidence or typed or shell_pars"` → 277 passed
- [x] `uv run pytest tests/unit/orchestrator/evidence/` → 25 passed
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy src/ouroboros/orchestrator/evidence/common.py` → Success

## R-run comparison

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (PR does not touch `src/ouroboros/auto/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)