### PR TITLE
fix(persistence): stage checkpoint writes so a failed save keeps the old chain

### DIFF
--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -286,8 +286,12 @@ class CheckpointStore:
                     self._publish_staged_checkpoint(checkpoint.seed_id, staged, checkpoint_path)
                 finally:
                     # A successful publish consumed the staged file via
-                    # rename; anything still here is failure debris.
-                    staged.unlink(missing_ok=True)
+                    # rename; anything still here is failure debris. The
+                    # cleanup itself must never fail a committed save.
+                    try:
+                        staged.unlink(missing_ok=True)
+                    except OSError:
+                        pass
 
             return Result.ok(None)
         except Exception as e:
@@ -324,20 +328,34 @@ class CheckpointStore:
         except Exception:
             # Undo in reverse order; a rename that fails mid-undo aborts the
             # walk but destroys nothing — every checkpoint still exists at
-            # some level, and load()'s rollback walk will find it.
+            # some level or in the retired file, and load()'s rollback walk
+            # finds the levels.
+            undo_complete = True
             for source, target in reversed(shifted):
                 try:
                     os.replace(target, source)
                 except OSError:
+                    undo_complete = False
                     break
-            if retired is not None and retired.exists():
+            # The retired checkpoint may be restored only into a provably
+            # vacated oldest slot. After a partial undo that slot can still
+            # hold an unshifted generation, and restoring over it would
+            # destroy that generation — the retired file then stays on disk
+            # as recoverable debris instead.
+            if retired is not None and retired.exists() and undo_complete and not oldest.exists():
                 try:
                     os.replace(retired, oldest)
                 except OSError:
                     pass
             raise
         if retired is not None:
-            retired.unlink(missing_ok=True)
+            try:
+                retired.unlink(missing_ok=True)
+            except OSError:
+                # Promotion is the commit point; cleanup debris after a
+                # committed save is preferable to reporting failure and
+                # inviting a retry of a transaction that already happened.
+                pass
 
     def load(self, seed_id: str) -> Result[CheckpointData, PersistenceError]:
         """Load latest valid checkpoint with automatic rollback on corruption.

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -258,10 +258,12 @@ class CheckpointStore:
         for rollback support (max 3 levels per NFR11).
 
         Uses file locking to prevent race conditions during concurrent access.
-        The new checkpoint is serialized to a staged sibling file and made
-        durable before any committed file moves, and the rotate-and-publish
-        step is reversible — a failed save leaves the current checkpoint and
-        the rollback chain exactly as they were (#1830).
+        The new checkpoint is serialized to a staged sibling file, flushed,
+        and fsynced — so any process-visible write failure surfaces before a
+        committed file moves (directory entries are not fsynced; power-loss
+        ordering is out of scope) — and the rotate-and-publish step is
+        reversible: a failed save leaves the current checkpoint and the
+        rollback chain exactly as they were (#1830).
 
         Args:
             checkpoint: Checkpoint data to save.
@@ -311,6 +313,7 @@ class CheckpointStore:
         undoes the rotation and restores the exact pre-save chain. All moves
         are same-directory renames.
         """
+        self._compact_checkpoint_levels(seed_id)
         oldest = self._get_checkpoint_path(seed_id, self.MAX_ROLLBACK_DEPTH)
         retired: Path | None = None
         if oldest.exists():
@@ -356,6 +359,27 @@ class CheckpointStore:
                 # committed save is preferable to reporting failure and
                 # inviting a retry of a transaction that already happened.
                 pass
