### PR TITLE
fix(providers): share response_format handling so the schema guard reaches every adapter

### DIFF
--- a/src/ouroboros/providers/gjc_llm_adapter.py
+++ b/src/ouroboros/providers/gjc_llm_adapter.py
@@ -11,9 +11,6 @@ import re
 from typing import Any
 from uuid import uuid4
 
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
-
 from ouroboros.config import get_gjc_cli_path
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.json_utils import extract_json_payload
@@ -36,6 +33,10 @@ from ouroboros.providers.gjc_rpc_protocol import (
     validate_response_ack,
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.response_format import (
+    build_response_format_directive,
+    validate_response_format_payload,
+)
 
 _SAFE_MODEL_PART_PATTERN = re.compile(r"^[A-Za-z0-9_.:@-]+$")
 
@@ -94,39 +95,7 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
         response_format: dict[str, object] | None,
     ) -> str | None:
         """Translate response_format into cooperative GJC prompt instructions."""
-        if not response_format:
-            return None
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return (
-                "Respond with ONLY a valid JSON object. Do not use markdown fences, "
-                "headers, or explanatory text."
-            )
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return None
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            top_type = (
-                schema_payload.get("type", "object")
-                if isinstance(schema_payload, dict)
-                else "object"
-            )
-            type_noun = {"array": "JSON array", "object": "JSON object"}.get(
-                str(top_type), "JSON value"
-            )
-            try:
-                rendered = json.dumps(schema_payload, indent=2, sort_keys=True)
-            except (TypeError, ValueError):
-                rendered = str(schema_payload)
-            return (
-                f"Respond with ONLY a valid {type_noun} that matches this schema. "
-                "Do not use markdown fences, headers, or explanatory text.\n\n"
-                f"JSON schema:\n{rendered}"
-            )
-        return None
+        return build_response_format_directive(response_format)
 
     def _validate_response_format_payload(
         self,
@@ -134,26 +103,7 @@ class GjcLLMAdapter(CodexCliLLMAdapter):
         response_format: dict[str, object],
     ) -> str | None:
         """Validate extracted JSON against the requested response_format."""
-        try:
-            parsed = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            return f"invalid JSON: {exc}"
-
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return None if isinstance(parsed, dict) else "expected a JSON object"
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return "json_schema response_format is missing a schema object"
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            try:
-                Draft202012Validator(schema_payload).validate(parsed)
-            except JsonSchemaValidationError as exc:
-                return exc.message
-        return None
+        return validate_response_format_payload(payload, response_format)
 
     def _compose_prompt(self, messages: list[Message]) -> str:
         return "\n\n".join(f"{message.role.value}: {message.content}" for message in messages)

--- a/src/ouroboros/providers/goose_cli_adapter.py
+++ b/src/ouroboros/providers/goose_cli_adapter.py
@@ -15,8 +15,6 @@ import shutil
 from typing import Any
 from uuid import uuid4
 
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 import structlog
 
 from ouroboros.config import get_goose_cli_path
@@ -26,6 +24,9 @@ from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionConfig, CompletionResponse, Message, MessageRole
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.response_format import (
+    validate_response_format_payload,
+)
 
 log = structlog.get_logger()
 
@@ -173,29 +174,7 @@ class GooseCliLLMAdapter(CodexCliLLMAdapter):
         response_format: dict[str, object],
     ) -> str | None:
         """Validate extracted JSON against the requested response_format."""
-        try:
-            parsed = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            return f"invalid JSON: {exc}"
-
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            if not isinstance(parsed, dict):
-                return "expected a JSON object"
-            return None
-
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return "json_schema response_format is missing a schema object"
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            try:
-                Draft202012Validator(schema_payload).validate(parsed)
-            except JsonSchemaValidationError as exc:
-                return exc.message
-        return None
+        return validate_response_format_payload(payload, response_format)
 
     def _update_last_content(self, last_content: str, event_content: str) -> str:
         """Accumulate Goose stream chunks for completion fallback."""

