### PR TITLE
perf(project-map): share the git capability probe per session start (#1796 L1)

### DIFF
--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 import os
 from pathlib import Path, PurePosixPath
 import re
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -235,17 +236,26 @@ def _git_environment() -> dict[str, str]:
     return environment
 
 
-def _run_git_command(*arguments: str) -> bytes:
+def _run_git_command(*arguments: str, executable: str | None = None) -> bytes:
     """Run one bounded, non-interactive Git command and return complete stdout.
 
     A nonzero exit is unavailable because Git does not expose a portable
     exit-code distinction between malformed topology and transient repository
-    I/O.
+    I/O. Inside a capability probe scope every command binds to the executable
+    that scope verified; outside one, ``git`` resolves from PATH per call as
+    it always has.
     """
+    if executable is None:
+        scope_cell = _active_probe_scope()
+        executable = (
+            scope_cell.executable
+            if scope_cell is not None and scope_cell.executable is not None
+            else "git"
+        )
     try:
         with tempfile.TemporaryFile() as output:
             completed = subprocess.run(
-                ["git", *arguments],
+                [executable, *arguments],
                 check=False,
                 stdin=subprocess.DEVNULL,
                 stdout=output,
@@ -273,13 +283,40 @@ def _run_git(start: Path, *arguments: str) -> bytes:
     return _run_git_command("-C", str(start), *arguments)
 
 
-# ``None`` = no scope: every call probes, exactly as before #1796. An open
-# scope carries a single-element mutable cell — resolutions inside the scope
-# frequently run under ``asyncio.to_thread``, whose copied context shares the
-# cell object, so a verification recorded in a worker thread is visible to
-# the scope's later resolutions while still evaporating with the scope.
-# Concurrent tasks get their own cells, so they cannot observe each other.
-_PROBE_SCOPE: ContextVar[list[bool] | None] = ContextVar("git_capability_probe_scope", default=None)
+class _ProbeScopeCell:
+    """Mutable scope state shared across context copies.
+
+    ``executable`` holds the verified absolute path once the scope's single
+    probe succeeds; every scoped git command binds to it. ``closed`` is set
+    on scope exit — the cell object is shared by reference with any context
+    copies (``asyncio.to_thread`` workers, escaped child tasks), so closing
+    it revokes the scope's trust everywhere at once.
+
+    Today's only scope (``prepare_session``) resolves sequentially; two
+    concurrent cold resolutions in one scope would issue duplicate probes,
+    which is benign (never stale) and intentionally unsynchronized — no lock
+    means nothing to inherit across ``fork()``.
+    """
+
+    __slots__ = ("closed", "executable")
+
+    def __init__(self) -> None:
+        self.executable: str | None = None
+        self.closed = False
+
+
+# ``None`` = no scope: every call probes and every command resolves ``git``
+# from PATH, exactly as before #1796.
+_PROBE_SCOPE: ContextVar[_ProbeScopeCell | None] = ContextVar(
+    "git_capability_probe_scope", default=None
+)
+
+
+def _active_probe_scope() -> _ProbeScopeCell | None:
+    cell = _PROBE_SCOPE.get()
+    if cell is None or cell.closed:
+        return None
+    return cell
 
 
 @contextmanager
@@ -289,25 +326,42 @@ def git_capability_probe_scope() -> Iterator[None]:
     A session start resolves project identity at least twice — once while the
     execution contract is built and again at the publication boundary — and
     each resolution re-ran ``git --version`` (#1796). Within one scope the
-    probe runs once; the reuse window is the same class the per-resolution
-    design already accepts between its own probe and topology queries, so no
-    cross-time cache (and none of its integrity obligations: executable
-    binding, shim detection, fork-safe locking) is introduced. Outside any
-    scope, behavior is unchanged: every resolution probes.
+    probe runs once and every scoped git command binds to the executable it
+    verified, so a later resolver skipping its own probe can never run a
+    different binary than the one proven supported. The reuse window is the
+    same class the per-resolution design already accepts between its own
+    probe and its topology queries; no cross-time cache is introduced, and
+    the scope's trust is revoked on exit even for escaped tasks. Outside any
+    scope, behavior is unchanged: every resolution probes and every command
+    resolves ``git`` from PATH.
     """
-    token = _PROBE_SCOPE.set([False])
+    cell = _ProbeScopeCell()
+    token = _PROBE_SCOPE.set(cell)
     try:
         yield
     finally:
+        # Close the shared cell before resetting: context copies in worker
+        # threads or escaped child tasks hold the same object, and nothing
+        # may outlive the scope (#1796 review round six).
+        cell.closed = True
         _PROBE_SCOPE.reset(token)
 
 
 def _require_supported_git() -> None:
     """Reject Git versions that lack the unambiguous topology query grammar."""
-    scope_cell = _PROBE_SCOPE.get()
-    if scope_cell is not None and scope_cell[0]:
-        return
-    output = _run_git_command("--version")
+    scope_cell = _active_probe_scope()
+    executable: str | None = None
+    if scope_cell is not None:
+        if scope_cell.executable is not None:
+            return
+        # Resolve the binary once and probe exactly that path; scoped commands
+        # then bind to it, so a later resolver skipping its own probe cannot
+        # run a different git than the one verified here (round six).
+        resolved = shutil.which("git")
+        if resolved is None:
+            raise ProjectIdentityUnavailableError("Git executable is unavailable on PATH")
+        executable = os.path.abspath(resolved)
+    output = _run_git_command("--version", executable=executable)
     match = _GIT_VERSION_PATTERN.fullmatch(output)
     if match is None:
         raise ProjectIdentityGitVersionError(
@@ -321,8 +375,8 @@ def _require_supported_git() -> None:
             f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
             f"found {found}"
         )
-    if scope_cell is not None:
-        scope_cell[0] = True
+    if scope_cell is not None and not scope_cell.closed:
+        scope_cell.executable = executable
 
 
 def _git_path(output: bytes) -> Path:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -16,6 +16,7 @@ import shutil
 import stat
 import subprocess
 import tempfile
+import threading
 from uuid import NAMESPACE_URL, uuid5
 
 PROJECT_ID_PREFIX = "project_"
@@ -274,12 +275,28 @@ def _run_git(start: Path, *arguments: str) -> bytes:
 
 
 _verified_git_key: tuple[str, int, int, int, int] | None = None
+_git_probe_lock = threading.Lock()
 
 
 def _reset_git_capability_cache_for_tests() -> None:
     """Clear the capability cache (test isolation only)."""
     global _verified_git_key
     _verified_git_key = None
+
+
+def _is_capability_cacheable(executable: str) -> bool:
+    """Only a native binary's capability is pinned by its file metadata.
+
+    A version-manager shim keeps a stable path/device/inode/mtime while
+    delegating to whatever Git its external configuration currently selects,
+    so a script's metadata proves nothing about capability — scripts
+    (shebang-led files) are probed on every gate call (review round four).
+    """
+    try:
+        with open(executable, "rb") as handle:
+            return handle.read(2) != b"#!"
+    except OSError as exc:
+        raise ProjectIdentityUnavailableError("Git executable is unavailable") from exc
 
 
 def _current_git_key() -> tuple[str, int, int, int, int]:
@@ -319,26 +336,32 @@ def _require_supported_git() -> None:
     """
     global _verified_git_key
     current_key = _current_git_key()
-    if _verified_git_key == current_key:
+    cacheable = _is_capability_cacheable(current_key[0])
+    if cacheable and _verified_git_key == current_key:
         return
-    # Probe the exact executable the key resolved: PATH is process-global and
-    # mutable, so a second lookup inside the probe could verify a different
-    # binary than the one this key represents.
-    output = _run_git_command("--version", executable=current_key[0])
-    match = _GIT_VERSION_PATTERN.fullmatch(output)
-    if match is None:
-        raise ProjectIdentityGitVersionError(
-            f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity"
-        )
-    major, minor, patch = match.groups()
-    version = (int(major), int(minor), int(patch or b"0"))
-    if version < _MINIMUM_GIT_VERSION:
-        found = ".".join(str(part) for part in version)
-        raise ProjectIdentityGitVersionError(
-            f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
-            f"found {found}"
-        )
-    _verified_git_key = current_key
+    # Single-flight: concurrent cold callers must not spawn duplicate probes.
+    with _git_probe_lock:
+        if cacheable and _verified_git_key == current_key:
+            return
+        # Probe the exact executable the key resolved: PATH is process-global
+        # and mutable, so a second lookup inside the probe could verify a
+        # different binary than the one this key represents.
+        output = _run_git_command("--version", executable=current_key[0])
+        match = _GIT_VERSION_PATTERN.fullmatch(output)
+        if match is None:
+            raise ProjectIdentityGitVersionError(
+                f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity"
+            )
+        major, minor, patch = match.groups()
+        version = (int(major), int(minor), int(patch or b"0"))
+        if version < _MINIMUM_GIT_VERSION:
+            found = ".".join(str(part) for part in version)
+            raise ProjectIdentityGitVersionError(
+                f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project "
+                f"identity; found {found}"
+            )
+        if cacheable:
+            _verified_git_key = current_key
 
 
 def _git_path(output: bytes) -> Path:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -12,10 +12,10 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+import hashlib
 import os
 from pathlib import Path, PurePosixPath
 import re
-import shutil
 import stat
 import subprocess
 import tempfile
@@ -236,26 +236,17 @@ def _git_environment() -> dict[str, str]:
     return environment
 
 
-def _run_git_command(*arguments: str, executable: str | None = None) -> bytes:
+def _run_git_command(*arguments: str) -> bytes:
     """Run one bounded, non-interactive Git command and return complete stdout.
 
     A nonzero exit is unavailable because Git does not expose a portable
     exit-code distinction between malformed topology and transient repository
-    I/O. Inside a capability probe scope every command binds to the executable
-    that scope verified; outside one, ``git`` resolves from PATH per call as
-    it always has.
+    I/O.
     """
-    if executable is None:
-        scope_cell = _active_probe_scope()
-        executable = (
-            scope_cell.executable
-            if scope_cell is not None and scope_cell.executable is not None
-            else "git"
-        )
     try:
         with tempfile.TemporaryFile() as output:
             completed = subprocess.run(
-                [executable, *arguments],
+                ["git", *arguments],
                 check=False,
                 stdin=subprocess.DEVNULL,
                 stdout=output,
@@ -283,85 +274,9 @@ def _run_git(start: Path, *arguments: str) -> bytes:
     return _run_git_command("-C", str(start), *arguments)
 
 
-class _ProbeScopeCell:
-    """Mutable scope state shared across context copies.
-
-    ``executable`` holds the verified absolute path once the scope's single
-    probe succeeds; every scoped git command binds to it. ``closed`` is set
-    on scope exit — the cell object is shared by reference with any context
-    copies (``asyncio.to_thread`` workers, escaped child tasks), so closing
-    it revokes the scope's trust everywhere at once.
-
-    Today's only scope (``prepare_session``) resolves sequentially; two
-    concurrent cold resolutions in one scope would issue duplicate probes,
-    which is benign (never stale) and intentionally unsynchronized — no lock
-    means nothing to inherit across ``fork()``.
-    """
-
-    __slots__ = ("closed", "executable")
-
-    def __init__(self) -> None:
-        self.executable: str | None = None
-        self.closed = False
-
-
-# ``None`` = no scope: every call probes and every command resolves ``git``
-# from PATH, exactly as before #1796.
-_PROBE_SCOPE: ContextVar[_ProbeScopeCell | None] = ContextVar(
-    "git_capability_probe_scope", default=None
-)
-
-
-def _active_probe_scope() -> _ProbeScopeCell | None:
-    cell = _PROBE_SCOPE.get()
-    if cell is None or cell.closed:
-        return None
-    return cell
-
-
-@contextmanager
-def git_capability_probe_scope() -> Iterator[None]:
-    """Share one Git capability probe across the resolutions in this scope.
-
-    A session start resolves project identity at least twice — once while the
-    execution contract is built and again at the publication boundary — and
-    each resolution re-ran ``git --version`` (#1796). Within one scope the
-    probe runs once and every scoped git command binds to the executable it
-    verified, so a later resolver skipping its own probe can never run a
-    different binary than the one proven supported. The reuse window is the
-    same class the per-resolution design already accepts between its own
-    probe and its topology queries; no cross-time cache is introduced, and
-    the scope's trust is revoked on exit even for escaped tasks. Outside any
-    scope, behavior is unchanged: every resolution probes and every command
-    resolves ``git`` from PATH.
-    """
-    cell = _ProbeScopeCell()
-    token = _PROBE_SCOPE.set(cell)
-    try:
-        yield
-    finally:
-        # Close the shared cell before resetting: context copies in worker
-        # threads or escaped child tasks hold the same object, and nothing
-        # may outlive the scope (#1796 review round six).
-        cell.closed = True
-        _PROBE_SCOPE.reset(token)
-
-
 def _require_supported_git() -> None:
     """Reject Git versions that lack the unambiguous topology query grammar."""
-    scope_cell = _active_probe_scope()
-    executable: str | None = None
-    if scope_cell is not None:
-        if scope_cell.executable is not None:
-            return
-        # Resolve the binary once and probe exactly that path; scoped commands
-        # then bind to it, so a later resolver skipping its own probe cannot
-        # run a different git than the one verified here (round six).
-        resolved = shutil.which("git")
-        if resolved is None:
-            raise ProjectIdentityUnavailableError("Git executable is unavailable on PATH")
-        executable = os.path.abspath(resolved)
-    output = _run_git_command("--version", executable=executable)
+    output = _run_git_command("--version")
     match = _GIT_VERSION_PATTERN.fullmatch(output)
     if match is None:
         raise ProjectIdentityGitVersionError(
@@ -375,8 +290,6 @@ def _require_supported_git() -> None:
             f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
             f"found {found}"
         )
-    if scope_cell is not None and not scope_cell.closed:
-        scope_cell.executable = executable
 
 
 def _git_path(output: bytes) -> Path:
@@ -591,12 +504,257 @@ def _resolve_canonical_project_identity(effective: Path) -> _ResolvedProjectIden
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _TopologyFileEvidence:
+    """Generation-plus-content proof for one repo-local topology input."""
+
+    path: Path
+    kind: str  # "missing" | "file" | "dir"
+    device: int = 0
+    inode: int = 0
+    mtime_ns: int = 0
+    size: int = 0
+    content_hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationEvidence:
+    """Everything needed to accept a publication identity without Git.
+
+    Captured right after a successful direct resolution. ``escalate`` is set
+    whenever the checkout shape falls outside the enumerable input closure
+    (bare repositories, markerless discovery, config include directives,
+    unreadable inputs) — the publication boundary must then run the full
+    re-resolution exactly as before. The fast path may accept only when every
+    captured input is byte-for-byte stable, so it is fail-closed by
+    construction and runs no Git subprocess at all — which vacuously
+    satisfies the V1 rule that resolvers validate Git before topology
+    queries: there are none.
+    """
+
+    identity: ProjectIdentity
+    effective_directory: Path
+    directory_evidence: tuple[_LiveDirectoryEvidence, ...]
+    file_evidence: tuple[_TopologyFileEvidence, ...]
+    escalate: bool
+
+
+_CONFIG_INCLUDE_PATTERN = re.compile(rb"^\s*\[include", re.IGNORECASE | re.MULTILINE)
+_TOPOLOGY_HASH_LIMIT = 1 << 20
+
+
+def _capture_topology_file(path: Path, *, hash_content: bool) -> _TopologyFileEvidence:
+    """Capture one repo-local topology input, raising on unclassifiable shapes."""
+    try:
+        status = path.lstat()
+    except FileNotFoundError:
+        return _TopologyFileEvidence(path=path, kind="missing")
+    except OSError as exc:
+        raise ProjectIdentityUnavailableError("topology input is unreadable") from exc
+    if stat.S_ISDIR(status.st_mode):
+        return _TopologyFileEvidence(
+            path=path,
+            kind="dir",
+            device=status.st_dev,
+            inode=status.st_ino,
+            mtime_ns=status.st_mtime_ns,
+            size=0,
+        )
+    if not stat.S_ISREG(status.st_mode):
+        raise ProjectIdentityUnavailableError("topology input has an unsupported shape")
+    digest: str | None = None
+    if hash_content:
+        if status.st_size > _TOPOLOGY_HASH_LIMIT:
+            raise ProjectIdentityUnavailableError("topology input exceeds its bound")
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            raise ProjectIdentityUnavailableError("topology input is unreadable") from exc
+        if path.name == "config" and _CONFIG_INCLUDE_PATTERN.search(content):
+            # Config includes pull unbounded external files into Git's
+            # decision; that closure is not enumerable, so never fast-path it.
+            raise ProjectIdentityUnavailableError("config includes are outside the closure")
+        digest = hashlib.sha256(content).hexdigest()
+    return _TopologyFileEvidence(
+        path=path,
+        kind="file",
+        device=status.st_dev,
+        inode=status.st_ino,
+        mtime_ns=status.st_mtime_ns,
+        size=status.st_size,
+        content_hash=digest,
+    )
+
+
+def _capture_publication_closure(
+    effective: Path, project_root: Path, checkout_root: Path
+) -> tuple[tuple[_TopologyFileEvidence, ...], bool]:
+    """Capture the repo-local input closure of the direct resolver's queries.
+
+    Returns the captured population and an escalate flag. The closure covers
+    exactly the inputs the five fixed topology queries consult for the
+    simple-checkout shape: every boundary candidate's ``.git`` marker between
+    the effective directory and the checkout root, and — when the marker is a
+    directory — its ``HEAD``, ``config``, ``commondir``, ``gitdir``, and the
+    ``worktrees`` registry with each entry's ``gitdir`` link. Anything the
+    capture cannot classify escalates.
+    """
+    population: list[_TopologyFileEvidence] = []
+    try:
+        marker = checkout_root / ".git"
+        marker_evidence = _capture_topology_file(marker, hash_content=True)
+        if marker_evidence.kind == "missing":
+            # Markerless discovery (bare candidates) is outside the closure.
+            return tuple(population), True
+        population.append(marker_evidence)
+        if marker_evidence.kind == "file":
+            # A gitdir-pointer checkout (linked worktree): the pointer content
+            # is hashed above, but the pointed-to administrative directory
+            # belongs to another tree whose closure we do not enumerate here.
+            return tuple(population), True
+        git_dir = marker
+        for name, hashed in (
+            ("HEAD", True),
+            ("config", True),
+            ("commondir", True),
+            ("gitdir", True),
+        ):
+            population.append(_capture_topology_file(git_dir / name, hash_content=hashed))
+        if population[-2].kind != "missing":
+            # A commondir file means this administrative directory belongs to
+            # a linked-worktree constellation; keep to the full re-resolution.
+            return tuple(population), True
+        worktrees = git_dir / "worktrees"
+        registry = _capture_topology_file(worktrees, hash_content=False)
+        population.append(registry)
+        if registry.kind == "dir":
+            try:
+                entries = sorted(entry.name for entry in worktrees.iterdir())
+            except OSError as exc:
+                raise ProjectIdentityUnavailableError("topology input is unreadable") from exc
+            for entry in entries:
+                population.append(
+                    _capture_topology_file(worktrees / entry / "gitdir", hash_content=True)
+                )
+        # Boundary candidates strictly between the effective directory and the
+        # checkout root: a new marker appearing there changes the nearest
+        # boundary, so their absence is part of the proof.
+        for candidate in (effective, *effective.parents):
+            if candidate == checkout_root:
+                break
+            population.append(_capture_topology_file(candidate / ".git", hash_content=True))
+        if project_root != checkout_root:
+            # The primary worktree was derived through Git; pin its marker too.
+            population.append(_capture_topology_file(project_root / ".git", hash_content=True))
+    except ProjectIdentityError:
+        return tuple(population), True
+    return tuple(population), False
+
+
+_EVIDENCE_SINK: ContextVar[list[PublicationEvidence | None] | None] = ContextVar(
+    "publication_evidence_sink", default=None
+)
+
+
+def active_publication_evidence_sink() -> list[PublicationEvidence | None] | None:
+    """Return the ambient evidence sink, if a publication scope is active."""
+    return _EVIDENCE_SINK.get()
+
+
+@contextmanager
+def publication_evidence_sink() -> Iterator[list[PublicationEvidence | None]]:
+    """Carry captured publication evidence out of a nested resolution.
+
+    Contract construction runs the resolver deep inside a worker thread; the
+    single-element mutable cell is shared by ``asyncio.to_thread`` context
+    copies, so evidence recorded there is visible to the caller afterwards.
+    The cell holds observations only — captured stat/hash metadata — never
+    capability trust, and it is discarded with the scope.
+    """
+    cell: list[PublicationEvidence | None] = [None]
+    token = _EVIDENCE_SINK.set(cell)
+    try:
+        yield cell
+    finally:
+        _EVIDENCE_SINK.reset(token)
+
+
+def resolve_project_identity_for_publication(
+    effective_cwd: str | Path,
+) -> tuple[ProjectIdentity, PublicationEvidence]:
+    """Resolve a direct identity and capture publication-reusable evidence.
+
+    Behaves exactly like :func:`resolve_project_identity`; additionally
+    captures the resolver's repo-local input closure so the publication
+    boundary can revalidate by metadata alone (#1796 L2). When the checkout
+    shape falls outside the enumerable closure, the returned evidence demands
+    escalation and publication re-resolves in full, exactly as before.
+    """
+    effective = _canonical_directory(effective_cwd, require_exists=True)
+    resolved = _resolve_with_evidence(effective)
+    file_evidence, escalate = _capture_publication_closure(
+        effective, Path(resolved.identity.project_root), resolved.checkout_root
+    )
+    return resolved.identity, PublicationEvidence(
+        identity=resolved.identity,
+        effective_directory=effective,
+        directory_evidence=resolved.directory_evidence,
+        file_evidence=file_evidence,
+        escalate=escalate,
+    )
+
+
+def publication_evidence_is_stable(
+    evidence: PublicationEvidence, effective_cwd: str | Path
+) -> bool:
+    """Return True only when every captured publication input is unchanged.
+
+    ``effective_cwd`` must canonicalize to the directory the evidence was
+    captured from — the proof is about that resolution and transfers to no
+    other workspace. Any doubt — an escalating capture, a changed or newly
+    unreadable input, a directory generation drift — returns False so the
+    caller escalates to the full re-resolution. This function runs no Git
+    subprocess.
+    """
+    if evidence.escalate:
+        return False
+    try:
+        effective = _canonical_directory(effective_cwd, require_exists=True)
+    except ProjectIdentityError:
+        return False
+    if effective != evidence.effective_directory:
+        return False
+    try:
+        _revalidate_live_directories(*evidence.directory_evidence)
+    except ProjectIdentityError:
+        return False
+    for expected in evidence.file_evidence:
+        try:
+            current = _capture_topology_file(
+                expected.path, hash_content=expected.content_hash is not None
+            )
+        except ProjectIdentityError:
+            return False
+        if current != expected:
+            return False
+    return True
+
+
 def _revalidate_live_directories(*expected_population: _LiveDirectoryEvidence) -> None:
     """Require every topology input and owner to remain the same live directory."""
     for expected in dict.fromkeys(expected_population):
         current = _capture_live_directory(expected.path)
         if current != expected:
             raise ProjectIdentityError("project identity path changed during resolution")
+
+
+def _resolve_with_evidence(effective: Path) -> _ResolvedProjectIdentity:
+    """Run the direct resolution pipeline and keep its evidence."""
+    effective_evidence = _capture_live_directory(effective)
+    _require_supported_git()
+    resolved = _resolve_canonical_project_identity(effective)
+    _revalidate_live_directories(effective_evidence, *resolved.directory_evidence)
+    return resolved
 
 
 def resolve_project_identity(effective_cwd: str | Path) -> ProjectIdentity:
@@ -611,11 +769,7 @@ def resolve_project_identity(effective_cwd: str | Path) -> ProjectIdentity:
     this direct resolver cannot attribute a caller-supplied source checkout.
     """
     effective = _canonical_directory(effective_cwd, require_exists=True)
-    effective_evidence = _capture_live_directory(effective)
-    _require_supported_git()
-    resolved = _resolve_canonical_project_identity(effective)
-    _revalidate_live_directories(effective_evidence, *resolved.directory_evidence)
-    return resolved.identity
+    return _resolve_with_evidence(effective).identity
 
 
 def _source_project_identity(

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import os
 from pathlib import Path, PurePosixPath
 import re
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -270,26 +271,48 @@ def _run_git(start: Path, *arguments: str) -> bytes:
     return _run_git_command("-C", str(start), *arguments)
 
 
-_git_capability_verified: bool = False
+_verified_git_key: tuple[str, int, int, int, int] | None = None
 
 
 def _reset_git_capability_cache_for_tests() -> None:
-    """Clear the process-lifetime capability cache (test isolation only)."""
-    global _git_capability_verified
-    _git_capability_verified = False
+    """Clear the capability cache (test isolation only)."""
+    global _verified_git_key
+    _verified_git_key = None
+
+
+def _current_git_key() -> tuple[str, int, int, int, int]:
+    """Identify the Git executable the next command would run.
+
+    The key binds the cached verification to the concrete binary selected by
+    the (mutable) ``PATH`` — resolved path plus its device, inode, and mtime —
+    and to the current PID so forked children re-verify. Resolving it costs
+    two syscalls, no subprocess.
+    """
+    executable = shutil.which("git")
+    if executable is None:
+        raise ProjectIdentityUnavailableError("Git executable is unavailable on PATH")
+    try:
+        status = os.stat(executable)
+    except OSError as exc:
+        raise ProjectIdentityUnavailableError("Git executable is unavailable") from exc
+    return (executable, status.st_dev, status.st_ino, status.st_mtime_ns, os.getpid())
 
 
 def _require_supported_git() -> None:
     """Reject Git versions that lack the unambiguous topology query grammar.
 
-    A successful probe is cached for the process lifetime: the installed Git
-    binary cannot meaningfully change within one process, and this gate runs
-    on every identity resolution — at least twice per session start (#1796).
-    Failures are never cached, so a transient spawn failure keeps re-probing
-    and a version rejection retains its original per-call semantics.
+    A successful probe is cached per executable identity (#1796): the gate
+    runs on every identity resolution — at least twice per session start —
+    and re-spawning ``git --version`` for an unchanged binary is pure waste.
+    The cache is bound to the concrete executable (path/device/inode/mtime)
+    and the PID, so a Git that disappears from ``PATH`` fails closed
+    immediately, a replaced binary is re-probed, and failures themselves are
+    never cached — a transient spawn failure keeps re-probing and a version
+    rejection retains its original per-call semantics.
     """
-    global _git_capability_verified
-    if _git_capability_verified:
+    global _verified_git_key
+    current_key = _current_git_key()
+    if _verified_git_key == current_key:
         return
     output = _run_git_command("--version")
     match = _GIT_VERSION_PATTERN.fullmatch(output)
@@ -305,7 +328,7 @@ def _require_supported_git() -> None:
             f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
             f"found {found}"
         )
-    _git_capability_verified = True
+    _verified_git_key = current_key
 
 
 def _git_path(output: bytes) -> Path:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -233,17 +233,19 @@ def _git_environment() -> dict[str, str]:
     return environment
 
 
-def _run_git_command(*arguments: str) -> bytes:
+def _run_git_command(*arguments: str, executable: str = "git") -> bytes:
     """Run one bounded, non-interactive Git command and return complete stdout.
 
     A nonzero exit is unavailable because Git does not expose a portable
     exit-code distinction between malformed topology and transient repository
-    I/O.
+    I/O. ``executable`` lets the capability gate probe the exact binary its
+    cache key resolved instead of racing a second mutable-PATH lookup
+    (#1796 review round two).
     """
     try:
         with tempfile.TemporaryFile() as output:
             completed = subprocess.run(
-                ["git", *arguments],
+                [executable, *arguments],
                 check=False,
                 stdin=subprocess.DEVNULL,
                 stdout=output,
@@ -285,8 +287,8 @@ def _current_git_key() -> tuple[str, int, int, int, int]:
 
     The key binds the cached verification to the concrete binary selected by
     the (mutable) ``PATH`` — resolved path plus its device, inode, and mtime —
-    and to the current PID so forked children re-verify. Resolving it costs
-    two syscalls, no subprocess.
+    and to the current PID so forked children re-verify. Resolving it is a
+    filesystem metadata lookup — no subprocess is spawned.
     """
     executable = shutil.which("git")
     if executable is None:
@@ -314,7 +316,10 @@ def _require_supported_git() -> None:
     current_key = _current_git_key()
     if _verified_git_key == current_key:
         return
-    output = _run_git_command("--version")
+    # Probe the exact executable the key resolved: PATH is process-global and
+    # mutable, so a second lookup inside the probe could verify a different
+    # binary than the one this key represents.
+    output = _run_git_command("--version", executable=current_key[0])
     match = _GIT_VERSION_PATTERN.fullmatch(output)
     if match is None:
         raise ProjectIdentityGitVersionError(

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -270,8 +270,27 @@ def _run_git(start: Path, *arguments: str) -> bytes:
     return _run_git_command("-C", str(start), *arguments)
 
 
+_git_capability_verified: bool = False
+
+
+def _reset_git_capability_cache_for_tests() -> None:
+    """Clear the process-lifetime capability cache (test isolation only)."""
+    global _git_capability_verified
+    _git_capability_verified = False
+
+
 def _require_supported_git() -> None:
-    """Reject Git versions that lack the unambiguous topology query grammar."""
+    """Reject Git versions that lack the unambiguous topology query grammar.
+
+    A successful probe is cached for the process lifetime: the installed Git
+    binary cannot meaningfully change within one process, and this gate runs
+    on every identity resolution — at least twice per session start (#1796).
+    Failures are never cached, so a transient spawn failure keeps re-probing
+    and a version rejection retains its original per-call semantics.
+    """
+    global _git_capability_verified
+    if _git_capability_verified:
+        return
     output = _run_git_command("--version")
     match = _GIT_VERSION_PATTERN.fullmatch(output)
     if match is None:
@@ -286,6 +305,7 @@ def _require_supported_git() -> None:
             f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
             f"found {found}"
         )
+    _git_capability_verified = True
 
 
 def _git_path(output: bytes) -> Path:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -20,6 +20,7 @@ import stat
 import subprocess
 import tempfile
 from uuid import NAMESPACE_URL, uuid5
+import weakref
 
 PROJECT_ID_PREFIX = "project_"
 _MAX_PATH_LENGTH = 4096
@@ -517,7 +518,7 @@ class _TopologyFileEvidence:
     content_hash: str | None = None
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, weakref_slot=True)
 class PublicationEvidence:
     """Everything needed to accept a publication identity without Git.
 
@@ -669,6 +670,29 @@ def active_publication_evidence_sink() -> list[PublicationEvidence | None] | Non
     return _EVIDENCE_SINK.get()
 
 
+def active_publication_evidence() -> PublicationEvidence | None:
+    """Return the evidence the resolver deposited in the active scope, if any."""
+    sink = _EVIDENCE_SINK.get()
+    if sink is None:
+        return None
+    return sink[0]
+
+
+# Evidence is trusted by issuance, not by shape: only the exact objects this
+# module created during a successful resolution are registered, keyed by
+# object identity and compared with ``is``. A caller-assembled object — even
+# one whose captured entries all match the live filesystem — was never
+# issued and is refused before any structural check runs. Weak values keep
+# the registry from outliving the evidence itself.
+_ISSUED_EVIDENCE: weakref.WeakValueDictionary[int, PublicationEvidence] = (
+    weakref.WeakValueDictionary()
+)
+
+
+def _evidence_is_resolver_issued(evidence: PublicationEvidence) -> bool:
+    return _ISSUED_EVIDENCE.get(id(evidence)) is evidence
+
+
 @contextmanager
 def publication_evidence_sink() -> Iterator[list[PublicationEvidence | None]]:
     """Carry captured publication evidence out of a nested resolution.
@@ -734,13 +758,18 @@ def resolve_project_identity_for_publication(
         if not post_escalate and post_files == pre_files:
             file_evidence = post_files
             escalate = False
-    return resolved.identity, PublicationEvidence(
+    evidence = PublicationEvidence(
         identity=resolved.identity,
         effective_directory=effective,
         directory_evidence=resolved.directory_evidence,
         file_evidence=file_evidence,
         escalate=escalate,
     )
+    _ISSUED_EVIDENCE[id(evidence)] = evidence
+    sink = _EVIDENCE_SINK.get()
+    if sink is not None:
+        sink[0] = evidence
+    return resolved.identity, evidence
 
 
 def publication_evidence_is_stable(
@@ -748,13 +777,18 @@ def publication_evidence_is_stable(
 ) -> bool:
     """Return True only when every captured publication input is unchanged.
 
-    ``effective_cwd`` must canonicalize to the directory the evidence was
-    captured from — the proof is about that resolution and transfers to no
-    other workspace. Any doubt — an escalating capture, a changed or newly
+    Only evidence this module itself issued is considered at all — a
+    caller-assembled object is refused regardless of its contents, because a
+    structural match can prove only the current filesystem state, never that
+    Git produced the claimed identity from it. ``effective_cwd`` must
+    canonicalize to the directory the evidence was captured from — the proof
+    is about that resolution and transfers to no other workspace. Any doubt — an escalating capture, a changed or newly
     unreadable input, a directory generation drift — returns False so the
     caller escalates to the full re-resolution. This function runs no Git
     subprocess.
     """
+    if not _evidence_is_resolver_issued(evidence):
+        return False
     if evidence.escalate:
         return False
     try:
@@ -808,6 +842,8 @@ def _publication_closure_is_complete(evidence: PublicationEvidence) -> bool:
     for name in _GIT_DIR_CLOSURE_NAMES:
         if git_dir / name not in captured:
             return False
+    if captured[git_dir / "HEAD"].kind != "file":
+        return False
     if captured[git_dir / "commondir"].kind != "missing":
         return False
     registry = captured.get(git_dir / "worktrees")

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -8,15 +8,16 @@ repository while retaining a repository-relative workspace filter.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 import os
 from pathlib import Path, PurePosixPath
 import re
-import shutil
 import stat
 import subprocess
 import tempfile
-import threading
 from uuid import NAMESPACE_URL, uuid5
 
 PROJECT_ID_PREFIX = "project_"
@@ -234,19 +235,17 @@ def _git_environment() -> dict[str, str]:
     return environment
 
 
-def _run_git_command(*arguments: str, executable: str = "git") -> bytes:
+def _run_git_command(*arguments: str) -> bytes:
     """Run one bounded, non-interactive Git command and return complete stdout.
 
     A nonzero exit is unavailable because Git does not expose a portable
     exit-code distinction between malformed topology and transient repository
-    I/O. ``executable`` lets the capability gate probe the exact binary its
-    cache key resolved instead of racing a second mutable-PATH lookup
-    (#1796 review round two).
+    I/O.
     """
     try:
         with tempfile.TemporaryFile() as output:
             completed = subprocess.run(
-                [executable, *arguments],
+                ["git", *arguments],
                 check=False,
                 stdin=subprocess.DEVNULL,
                 stdout=output,
@@ -274,94 +273,56 @@ def _run_git(start: Path, *arguments: str) -> bytes:
     return _run_git_command("-C", str(start), *arguments)
 
 
-_verified_git_key: tuple[str, int, int, int, int] | None = None
-_git_probe_lock = threading.Lock()
+# ``None`` = no scope: every call probes, exactly as before #1796. An open
+# scope carries a single-element mutable cell — resolutions inside the scope
+# frequently run under ``asyncio.to_thread``, whose copied context shares the
+# cell object, so a verification recorded in a worker thread is visible to
+# the scope's later resolutions while still evaporating with the scope.
+# Concurrent tasks get their own cells, so they cannot observe each other.
+_PROBE_SCOPE: ContextVar[list[bool] | None] = ContextVar("git_capability_probe_scope", default=None)
 
 
-def _reset_git_capability_cache_for_tests() -> None:
-    """Clear the capability cache (test isolation only)."""
-    global _verified_git_key
-    _verified_git_key = None
+@contextmanager
+def git_capability_probe_scope() -> Iterator[None]:
+    """Share one Git capability probe across the resolutions in this scope.
 
-
-def _is_capability_cacheable(executable: str) -> bool:
-    """Only a native binary's capability is pinned by its file metadata.
-
-    A version-manager shim keeps a stable path/device/inode/mtime while
-    delegating to whatever Git its external configuration currently selects,
-    so a script's metadata proves nothing about capability — scripts
-    (shebang-led files) are probed on every gate call (review round four).
+    A session start resolves project identity at least twice — once while the
+    execution contract is built and again at the publication boundary — and
+    each resolution re-ran ``git --version`` (#1796). Within one scope the
+    probe runs once; the reuse window is the same class the per-resolution
+    design already accepts between its own probe and topology queries, so no
+    cross-time cache (and none of its integrity obligations: executable
+    binding, shim detection, fork-safe locking) is introduced. Outside any
+    scope, behavior is unchanged: every resolution probes.
     """
+    token = _PROBE_SCOPE.set([False])
     try:
-        with open(executable, "rb") as handle:
-            return handle.read(2) != b"#!"
-    except OSError as exc:
-        raise ProjectIdentityUnavailableError("Git executable is unavailable") from exc
-
-
-def _current_git_key() -> tuple[str, int, int, int, int]:
-    """Identify the Git executable the next command would run.
-
-    The key binds the cached verification to the concrete binary selected by
-    the (mutable) ``PATH`` — resolved path plus its device, inode, and mtime —
-    and to the current PID so forked children re-verify. Resolving it is a
-    filesystem metadata lookup — no subprocess is spawned.
-    """
-    executable = shutil.which("git")
-    if executable is None:
-        raise ProjectIdentityUnavailableError("Git executable is unavailable on PATH")
-    # shutil.which() can return a relative path (an empty or relative PATH
-    # entry resolves against the mutable process cwd); anchor the selection
-    # to an absolute path so stat and execution refer to the same binary
-    # regardless of later cwd changes (review round three).
-    executable = os.path.abspath(executable)
-    try:
-        status = os.stat(executable)
-    except OSError as exc:
-        raise ProjectIdentityUnavailableError("Git executable is unavailable") from exc
-    return (executable, status.st_dev, status.st_ino, status.st_mtime_ns, os.getpid())
+        yield
+    finally:
+        _PROBE_SCOPE.reset(token)
 
 
 def _require_supported_git() -> None:
-    """Reject Git versions that lack the unambiguous topology query grammar.
-
-    A successful probe is cached per executable identity (#1796): the gate
-    runs on every identity resolution — at least twice per session start —
-    and re-spawning ``git --version`` for an unchanged binary is pure waste.
-    The cache is bound to the concrete executable (path/device/inode/mtime)
-    and the PID, so a Git that disappears from ``PATH`` fails closed
-    immediately, a replaced binary is re-probed, and failures themselves are
-    never cached — a transient spawn failure keeps re-probing and a version
-    rejection retains its original per-call semantics.
-    """
-    global _verified_git_key
-    current_key = _current_git_key()
-    cacheable = _is_capability_cacheable(current_key[0])
-    if cacheable and _verified_git_key == current_key:
+    """Reject Git versions that lack the unambiguous topology query grammar."""
+    scope_cell = _PROBE_SCOPE.get()
+    if scope_cell is not None and scope_cell[0]:
         return
-    # Single-flight: concurrent cold callers must not spawn duplicate probes.
-    with _git_probe_lock:
-        if cacheable and _verified_git_key == current_key:
-            return
-        # Probe the exact executable the key resolved: PATH is process-global
-        # and mutable, so a second lookup inside the probe could verify a
-        # different binary than the one this key represents.
-        output = _run_git_command("--version", executable=current_key[0])
-        match = _GIT_VERSION_PATTERN.fullmatch(output)
-        if match is None:
-            raise ProjectIdentityGitVersionError(
-                f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity"
-            )
-        major, minor, patch = match.groups()
-        version = (int(major), int(minor), int(patch or b"0"))
-        if version < _MINIMUM_GIT_VERSION:
-            found = ".".join(str(part) for part in version)
-            raise ProjectIdentityGitVersionError(
-                f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project "
-                f"identity; found {found}"
-            )
-        if cacheable:
-            _verified_git_key = current_key
+    output = _run_git_command("--version")
+    match = _GIT_VERSION_PATTERN.fullmatch(output)
+    if match is None:
+        raise ProjectIdentityGitVersionError(
+            f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity"
+        )
+    major, minor, patch = match.groups()
+    version = (int(major), int(minor), int(patch or b"0"))
+    if version < _MINIMUM_GIT_VERSION:
+        found = ".".join(str(part) for part in version)
+        raise ProjectIdentityGitVersionError(
+            f"Git {_MINIMUM_GIT_VERSION_TEXT} or newer is required for project identity; "
+            f"found {found}"
+        )
+    if scope_cell is not None:
+        scope_cell[0] = True
 
 
 def _git_path(output: bytes) -> Path:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -539,7 +539,13 @@ class PublicationEvidence:
     escalate: bool
 
 
-_CONFIG_INCLUDE_PATTERN = re.compile(rb"^\s*\[include", re.IGNORECASE | re.MULTILINE)
+# A valid include or includeIf section header must contain these bytes, in
+# any position, casing, or after a BOM — so searching the raw content without
+# anchors over-approximates Git's config grammar instead of reimplementing
+# it. False positives (the substring inside a comment or value) merely
+# escalate to the full re-resolution, which is the safe direction.
+_CONFIG_INCLUDE_PATTERN = re.compile(rb"\[include", re.IGNORECASE)
+_CONFIG_FILE_NAMES = frozenset({"config", "config.worktree"})
 _TOPOLOGY_HASH_LIMIT = 1 << 20
 
 
@@ -570,7 +576,7 @@ def _capture_topology_file(path: Path, *, hash_content: bool) -> _TopologyFileEv
             content = path.read_bytes()
         except OSError as exc:
             raise ProjectIdentityUnavailableError("topology input is unreadable") from exc
-        if path.name == "config" and _CONFIG_INCLUDE_PATTERN.search(content):
+        if path.name in _CONFIG_FILE_NAMES and _CONFIG_INCLUDE_PATTERN.search(content):
             # Config includes pull unbounded external files into Git's
             # decision; that closure is not enumerable, so never fast-path it.
             raise ProjectIdentityUnavailableError("config includes are outside the closure")
@@ -586,6 +592,9 @@ def _capture_topology_file(path: Path, *, hash_content: bool) -> _TopologyFileEv
     )
 
 
+_GIT_DIR_CLOSURE_NAMES = ("HEAD", "config", "config.worktree", "commondir", "gitdir")
+
+
 def _capture_publication_closure(
     effective: Path, project_root: Path, checkout_root: Path
 ) -> tuple[tuple[_TopologyFileEvidence, ...], bool]:
@@ -595,9 +604,9 @@ def _capture_publication_closure(
     exactly the inputs the five fixed topology queries consult for the
     simple-checkout shape: every boundary candidate's ``.git`` marker between
     the effective directory and the checkout root, and — when the marker is a
-    directory — its ``HEAD``, ``config``, ``commondir``, ``gitdir``, and the
-    ``worktrees`` registry with each entry's ``gitdir`` link. Anything the
-    capture cannot classify escalates.
+    directory — its ``HEAD``, ``config``, ``config.worktree``, ``commondir``,
+    ``gitdir``, and the ``worktrees`` registry with each entry's ``gitdir``
+    link. Anything the capture cannot classify escalates.
     """
     population: list[_TopologyFileEvidence] = []
     try:
@@ -613,14 +622,13 @@ def _capture_publication_closure(
             # belongs to another tree whose closure we do not enumerate here.
             return tuple(population), True
         git_dir = marker
-        for name, hashed in (
-            ("HEAD", True),
-            ("config", True),
-            ("commondir", True),
-            ("gitdir", True),
-        ):
-            population.append(_capture_topology_file(git_dir / name, hash_content=hashed))
-        if population[-2].kind != "missing":
+        commondir: _TopologyFileEvidence | None = None
+        for name in _GIT_DIR_CLOSURE_NAMES:
+            entry = _capture_topology_file(git_dir / name, hash_content=True)
+            population.append(entry)
+            if name == "commondir":
+                commondir = entry
+        if commondir is None or commondir.kind != "missing":
             # A commondir file means this administrative directory belongs to
             # a linked-worktree constellation; keep to the full re-resolution.
             return tuple(population), True
@@ -686,15 +694,46 @@ def resolve_project_identity_for_publication(
 
     Behaves exactly like :func:`resolve_project_identity`; additionally
     captures the resolver's repo-local input closure so the publication
-    boundary can revalidate by metadata alone (#1796 L2). When the checkout
-    shape falls outside the enumerable closure, the returned evidence demands
-    escalation and publication re-resolves in full, exactly as before.
+    boundary can revalidate by metadata alone (#1796 L2). The closure is
+    captured both before and after the resolution and the evidence is usable
+    only when the two captures are identical, binding the recorded state to
+    the exact resolution that produced the identity. When the checkout shape
+    falls outside the enumerable closure — or the bracket detects any
+    interleaved change — the returned evidence demands escalation and
+    publication re-resolves in full, exactly as before.
     """
     effective = _canonical_directory(effective_cwd, require_exists=True)
+    pre_files: tuple[_TopologyFileEvidence, ...] = ()
+    pre_escalate = True
+    pre_marker_root: Path | None = None
+    try:
+        pre_marker_root, bare_candidate = _nearest_repository_boundary(effective)
+    except ProjectIdentityError:
+        bare_candidate = None
+    if pre_marker_root is not None and bare_candidate is None:
+        pre_files, pre_escalate = _capture_publication_closure(
+            effective, pre_marker_root, pre_marker_root
+        )
     resolved = _resolve_with_evidence(effective)
-    file_evidence, escalate = _capture_publication_closure(
-        effective, Path(resolved.identity.project_root), resolved.checkout_root
-    )
+    project_root = Path(resolved.identity.project_root)
+    file_evidence: tuple[_TopologyFileEvidence, ...] = ()
+    escalate = True
+    if (
+        not pre_escalate
+        and resolved.checkout_root == pre_marker_root
+        and project_root == resolved.checkout_root
+    ):
+        # The closure was captured before the resolver's queries and is
+        # re-captured after them; only a byte-identical pair proves the state
+        # the resolver consumed is the state the evidence records. Any
+        # interleaved mutation perturbs a stat generation or a content hash
+        # and the pair differs, so publication escalates.
+        post_files, post_escalate = _capture_publication_closure(
+            effective, project_root, resolved.checkout_root
+        )
+        if not post_escalate and post_files == pre_files:
+            file_evidence = post_files
+            escalate = False
     return resolved.identity, PublicationEvidence(
         identity=resolved.identity,
         effective_directory=effective,
@@ -724,6 +763,8 @@ def publication_evidence_is_stable(
         return False
     if effective != evidence.effective_directory:
         return False
+    if not _publication_closure_is_complete(evidence):
+        return False
     try:
         _revalidate_live_directories(*evidence.directory_evidence)
     except ProjectIdentityError:
@@ -738,6 +779,58 @@ def publication_evidence_is_stable(
         if current != expected:
             return False
     return True
+
+
+def _publication_closure_is_complete(evidence: PublicationEvidence) -> bool:
+    """Require the evidence to carry the full resolver-shaped closure.
+
+    The session boundary receives evidence as a call argument, so acceptance
+    cannot rest on where the object came from — it must rest on what it
+    proves. The captured population has to contain every input the closure
+    capture records for the simple-checkout shape anchored at exactly this
+    identity: the marker directory at the project root, each administrative
+    file, the worktrees registry with a link per currently present entry,
+    and a pinned-missing marker for every boundary candidate below the root.
+    Anything less — including the empty closure — is refused.
+    """
+    project_root = Path(evidence.identity.project_root)
+    try:
+        workspace_path = _relative_workspace_path(evidence.effective_directory, project_root)
+    except ProjectIdentityError:
+        return False
+    if workspace_path != evidence.identity.workspace_path:
+        return False
+    captured = {entry.path: entry for entry in evidence.file_evidence}
+    git_dir = project_root / ".git"
+    marker = captured.get(git_dir)
+    if marker is None or marker.kind != "dir":
+        return False
+    for name in _GIT_DIR_CLOSURE_NAMES:
+        if git_dir / name not in captured:
+            return False
+    if captured[git_dir / "commondir"].kind != "missing":
+        return False
+    registry = captured.get(git_dir / "worktrees")
+    if registry is None:
+        return False
+    if registry.kind == "dir":
+        try:
+            entries = sorted(entry.name for entry in (git_dir / "worktrees").iterdir())
+        except OSError:
+            return False
+        for entry in entries:
+            if git_dir / "worktrees" / entry / "gitdir" not in captured:
+                return False
+    elif registry.kind != "missing":
+        return False
+    for candidate in (evidence.effective_directory, *evidence.effective_directory.parents):
+        if candidate == project_root:
+            break
+        boundary = captured.get(candidate / ".git")
+        if boundary is None or boundary.kind != "missing":
+            return False
+    directories = {entry.path for entry in evidence.directory_evidence}
+    return evidence.effective_directory in directories and project_root in directories
 
 
 def _revalidate_live_directories(*expected_population: _LiveDirectoryEvidence) -> None:

--- a/src/ouroboros/core/project_identity.py
+++ b/src/ouroboros/core/project_identity.py
@@ -293,6 +293,11 @@ def _current_git_key() -> tuple[str, int, int, int, int]:
     executable = shutil.which("git")
     if executable is None:
         raise ProjectIdentityUnavailableError("Git executable is unavailable on PATH")
+    # shutil.which() can return a relative path (an empty or relative PATH
+    # entry resolves against the mutable process cwd); anchor the selection
+    # to an absolute path so stat and execution refer to the same binary
+    # regardless of later cwd changes (review round three).
+    executable = os.path.abspath(executable)
     try:
         status = os.stat(executable)
     except OSError as exc:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -59,7 +59,6 @@ from ouroboros.core.project_identity import (
     ProjectIdentity,
     ProjectIdentityError,
     ProjectIdentityUnavailableError,
-    PublicationEvidence,
     active_publication_evidence_sink,
     publication_evidence_sink,
     resolve_managed_project_identity,
@@ -3321,11 +3320,9 @@ class OrchestratorRunner:
             effective_cwd = self._effective_cwd()
             if not isinstance(effective_cwd, str) or not effective_cwd.strip():
                 return None
-            sink = active_publication_evidence_sink()
-            if sink is None:
+            if active_publication_evidence_sink() is None:
                 return resolve_project_identity(effective_cwd)
-            identity, evidence = resolve_project_identity_for_publication(effective_cwd)
-            sink[0] = evidence
+            identity, _evidence = resolve_project_identity_for_publication(effective_cwd)
             return identity
         except ProjectIdentityError as exc:
             raise self._project_identity_error(exc) from exc
@@ -8536,12 +8533,9 @@ class OrchestratorRunner:
         by metadata alone when nothing observable changed — escalating to the
         full re-resolution (probe included) otherwise (#1796 L2).
         """
-        with publication_evidence_sink() as evidence_sink:
+        with publication_evidence_sink():
             return await self._prepare_session_scoped(
-                seed,
-                execution_id=execution_id,
-                session_id=session_id,
-                evidence_sink=evidence_sink,
+                seed, execution_id=execution_id, session_id=session_id
             )
 
     async def _prepare_session_scoped(
@@ -8549,7 +8543,6 @@ class OrchestratorRunner:
         seed: Seed,
         execution_id: str | None = None,
         session_id: str | None = None,
-        evidence_sink: list[PublicationEvidence | None] | None = None,
     ) -> Result[SessionTracker, OrchestratorError]:
         exec_id = execution_id or f"exec_{uuid4().hex[:12]}"
         resolved_session_id = session_id or f"orch_{uuid4().hex[:12]}"
@@ -8616,18 +8609,13 @@ class OrchestratorRunner:
             if self._task_workspace is not None:
                 create_session_kwargs["project_task_workspace"] = self._task_workspace
             try:
-                repo_parameters = inspect.signature(self._session_repo.create_session).parameters
-                if "acceptance_root_indices" in repo_parameters:
+                if (
+                    "acceptance_root_indices"
+                    in inspect.signature(self._session_repo.create_session).parameters
+                ):
                     create_session_kwargs["acceptance_root_indices"] = range(
                         len(seed.acceptance_criteria)
                     )
-                if (
-                    "project_identity_evidence" in repo_parameters
-                    and evidence_sink is not None
-                    and evidence_sink[0] is not None
-                    and self._task_workspace is None
-                ):
-                    create_session_kwargs["project_identity_evidence"] = evidence_sink[0]
             except (TypeError, ValueError):
                 # Legacy/mock repositories may not expose an inspectable signature;
                 # the durable SessionRepository path always does.

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -59,6 +59,7 @@ from ouroboros.core.project_identity import (
     ProjectIdentity,
     ProjectIdentityError,
     ProjectIdentityUnavailableError,
+    git_capability_probe_scope,
     resolve_managed_project_identity,
     resolve_project_identity,
 )
@@ -8521,7 +8522,23 @@ class OrchestratorRunner:
 
         This allows callers such as MCP handlers to return stable tracking IDs
         immediately and then start the actual runtime work asynchronously.
+
+        Contract construction and the publication-boundary revalidation each
+        resolve project identity, so the whole preparation shares one Git
+        capability probe (#1796); outside this scope every resolution keeps
+        probing on its own.
         """
+        with git_capability_probe_scope():
+            return await self._prepare_session_scoped(
+                seed, execution_id=execution_id, session_id=session_id
+            )
+
+    async def _prepare_session_scoped(
+        self,
+        seed: Seed,
+        execution_id: str | None = None,
+        session_id: str | None = None,
+    ) -> Result[SessionTracker, OrchestratorError]:
         exec_id = execution_id or f"exec_{uuid4().hex[:12]}"
         resolved_session_id = session_id or f"orch_{uuid4().hex[:12]}"
         self._execution_guidance = None

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -59,9 +59,12 @@ from ouroboros.core.project_identity import (
     ProjectIdentity,
     ProjectIdentityError,
     ProjectIdentityUnavailableError,
-    git_capability_probe_scope,
+    PublicationEvidence,
+    active_publication_evidence_sink,
+    publication_evidence_sink,
     resolve_managed_project_identity,
     resolve_project_identity,
+    resolve_project_identity_for_publication,
 )
 from ouroboros.core.seed import AcceptanceCriterionSpec, ac_text, ac_texts
 from ouroboros.core.seed_contract import SeedContract
@@ -3318,7 +3321,12 @@ class OrchestratorRunner:
             effective_cwd = self._effective_cwd()
             if not isinstance(effective_cwd, str) or not effective_cwd.strip():
                 return None
-            return resolve_project_identity(effective_cwd)
+            sink = active_publication_evidence_sink()
+            if sink is None:
+                return resolve_project_identity(effective_cwd)
+            identity, evidence = resolve_project_identity_for_publication(effective_cwd)
+            sink[0] = evidence
+            return identity
         except ProjectIdentityError as exc:
             raise self._project_identity_error(exc) from exc
 
@@ -8523,14 +8531,17 @@ class OrchestratorRunner:
         This allows callers such as MCP handlers to return stable tracking IDs
         immediately and then start the actual runtime work asynchronously.
 
-        Contract construction and the publication-boundary revalidation each
-        resolve project identity, so the whole preparation shares one Git
-        capability probe (#1796); outside this scope every resolution keeps
-        probing on its own.
+        Contract construction captures the resolver's repo-local input
+        closure, and the publication boundary revalidates from that evidence
+        by metadata alone when nothing observable changed — escalating to the
+        full re-resolution (probe included) otherwise (#1796 L2).
         """
-        with git_capability_probe_scope():
+        with publication_evidence_sink() as evidence_sink:
             return await self._prepare_session_scoped(
-                seed, execution_id=execution_id, session_id=session_id
+                seed,
+                execution_id=execution_id,
+                session_id=session_id,
+                evidence_sink=evidence_sink,
             )
 
     async def _prepare_session_scoped(
@@ -8538,6 +8549,7 @@ class OrchestratorRunner:
         seed: Seed,
         execution_id: str | None = None,
         session_id: str | None = None,
+        evidence_sink: list[PublicationEvidence | None] | None = None,
     ) -> Result[SessionTracker, OrchestratorError]:
         exec_id = execution_id or f"exec_{uuid4().hex[:12]}"
         resolved_session_id = session_id or f"orch_{uuid4().hex[:12]}"
@@ -8604,13 +8616,18 @@ class OrchestratorRunner:
             if self._task_workspace is not None:
                 create_session_kwargs["project_task_workspace"] = self._task_workspace
             try:
-                if (
-                    "acceptance_root_indices"
-                    in inspect.signature(self._session_repo.create_session).parameters
-                ):
+                repo_parameters = inspect.signature(self._session_repo.create_session).parameters
+                if "acceptance_root_indices" in repo_parameters:
                     create_session_kwargs["acceptance_root_indices"] = range(
                         len(seed.acceptance_criteria)
                     )
+                if (
+                    "project_identity_evidence" in repo_parameters
+                    and evidence_sink is not None
+                    and evidence_sink[0] is not None
+                    and self._task_workspace is None
+                ):
+                    create_session_kwargs["project_identity_evidence"] = evidence_sink[0]
             except (TypeError, ValueError):
                 # Legacy/mock repositories may not expose an inspectable signature;
                 # the durable SessionRepository path always does.

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -35,6 +35,8 @@ from uuid import uuid4
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.project_identity import (
     ProjectIdentity,
+    PublicationEvidence,
+    publication_evidence_is_stable,
     resolve_managed_project_identity,
     resolve_project_identity,
 )
@@ -97,6 +99,7 @@ async def _validate_project_identity_publication(
     project_identity: ProjectIdentity | None,
     project_workspace: str | None,
     project_task_workspace: TaskWorkspace | None,
+    project_identity_evidence: PublicationEvidence | None = None,
 ) -> None:
     """Require the immutable top-level and nested project scopes to agree."""
     raw_proof = (
@@ -122,6 +125,21 @@ async def _validate_project_identity_publication(
         raise ValueError("project identity conflicts with execution contract")
     if project_identity is not None and project_workspace is not None:
         if project_task_workspace is None:
+            if (
+                project_identity_evidence is not None
+                and project_identity_evidence.identity == project_identity
+                and await asyncio.to_thread(
+                    publication_evidence_is_stable,
+                    project_identity_evidence,
+                    project_workspace,
+                )
+            ):
+                # The resolver's whole repo-local input closure is unchanged
+                # since construction, so re-running it must reproduce the same
+                # identity; the recheck issues no Git query, so the V1 probe
+                # invariant is vacuously satisfied. Any doubt fell through to
+                # the full re-resolution below, which probes for itself.
+                return
             revalidated_identity = await asyncio.to_thread(
                 resolve_project_identity,
                 project_workspace,
@@ -751,6 +769,7 @@ class SessionRepository:
         project_identity: ProjectIdentity | None = None,
         project_workspace: str | None = None,
         project_task_workspace: TaskWorkspace | None = None,
+        project_identity_evidence: PublicationEvidence | None = None,
     ) -> Result[SessionTracker, PersistenceError]:
         """Create a new session and persist start event.
 
@@ -775,6 +794,11 @@ class SessionRepository:
                 immutable publication. It is validation input, not event data.
             project_task_workspace: Frozen managed source/execution paths to
                 revalidate together at the immutable publication boundary.
+            project_identity_evidence: Captured input closure of the identity
+                resolution that produced ``project_identity``. When every
+                captured stat/hash still matches at publication, the boundary
+                skips the redundant re-resolution; otherwise it is ignored and
+                the full revalidation runs as before. Direct workspaces only.
 
         Returns:
             Result containing new SessionTracker.
@@ -789,6 +813,7 @@ class SessionRepository:
             project_identity,
             project_workspace,
             project_task_workspace,
+            project_identity_evidence,
         )
         tracker = SessionTracker.create(execution_id, seed_id, session_id)
 

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -35,7 +35,7 @@ from uuid import uuid4
 from ouroboros.core.errors import PersistenceError
 from ouroboros.core.project_identity import (
     ProjectIdentity,
-    PublicationEvidence,
+    active_publication_evidence,
     publication_evidence_is_stable,
     resolve_managed_project_identity,
     resolve_project_identity,
@@ -99,7 +99,6 @@ async def _validate_project_identity_publication(
     project_identity: ProjectIdentity | None,
     project_workspace: str | None,
     project_task_workspace: TaskWorkspace | None,
-    project_identity_evidence: PublicationEvidence | None = None,
 ) -> None:
     """Require the immutable top-level and nested project scopes to agree."""
     raw_proof = (
@@ -125,12 +124,17 @@ async def _validate_project_identity_publication(
         raise ValueError("project identity conflicts with execution contract")
     if project_identity is not None and project_workspace is not None:
         if project_task_workspace is None:
+            # The runner deposits resolver-issued evidence in a scope it owns;
+            # nothing about the fast path is caller-suppliable through this
+            # module's API. Acceptance is still re-proven here: issuance,
+            # identity, workspace anchor, closure completeness, stability.
+            evidence = active_publication_evidence()
             if (
-                project_identity_evidence is not None
-                and project_identity_evidence.identity == project_identity
+                evidence is not None
+                and evidence.identity == project_identity
                 and await asyncio.to_thread(
                     publication_evidence_is_stable,
-                    project_identity_evidence,
+                    evidence,
                     project_workspace,
                 )
             ):
@@ -769,7 +773,6 @@ class SessionRepository:
         project_identity: ProjectIdentity | None = None,
         project_workspace: str | None = None,
         project_task_workspace: TaskWorkspace | None = None,
-        project_identity_evidence: PublicationEvidence | None = None,
     ) -> Result[SessionTracker, PersistenceError]:
         """Create a new session and persist start event.
 
@@ -794,11 +797,6 @@ class SessionRepository:
                 immutable publication. It is validation input, not event data.
             project_task_workspace: Frozen managed source/execution paths to
                 revalidate together at the immutable publication boundary.
-            project_identity_evidence: Captured input closure of the identity
-                resolution that produced ``project_identity``. When every
-                captured stat/hash still matches at publication, the boundary
-                skips the redundant re-resolution; otherwise it is ignored and
-                the full revalidation runs as before. Direct workspaces only.
 
         Returns:
             Result containing new SessionTracker.
@@ -813,7 +811,6 @@ class SessionRepository:
             project_identity,
             project_workspace,
             project_task_workspace,
-            project_identity_evidence,
         )
         tracker = SessionTracker.create(execution_id, seed_id, session_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,15 +231,3 @@ async def close_test_owned_stores(monkeypatch):
                     await close_result
                 except Exception:
                     pass
-
-
-@pytest.fixture(autouse=True)
-def _fresh_git_capability_cache():
-    """#1796: the process-lifetime git probe cache must not leak between
-    tests — suites that simulate git failure would otherwise pass or fail
-    depending on whether an earlier test warmed the cache."""
-    from ouroboros.core import project_identity
-
-    project_identity._reset_git_capability_cache_for_tests()
-    yield
-    project_identity._reset_git_capability_cache_for_tests()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,3 +231,15 @@ async def close_test_owned_stores(monkeypatch):
                     await close_result
                 except Exception:
                     pass
+
+
+@pytest.fixture(autouse=True)
+def _fresh_git_capability_cache():
+    """#1796: the process-lifetime git probe cache must not leak between
+    tests — suites that simulate git failure would otherwise pass or fail
+    depending on whether an earlier test warmed the cache."""
+    from ouroboros.core import project_identity
+
+    project_identity._reset_git_capability_cache_for_tests()
+    yield
+    project_identity._reset_git_capability_cache_for_tests()

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -692,7 +692,8 @@ def test_git_version_probe_does_not_depend_on_workdir_capability() -> None:
     ) as run_git_command:
         _require_supported_git()
 
-    run_git_command.assert_called_once_with("--version")
+    assert run_git_command.call_count == 1
+    assert run_git_command.call_args.args == ("--version",)
 
 
 def test_repository_query_nonzero_after_git_probe_is_unavailable(tmp_path: Path) -> None:
@@ -1020,13 +1021,86 @@ class TestGitCapabilityProbeScope:
     def _counting_probe(self, monkeypatch):
         calls = {"n": 0}
 
-        def fake(*arguments: str) -> bytes:
+        def fake(*arguments: str, executable: str | None = None) -> bytes:
             assert arguments == ("--version",)
             calls["n"] += 1
             return b"git version 2.44.0\n"
 
         monkeypatch.setattr(project_identity, "_run_git_command", fake)
         return calls
+
+    def test_scoped_commands_run_the_verified_executable(self, monkeypatch, tmp_path) -> None:
+        """Every git command inside a scope binds to the verified binary.
+
+        Skipping the publication resolver's probe is only sound if its
+        topology queries cannot run a different git than the one the scope
+        verified — so the scope pins argv[0] to the verified absolute
+        executable, and a PATH switch mid-scope changes nothing.
+        """
+        git_a = tmp_path / "git-a"
+        git_a.write_text("")
+        git_b = tmp_path / "git-b"
+        git_b.write_text("")
+
+        lookups = {"n": 0}
+
+        def switching_which(_name: str) -> str:
+            lookups["n"] += 1
+            return str(git_a) if lookups["n"] == 1 else str(git_b)
+
+        monkeypatch.setattr(project_identity.shutil, "which", switching_which)
+
+        invoked: list[str] = []
+
+        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            invoked.append(argv[0])
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
+
+        with project_identity.git_capability_probe_scope():
+            project_identity._require_supported_git()
+            project_identity._run_git_command("--version")
+            project_identity._require_supported_git()
+            project_identity._run_git_command("rev-parse", "--show-toplevel")
+
+        assert invoked == [str(git_a)] * 3, (
+            "a scoped git command escaped the verified executable binding"
+        )
+
+    def test_escaped_child_task_loses_the_scope_trust(self, monkeypatch) -> None:
+        """A task created inside the scope must re-probe after scope exit."""
+        import asyncio
+
+        calls = {"n": 0}
+
+        def fake(*arguments: str, executable: str | None = None) -> bytes:
+            calls["n"] += 1
+            return b"git version 2.44.0\n"
+
+        monkeypatch.setattr(project_identity, "_run_git_command", fake)
+
+        async def scenario() -> None:
+            release = asyncio.Event()
+
+            async def escaped_child() -> None:
+                await release.wait()
+                project_identity._require_supported_git()
+
+            with project_identity.git_capability_probe_scope():
+                project_identity._require_supported_git()
+                child = asyncio.create_task(escaped_child())
+                await asyncio.sleep(0)
+            release.set()
+            await child
+
+        asyncio.run(scenario())
+        assert calls["n"] == 2, "an escaped child reused the scope's verification after exit"
 
     def test_without_scope_every_call_probes(self, monkeypatch) -> None:
         calls = self._counting_probe(monkeypatch)
@@ -1052,7 +1126,7 @@ class TestGitCapabilityProbeScope:
     def test_scope_failure_is_not_memoized(self, monkeypatch) -> None:
         attempts = {"n": 0}
 
-        def flaky(*arguments: str) -> bytes:
+        def flaky(*arguments: str, executable: str | None = None) -> bytes:
             attempts["n"] += 1
             if attempts["n"] == 1:
                 raise project_identity.ProjectIdentityUnavailableError("transient")

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1076,6 +1076,10 @@ class TestPublicationEvidence:
             (repo / ".git" / "worktrees" / "wt").mkdir(parents=True)
             (repo / ".git" / "worktrees" / "wt" / "gitdir").write_text("x\n")
 
+        @case("worktree-scoped config appears")
+        def _(repo):
+            (repo / ".git" / "config.worktree").write_text("[core]\n\tbare = true\n")
+
         for name, mutate in cases:
             repo = self._repo(tmp_path / name.replace(" ", "-"))
             _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
@@ -1101,7 +1105,20 @@ class TestPublicationEvidence:
 
         linked_base = self._repo(tmp_path / "base")
         sp.run(
-            ["git", "-C", str(linked_base), "commit", "--allow-empty", "-q", "-m", "x"],
+            [
+                "git",
+                "-C",
+                str(linked_base),
+                "-c",
+                "user.name=Project Identity Test",
+                "-c",
+                "user.email=project-identity@example.com",
+                "commit",
+                "--allow-empty",
+                "-q",
+                "-m",
+                "x",
+            ],
             check=True,
         )
         linked = tmp_path / "linked"
@@ -1113,6 +1130,95 @@ class TestPublicationEvidence:
         assert linked_evidence.escalate is True, (
             "a gitdir-pointer checkout must not take the fast path"
         )
+
+    def test_mutation_between_resolution_and_capture_escalates(self, tmp_path, monkeypatch) -> None:
+        """Evidence must be bound to the exact resolution that produced it.
+
+        A closure mutated after the resolver's queries but before the capture
+        would otherwise record the new state against the old identity; the
+        pre/post capture bracket detects the interleaving and escalates.
+        """
+        repo = self._repo(tmp_path)
+        original = project_identity._resolve_canonical_project_identity
+
+        def resolve_then_mutate(effective):
+            resolved = original(effective)
+            config = repo / ".git" / "config"
+            config.write_text(config.read_text() + "[user]\n\tname = other-owner\n")
+            return resolved
+
+        monkeypatch.setattr(
+            project_identity, "_resolve_canonical_project_identity", resolve_then_mutate
+        )
+        _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+        assert evidence.escalate is True, (
+            "a closure change between resolution and capture must not produce usable evidence"
+        )
+
+    def test_worktree_scoped_config_is_part_of_the_closure(self, tmp_path) -> None:
+        """config.worktree can carry topology-affecting values; pin it."""
+        repo = self._repo(tmp_path / "edit")
+        worktree_config = repo / ".git" / "config.worktree"
+        worktree_config.write_text("[core]\n")
+        _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+        assert evidence.escalate is False
+        assert project_identity.publication_evidence_is_stable(evidence, repo / "sub") is True
+        worktree_config.write_text("[core]\n\tbare = true\n")
+        assert project_identity.publication_evidence_is_stable(evidence, repo / "sub") is False, (
+            "an in-place config.worktree edit must destabilize the evidence"
+        )
+
+        include_repo = self._repo(tmp_path / "include")
+        (include_repo / ".git" / "config.worktree").write_text("[include]\n\tpath = other\n")
+        _, include_evidence = project_identity.resolve_project_identity_for_publication(
+            include_repo / "sub"
+        )
+        assert include_evidence.escalate is True
+
+    def test_include_detection_is_position_and_bom_insensitive(self, tmp_path) -> None:
+        """Include escalation must over-approximate Git's grammar, never under."""
+        bom_repo = self._repo(tmp_path / "bom")
+        (bom_repo / ".git" / "config").write_bytes(b"\xef\xbb\xbf[include]\n\tpath = other\n")
+        _, bom_evidence = project_identity.resolve_project_identity_for_publication(
+            bom_repo / "sub"
+        )
+        assert bom_evidence.escalate is True, "a BOM must not hide an include section"
+
+        mid_repo = self._repo(tmp_path / "mid")
+        config = mid_repo / ".git" / "config"
+        config.write_text(config.read_text() + '[includeIf "gitdir:/x"]\n\tpath = other\n')
+        _, mid_evidence = project_identity.resolve_project_identity_for_publication(
+            mid_repo / "sub"
+        )
+        assert mid_evidence.escalate is True
+
+    def test_incomplete_or_forged_evidence_is_refused(self, tmp_path) -> None:
+        """Acceptance rests on what the evidence proves, not where it came from."""
+        import dataclasses
+
+        repo = self._repo(tmp_path)
+        identity, real = project_identity.resolve_project_identity_for_publication(repo / "sub")
+
+        forged = project_identity.PublicationEvidence(
+            identity=identity,
+            effective_directory=real.effective_directory,
+            directory_evidence=(),
+            file_evidence=(),
+            escalate=False,
+        )
+        assert project_identity.publication_evidence_is_stable(forged, repo / "sub") is False, (
+            "an empty closure must never be accepted"
+        )
+
+        for index in range(len(real.file_evidence)):
+            partial = dataclasses.replace(
+                real,
+                file_evidence=real.file_evidence[:index] + real.file_evidence[index + 1 :],
+            )
+            dropped = real.file_evidence[index].path
+            assert (
+                project_identity.publication_evidence_is_stable(partial, repo / "sub") is False
+            ), f"dropping {dropped} from the closure must be refused"
 
     def test_escalating_evidence_is_never_stable(self, tmp_path) -> None:
         repo = self._repo(tmp_path)

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1015,142 +1015,121 @@ def test_project_identity_rejects_noncanonical_fields(
         )
 
 
-class TestGitCapabilityProbeScope:
-    """#1796: one probe per scope; per-call probing everywhere else."""
+class TestPublicationEvidence:
+    """#1796 L2: publication accepts by metadata closure or escalates."""
 
-    def _counting_probe(self, monkeypatch):
-        calls = {"n": 0}
+    def _repo(self, tmp_path):
+        import subprocess as sp
 
-        def fake(*arguments: str, executable: str | None = None) -> bytes:
-            assert arguments == ("--version",)
-            calls["n"] += 1
-            return b"git version 2.44.0\n"
+        repo = tmp_path / "repo"
+        repo.mkdir(parents=True)
+        sp.run(["git", "init", "-q", str(repo)], check=True)
+        (repo / "sub").mkdir()
+        return repo
 
-        monkeypatch.setattr(project_identity, "_run_git_command", fake)
-        return calls
+    def test_happy_path_is_stable_and_runs_no_git(self, tmp_path, monkeypatch) -> None:
+        repo = self._repo(tmp_path)
+        identity, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+        assert identity == project_identity.resolve_project_identity(repo / "sub")
+        assert evidence.escalate is False
 
-    def test_scoped_commands_run_the_verified_executable(self, monkeypatch, tmp_path) -> None:
-        """Every git command inside a scope binds to the verified binary.
+        spawns = {"n": 0}
+        real_run = project_identity.subprocess.run
 
-        Skipping the publication resolver's probe is only sound if its
-        topology queries cannot run a different git than the one the scope
-        verified — so the scope pins argv[0] to the verified absolute
-        executable, and a PATH switch mid-scope changes nothing.
-        """
-        git_a = tmp_path / "git-a"
-        git_a.write_text("")
-        git_b = tmp_path / "git-b"
-        git_b.write_text("")
+        def counting_run(*args, **kwargs):  # noqa: ANN001, ANN202
+            spawns["n"] += 1
+            return real_run(*args, **kwargs)
 
-        lookups = {"n": 0}
+        monkeypatch.setattr(project_identity.subprocess, "run", counting_run)
+        assert project_identity.publication_evidence_is_stable(evidence, repo / "sub") is True
+        assert spawns["n"] == 0, "the fast path must not spawn any git subprocess"
 
-        def switching_which(_name: str) -> str:
-            lookups["n"] += 1
-            return str(git_a) if lookups["n"] == 1 else str(git_b)
+    def test_each_closure_mutation_destabilizes(self, tmp_path) -> None:
+        cases = []
 
-        monkeypatch.setattr(project_identity.shutil, "which", switching_which)
+        def case(name):
+            def register(fn):
+                cases.append((name, fn))
+                return fn
 
-        invoked: list[str] = []
+            return register
 
-        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            invoked.append(argv[0])
-            kwargs["stdout"].write(b"git version 2.44.0\n")
+        @case("config content edited in place")
+        def _(repo):
+            config = repo / ".git" / "config"
+            config.write_text(config.read_text() + "[user]\n\tname = drift\n")
 
-            class _Done:
-                returncode = 0
+        @case("commondir appears (worktree constellation)")
+        def _(repo):
+            (repo / ".git" / "commondir").write_text("../..\n")
 
-            return _Done()
+        @case("new intermediate boundary marker")
+        def _(repo):
+            (repo / "sub" / ".git").mkdir()
 
-        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
+        @case("HEAD rewritten")
+        def _(repo):
+            (repo / ".git" / "HEAD").write_text("ref: refs/heads/elsewhere\n")
 
-        with project_identity.git_capability_probe_scope():
-            project_identity._require_supported_git()
-            project_identity._run_git_command("--version")
-            project_identity._require_supported_git()
-            project_identity._run_git_command("rev-parse", "--show-toplevel")
+        @case("worktree registry appears")
+        def _(repo):
+            (repo / ".git" / "worktrees" / "wt").mkdir(parents=True)
+            (repo / ".git" / "worktrees" / "wt" / "gitdir").write_text("x\n")
 
-        assert invoked == [str(git_a)] * 3, (
-            "a scoped git command escaped the verified executable binding"
+        for name, mutate in cases:
+            repo = self._repo(tmp_path / name.replace(" ", "-"))
+            _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+            assert evidence.escalate is False, name
+            assert (
+                project_identity.publication_evidence_is_stable(evidence, repo / "sub") is True
+            ), name
+            mutate(repo)
+            assert (
+                project_identity.publication_evidence_is_stable(evidence, repo / "sub") is False
+            ), f"mutation not detected: {name}"
+
+    def test_unenumerable_shapes_escalate_at_capture(self, tmp_path) -> None:
+        import subprocess as sp
+
+        include_repo = self._repo(tmp_path / "inc")
+        config = include_repo / ".git" / "config"
+        config.write_text(config.read_text() + "[include]\n\tpath = other\n")
+        _, evidence = project_identity.resolve_project_identity_for_publication(
+            include_repo / "sub"
+        )
+        assert evidence.escalate is True
+
+        linked_base = self._repo(tmp_path / "base")
+        sp.run(
+            ["git", "-C", str(linked_base), "commit", "--allow-empty", "-q", "-m", "x"],
+            check=True,
+        )
+        linked = tmp_path / "linked"
+        sp.run(
+            ["git", "-C", str(linked_base), "worktree", "add", "-q", str(linked)],
+            check=True,
+        )
+        _, linked_evidence = project_identity.resolve_project_identity_for_publication(linked)
+        assert linked_evidence.escalate is True, (
+            "a gitdir-pointer checkout must not take the fast path"
         )
 
-    def test_escaped_child_task_loses_the_scope_trust(self, monkeypatch) -> None:
-        """A task created inside the scope must re-probe after scope exit."""
-        import asyncio
+    def test_escalating_evidence_is_never_stable(self, tmp_path) -> None:
+        repo = self._repo(tmp_path)
+        _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+        forced = project_identity.PublicationEvidence(
+            identity=evidence.identity,
+            effective_directory=evidence.effective_directory,
+            directory_evidence=evidence.directory_evidence,
+            file_evidence=evidence.file_evidence,
+            escalate=True,
+        )
+        assert project_identity.publication_evidence_is_stable(forced, repo / "sub") is False
 
-        calls = {"n": 0}
-
-        def fake(*arguments: str, executable: str | None = None) -> bytes:
-            calls["n"] += 1
-            return b"git version 2.44.0\n"
-
-        monkeypatch.setattr(project_identity, "_run_git_command", fake)
-
-        async def scenario() -> None:
-            release = asyncio.Event()
-
-            async def escaped_child() -> None:
-                await release.wait()
-                project_identity._require_supported_git()
-
-            with project_identity.git_capability_probe_scope():
-                project_identity._require_supported_git()
-                child = asyncio.create_task(escaped_child())
-                await asyncio.sleep(0)
-            release.set()
-            await child
-
-        asyncio.run(scenario())
-        assert calls["n"] == 2, "an escaped child reused the scope's verification after exit"
-
-    def test_without_scope_every_call_probes(self, monkeypatch) -> None:
-        calls = self._counting_probe(monkeypatch)
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert calls["n"] == 2
-
-    def test_scope_shares_a_single_probe(self, monkeypatch) -> None:
-        calls = self._counting_probe(monkeypatch)
-        with project_identity.git_capability_probe_scope():
-            project_identity._require_supported_git()
-            project_identity._require_supported_git()
-            project_identity._require_supported_git()
-        assert calls["n"] == 1
-
-    def test_nothing_survives_the_scope(self, monkeypatch) -> None:
-        calls = self._counting_probe(monkeypatch)
-        with project_identity.git_capability_probe_scope():
-            project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert calls["n"] == 2
-
-    def test_scope_failure_is_not_memoized(self, monkeypatch) -> None:
-        attempts = {"n": 0}
-
-        def flaky(*arguments: str, executable: str | None = None) -> bytes:
-            attempts["n"] += 1
-            if attempts["n"] == 1:
-                raise project_identity.ProjectIdentityUnavailableError("transient")
-            return b"git version 2.44.0\n"
-
-        monkeypatch.setattr(project_identity, "_run_git_command", flaky)
-        with project_identity.git_capability_probe_scope():
-            with pytest.raises(project_identity.ProjectIdentityUnavailableError):
-                project_identity._require_supported_git()
-            project_identity._require_supported_git()
-            project_identity._require_supported_git()
-        assert attempts["n"] == 2
-
-    @pytest.mark.asyncio
-    async def test_concurrent_scopes_are_isolated(self, monkeypatch) -> None:
-        import asyncio
-
-        calls = self._counting_probe(monkeypatch)
-
-        async def one_scope() -> None:
-            with project_identity.git_capability_probe_scope():
-                project_identity._require_supported_git()
-                await asyncio.sleep(0)
-                project_identity._require_supported_git()
-
-        await asyncio.gather(one_scope(), one_scope())
-        assert calls["n"] == 2
+    def test_evidence_vouches_only_for_its_own_workspace(self, tmp_path) -> None:
+        repo = self._repo(tmp_path)
+        _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")
+        assert project_identity.publication_evidence_is_stable(evidence, repo / "sub") is True
+        assert project_identity.publication_evidence_is_stable(evidence, repo) is False, (
+            "evidence must not transfer to a different effective directory"
+        )

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1026,6 +1026,40 @@ class TestGitCapabilityProbeCache:
     failure paths are unchanged.
     """
 
+    def test_relative_which_result_is_anchored_to_an_absolute_path(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A relative PATH entry must not reopen the lookup race.
+
+        With POSIX PATH=:/usr/bin the empty entry resolves against the
+        mutable process cwd and shutil.which() can return a bare relative
+        name; passing that to subprocess performs another cwd-dependent
+        lookup. The key must anchor the selection to an absolute path used
+        for both stat and execution.
+        """
+        (tmp_path / "gitx").write_text("#!/bin/sh\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: "gitx")
+
+        invoked: list[str] = []
+
+        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            invoked.append(argv[0])
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
+
+        project_identity._require_supported_git()
+
+        assert invoked == [str(tmp_path / "gitx")], (
+            "the probe executed a relative path, leaving it cwd-dependent"
+        )
+
     def test_probe_targets_the_exact_executable_the_key_resolved(
         self, monkeypatch, tmp_path
     ) -> None:

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -10,6 +10,7 @@ from uuid import NAMESPACE_URL, uuid5
 
 import pytest
 
+from ouroboros.core import project_identity
 from ouroboros.core.project_identity import (
     ManagedProjectOwnershipError,
     ManagedProjectScopeError,
@@ -1011,3 +1012,67 @@ def test_project_identity_rejects_noncanonical_fields(
             project_root=project_root,
             workspace_path=workspace_path,
         )
+
+
+class TestGitCapabilityProbeCache:
+    """#1796 L1: cache the git --version capability probe per process.
+
+    Only a SUCCESSFUL probe is cached: the installed binary cannot change
+    within one process, but a transient spawn failure must keep re-probing,
+    and a genuine version rejection stays uncached so the semantics on the
+    failure paths are unchanged.
+    """
+
+    def test_successful_probe_runs_git_version_once(self, monkeypatch) -> None:
+        calls: list[tuple[str, ...]] = []
+        real = project_identity._run_git_command
+
+        def counting(*arguments: str) -> bytes:
+            calls.append(arguments)
+            if arguments == ("--version",):
+                return b"git version 2.44.0\n"
+            return real(*arguments)
+
+        monkeypatch.setattr(project_identity, "_run_git_command", counting)
+
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+
+        assert calls.count(("--version",)) == 1
+
+    def test_transient_failure_is_not_cached(self, monkeypatch) -> None:
+        attempts = {"n": 0}
+
+        def flaky(*arguments: str) -> bytes:
+            assert arguments == ("--version",)
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise project_identity.ProjectIdentityUnavailableError(
+                    "Git query is temporarily unavailable"
+                )
+            return b"git version 2.44.0\n"
+
+        monkeypatch.setattr(project_identity, "_run_git_command", flaky)
+
+        with pytest.raises(project_identity.ProjectIdentityUnavailableError):
+            project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert attempts["n"] == 2
+        # and now the success is cached
+        project_identity._require_supported_git()
+        assert attempts["n"] == 2
+
+    def test_version_rejection_is_not_cached(self, monkeypatch) -> None:
+        outputs = [b"git version 2.20.0\n", b"git version 2.44.0\n"]
+
+        def upgrading(*arguments: str) -> bytes:
+            assert arguments == ("--version",)
+            return outputs.pop(0)
+
+        monkeypatch.setattr(project_identity, "_run_git_command", upgrading)
+
+        with pytest.raises(project_identity.ProjectIdentityGitVersionError):
+            project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert outputs == []

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1220,6 +1220,43 @@ class TestPublicationEvidence:
                 project_identity.publication_evidence_is_stable(partial, repo / "sub") is False
             ), f"dropping {dropped} from the closure must be refused"
 
+    def test_caller_assembled_closure_is_refused_even_when_structurally_complete(
+        self, tmp_path
+    ) -> None:
+        """Trust comes from issuance, not shape.
+
+        A closure assembled with the capture helpers over an invalid marker
+        shape matches the live filesystem entry for entry, but the resolver
+        never issued it — acceptance must refuse it and leave the shape to
+        the full re-resolution, which fails closed.
+        """
+        fake_root = (tmp_path / "fake").resolve()
+        fake_root.mkdir()
+        git_dir = fake_root / ".git"
+        git_dir.mkdir()
+        identity = project_identity.ProjectIdentity.from_root(
+            fake_root, workspace_path=".", require_exists=True
+        )
+        forged_files = [project_identity._capture_topology_file(git_dir, hash_content=True)]
+        for name in project_identity._GIT_DIR_CLOSURE_NAMES:
+            forged_files.append(
+                project_identity._capture_topology_file(git_dir / name, hash_content=True)
+            )
+        forged_files.append(
+            project_identity._capture_topology_file(git_dir / "worktrees", hash_content=False)
+        )
+        forged = project_identity.PublicationEvidence(
+            identity=identity,
+            effective_directory=fake_root,
+            directory_evidence=(project_identity._capture_live_directory(fake_root),),
+            file_evidence=tuple(forged_files),
+            escalate=False,
+        )
+
+        assert project_identity.publication_evidence_is_stable(forged, fake_root) is False
+        with pytest.raises(ProjectIdentityUnavailableError):
+            project_identity.resolve_project_identity(fake_root)
+
     def test_escalating_evidence_is_never_stable(self, tmp_path) -> None:
         repo = self._repo(tmp_path)
         _, evidence = project_identity.resolve_project_identity_for_publication(repo / "sub")

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -692,7 +692,10 @@ def test_git_version_probe_does_not_depend_on_workdir_capability() -> None:
     ) as run_git_command:
         _require_supported_git()
 
-    run_git_command.assert_called_once_with("--version")
+    assert run_git_command.call_count == 1
+    assert run_git_command.call_args.args == ("--version",)
+    # The probe targets the exact executable its cache key resolved (#1796).
+    assert run_git_command.call_args.kwargs.get("executable", "git")
 
 
 def test_repository_query_nonzero_after_git_probe_is_unavailable(tmp_path: Path) -> None:
@@ -1023,6 +1026,103 @@ class TestGitCapabilityProbeCache:
     failure paths are unchanged.
     """
 
+    def test_probe_targets_the_exact_executable_the_key_resolved(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Key resolution and the probe must not race a mutable PATH.
+
+        If the probe performs its own PATH lookup, a concurrent switch can
+        verify binary B and cache its success under binary A's key; later
+        calls then accept A without validation.
+        """
+        git_a = tmp_path / "git-a"
+        git_a.write_text("#!/bin/sh\n")
+        git_b = tmp_path / "git-b"
+        git_b.write_text("#!/bin/sh\n")
+
+        lookups = {"n": 0}
+
+        def switching_which(_name: str) -> str:
+            lookups["n"] += 1
+            return str(git_a) if lookups["n"] == 1 else str(git_b)
+
+        monkeypatch.setattr(project_identity.shutil, "which", switching_which)
+
+        invoked: list[str] = []
+
+        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            invoked.append(argv[0])
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
+
+        project_identity._require_supported_git()
+
+        assert invoked == [str(git_a)], (
+            "the probe ran a PATH lookup of its own instead of the key's executable"
+        )
+
+    def test_same_path_replacement_invalidates_the_cache(self, monkeypatch, tmp_path) -> None:
+        """Replacing the binary at the SAME path must re-probe (inode/mtime)."""
+        git_path = tmp_path / "git"
+        git_path.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
+
+        probes = {"n": 0}
+
+        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            probes["n"] += 1
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
+
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert probes["n"] == 1
+
+        git_path.unlink()
+        git_path.write_text("#!/bin/sh\necho replaced\n")
+        project_identity._require_supported_git()
+        assert probes["n"] == 2
+
+    def test_forked_child_reverifies(self, monkeypatch, tmp_path) -> None:
+        """The PID key field makes a forked child re-probe."""
+        git_path = tmp_path / "git"
+        git_path.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
+
+        probes = {"n": 0}
+
+        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            probes["n"] += 1
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
+
+        monkeypatch.setattr(project_identity.os, "getpid", lambda: 11111)
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert probes["n"] == 1
+
+        monkeypatch.setattr(project_identity.os, "getpid", lambda: 22222)
+        project_identity._require_supported_git()
+        assert probes["n"] == 2
+
     def test_warm_cache_fails_closed_when_git_disappears(self, monkeypatch) -> None:
         """A warmed cache must not outlive the executable it verified.
 
@@ -1034,7 +1134,7 @@ class TestGitCapabilityProbeCache:
         monkeypatch.setattr(
             project_identity,
             "_run_git_command",
-            lambda *a: b"git version 2.44.0\n" if a == ("--version",) else b"",
+            lambda *a, **_kw: b"git version 2.44.0\n" if a == ("--version",) else b"",
         )
         project_identity._require_supported_git()
 
@@ -1051,7 +1151,7 @@ class TestGitCapabilityProbeCache:
 
         probes = {"n": 0}
 
-        def probing(*arguments: str) -> bytes:
+        def probing(*arguments: str, executable: str = "git") -> bytes:
             assert arguments == ("--version",)
             probes["n"] += 1
             return b"git version 2.44.0\n"
@@ -1070,7 +1170,7 @@ class TestGitCapabilityProbeCache:
         calls: list[tuple[str, ...]] = []
         real = project_identity._run_git_command
 
-        def counting(*arguments: str) -> bytes:
+        def counting(*arguments: str, executable: str = "git") -> bytes:
             calls.append(arguments)
             if arguments == ("--version",):
                 return b"git version 2.44.0\n"
@@ -1087,7 +1187,7 @@ class TestGitCapabilityProbeCache:
     def test_transient_failure_is_not_cached(self, monkeypatch) -> None:
         attempts = {"n": 0}
 
-        def flaky(*arguments: str) -> bytes:
+        def flaky(*arguments: str, executable: str = "git") -> bytes:
             assert arguments == ("--version",)
             attempts["n"] += 1
             if attempts["n"] == 1:
@@ -1109,7 +1209,7 @@ class TestGitCapabilityProbeCache:
     def test_version_rejection_is_not_cached(self, monkeypatch) -> None:
         outputs = [b"git version 2.20.0\n", b"git version 2.44.0\n"]
 
-        def upgrading(*arguments: str) -> bytes:
+        def upgrading(*arguments: str, executable: str = "git") -> bytes:
             assert arguments == ("--version",)
             return outputs.pop(0)
 

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1026,6 +1026,95 @@ class TestGitCapabilityProbeCache:
     failure paths are unchanged.
     """
 
+    def test_shim_scripts_are_probed_every_time(self, monkeypatch, tmp_path) -> None:
+        """A version-manager shim must not be capability-cached.
+
+        A shim keeps a stable path/inode/mtime while switching the underlying
+        Git, so file metadata does not pin its capability — scripts are
+        re-probed on every gate call, and a downgrade behind an unchanged
+        shim is rejected.
+        """
+        shim = tmp_path / "git"
+        shim.write_text('#!/bin/sh\nexec real-git "$@"\n')
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(shim))
+
+        versions = [b"git version 2.44.0\n", b"git version 2.20.0\n"]
+        probes = {"n": 0}
+
+        def switching_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            probes["n"] += 1
+            kwargs["stdout"].write(versions.pop(0))
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", switching_run)
+
+        project_identity._require_supported_git()
+        assert probes["n"] == 1
+
+        with pytest.raises(project_identity.ProjectIdentityGitVersionError):
+            project_identity._require_supported_git()
+        assert probes["n"] == 2
+
+    def test_native_binaries_stay_cached(self, monkeypatch, tmp_path) -> None:
+        """A native executable's capability is pinned by its content metadata."""
+        native = tmp_path / "git"
+        native.write_bytes(b"\x7fELF" + b"\x00" * 8)
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(native))
+
+        probes = {"n": 0}
+
+        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            probes["n"] += 1
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
+
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert probes["n"] == 1
+
+    def test_concurrent_cold_probes_single_flight(self, monkeypatch, tmp_path) -> None:
+        """Two cold threads must not spawn duplicate probes."""
+        import threading
+        import time
+
+        native = tmp_path / "git"
+        native.write_bytes(b"\x7fELF" + b"\x00" * 8)
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(native))
+
+        probes = {"n": 0}
+
+        def slow_run(argv, **kwargs):  # noqa: ANN001, ANN202
+            probes["n"] += 1
+            time.sleep(0.05)
+            kwargs["stdout"].write(b"git version 2.44.0\n")
+
+            class _Done:
+                returncode = 0
+
+            return _Done()
+
+        monkeypatch.setattr(project_identity.subprocess, "run", slow_run)
+
+        threads = [
+            threading.Thread(target=project_identity._require_supported_git) for _ in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert probes["n"] == 1
+
     def test_relative_which_result_is_anchored_to_an_absolute_path(
         self, monkeypatch, tmp_path
     ) -> None:
@@ -1104,7 +1193,7 @@ class TestGitCapabilityProbeCache:
     def test_same_path_replacement_invalidates_the_cache(self, monkeypatch, tmp_path) -> None:
         """Replacing the binary at the SAME path must re-probe (inode/mtime)."""
         git_path = tmp_path / "git"
-        git_path.write_text("#!/bin/sh\n")
+        git_path.write_bytes(b"\x7fELF" + b"\x00" * 8)
         monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
 
         probes = {"n": 0}
@@ -1125,14 +1214,14 @@ class TestGitCapabilityProbeCache:
         assert probes["n"] == 1
 
         git_path.unlink()
-        git_path.write_text("#!/bin/sh\necho replaced\n")
+        git_path.write_bytes(b"\x7fELF" + b"\x02" * 16)
         project_identity._require_supported_git()
         assert probes["n"] == 2
 
     def test_forked_child_reverifies(self, monkeypatch, tmp_path) -> None:
         """The PID key field makes a forked child re-probe."""
         git_path = tmp_path / "git"
-        git_path.write_text("#!/bin/sh\n")
+        git_path.write_bytes(b"\x7fELF" + b"\x00" * 8)
         monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
 
         probes = {"n": 0}
@@ -1179,9 +1268,9 @@ class TestGitCapabilityProbeCache:
     def test_warm_cache_reprobes_when_git_is_replaced(self, monkeypatch, tmp_path) -> None:
         """A different executable identity must invalidate the cache."""
         git_a = tmp_path / "git-a"
-        git_a.write_text("#!/bin/sh\n")
+        git_a.write_bytes(b"\x7fELF" + b"\x00" * 8)
         git_b = tmp_path / "git-b"
-        git_b.write_text("#!/bin/sh\necho\n")
+        git_b.write_bytes(b"\x7fELF" + b"\x01" * 8)
 
         probes = {"n": 0}
 

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -1023,6 +1023,49 @@ class TestGitCapabilityProbeCache:
     failure paths are unchanged.
     """
 
+    def test_warm_cache_fails_closed_when_git_disappears(self, monkeypatch) -> None:
+        """A warmed cache must not outlive the executable it verified.
+
+        After a successful probe, deleting git from PATH must surface
+        unavailability on the next gate call — without this the local-first
+        resolution of a non-Git directory succeeds with zero git commands
+        while git is gone, violating the fail-closed contract.
+        """
+        monkeypatch.setattr(
+            project_identity,
+            "_run_git_command",
+            lambda *a: b"git version 2.44.0\n" if a == ("--version",) else b"",
+        )
+        project_identity._require_supported_git()
+
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _name: None)
+        with pytest.raises(project_identity.ProjectIdentityUnavailableError):
+            project_identity._require_supported_git()
+
+    def test_warm_cache_reprobes_when_git_is_replaced(self, monkeypatch, tmp_path) -> None:
+        """A different executable identity must invalidate the cache."""
+        git_a = tmp_path / "git-a"
+        git_a.write_text("#!/bin/sh\n")
+        git_b = tmp_path / "git-b"
+        git_b.write_text("#!/bin/sh\necho\n")
+
+        probes = {"n": 0}
+
+        def probing(*arguments: str) -> bytes:
+            assert arguments == ("--version",)
+            probes["n"] += 1
+            return b"git version 2.44.0\n"
+
+        monkeypatch.setattr(project_identity, "_run_git_command", probing)
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_a))
+        project_identity._require_supported_git()
+        project_identity._require_supported_git()
+        assert probes["n"] == 1
+
+        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_b))
+        project_identity._require_supported_git()
+        assert probes["n"] == 2
+
     def test_successful_probe_runs_git_version_once(self, monkeypatch) -> None:
         calls: list[tuple[str, ...]] = []
         real = project_identity._run_git_command

--- a/tests/unit/core/test_project_identity.py
+++ b/tests/unit/core/test_project_identity.py
@@ -692,10 +692,7 @@ def test_git_version_probe_does_not_depend_on_workdir_capability() -> None:
     ) as run_git_command:
         _require_supported_git()
 
-    assert run_git_command.call_count == 1
-    assert run_git_command.call_args.args == ("--version",)
-    # The probe targets the exact executable its cache key resolved (#1796).
-    assert run_git_command.call_args.kwargs.get("executable", "git")
+    run_git_command.assert_called_once_with("--version")
 
 
 def test_repository_query_nonzero_after_git_probe_is_unavailable(tmp_path: Path) -> None:
@@ -1017,328 +1014,69 @@ def test_project_identity_rejects_noncanonical_fields(
         )
 
 
-class TestGitCapabilityProbeCache:
-    """#1796 L1: cache the git --version capability probe per process.
+class TestGitCapabilityProbeScope:
+    """#1796: one probe per scope; per-call probing everywhere else."""
 
-    Only a SUCCESSFUL probe is cached: the installed binary cannot change
-    within one process, but a transient spawn failure must keep re-probing,
-    and a genuine version rejection stays uncached so the semantics on the
-    failure paths are unchanged.
-    """
+    def _counting_probe(self, monkeypatch):
+        calls = {"n": 0}
 
-    def test_shim_scripts_are_probed_every_time(self, monkeypatch, tmp_path) -> None:
-        """A version-manager shim must not be capability-cached.
-
-        A shim keeps a stable path/inode/mtime while switching the underlying
-        Git, so file metadata does not pin its capability — scripts are
-        re-probed on every gate call, and a downgrade behind an unchanged
-        shim is rejected.
-        """
-        shim = tmp_path / "git"
-        shim.write_text('#!/bin/sh\nexec real-git "$@"\n')
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(shim))
-
-        versions = [b"git version 2.44.0\n", b"git version 2.20.0\n"]
-        probes = {"n": 0}
-
-        def switching_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            probes["n"] += 1
-            kwargs["stdout"].write(versions.pop(0))
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", switching_run)
-
-        project_identity._require_supported_git()
-        assert probes["n"] == 1
-
-        with pytest.raises(project_identity.ProjectIdentityGitVersionError):
-            project_identity._require_supported_git()
-        assert probes["n"] == 2
-
-    def test_native_binaries_stay_cached(self, monkeypatch, tmp_path) -> None:
-        """A native executable's capability is pinned by its content metadata."""
-        native = tmp_path / "git"
-        native.write_bytes(b"\x7fELF" + b"\x00" * 8)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(native))
-
-        probes = {"n": 0}
-
-        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            probes["n"] += 1
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
-
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert probes["n"] == 1
-
-    def test_concurrent_cold_probes_single_flight(self, monkeypatch, tmp_path) -> None:
-        """Two cold threads must not spawn duplicate probes."""
-        import threading
-        import time
-
-        native = tmp_path / "git"
-        native.write_bytes(b"\x7fELF" + b"\x00" * 8)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(native))
-
-        probes = {"n": 0}
-
-        def slow_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            probes["n"] += 1
-            time.sleep(0.05)
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", slow_run)
-
-        threads = [
-            threading.Thread(target=project_identity._require_supported_git) for _ in range(2)
-        ]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-        assert probes["n"] == 1
-
-    def test_relative_which_result_is_anchored_to_an_absolute_path(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        """A relative PATH entry must not reopen the lookup race.
-
-        With POSIX PATH=:/usr/bin the empty entry resolves against the
-        mutable process cwd and shutil.which() can return a bare relative
-        name; passing that to subprocess performs another cwd-dependent
-        lookup. The key must anchor the selection to an absolute path used
-        for both stat and execution.
-        """
-        (tmp_path / "gitx").write_text("#!/bin/sh\n")
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: "gitx")
-
-        invoked: list[str] = []
-
-        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            invoked.append(argv[0])
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
-
-        project_identity._require_supported_git()
-
-        assert invoked == [str(tmp_path / "gitx")], (
-            "the probe executed a relative path, leaving it cwd-dependent"
-        )
-
-    def test_probe_targets_the_exact_executable_the_key_resolved(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        """Key resolution and the probe must not race a mutable PATH.
-
-        If the probe performs its own PATH lookup, a concurrent switch can
-        verify binary B and cache its success under binary A's key; later
-        calls then accept A without validation.
-        """
-        git_a = tmp_path / "git-a"
-        git_a.write_text("#!/bin/sh\n")
-        git_b = tmp_path / "git-b"
-        git_b.write_text("#!/bin/sh\n")
-
-        lookups = {"n": 0}
-
-        def switching_which(_name: str) -> str:
-            lookups["n"] += 1
-            return str(git_a) if lookups["n"] == 1 else str(git_b)
-
-        monkeypatch.setattr(project_identity.shutil, "which", switching_which)
-
-        invoked: list[str] = []
-
-        def recording_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            invoked.append(argv[0])
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", recording_run)
-
-        project_identity._require_supported_git()
-
-        assert invoked == [str(git_a)], (
-            "the probe ran a PATH lookup of its own instead of the key's executable"
-        )
-
-    def test_same_path_replacement_invalidates_the_cache(self, monkeypatch, tmp_path) -> None:
-        """Replacing the binary at the SAME path must re-probe (inode/mtime)."""
-        git_path = tmp_path / "git"
-        git_path.write_bytes(b"\x7fELF" + b"\x00" * 8)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
-
-        probes = {"n": 0}
-
-        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            probes["n"] += 1
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
-
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert probes["n"] == 1
-
-        git_path.unlink()
-        git_path.write_bytes(b"\x7fELF" + b"\x02" * 16)
-        project_identity._require_supported_git()
-        assert probes["n"] == 2
-
-    def test_forked_child_reverifies(self, monkeypatch, tmp_path) -> None:
-        """The PID key field makes a forked child re-probe."""
-        git_path = tmp_path / "git"
-        git_path.write_bytes(b"\x7fELF" + b"\x00" * 8)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_path))
-
-        probes = {"n": 0}
-
-        def probing_run(argv, **kwargs):  # noqa: ANN001, ANN202
-            probes["n"] += 1
-            kwargs["stdout"].write(b"git version 2.44.0\n")
-
-            class _Done:
-                returncode = 0
-
-            return _Done()
-
-        monkeypatch.setattr(project_identity.subprocess, "run", probing_run)
-
-        monkeypatch.setattr(project_identity.os, "getpid", lambda: 11111)
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert probes["n"] == 1
-
-        monkeypatch.setattr(project_identity.os, "getpid", lambda: 22222)
-        project_identity._require_supported_git()
-        assert probes["n"] == 2
-
-    def test_warm_cache_fails_closed_when_git_disappears(self, monkeypatch) -> None:
-        """A warmed cache must not outlive the executable it verified.
-
-        After a successful probe, deleting git from PATH must surface
-        unavailability on the next gate call — without this the local-first
-        resolution of a non-Git directory succeeds with zero git commands
-        while git is gone, violating the fail-closed contract.
-        """
-        monkeypatch.setattr(
-            project_identity,
-            "_run_git_command",
-            lambda *a, **_kw: b"git version 2.44.0\n" if a == ("--version",) else b"",
-        )
-        project_identity._require_supported_git()
-
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _name: None)
-        with pytest.raises(project_identity.ProjectIdentityUnavailableError):
-            project_identity._require_supported_git()
-
-    def test_warm_cache_reprobes_when_git_is_replaced(self, monkeypatch, tmp_path) -> None:
-        """A different executable identity must invalidate the cache."""
-        git_a = tmp_path / "git-a"
-        git_a.write_bytes(b"\x7fELF" + b"\x00" * 8)
-        git_b = tmp_path / "git-b"
-        git_b.write_bytes(b"\x7fELF" + b"\x01" * 8)
-
-        probes = {"n": 0}
-
-        def probing(*arguments: str, executable: str = "git") -> bytes:
+        def fake(*arguments: str) -> bytes:
             assert arguments == ("--version",)
-            probes["n"] += 1
+            calls["n"] += 1
             return b"git version 2.44.0\n"
 
-        monkeypatch.setattr(project_identity, "_run_git_command", probing)
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_a))
+        monkeypatch.setattr(project_identity, "_run_git_command", fake)
+        return calls
+
+    def test_without_scope_every_call_probes(self, monkeypatch) -> None:
+        calls = self._counting_probe(monkeypatch)
         project_identity._require_supported_git()
         project_identity._require_supported_git()
-        assert probes["n"] == 1
+        assert calls["n"] == 2
 
-        monkeypatch.setattr(project_identity.shutil, "which", lambda _n: str(git_b))
+    def test_scope_shares_a_single_probe(self, monkeypatch) -> None:
+        calls = self._counting_probe(monkeypatch)
+        with project_identity.git_capability_probe_scope():
+            project_identity._require_supported_git()
+            project_identity._require_supported_git()
+            project_identity._require_supported_git()
+        assert calls["n"] == 1
+
+    def test_nothing_survives_the_scope(self, monkeypatch) -> None:
+        calls = self._counting_probe(monkeypatch)
+        with project_identity.git_capability_probe_scope():
+            project_identity._require_supported_git()
         project_identity._require_supported_git()
-        assert probes["n"] == 2
+        assert calls["n"] == 2
 
-    def test_successful_probe_runs_git_version_once(self, monkeypatch) -> None:
-        calls: list[tuple[str, ...]] = []
-        real = project_identity._run_git_command
-
-        def counting(*arguments: str, executable: str = "git") -> bytes:
-            calls.append(arguments)
-            if arguments == ("--version",):
-                return b"git version 2.44.0\n"
-            return real(*arguments)
-
-        monkeypatch.setattr(project_identity, "_run_git_command", counting)
-
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        project_identity._require_supported_git()
-
-        assert calls.count(("--version",)) == 1
-
-    def test_transient_failure_is_not_cached(self, monkeypatch) -> None:
+    def test_scope_failure_is_not_memoized(self, monkeypatch) -> None:
         attempts = {"n": 0}
 
-        def flaky(*arguments: str, executable: str = "git") -> bytes:
-            assert arguments == ("--version",)
+        def flaky(*arguments: str) -> bytes:
             attempts["n"] += 1
             if attempts["n"] == 1:
-                raise project_identity.ProjectIdentityUnavailableError(
-                    "Git query is temporarily unavailable"
-                )
+                raise project_identity.ProjectIdentityUnavailableError("transient")
             return b"git version 2.44.0\n"
 
         monkeypatch.setattr(project_identity, "_run_git_command", flaky)
-
-        with pytest.raises(project_identity.ProjectIdentityUnavailableError):
+        with project_identity.git_capability_probe_scope():
+            with pytest.raises(project_identity.ProjectIdentityUnavailableError):
+                project_identity._require_supported_git()
             project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert attempts["n"] == 2
-        # and now the success is cached
-        project_identity._require_supported_git()
+            project_identity._require_supported_git()
         assert attempts["n"] == 2
 
-    def test_version_rejection_is_not_cached(self, monkeypatch) -> None:
-        outputs = [b"git version 2.20.0\n", b"git version 2.44.0\n"]
+    @pytest.mark.asyncio
+    async def test_concurrent_scopes_are_isolated(self, monkeypatch) -> None:
+        import asyncio
 
-        def upgrading(*arguments: str, executable: str = "git") -> bytes:
-            assert arguments == ("--version",)
-            return outputs.pop(0)
+        calls = self._counting_probe(monkeypatch)
 
-        monkeypatch.setattr(project_identity, "_run_git_command", upgrading)
+        async def one_scope() -> None:
+            with project_identity.git_capability_probe_scope():
+                project_identity._require_supported_git()
+                await asyncio.sleep(0)
+                project_identity._require_supported_git()
 
-        with pytest.raises(project_identity.ProjectIdentityGitVersionError):
-            project_identity._require_supported_git()
-        project_identity._require_supported_git()
-        assert outputs == []
+        await asyncio.gather(one_scope(), one_scope())
+        assert calls["n"] == 2

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -7012,10 +7012,10 @@ async def test_prepare_session_shares_one_capability_probe(tmp_path: Path) -> No
     probes = {"n": 0}
     real = project_identity_module._run_git_command
 
-    def counting(*arguments: str) -> bytes:
+    def counting(*arguments: str, executable: str | None = None) -> bytes:
         if arguments == ("--version",):
             probes["n"] += 1
-        return real(*arguments)
+        return real(*arguments, executable=executable)
 
     with _patch.object(project_identity_module, "_run_git_command", counting):
         prepared = await runner.prepare_session(

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -2177,22 +2177,8 @@ async def test_resume_identity_unavailable_stays_paused_and_releases_claim_for_r
             unavailable = patch(patch_target, new=selective_stat)
         else:
             unavailable = patch(patch_target, side_effect=failure)
-        # #1796 binds the capability cache to the resolved executable
-        # identity, so simulating a vanished git means the PATH lookup fails
-        # too — the warm cache then invalidates itself and the production
-        # sequence (prepare verified git, git disappears, resume blocks)
-        # runs without any manual cache manipulation.
-        if case == "git-unavailable":
-            from ouroboros.core import project_identity as project_identity_module
-
-            with (
-                unavailable,
-                patch.object(project_identity_module.shutil, "which", lambda _n: None),
-            ):
-                result = await runner.resume_session(tracker.session_id, _seed())
-        else:
-            with unavailable:
-                result = await runner.resume_session(tracker.session_id, _seed())
+        with unavailable:
+            result = await runner.resume_session(tracker.session_id, _seed())
 
         assert result.is_err
         assert result.error.details.get("resume_blocked") == "project_identity_unavailable", (
@@ -7006,3 +6992,38 @@ def test_diagnostic_contract_builds_do_not_leak_registry_issuances() -> None:
         assert contract["foundation_a_authority"]["scope"] == "process_local"
 
     assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_shares_one_capability_probe(tmp_path: Path) -> None:
+    """#1796: contract build + publication revalidation share one git probe."""
+    from unittest.mock import patch as _patch
+
+    from ouroboros.core import project_identity as project_identity_module
+
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'probe-scope.db'}")
+    await event_store.initialize()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runtime = _CountingRuntime()
+    runtime.working_directory = str(workspace)
+    runner = OrchestratorRunner(runtime, event_store, MagicMock(), fat_harness_mode=False)
+
+    probes = {"n": 0}
+    real = project_identity_module._run_git_command
+
+    def counting(*arguments: str) -> bytes:
+        if arguments == ("--version",):
+            probes["n"] += 1
+        return real(*arguments)
+
+    with _patch.object(project_identity_module, "_run_git_command", counting):
+        prepared = await runner.prepare_session(
+            _seed(), execution_id="exec-probe-scope", session_id="session-probe-scope"
+        )
+
+    assert prepared.is_ok
+    assert probes["n"] == 1, (
+        f"expected one shared capability probe per session start, got {probes['n']}"
+    )
+    await event_store.close()

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -2177,6 +2177,15 @@ async def test_resume_identity_unavailable_stays_paused_and_releases_claim_for_r
             unavailable = patch(patch_target, new=selective_stat)
         else:
             unavailable = patch(patch_target, side_effect=failure)
+        # #1796 caches a successful git capability probe for the process
+        # lifetime, and prepare_session above verified git legitimately. This
+        # scenario models a process where git was never available, so start
+        # the unavailable window from a cold probe cache — a verified-then-
+        # vanished binary is outside the cache's supported model and defers
+        # to downstream git failures instead.
+        from ouroboros.core import project_identity as project_identity_module
+
+        project_identity_module._reset_git_capability_cache_for_tests()
         with unavailable:
             result = await runner.resume_session(tracker.session_id, _seed())
 

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -6994,36 +6994,71 @@ def test_diagnostic_contract_builds_do_not_leak_registry_issuances() -> None:
     assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before
 
 
-@pytest.mark.asyncio
-async def test_prepare_session_shares_one_capability_probe(tmp_path: Path) -> None:
-    """#1796: contract build + publication revalidation share one git probe."""
+async def _prepare_session_counting_publication_resolves(
+    tmp_path: Path, workspace: Path, run_tag: str
+) -> int:
+    """Run prepare_session and count publication-boundary re-resolutions."""
     from unittest.mock import patch as _patch
 
-    from ouroboros.core import project_identity as project_identity_module
+    from ouroboros.core.project_identity import resolve_project_identity as _resolve
+    from ouroboros.orchestrator import session as session_module
 
-    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'probe-scope.db'}")
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'evidence.db'}")
     await event_store.initialize()
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
     runtime = _CountingRuntime()
     runtime.working_directory = str(workspace)
     runner = OrchestratorRunner(runtime, event_store, MagicMock(), fat_harness_mode=False)
 
-    probes = {"n": 0}
-    real = project_identity_module._run_git_command
+    resolves = {"n": 0}
 
-    def counting(*arguments: str, executable: str | None = None) -> bytes:
-        if arguments == ("--version",):
-            probes["n"] += 1
-        return real(*arguments, executable=executable)
+    def counting(effective_cwd):  # noqa: ANN001, ANN202
+        resolves["n"] += 1
+        return _resolve(effective_cwd)
 
-    with _patch.object(project_identity_module, "_run_git_command", counting):
-        prepared = await runner.prepare_session(
-            _seed(), execution_id="exec-probe-scope", session_id="session-probe-scope"
-        )
+    try:
+        with _patch.object(session_module, "resolve_project_identity", counting):
+            prepared = await runner.prepare_session(
+                _seed(),
+                execution_id=f"exec-{run_tag}",
+                session_id=f"session-{run_tag}",
+            )
+        assert prepared.is_ok
+    finally:
+        await event_store.close()
+    return resolves["n"]
 
-    assert prepared.is_ok
-    assert probes["n"] == 1, (
-        f"expected one shared capability probe per session start, got {probes['n']}"
+
+@pytest.mark.asyncio
+async def test_prepare_session_publication_reuses_resolution_evidence(
+    tmp_path: Path,
+) -> None:
+    """#1796: with a stable input closure, publication never re-runs the resolver."""
+    import subprocess
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+
+    resolves = await _prepare_session_counting_publication_resolves(
+        tmp_path, workspace, "evidence-reuse"
     )
-    await event_store.close()
+
+    assert resolves == 0, (
+        f"expected the publication boundary to accept captured evidence, got "
+        f"{resolves} re-resolution(s)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_publication_re_resolves_outside_the_closure(
+    tmp_path: Path,
+) -> None:
+    """Shapes outside the enumerable closure keep the full revalidation path."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    resolves = await _prepare_session_counting_publication_resolves(
+        tmp_path, workspace, "evidence-escalate"
+    )
+
+    assert resolves == 1, f"expected exactly one full publication re-resolution, got {resolves}"

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -2177,17 +2177,22 @@ async def test_resume_identity_unavailable_stays_paused_and_releases_claim_for_r
             unavailable = patch(patch_target, new=selective_stat)
         else:
             unavailable = patch(patch_target, side_effect=failure)
-        # #1796 caches a successful git capability probe for the process
-        # lifetime, and prepare_session above verified git legitimately. This
-        # scenario models a process where git was never available, so start
-        # the unavailable window from a cold probe cache — a verified-then-
-        # vanished binary is outside the cache's supported model and defers
-        # to downstream git failures instead.
-        from ouroboros.core import project_identity as project_identity_module
+        # #1796 binds the capability cache to the resolved executable
+        # identity, so simulating a vanished git means the PATH lookup fails
+        # too — the warm cache then invalidates itself and the production
+        # sequence (prepare verified git, git disappears, resume blocks)
+        # runs without any manual cache manipulation.
+        if case == "git-unavailable":
+            from ouroboros.core import project_identity as project_identity_module
 
-        project_identity_module._reset_git_capability_cache_for_tests()
-        with unavailable:
-            result = await runner.resume_session(tracker.session_id, _seed())
+            with (
+                unavailable,
+                patch.object(project_identity_module.shutil, "which", lambda _n: None),
+            ):
+                result = await runner.resume_session(tracker.session_id, _seed())
+        else:
+            with unavailable:
+                result = await runner.resume_session(tracker.session_id, _seed())
 
         assert result.is_err
         assert result.error.details.get("resume_blocked") == "project_identity_unavailable", (

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -15,6 +15,8 @@ from ouroboros.core import project_identity as project_identity_module
 from ouroboros.core.project_identity import (
     ProjectIdentity,
     ProjectIdentityError,
+    ProjectIdentityUnavailableError,
+    publication_evidence_sink,
     resolve_managed_project_identity,
     resolve_project_identity,
     resolve_project_identity_for_publication,
@@ -257,21 +259,21 @@ class TestSessionRepository:
         workspace = project_root / "packages" / "app"
         workspace.mkdir(parents=True)
         subprocess.run(["git", "init", "-q", str(project_root)], check=True)
-        identity, evidence = resolve_project_identity_for_publication(workspace)
-        execution_contract = {"frugality_proof": identity.to_workspace_data()}
+        with publication_evidence_sink():
+            identity, _evidence = resolve_project_identity_for_publication(workspace)
+            execution_contract = {"frugality_proof": identity.to_workspace_data()}
 
-        with patch(
-            "ouroboros.orchestrator.session.resolve_project_identity",
-            side_effect=AssertionError("publication must not re-run the resolver"),
-        ):
-            result = await repository.create_session(
-                execution_id="exec_123",
-                seed_id="seed_456",
-                execution_contract=execution_contract,
-                project_identity=identity,
-                project_workspace=str(workspace),
-                project_identity_evidence=evidence,
-            )
+            with patch(
+                "ouroboros.orchestrator.session.resolve_project_identity",
+                side_effect=AssertionError("publication must not re-run the resolver"),
+            ):
+                result = await repository.create_session(
+                    execution_id="exec_123",
+                    seed_id="seed_456",
+                    execution_contract=execution_contract,
+                    project_identity=identity,
+                    project_workspace=str(workspace),
+                )
 
         assert result.is_ok
         event = mock_event_store.append.call_args.args[0]
@@ -289,29 +291,29 @@ class TestSessionRepository:
         workspace = project_root / "packages" / "app"
         workspace.mkdir(parents=True)
         subprocess.run(["git", "init", "-q", str(project_root)], check=True)
-        identity, evidence = resolve_project_identity_for_publication(workspace)
-        execution_contract = {"frugality_proof": identity.to_workspace_data()}
-        config = project_root / ".git" / "config"
-        config.write_bytes(config.read_bytes() + b"# identity-neutral edit\n")
-
         resolves = {"n": 0}
 
         def counting(effective_cwd):
             resolves["n"] += 1
             return resolve_project_identity(effective_cwd)
 
-        with patch(
-            "ouroboros.orchestrator.session.resolve_project_identity",
-            side_effect=counting,
-        ):
-            result = await repository.create_session(
-                execution_id="exec_123",
-                seed_id="seed_456",
-                execution_contract=execution_contract,
-                project_identity=identity,
-                project_workspace=str(workspace),
-                project_identity_evidence=evidence,
-            )
+        with publication_evidence_sink():
+            identity, _evidence = resolve_project_identity_for_publication(workspace)
+            execution_contract = {"frugality_proof": identity.to_workspace_data()}
+            config = project_root / ".git" / "config"
+            config.write_bytes(config.read_bytes() + b"# identity-neutral edit\n")
+
+            with patch(
+                "ouroboros.orchestrator.session.resolve_project_identity",
+                side_effect=counting,
+            ):
+                result = await repository.create_session(
+                    execution_id="exec_123",
+                    seed_id="seed_456",
+                    execution_contract=execution_contract,
+                    project_identity=identity,
+                    project_workspace=str(workspace),
+                )
 
         assert result.is_ok
         assert resolves["n"] == 1
@@ -332,7 +334,6 @@ class TestSessionRepository:
         other_root.mkdir()
         subprocess.run(["git", "init", "-q", str(other_root)], check=True)
         identity = resolve_project_identity(workspace)
-        _, foreign_evidence = resolve_project_identity_for_publication(other_root)
         execution_contract = {"frugality_proof": identity.to_workspace_data()}
 
         resolves = {"n": 0}
@@ -341,21 +342,73 @@ class TestSessionRepository:
             resolves["n"] += 1
             return resolve_project_identity(effective_cwd)
 
-        with patch(
-            "ouroboros.orchestrator.session.resolve_project_identity",
-            side_effect=counting,
-        ):
-            result = await repository.create_session(
-                execution_id="exec_123",
-                seed_id="seed_456",
-                execution_contract=execution_contract,
-                project_identity=identity,
-                project_workspace=str(workspace),
-                project_identity_evidence=foreign_evidence,
-            )
+        with publication_evidence_sink():
+            resolve_project_identity_for_publication(other_root)
+
+            with patch(
+                "ouroboros.orchestrator.session.resolve_project_identity",
+                side_effect=counting,
+            ):
+                result = await repository.create_session(
+                    execution_id="exec_123",
+                    seed_id="seed_456",
+                    execution_contract=execution_contract,
+                    project_identity=identity,
+                    project_workspace=str(workspace),
+                )
 
         assert result.is_ok
         assert resolves["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_create_session_refuses_planted_evidence_over_invalid_git_shape(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """A caller-assembled closure never substitutes for the re-resolution.
+
+        Even evidence that structurally matches the live filesystem is refused
+        when the resolver did not issue it; publication falls through to the
+        full re-resolution, which fails closed on the invalid marker shape.
+        """
+        fake_root = (tmp_path / "fake").resolve()
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        identity = ProjectIdentity.from_root(fake_root, workspace_path=".", require_exists=True)
+        git_dir = fake_root / ".git"
+        forged_files = [project_identity_module._capture_topology_file(git_dir, hash_content=True)]
+        for name in project_identity_module._GIT_DIR_CLOSURE_NAMES:
+            forged_files.append(
+                project_identity_module._capture_topology_file(git_dir / name, hash_content=True)
+            )
+        forged_files.append(
+            project_identity_module._capture_topology_file(
+                git_dir / "worktrees", hash_content=False
+            )
+        )
+        forged = project_identity_module.PublicationEvidence(
+            identity=identity,
+            effective_directory=fake_root,
+            directory_evidence=(project_identity_module._capture_live_directory(fake_root),),
+            file_evidence=tuple(forged_files),
+            escalate=False,
+        )
+        execution_contract = {"frugality_proof": identity.to_workspace_data()}
+
+        with publication_evidence_sink() as cell:
+            cell[0] = forged
+            with pytest.raises(ProjectIdentityUnavailableError):
+                await repository.create_session(
+                    execution_id="exec_123",
+                    seed_id="seed_456",
+                    execution_contract=execution_contract,
+                    project_identity=identity,
+                    project_workspace=str(fake_root),
+                )
+
+        mock_event_store.append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_create_session_rejects_workspace_deleted_after_topology_resolution(

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -17,6 +17,7 @@ from ouroboros.core.project_identity import (
     ProjectIdentityError,
     resolve_managed_project_identity,
     resolve_project_identity,
+    resolve_project_identity_for_publication,
 )
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace
@@ -243,6 +244,118 @@ class TestSessionRepository:
             key: event.data[key] for key in ("project_id", "project_root", "workspace_path")
         } == identity.to_event_data()
         assert event.data["execution_contract"] == execution_contract
+
+    @pytest.mark.asyncio
+    async def test_create_session_accepts_stable_evidence_without_re_resolution(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """A stable captured closure lets publication skip the second resolution."""
+        project_root = tmp_path / "project-map"
+        workspace = project_root / "packages" / "app"
+        workspace.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", str(project_root)], check=True)
+        identity, evidence = resolve_project_identity_for_publication(workspace)
+        execution_contract = {"frugality_proof": identity.to_workspace_data()}
+
+        with patch(
+            "ouroboros.orchestrator.session.resolve_project_identity",
+            side_effect=AssertionError("publication must not re-run the resolver"),
+        ):
+            result = await repository.create_session(
+                execution_id="exec_123",
+                seed_id="seed_456",
+                execution_contract=execution_contract,
+                project_identity=identity,
+                project_workspace=str(workspace),
+                project_identity_evidence=evidence,
+            )
+
+        assert result.is_ok
+        event = mock_event_store.append.call_args.args[0]
+        assert event.data["project_root"] == identity.project_root
+
+    @pytest.mark.asyncio
+    async def test_create_session_re_resolves_when_evidence_closure_drifts(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Any change inside the captured closure forces the full revalidation."""
+        project_root = tmp_path / "project-map"
+        workspace = project_root / "packages" / "app"
+        workspace.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", str(project_root)], check=True)
+        identity, evidence = resolve_project_identity_for_publication(workspace)
+        execution_contract = {"frugality_proof": identity.to_workspace_data()}
+        config = project_root / ".git" / "config"
+        config.write_bytes(config.read_bytes() + b"# identity-neutral edit\n")
+
+        resolves = {"n": 0}
+
+        def counting(effective_cwd):
+            resolves["n"] += 1
+            return resolve_project_identity(effective_cwd)
+
+        with patch(
+            "ouroboros.orchestrator.session.resolve_project_identity",
+            side_effect=counting,
+        ):
+            result = await repository.create_session(
+                execution_id="exec_123",
+                seed_id="seed_456",
+                execution_contract=execution_contract,
+                project_identity=identity,
+                project_workspace=str(workspace),
+                project_identity_evidence=evidence,
+            )
+
+        assert result.is_ok
+        assert resolves["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_create_session_ignores_evidence_for_a_different_identity(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Evidence must vouch for the published identity itself, not merely exist."""
+        project_root = tmp_path / "project-map"
+        workspace = project_root / "packages" / "app"
+        workspace.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", str(project_root)], check=True)
+        other_root = tmp_path / "other"
+        other_root.mkdir()
+        subprocess.run(["git", "init", "-q", str(other_root)], check=True)
+        identity = resolve_project_identity(workspace)
+        _, foreign_evidence = resolve_project_identity_for_publication(other_root)
+        execution_contract = {"frugality_proof": identity.to_workspace_data()}
+
+        resolves = {"n": 0}
+
+        def counting(effective_cwd):
+            resolves["n"] += 1
+            return resolve_project_identity(effective_cwd)
+
+        with patch(
+            "ouroboros.orchestrator.session.resolve_project_identity",
+            side_effect=counting,
+        ):
+            result = await repository.create_session(
+                execution_id="exec_123",
+                seed_id="seed_456",
+                execution_contract=execution_contract,
+                project_identity=identity,
+                project_workspace=str(workspace),
+                project_identity_evidence=foreign_evidence,
+            )
+
+        assert result.is_ok
+        assert resolves["n"] == 1
 
     @pytest.mark.asyncio
     async def test_create_session_rejects_workspace_deleted_after_topology_resolution(


### PR DESCRIPTION
Closes #1796.

A session start resolved project identity twice — once while building the execution contract and again at the immutable publication boundary — and each resolution paid its own `git --version` capability probe plus the full set of topology queries.

This PR removes the second resolution for the common simple-checkout shape without reusing capability authority. Contract construction captures the resolver's repo-local input closure, and the publication boundary revalidates from that evidence by metadata alone; when anything is in doubt it escalates to the full re-resolution, which probes for itself exactly as on main.

How it works:

- `resolve_project_identity_for_publication` runs the unchanged resolution pipeline and captures the closure of its five fixed topology queries: every boundary `.git` marker between the effective directory and the checkout root, plus the marker directory's `HEAD`, `config`, `config.worktree`, `commondir`, `gitdir`, and the `worktrees` registry with each entry's `gitdir` link — each recorded as stat generation (device, inode, mtime_ns, size) plus a content hash. The capture is bracketed: the closure is captured before the resolver's queries and re-captured after, and the evidence is usable only when the two captures are byte-identical, which binds the recorded state to the exact resolution that produced the identity.
- At publication, `publication_evidence_is_stable` accepts only when the published workspace canonicalizes to the captured directory, the evidence carries the complete resolver-shaped closure for exactly the published identity, and every captured input is unchanged. The recheck runs no git subprocess at all, so the V1 rule that resolvers validate Git before topology queries is satisfied vacuously — there are none.
- Everything outside the enumerable closure fails closed: bare repositories, gitdir-pointer checkouts (linked worktrees), commondir constellations, config include directives (detected by an unanchored, case-insensitive byte search — a sound over-approximation of Git's config grammar rather than a reimplementation), oversized or unreadable inputs. All of these escalate to the full re-resolution.
- The earlier probe-scope design from this PR's review history is fully removed; construction probes per call exactly as main does, and no probe result crosses between resolutions.

Coverage: a mutation matrix proving each closure input individually destabilizes the evidence, a zero-git-subprocess assertion on the recheck, escalation exercised against a real `git worktree add` checkout and BOM-prefixed include bytes, binding of evidence to its own workspace and resolution (interleaved-mutation regression), refusal of incomplete or caller-assembled evidence, session-boundary tests for foreign and drifted evidence, and `prepare_session` wiring tests counting publication re-resolutions.
