### PR TITLE
fix(mcp): isolate PM and interview question generation from host MCP servers (#1768)

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -2093,9 +2093,12 @@ def create_ouroboros_server(
         agent_runtime_backend=execute_runtime_backend,
         opencode_mode=opencode_mode,
     )
+    # No shared-adapter injection for interview handlers: the injected stage
+    # adapter has no strict MCP isolation, and ``self.llm_adapter or ...``
+    # would bypass the handler's own strict factory (#765, #1768). Injection
+    # remains available for tests and custom wiring only.
     interview = InterviewHandler(
         event_store=event_store,
-        llm_adapter=llm_adapter,
         llm_backend=interview_llm_backend,
         agent_runtime_backend=interview_runtime_backend,
         opencode_mode=opencode_mode,
@@ -2189,7 +2192,6 @@ def create_ouroboros_server(
         InterviewHandler(
             interview_engine=interview_engine,
             event_store=event_store,
-            llm_adapter=llm_adapter,
             llm_backend=interview_llm_backend,
             agent_runtime_backend=interview_runtime_backend,
             opencode_mode=opencode_mode,
@@ -2197,7 +2199,6 @@ def create_ouroboros_server(
         ),
         PMInterviewHandler(
             data_dir=state_dir_path,
-            llm_adapter=llm_adapter,
             llm_backend=interview_llm_backend,
             event_store=event_store,
             agent_runtime_backend=interview_runtime_backend,

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -423,6 +423,11 @@ class PMInterviewHandler:
         if self.pm_engine is not None:
             return self.pm_engine
         backend = get_llm_backend_for_role("pm_interview", explicit_backend=self.llm_backend)
+        # ``strict_mcp_config=True`` mirrors InterviewHandler's #765 opt-in:
+        # the PM question-generation subprocess runs as a child of Claude
+        # Code's MCP host, and without strict isolation it re-discovers every
+        # plugin/project MCP server — under a heavy harness the front-loaded
+        # catalog alone overflows the context from round two (#1768).
         adapter = self.llm_adapter or create_llm_adapter(
             backend=backend,
             max_turns=1,
@@ -430,6 +435,7 @@ class PMInterviewHandler:
             allowed_tools=[]
             if backend_supports_tool_envelope(resolve_llm_backend(backend))
             else None,
+            strict_mcp_config=True,
         )
         model = get_llm_model_for_role("pm_interview", backend=backend)
         return PMInterviewEngine.create(

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -649,6 +649,7 @@ class TestGetEngine:
                 max_turns=1,
                 use_case="interview",
                 allowed_tools=[],
+                strict_mcp_config=True,
             )
             mock_engine_cls.create.assert_called_once()
             call_kwargs = mock_engine_cls.create.call_args
@@ -674,6 +675,7 @@ class TestGetEngine:
                 max_turns=1,
                 use_case="interview",
                 allowed_tools=None,
+                strict_mcp_config=True,
             )
 
     def test_omits_tool_envelope_for_configured_hermes_backend(self) -> None:
@@ -700,6 +702,7 @@ class TestGetEngine:
                 max_turns=1,
                 use_case="interview",
                 allowed_tools=None,
+                strict_mcp_config=True,
             )
 
     def test_uses_custom_data_dir(self, tmp_path: Path) -> None:

--- a/tests/unit/mcp/tools/test_pm_interview_strict_isolation.py
+++ b/tests/unit/mcp/tools/test_pm_interview_strict_isolation.py
@@ -1,0 +1,76 @@
+"""Wiring locks for #1768: PM interview strict-MCP isolation.
+
+Two layers regressed together: ``PMInterviewHandler._get_engine()`` missed
+the ``strict_mcp_config=True`` opt-in that ``InterviewHandler`` gained in
+#765, and the production server assembly injected the shared stage adapter
+into both interview handlers — which short-circuits the strict factory path
+entirely (``self.llm_adapter or create_llm_adapter(...)``). Under a heavy
+Claude Code harness the un-isolated question-generation subprocess then
+front-loads every plugin MCP server and dies with ``Prompt is too long``
+from round two.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
+
+
+class TestPMEngineStrictOptIn:
+    def test_get_engine_requests_strict_mcp_config(self, tmp_path) -> None:
+        handler = PMInterviewHandler(data_dir=tmp_path)
+
+        with (
+            patch("ouroboros.mcp.tools.pm_handler.create_llm_adapter") as create_adapter,
+            patch("ouroboros.mcp.tools.pm_handler.PMInterviewEngine") as engine_cls,
+        ):
+            create_adapter.return_value = MagicMock()
+            engine_cls.create.return_value = MagicMock()
+            handler._get_engine()
+
+        assert create_adapter.call_count == 1
+        kwargs = create_adapter.call_args.kwargs
+        assert kwargs.get("strict_mcp_config") is True
+
+
+class TestProductionAssemblyLeavesHandlersIsolated:
+    """The shared stage adapter must not be injected into interview handlers.
+
+    With an injected adapter the strict factory branch never runs, so the
+    per-handler opt-in is dead code on the MCP-server path — the exact
+    production shape the issue reproduces.
+    """
+
+    def test_interview_handlers_have_no_injected_adapter(self) -> None:
+        from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+        server = create_ouroboros_server()
+        interview_handlers = [
+            handler
+            for handler in server._tool_handlers.values()
+            if isinstance(handler, (InterviewHandler, PMInterviewHandler))
+        ]
+        assert interview_handlers, "no interview handlers registered"
+        for handler in interview_handlers:
+            assert handler.llm_adapter is None, (
+                f"{type(handler).__name__} received the shared stage adapter; "
+                "the strict-isolation factory path is unreachable"
+            )
+
+    def test_auto_path_interview_handler_has_no_injected_adapter(self) -> None:
+        from ouroboros.mcp.server.adapter import create_ouroboros_server
+        from ouroboros.mcp.tools.auto_handler import AutoHandler
+
+        server = create_ouroboros_server()
+        auto = next(
+            (
+                handler
+                for handler in server._tool_handlers.values()
+                if isinstance(handler, AutoHandler)
+            ),
+            None,
+        )
+        assert auto is not None, "AutoHandler not registered"
+        assert auto.interview_handler.llm_adapter is None


### PR DESCRIPTION
## Summary

Fixes #1768 following the report's two-layer diagnosis (which made this straightforward to confirm — thank you for the write-up).

**Layer 1 — missing sibling opt-in.** `PMInterviewHandler._get_engine()` now passes `strict_mcp_config=True`, mirroring the #765 opt-in in `InterviewHandler._create_interview_engine()` and its rationale comment: the PM question-generation subprocess runs as a child of Claude Code's MCP host, and without strict isolation it re-discovers every plugin/project MCP server — under a heavy harness the front-loaded catalog alone overflows the context from round two.

**Layer 2 — production injection made the opt-in unreachable.** `create_ouroboros_server()` injected the shared stage adapter into the interview handlers, and with the `self.llm_adapter or create_llm_adapter(...)` pattern an injected adapter short-circuits the strict factory branch entirely. The three interview injections are removed — the Auto-path `InterviewHandler`, the tool-registry `InterviewHandler`, and `PMInterviewHandler` — so each handler builds its own isolated adapter, matching the failed bot attempt's scope (regular/PM/Auto). Injection remains for tests and custom wiring; the shared adapter keeps serving non-interview consumers (seed generation, the shared `InterviewEngine` used for state operations).

## Test plan

- [x] New wiring locks: `_get_engine()` must request `strict_mcp_config=True`; the assembled server's interview handlers (tool registry and the Auto path's `interview_handler`) must carry no injected adapter — all three verified failing before the fix
- [x] Existing `_get_engine` kwargs assertions updated to the new contract
- [x] `uv run pytest tests/unit/mcp -q` — 1417 passed (rebased onto current main; branch carries only this change)
- [x] `uv run pytest tests/ -q -n 4` — 14743 passed, 18 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ouroboros` — clean
