### PR TITLE
docs(mcp): align host guides with isolated launchers

### DIFF
--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -24,11 +24,14 @@ key to manage.
 | `copilot` CLI    | Provider — install per the [Copilot CLI install guide](https://docs.github.com/copilot/concepts/agents/about-copilot-cli) |
 | `gh` CLI         | Used to discover the live Copilot model catalog (`gh auth token`)  |
 | GitHub auth      | `gh auth login` once before first use                              |
-| Ouroboros (mcp)  | `pipx install 'ouroboros-ai[mcp]'` (or `uv tool install` / `pip install`) |
+| Ouroboros (mcp)  | `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'` |
 
 > Copilot runs on the **base** Ouroboros package plus the `[mcp]` extra. It
 > does not require the `[claude]` extra; the MCP entry is registered with
-> `ouroboros-ai[mcp]`.
+> `ouroboros-ai[mcp]`. Host registration requires the package-isolated `uvx`
+> or `pipx run` launcher. A plain `pip install` is suitable for embedding in
+> an already isolated environment, but it does not satisfy this host-launcher
+> requirement by itself; setup fails closed if neither launcher is available.
 
 ## Quick start
 

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -174,7 +174,15 @@ install method the wizard detected:
 }
 ```
 
-When `uvx` is unavailable, setup uses `pipx run --spec ouroboros-ai[mcp]`.
+When `uvx` is unavailable, setup writes the equivalent `pipx` entry:
+
+```json
+{
+  "command": "pipx",
+  "args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]
+}
+```
+
 It never registers a direct global binary or `python -m` fallback because
 those environments cannot guarantee MCP 2. The wizard is idempotent and
 updates setup-managed entries to the current isolated launcher.

--- a/docs/runtime-guides/hermes.md
+++ b/docs/runtime-guides/hermes.md
@@ -13,16 +13,37 @@ hermes version
 
 ## Setup
 
-Run the Ouroboros setup command and select the `hermes` runtime:
+Install the MCP profile with a package-isolated launcher, then select the
+`hermes` runtime:
 
 ```bash
+pipx install 'ouroboros-ai[mcp]'         # or: uv tool install 'ouroboros-ai[mcp]'
 ouroboros setup --runtime hermes
 ```
+
+Setup requires `uvx` or `pipx` and registers the MCP 2 server through that
+isolated process. It never falls back to a direct `ouroboros` binary or
+`python -m`, because those environments may contain the Claude SDK's MCP 1.x
+dependency or no MCP extra. If neither launcher is available, setup exits
+non-zero before changing persistent Ouroboros runtime configuration.
 
 This will:
 1.  Configure `~/.ouroboros/config.yaml` to use the `hermes` backend.
 2.  Install Ouroboros skills into `~/.hermes/skills/autonomous-ai-agents/ouroboros/`.
 3.  Register the Ouroboros MCP server in `~/.hermes/config.yaml`.
+
+With `uvx`, the generated host entry is:
+
+```yaml
+mcp_servers:
+  ouroboros:
+    command: uvx
+    args: [--from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
+    enabled: true
+```
+
+When only `pipx` is available, setup uses `command: pipx` with
+`args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]`.
 
 ## Usage
 

--- a/docs/runtime-guides/hermes.md
+++ b/docs/runtime-guides/hermes.md
@@ -42,8 +42,15 @@ mcp_servers:
     enabled: true
 ```
 
-When only `pipx` is available, setup uses `command: pipx` with
-`args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]`.
+When only `pipx` is available, setup writes:
+
+```yaml
+mcp_servers:
+  ouroboros:
+    command: pipx
+    args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
+    enabled: true
+```
 
 ## Usage
 

--- a/docs/runtime-guides/kiro.md
+++ b/docs/runtime-guides/kiro.md
@@ -26,11 +26,11 @@ pipx install 'ouroboros-ai[mcp]'         # or: uv tool install 'ouroboros-ai[mcp
 ouroboros setup --runtime kiro
 ```
 
-This will:
-
 Setup requires `uvx` or `pipx` so the MCP 2 server cannot inherit an
 incompatible host Python environment. If neither launcher is available, setup
 exits non-zero before changing `~/.ouroboros/config.yaml`.
+
+This will:
 
 1. Confirm `kiro-cli` is on `PATH` (or honour `OUROBOROS_KIRO_CLI_PATH` /
    `orchestrator.kiro_cli_path` from your config).
@@ -49,8 +49,8 @@ exits non-zero before changing `~/.ouroboros/config.yaml`.
    {
      "mcpServers": {
        "ouroboros": {
-         "command": "/path/to/ouroboros",
-         "args": ["mcp", "serve"],
+         "command": "uvx",
+         "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
          "disabled": false,
          "env": {
            "OUROBOROS_RUNTIME": "kiro",
@@ -58,6 +58,15 @@ exits non-zero before changing `~/.ouroboros/config.yaml`.
          }
        }
      }
+   }
+   ```
+
+   If `uvx` is unavailable but `pipx` exists, setup writes the equivalent
+   isolated launcher instead:
+   ```json
+   {
+     "command": "pipx",
+     "args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]
    }
    ```
 
@@ -157,18 +166,20 @@ callers.
 
 ### `connection closed: initialize response` in Kiro logs
 
