### PR TITLE
fix(persistence): fence writes across shutdown

### DIFF
--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -7,7 +7,7 @@ with aiosqlite backend.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 import hashlib
@@ -95,35 +95,6 @@ _AC_ACCEPTANCE_OUTCOMES = frozenset(
 )
 
 
-async def _await_sqlite_write_atomically[T](awaitable: Awaitable[T]) -> T:
-    """Let a SQLite write transaction finish even if its caller is cancelled.
-
-    aiosqlite performs DB work on a worker thread. If an asyncio task is
-    cancelled while a transaction is in flight, returning to the caller before
-    the worker has finished can leave SQLite's write lock visible to the next
-    operation on the same EventStore. The cancellation still wins; this helper
-    only waits for the transaction coroutine to finish its commit/rollback path
-    before re-raising ``CancelledError``.
-    """
-    task: asyncio.Task[T] = asyncio.create_task(awaitable)
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError:
-                continue
-        try:
-            task.result()
-        except Exception:
-            logger.debug(
-                "event_store.sqlite_write.cleanup_after_cancellation_failed",
-                exc_info=True,
-            )
-        raise
-
-
 _AC_ACCEPTANCE_DISPOSITIONS = frozenset(
     {
         "accepted",
@@ -134,6 +105,107 @@ _AC_ACCEPTANCE_DISPOSITIONS = frozenset(
         "invalid",
     }
 )
+
+
+async def _run_to_settlement[T](
+    coro: Coroutine[Any, Any, T],
+    *,
+    registry: set[asyncio.Task[Any]] | None = None,
+    refuse_when: Callable[[], bool] | None = None,
+    operation: str = "append",
+) -> T:
+    """Run a transactional coroutine, settling it before cancellation surfaces.
+
+    A write, once begun, must commit or roll back inside the caller's
+    lifetime: shield-only semantics let a cancelled caller (and even
+    ``EventStore.close()``) return while the transaction was still pending,
+    so durable history could change after shutdown. Cancellation is re-raised
+    only after the inner task completes, which both preserves the
+    cancellation-atomicity contract and keeps every write within the store
+    lifecycle (#1794 review rounds one and two).
+    """
+    if refuse_when is not None and refuse_when():
+        # Admission is synchronized with close(): this check and the registry
+        # add below run in one synchronous block on the event loop, so a
+        # write either registers before close() snapshots the registry or is
+        # refused outright — it can never slip past the drain (round five).
+        coro.close()
+        raise PersistenceError(
+            "EventStore is closing; write refused.",
+            operation=operation,
+        )
+    inner: asyncio.Task[T] = asyncio.ensure_future(coro)
+    if registry is not None:
+        # close() drains this registry so no settling write can escape the
+        # store lifecycle (review round four).
+        registry.add(inner)
+        inner.add_done_callback(registry.discard)
+    try:
+        return await asyncio.shield(inner)
+    except asyncio.CancelledError as caller_cancellation:
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                # A further caller cancellation — keep settling.
+                continue
+            except Exception:
+                # The transaction settled by failing; the loop exits below.
+                break
+        settlement_error: BaseException | None = None
+        if not inner.cancelled():
+            settlement_error = inner.exception()
+        if settlement_error is not None:
+            # Cancellation outranks the write's own failure: lifecycle code
+            # awaiting a cancelled task must still observe CancelledError
+            # (e.g. the watchdog's decision batch depends on it). The
+            # transaction failure is preserved as the cause.
+            logger.debug(
+                "event_store.append.settled_with_error",
+                exc_info=settlement_error,
+            )
+            raise caller_cancellation from settlement_error
+        raise
+
+
+async def _await_sqlite_write_atomically[T](awaitable: Coroutine[Any, Any, T]) -> T:
+    """Compatibility wrapper for cancellation-atomic SQLite writes.
+
+    The lifecycle-aware settlement primitive now also supports write
+    registration and close admission fencing. Keep the narrower helper for
+    callers and regressions that only need transaction settlement.
+    """
+    return await _run_to_settlement(awaitable)
+
+
+async def _run_with_write_lifecycle[T](
+    coro: Coroutine[Any, Any, T],
+    *,
+    registry: set[asyncio.Task[Any]],
+    refuse_when: Callable[[], bool],
+    operation: str,
+) -> T:
+    """Keep a complete logical write registered across retries and backoff."""
+    if refuse_when():
+        coro.close()
+        raise PersistenceError(
+            "EventStore is closing; write refused.",
+            operation=operation,
+        )
+    task = asyncio.current_task()
+    if task is None:  # pragma: no cover - async functions always have a task here.
+        coro.close()
+        raise PersistenceError(
+            "EventStore write has no owning task.",
+            operation=operation,
+        )
+    already_registered = task in registry
+    registry.add(task)
+    try:
+        return await coro
+    finally:
+        if not already_registered:
+            registry.discard(task)
 
 
 def acceptance_generation_id_for_session(session_id: str, execution_id: str) -> str:
@@ -519,6 +591,8 @@ class EventStore:
         await store.close()
     """
 
+    _settling_writes: set[asyncio.Task[Any]]
+
     def __init__(
         self,
         database_url: str | None = None,
@@ -557,6 +631,9 @@ class EventStore:
             database_url = sqlite_database_url(db_path)
 
         self._read_only = read_only
+        self._settling_writes = set()
+        self._closing = False
+        self._lifecycle_lock = asyncio.Lock()
         if read_only:
             database_url = self._coerce_to_readonly_url(database_url)
         self._database_url = database_url
@@ -686,12 +763,20 @@ class EventStore:
         shared database with normal connection-scoped transactions, and a
         keepalive connection anchors the database's lifetime.
         """
+        # Mutually exclusive with close() in BOTH orders (review rounds
+        # seven and eight): initialization during an in-flight close waits for
+        # the full drain/checkpoint/dispose sequence, and a close started
+        # during initialization waits for initialization to finish.
+        async with self._lifecycle_lock:
+            self._closing = False
+            await self._initialize_locked(create_schema=create_schema)
+
+    async def _initialize_locked(self, *, create_schema: bool | None = None) -> None:
         if self._configuration_error is not None:
             raise PersistenceError(
                 "Invalid EventStore configuration.",
                 operation="initialize",
             ) from self._configuration_error
-
         if create_schema is None:
             create_schema = not self._read_only
 
@@ -825,6 +910,21 @@ class EventStore:
         return None
 
     async def append_session_start_if_absent(self, event: BaseEvent) -> None:
+        """Fenced wrapper: admission + settlement for the CAS below.
+
+        Session lifecycle appends dispatch above append()'s settlement
+        path, so they carry their own closing fence and registry entry —
+        a lifecycle event can neither start during close() nor commit
+        after it (review round six).
+        """
+        return await _run_to_settlement(
+            self._append_session_start_if_absent_unfenced(event),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_session_start_if_absent",
+        )
+
+    async def _append_session_start_if_absent_unfenced(self, event: BaseEvent) -> None:
         """Publish exactly one immutable start identity for a session ID."""
         if self._engine is None:
             raise PersistenceError(
@@ -934,6 +1034,21 @@ class EventStore:
         )
 
     async def append_session_terminal_if_active(self, event: BaseEvent) -> bool:
+        """Fenced wrapper: admission + settlement for the CAS below.
+
+        Session lifecycle appends dispatch above append()'s settlement
+        path, so they carry their own closing fence and registry entry —
+        a lifecycle event can neither start during close() nor commit
+        after it (review round six).
+        """
+        return await _run_to_settlement(
+            self._append_session_terminal_if_active_unfenced(event),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_session_terminal_if_active",
+        )
+
+    async def _append_session_terminal_if_active_unfenced(self, event: BaseEvent) -> bool:
         """Append one terminal session event only while no terminal event exists.
 
         Returns ``True`` when ``event`` was inserted and ``False`` when another
@@ -1188,6 +1303,21 @@ class EventStore:
         return True
 
     async def append_session_pause_if_active(self, event: BaseEvent) -> bool:
+        """Fenced wrapper: admission + settlement for the CAS below.
+
+        Session lifecycle appends dispatch above append()'s settlement
+        path, so they carry their own closing fence and registry entry —
+        a lifecycle event can neither start during close() nor commit
+        after it (review round six).
+        """
+        return await _run_to_settlement(
+            self._append_session_pause_if_active_unfenced(event),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_session_pause_if_active",
+        )
+
+    async def _append_session_pause_if_active_unfenced(self, event: BaseEvent) -> bool:
         """Append PAUSED only while no explicit terminal session event exists.
 
         Returns ``True`` when the pause event was inserted and ``False`` when
@@ -1296,6 +1426,23 @@ class EventStore:
         _skip_workflow_ir_guard: bool = False,
     ) -> int:
         """Append an event and return its exact SQLite rowid."""