--- a/src/ouroboros/providers/ourocode_llm_adapter.py
+++ b/src/ouroboros/providers/ourocode_llm_adapter.py
@@ -18,12 +18,9 @@ runtime.
 from __future__ import annotations
 
 from dataclasses import replace
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 import structlog
 
 from ouroboros.config._model_defaults import (
@@ -45,6 +42,10 @@ from ouroboros.providers.base import (
 )
 from ouroboros.providers.ourocode_acp_client import AcpClientError, OurocodeAcpClient
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.response_format import (
+    build_response_format_directive,
+    validate_response_format_payload,
+)
 
 if TYPE_CHECKING:
     from ouroboros.events.io_recorder import IOJournalRecorder
@@ -307,39 +308,7 @@ class OurocodeLLMAdapter:
         response_format: dict[str, object] | None,
     ) -> str | None:
         """Translate response_format into cooperative ourocode prompt instructions."""
-        if not response_format:
-            return None
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return (
-                "Respond with ONLY a valid JSON object. Do not use markdown fences, "
-                "headers, or explanatory text."
-            )
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return None
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            top_type = (
-                schema_payload.get("type", "object")
-                if isinstance(schema_payload, dict)
-                else "object"
-            )
-            type_noun = {"array": "JSON array", "object": "JSON object"}.get(
-                str(top_type), "JSON value"
-            )
-            try:
-                rendered = json.dumps(schema_payload, indent=2, sort_keys=True)
-            except (TypeError, ValueError):
-                rendered = str(schema_payload)
-            return (
-                f"Respond with ONLY a valid {type_noun} that matches this schema. "
-                "Do not use markdown fences, headers, or explanatory text.\n\n"
-                f"JSON schema:\n{rendered}"
-            )
-        return None
+        return build_response_format_directive(response_format)
 
     @staticmethod
     def _validate_response_format_payload(
@@ -347,26 +316,7 @@ class OurocodeLLMAdapter:
         response_format: dict[str, object],
     ) -> str | None:
         """Validate extracted JSON against the requested response_format."""
-        try:
-            parsed = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            return f"invalid JSON: {exc}"
-
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return None if isinstance(parsed, dict) else "expected a JSON object"
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return "json_schema response_format is missing a schema object"
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            try:
-                Draft202012Validator(schema_payload).validate(parsed)
-            except JsonSchemaValidationError as exc:
-                return exc.message
-        return None
+        return validate_response_format_payload(payload, response_format)
 
     @staticmethod
     def _finish_reason(stop_reason: str) -> str:

--- a/src/ouroboros/providers/pi_llm_adapter.py
+++ b/src/ouroboros/providers/pi_llm_adapter.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import replace
-import json
 from pathlib import Path
 from typing import Any
-
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
 
 from ouroboros.config import get_pi_cli_path
 from ouroboros.core.errors import ProviderError
@@ -17,6 +13,10 @@ from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionConfig, CompletionResponse, Message, MessageRole
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.response_format import (
+    build_response_format_directive,
+    validate_response_format_payload,
+)
 
 
 class PiLLMAdapter(CodexCliLLMAdapter):
@@ -116,40 +116,7 @@ class PiLLMAdapter(CodexCliLLMAdapter):
         flag, so structured output is cooperatively enforced through the
         prompt and validated after extraction.
         """
-        if not response_format:
-            return None
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return (
-                "Respond with ONLY a valid JSON object. Do not use markdown fences, "
-                "headers, or explanatory text."
-            )
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return None
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            top_type = (
-                schema_payload.get("type", "object")
-                if isinstance(schema_payload, dict)
-                else "object"
-            )
-            type_noun = {
-                "array": "JSON array",
-                "object": "JSON object",
-            }.get(str(top_type), "JSON value")
-            try:
-                rendered = json.dumps(schema_payload, indent=2, sort_keys=True)
-            except (TypeError, ValueError):
-                rendered = str(schema_payload)
-            return (
-                f"Respond with ONLY a valid {type_noun} that matches this schema. "
-                "Do not use markdown fences, headers, or explanatory text.\n\n"
-                f"JSON schema:\n{rendered}"
-            )
-        return None
+        return build_response_format_directive(response_format)
 
     def _validate_response_format_payload(
         self,
@@ -157,27 +124,7 @@ class PiLLMAdapter(CodexCliLLMAdapter):
         response_format: dict[str, object],
     ) -> str | None:
         """Validate extracted JSON against the requested response_format."""
-        try:
-            parsed = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            return f"invalid JSON: {exc}"
-
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return None if isinstance(parsed, dict) else "expected a JSON object"
-
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return "json_schema response_format is missing a schema object"
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            try:
-                Draft202012Validator(schema_payload).validate(parsed)
-            except JsonSchemaValidationError as exc:
-                return exc.message
-        return None
+        return validate_response_format_payload(payload, response_format)
 
     def _update_last_content(self, last_content: str, event_content: str) -> str:
         """Accumulate streaming deltas but replace them with terminal Pi content.

