### PR TITLE
fix(auto): detect git worktrees as brownfield

### DIFF
--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -83,7 +83,7 @@ def brownfield_context_from_cwd(cwd: str | Path | None) -> BrownfieldContext:
         from ouroboros.bigbang.explore import detect_brownfield
 
         root = Path(cwd).expanduser()
-        if not root.is_dir() or not detect_brownfield(root):
+        if not root.is_dir() or not ((root / ".git").exists() or detect_brownfield(root)):
             return BrownfieldContext()
         return BrownfieldContext(
             project_type="brownfield",

--- a/tests/unit/auto/test_ledger_seed_brownfield.py
+++ b/tests/unit/auto/test_ledger_seed_brownfield.py
@@ -57,6 +57,16 @@ class TestBrownfieldContextFromCwd:
         assert ctx.context_references[0].path == str(tmp_path)
         assert ctx.context_references[0].role == "primary"
 
+    def test_brownfield_when_git_directory_present(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        ctx = brownfield_context_from_cwd(tmp_path)
+        assert ctx.project_type == "brownfield"
+
+    def test_brownfield_when_git_file_present(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").write_text("gitdir: /tmp/example.git\n", encoding="utf-8")
+        ctx = brownfield_context_from_cwd(tmp_path)
+        assert ctx.project_type == "brownfield"
+
     def test_none_cwd_is_greenfield(self) -> None:
         assert brownfield_context_from_cwd(None).project_type == "greenfield"
 


### PR DESCRIPTION
## Summary
- classify Git repositories as brownfield even without a recognized root manifest
- support linked worktrees whose `.git` entry is a file
- preserve manifest-based and empty-directory behavior

## Test plan
- [x] red: both Git-directory and Git-file regression tests failed as greenfield before the fix
- [x] targeted: `8 passed`
- [x] Ruff passed; mypy passed
- [x] full suite: `14747 passed, 18 skipped, 2 warnings in 478.28s`
- [ ] canonical live R-run: attempted, but blocked before round 1 because the local Claude backend was not logged in; no auth/config changes were made

## R-run comparison

This is a substrate-only predicate evaluated once during Seed synthesis, not a per-round interview-loop change. A fresh canonical run was attempted but produced no rounds because the Claude backend returned `Not logged in`. Per the template substrate-only contract, all comparison cells are explicitly N/A.

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [x] N/A — this change does not execute per round.

## Scope
One production predicate and two regression tests; no database or public API changes.

## Related issues

Closes #1809.