+        return await _run_with_write_lifecycle(
+            self._append_with_rowid_registered(
+                event,
+                _skip_workflow_ir_guard=_skip_workflow_ir_guard,
+            ),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_with_rowid",
+        )
+
+    async def _append_with_rowid_registered(
+        self,
+        event: BaseEvent,
+        *,
+        _skip_workflow_ir_guard: bool = False,
+    ) -> int:
+        """Implement one registered append, including all retries and backoff."""
         if self._engine is None:
             raise PersistenceError(
                 "EventStore not initialized. Call initialize() first.",
@@ -1345,8 +1492,16 @@ class EventStore:
                 },
             )
 
-        async def _insert_event() -> int:
-            async with self._engine.begin() as conn:
+        engine = self._engine
+
+        async def _insert_once() -> int:
+            # Shielded by the caller: a transaction, once begun, must commit or
+            # roll back even when the awaiting task is cancelled mid-append.
+            # An abandoned in-flight transaction poisons the pooled connection
+            # and fails the next writer — e.g. a watchdog cancelling a
+            # generation mid-append could then lose its own decision events,
+            # violating the durable-replay contract (#1794).
+            async with engine.begin() as conn:
                 await conn.execute(events_table.insert().values(**event.to_db_dict()))
                 rowid = await conn.scalar(
                     select(text("rowid"))
@@ -1360,11 +1515,18 @@ class EventStore:
                         table="events",
                         details={"event_id": event.id, "event_type": event.type},
                     )
