### PR TITLE
fix(orchestrator): gate Ralph's stop decision on the QA result, not the verdict string

### DIFF
--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -603,7 +603,8 @@ class EvolveStepHandler(BridgeAwareMixin):
         # Post-execution QA
         qa_meta = None
         skip_qa = arguments.get("skip_qa", False)
-        if step.action.value in ("continue", "converged") and execute and not skip_qa:
+        qa_attempted = step.action.value in ("continue", "converged") and execute and not skip_qa
+        if qa_attempted:
             from ouroboros.mcp.tools.qa import QAHandler
 
             qa_handler = QAHandler()
@@ -650,6 +651,7 @@ class EvolveStepHandler(BridgeAwareMixin):
             "converged": sig.converged,
             "next_generation": step.next_generation,
             "executed": execute,
+            "qa_attempted": qa_attempted,
             "has_execution_output": gen.execution_output is not None,
             "checkpoint_commits": checkpoint_commits,
             "checkpoint_attempted_ac_ids": checkpoint_attempted_ac_ids,

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -298,8 +298,17 @@ class RalphLoopRunner:
                 stop_reason = "qa passed"
                 break
             if action in _TERMINAL_SUCCESS_ACTIONS:
-                status = "completed"
-                stop_reason = action
+                # evolve_step runs post-execution QA for `converged` too and
+                # publishes the pre-QA action unchanged, so a converged step can
+                # arrive carrying an authoritative QA failure. Guarding only the
+                # `qa passed` branch above would leave this exit reporting a
+                # terminal success for the very payload that branch rejected.
+                if _qa_authoritative_failure(final_result.meta):
+                    status = "failed"
+                    stop_reason = "qa_failed"
+                else:
+                    status = "completed"
+                    stop_reason = action
                 break
             if action in _TERMINAL_FAILURE_ACTIONS or final_result.is_error:
                 status = "failed"
@@ -319,7 +328,12 @@ class RalphLoopRunner:
             seed_content = None
         else:
             if final_result is not None:
-                status = "completed"
+                # Exhausting the budget without ever obtaining a QA pass is not a
+                # success. `max_generations reached` is already a recoverable
+                # BLOCKED stop_reason downstream (`auto/pipeline.py`), so only the
+                # status changes: the run stays retryable, it just stops claiming
+                # it succeeded.
+                status = "failed" if _qa_authoritative_failure(final_result.meta) else "completed"
                 stop_reason = "max_generations reached"
 
         if final_result is None:
@@ -372,6 +386,19 @@ def _qa_result_contradicts_pass(qa: dict[str, Any]) -> bool:
         return False
     # A NaN score compares False here, which lands on the fail-closed side.
     return not score >= threshold
+
+
+def _qa_authoritative_failure(meta: dict[str, Any]) -> bool:
+    """Return True when this generation's QA payload authoritatively failed it.
+
+    Distinct from ``not _qa_passed(...)``: a payload with no QA block, or one
+    carrying only a verdict string, is *not* an authoritative failure and keeps
+    its legacy terminal behaviour. Only the gate's own computed fields count.
+    """
+    qa = meta.get("qa")
+    if not isinstance(qa, dict):
+        return False
+    return _qa_result_contradicts_pass(qa)
 
 
 def _qa_passed(meta: dict[str, Any]) -> bool:

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -350,9 +350,45 @@ def _extract_qa_verdict(meta: dict[str, Any]) -> str | None:
     return str(verdict).lower() if verdict is not None else None
 
 