--- a/src/ouroboros/providers/response_format.py
+++ b/src/ouroboros/providers/response_format.py
@@ -1,0 +1,115 @@
+"""Shared OpenAI-style ``response_format`` handling for provider adapters.
+
+Backends without a native JSON-schema flag enforce structured output
+cooperatively: the request carries a prompt directive, and the response is
+validated after extraction. Five adapters implemented that pair independently,
+and the copies drifted -- per Q00/ouroboros#1785, a schema-validity guard was
+added to ``zcode_cli_adapter`` and never reached the other four, so a malformed
+``json_schema`` raised an uncaught ``UnknownType`` there instead of returning a
+message. Both halves now live here so a fix lands once.
+"""
+
+from __future__ import annotations
+
+import json
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError as JsonSchemaError
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+
+_TYPE_NOUNS = {
+    "array": "JSON array",
+    "object": "JSON object",
+}
+
+_JSON_OBJECT_DIRECTIVE = (
+    "Respond with ONLY a valid JSON object. Do not use markdown fences, "
+    "headers, or explanatory text."
+)
+
+
+def build_response_format_directive(response_format: dict[str, object] | None) -> str | None:
+    """Translate ``response_format`` into a prompt directive.
+
+    Returns ``None`` when there is nothing to instruct: no ``response_format``,
+    an unrecognized ``type``, or a ``json_schema`` entry that is not an object.
+
+    A ``json_schema`` payload may be either the schema itself or an OpenAI-style
+    wrapper holding it under a ``schema`` key; both spellings are accepted. A
+    schema that cannot be serialized falls back to ``str()`` rather than failing
+    the request, since the directive is advisory and the payload is validated
+    separately by :func:`validate_response_format_payload`.
+    """
+    if not response_format:
+        return None
+
+    fmt_type = response_format.get("type")
+    if fmt_type == "json_object":
+        return _JSON_OBJECT_DIRECTIVE
+
+    if fmt_type == "json_schema":
+        schema = response_format.get("json_schema")
+        if not isinstance(schema, dict):
+            return None
+        schema_payload = schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
+        top_type = (
+            schema_payload.get("type", "object") if isinstance(schema_payload, dict) else "object"
+        )
+        type_noun = _TYPE_NOUNS.get(str(top_type), "JSON value")
+        try:
+            rendered = json.dumps(schema_payload, indent=2, sort_keys=True)
+        except (TypeError, ValueError):
+            rendered = str(schema_payload)
+        return (
+            f"Respond with ONLY a valid {type_noun} that matches this schema. "
+            "Do not use markdown fences, headers, or explanatory text.\n\n"
+            f"JSON schema:\n{rendered}"
+        )
+
+    return None
+
+
+def validate_response_format_payload(
+    payload: str,
+    response_format: dict[str, object],
+) -> str | None:
+    """Validate extracted JSON against ``response_format``.
+
+    Returns ``None`` when the payload satisfies the requested format, otherwise
+    a human-readable reason. This function reports problems by returning them;
+    it does not raise for bad input.
+
+    ``check_schema`` runs before validation because a schema that is itself
+    invalid makes ``Draft202012Validator(...).validate(...)`` raise
+    ``UnknownType`` -- which is not a ``ValidationError`` and so escaped the
+    ``except`` clause in four of the five original copies (#1785).
+    """
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        return f"invalid JSON: {exc}"
+
+    fmt_type = response_format.get("type")
+    if fmt_type == "json_object":
+        return None if isinstance(parsed, dict) else "expected a JSON object"
+
+    if fmt_type == "json_schema":
+        schema = response_format.get("json_schema")
+        if not isinstance(schema, dict):
+            return "json_schema response_format is missing a schema object"
+        schema_payload = schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
+        try:
+            Draft202012Validator.check_schema(schema_payload)
+            Draft202012Validator(schema_payload).validate(parsed)
+        except JsonSchemaError as exc:
+            return f"invalid JSON schema: {exc.message}"
+        except JsonSchemaValidationError as exc:
+            return exc.message
+
+    return None
+
+
+__all__ = [
+    "build_response_format_directive",
+    "validate_response_format_payload",
+]