-            return rowid
+                return rowid
 
         for attempt in range(3):
             try:
-                return await _await_sqlite_write_atomically(_insert_event())
+                return await _run_to_settlement(
+                    _insert_once(),
+                    registry=self._settling_writes,
+                    refuse_when=lambda: self._closing,
+                    operation="append_with_rowid",
+                )
+            except PersistenceError:
+                raise
             except Exception as e:
                 if "database is locked" in str(e) and attempt < 2:
                     logger.warning(
@@ -1402,6 +1564,15 @@ class EventStore:
             PersistenceError: If the batch operation fails. No events
                              will be persisted if this is raised.
         """
+        await _run_with_write_lifecycle(
+            self._append_batch_registered(events),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_batch",
+        )
+
+    async def _append_batch_registered(self, events: list[BaseEvent]) -> None:
+        """Implement one registered batch, including all retries and backoff."""
         if self._engine is None:
             raise PersistenceError(
                 "EventStore not initialized. Call initialize() first.",
@@ -1472,8 +1643,13 @@ class EventStore:
                 details={"count": len(acceptance_events)},
             )
 
-        async def _insert_batch() -> None:
-            async with self._engine.begin() as conn:
+        engine = self._engine
+
+        async def _insert_batch_once() -> None:
+            # Same cancellation-atomicity contract as append_with_rowid: the
+            # batch transaction must complete or roll back even if the caller
+            # is cancelled mid-append (#1794).
+            async with engine.begin() as conn:
                 await conn.execute(
                     events_table.insert(),
                     [event.to_db_dict() for event in events],
@@ -1481,8 +1657,15 @@ class EventStore:
 
         for attempt in range(3):
             try:
-                await _await_sqlite_write_atomically(_insert_batch())
+                await _run_to_settlement(
+                    _insert_batch_once(),
+                    registry=self._settling_writes,
+                    refuse_when=lambda: self._closing,
+                    operation="append_batch",
+                )
                 return
+            except PersistenceError:
+                raise
             except Exception as e:
                 if "database is locked" in str(e) and attempt < 2:
                     logger.warning(
@@ -2865,20 +3048,45 @@ class EventStore:
         return True
 
     async def close(self) -> None:
-        """Close the database connection."""
-        if self._engine is not None:
-            # Collapse the WAL before disposing so the -wal file does not
-            # survive shutdown. Best effort — see checkpoint_wal().
-            await self.checkpoint_wal()
-            await self._engine.dispose()
-            self._engine = None
-        if self._memory_keepalive is not None:
-            # Release the shared in-memory database anchor last so pooled
-            # connections never observe the database disappearing mid-dispose.
+        """Close the database connection.
+
+        Drains settling writes first: a transaction that outlived a cancelled
+        caller must land before the WAL checkpoint and engine disposal, or
+        durable history could change after shutdown (review round four).
+        """
+        async with self._lifecycle_lock:
+            self._closing = True
             try:
-                self._memory_keepalive.close()
-            finally:
-                self._memory_keepalive = None
+                while self._settling_writes:
+                    done, _ = await asyncio.wait(tuple(self._settling_writes))
+                    for task in done:
+                        if not task.cancelled() and task.exception() is not None:
+                            logger.debug(
+                                "event_store.close.drained_failed_write",
+                                exc_info=task.exception(),
+                            )
+                if self._engine is not None:
+                    # Collapse the WAL before disposing so the -wal file does
+                    # not survive shutdown. Best effort — see checkpoint_wal().
+                    await self.checkpoint_wal()
+                    await self._engine.dispose()
+                    self._engine = None
+                if self._memory_keepalive is not None:
+                    # Release the shared in-memory database anchor last so
+                    # pooled connections never observe the database
+                    # disappearing mid-dispose.
+                    try:
+                        self._memory_keepalive.close()
+                    finally:
+                        self._memory_keepalive = None
+            except asyncio.CancelledError:
+                # A cancelled close must leave a recoverable lifecycle, not a
+                # permanently closing store: writes drained so far are
+                # durable, and if the engine still exists the store stays
+                # usable (review round eight).
+                if self._engine is not None:
+                    self._closing = False
+                raise
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
+from pathlib import Path
 import shutil
 
 import pytest
@@ -2377,3 +2378,639 @@ class TestEventStoreCloseWalCheckpoint:
 
         assert not any("wal_checkpoint" in sql.lower() for sql in executed)
         assert store._engine is None  # type: ignore[attr-defined]
+
+
+def _make_event(*, aggregate_id: str) -> BaseEvent:
+    return BaseEvent(
+        type="test.event.created",
+        aggregate_type="test",
+        aggregate_id=aggregate_id,
+        data={},
+    )
+
+
+class TestCancellationSettlement:
+    """#1794: a cancelled append must settle before cancellation surfaces.
+
+    Shield-only semantics let the write outlive the caller — a probe that
+    blocked ``aiosqlite.Connection.commit`` showed ``close()`` returning and
+    the events committing afterward, mutating durable history after shutdown.
+    The contract pinned here: cancellation is re-raised only once the
+    transaction task has completed, so no write can escape the store
+    lifecycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancelled_append_settles_before_cancellation_surfaces(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import aiosqlite
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        event = _make_event(aggregate_id="settle-append")
+        task = asyncio.create_task(store.append(event))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done(), (
+            "cancellation surfaced while the commit was still in flight — "
+            "the write escaped the caller's lifetime"
+        )
+
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        events = await store.replay("test", "settle-append")
+        assert len(events) == 1
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_close_waits_for_settling_append(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """close() must drain in-flight writes so history is durable at close.
+
+        A gated-commit probe showed close() returning while a cancelled
+        append's transaction was still settling — the event then committed
+        after close and appeared on reopen, mutating durable history after
+        shutdown.
+        """
+        import aiosqlite
+
+        db_path = tmp_path / "settle-close.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        append_task = asyncio.create_task(store.append(_make_event(aggregate_id="race-close")))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        append_task.cancel()
+
+        close_task = asyncio.create_task(store.close())
+        # Outlast checkpoint_wal's 2s busy timeout: without an explicit drain,
+        # close() gives up on the checkpoint and disposes while the write is
+        # still settling — the drain contract must hold beyond that window.
+        await asyncio.sleep(2.5)
+        assert not close_task.done(), "close() returned while a settling write was still in flight"
+
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(append_task, timeout=5)
+        await asyncio.wait_for(close_task, timeout=5)
+        monkeypatch.setattr(aiosqlite.Connection, "commit", orig_commit)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        events = await reopened.replay("test", "race-close")
+        assert len(events) == 1
+        await reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_close_waits_for_settling_batch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import aiosqlite
+
+        db_path = tmp_path / "settle-close-batch.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        batch_task = asyncio.create_task(
+            store.append_batch([_make_event(aggregate_id="race-close-batch")])
+        )
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        batch_task.cancel()
+
+        close_task = asyncio.create_task(store.close())
+        # Outlast checkpoint_wal's 2s busy timeout: without an explicit drain,
+        # close() gives up on the checkpoint and disposes while the write is
+        # still settling — the drain contract must hold beyond that window.
+        await asyncio.sleep(2.5)
+        assert not close_task.done(), "close() returned while a settling batch was still in flight"
+
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(batch_task, timeout=5)
+        await asyncio.wait_for(close_task, timeout=5)
+        monkeypatch.setattr(aiosqlite.Connection, "commit", orig_commit)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        events = await reopened.replay("test", "race-close-batch")
+        assert len(events) == 1
+        await reopened.close()
+
+    @pytest.mark.parametrize("batch", [False, True], ids=["single", "batch"])
+    @pytest.mark.asyncio
+    async def test_close_fences_complete_retry_lifecycle(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        batch: bool,
+    ) -> None:
+        """A retrying write cannot escape close through its backoff gap."""
+        from sqlalchemy.exc import OperationalError
+
+        db_path = tmp_path / f"retry-close-{batch}.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        assert store._engine is not None
+
+        engine_type = type(store._engine)
+        original_begin = engine_type.begin
+        attempts = 0
+
+        class _LockedTransaction:
+            async def __aenter__(self):  # noqa: ANN204
+                raise OperationalError("INSERT", {}, Exception("database is locked"))
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+        def flaky_begin(engine):  # noqa: ANN001, ANN202
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return _LockedTransaction()
+            return original_begin(engine)
+
+        monkeypatch.setattr(engine_type, "begin", flaky_begin)
+        backoff_entered = asyncio.Event()
+        release_backoff = asyncio.Event()
+        original_sleep = asyncio.sleep
+
+        async def gated_sleep(delay: float) -> None:
+            if delay == 0.1 and not backoff_entered.is_set():
+                backoff_entered.set()
+                await release_backoff.wait()
+                return
+            await original_sleep(delay)
+
+        monkeypatch.setattr("ouroboros.persistence.event_store.asyncio.sleep", gated_sleep)
+        event = _make_event(aggregate_id=f"retry-close-{batch}")
+        write_task = asyncio.create_task(
+            store.append_batch([event]) if batch else store.append(event)
+        )
+        await asyncio.wait_for(backoff_entered.wait(), timeout=5)
+
+        close_task = asyncio.create_task(store.close())
+        await original_sleep(0)
+        assert not close_task.done(), "close escaped while the logical write was backing off"
+
+        release_backoff.set()
+        with pytest.raises(PersistenceError) as exc_info:
+            await asyncio.wait_for(write_task, timeout=5)
+        assert exc_info.value.operation == ("append_batch" if batch else "append_with_rowid")
+        await asyncio.wait_for(close_task, timeout=10)
+
+        await store.initialize()
+        assert await store.replay("test", f"retry-close-{batch}") == []
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_append_started_during_close_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Write admission must be synchronized with closing.
+
+        Draining alone is not enough: a write that starts after the drain but
+        before disposal would still commit post-shutdown. A write arriving
+        while close() is in flight must be refused outright.
+        """
+        db_path = tmp_path / "admission.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_checkpoint = store.checkpoint_wal
+
+        async def gated_checkpoint() -> bool:
+            entered.set()
+            await gate.wait()
+            return await orig_checkpoint()
+
+        monkeypatch.setattr(store, "checkpoint_wal", gated_checkpoint)
+
+        close_task = asyncio.create_task(store.close())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            with pytest.raises(PersistenceError):
+                await store.append(_make_event(aggregate_id="during-close"))
+        finally:
+            gate.set()
+            await asyncio.wait_for(close_task, timeout=10)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        assert await reopened.replay("test", "during-close") == []
+        await reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_batch_started_during_close_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "admission-batch.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_checkpoint = store.checkpoint_wal
+
+        async def gated_checkpoint() -> bool:
+            entered.set()
+            await gate.wait()
+            return await orig_checkpoint()
+
+        monkeypatch.setattr(store, "checkpoint_wal", gated_checkpoint)
+
+        close_task = asyncio.create_task(store.close())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            with pytest.raises(PersistenceError):
+                await store.append_batch([_make_event(aggregate_id="during-close-batch")])
+        finally:
+            gate.set()
+            await asyncio.wait_for(close_task, timeout=10)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        assert await reopened.replay("test", "during-close-batch") == []
+        await reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_session_lifecycle_appends_during_close_are_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Session start/terminal CAS paths must honor the closing fence too.
+
+        They dispatch above append()'s settlement wrapper, so without their
+        own admission a session-start racing close() committed after
+        disposal.
+        """
+        db_path = tmp_path / "lifecycle-close.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        started = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id="sess-live",
+            data={"execution_id": "exec-live"},
+        )
+        await store.append(started)
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_checkpoint = store.checkpoint_wal
+
+        async def gated_checkpoint() -> bool:
+            entered.set()
+            await gate.wait()
+            return await orig_checkpoint()
+
+        monkeypatch.setattr(store, "checkpoint_wal", gated_checkpoint)
+
+        close_task = asyncio.create_task(store.close())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+
+            with pytest.raises(PersistenceError):
+                await store.append(
+                    BaseEvent(
+                        type="orchestrator.session.started",
+                        aggregate_type="session",
+                        aggregate_id="sess-during-close",
+                        data={"execution_id": "exec-during-close"},
+                    )
+                )
+            with pytest.raises(PersistenceError):
+                await store.append(
+                    BaseEvent(
+                        type="orchestrator.session.completed",
+                        aggregate_type="session",
+                        aggregate_id="sess-live",
+                        data={},
+                    )
+                )
+        finally:
+            gate.set()
+            await asyncio.wait_for(close_task, timeout=10)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        assert await reopened.replay("session", "sess-during-close") == []
+        terminal = [
+            e
+            for e in await reopened.replay("session", "sess-live")
+            if e.type == "orchestrator.session.completed"
+        ]
+        assert terminal == []
+        await reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_initialize_cannot_reopen_admission_during_close(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """initialize() must serialize with an in-flight close().
+
+        Clearing the closing flag mid-close reopened write admission: a probe
+        paused close in the checkpoint, called initialize(), appended, and
+        found the event durable after reopen.
+        """
+        db_path = tmp_path / "init-during-close.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_checkpoint = store.checkpoint_wal
+
+        async def gated_checkpoint() -> bool:
+            entered.set()
+            await gate.wait()
+            return await orig_checkpoint()
+
+        monkeypatch.setattr(store, "checkpoint_wal", gated_checkpoint)
+
+        close_task = asyncio.create_task(store.close())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+
+            init_task = asyncio.create_task(store.initialize())
+            await asyncio.sleep(0.05)
+            with pytest.raises(PersistenceError):
+                await store.append(_make_event(aggregate_id="init-during-close"))
+        finally:
+            gate.set()
+            await asyncio.wait_for(close_task, timeout=10)
+        await asyncio.wait_for(init_task, timeout=10)
+
+        assert await store.replay("test", "init-during-close") == []
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_session_pause_append_during_close_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "pause-close.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess-pause",
+                data={"execution_id": "exec-pause"},
+            )
+        )
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_checkpoint = store.checkpoint_wal
+
+        async def gated_checkpoint() -> bool:
+            entered.set()
+            await gate.wait()
+            return await orig_checkpoint()
+
+        monkeypatch.setattr(store, "checkpoint_wal", gated_checkpoint)
+
+        close_task = asyncio.create_task(store.close())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            with pytest.raises(PersistenceError):
+                await store.append_session_pause_if_active(
+                    BaseEvent(
+                        type="orchestrator.session.paused",
+                        aggregate_type="session",
+                        aggregate_id="sess-pause",
+                        data={},
+                    )
+                )
+        finally:
+            gate.set()
+            await asyncio.wait_for(close_task, timeout=10)
+
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        paused = [
+            e
+            for e in await reopened.replay("session", "sess-pause")
+            if e.type == "orchestrator.session.paused"
+        ]
+        assert paused == []
+        await reopened.close()
+
+    @pytest.mark.asyncio
+    async def test_close_started_during_initialize_waits_for_it(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """initialize/close must be mutually exclusive in both orders.
+
+        The close gate only guarded an already-running close; a close started
+        DURING initialization returned first, leaving initialize reporting
+        success on a disposed store.
+        """
+        import aiosqlite
+
+        db_path = tmp_path / "init-order.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        init_task = asyncio.create_task(store.initialize())
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            close_task = asyncio.create_task(store.close())
+            await asyncio.sleep(0.05)
+            assert not close_task.done(), "close() finished while initialize() was still in flight"
+        finally:
+            gate.set()
+        await asyncio.wait_for(init_task, timeout=10)
+        await asyncio.wait_for(close_task, timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_close_leaves_recoverable_state(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Cancelling close() mid-drain must not wedge the lifecycle.
+
+        Before the fix, cancellation during the drain left the closing flag
+        set and the gate cleared forever; the next initialize() hung.
+        """
+        import aiosqlite
+
+        db_path = tmp_path / "close-cancel.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        append_task = asyncio.create_task(store.append(_make_event(aggregate_id="wedge")))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        append_task.cancel()
+
+        close_task = asyncio.create_task(store.close())
+        await asyncio.sleep(0.05)
+        close_task.cancel()
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(close_task, timeout=10)
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(append_task, timeout=10)
+
+        await asyncio.wait_for(store.initialize(), timeout=5)
+        await store.append(_make_event(aggregate_id="recovered"))
+        events = await store.replay("test", "recovered")
+        assert len(events) == 1
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_append_with_failing_commit_still_raises_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A settling transaction that fails must not replace the cancellation.
+
+        The caller was cancelled; the write's own failure is secondary and is
+        chained as the cause, so lifecycle code awaiting a cancelled task
+        (e.g. the watchdog) still sees CancelledError and proceeds to its
+        durable decision batch.
+        """
+        import aiosqlite
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+
+        async def failing_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            raise RuntimeError("commit blew up mid-settlement")
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", failing_commit)
+
+        task = asyncio.create_task(store.append(_make_event(aggregate_id="fail-append")))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        task.cancel()
+        gate.set()
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await asyncio.wait_for(task, timeout=5)
+        assert exc_info.value.__cause__ is not None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_batch_with_failing_commit_still_raises_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import aiosqlite
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+
+        async def failing_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            raise RuntimeError("batch commit blew up mid-settlement")
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", failing_commit)
+
+        task = asyncio.create_task(store.append_batch([_make_event(aggregate_id="fail-batch")]))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        task.cancel()
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_append_batch_settles_before_cancellation_surfaces(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import aiosqlite
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+        orig_commit = aiosqlite.Connection.commit
+
+        async def gated_commit(self):  # noqa: ANN001, ANN202
+            entered.set()
+            await gate.wait()
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", gated_commit)
+
+        events = [_make_event(aggregate_id="settle-batch") for _ in range(2)]
+        task = asyncio.create_task(store.append_batch(events))
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done(), "batch cancellation surfaced while the commit was still in flight"
+
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+
+        stored = await store.replay("test", "settle-batch")
+        assert len(stored) == 2
+        await store.close()


### PR DESCRIPTION
## Summary

- split the EventStore cancellation and lifecycle safety work out of #1801 as requested
- keep a complete logical write registered across retries and backoff
- settle cancellation before surfacing it to callers
- reject stale writes once shutdown begins and drain admitted work before disposal
- serialize initialize/close and keep cancelled close recoverable

## Why this is separate

#1801 also carries watchdog/logging test work. The maintainer requested that this persistence subsystem change remain independently reviewable, so this PR contains only `event_store.py` and its focused tests on top of current `main` / #1817.

## Verification

- 180 focused persistence/evolution/logging tests passed
- Ruff check and format passed
- MyPy passed for `event_store.py`

Related to #1801.