-Kiro's MCP init timed out before the Ouroboros server responded. Most
-commonly the server was started inside a virtualenv whose Python is
-incompatible with the installed `pydantic` — check
-`~/.kiro/settings/mcp.json` and ensure the `command` points at an
-`ouroboros` binary from a Python 3.12 / 3.13 environment, not a
-Python 3.14 rc venv.
+Kiro's MCP init timed out before the isolated Ouroboros server responded.
+Check `~/.kiro/settings/mcp.json`: the `command` must be `uvx` or `pipx`,
+with the matching `ouroboros-ai[mcp]` arguments shown in Setup above. A first
+`uvx` launch may need a longer Kiro startup timeout while it resolves the
+package. Never replace the entry with a direct `ouroboros` or `python -m`
+command; those environments cannot guarantee MCP 2.
 
 ### `I don't have a tool called ouroboros_*`
 
-MCP server loaded with a different name or did not load at all. Re-run
-`ouroboros setup --runtime kiro` from the venv that owns the installed
-`ouroboros` binary, then restart the Kiro session.
+MCP server loaded with a different name or did not load at all. Ensure `uvx`
+or `pipx` is on `PATH`, re-run `ouroboros setup --runtime kiro` from any
+terminal, then restart the Kiro session. Setup replaces legacy direct-binary
+entries with the supported isolated launcher and exits non-zero without
+persisting runtime changes if no launcher is available.
 
 ### Responses start with `> ` or contain escape sequences
 

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -200,16 +200,45 @@ def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
         for runtime in ("kiro", "copilot", "hermes")
     }
 
-    for content in guides.values():
+    exact_launcher_contracts = {
+        "kiro": (
+            '"command": "uvx"',
+            '"args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"command": "pipx"',
+            '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+        ),
+        "copilot": (
+            '"command": "uvx"',
+            '"args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"command": "pipx"',
+            '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+        ),
+        "hermes": (
+            "command: uvx",
+            'args: [--from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
+            "command: pipx",
+            'args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
+        ),
+    }
+    forbidden_host_commands = (
+        '"command": "/path/to/ouroboros"',
+        '"command": "ouroboros"',
+        '"command": "python"',
+        '"command": "python3"',
+        "command: ouroboros",
+        "command: python",
+        "command: python3",
+    )
+
+    for runtime, content in guides.items():
         assert "pipx install 'ouroboros-ai[mcp]'" in content
         assert "uv tool install 'ouroboros-ai[mcp]'" in content
-        assert "uvx" in content
-        assert "pipx" in content
+        for snippet in exact_launcher_contracts[runtime]:
+            assert snippet in content
+        for forbidden in forbidden_host_commands:
+            assert forbidden not in content
 
-    assert '"command": "/path/to/ouroboros"' not in guides["kiro"]
     assert "from the venv that owns" not in guides["kiro"]
-    assert '"command": "uvx"' in guides["kiro"]
-    assert '"command": "pipx"' in guides["kiro"]
     assert "`uv tool install` / `pip install`" not in guides["copilot"]
     assert "plain `pip install`" in guides["copilot"]
     assert "setup fails closed" in guides["copilot"]

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -192,6 +192,30 @@ def test_shipped_mcp_launchers_use_the_isolated_mcp_profile() -> None:
         assert entry["args"] == expected_args
 
 
+def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
+    """Host guides must match setup's fail-closed uvx/pipx contract."""
+    root = Path(__file__).parent.parent.parent
+    guides = {
+        runtime: (root / "docs" / "runtime-guides" / f"{runtime}.md").read_text(encoding="utf-8")
+        for runtime in ("kiro", "copilot", "hermes")
+    }
+
+    for content in guides.values():
+        assert "pipx install 'ouroboros-ai[mcp]'" in content
+        assert "uv tool install 'ouroboros-ai[mcp]'" in content
+        assert "uvx" in content
+        assert "pipx" in content
+
+    assert '"command": "/path/to/ouroboros"' not in guides["kiro"]
+    assert "from the venv that owns" not in guides["kiro"]
+    assert '"command": "uvx"' in guides["kiro"]
+    assert '"command": "pipx"' in guides["kiro"]
+    assert "`uv tool install` / `pip install`" not in guides["copilot"]
+    assert "plain `pip install`" in guides["copilot"]
+    assert "setup fails closed" in guides["copilot"]
+    assert "never falls back to a direct `ouroboros` binary" in guides["hermes"]
+
+
 @pytest.mark.parametrize(
     "skill_path",
     [


### PR DESCRIPTION
## Summary

- Align the Kiro, Copilot, and Hermes guides with the fail-closed `uvx`/`pipx run` launcher contract introduced in #1807.
- Prevent users from recreating legacy direct-binary MCP entries that may load MCP 1.x or omit MCP dependencies.
- Add a contract test so shipped host documentation stays synchronized with setup behavior.

## Changes

- Replace Kiro’s direct `ouroboros` JSON with exact `uvx` and `pipx run` examples, and rewrite troubleshooting around isolated launchers.
- Clarify that plain pip alone does not satisfy Copilot host registration.
- Add Hermes installation prerequisites, generated launcher examples, and fail-closed behavior.
- Assert all three guides retain supported installation and launcher guidance.

## Notes

Follow-up to the approved review findings on #1807.

Verification: `28 passed`; Ruff format/check, `uv lock --check`, and `git diff --check` pass.