### PR TITLE
fix: persist status and classify browser apps

### DIFF
--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -336,6 +336,19 @@ def _matches_game_2d(ledger: SeedDraftLedger) -> bool:
     )
 
 
+def _matches_web_app(ledger: SeedDraftLedger) -> bool:
+    outputs = _section_text(ledger, "outputs")
+    runtime = _section_text(ledger, "runtime_context")
+    goal = _goal_text(ledger)
+    text = " ".join((outputs, runtime, goal))
+    browser_signal = _any_of(text, ("browser", "dom", "html", "website", "web app"))
+    interaction_signal = _any_of(
+        text,
+        ("user interface", "web ui", "form", "button", "page", "panel", "validation message"),
+    )
+    return browser_signal and interaction_signal
+
+
 def _matches_refactor_in_place(ledger: SeedDraftLedger) -> bool:
     goal = _goal_text(ledger)
     constraints = _section_text(ledger, "constraints")
@@ -366,8 +379,9 @@ def _matches_library(ledger: SeedDraftLedger) -> bool:
     # many false positives that shadowed cli / web_service inference
     # under ledger_only closures. The remaining keywords are
     # library-distinctive surface terms. See #1170 R2 evidence.
+    text = (outputs + " " + goal).replace("package.json", "")
     return _any_of(
-        outputs + " " + goal,
+        text,
         (
             "library",
             "package",
@@ -383,6 +397,7 @@ _PATTERN_REGISTRY: dict[TaskClass, _PatternFn] = {
     TaskClass.CLI: _matches_cli,
     TaskClass.WEBHOOK: _matches_webhook,
     TaskClass.WEB_SERVICE: _matches_web_service,
+    TaskClass.WEB_APP: _matches_web_app,
     TaskClass.DATA_PIPELINE: _matches_data_pipeline,
     TaskClass.GAME_2D: _matches_game_2d,
     TaskClass.REFACTOR_IN_PLACE: _matches_refactor_in_place,

--- a/src/ouroboros/auto/task_classes.py
+++ b/src/ouroboros/auto/task_classes.py
@@ -78,7 +78,7 @@ class CompletionMode(StrEnum):
 class TaskClass(StrEnum):
     """Canonical task classes for L1-a.
 
-    Frozen at this PR. Additional classes (``game_3d``, ``desktop_app``,
+    Additional classes (``game_3d``, ``desktop_app``,
     ``notebook_analysis``, ...) land as their own follow-up PRs of
     ~10 LoC plus a unit test once a canonical scenario demonstrates
     real need.
@@ -87,6 +87,7 @@ class TaskClass(StrEnum):
     LIBRARY = "library"
     CLI = "cli"
     WEB_SERVICE = "web_service"
+    WEB_APP = "web_app"
     WEBHOOK = "webhook"
     DATA_PIPELINE = "data_pipeline"
     GAME_2D = "game_2d"
@@ -169,6 +170,16 @@ _CATALOG: dict[TaskClass, TaskClassProfile] = {
             "The service starts and shuts down cleanly via the documented launch command.",
         ),
         probes=("headless_run", "api_smoke"),
+    ),
+    TaskClass.WEB_APP: _profile(
+        name=TaskClass.WEB_APP,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "The documented browser launch command serves the application without console or missing-asset errors.",
+            "Representative primary and invalid user flows produce the contracted DOM state in a real browser.",
+            "Browser verification emits durable evidence such as a Playwright report or screenshots.",
+        ),
+        probes=("headless_run", "browser_smoke"),
     ),
     TaskClass.WEBHOOK: _profile(
         name=TaskClass.WEBHOOK,

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -8,7 +8,9 @@ import json
 import os
 from pathlib import Path
 import shutil
+import sqlite3
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from rich.table import Table
 from rich.text import Text
@@ -24,7 +26,12 @@ from ouroboros.backends import (
 )
 from ouroboros.cli.commands.config import _load_config, _resolve_db_path
 from ouroboros.cli.formatters.panels import print_error, print_info
-from ouroboros.cli.formatters.tables import create_status_table, print_table
+from ouroboros.cli.formatters.tables import (
+    create_key_value_table,
+    create_status_table,
+    create_table,
+    print_table,
+)
 from ouroboros.config.loader import load_config
 from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
 
@@ -258,13 +265,17 @@ def executions(
 
     Shows execution history with status information.
     """
-    # Placeholder implementation with example data
-    example_data = [
-        {"name": "exec-001", "status": "complete"},
-        {"name": "exec-002", "status": "running"},
-        {"name": "exec-003", "status": "failed"},
-    ]
-    table = create_status_table(example_data, "Recent Executions")
+    if limit <= 0:
+        print_error("Execution limit must be a positive integer")
+        raise typer.Exit(1)
+    data, config_path = _load_config()
+    db_path = _database_file_path(data, config_path)
+    try:
+        rows = _execution_summaries(db_path, None if all_ else limit)
+    except (OSError, sqlite3.Error) as exc:
+        print_error(f"Database unavailable: {db_path} ({exc})")
+        raise typer.Exit(1) from None
+    table = create_status_table(rows, "Recent Executions")
     print_table(table)
 
     if not all_:
@@ -286,10 +297,34 @@ def execution(
 
     Displays execution metadata, progress, and optionally events.
     """
-    # Placeholder implementation
-    print_info(f"Would show details for execution: {execution_id}")
+    data, config_path = _load_config()
+    db_path = _database_file_path(data, config_path)
+    try:
+        rows = _execution_events(db_path, execution_id)
+    except (OSError, sqlite3.Error) as exc:
+        print_error(f"Database unavailable: {db_path} ({exc})")
+        raise typer.Exit(1) from None
+    if not rows:
+        print_error(f"Execution not found: {execution_id}")
+        raise typer.Exit(1)
+    terminal = next((row for row in rows if row["event_type"] == "execution.terminal"), None)
+    status = _event_status(terminal) if terminal is not None else "running"
+    details = {
+        "Execution": execution_id,
+        "Status": status,
+        "Events": len(rows),
+        "Last update": rows[0]["timestamp"],
+        "Database": str(db_path),
+    }
+    print_table(create_key_value_table(details, "Execution Details"))
     if events:
-        print_info("Would include event history")
+        table = create_table("Execution Events")
+        table.add_column("Timestamp", no_wrap=True)
+        table.add_column("Event")
+        table.add_column("Aggregate", no_wrap=True)
+        for row in rows:
+            table.add_row(str(row["timestamp"]), row["event_type"], row["aggregate_id"])
+        print_table(table)
 
 
 _CREDENTIAL_PROVIDER_BY_LLM_BACKEND = {
@@ -371,6 +406,71 @@ def _database_file_path(data: dict, config_path: Path) -> Path:
             return path
         return config_path.parent / path
     return config_path.parent / "ouroboros.db"
+
+
+def _readonly_connection(db_path: Path) -> sqlite3.Connection:
+    encoded = quote(str(db_path.expanduser().resolve()), safe="/")
+    connection = sqlite3.connect(f"file:{encoded}?mode=ro", uri=True, timeout=5.0)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _event_count(db_path: Path) -> int:
+    with _readonly_connection(db_path) as connection:
+        table = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'events'"
+        ).fetchone()
+        if table is None:
+            return 0
+        row = connection.execute("SELECT COUNT(*) AS count FROM events").fetchone()
+    return int(row["count"])
+
+
+def _event_status(row: sqlite3.Row) -> str:
+    payload = json.loads(row["payload"])
+    value = payload.get("status")
+    return str(value) if value else "unknown"
+
+
+def _execution_summaries(db_path: Path, limit: int | None) -> list[dict[str, str]]:
+    sql = (
+        "SELECT json_extract(payload, '$.execution_id') AS execution_id, "
+        "MAX(timestamp) AS started_at FROM events "
+        "WHERE event_type = 'orchestrator.session.started' "
+        "AND json_extract(payload, '$.execution_id') IS NOT NULL "
+        "GROUP BY execution_id ORDER BY started_at DESC"
+    )
+    parameters: list[int] = []
+    if limit is not None:
+        sql += " LIMIT ?"
+        parameters.append(limit)
+    with _readonly_connection(db_path) as connection:
+        executions = connection.execute(sql, parameters).fetchall()
+        summaries: list[dict[str, str]] = []
+        for row in executions:
+            execution_id = str(row["execution_id"])
+            terminal = connection.execute(
+                "SELECT payload FROM events WHERE aggregate_id = ? "
+                "AND event_type = 'execution.terminal' ORDER BY timestamp DESC LIMIT 1",
+                [execution_id],
+            ).fetchone()
+            summaries.append(
+                {
+                    "name": execution_id,
+                    "status": _event_status(terminal) if terminal is not None else "running",
+                }
+            )
+    return summaries
+
+
+def _execution_events(db_path: Path, execution_id: str) -> list[sqlite3.Row]:
+    with _readonly_connection(db_path) as connection:
+        return connection.execute(
+            "SELECT aggregate_id, event_type, payload, timestamp FROM events "
+            "WHERE aggregate_id = ? OR json_extract(payload, '$.execution_id') = ? "
+            "ORDER BY timestamp DESC",
+            [execution_id, execution_id],
+        ).fetchall()
 
 
 def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
@@ -578,7 +678,14 @@ def health() -> None:
                 except OSError as exc:
                     checks.append(_health_row("Database", "error", f"not readable: {exc}"))
                 else:
-                    checks.append(_health_row("Database", "ok", db_detail))
+                    try:
+                        event_count = _event_count(db_path)
+                    except (OSError, sqlite3.DatabaseError) as exc:
+                        checks.append(_health_row("Database", "error", f"invalid: {exc}"))
+                    else:
+                        checks.append(
+                            _health_row("Database", "ok", f"{db_detail}; events={event_count}")
+                        )
         except Exception as exc:
             checks.append(_health_row("Database", "error", str(exc)))
 

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -93,6 +93,21 @@ def test_single_match_web_service() -> None:
     assert result.single is TaskClass.WEB_SERVICE
 
 
+def test_browser_ui_with_package_json_is_a_web_app() -> None:
+    ledger = _bare_ledger("Build a local browser web UI with package.json")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="Interactive browser form, result panel, and validation message",
+    )
+    _seed_section(ledger, "runtime_context", value="Node.js browser application")
+
+    result = derive_domain_from_ledger(ledger)
+
+    assert result.single is not None
+    assert result.single.value == "web_app"
+
+
 def test_single_match_data_pipeline() -> None:
     ledger = _bare_ledger("Aggregate daily logs into Parquet")
     _seed_section(ledger, "inputs", value="Dataset of log files split per day")

--- a/tests/unit/cli/test_status_persistence.py
+++ b/tests/unit/cli/test_status_persistence.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from ouroboros.cli.commands.status import app
+
+runner = CliRunner(env={"COLUMNS": "240"})
+
+
+@pytest.fixture
+def persisted_status_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    config_dir = tmp_path / ".ouroboros"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "orchestrator": {"runtime_backend": "codex"},
+                "llm": {"backend": "codex"},
+                "persistence": {"enabled": True, "database_path": "ouroboros.db"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setattr("shutil.which", lambda name: f"/opt/bin/{name}")
+
+    with sqlite3.connect(config_dir / "ouroboros.db") as connection:
+        connection.execute(
+            "CREATE TABLE events ("
+            "id TEXT PRIMARY KEY, aggregate_type TEXT NOT NULL, "
+            "aggregate_id TEXT NOT NULL, event_type TEXT NOT NULL, "
+            "payload JSON NOT NULL, timestamp DATETIME NOT NULL)"
+        )
+        connection.executemany(
+            "INSERT INTO events VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    "evt-start",
+                    "orchestrator_session",
+                    "orch_fixture",
+                    "orchestrator.session.started",
+                    json.dumps({"execution_id": "exec_fixture"}),
+                    "2026-07-29 00:00:00",
+                ),
+                (
+                    "evt-terminal",
+                    "execution",
+                    "exec_fixture",
+                    "execution.terminal",
+                    json.dumps({"session_id": "orch_fixture", "status": "complete"}),
+                    "2026-07-29 00:01:00",
+                ),
+            ],
+        )
+    return config_dir
+
+
+def test_health_reports_event_store_count(persisted_status_home: Path) -> None:
+    # Given: a configured canonical event store with two persisted rows.
+    # When: health inspects the database.
+    result = runner.invoke(app, ["health"])
+
+    # Then: the observable detail binds health to the actual event count.
+    assert result.exit_code == 0
+    assert "ouroboros.db" in result.output
+    assert "events=2" in result.output
+
+
+def test_executions_lists_persisted_terminal_status(persisted_status_home: Path) -> None:
+    # Given: one execution with a terminal event.
+    # When: the execution list is requested.
+    result = runner.invoke(app, ["executions", "--limit", "1"])
+
+    # Then: persisted identity and status replace example rows.
+    assert result.exit_code == 0
+    assert "exec_fixture" in result.output
+    assert "complete" in result.output
+    assert "exec-001" not in result.output
+
+
+def test_execution_shows_persisted_details_and_events(persisted_status_home: Path) -> None:
+    # Given: one persisted execution and its event history.
+    # When: details with events are requested.
+    result = runner.invoke(app, ["execution", "exec_fixture", "--events"])
+
+    # Then: the CLI renders the stored terminal state and event type.
+    assert result.exit_code == 0
+    assert "exec_fixture" in result.output
+    assert "complete" in result.output
+    assert "execution.terminal" in result.output
+    assert "Would show details" not in result.output
+
+
+def test_executions_reports_missing_database_without_traceback(
+    persisted_status_home: Path,
+) -> None:
+    # Given: configuration points to a database that is no longer available.
+    (persisted_status_home / "ouroboros.db").unlink()
+
+    # When: execution history is requested.
+    result = runner.invoke(app, ["executions"])
+
+    # Then: the boundary fails loudly without leaking a traceback.
+    assert result.exit_code == 1
+    assert "Database unavailable" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary

- replace placeholder status execution output with read-only queries against the configured SQLite event store
- bind health output to the persisted event count and fail cleanly when history is unavailable
- add a product-complete `web_app` task class and deterministic browser UI inference
- prevent the literal `package.json` filename from creating a library false positive

## Test plan

- [x] regression toggle: 5 failed before implementation, 5 passed after
- [x] relevant units: 83 passed
- [x] full suite: 14,751 passed, 18 skipped
- [x] `uv run --frozen ruff check .`
- [x] `uv run --frozen mypy src` (481 source files)

## R-run comparison

This is a deterministic task-class catalog/matcher extension plus a read-only status CLI repair. It does not change the Auto generation loop or the canonical CLI-todo path, so a per-round comparison is not applicable.

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|----------------|-------|
| Rounds completed in 600 s      | N/A            | N/A            | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A            | n/a   |
| Terminal reason                | N/A            | N/A            | n/a   |
| EventStore event count         | N/A            | N/A            | n/a   |

Budget compliance: [x] N/A (deterministic substrate only; canonical generation loop unchanged)

## Related issues

Fixes #1813