### PR TITLE
feat(bigbang): extract CONTEXT_REFERENCES as JSON object arrays (#1729 slice 4)

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -65,7 +65,7 @@ Format: single-line JSON array of objects with "name", "description", and "crite
 ### 7. BROWNFIELD CONTEXT (if applicable)
 If the interview mentions existing codebases, extract:
 - **PROJECT_TYPE**: 'greenfield' or 'brownfield'
-- **CONTEXT_REFERENCES**: path:role:summary (pipe-separated, role is 'primary' or 'reference')
+- **CONTEXT_REFERENCES**: single-line JSON array of objects with "path", "role" (primary or reference), and optional "summary"
 - **EXISTING_PATTERNS**: Key patterns that must be followed (single-line JSON array of strings)
 - **EXISTING_DEPENDENCIES**: Key dependencies to reuse (single-line JSON array of strings)
 
@@ -85,7 +85,7 @@ ONTOLOGY_FIELDS: [{"name": "<name>", "type": "<string|number|boolean|array|objec
 EVALUATION_PRINCIPLES: [{"name": "<name>", "description": "<description>", "weight": <0.0-1.0>}, ...]
 EXIT_CONDITIONS: [{"name": "<name>", "description": "<description>", "criteria": "<criteria>"}, ...]
 PROJECT_TYPE: greenfield|brownfield
-CONTEXT_REFERENCES: <path>:<role>:<summary> | ...
+CONTEXT_REFERENCES: [{"path": "<path>", "role": "<primary|reference>", "summary": "<summary>"}, ...]
 EXISTING_PATTERNS: ["<pattern 1>", "<pattern 2>", ...]
 EXISTING_DEPENDENCIES: ["<dep 1>", "<dep 2>", ...]
 ```

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -502,6 +502,91 @@ def _parse_ontology_fields(raw_value: object, *, strict: bool = False) -> tuple[
     return tuple(fields)
 
 
+def _parse_context_references(
+    raw_value: object, *, strict: bool = False
+) -> tuple[ContextReference, ...]:
+    """Parse CONTEXT_REFERENCES from JSON object arrays or the legacy pipe list.
+
+    Mirrors the other #1729 object-array parsers: the extraction format
+    requests a single-line JSON array of ``{"path", "role", "summary"}``
+    objects — ``summary`` is optional and defaults to empty — so colons in
+    paths (e.g. Windows drives) and colons/pipes in summaries survive as
+    data. Strict mode raises on anything else so the retry path reformats;
+    lenient mode keeps the historical ``path:role:summary`` split where the
+    summary absorbs further colons, skips malformed entries, and never
+    raises.
+    """
+    field_label = "CONTEXT_REFERENCES"
+
+    def _build(entry: object) -> ContextReference | None:
+        if isinstance(entry, ContextReference):
+            return entry
+        if not isinstance(entry, dict):
+            if strict:
+                raise ValueError(
+                    f"{field_label} entries must be JSON objects; got "
+                    f"{type(entry).__name__}: {entry!r}"
+                )
+            return None
+        try:
+            summary = entry.get("summary", "")
+            if not isinstance(summary, str):
+                raise ValueError(
+                    f"{field_label} entry field 'summary' must be a string; got {summary!r}."
+                )
+            return ContextReference(
+                path=_require_object_string(entry, "path", field_label=field_label),
+                role=_require_object_string(entry, "role", field_label=field_label),
+                summary=summary.strip(),
+            )
+        except (ValueError, TypeError, PydanticValidationError):
+            if strict:
+                raise
+            return None
+
+    def _build_all(entries: list | tuple) -> tuple[ContextReference, ...]:
+        return tuple(built for built in (_build(entry) for entry in entries) if built)
+
+    if isinstance(raw_value, list | tuple):
+        return _build_all(raw_value)
+    if not isinstance(raw_value, str):
+        return ()
+    text = raw_value.strip()
+    if not text:
+        if strict:
+            raise ValueError(
+                f"{field_label} must be a single-line JSON array of objects; "
+                "use [] for an intentionally empty list."
+            )
+        return ()
+    decoded = _decode_object_array(text, field_label=field_label, strict=strict)
+    if decoded is not None:
+        return _build_all(decoded)
+
+    references: list[ContextReference] = []
+    for ref_str in text.split("|"):
+        ref_str = ref_str.strip()
+        if not ref_str:
+            continue
+        parts = ref_str.split(":")
+        if len(parts) < 2:
+            continue
+        path = parts[0].strip()
+        role = parts[1].strip()
+        if not path or not role:
+            # Stored legacy data has no retry path; skip malformed entries
+            # instead of raising at model construction.
+            continue
+        references.append(
+            ContextReference(
+                path=path,
+                role=role,
+                summary=":".join(parts[2:]).strip() if len(parts) > 2 else "",
+            )
+        )
+    return tuple(references)
+
+
 def _parse_acceptance_criteria_contracts(
     raw_value: object,
 ) -> tuple[AcceptanceCriterionSpec | str, ...]:
@@ -1046,7 +1131,7 @@ EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria"
             return "PROJECT_TYPE: greenfield"
         return (
             "PROJECT_TYPE: brownfield\n"
-            "CONTEXT_REFERENCES: <path>:<role primary|reference>:<summary> | ...\n"
+            'CONTEXT_REFERENCES: [{{"path": "<path>", "role": "<primary|reference>", "summary": "<summary>"}}, ...]\n'
             'EXISTING_PATTERNS: ["<pattern 1>", "<pattern 2>", ...]\n'
             'EXISTING_DEPENDENCIES: ["<dependency 1>", "<dependency 2>", ...]\n'
             "EXISTING_PATTERNS rule: respond with one single-line JSON array of strings. "
@@ -1267,6 +1352,10 @@ EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria"
             requirements["ontology_fields"] = _parse_ontology_fields(
                 requirements["ontology_fields"], strict=True
             )
+        if "context_references" in requirements:
+            requirements["context_references"] = _parse_context_references(
+                requirements["context_references"], strict=True
+            )
 
         return requirements
 
@@ -1314,22 +1403,9 @@ EXIT_CONDITIONS: [{{"name": "<name>", "description": "<description>", "criteria"
         brownfield_context = BrownfieldContext()
         project_type = requirements.get("project_type", "greenfield").strip().lower()
         if project_type == "brownfield":
-            # Parse context references: path:role:summary | ...
-            context_refs: list[ContextReference] = []
-            if "context_references" in requirements and requirements["context_references"]:
-                for ref_str in requirements["context_references"].split("|"):
-                    ref_str = ref_str.strip()
-                    if not ref_str:
-                        continue
-                    parts = ref_str.split(":")
-                    if len(parts) >= 2:
-                        context_refs.append(
-                            ContextReference(
-                                path=parts[0].strip(),
-                                role=parts[1].strip() if len(parts) > 1 else "reference",
-                                summary=":".join(parts[2:]).strip() if len(parts) > 2 else "",
-                            )
-                        )
+            # Parse context references (JSON object arrays preferred; legacy
+            # colon/pipe lists supported for stored requirements)
+            context_refs = _parse_context_references(requirements.get("context_references"))
 
             # Parse existing patterns (lenient: stored data has no retry path)
             existing_patterns = _parse_string_array_values(

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -21,6 +21,7 @@ from ouroboros.bigbang.interview import (
 )
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
+    _parse_context_references,
     _parse_evaluation_principles,
     _parse_exit_conditions,
     _parse_ontology_fields,
@@ -32,6 +33,7 @@ from ouroboros.config.loader import get_clarification_model
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import (
     AcceptanceCriterionSpec,
+    ContextReference,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
@@ -1568,6 +1570,60 @@ class TestObjectArrayExtractionContract:
             '[{"name": "x", "description": "d", "weight": -1e999}]', strict=True
         )
         assert json_neg_strict[0].weight == 0.0
+
+    def test_context_refs_strict_parses_json_with_colons_in_paths(self) -> None:
+        refs = _parse_context_references(
+            '[{"path": "C:/repos/api", "role": "primary",'
+            ' "summary": "API layer: handlers | middleware"}]',
+            strict=True,
+        )
+        assert refs == (
+            ContextReference(
+                path="C:/repos/api",
+                role="primary",
+                summary="API layer: handlers | middleware",
+            ),
+        )
+        no_summary = _parse_context_references(
+            '[{"path": "/repo/lib", "role": "reference"}]', strict=True
+        )
+        assert no_summary[0].summary == ""
+
+    def test_context_refs_strict_rejects_legacy_and_malformed(self) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_context_references("/repo/api:primary:API layer", strict=True)
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_context_references("", strict=True)
+        assert _parse_context_references("[]", strict=True) == ()
+        malformed = (
+            '["not an object"]',
+            '[{"role": "primary"}]',
+            '[{"path": "/repo", "role": "  "}]',
+            '[{"path": "/repo", "role": "primary", "summary": 42}]',
+        )
+        for case in malformed:
+            with pytest.raises(ValueError, match="CONTEXT_REFERENCES"):
+                _parse_context_references(case, strict=True)
+
+    def test_context_refs_lenient_keeps_legacy_split_and_never_raises(self) -> None:
+        legacy = _parse_context_references(
+            "/repo/api:primary:API layer: v2 | /repo/lib:reference | :primary:bad | x"
+        )
+        assert legacy == (
+            ContextReference(path="/repo/api", role="primary", summary="API layer: v2"),
+            ContextReference(path="/repo/lib", role="reference", summary=""),
+        )
+        stored_json = _parse_context_references(
+            '[{"path": "/a", "role": "primary", "summary": "s | t"}, {"role": "x"}, 7]'
+        )
+        assert len(stored_json) == 1
+        assert stored_json[0].summary == "s | t"
+        # Bracket-led malformed JSON falls back to the legacy split (junk
+        # tolerated, never raises) — same contract as the other parsers.
+        assert isinstance(_parse_context_references('[{"path":]'), tuple)
+        assert _parse_context_references(None) == ()
+        model = ContextReference(path="/m", role="reference", summary="")
+        assert _parse_context_references([model]) == (model,)
 
     def test_ontology_strict_parses_json_object_arrays(self) -> None:
         fields = _parse_ontology_fields(

--- a/tests/unit/bigbang/test_seed_generator_brownfield.py
+++ b/tests/unit/bigbang/test_seed_generator_brownfield.py
@@ -77,7 +77,7 @@ class TestBrownfieldParsingRoundTrip:
             "ONTOLOGY_NAME: Svc\n"
             "ONTOLOGY_DESCRIPTION: A service\n"
             "PROJECT_TYPE: brownfield\n"
-            "CONTEXT_REFERENCES: /repo/api:primary:API layer\n"
+            'CONTEXT_REFERENCES: [{"path": "/repo/api", "role": "primary", "summary": "API layer"}]\n'
             'EXISTING_PATTERNS: ["repository pattern", "dependency injection"]\n'
             'EXISTING_DEPENDENCIES: ["fastapi", "sqlalchemy"]'
         )
@@ -98,7 +98,7 @@ class TestBrownfieldListExtractionContract:
         "ONTOLOGY_NAME: Svc\n"
         "ONTOLOGY_DESCRIPTION: A service\n"
         "PROJECT_TYPE: brownfield\n"
-        "CONTEXT_REFERENCES: /repo/api:primary:API layer\n"
+        'CONTEXT_REFERENCES: [{"path": "/repo/api", "role": "primary", "summary": "API layer"}]\n'
     )
 
     def test_strict_rejects_pipe_list_existing_patterns(self) -> None:


### PR DESCRIPTION
## Summary

Slice 4 of #1729 — the final slice: CONTEXT_REFERENCES moves to a single-line JSON object array, completing the object-array rollout across all six fields (#1714 → #1730 → #1762 → #1767 → this).

This field is where the legacy colon split hurts most: a Windows path like `C:\repos\api` loses its drive letter to the role position, and a summary like `API layer: handlers | middleware` is truncated at both delimiters.

| Lane | Behavior |
|---|---|
| Extraction (strict) | Must be a valid JSON array of `{"path", "role", "summary"}` objects — `summary` is optional and defaults to empty, and a present non-string summary poisons the claim; legacy pipe lines, blank values, non-objects, and missing or blank path/role raise so the reformat-retry path resends. `[]` is the explicit empty spelling. |
| Stored requirements (lenient) | Bracket-led valid JSON arrays parse to models; everything else keeps the historical `path:role:summary` split with the summary absorbing further colons; malformed or blank-segment entries are skipped instead of raising (the legacy loop previously raised a model ValidationError on e.g. `:primary:x`); pre-parsed model tuples pass through; never raises. |

The brownfield extraction trailer and the seed-architect agent template request the new format, and the brownfield test fixture migrates with it. Reuses the shared decode/validation helpers hardened across the previous slices' reviews.

## Rollout status

With this slice, every pipe-delimited extraction field named in #1729 is on the JSON contract, and no in-repo producer emits the legacy format anywhere. Stored legacy data remains readable indefinitely through the lenient lane.

## Test plan

- [x] 3 new regression tests: strict parsing with drive colons in paths and colons/pipes in summaries plus optional-summary handling, strict rejection of legacy/blank/malformed values, lenient legacy-split preservation and never-raise fallbacks (including blank segments the old loop raised on) with stored-JSON and pass-through coverage
- [x] `uv run pytest tests/unit/bigbang -q` — 708 passed
- [x] `uv run pytest tests/ -q -n 4` — 14547 passed, 12 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ouroboros` — clean

Closes #1729 (slice 4 of 4)