+def _numeric(value: Any) -> float | None:
+    """Return ``value`` as a float, rejecting bools (a subclass of int)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _qa_result_contradicts_pass(qa: dict[str, Any]) -> bool:
+    """Return True when the QA gate's own numbers refute a ``pass`` verdict.
+
+    ``verdict`` is kept verbatim from the model whenever it is one of the valid
+    tokens, while ``passed``/``score``/``pass_threshold`` are computed by the QA
+    gate itself. Only the computed fields are authoritative here.
+    """
+    if qa.get("passed") is False:
+        return True
+    score = _numeric(qa.get("score"))
+    threshold = _numeric(qa.get("pass_threshold"))
+    if score is None or threshold is None:
+        return False
+    # A NaN score compares False here, which lands on the fail-closed side.
+    return not score >= threshold
+
+
 def _qa_passed(meta: dict[str, Any]) -> bool:
-    verdict = _extract_qa_verdict(meta)
-    return verdict in {"pass", "passed"}
+    """Return True only when the QA verdict *and* its own numbers agree on a pass.
+
+    Stopping the loop here reports the run as ``completed``, which downstream
+    (``auto/pipeline.py``) reads as a terminal success, so a model-authored
+    ``verdict`` string must never outrank the gate's computed result. Every
+    other reader of this payload already gates on ``passed`` (``auto/adapters.py``,
+    ``auto/pipeline.py``); this brings the loop's stop decision in line.
+    """
+    qa = meta.get("qa")
+    if not isinstance(qa, dict):
+        return False
+    if _extract_qa_verdict(meta) not in {"pass", "passed"}:
+        return False
+    return not _qa_result_contradicts_pass(qa)
 
 
 def _extract_findings_hash(meta: dict[str, Any]) -> str | None:

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -395,15 +395,19 @@ def _qa_result_contradicts_pass(qa: dict[str, Any]) -> bool:
 def _qa_was_attempted(meta: dict[str, Any], skip_qa: bool) -> bool:
     """Return True when the producer ran post-execution QA for this generation.
 
-    Mirrors the condition in ``evolution_handlers`` that decides whether to run
-    QA at all, using the fields that same producer publishes. Payloads that
-    predate those fields answer False and keep their legacy terminal behaviour.
+    New producers publish the decision explicitly, keeping this consumer
+    independent of the producer's evolving action vocabulary. The derived
+    branch is compatibility-only for payloads written before ``qa_attempted``
+    existed.
     """
-    return (
-        not skip_qa
-        and meta.get("executed") is True
-        and meta.get("action") in _TERMINAL_SUCCESS_ACTIONS | {"continue"}
-    )
+    if skip_qa:
+        return False
+    attempted = meta.get("qa_attempted")
+    if isinstance(attempted, bool):
+        return attempted
+    return meta.get("executed") is True and meta.get("action") in _TERMINAL_SUCCESS_ACTIONS | {
+        "continue"
+    }
 
 
 def _qa_authoritative_failure(meta: dict[str, Any], skip_qa: bool = False) -> bool:

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -303,7 +303,7 @@ class RalphLoopRunner:
                 # arrive carrying an authoritative QA failure. Guarding only the
                 # `qa passed` branch above would leave this exit reporting a
                 # terminal success for the very payload that branch rejected.
-                if _qa_authoritative_failure(final_result.meta):
+                if _qa_authoritative_failure(final_result.meta, config.skip_qa):
                     status = "failed"
                     stop_reason = "qa_failed"
                 else:
@@ -333,7 +333,11 @@ class RalphLoopRunner:
                 # BLOCKED stop_reason downstream (`auto/pipeline.py`), so only the
                 # status changes: the run stays retryable, it just stops claiming
                 # it succeeded.
-                status = "failed" if _qa_authoritative_failure(final_result.meta) else "completed"
+                status = (
+                    "failed"
+                    if _qa_authoritative_failure(final_result.meta, config.skip_qa)
+                    else "completed"
+                )
                 stop_reason = "max_generations reached"
 
         if final_result is None:
@@ -388,16 +392,33 @@ def _qa_result_contradicts_pass(qa: dict[str, Any]) -> bool:
     return not score >= threshold
 
 
-def _qa_authoritative_failure(meta: dict[str, Any]) -> bool:
-    """Return True when this generation's QA payload authoritatively failed it.
+def _qa_was_attempted(meta: dict[str, Any], skip_qa: bool) -> bool:
+    """Return True when the producer ran post-execution QA for this generation.
 
-    Distinct from ``not _qa_passed(...)``: a payload with no QA block, or one
-    carrying only a verdict string, is *not* an authoritative failure and keeps
-    its legacy terminal behaviour. Only the gate's own computed fields count.
+    Mirrors the condition in ``evolution_handlers`` that decides whether to run
+    QA at all, using the fields that same producer publishes. Payloads that
+    predate those fields answer False and keep their legacy terminal behaviour.
+    """
+    return (
+        not skip_qa
+        and meta.get("executed") is True
+        and meta.get("action") in _TERMINAL_SUCCESS_ACTIONS | {"continue"}
+    )
+
+
+def _qa_authoritative_failure(meta: dict[str, Any], skip_qa: bool = False) -> bool:
+    """Return True when this generation carries no authoritative QA pass.
+
+    Deliberately not `not _qa_passed(...)`: a payload from a run where QA never
+    ran keeps its legacy terminal behaviour. But absence of the block is *not*
+    evidence of success when QA did run — ``evolution_handlers`` drops the whole
+    ``qa`` key whenever ``QAHandler`` errors, which is exactly what a truncated or
+    malformed QA completion produces. Keying only on a parsed failure would make a
+    garbled QA response safer for the run than an honest failing one.
     """
     qa = meta.get("qa")
     if not isinstance(qa, dict):