+
+    def _compact_checkpoint_levels(self, seed_id: str) -> None:
+        """Slide existing generations down to fill holes in the chain.
+
+        A partially undone save can leave the chain sparse. Rotating a
+        sparse chain would retire the oldest generation while an empty slot
+        remains below it — silently shrinking the rollback window — so every
+        save first compacts the chain. Moves only fill previously empty
+        slots, never overwrite, so a failure here cannot lose a generation.
+        """
+        occupied = [
+            level
+            for level in range(self.MAX_ROLLBACK_DEPTH + 1)
+            if self._get_checkpoint_path(seed_id, level).exists()
+        ]
+        for index, level in enumerate(occupied):
+            if index != level:
+                os.replace(
+                    self._get_checkpoint_path(seed_id, level),
+                    self._get_checkpoint_path(seed_id, index),
+                )
 
     def load(self, seed_id: str) -> Result[CheckpointData, PersistenceError]:
         """Load latest valid checkpoint with automatic rollback on corruption.

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -18,6 +18,7 @@ import json
 import os
 from pathlib import Path
 import re
+import secrets
 from typing import Any
 
 from ouroboros.core.errors import PersistenceError
@@ -257,6 +258,10 @@ class CheckpointStore:
         for rollback support (max 3 levels per NFR11).
 
         Uses file locking to prevent race conditions during concurrent access.
+        The new checkpoint is serialized to a staged sibling file and made
+        durable before any committed file moves, and the rotate-and-publish
+        step is reversible — a failed save leaves the current checkpoint and
+        the rollback chain exactly as they were (#1830).
 
         Args:
             checkpoint: Checkpoint data to save.
@@ -269,12 +274,20 @@ class CheckpointStore:
 
             # Use file locking to prevent race conditions
             with _file_lock(checkpoint_path, exclusive=True):
-                # Rotate existing checkpoints for rollback support
-                self._rotate_checkpoints(checkpoint.seed_id)
-
-                # Write new checkpoint
-                with checkpoint_path.open("w") as f:
-                    json.dump(checkpoint.to_dict(), f, indent=2)
+                # The staged name is constant-length and seed-free so it can
+                # never breach the 255-byte filename budget that the seed
+                # sanitizer enforces for the real checkpoint files.
+                staged = checkpoint_path.with_name(f".tmp-{secrets.token_hex(8)}.json")
+                try:
+                    with staged.open("w") as f:
+                        json.dump(checkpoint.to_dict(), f, indent=2)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    self._publish_staged_checkpoint(checkpoint.seed_id, staged, checkpoint_path)
+                finally:
+                    # A successful publish consumed the staged file via
+                    # rename; anything still here is failure debris.
+                    staged.unlink(missing_ok=True)
 
             return Result.ok(None)
         except Exception as e:
@@ -285,6 +298,46 @@ class CheckpointStore:
                     details={"seed_id": checkpoint.seed_id, "phase": checkpoint.phase},
                 )
             )
+
+    def _publish_staged_checkpoint(self, seed_id: str, staged: Path, destination: Path) -> None:
+        """Rotate history and promote the staged file as one reversible step.
+
+        The oldest checkpoint is retired aside rather than deleted and every
+        shift is recorded, so a failure while promoting the staged file
+        undoes the rotation and restores the exact pre-save chain. All moves
+        are same-directory renames.
+        """
+        oldest = self._get_checkpoint_path(seed_id, self.MAX_ROLLBACK_DEPTH)
+        retired: Path | None = None
+        if oldest.exists():
+            retired = oldest.with_name(f".retire-{secrets.token_hex(8)}.json")
+            os.replace(oldest, retired)
+        shifted: list[tuple[Path, Path]] = []
+        try:
+            for level in range(self.MAX_ROLLBACK_DEPTH - 1, -1, -1):
+                source = self._get_checkpoint_path(seed_id, level)
+                if source.exists():
+                    target = self._get_checkpoint_path(seed_id, level + 1)
+                    os.replace(source, target)
+                    shifted.append((source, target))
+            os.replace(staged, destination)
+        except Exception:
+            # Undo in reverse order; a rename that fails mid-undo aborts the
+            # walk but destroys nothing — every checkpoint still exists at
+            # some level, and load()'s rollback walk will find it.
+            for source, target in reversed(shifted):
+                try:
+                    os.replace(target, source)
+                except OSError:
+                    break
+            if retired is not None and retired.exists():
+                try:
+                    os.replace(retired, oldest)
+                except OSError:
+                    pass
+            raise
+        if retired is not None:
+            retired.unlink(missing_ok=True)
 
     def load(self, seed_id: str) -> Result[CheckpointData, PersistenceError]:
         """Load latest valid checkpoint with automatic rollback on corruption.

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -452,6 +454,120 @@ class TestCheckpointStoreRollback:
         assert rollback2_path.exists()
         assert rollback3_path.exists()
         assert not rollback4_path.exists()  # Should be deleted