--- a/src/ouroboros/providers/response_format.py
+++ b/src/ouroboros/providers/response_format.py
@@ -79,10 +79,15 @@ def validate_response_format_payload(
     a human-readable reason. This function reports problems by returning them;
     it does not raise for bad input.
 
-    ``check_schema`` runs before validation because a schema that is itself
-    invalid makes ``Draft202012Validator(...).validate(...)`` raise
-    ``UnknownType`` -- which is not a ``ValidationError`` and so escaped the
-    ``except`` clause in four of the five original copies (#1785).
+    Two failure modes are easy to miss, both of which raise from inside
+    ``jsonschema`` without being a ``ValidationError``:
+
+    * a schema that is itself invalid (``{"type": "not-a-real-type"}``) makes
+      ``validate`` raise ``UnknownType``, which escaped the ``except`` clause
+      in four of the five original copies;
+    * a ``$ref`` pointing at nothing passes ``check_schema`` and then raises
+      ``_WrappedReferencingError`` during ``validate`` -- which every copy
+      missed, including the one that had the ``check_schema`` guard.
     """
     try:
         parsed = json.loads(payload)
@@ -105,6 +110,19 @@ def validate_response_format_payload(
             return f"invalid JSON schema: {exc.message}"
         except JsonSchemaValidationError as exc:
             return exc.message
+        except Exception as exc:  # noqa: BLE001 - the contract is to report, never raise
+            # `jsonschema` raises outside its own exception hierarchy. A `$ref`
+            # pointing at nothing is structurally valid, so `check_schema`
+            # passes and `validate` raises `_WrappedReferencingError`, whose
+            # MRO is `_RefResolutionError -> referencing.exceptions.Unresolvable
+            # -> Exception` -- neither a `SchemaError` nor a `ValidationError`.
+            #
+            # Catching that one class by name would mean importing
+            # `referencing`, an undeclared transitive dependency of
+            # `jsonschema`, and would leave the next such class uncovered. The
+            # caller-visible contract is that this function reports rather than
+            # raises, so it is enforced here rather than enumerated.
+            return f"could not validate against JSON schema: {type(exc).__name__}: {exc}"
 
     return None
 

--- a/src/ouroboros/providers/zcode_cli_adapter.py
+++ b/src/ouroboros/providers/zcode_cli_adapter.py
@@ -25,13 +25,6 @@ from dataclasses import replace
 import json
 from typing import Any
 
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import (
-    SchemaError as JsonSchemaError,
-)
-from jsonschema.exceptions import (
-    ValidationError as JsonSchemaValidationError,
-)
 import structlog
 
 from ouroboros.config import get_zcode_cli_path
@@ -48,6 +41,10 @@ from ouroboros.providers.base import (
 )
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.response_format import (
+    build_response_format_directive,
+    validate_response_format_payload,
+)
 from ouroboros.runtime.child_env import build_child_env
 from ouroboros.zcode_cli_launcher import (
     build_zcode_command_prefix,
@@ -277,39 +274,7 @@ class ZcodeCliLLMAdapter(CodexCliLLMAdapter):
         provider contract by asking for JSON in the prompt, extracting JSON from
         the response, and validating it before returning success.
         """
-        if not response_format:
-            return None
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return (
-                "Respond with ONLY a valid JSON object. Do not use markdown fences, "
-                "headers, or explanatory text."
-            )
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return None
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            top_type = (
-                schema_payload.get("type", "object")
-                if isinstance(schema_payload, dict)
-                else "object"
-            )
-            type_noun = {"array": "JSON array", "object": "JSON object"}.get(
-                str(top_type), "JSON value"
-            )
-            try:
-                rendered = json.dumps(schema_payload, indent=2, sort_keys=True)
-            except (TypeError, ValueError):
-                rendered = str(schema_payload)
-            return (
-                f"Respond with ONLY a valid {type_noun} that matches this schema. "
-                "Do not use markdown fences, headers, or explanatory text.\n\n"
-                f"JSON schema:\n{rendered}"
-            )
-        return None
+        return build_response_format_directive(response_format)
 
     def _validate_response_format_payload(
         self,
@@ -317,29 +282,7 @@ class ZcodeCliLLMAdapter(CodexCliLLMAdapter):
         response_format: dict[str, object],
     ) -> str | None:
         """Validate extracted JSON against the requested response_format."""
-        try:
-            parsed = json.loads(payload)
-        except json.JSONDecodeError as exc:
-            return f"invalid JSON: {exc}"
-
-        fmt_type = response_format.get("type")
-        if fmt_type == "json_object":
-            return None if isinstance(parsed, dict) else "expected a JSON object"
-        if fmt_type == "json_schema":
-            schema = response_format.get("json_schema")
-            if not isinstance(schema, dict):
-                return "json_schema response_format is missing a schema object"
-            schema_payload = (
-                schema.get("schema") if isinstance(schema.get("schema"), dict) else schema
-            )
-            try:
-                Draft202012Validator.check_schema(schema_payload)
-                Draft202012Validator(schema_payload).validate(parsed)
-            except JsonSchemaError as exc:
-                return f"invalid JSON schema: {exc.message}"
-            except JsonSchemaValidationError as exc:
-                return exc.message
-        return None
+        return validate_response_format_payload(payload, response_format)
 
     # -- Response parsing (single JSON summary) --------------------------
 

--- a/tests/unit/providers/test_response_format.py
+++ b/tests/unit/providers/test_response_format.py
@@ -1,0 +1,182 @@
+"""Tests for the shared ``response_format`` directive builder and validator.
+
+Per #1785 these lived as five independent copies. A schema-validity guard was
+added to `zcode_cli_adapter` and never reached the other four, so a malformed
+`json_schema` raised an uncaught `UnknownType` from them instead of returning a
+message. `TestMalformedSchemaNoLongerCrashes` pins that per adapter.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.providers.response_format import (
+    build_response_format_directive,
+    validate_response_format_payload,
+)
+
+MALFORMED_SCHEMA = {
+    "type": "json_schema",
+    "json_schema": {"schema": {"type": "not-a-real-type"}},
+}
+
+
+class TestBuildDirective:
+    @pytest.mark.parametrize(
+        "response_format",
+        [
+            pytest.param(None, id="none"),
+            pytest.param({}, id="empty"),
+            pytest.param({"type": "unrecognized"}, id="unknown-type"),
+            pytest.param({"type": "json_schema"}, id="json-schema-missing"),
+            pytest.param(
+                {"type": "json_schema", "json_schema": "not-a-dict"}, id="schema-not-dict"
+            ),
+        ],
+    )
+    def test_nothing_to_instruct_returns_none(self, response_format: dict | None) -> None:
+        assert build_response_format_directive(response_format) is None
+
+    def test_json_object_directive(self) -> None:
+        directive = build_response_format_directive({"type": "json_object"})
+        assert directive is not None
+        assert "ONLY a valid JSON object" in directive
+        assert "markdown fences" in directive
+
+    @pytest.mark.parametrize(
+        ("schema", "expected_noun"),
+        [
+            pytest.param({"type": "object"}, "JSON object", id="object"),
+            pytest.param({"type": "array"}, "JSON array", id="array"),
+            pytest.param({"type": "string"}, "JSON value", id="other-type-falls-back"),
+            pytest.param({}, "JSON object", id="missing-type-defaults-to-object"),
+        ],
+    )
+    def test_type_noun_follows_the_schema(self, schema: dict, expected_noun: str) -> None:
+        directive = build_response_format_directive({"type": "json_schema", "json_schema": schema})
+        assert directive is not None
+        assert f"ONLY a valid {expected_noun}" in directive
+
+    def test_openai_style_wrapper_is_unwrapped(self) -> None:
+        """`json_schema` may hold the schema directly or under a `schema` key."""
+        wrapped = build_response_format_directive(
+            {"type": "json_schema", "json_schema": {"name": "x", "schema": {"type": "array"}}}
+        )
+        direct = build_response_format_directive(
+            {"type": "json_schema", "json_schema": {"type": "array"}}
+        )
+        assert wrapped is not None and direct is not None
+        assert "ONLY a valid JSON array" in wrapped
+        assert "ONLY a valid JSON array" in direct
+        assert '"name"' not in wrapped
+
+    def test_unserializable_schema_falls_back_to_str(self) -> None:
+        """The directive is advisory; an odd schema must not fail the request."""
+        directive = build_response_format_directive(
+            {"type": "json_schema", "json_schema": {"schema": {"a": {1, 2}}}}
+        )
+        assert directive is not None
+        assert "JSON schema:" in directive
+
+    def test_schema_is_rendered_deterministically(self) -> None:
+        """Sorted keys keep the prompt stable across runs, which caching relies on."""
+        schema = {
+            "type": "object",
+            "properties": {"b": {"type": "string"}, "a": {"type": "string"}},
+        }
+        directive = build_response_format_directive({"type": "json_schema", "json_schema": schema})
+        assert directive is not None
+        rendered = directive.split("JSON schema:\n", 1)[1]
+        assert rendered == json.dumps(schema, indent=2, sort_keys=True)
+
+
+class TestValidatePayload:
+    def test_valid_object_passes(self) -> None:
+        assert validate_response_format_payload('{"a": 1}', {"type": "json_object"}) is None
+
+    def test_non_object_is_reported(self) -> None:
+        assert validate_response_format_payload("[1]", {"type": "json_object"}) == (
+            "expected a JSON object"
+        )
+
+    def test_unparseable_json_is_reported(self) -> None:
+        reason = validate_response_format_payload("{not json", {"type": "json_object"})
+        assert reason is not None
+        assert reason.startswith("invalid JSON:")
+
+    def test_schema_violation_is_reported(self) -> None:
+        reason = validate_response_format_payload(
+            '{"a": 1}',
+            {"type": "json_schema", "json_schema": {"schema": {"type": "array"}}},
+        )
+        assert reason is not None
+        assert "array" in reason
+
+    def test_schema_match_passes(self) -> None:
+        assert (
+            validate_response_format_payload(
+                '{"a": "x"}',
+                {
+                    "type": "json_schema",
+                    "json_schema": {"schema": {"type": "object", "required": ["a"]}},
+                },
+            )
+            is None
+        )
+
+    def test_missing_schema_object_is_reported(self) -> None:
+        assert validate_response_format_payload(
+            '{"a": 1}', {"type": "json_schema", "json_schema": "nope"}
+        ) == ("json_schema response_format is missing a schema object")
+
+    def test_malformed_schema_is_reported_not_raised(self) -> None:
+        """The #1785 regression. `UnknownType` is not a `ValidationError`."""
+        reason = validate_response_format_payload('{"a": 1}', MALFORMED_SCHEMA)
+        assert reason is not None
+        assert reason.startswith("invalid JSON schema:")
+
+    def test_unrecognized_format_type_passes(self) -> None:
+        assert validate_response_format_payload("{}", {"type": "something-else"}) is None
+
+
+class TestMalformedSchemaNoLongerCrashes:
+    """Each adapter that validates must report, not raise.
+
+    Before #1785 only `zcode` survived this input; the other four propagated
+    `jsonschema.exceptions.UnknownType` to the caller.
+    """
+
+    @staticmethod
+    def _validate(module_name: str, class_name: str, payload: str, response_format: dict) -> object:
+        """Call the adapter's validator, whether it is a staticmethod or bound.
+
+        `ourocode` declares it `@staticmethod`; the rest take `self`. The point
+        of this suite is the returned reason, not the binding, so normalize.
+        """
+        import importlib
+        import inspect
+
+        module = importlib.import_module(f"ouroboros.providers.{module_name}")
+        cls = getattr(module, class_name)
+        func = inspect.getattr_static(cls, "_validate_response_format_payload")
+        if isinstance(func, staticmethod):
+            return cls._validate_response_format_payload(payload, response_format)
+        return cls._validate_response_format_payload(object(), payload, response_format)
+
+    @pytest.mark.parametrize(
+        ("module_name", "class_name"),
+        [
+            pytest.param("pi_llm_adapter", "PiLLMAdapter", id="pi"),
+            pytest.param("gjc_llm_adapter", "GjcLLMAdapter", id="gjc"),
+            pytest.param("ourocode_llm_adapter", "OurocodeLLMAdapter", id="ourocode"),
+            pytest.param("goose_cli_adapter", "GooseCliLLMAdapter", id="goose"),
+            pytest.param("zcode_cli_adapter", "ZcodeCliLLMAdapter", id="zcode"),
+        ],
+    )
+    def test_adapter_reports_malformed_schema(self, module_name: str, class_name: str) -> None:
+        reason = self._validate(module_name, class_name, '{"a": 1}', MALFORMED_SCHEMA)
+
+        assert isinstance(reason, str)
+        assert reason.startswith("invalid JSON schema:")

--- a/tests/unit/providers/test_response_format.py
+++ b/tests/unit/providers/test_response_format.py
@@ -180,3 +180,58 @@ class TestMalformedSchemaNoLongerCrashes:
 
         assert isinstance(reason, str)
         assert reason.startswith("invalid JSON schema:")
+
+
+UNRESOLVABLE_REF_SCHEMA = {
+    "type": "json_schema",
+    "json_schema": {"schema": {"$ref": "#/$defs/missing"}},
+}
+
+
+class TestUnresolvableReferenceIsReported:
+    """A `$ref` pointing at nothing is structurally valid but cannot validate.
+
+    `check_schema` passes, then `validate` raises `_WrappedReferencingError`,
+    whose MRO is `_RefResolutionError -> referencing.exceptions.Unresolvable ->
+    Exception`. It is neither a `SchemaError` nor a `ValidationError`, so it
+    escaped both clauses -- including in the one copy that already had the
+    `check_schema` guard.
+    """
+
+    def test_shared_validator_reports_instead_of_raising(self) -> None:
+        reason = validate_response_format_payload('{"a": 1}', UNRESOLVABLE_REF_SCHEMA)
+        assert reason is not None
+        assert reason.startswith("could not validate against JSON schema:")
+
+    def test_a_resolvable_ref_still_validates(self) -> None:
+        """The guard must not swallow schemas whose `$ref` does resolve."""
+        schema = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": {
+                    "$defs": {"positive": {"type": "integer", "minimum": 1}},
+                    "$ref": "#/$defs/positive",
+                }
+            },
+        }
+        assert validate_response_format_payload("5", schema) is None
+        assert validate_response_format_payload("0", schema) is not None
+
+    @pytest.mark.parametrize(
+        ("module_name", "class_name"),
+        [
+            pytest.param("pi_llm_adapter", "PiLLMAdapter", id="pi"),
+            pytest.param("gjc_llm_adapter", "GjcLLMAdapter", id="gjc"),
+            pytest.param("ourocode_llm_adapter", "OurocodeLLMAdapter", id="ourocode"),
+            pytest.param("goose_cli_adapter", "GooseCliLLMAdapter", id="goose"),
+            pytest.param("zcode_cli_adapter", "ZcodeCliLLMAdapter", id="zcode"),
+        ],
+    )
+    def test_adapter_reports_unresolvable_reference(
+        self, module_name: str, class_name: str
+    ) -> None:
+        reason = TestMalformedSchemaNoLongerCrashes._validate(
+            module_name, class_name, '{"a": 1}', UNRESOLVABLE_REF_SCHEMA
+        )
+        assert isinstance(reason, str)
+        assert reason.startswith("could not validate against JSON schema:")


