### PR TITLE
fix(tests): make the watchdog and logging flakes deterministic

### DIFF
--- a/src/ouroboros/observability/logging.py
+++ b/src/ouroboros/observability/logging.py
@@ -45,7 +45,6 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import os
 from pathlib import Path
-import sys
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -637,6 +636,17 @@ def reset_logging() -> None:
     regression. ``_configured`` stays false and ``_current_config`` stays
     ``None``, so the next :func:`get_logger` still performs a full
     reconfiguration.
+
+    The stream is carried by reusing the project's own factory with no file
+    handler, not by handing ``sys.stderr`` to ``structlog.PrintLoggerFactory``.
+    Two reasons, both of which a captured stream gets wrong.
+    ``_FileWritingPrintLogger._log`` resolves ``sys.stderr`` at emit time, so a
+    reset that runs while pytest's ``capsys`` is active cannot pin that
+    fixture's buffer into the global configuration and raise on a write after
+    its teardown. And that logger is the only one that consults
+    ``_console_logging_enabled``, so routing through it keeps
+    :func:`set_console_logging` honored across a reset instead of silently
+    re-enabling console output.
     """
     global _configured, _current_config
     # Read before clearing: the reset must not be louder than what it replaces.
@@ -650,5 +660,7 @@ def reset_logging() -> None:
     structlog.reset_defaults()
     structlog.configure(
         wrapper_class=structlog.make_filtering_bound_logger(outgoing_level),
-        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+        # No file handler: the outgoing one was just closed by
+        # _close_root_handlers(), and a reset must not hold a resource.
+        logger_factory=_FileWritingPrintLoggerFactory(None),
     )

--- a/src/ouroboros/observability/logging.py
+++ b/src/ouroboros/observability/logging.py
@@ -610,6 +610,25 @@ def reset_logging() -> None:
 
     This is primarily for testing purposes. It resets the module state
     but does not reconfigure the loggers.
+
+    A reset must never leave the process *louder* than a configured one.
+    ``structlog.reset_defaults()`` restores the library defaults, which
+    emit every level — including debug — through a ``PrintLogger`` bound
+    to stdout, while a configured Ouroboros logger filters at
+    ``LoggingConfig.log_level`` and writes to stderr so stdout stays
+    reserved for command output.
+
+    That gap is not self-healing. Most modules bind their logger once at
+    import time via a bare ``structlog.get_logger``, which never routes
+    through :func:`get_logger` and so never triggers the lazy
+    reconfiguration that clearing ``_configured`` sets up. Once those
+    proxies exist, a reset silently turns every ``log.debug`` in the
+    process into stdout output, which contaminates any CLI result parsed
+    by a caller or asserted on by a later test.
+
+    So restore the default filter alongside the reset. ``_configured``
+    stays false and ``_current_config`` stays ``None``, so the next
+    :func:`get_logger` still performs a full reconfiguration.
     """
     global _configured, _current_config
     _configured = False
@@ -619,3 +638,8 @@ def reset_logging() -> None:
     structlog.contextvars.clear_contextvars()
     # Reset structlog configuration
     structlog.reset_defaults()
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(
+            _get_log_level(LoggingConfig().log_level)
+        )
+    )

--- a/src/ouroboros/observability/logging.py
+++ b/src/ouroboros/observability/logging.py
@@ -45,6 +45,7 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import os
 from pathlib import Path