+
+
+class TestCheckpointStoreAtomicSave:
+    """#1830: a failed save must not disturb the committed checkpoint chain."""
+
+    def _files(self, store: CheckpointStore) -> list[str]:
+        return sorted(entry.name for entry in store._base_path.iterdir())
+
+    def test_failed_write_preserves_current_checkpoint_and_history(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """A partial serialization failure leaves the previous save untouched.
+
+        save() used to rotate the committed checkpoint to level 1 and then
+        truncate the destination before serializing, so a mid-write failure
+        destroyed the current checkpoint and consumed rollback history.
+        """
+        first = CheckpointData.create("atomic-write", "execution", {"step": 1})
+        assert checkpoint_store.save(first).is_ok
+        current = checkpoint_store._get_checkpoint_path("atomic-write")
+        original = current.read_bytes()
+        files_before = self._files(checkpoint_store)
+
+        def partial_dump(obj, fp, *args, **kwargs):
+            fp.write('{"seed_id":"atomic-write","phase":')
+            fp.flush()
+            raise OSError("simulated disk write failure")
+
+        second = CheckpointData.create("atomic-write", "execution", {"step": 2})
+        with patch("ouroboros.persistence.checkpoint.json.dump", side_effect=partial_dump):
+            result = checkpoint_store.save(second)
+
+        assert result.is_err
+        assert current.read_bytes() == original, "failed save mutated the committed checkpoint"
+        assert self._files(checkpoint_store) == files_before, (
+            "failed save rotated history or left temporary files behind"
+        )
+        loaded = checkpoint_store.load("atomic-write")
+        assert loaded.is_ok
+        assert loaded.value.state == {"step": 1}
+
+    def test_failed_first_save_leaves_no_partial_checkpoint(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """With no prior save, a failed write must leave the store empty."""
+
+        def failing_dump(obj, fp, *args, **kwargs):
+            fp.write("{")
+            raise OSError("simulated disk write failure")
+
+        checkpoint = CheckpointData.create("first-save", "execution", {"step": 1})
+        with patch("ouroboros.persistence.checkpoint.json.dump", side_effect=failing_dump):
+            result = checkpoint_store.save(checkpoint)
+
+        assert result.is_err
+        current = checkpoint_store._get_checkpoint_path("first-save")
+        assert not current.exists(), "failed first save left a partial level-0 checkpoint"
+        litter = [name for name in self._files(checkpoint_store) if not name.endswith(".lock")]
+        assert litter == [], f"failed first save left files behind: {litter}"
+        assert checkpoint_store.load("first-save").is_err
+
+    def test_failed_publish_restores_rotated_history(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """If promoting the staged file fails, the rotation is rolled back.
+
+        The transaction is rotate-then-publish; a failure between the two
+        must not leave the chain shifted with no current checkpoint.
+        """
+        for step in range(1, 6):
+            saved = checkpoint_store.save(
+                CheckpointData.create("publish-fail", "execution", {"step": step})
+            )
+            assert saved.is_ok
+        current = checkpoint_store._get_checkpoint_path("publish-fail")
+        original = current.read_bytes()
+        files_before = self._files(checkpoint_store)
+        real_replace = os.replace
+
+        def failing_publish(src, dst):
+            if Path(dst) == current and ".tmp-" in Path(src).name:
+                raise OSError("simulated rename failure")
+            return real_replace(src, dst)
+
+        sixth = CheckpointData.create("publish-fail", "execution", {"step": 6})
+        with patch("ouroboros.persistence.checkpoint.os.replace", side_effect=failing_publish):
+            result = checkpoint_store.save(sixth)
+
+        assert result.is_err
+        assert current.read_bytes() == original, "publish failure lost the committed checkpoint"
+        assert self._files(checkpoint_store) == files_before, (
+            "publish failure left the rotation shifted or files behind"
+        )
+        loaded = checkpoint_store.load("publish-fail")
+        assert loaded.is_ok
+        assert loaded.value.state == {"step": 5}
+
+    def test_successful_save_rotates_and_leaves_no_temp_files(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """The staged-write path keeps the existing rotation contract."""
+        for step in (1, 2):
+            saved = checkpoint_store.save(
+                CheckpointData.create("happy-save", "execution", {"step": step})
+            )
+            assert saved.is_ok
+
+        assert checkpoint_store.load("happy-save").value.state == {"step": 2}
+        rollback = checkpoint_store._get_checkpoint_path("happy-save", 1)
+        assert json.loads(rollback.read_text())["state"] == {"step": 1}
+        litter = [
+            name for name in self._files(checkpoint_store) if ".tmp-" in name or ".retire-" in name
+        ]
+        assert litter == [], f"save left temporary files behind: {litter}"
 
 
 class TestPeriodicCheckpointer:

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -551,6 +551,87 @@ class TestCheckpointStoreAtomicSave:
         assert loaded.is_ok
         assert loaded.value.state == {"step": 5}
 
+    @pytest.mark.parametrize("failing_undo_step", [1, 2, 3])
+    def test_partial_undo_never_overwrites_a_generation(
+        self, checkpoint_store: CheckpointStore, failing_undo_step: int
+    ) -> None:
+        """No committed generation may be lost, whichever undo rename fails.
+
+        After a failed promotion the rotation is undone in reverse; if an
+        undo rename itself fails, the retired oldest checkpoint must not be
+        restored over a level that still holds an unshifted generation.
+        Every pre-save generation has to survive somewhere on disk.
+        """
+        for step in range(1, 6):
+            assert checkpoint_store.save(
+                CheckpointData.create("undo-fail", "execution", {"step": step})
+            ).is_ok
+        real_replace = os.replace
+        state = {"publish_failed": False, "undo_calls": 0}
+
+        def faulty_replace(src, dst):
+            if ".tmp-" in Path(src).name:
+                state["publish_failed"] = True
+                raise OSError("simulated promotion failure")
+            if state["publish_failed"]:
+                state["undo_calls"] += 1
+                if state["undo_calls"] == failing_undo_step:
+                    raise OSError("simulated undo failure")
+            return real_replace(src, dst)
+
+        sixth = CheckpointData.create("undo-fail", "execution", {"step": 6})
+        with patch("ouroboros.persistence.checkpoint.os.replace", side_effect=faulty_replace):
+            result = checkpoint_store.save(sixth)
+
+        assert result.is_err
+        surviving_steps = set()
+        for entry in checkpoint_store._base_path.iterdir():
+            if entry.name.endswith(".lock"):
+                continue
+            try:
+                surviving_steps.add(json.loads(entry.read_text())["state"]["step"])
+            except (OSError, ValueError, KeyError):
+                continue
+        assert {2, 3, 4, 5} <= surviving_steps, (
+            f"failed undo step {failing_undo_step} lost generations: "
+            f"only {sorted(surviving_steps)} survive"
+        )
+
+    def test_post_commit_cleanup_failure_still_reports_success(
+        self, checkpoint_store: CheckpointStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Promotion is the commit point; later cleanup must not fail the save.
+
+        Once the staged checkpoint is promoted, a failure while unlinking the
+        retired oldest checkpoint has to surface as debris, not as an error —
+        otherwise callers retry a transaction that already committed.
+        """
+        for step in range(1, 6):
+            assert checkpoint_store.save(
+                CheckpointData.create("cleanup-fail", "execution", {"step": step})
+            ).is_ok
+        real_unlink = Path.unlink
+
+        def failing_retire_unlink(self, *args, **kwargs):
+            if ".retire-" in self.name:
+                raise OSError("simulated cleanup failure")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr("ouroboros.persistence.checkpoint.Path.unlink", failing_retire_unlink)
+        sixth = CheckpointData.create("cleanup-fail", "execution", {"step": 6})
+        result = checkpoint_store.save(sixth)
+
+        assert result.is_ok, "a committed save must not be reported as failed"
+        loaded = checkpoint_store.load("cleanup-fail")
+        assert loaded.is_ok
+        assert loaded.value.state == {"step": 6}
+        debris = [
+            entry.name
+            for entry in checkpoint_store._base_path.iterdir()
+            if ".retire-" in entry.name
+        ]
+        assert debris, "expected the retired checkpoint to remain as debris"
+
     def test_successful_save_rotates_and_leaves_no_temp_files(
         self, checkpoint_store: CheckpointStore
     ) -> None:

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -597,6 +597,54 @@ class TestCheckpointStoreAtomicSave:
             f"only {sorted(surviving_steps)} survive"
         )
 
+    @pytest.mark.parametrize("failing_undo_step", [1, 2, 3])
+    def test_retry_after_partial_undo_keeps_full_rollback_history(
+        self, checkpoint_store: CheckpointStore, failing_undo_step: int
+    ) -> None:
+        """A retried save must rebuild the full chain, not discard through holes.
+
+        A partial undo leaves the chain sparse; the next successful save has
+        to compact those holes before rotating so that a generation still
+        inside the three-level rollback window is never dropped while an
+        empty slot remains.
+        """
+        for step in range(1, 6):
+            assert checkpoint_store.save(
+                CheckpointData.create("retry-undo", "execution", {"step": step})
+            ).is_ok
+        real_replace = os.replace
+        state = {"publish_failed": False, "undo_calls": 0}
+
+        def faulty_replace(src, dst):
+            if ".tmp-" in Path(src).name:
+                state["publish_failed"] = True
+                raise OSError("simulated promotion failure")
+            if state["publish_failed"]:
+                state["undo_calls"] += 1
+                if state["undo_calls"] == failing_undo_step:
+                    raise OSError("simulated undo failure")
+            return real_replace(src, dst)
+
+        sixth = CheckpointData.create("retry-undo", "execution", {"step": 6})
+        with patch("ouroboros.persistence.checkpoint.os.replace", side_effect=faulty_replace):
+            assert checkpoint_store.save(sixth).is_err
+
+        retried = checkpoint_store.save(
+            CheckpointData.create("retry-undo", "execution", {"step": 6})
+        )
+        assert retried.is_ok
+
+        for level, expected_step in ((0, 6), (1, 5), (2, 4), (3, 3)):
+            level_path = checkpoint_store._get_checkpoint_path("retry-undo", level)
+            assert level_path.exists(), (
+                f"undo step {failing_undo_step}: level {level} is a hole after retry"
+            )
+            actual = json.loads(level_path.read_text())["state"]["step"]
+            assert actual == expected_step, (
+                f"undo step {failing_undo_step}: level {level} holds generation "
+                f"{actual}, expected {expected_step}"
+            )
+
     def test_post_commit_cleanup_failure_still_reports_success(
         self, checkpoint_store: CheckpointStore, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Closes #1830.

## Problem

`CheckpointStore.save()` rotated the committed checkpoint to level 1 and then opened the destination with mode `"w"` before serializing. A serialization or write failure therefore destroyed the last committed state: level 0 was left as partial JSON, the previous checkpoint had already moved into the rollback chain, and a subsequent `load()` silently recovered an older generation. On a first save there was no rollback at all, and repeated failed saves consumed rollback history.

## Fix

`save()` now serializes the new checkpoint to a staged sibling file, flushes and fsyncs it, and only then rotates and publishes — as one reversible transaction inside the existing file lock:

- The oldest checkpoint is retired aside rather than deleted, and every rotation shift is recorded.
- The staged file is promoted over the current checkpoint with `os.replace`; all moves are same-directory renames.
- If the promotion fails, the recorded shifts are undone in reverse order and the retired oldest checkpoint is restored, reproducing the exact pre-save chain. A rename that fails mid-undo aborts the walk but destroys nothing — every checkpoint still exists at some level, where `load()`'s rollback walk finds it.
- The staged file is consumed by the successful rename; anything left is removed in a `finally`, so failed saves leave no temporary files.
- The staged and retired names are constant-length and seed-free, so they cannot breach the 255-byte filename budget the seed sanitizer enforces for real checkpoint files.

`_rotate_checkpoints` is left in place unchanged — two orchestrator tests drive it directly to simulate post-rotate states.

## Tests

- `test_failed_write_preserves_current_checkpoint_and_history` — the reproduction from the issue: a partial `json.dump` failure must leave the committed bytes, the rotation state, and the directory listing untouched, and `load()` must still return the committed generation. Verified failing on the baseline.
- `test_failed_first_save_leaves_no_partial_checkpoint` — with no prior save, a failed write leaves no level-0 file and no litter. Verified failing on the baseline.
- `test_failed_publish_restores_rotated_history` — fails the staged-file promotion itself after a full rotation history exists; the chain must be restored byte-for-byte and `load()` must return the previous generation.
- `test_successful_save_rotates_and_leaves_no_temp_files` — the staged path preserves the existing rotation contract with no staging or retirement debris.

All 49 checkpoint tests pass, plus the orchestrator agent-process suite that drives rotation directly (319 total). Ruff, mypy, and the module-size gate pass.