### PR DESCRIPTION
## Summary

`_build_response_format_directive` and `_validate_response_format_payload` were copy-pasted across five provider adapters. One copy got a fix; the other four did not, and the gap is a crash. Both halves now live in `providers/response_format.py`.

Closes #1785.

## The bug

`zcode_cli_adapter` validates the schema before using it; pi, gjc, ourocode, and goose do not. Given a `json_schema` that is not itself a valid schema:

```python
>>> Draft202012Validator({"type": "not-a-real-type"}).validate({"a": 1})
jsonschema.exceptions.UnknownType: Unknown type 'not-a-real-type' for validator ...
```

`UnknownType` is **not** a `ValidationError`, so the lone `except JsonSchemaValidationError` clause did not catch it and it propagated to the caller. The function's contract is to *return* a reason string; four of five adapters threw instead. `grep -c check_schema src/ouroboros/providers/*.py` matched exactly one file.

## Why it happened

Nothing connected the copies, so a fix could not travel:

| function | identical copies before |
|---|---|
| `_build_response_format_directive` | 4 — pi, gjc, ourocode, zcode (verified by AST body hash) |
| `_validate_response_format_payload` | 3 — pi, gjc, ourocode; goose differs only in `if/return` vs a conditional expression; zcode carries the fix |

## Changes

