### PR TITLE
fix(cli/plugin): stage URL cache refresh so failed clones keep the old cache

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -28,6 +28,10 @@ from typing import Annotated
 
 import typer
 
+from ouroboros.cli.commands.plugin_cache import (
+    stage_url_cache_refresh,
+    url_cache_destination,
+)
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
     print_error,
@@ -1864,20 +1868,13 @@ def add_command(
     trust = TrustStore(root=trust_root or DEFAULT_TRUST_ROOT)
 
     if _looks_like_url(target):
-        # Shallow clone into cache_root/<sanitized-host-path>.
-        sanitized = (
-            target.replace("https://", "")
-            .replace("http://", "")
-            .replace("git@", "")
-            .replace(":", "_")
-            .replace("/", "_")
-            .strip("_")
-        )
-        clone_dest = cache_root / sanitized
-        if clone_dest.exists():
-            shutil.rmtree(clone_dest)
+        # Staged shallow clone into cache_root/<sanitized-host-path>; a
+        # failed refresh preserves the last-known-good cache (#1826).
+        clone_dest = url_cache_destination(cache_root, target)
         try:
-            git_sha = _shallow_clone(target, clone_dest)
+            git_sha = stage_url_cache_refresh(
+                lambda staging: _shallow_clone(target, staging), clone_dest
+            )
         except subprocess.CalledProcessError as exc:
             print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
             raise typer.Exit(code=1) from exc
@@ -2464,19 +2461,11 @@ def _install_named_from_url(
 ) -> None:
     """`install <name> --from <repo-url>` qualified form for plugin_home sources."""
     _reject_subdirectory_form(repo_url)
-    sanitized = (
-        repo_url.replace("https://", "")
-        .replace("http://", "")
-        .replace("git@", "")
-        .replace(":", "_")
-        .replace("/", "_")
-        .strip("_")
-    )
-    clone_dest = cache_root / sanitized
-    if clone_dest.exists():
-        shutil.rmtree(clone_dest)
+    clone_dest = url_cache_destination(cache_root, repo_url)
     try:
-        git_sha = _shallow_clone(repo_url, clone_dest)
+        git_sha = stage_url_cache_refresh(
+            lambda staging: _shallow_clone(repo_url, staging), clone_dest
+        )
     except subprocess.CalledProcessError as exc:
         print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
         raise typer.Exit(code=1) from exc

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -28,10 +28,7 @@ from typing import Annotated
 
 import typer
 
-from ouroboros.cli.commands.plugin_cache import (
-    stage_url_cache_refresh,
-    url_cache_destination,
-)
+from ouroboros.cli.commands import plugin_cache
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
     print_error,
@@ -1870,20 +1867,13 @@ def add_command(
     if _looks_like_url(target):
         # Staged shallow clone into cache_root/<sanitized-host-path>; a
         # failed refresh preserves the last-known-good cache (#1826).
-        clone_dest = url_cache_destination(cache_root, target)
+        clone_dest = plugin_cache.url_cache_destination(cache_root, target)
         try:
-            git_sha = stage_url_cache_refresh(
+            git_sha = plugin_cache.stage_url_cache_refresh(
                 lambda staging: _shallow_clone(target, staging), clone_dest
             )
-        except subprocess.CalledProcessError as exc:
-            print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
-            raise typer.Exit(code=1) from exc
-        except OSError as exc:
-            print_error(
-                f"plugin cache refresh failed at {clone_dest}: {exc}. "
-                "The previous cache was preserved when recovery was possible; "
-                "check sibling .bak-* directories before retrying."
-            )
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print_error(plugin_cache.url_cache_refresh_error(exc, clone_dest))
             raise typer.Exit(code=1) from exc
         repo_root = clone_dest
         source_kind = "git"
@@ -2468,20 +2458,13 @@ def _install_named_from_url(
 ) -> None:
     """`install <name> --from <repo-url>` qualified form for plugin_home sources."""
     _reject_subdirectory_form(repo_url)
-    clone_dest = url_cache_destination(cache_root, repo_url)
+    clone_dest = plugin_cache.url_cache_destination(cache_root, repo_url)
     try:
-        git_sha = stage_url_cache_refresh(
+        git_sha = plugin_cache.stage_url_cache_refresh(
             lambda staging: _shallow_clone(repo_url, staging), clone_dest
         )
-    except subprocess.CalledProcessError as exc:
-        print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
-        raise typer.Exit(code=1) from exc
-    except OSError as exc:
-        print_error(
-            f"plugin cache refresh failed at {clone_dest}: {exc}. "
-            "The previous cache was preserved when recovery was possible; "
-            "check sibling .bak-* directories before retrying."
-        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print_error(plugin_cache.url_cache_refresh_error(exc, clone_dest))
         raise typer.Exit(code=1) from exc
 
     catalog = _enumerate_catalog(clone_dest)

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1878,6 +1878,13 @@ def add_command(
         except subprocess.CalledProcessError as exc:
             print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
             raise typer.Exit(code=1) from exc
+        except OSError as exc:
+            print_error(
+                f"plugin cache refresh failed at {clone_dest}: {exc}. "
+                "The previous cache was preserved when recovery was possible; "
+                "check sibling .bak-* directories before retrying."
+            )
+            raise typer.Exit(code=1) from exc
         repo_root = clone_dest
         source_kind = "git"
         repository = target
@@ -2468,6 +2475,13 @@ def _install_named_from_url(
         )
     except subprocess.CalledProcessError as exc:
         print_error(f"git clone failed: {exc.stderr.strip() if exc.stderr else exc}")
+        raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        print_error(
+            f"plugin cache refresh failed at {clone_dest}: {exc}. "
+            "The previous cache was preserved when recovery was possible; "
+            "check sibling .bak-* directories before retrying."
+        )
         raise typer.Exit(code=1) from exc
 
     catalog = _enumerate_catalog(clone_dest)

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -13,6 +13,7 @@ installs already follow.
 from __future__ import annotations
 
 from collections.abc import Callable
+import hashlib
 import os
 from pathlib import Path
 import secrets
@@ -57,8 +58,13 @@ def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> s
     """
     clone_dest.parent.mkdir(parents=True, exist_ok=True)
     suffix = secrets.token_hex(6)
-    staging = clone_dest.with_name(f"{clone_dest.name}.staging-{suffix}")
-    backup = clone_dest.with_name(f"{clone_dest.name}.bak-{suffix}")
+    # Do not extend the destination basename: a valid cache component may
+    # already be near NAME_MAX. A bounded digest keeps temporary siblings
+    # attributable to the destination without inheriting its length.
+    identity = hashlib.sha256(os.fsencode(clone_dest.name)).hexdigest()[:12]
+    sibling_prefix = f".ouroboros-cache-{identity}"
+    staging = clone_dest.with_name(f"{sibling_prefix}.staging-{suffix}")
+    backup = clone_dest.with_name(f"{sibling_prefix}.bak-{suffix}")
 
     try:
         git_sha = clone(staging)

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -21,11 +21,25 @@ import shutil
 import subprocess
 
 
+class CacheRefreshRecoveryError(OSError):
+    """Promotion failed and the previous cache remains at ``backup_path``."""
+
+    def __init__(self, message: str, *, backup_path: Path) -> None:
+        super().__init__(message)
+        self.backup_path = backup_path
+
+
 def url_cache_refresh_error(exc: subprocess.CalledProcessError | OSError, dest: Path) -> str:
     """Render clone and filesystem failures through one public CLI contract."""
     if isinstance(exc, subprocess.CalledProcessError):
         detail = exc.stderr.strip() if exc.stderr else exc
         return f"git clone failed: {detail}"
+    if isinstance(exc, CacheRefreshRecoveryError):
+        return (
+            f"plugin cache refresh failed at {dest}: {exc}. "
+            f"The previous cache is retained at {exc.backup_path}; "
+            f"restore it to {dest} before retrying."
+        )
     return (
         f"plugin cache refresh failed at {dest}: {exc}. "
         "The previous cache was preserved when recovery was possible; "
@@ -85,18 +99,25 @@ def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> s
             backup_used = True
             os.rename(clone_dest, backup)
         os.rename(staging, clone_dest)
-    except BaseException:
+    except BaseException as exc:
         # The live cache may already be parked at ``backup`` here. User
         # interruption must take the same rollback path as an OSError rather
         # than strand the public destination and staging directory.
+        recovery_error: CacheRefreshRecoveryError | None = None
         if backup_used and not clone_dest.exists() and backup.exists():
             try:
                 os.rename(backup, clone_dest)
-            except OSError:
+            except OSError as restore_error:
                 # Restore failed; the backup stays on disk for manual
                 # recovery rather than being deleted with the staging tree.
-                pass
+                if isinstance(exc, Exception):
+                    recovery_error = CacheRefreshRecoveryError(
+                        f"promotion failed ({exc}); automatic restoration failed ({restore_error})",
+                        backup_path=backup,
+                    )
         shutil.rmtree(staging, ignore_errors=True)
+        if recovery_error is not None:
+            raise recovery_error from exc
         raise
 
     # The old cache is gone from its live path; dropping the backup is

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -62,7 +62,9 @@ def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> s
 
     try:
         git_sha = clone(staging)
-    except Exception:
+    except BaseException:
+        # BaseException so a user interrupt during the clone also drops the
+        # partial staging tree; the live cache is untouched either way.
         shutil.rmtree(staging, ignore_errors=True)
         raise
 

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -1,0 +1,77 @@
+"""Staged refresh of URL-backed plugin source caches.
+
+Both URL entry points (``ooo plugin add <repo-url>`` and
+``ooo plugin install <name> --from <repo-url>``) cache their clone under
+``cache_root/<sanitized-host-path>``. They used to delete that directory
+before attempting the replacement clone, so a transient clone failure
+destroyed the last-known-good cache (#1826). The refresh here clones into
+a staging sibling and promotes it over the live cache only after the clone
+has fully succeeded, mirroring the atomic-swap discipline the plugin_home
+installs already follow.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import os
+from pathlib import Path
+import secrets
+import shutil
+
+
+def url_cache_destination(cache_root: Path, repo_url: str) -> Path:
+    """Map a repository URL to its sanitized cache directory."""
+    sanitized = (
+        repo_url.replace("https://", "")
+        .replace("http://", "")
+        .replace("git@", "")
+        .replace(":", "_")
+        .replace("/", "_")
+        .strip("_")
+    )
+    return cache_root / sanitized
+
+
+def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> str:
+    """Refresh ``clone_dest`` from a staged clone; keep the old cache on failure.
+
+    ``clone`` populates the staging directory and returns the resolved git
+    SHA. Only after it succeeds is the previous cache renamed aside and the
+    staging tree promoted — both renames are atomic because staging and
+    backup are siblings of the destination on the same filesystem. Any
+    failure drops the staging tree, restores the prior cache, and re-raises,
+    so a failed refresh leaves the last-known-good bytes untouched.
+    """
+    clone_dest.parent.mkdir(parents=True, exist_ok=True)
+    suffix = secrets.token_hex(6)
+    staging = clone_dest.with_name(f"{clone_dest.name}.staging-{suffix}")
+    backup = clone_dest.with_name(f"{clone_dest.name}.bak-{suffix}")
+
+    try:
+        git_sha = clone(staging)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    backup_used = False
+    try:
+        if clone_dest.exists():
+            os.rename(clone_dest, backup)
+            backup_used = True
+        os.rename(staging, clone_dest)
+    except Exception:
+        if backup_used and not clone_dest.exists() and backup.exists():
+            try:
+                os.rename(backup, clone_dest)
+            except OSError:
+                # Restore failed; the backup stays on disk for manual
+                # recovery rather than being deleted with the staging tree.
+                pass
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    # The old cache is gone from its live path; dropping the backup is
+    # best-effort cleanup, not a correctness step.
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
+    return git_sha

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -17,6 +17,19 @@ import os
 from pathlib import Path
 import secrets
 import shutil
+import subprocess
+
+
+def url_cache_refresh_error(exc: subprocess.CalledProcessError | OSError, dest: Path) -> str:
+    """Render clone and filesystem failures through one public CLI contract."""
+    if isinstance(exc, subprocess.CalledProcessError):
+        detail = exc.stderr.strip() if exc.stderr else exc
+        return f"git clone failed: {detail}"
+    return (
+        f"plugin cache refresh failed at {dest}: {exc}. "
+        "The previous cache was preserved when recovery was possible; "
+        "check sibling .bak-* directories before retrying."
+    )
 
 
 def url_cache_destination(cache_root: Path, repo_url: str) -> Path:

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -71,8 +71,13 @@ def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> s
     backup_used = False
     try:
         if clone_dest.exists():
-            os.rename(clone_dest, backup)
+            # Ownership is recorded before the rename: an interrupt landing
+            # between the rename's side effect and this flag would otherwise
+            # skip restoration and strand the cache under the backup name.
+            # The handler's ``backup.exists()`` guard keeps the early flag
+            # harmless when the rename itself never happened.
             backup_used = True
+            os.rename(clone_dest, backup)
         os.rename(staging, clone_dest)
     except BaseException:
         # The live cache may already be parked at ``backup`` here. User

--- a/src/ouroboros/cli/commands/plugin_cache.py
+++ b/src/ouroboros/cli/commands/plugin_cache.py
@@ -74,7 +74,10 @@ def stage_url_cache_refresh(clone: Callable[[Path], str], clone_dest: Path) -> s
             os.rename(clone_dest, backup)
             backup_used = True
         os.rename(staging, clone_dest)
-    except Exception:
+    except BaseException:
+        # The live cache may already be parked at ``backup`` here. User
+        # interruption must take the same rollback path as an OSError rather
+        # than strand the public destination and staging directory.
         if backup_used and not clone_dest.exists() and backup.exists():
             try:
                 os.rename(backup, clone_dest)

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2489,7 +2489,7 @@ def test_url_refresh_filesystem_failure_is_reported_without_traceback(
         raise OSError(28, "No space left on device")
 
     monkeypatch.setattr(
-        "ouroboros.cli.commands.plugin.stage_url_cache_refresh", _disk_failure
+        "ouroboros.cli.commands.plugin_cache.stage_url_cache_refresh", _disk_failure
     )
     selector = (
         ["add", url, "--plugin", "github-pr-ops"]

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2606,6 +2606,79 @@ def test_stage_url_cache_refresh_restores_backup_when_promote_fails(
     )
 
 
+def test_failed_restore_preserves_backup_for_manual_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even when promotion AND restoration both fail, the old bytes survive.
+
+    The restore rename is the last automatic recovery step; when it also
+    fails, the renamed-aside backup directory is the sole remaining copy of
+    the last-known-good cache and must stay on disk for manual recovery.
+    """
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    dest = cache_root / "repo"
+    dest.mkdir(parents=True)
+    (dest / "good.txt").write_text("keep me")
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def double_fault(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:  # staging → dest promotion
+            raise OSError(28, "No space left on device")
+        if calls["n"] == 3:  # backup → dest restoration
+            raise OSError(5, "Input/output error")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin_cache.os.rename", double_fault)
+
+    def _clone(staging: Path) -> str:
+        staging.mkdir()
+        (staging / "new.txt").write_text("fresh clone")
+        return "cafef00d"
+
+    with pytest.raises(OSError):
+        stage_url_cache_refresh(_clone, dest)
+
+    assert calls["n"] == 3, "expected promotion and restoration to both be attempted"
+    backups = [entry for entry in cache_root.iterdir() if ".bak-" in entry.name]
+    assert len(backups) == 1, f"expected the backup to survive, found {backups}"
+    assert (backups[0] / "good.txt").read_text() == "keep me", (
+        "the last-known-good bytes were lost with no automatic copy remaining"
+    )
+    assert [entry for entry in cache_root.iterdir() if ".staging-" in entry.name] == [], (
+        "staging debris left behind"
+    )
+
+
+def test_interrupted_clone_drops_staging_and_keeps_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user interrupt mid-clone cleans staging and leaves the cache alone."""
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    dest = cache_root / "repo"
+    dest.mkdir(parents=True)
+    (dest / "good.txt").write_text("keep me")
+
+    def _interrupted_clone(staging: Path) -> str:
+        staging.mkdir()
+        (staging / "partial.txt").write_text("half a clone")
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        stage_url_cache_refresh(_interrupted_clone, dest)
+
+    assert (dest / "good.txt").read_text() == "keep me"
+    assert [entry for entry in cache_root.iterdir() if ".staging-" in entry.name] == [], (
+        "an interrupted clone left a partial staging tree"
+    )
+
+
 def test_trust_rejects_undeclared_scope(runner: CliRunner, tmp_path: Path) -> None:
     """`ooo plugin trust --scope <typo>` must refuse to persist a grant
     for a scope the manifest does not declare. Otherwise the command

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2713,6 +2713,49 @@ def test_interrupted_promotion_restores_cache_and_drops_staging(
     assert sorted(entry.name for entry in cache_root.iterdir()) == ["repo"]
 
 
+def test_interrupt_after_backup_rename_still_restores_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupt landing right after the backup rename must not strand the cache.
+
+    Ownership of the parked backup has to be recorded before the rename's
+    side effect exists; otherwise an interrupt in that window skips the
+    restore branch and the public cache path is left absent.
+    """
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    dest = cache_root / "repo"
+    dest.mkdir(parents=True)
+    (dest / "good.txt").write_text("keep me")
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def rename_then_interrupt(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 1:  # dest → backup: perform the side effect, then interrupt
+            real_rename(src, dst)
+            raise KeyboardInterrupt
+        return real_rename(src, dst)
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin_cache.os.rename", rename_then_interrupt)
+
+    def _clone(staging: Path) -> str:
+        staging.mkdir()
+        (staging / "new.txt").write_text("fresh clone")
+        return "cafef00d"
+
+    with pytest.raises(KeyboardInterrupt):
+        stage_url_cache_refresh(_clone, dest)
+
+    assert dest.exists() and (dest / "good.txt").read_text() == "keep me", (
+        "the cache was stranded under .bak-* instead of being restored"
+    )
+    litter = [entry.name for entry in cache_root.iterdir() if entry.name != "repo"]
+    assert litter == [], f"interrupt left litter behind: {litter}"
+
+
 def test_trust_rejects_undeclared_scope(runner: CliRunner, tmp_path: Path) -> None:
     """`ooo plugin trust --scope <typo>` must refuse to persist a grant
     for a scope the manifest does not declare. Otherwise the command

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2519,6 +2519,56 @@ def test_url_refresh_filesystem_failure_is_reported_without_traceback(
 
 
 @pytest.mark.parametrize("mode", ["add", "install"])
+def test_url_refresh_reports_exact_retained_backup_path(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """Both public commands identify the sole surviving recovery copy."""
+    from ouroboros.cli.commands.plugin_cache import CacheRefreshRecoveryError
+
+    paths = _common_paths(tmp_path)
+    cache_root = tmp_path / "cache"
+    backup = cache_root / ".ouroboros-cache-deadbeefcafe.bak-123456789abc"
+    url = "https://github.com/Q00/ouroboros-plugins.git"
+
+    def _double_failure(*_args: object, **_kwargs: object) -> str:
+        raise CacheRefreshRecoveryError(
+            "promotion and automatic restoration failed", backup_path=backup
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.plugin_cache.stage_url_cache_refresh", _double_failure
+    )
+    selector = (
+        ["add", url, "--plugin", "github-pr-ops"]
+        if mode == "add"
+        else ["install", "github-pr-ops", "--from", url]
+    )
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            *selector,
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+
+    assert result.exit_code == 1
+    # Rich wraps long paths inside a bordered panel. Remove only rendering
+    # characters so the exact path can be asserted independent of width.
+    import re
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    squashed = re.sub(r"[│╭╮╰╯─\s]+", "", plain)
+    assert str(backup) in squashed
+    assert "restoreitto" in squashed
+
+
+@pytest.mark.parametrize("mode", ["add", "install"])
 def test_successful_url_refresh_replaces_stale_cache(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
 ) -> None:
@@ -2615,7 +2665,10 @@ def test_failed_restore_preserves_backup_for_manual_recovery(
     fails, the renamed-aside backup directory is the sole remaining copy of
     the last-known-good cache and must stay on disk for manual recovery.
     """
-    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+    from ouroboros.cli.commands.plugin_cache import (
+        CacheRefreshRecoveryError,
+        stage_url_cache_refresh,
+    )
 
     cache_root = tmp_path / "cache"
     dest = cache_root / "repo"
@@ -2640,7 +2693,7 @@ def test_failed_restore_preserves_backup_for_manual_recovery(
         (staging / "new.txt").write_text("fresh clone")
         return "cafef00d"
 
-    with pytest.raises(OSError):
+    with pytest.raises(CacheRefreshRecoveryError) as exc_info:
         stage_url_cache_refresh(_clone, dest)
 
     assert calls["n"] == 3, "expected promotion and restoration to both be attempted"
@@ -2649,6 +2702,7 @@ def test_failed_restore_preserves_backup_for_manual_recovery(
     assert (backups[0] / "good.txt").read_text() == "keep me", (
         "the last-known-good bytes were lost with no automatic copy remaining"
     )
+    assert exc_info.value.backup_path == backups[0]
     assert [entry for entry in cache_root.iterdir() if ".staging-" in entry.name] == [], (
         "staging debris left behind"
     )

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -2419,6 +2420,148 @@ def test_add_routes_git_plus_ssh_url_through_clone(
     assert cloned_url == "ssh://git@github.com/Q00/ouroboros-plugins.git", cloned_url
     # And lockfile records source_kind="git".
     assert Lockfile(paths["lockfile"]).read()["github-pr-ops"].source_kind == "git"
+
+
+@pytest.mark.parametrize("mode", ["add", "install"])
+def test_failed_url_refresh_preserves_last_known_good_cache(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """#1826: a failed clone must not destroy the previous cached repository.
+
+    Both URL entry points used to delete the live cache directory before
+    attempting the replacement clone, so a transient network failure turned
+    into irreversible loss of the last-known-good cache. The refresh must
+    stage the new clone beside the cache and leave the old bytes untouched
+    on any failure, without littering the cache root.
+    """
+    paths = _common_paths(tmp_path)
+    cache_root = tmp_path / "cache"
+    url = "https://github.com/Q00/ouroboros-plugins.git"
+    clone_dest = cache_root / "github.com_Q00_ouroboros-plugins.git"
+    clone_dest.mkdir(parents=True)
+    (clone_dest / "sentinel.txt").write_text("last known good")
+
+    def _network_down(repo_url: str, dest: Path) -> str:
+        raise subprocess.CalledProcessError(
+            128, ["git", "clone"], stderr="simulated network failure"
+        )
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin._shallow_clone", _network_down)
+
+    selector = (
+        ["add", url, "--plugin", "github-pr-ops"]
+        if mode == "add"
+        else ["install", "github-pr-ops", "--from", url]
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            *selector,
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "git clone failed" in result.output
+    assert (clone_dest / "sentinel.txt").read_text() == "last known good", (
+        "a failed refresh deleted the last-known-good cache"
+    )
+    assert sorted(entry.name for entry in cache_root.iterdir()) == [clone_dest.name], (
+        "a failed refresh left staging or backup litter in the cache root"
+    )
+
+
+@pytest.mark.parametrize("mode", ["add", "install"])
+def test_successful_url_refresh_replaces_stale_cache(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """A successful refresh fully replaces the stale cache, with no litter."""
+    paths = _common_paths(tmp_path)
+    cache_root = tmp_path / "cache"
+    url = "https://github.com/Q00/ouroboros-plugins.git"
+    clone_dest = cache_root / "github.com_Q00_ouroboros-plugins.git"
+    clone_dest.mkdir(parents=True)
+    (clone_dest / "stale.txt").write_text("previous refresh")
+
+    def _fake_clone(repo_url: str, dest: Path) -> str:
+        plugin_dir = dest / "plugins" / "github-pr-ops"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "ouroboros.plugin.json").write_text(json.dumps(REFERENCE_MANIFEST))
+        return "cafef00d"
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin._shallow_clone", _fake_clone)
+
+    selector = (
+        ["add", url, "--plugin", "github-pr-ops"]
+        if mode == "add"
+        else ["install", "github-pr-ops", "--from", url]
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            *selector,
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not (clone_dest / "stale.txt").exists(), "stale cache content survived the refresh"
+    assert (clone_dest / "plugins" / "github-pr-ops" / "ouroboros.plugin.json").exists()
+    assert sorted(entry.name for entry in cache_root.iterdir()) == [clone_dest.name], (
+        "refresh left staging or backup litter in the cache root"
+    )
+    assert Lockfile(paths["lockfile"]).read()["github-pr-ops"].source_kind == "git"
+
+
+def test_stage_url_cache_refresh_restores_backup_when_promote_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If promoting the staged clone fails, the previous cache is restored.
+
+    The swap renames the live cache aside before promoting staging; a
+    failure between those two steps must put the old bytes back rather
+    than leaving the destination missing.
+    """
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    dest = cache_root / "repo"
+    dest.mkdir(parents=True)
+    (dest / "good.txt").write_text("keep me")
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:  # dest→backup succeeds, staging→dest fails
+            raise OSError(28, "No space left on device")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin_cache.os.rename", flaky_rename)
+
+    def _clone(staging: Path) -> str:
+        staging.mkdir()
+        (staging / "new.txt").write_text("fresh clone")
+        return "cafef00d"
+
+    with pytest.raises(OSError):
+        stage_url_cache_refresh(_clone, dest)
+
+    assert (dest / "good.txt").read_text() == "keep me", "prior cache was not restored"
+    assert sorted(entry.name for entry in cache_root.iterdir()) == ["repo"], (
+        "promote failure left staging or backup litter"
+    )
 
 
 def test_trust_rejects_undeclared_scope(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2756,6 +2756,32 @@ def test_interrupt_after_backup_rename_still_restores_cache(
     assert litter == [], f"interrupt left litter behind: {litter}"
 
 
+def test_refresh_uses_bounded_sibling_names_near_name_max(tmp_path: Path) -> None:
+    """Temporary artifacts stay valid when the destination is already long."""
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    dest = cache_root / ("r" * 235)
+    dest.mkdir()
+    (dest / "old.txt").write_text("old")
+    seen_staging_name = ""
+
+    def _clone(staging: Path) -> str:
+        nonlocal seen_staging_name
+        seen_staging_name = staging.name
+        staging.mkdir()
+        (staging / "new.txt").write_text("new")
+        return "cafef00d"
+
+    assert stage_url_cache_refresh(_clone, dest) == "cafef00d"
+
+    name_max = os.pathconf(cache_root, "PC_NAME_MAX")
+    assert len(os.fsencode(seen_staging_name)) <= name_max
+    assert (dest / "new.txt").read_text() == "new"
+    assert sorted(entry.name for entry in cache_root.iterdir()) == [dest.name]
+
+
 def test_trust_rejects_undeclared_scope(runner: CliRunner, tmp_path: Path) -> None:
     """`ooo plugin trust --scope <typo>` must refuse to persist a grant
     for a scope the manifest does not declare. Otherwise the command

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2679,6 +2679,40 @@ def test_interrupted_clone_drops_staging_and_keeps_cache(
     )
 
 
+def test_interrupted_promotion_restores_cache_and_drops_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupt after parking the live cache still rolls the swap back."""
+    from ouroboros.cli.commands.plugin_cache import stage_url_cache_refresh
+
+    cache_root = tmp_path / "cache"
+    dest = cache_root / "repo"
+    dest.mkdir(parents=True)
+    (dest / "good.txt").write_text("keep me")
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def interrupted_promote(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+        return real_rename(src, dst)
+
+    monkeypatch.setattr("ouroboros.cli.commands.plugin_cache.os.rename", interrupted_promote)
+
+    def _clone(staging: Path) -> str:
+        staging.mkdir()
+        (staging / "new.txt").write_text("fresh clone")
+        return "cafef00d"
+
+    with pytest.raises(KeyboardInterrupt):
+        stage_url_cache_refresh(_clone, dest)
+
+    assert calls["n"] == 3, "the parked backup was not restored after interruption"
+    assert (dest / "good.txt").read_text() == "keep me"
+    assert sorted(entry.name for entry in cache_root.iterdir()) == ["repo"]
+
+
 def test_trust_rejects_undeclared_scope(runner: CliRunner, tmp_path: Path) -> None:
     """`ooo plugin trust --scope <typo>` must refuse to persist a grant
     for a scope the manifest does not declare. Otherwise the command

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -2477,6 +2477,48 @@ def test_failed_url_refresh_preserves_last_known_good_cache(
 
 
 @pytest.mark.parametrize("mode", ["add", "install"])
+def test_url_refresh_filesystem_failure_is_reported_without_traceback(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """Promotion errors follow the CLI error contract and name recovery artifacts."""
+    paths = _common_paths(tmp_path)
+    cache_root = tmp_path / "cache"
+    url = "https://github.com/Q00/ouroboros-plugins.git"
+
+    def _disk_failure(*_args: object, **_kwargs: object) -> str:
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.plugin.stage_url_cache_refresh", _disk_failure
+    )
+    selector = (
+        ["add", url, "--plugin", "github-pr-ops"]
+        if mode == "add"
+        else ["install", "github-pr-ops", "--from", url]
+    )
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            *selector,
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--cache-root",
+            str(cache_root),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "plugin cache refresh failed" in result.output
+    assert "No space left on device" in result.output
+    assert ".bak-*" in result.output
+    assert result.exception is not None
+    assert not isinstance(result.exception, OSError)
+
+
+@pytest.mark.parametrize("mode", ["add", "install"])
 def test_successful_url_refresh_replaces_stale_cache(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
 ) -> None:


### PR DESCRIPTION
Closes #1826.

## Problem

Both URL-backed plugin entry points — `ooo plugin add <repo-url>` and `ooo plugin install <name> --from <repo-url>` — removed the existing cache directory before attempting the replacement clone. A transient network, authentication, or remote error after that point exited cleanly but the last-known-good cached repository was already gone, turning a failed refresh into irreversible local cache loss.

## Fix

The refresh clones into a unique staging sibling (`<dest>.staging-<rand>`) and promotes it over the live cache only after the clone and its HEAD resolution both succeed. The promotion follows the same sibling-rename swap discipline the plugin_home installs already use in `_atomic_replace_dir`: rename the previous cache aside, rename staging into place, restore the backup if the promote fails, and only then drop the backup. A failure at any earlier point removes the staging tree and leaves the previous cache byte-for-byte untouched. The controlled `git clone failed: ...` error and exit code 1 are preserved.

The shared URL→destination sanitization (previously duplicated in both entry points) and the staged refresh live in a new focused module, `cli/commands/plugin_cache.py`. That keeps `plugin.py` under its module-size budget — it shrinks from 3,053 to 3,042 lines against a ratcheted budget of 3,053.

## Tests

- `test_failed_url_refresh_preserves_last_known_good_cache` (parametrized over both entry points) reproduces the issue exactly as reported: sentinel cache in place, `_shallow_clone` patched to raise `CalledProcessError(128, ..., stderr="simulated network failure")`. Verified failing on the baseline (sentinel deleted) and passing with the fix; also asserts no staging/backup litter remains.
- `test_successful_url_refresh_replaces_stale_cache` (both entry points) verifies a successful refresh fully replaces stale cache content, leaves no litter, and still records `source_kind="git"` in the lockfile.
- `test_stage_url_cache_refresh_restores_backup_when_promote_fails` fails the staging→dest rename mid-swap and requires the previous cache to be restored with no litter.

All five plugin CLI test files pass (173 tests), `scripts/check-module-size.py --baseline-ref origin/main` passes, ruff and mypy clean.