-        return False
+        return _qa_was_attempted(meta, skip_qa)
     return _qa_result_contradicts_pass(qa)
 
 

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -1396,6 +1396,52 @@ class TestEvolveStepHandler:
         assert result.is_ok
         assert "Generation 1" in result.value.text_content
         assert result.value.meta["action"] == "continue"
+        assert result.value.meta["qa_attempted"] is False
+
+    @pytest.mark.asyncio
+    async def test_handler_publishes_qa_attempt_when_qa_returns_no_result(self) -> None:
+        """Consumers can fail closed without reconstructing producer policy."""
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        store = await create_event_store()
+        seed = make_seed()
+        gen_result = GenerationResult(
+            generation_number=1,
+            seed=seed,
+            evaluation_summary=make_eval_summary(),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        handler = EvolveStepHandler(evolutionary_loop=make_loop(store, gen_result=gen_result))
+
+        class _FailingQAHandler:
+            async def handle(self, _arguments):  # noqa: ANN001
+                return Result.err(ProviderError(message="unparseable QA response"))
+
+        import yaml
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+                return_value=None,
+            ),
+            patch("ouroboros.mcp.tools.qa.QAHandler", _FailingQAHandler),
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.build_verification_artifacts",
+                new=AsyncMock(side_effect=RuntimeError("no artifact")),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_handler_qa_attempt",
+                    "seed_content": yaml.dump(seed.to_dict()),
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["qa_attempted"] is True
+        assert "qa" not in result.value.meta
 
     @pytest.mark.asyncio
     async def test_handler_resets_project_dir_after_call(self) -> None:

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -538,3 +538,65 @@ async def test_plugin_dispatch_uses_default_progress_windows_when_omitted(
     sub = body["_subagent"]
     assert sub["context"]["oscillation_window"] == DEFAULT_OSCILLATION_WINDOW
     assert sub["context"]["grade_regression_window"] == DEFAULT_GRADE_REGRESSION_WINDOW
+
+
+def _qa_meta(score: float, verdict: str, pass_threshold: float = 0.8) -> dict[str, Any]:
+    """Build the ``meta["qa"]`` payload exactly as ``QAHandler.handle`` publishes it.
+
+    ``passed`` is derived from the score, never from the model's ``verdict``
+    string (``src/ouroboros/mcp/tools/qa.py``), which is what makes the two
+    fields capable of contradicting each other.
+    """
+    return {
+        "score": score,
+        "verdict": verdict,
+        "pass_threshold": pass_threshold,
+        "passed": score >= pass_threshold,
+        "loop_action": "escalate" if score < pass_threshold else "complete",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sub_threshold_score_does_not_stop_the_loop_on_a_pass_verdict() -> None:
+    """A model-authored ``verdict: "pass"`` must not outrank the QA gate's own numbers.
+
+    The verdict string comes straight from the model whenever it is one of the
+    valid tokens; ``passed``/``score``/``pass_threshold`` are computed by the QA
+    gate itself. When they contradict, the computed result wins — otherwise one
+    string field converts a failed generation into a terminal success.
+    """
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": _qa_meta(0.1, "pass")},
+            {"action": "continue", "qa": _qa_meta(0.1, "pass")},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(lineage_id="lin_contradicted_pass", max_generations=2)
+    )
+
+    assert result.stop_reason != "qa passed"
+    assert result.stop_reason == "max_generations reached"
+    assert result.iteration_count == 2
+    assert evolve.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_uncontradicted_pass_verdict_still_stops_the_loop() -> None:
+    """The guard must only fire on contradiction: an honest pass still stops at once."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": _qa_meta(0.95, "pass")},
+            {"action": "continue", "qa": _qa_meta(0.95, "pass")},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_honest_pass", max_generations=2))
+
+    assert result.status == "completed"
+    assert result.stop_reason == "qa passed"
+    assert result.iteration_count == 1
+    assert evolve.calls == 1

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 
 from ouroboros.core.types import Result
+from ouroboros.mcp.tools.qa import FAIL_THRESHOLD
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.ralph_loop import RalphLoopConfig, RalphLoopRunner
@@ -547,12 +548,18 @@ def _qa_meta(score: float, verdict: str, pass_threshold: float = 0.8) -> dict[st
     string (``src/ouroboros/mcp/tools/qa.py``), which is what makes the two
     fields capable of contradicting each other.
     """
+    if score >= pass_threshold:
+        loop_action = "done"
+    elif score >= FAIL_THRESHOLD:
+        loop_action = "continue"
+    else:
+        loop_action = "escalate"
     return {
         "score": score,
         "verdict": verdict,
         "pass_threshold": pass_threshold,
         "passed": score >= pass_threshold,
-        "loop_action": "escalate" if score < pass_threshold else "complete",
+        "loop_action": loop_action,
     }
 
 
@@ -581,6 +588,10 @@ async def test_sub_threshold_score_does_not_stop_the_loop_on_a_pass_verdict() ->
     assert result.stop_reason == "max_generations reached"
     assert result.iteration_count == 2
     assert evolve.calls == 2
+    # An authoritative QA failure must not serialize as a successful, non-error
+    # terminal result — `to_tool_result` is what the job/auto layer reads.
+    assert result.status == "failed"
+    assert result.to_tool_result().is_error is True
 
 
 @pytest.mark.asyncio
@@ -600,3 +611,49 @@ async def test_uncontradicted_pass_verdict_still_stops_the_loop() -> None:
     assert result.stop_reason == "qa passed"
     assert result.iteration_count == 1
     assert evolve.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_converged_action_does_not_complete_on_a_contradicted_qa_pass() -> None:
+    """``converged`` is the sibling success exit and must consult the same QA result.
+
+    ``evolution_handlers`` runs post-execution QA for both ``continue`` and
+    ``converged`` and publishes the pre-QA action unchanged, so a converged step
+    can arrive carrying an authoritative QA failure. Guarding only the ``qa
+    passed`` branch would leave this exit reporting terminal success.
+    """
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "qa": _qa_meta(0.1, "pass")}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_bad_qa", max_generations=3))
+
+    assert result.status == "failed"
+    assert result.stop_reason == "qa_failed"
+    assert result.to_tool_result().is_error is True
+    assert result.iteration_count == 1
+
+
+@pytest.mark.asyncio
+async def test_converged_action_still_completes_on_an_uncontradicted_qa_pass() -> None:
+    """The converged guard must fire only on contradiction, not on every converge."""
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "qa": _qa_meta(0.95, "pass")}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_ok", max_generations=3))
+
+    assert result.status == "completed"
+    assert result.to_tool_result().is_error is False
+    assert result.iteration_count == 1
+
+
+@pytest.mark.asyncio
+async def test_converged_without_qa_numbers_keeps_completing() -> None:
+    """A payload with no computed QA fields keeps its legacy terminal behaviour."""
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged"}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_legacy", max_generations=3))
+
+    assert result.status == "completed"
+    assert result.stop_reason == "converged"
+    assert result.to_tool_result().is_error is False

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -677,9 +677,9 @@ async def test_exhaustion_fails_when_qa_ran_but_returned_no_verdict() -> None:
     """
     evolve = _ScriptedEvolveHandler(
         metas=[
-            {"action": "continue", "executed": True, "qa": _qa_meta(0.1, "fail")},
+            {"action": "continue", "qa_attempted": True, "qa": _qa_meta(0.1, "fail")},
             # QA ran again but its completion could not be parsed → no `qa` key.
-            {"action": "continue", "executed": True},
+            {"action": "continue", "qa_attempted": True},
         ]
     )
     runner = RalphLoopRunner(evolve)
@@ -694,7 +694,7 @@ async def test_exhaustion_fails_when_qa_ran_but_returned_no_verdict() -> None:
 @pytest.mark.asyncio
 async def test_converged_fails_when_qa_ran_but_returned_no_verdict() -> None:
     """The converged exit must not mint a success out of a missing QA verdict."""
-    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "executed": True}])
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "qa_attempted": True}])
     runner = RalphLoopRunner(evolve)
 
     result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_no_qa", max_generations=3))

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -647,12 +647,72 @@ async def test_converged_action_still_completes_on_an_uncontradicted_qa_pass() -
 
 
 @pytest.mark.asyncio
-async def test_converged_without_qa_numbers_keeps_completing() -> None:
-    """A payload with no computed QA fields keeps its legacy terminal behaviour."""
+async def test_converged_without_any_qa_attempt_keeps_completing() -> None:
+    """A payload from a generation where QA never ran keeps its legacy behaviour.
+
+    Narrow on purpose: no ``executed`` marker means the producer never reached its
+    QA branch, so there is no missing verdict to fail closed on. Contrast with
+    ``test_converged_fails_when_qa_ran_but_returned_no_verdict``, where QA did run
+    and the absent block is the evidence that it failed.
+    """
     evolve = _ScriptedEvolveHandler(metas=[{"action": "converged"}])
     runner = RalphLoopRunner(evolve)
 
     result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_legacy", max_generations=3))
+
+    assert result.status == "completed"
+    assert result.stop_reason == "converged"
+    assert result.to_tool_result().is_error is False
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_fails_when_qa_ran_but_returned_no_verdict() -> None:
+    """Absent QA evidence must fail closed when QA was actually attempted.
+
+    ``evolution_handlers`` drops the whole ``qa`` block when ``QAHandler`` returns
+    an error, which is exactly what a malformed or truncated QA completion
+    produces. Gating on "did QA authoritatively fail?" would then make a garbled
+    QA response *safer* than a parseable failing one, so the gate has to key on
+    evidence of a pass. ``executed`` marks the runs where QA was in fact run.
+    """
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "executed": True, "qa": _qa_meta(0.1, "fail")},
+            # QA ran again but its completion could not be parsed → no `qa` key.
+            {"action": "continue", "executed": True},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_qa_unparseable", max_generations=2))
+
+    assert result.status == "failed"
+    assert result.stop_reason == "max_generations reached"
+    assert result.to_tool_result().is_error is True
+
+
+@pytest.mark.asyncio
+async def test_converged_fails_when_qa_ran_but_returned_no_verdict() -> None:
+    """The converged exit must not mint a success out of a missing QA verdict."""
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "executed": True}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(RalphLoopConfig(lineage_id="lin_converged_no_qa", max_generations=3))
+
+    assert result.status == "failed"
+    assert result.stop_reason == "qa_failed"
+    assert result.to_tool_result().is_error is True
+
+
+@pytest.mark.asyncio
+async def test_skip_qa_keeps_completing_without_any_qa_evidence() -> None:
+    """The legitimate QA-disabled opt-out must stay intact."""
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "converged", "executed": True}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(lineage_id="lin_skip_qa", max_generations=3, skip_qa=True)
+    )
 
     assert result.status == "completed"
     assert result.stop_reason == "converged"


### PR DESCRIPTION
Refs #1827

## What

`_qa_passed` (`src/ouroboros/ralph_loop.py`) decided whether to stop the Ralph loop
from `meta["qa"]["verdict"]` alone. That string is kept verbatim from the model
whenever it is one of the valid tokens (`mcp/tools/qa.py:308-314` only re-derives it
when the model's verdict is _invalid_), while `passed` / `score` / `pass_threshold`
in the same payload are computed by the QA gate itself:

```python
"passed": verdict.score >= pass_threshold,
```

So a completion of `{"score": 0.10, "verdict": "pass"}` stopped the entire
multi-generation loop with `status="completed"`, `stop_reason="qa passed"` — while
that same payload carried `passed=False`, `loop_action="escalate"` against a 0.80 bar.

`completed` is terminal downstream: `RalphLoopResult.to_tool_result()` sets
`is_error = (status == "failed")`, JobManager records `JobStatus.COMPLETED`
(`mcp/job_manager.py:723`), and `auto/pipeline.py:2656` only diverts on `"failed"` —
so a failed generation falls through to `_emit_product_emitted_terminal` +
`AutoPhase.COMPLETE`. One model-authored string turned a failed generation into a
terminal "product emitted".

## Why this is a bug and not a deliberate policy

Every other reader of this payload already gates on the computed field:

| reader                               | gates on                                 |
| ------------------------------------ | ---------------------------------------- |
| `auto/adapters.py:805`, `:879`       | `passed=bool(meta.get("passed", False))` |
| `auto/pipeline.py:2859-2862`         | `qa_result.passed`                       |
| `ralph_loop.py:353` (before this PR) | `verdict` string only                    |

The loop's stop decision was the sole exception. This brings it in line.

## The fix

Treat a `pass` verdict as a pass only when the gate's own numbers do not contradict
it — `qa["passed"] is False`, or `score < pass_threshold` when both are numeric.

A NaN score compares `False` and so lands on the fail-closed side, without needing a
special case.

Payloads that carry a verdict but no numbers keep their current behaviour, which is
what the existing fixtures use — no existing test changed.

## Tests

Two new tests in `tests/unit/test_ralph_loop_progress.py`:

1. **`test_sub_threshold_score_does_not_stop_the_loop_on_a_pass_verdict`** — the
   regression proof. Builds `meta["qa"]` exactly as `QAHandler.handle` publishes it
   and drives the public `RalphLoopRunner.run()`. Verified to **FAIL against the
   reviewed baseline**:

   ```
   >       assert result.stop_reason != "qa passed"
   E       AssertionError: assert 'qa passed' != 'qa passed'
   ```

2. **`test_uncontradicted_pass_verdict_still_stops_the_loop`** — an honest
   `0.95 / "pass"` must still stop immediately. To be explicit: **this one passes both
   before and after the fix.** It is not a regression proof; it is a guard against
   over-correcting the first one into "never stop on a pass verdict".

Existing coverage only ever exercised the _safe_ divergence (high score +
`verdict: "fail"` → keep going, `test_ralph_loop_progress.py:106-161`) and a
`verdict="pass"` with no score at all (`test_ralph_handler.py:189-206`). The unsafe
direction was untested.

## Verification

- `pytest tests/unit/test_ralph_loop_progress.py tests/unit/mcp/tools/test_ralph_handler.py` → **37 passed** (35 before + 2 new)
- `pytest tests/unit/auto` (the downstream consumers) + the two above → **1392 passed**
- `pytest tests/unit/mcp/tools/test_qa_parser.py tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py` → **10 passed**
- Full suite as CI runs it: `pytest tests/ -n 4 --dist worksteal` → **16438 passed, 19 skipped, 1 xfailed** (7m52s)
- `ruff check`, `ruff format --check`, `mypy` on the changed files → clean
- `scripts/check-module-size.py` → OK; no file under `src/ouroboros/auto/` is touched