- **`build_response_format_directive`** — the 4-way identical version. Verified byte-identical output against the pre-change implementation across nine inputs, including the OpenAI-style `schema` wrapper, a missing `type`, an unrecognized `type`, and an unserializable schema. **No behaviour change.**
- **`validate_response_format_payload`** — zcode's corrected version, which fixes the crash for the other four.
- Each adapter keeps its method and its docstring; only the body becomes a delegation. Those docstrings carry backend-specific rationale ("Pi JSON mode does not expose a Codex-style hard `--output-schema` flag") that a shared implementation cannot express, so they stay at the call site.

Net **-231 lines**.

## Deliberately out of scope

`goose` and `copilot` carry genuinely divergent **directive** builders — goose does not unwrap a nested `schema` key and omits the `json.dumps` fallback; copilot renders through module-level templates and unwraps differently. Converging those changes prompt text, which is a separate judgement this PR does not make. The divergence is recorded in #1785 rather than silently left unmentioned.

## A note on the original scope

This started as "converge the runtime adapter property boilerplate" — `_feeds_prompt_via_stdin`, `_build_permission_args`, `working_directory`/`permission_mode`/`llm_backend`. On inspection that would have been the wrong change: those bodies are trivial (`return False`, `return []`, `return self._cwd`) but each carries a **distinct** docstring naming the backend and its reason:

