### PR TITLE
fix(bigbang): lenient non-finite tokens default to 1.0 instead of sign-saturating (#1766)

### DIFF
--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -197,6 +197,13 @@ def _clamp_weight(raw_weight: object, *, field_label: str, strict: bool) -> floa
             raise ValueError(
                 f"{field_label} entry field 'weight' must be a number; got {raw_weight!r}."
             )
+        if isinstance(raw_weight, _JsonNonFiniteToken):
+            # Non-standard constants (NaN/Infinity/-Infinity) are not JSON
+            # numbers, so they take the documented 1.0 default rather than
+            # the sign-saturation reserved for genuine numeric overflow;
+            # without this check float(str(...)) below would turn a stored
+            # -Infinity literal into a 0.0 clamp (#1766).
+            return 1.0
         try:
             numeric = float(str(raw_weight).strip())
         except (ValueError, OverflowError):

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -1544,6 +1544,23 @@ class TestObjectArrayExtractionContract:
             ":description:0.5 | complete::0.4 | valid:Description:0.25"
         ) == (EvaluationPrinciple(name="valid", description="Description", weight=0.25),)
 
+    def test_lenient_nonfinite_tokens_all_default_to_one(self) -> None:
+        """#1766: every non-standard constant defaults to 1.0 in lenient mode.
+
+        The token marker must be recognized before numeric conversion so a
+        stored -Infinity literal is not conflated with genuine negative
+        overflow (which keeps saturating to 0.0 by sign).
+        """
+        for token in ("NaN", "Infinity", "-Infinity"):
+            principles = _parse_evaluation_principles(
+                f'[{{"name": "x", "description": "d", "weight": {token}}}]'
+            )
+            assert principles[0].weight == 1.0, f"token {token} did not default to 1.0"
+        overflow = _parse_evaluation_principles(
+            '[{"name": "x", "description": "d", "weight": -1e999}]'
+        )
+        assert overflow[0].weight == 0.0
+
     def test_weights_beyond_interpreter_digit_limit_never_raise(self) -> None:
         huge = "9" * 5000
         lenient = _parse_evaluation_principles(


### PR DESCRIPTION
## Summary

Follow-up on the weight parsing from #1762, fixing the lenient-path inconsistency described in #1766.

`_clamp_weight`'s lenient branch fell through to `float(str(raw_weight))` for `_JsonNonFiniteToken`, so a stored `-Infinity` literal became `-inf` and took the sign-saturation path to 0.0 — even though the marker's docstring promises the non-standard constants fall back to the default weight, unlike genuine numeric overflow. NaN and Infinity happened to land on 1.0 through that conversion, which is why the divergence only shows on the negative constant.

The fix recognizes the token before any numeric conversion and returns the documented 1.0 default in lenient mode. Strict extraction is unchanged (tokens still raise into the reformat retry), and genuine overflow — `-1e999` or a bounded-out integer — keeps saturating by sign.

## Test plan

- [x] New regression test pins all three constants (NaN/Infinity/-Infinity) to the 1.0 lenient default, alongside the preserved 0.0 saturation for `-1e999`
- [x] `uv run pytest tests/unit/bigbang -q` — 709 passed
- [x] `uv run pytest tests/ -q -n 4` — 14741 passed, 18 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ouroboros` — clean

Closes #1766