+import sys
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -608,29 +609,38 @@ def is_configured() -> bool:
 def reset_logging() -> None:
     """Reset logging configuration state.
 
-    This is primarily for testing purposes. It resets the module state
-    but does not reconfigure the loggers.
+    This is primarily for testing purposes. It clears the Ouroboros module
+    state and installs a neutral global structlog configuration in place of
+    the application one.
 
-    A reset must never leave the process *louder* than a configured one.
-    ``structlog.reset_defaults()`` restores the library defaults, which
-    emit every level — including debug — through a ``PrintLogger`` bound
-    to stdout, while a configured Ouroboros logger filters at
-    ``LoggingConfig.log_level`` and writes to stderr so stdout stays
-    reserved for command output.
+    Neutral, not absent. ``structlog.reset_defaults()`` on its own restores
+    the *library* defaults, which emit every level — down to debug —
+    through a ``PrintLogger`` bound to stdout. A configured Ouroboros
+    logger filters at ``LoggingConfig.log_level`` and prints to stderr (see
+    ``_FileWritingPrintLogger._log``), so stdout stays reserved for command
+    output. Dropping to library defaults therefore makes the process both
+    louder and misdirected.
 
     That gap is not self-healing. Most modules bind their logger once at
     import time via a bare ``structlog.get_logger``, which never routes
     through :func:`get_logger` and so never triggers the lazy
     reconfiguration that clearing ``_configured`` sets up. Once those
-    proxies exist, a reset silently turns every ``log.debug`` in the
-    process into stdout output, which contaminates any CLI result parsed
-    by a caller or asserted on by a later test.
+    proxies exist, a reset silently redirects the process's logging to
+    stdout, which contaminates any CLI result parsed by a caller or
+    asserted on by a later test.
 
-    So restore the default filter alongside the reset. ``_configured``
-    stays false and ``_current_config`` stays ``None``, so the next
-    :func:`get_logger` still performs a full reconfiguration.
+    So carry both halves of the contract across the reset: keep the
+    outgoing configuration's level, and keep writing to stderr. Preserving
+    the level rather than assuming the ``LoggingConfig`` default matters
+    when the outgoing configuration was quieter — resetting an
+    ``ERROR``-level process to ``INFO`` would be its own volume
+    regression. ``_configured`` stays false and ``_current_config`` stays
+    ``None``, so the next :func:`get_logger` still performs a full
+    reconfiguration.
     """
     global _configured, _current_config
+    # Read before clearing: the reset must not be louder than what it replaces.
+    outgoing_level = _get_log_level((_current_config or LoggingConfig()).log_level)
     _configured = False
     _current_config = None
     _close_root_handlers()
@@ -639,7 +649,6 @@ def reset_logging() -> None:
     # Reset structlog configuration
     structlog.reset_defaults()
     structlog.configure(
-        wrapper_class=structlog.make_filtering_bound_logger(
-            _get_log_level(LoggingConfig().log_level)
-        )
+        wrapper_class=structlog.make_filtering_bound_logger(outgoing_level),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )

--- a/tests/unit/evolution/test_generation_watchdog.py
+++ b/tests/unit/evolution/test_generation_watchdog.py
@@ -201,8 +201,22 @@ async def test_productive_long_run_resets_material_progress_timeout(
 
 
 @pytest.mark.asyncio
-async def test_busy_run_without_material_progress_times_out() -> None:
-    """Activity alone does not count as material progress."""
+async def test_busy_run_without_material_progress_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Activity alone does not count as material progress.
+
+    Driven by the fake clock because the two thresholds otherwise race on
+    wall-clock time: the watchdog checks ``idle_timeout`` (1s by default
+    here) before ``no_material_progress_timeout``, and a poll loop starved
+    for a second under a loaded parallel CI run reaches the idle threshold
+    first. The generation is then cancelled for the wrong reason, which is
+    an assertion failure here and a misattributed timeout in production.
+    Advancing a fake clock only from inside the work coroutine orders the
+    thresholds by simulated time instead of by scheduler luck.
+    """
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     lineage_id = "lin-busy"
     execution_id = "exec-busy"
@@ -218,6 +232,10 @@ async def test_busy_run_without_material_progress_times_out() -> None:
         try:
             while True:
                 await asyncio.sleep(0.02)
+                # Each step both proves liveness (resetting idle) and fails
+                # to advance completion, so only the no-progress threshold
+                # can accumulate.
+                clock.advance(0.05)
                 await event_store.append(_workflow_progress(execution_id, completed_count=0))
         except asyncio.CancelledError:
             try:
@@ -266,7 +284,9 @@ async def test_busy_run_without_material_progress_times_out() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_progress_timeout_emits_retry_directive() -> None:
+async def test_no_progress_timeout_emits_retry_directive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Issue #578 directive-mapping contract.
 
     A ``no_material_progress_timeout`` is surfaced as a failed generation
@@ -283,7 +303,16 @@ async def test_no_progress_timeout_emits_retry_directive() -> None:
        on the lineage aggregate, with ``emitted_by="generation.watchdog"`` so
        projectors can attribute the directive to its source.
     3. ``is_terminal`` matches the directive (RETRY is non-terminal).
+
+    The idempotency key embeds the timeout kind, so this test only holds
+    while the *right* threshold fires. On wall-clock time it did not: a
+    starved poll loop in the parallel CI run tripped ``idle_timeout``
+    first and produced ``...:1:idle_timeout:reflecting``. The fake clock
+    makes the threshold ordering a property of the scenario rather than of
+    machine load.
     """
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     lineage_id = "lin-578-unstuck"
     execution_id = "exec-578-unstuck"
@@ -300,6 +329,7 @@ async def test_no_progress_timeout_emits_retry_directive() -> None:
         try:
             while True:
                 await asyncio.sleep(0.02)
+                clock.advance(0.05)
                 await event_store.append(_workflow_progress(execution_id, completed_count=0))
         except asyncio.CancelledError:
             raise
@@ -442,8 +472,19 @@ async def test_directive_emission_alphabet_matches_watchdog_raises(
 
 
 @pytest.mark.asyncio
-async def test_session_activity_resets_idle_timeout() -> None:
-    """Session aggregate tool/message events prove generation liveness."""
+async def test_session_activity_resets_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session aggregate tool/message events prove generation liveness.
+
+    Stepped against a fake clock instead of racing real ``asyncio.sleep``
+    calls against a 0.07s idle threshold. This test asserts the generation
+    stays *alive*, so under parallel CI load any scheduling hiccup longer
+    than the threshold failed it without anything being wrong — the
+    inverse of the no-progress tests, and the same underlying cause.
+    """
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     session_id = "session-active"
     execution_id = "exec-session-active"
@@ -454,14 +495,23 @@ async def test_session_activity_resets_idle_timeout() -> None:
         generation_no_progress_timeout_seconds=0,
     )
 
-    async def session_work() -> str:
-        await event_store.append(_session_started(session_id, execution_id))
-        for _ in range(4):
-            await asyncio.sleep(0.04)
-            await event_store.append(_session_tool_called(session_id))
-        return "done"
+    await watchdog.initialize_baseline()
+    await event_store.append(_session_started(session_id, execution_id))
+    await watchdog.poll()
 
-    assert await watchdog.watch(session_work()) == "done"
+    for _ in range(4):
+        clock.advance(0.06)
+        watchdog._raise_if_threshold_exceeded()
+
+        await event_store.append(_session_tool_called(session_id))
+        await watchdog.poll()
+
+        assert watchdog._last_event_type == "orchestrator.tool.called"
+
+    # Elapsed time is now several multiples of the idle threshold; only the
+    # per-event resets keep the generation alive.
+    clock.advance(0.06)
+    watchdog._raise_if_threshold_exceeded()
 
 
 @pytest.mark.asyncio
@@ -781,8 +831,18 @@ async def test_parent_cancellation_cancels_watched_generation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_material_progress_timeout_emits_cancellation_mode() -> None:
-    """watchdog_decision event carries cancellation_mode after a no-progress timeout."""
+async def test_no_material_progress_timeout_emits_cancellation_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """watchdog_decision event carries cancellation_mode after a no-progress timeout.
+
+    Fake-clocked for the same reason as the other no-progress tests: the
+    asserted ``timeout_kind`` is only reachable when the no-progress
+    threshold beats the idle one, which wall-clock time does not
+    guarantee under parallel CI load.
+    """
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     lineage_id = "lin-cancel-mode"
     execution_id = "exec-cancel-mode"
@@ -797,6 +857,7 @@ async def test_no_material_progress_timeout_emits_cancellation_mode() -> None:
         try:
             while True:
                 await asyncio.sleep(0.02)
+                clock.advance(0.05)
                 await event_store.append(_workflow_progress(execution_id, completed_count=0))
         except asyncio.CancelledError:
             raise

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
 from pathlib import Path
+import sys
 import tempfile
 from typing import Any
 from unittest.mock import patch
@@ -558,6 +560,45 @@ class TestResetLogging:
         captured = capsys.readouterr()
         assert "reset.info.must.stay.silent" not in captured.out
         assert "reset.info.must.stay.silent" not in captured.err
+
+    def test_reset_resolves_the_stream_at_emit_time(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The reset must not pin whatever ``sys.stderr`` happened to be.
+
+        A reset that runs under a capture fixture (``capsys``, or any
+        ``redirect_stderr``) would otherwise bind that fixture's buffer into
+        the global configuration and keep writing to it after teardown --
+        raising on a closed buffer, or silently swallowing later output.
+        Rebinding ``sys.stderr`` after the reset and asserting the new stream
+        receives the record is the direct proof that the lookup is late.
+        """
+        configure_logging(LoggingConfig(enable_file_logging=False, log_level="INFO"))
+        reset_logging()
+
+        replacement = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", replacement)
+        structlog.get_logger("reset.stream.probe").info("reset.late.bound.stream")
+
+        assert "reset.late.bound.stream" in replacement.getvalue()
+
+    def test_reset_keeps_console_suppression(self, capsys: Any) -> None:
+        """``set_console_logging(False)`` must survive the reset.
+
+        Only ``_FileWritingPrintLogger`` consults ``_console_logging_enabled``.
+        Reconfiguring onto a plain ``structlog.PrintLoggerFactory`` would route
+        around that gate and silently re-enable console output for a process
+        that had asked for silence.
+        """
+        configure_logging(LoggingConfig(enable_file_logging=False, log_level="INFO"))
+        set_console_logging(False)
+        try:
+            reset_logging()
+            structlog.get_logger("reset.console.probe").info("reset.console.must.stay.off")
+
+            captured = capsys.readouterr()
+            assert "reset.console.must.stay.off" not in captured.out
+            assert "reset.console.must.stay.off" not in captured.err
+        finally:
+            set_console_logging(True)
 
 
 class TestIsConfigured:

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -526,6 +526,39 @@ class TestResetLogging:
         assert "reset.debug.must.stay.silent" not in captured.out
         assert "reset.debug.must.stay.silent" not in captured.err
 
+    def test_reset_keeps_emitted_levels_off_stdout(self, capsys: Any) -> None:
+        """Whatever survives the level filter must still avoid stdout.
+
+        Filtering debug is only half the contract. structlog's default
+        ``PrintLoggerFactory`` writes to stdout, so an INFO record emitted
+        after a reset still lands in command output — the same
+        contamination as the debug case, one level up.
+        """
+        configure_logging(LoggingConfig(enable_file_logging=False))
+        reset_logging()
+
+        structlog.get_logger("reset.probe").info("reset.info.belongs.on.stderr")
+
+        captured = capsys.readouterr()
+        assert "reset.info.belongs.on.stderr" not in captured.out
+        assert "reset.info.belongs.on.stderr" in captured.err
+
+    def test_reset_preserves_a_quieter_configured_level(self, capsys: Any) -> None:
+        """Resetting an ERROR-level process must not restore it to INFO.
+
+        Assuming the ``LoggingConfig`` default on reset is a volume
+        regression in its own right for any process configured quieter
+        than INFO.
+        """
+        configure_logging(LoggingConfig(enable_file_logging=False, log_level="ERROR"))
+        reset_logging()
+
+        structlog.get_logger("reset.quiet.probe").info("reset.info.must.stay.silent")
+
+        captured = capsys.readouterr()
+        assert "reset.info.must.stay.silent" not in captured.out
+        assert "reset.info.must.stay.silent" not in captured.err
+
 
 class TestIsConfigured:
     """Test is_configured function."""

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import warnings
 
 import pytest
+import structlog
 
 from ouroboros.observability.logging import (
     LoggingConfig,
@@ -498,6 +499,32 @@ class TestResetLogging:
 
         captured = capsys.readouterr()
         assert "test_value" not in captured.err
+
+    def test_reset_does_not_leave_the_process_louder_than_configured(self, capsys: Any) -> None:
+        """A reset must not re-enable debug output, least of all on stdout.
+
+        ``structlog.reset_defaults()`` alone restores the library defaults,
+        which emit every level through a ``PrintLogger`` bound to stdout.
+        Most modules bind their logger once at import time with a bare
+        ``structlog.get_logger``, so they never route through
+        :func:`get_logger` and never trigger the lazy reconfiguration that
+        clearing ``_configured`` sets up — they just keep logging through
+        whatever the reset left behind.
+
+        The observable damage is stdout contamination: ``ouroboros job
+        wait`` emits debug events, and its output is parsed by callers and
+        asserted on verbatim in ``tests/unit/cli``. Because a reset only
+        happens in tests, this surfaced as an order-dependent failure in
+        the full parallel suite rather than anywhere reproducible.
+        """
+        configure_logging(LoggingConfig(enable_file_logging=False))
+        reset_logging()
+
+        structlog.get_logger("reset.probe").debug("reset.debug.must.stay.silent")
+
+        captured = capsys.readouterr()
+        assert "reset.debug.must.stay.silent" not in captured.out
+        assert "reset.debug.must.stay.silent" not in captured.err
 
 
 class TestIsConfigured:


### PR DESCRIPTION
Refs #1794

Two `Tests` failures landed on `main` during the 2026-07-28 merge batch (`38df811`, `18944f5`). Neither reproduces on a rerun, and neither is caused by the code it failed on.

## 1. Watchdog tests raced two thresholds on wall-clock time

`_raise_if_threshold_exceeded` checks `idle_timeout` before `no_material_progress_timeout`. The affected tests set the no-progress threshold to 0.07s, leave idle at the helper default of 1.0s, and rely on real `asyncio.sleep` to reach the shorter one first. But `_last_activity_at` only advances when a poll actually *observes* an event, so a poll loop starved for a second under a loaded parallel run reaches the idle threshold first — and the generation is cancelled for the wrong reason:

```
- generation.watchdog:lin-578-unstuck:1:no_material_progress_timeout:reflecting
+ generation.watchdog:lin-578-unstuck:1:idle_timeout:reflecting
```

The file already establishes a `_FakeMonotonicClock` idiom for this; these tests just did not use it. Simulated time now advances only from inside the work coroutine, so the thresholds are ordered by the scenario rather than by machine load.

`test_session_activity_resets_idle_timeout` is the inverse form of the same defect — it asserts the generation stays *alive* across four real 0.04s sleeps against a 0.07s idle threshold, so one scheduling hiccup failed it. It is now stepped deterministically, mirroring the sibling `test_parent_execution_child_events_reset_idle_timeout`.

## 2. `reset_logging()` left structlog louder than any configured state

`reset_logging()` ended with `structlog.reset_defaults()`, restoring the library defaults: every level emitted, through a `PrintLogger` bound to **stdout**. A configured Ouroboros logger filters at `LoggingConfig.log_level` and writes to **stderr**, so stdout stays reserved for command output.

Clearing `_configured` is supposed to make the next `get_logger()` reconfigure, but that never fires for the 68 `src` modules that bind a bare `structlog.get_logger` at import time — they keep logging through whatever the reset left behind. `tests/unit/observability/test_logging.py` calls `reset_logging()` from an autouse fixture, so it poisoned its xdist worker for every later test asserting on CLI output, and `mcp.tool.job_wait.*` debug lines landed in `result.output`.

The fix restores the default filter alongside the reset. `_configured` and `_current_config` still clear, so the next `get_logger()` performs a full reconfiguration.

## Verification

| Check | Result |
|---|---|
| Watchdog file, 20 runs under full CPU saturation — **before** | 1/20 failed (`test_busy_run_without_material_progress_times_out`, the test that failed on #1767) |
| Watchdog file, 20 runs under identical load — **after** | **0/20 failed** |
| Logging leak, deterministic repro (import CLI modules → `reset_logging()` → invoke `job wait`) | reproduced byte-identically to CI, then fixed |
| New regression test without the `logging.py` fix | fails |
| `tests/unit/{evolution,observability,cli,orchestrator}` | 5659 passed, 7 skipped |
| `ruff check` / `ruff format --check` / `mypy src/` | clean |

This changes no production behaviour: `reset_logging()` has no callers outside tests, and the real `ouroboros job wait` stdout was already clean because the CLI configures logging before anything logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)