```
"""Return False — Copilot CLI accepts the prompt via the -p flag."""
"""Return False — Gemini CLI accepts the prompt via the --prompt flag."""
"""Goose permission mode is provided through GOOSE_MODE env."""
```

Deduplicating those destroys per-backend documentation to save three lines each, and the accessors exist to satisfy `AgentRuntime`, which is a `Protocol` — structural typing whose point is *not* requiring a shared base. Restricting the AST duplicate scan to functions above 30 nodes surfaced this response-format cluster instead: real duplicated logic, and a real bug.

## Test plan

- [x] New `tests/unit/providers/test_response_format.py` — 26 cases
- [x] `TestMalformedSchemaNoLongerCrashes` asserts the regression per adapter (pi, gjc, ourocode, goose, zcode), normalizing over the fact that `ourocode` declares its validator `@staticmethod` while the rest take `self`
- [x] Directive equivalence verified against the pre-change implementation across nine inputs — 0 differences
- [x] `uv run pytest tests/unit/providers/ -q` → 655 passed
- [x] `uv run pytest tests/unit/providers tests/unit/orchestrator -q` → **4754 passed, 1 skipped**
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy src/ouroboros/providers/` → Success (25 source files)

## R-run comparison

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (PR does not touch `src/ouroboros/auto/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)