### PR TITLE
fix(evaluation): refuse regexes that match any input as verification evidence

### DIFF
--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -65,34 +65,94 @@ _NEGATIONS = frozenset(
         "neednt",
     }
 )
+# A copula is what puts the emptiness on the subject. Without one the criterion
+# is saying something else about the file — "MUST contain an empty field" asks
+# about a value nested inside a file that is anything but empty.
+_COPULAS = frozenset(
+    {
+        "be",
+        "is",
+        "are",
+        "was",
+        "were",
+        "remain",
+        "remains",
+        "stay",
+        "stays",
+        "become",
+        "becomes",
+    }
+)
+# An article after the copula makes the adjective attributive: "be empty" is a
+# statement about the file, "be an empty JSON object" is a statement about the
+# two bytes it is required to hold.
+_ARTICLES = frozenset({"a", "an", "the"})
+# Where the predicate is allowed to stop. An emptiness word followed by anything
+# else is qualifying that thing rather than the file.
+_CLAUSE_ENDS = frozenset({".", ",", ";", ":", "and", "or", "but", "then", "while", "unless", "so"})
 # Far enough to cross "must not be", "should never be", "cannot ever be";
 # short enough that a negation belonging to a different clause does not reach.
 _NEGATION_LOOKBACK = 4
 
 
-def _positively_requires_emptiness(ac_text: str) -> bool:
-    """True when the criterion asks for the file to be empty, not for it not to be.
+def _mask_file_hint(ac_text: str, file_hint: str) -> str:
+    """Blank out mentions of the file's own name before the wording is read.
 
-    Read off words, not substrings, so `nonempty` is its own word and never an
-    occurrence of `empty` at all. Hyphenated and spaced forms split into two
-    words, which puts `non` in the lookback where the other negations are.
-
-    One un-negated occurrence is enough: "must be empty, and must not be
-    deleted" requires emptiness despite carrying a negation elsewhere. Every
-    occurrence being negated is what makes the criterion the opposite one.
+    `empty.txt MUST contain data` says nothing about emptiness; the word is in
+    the filename. Names are matched as whole tokens for the same reason the
+    mention check is — `a.py` sits inside `data.py`.
     """
-    words = re.findall(r"[a-z]+", ac_text.lower().replace("'", "").replace("’", ""))
-    for position, word in enumerate(words):
+    if not file_hint:
+        return ac_text
+    return re.sub(
+        rf"(\A|[\s'\"`(\[]){re.escape(file_hint)}(?=\Z|[\s'\"`)\],.;:])",
+        r"\1__file__",
+        ac_text,
+    )
+
+
+def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
+    """The emptiness word the criterion predicates of the file, or None.
+
+    Returns `empty` or `blank` because the two do not mean the same thing to a
+    file holding one tab, and the caller has to answer the question that was
+    actually asked.
+
+    Four conditions, each closing a way the word can appear without the file
+    being what has to be empty. It is read off words rather than substrings, so
+    `nonempty` is its own word and never an occurrence of `empty`. It is not
+    negated within the lookback, which is what separates "must be empty" from
+    "must not be empty". It follows a copula, without which the criterion is
+    predicating emptiness of something other than its subject. And it ends its
+    clause, because `empty JSON object` describes the contents rather than the
+    file.
+
+    One qualifying occurrence is enough: "must be empty, and must not be
+    deleted" requires emptiness despite carrying a negation elsewhere. Anything
+    this cannot place on the file itself returns None and fails closed.
+    """
+    text = _mask_file_hint(ac_text, file_hint).lower().replace("'", "").replace("’", "")
+    tokens = re.findall(r"[a-z_]+|[.,;:]", text)
+    for position, word in enumerate(tokens):
         if word not in _EMPTINESS_WORDS:
             continue
-        lookback = words[max(0, position - _NEGATION_LOOKBACK) : position]
-        if not any(token in _NEGATIONS for token in lookback):
-            return True
-    return False
+        lookback = tokens[max(0, position - _NEGATION_LOOKBACK) : position]
+        if any(token in _NEGATIONS for token in lookback):
+            continue
+        copulas = [index for index, token in enumerate(lookback) if token in _COPULAS]
+        if not copulas:
+            continue
+        if any(token in _ARTICLES for token in lookback[copulas[-1] + 1 :]):
+            continue
+        following = tokens[position + 1] if position + 1 < len(tokens) else None
+        if following is not None and following not in _CLAUSE_ENDS:
+            continue
+        return word
+    return None
 
 
-def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> bool:
-    """True when the criterion itself asks whether the file its hint names is empty.
+def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> str | None:
+    """The emptiness the criterion asks of the file its hint names, or None.
 
     All three halves are load-bearing. The hint must name one file, because
     `\\A\\Z` over `**/*.py` stops at whichever candidate is empty first — in a
@@ -100,29 +160,27 @@ def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> bool:
     criterion must name that same file, because `pkg/__init__.py` is empty in
     most repositories, so an exact hint pointed at it would otherwise "verify" a
     criterion about something else entirely. And the criterion must *require*
-    emptiness rather than forbid it, because an empty file satisfies one reading
-    and violates the other while the pattern looks the same either way.
+    emptiness of that file rather than forbid it, mention it in a filename, or
+    ask it of a value nested inside — an empty file satisfies one reading and
+    violates the others while the pattern looks the same for all of them.
 
     The hint comes from the same model completion as the pattern and licenses
     nothing on its own; `ac_text` is the spec's own wording, which the model
-    selects by index but does not write. Anything this returns False for falls
+    selects by index but does not write. Anything this returns None for falls
     through to the ordinary path, where `_safe_compile` refuses `\\A\\Z` and the
     criterion fails closed.
     """
     hint = assertion.file_hint
     if not hint or any(c in hint for c in "*?["):
-        return False
-    if not _positively_requires_emptiness(assertion.ac_text):
-        return False
+        return None
     # As a whole token, not a substring: `a.py` sits inside `data.py`, and a
     # criterion about the latter must not license a hint pointed at the former.
-    return (
-        re.search(
-            rf"(?:\A|[\s'\"`(\[]){re.escape(hint.lower())}(?=\Z|[\s'\"`)\],.;:])",
-            assertion.ac_text.lower(),
-        )
-        is not None
-    )
+    if not re.search(
+        rf"(?:\A|[\s'\"`(\[]){re.escape(hint.lower())}(?=\Z|[\s'\"`)\],.;:])",
+        assertion.ac_text.lower(),
+    ):
+        return None
+    return _emptiness_the_criterion_requires(assertion.ac_text, hint)
 
 
 def _skip_inline_space(text: str, index: int) -> int:
@@ -321,7 +379,8 @@ class SpecVerifier:
         """
         if assertion.tier not in (VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL):
             return None
-        if not _asks_whether_a_named_file_is_empty(assertion):
+        requirement = _asks_whether_a_named_file_is_empty(assertion)
+        if requirement is None:
             return None
 
         # The pattern still decides which way the criterion is being asked. One that
@@ -339,20 +398,24 @@ class SpecVerifier:
         if content is None:
             return None
 
-        # `content.strip()` and not the pattern: a file of one tab is as empty as a
-        # file of zero bytes, and no pattern has to be trusted to agree.
-        empty = not content.strip()
+        # Which word the criterion used decides the test, because they are not the
+        # same test. A file of one tab is blank and is not empty, and `\A\Z` — the
+        # pattern that motivates this whole path — draws exactly that line.
+        # Answering "empty" with the looser reading would formally approve a file
+        # the criterion rejects.
+        remainder = content if requirement == "empty" else content.strip()
+        satisfied = not remainder
         basename = os.path.basename(files[0])
         return SpecVerificationResult(
             assertion=assertion,
-            verified=empty,
+            verified=satisfied,
             file_path=files[0],
-            discrepancy=not empty,
+            discrepancy=not satisfied,
             detail=(
-                f"Criterion asks whether {basename} is empty; it is empty"
-                if empty
-                else f"Criterion asks whether {basename} is empty; it holds "
-                f"{len(content.strip())} characters of content"
+                f"Criterion asks whether {basename} is {requirement}; it is {requirement}"
+                if satisfied
+                else f"Criterion asks whether {basename} is {requirement}; it holds "
+                f"{len(remainder)} characters of content"
             ),
         )
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -27,6 +27,39 @@ MAX_FILES_PER_HINT = 100
 MAX_PATTERN_LENGTH = 200  # Limit LLM-generated regex length to reduce ReDoS risk
 MAX_SCALAR_LENGTH = 4096
 
+# Inputs a pattern is tried against to decide whether it discriminates at all. A
+# pattern that matches *every* one of these matches any file it is pointed at.
+#
+# Empty is one probe among several, not the test on its own: `\A\Z` matches the
+# empty string and nothing else, which is exactly how "this file MUST remain empty"
+# is expressed, and rejecting it turns an honest criterion into a formal failure.
+# The distinction that matters is not "can match nothing" but "cannot tell two
+# files apart". Deliberately short and few — these run on every model-supplied
+# pattern, and a long probe is how a screen against ReDoS becomes its own ReDoS.
+_INDISCRIMINATE_PROBES = ("", "a", "0\n", " ")
+
+# Inputs carrying no content of their own. A pattern one of these satisfies is
+# saying "this file is empty" — a claim about one named file, not about a set.
+_CONTENTLESS_PROBES = ("", " ", "\n")
+
+
+def _satisfied_by_an_empty_file(compiled: re.Pattern) -> bool:
+    """True when an empty or blank file alone is enough to make this pattern hit."""
+    return any(compiled.search(probe) is not None for probe in _CONTENTLESS_PROBES)
+
+
+def _unnamed_empty_file(compiled: re.Pattern, files: list[str]) -> bool:
+    """True when a hit would only say "one of these candidates happens to be empty".
+
+    `\\A\\Z` is honest evidence for "`pkg/__init__.py` MUST remain empty" — but only
+    because that hint names the file the criterion is about. Point the same pattern
+    at `**/*.py` and the search stops at whichever candidate is empty first, which
+    in a Python project is some package marker that no criterion ever mentioned.
+    The pattern discriminates between files; searching a set for *any* hit is what
+    throws that away, so this is a property of the pair, not of the regex.
+    """
+    return len(files) > 1 and _satisfied_by_an_empty_file(compiled)
+
 
 def _skip_inline_space(text: str, index: int) -> int:
     while index < len(text) and text[index] in " \t\f\v":
@@ -195,13 +228,11 @@ class SpecVerifier:
         except (re.error, OverflowError) as e:
             logger.warning("Invalid regex pattern: %s", e)
             return None
-        if compiled.search("") is not None:
-            # A pattern that can match the empty string can succeed without any
-            # criterion-specific content, so a hit is evidence that a file was read,
-            # not evidence about the criterion. `.*`, `x?`, `\s*`, `(?:)`, `|` and `^`
-            # succeed against any file; `\A\Z` succeeds against an empty one, which an
-            # ordinary `__init__.py` supplies. All compile, and all verified whatever
-            # criterion they were pointed at.
+        if all(compiled.search(probe) is not None for probe in _INDISCRIMINATE_PROBES):
+            # A pattern that matches every one of these matches whatever file it is
+            # pointed at, so a hit is evidence that a file was read, not evidence
+            # about the criterion. `.*`, `x?`, `\s*`, `(?:)`, `|` and `^` all compile,
+            # and all verified whatever criterion they were given.
             logger.warning(
                 "Regex pattern can match without criterion content, skipping: %r", pattern
             )
@@ -244,6 +275,18 @@ class SpecVerifier:
                 verified=False,
                 discrepancy=True,
                 detail="Unusable regex pattern: invalid, too long, or matches any input",
+            )
+
+        if _unnamed_empty_file(pattern, files):
+            return SpecVerificationResult(
+                assertion=assertion,
+                verified=False,
+                discrepancy=True,
+                detail=(
+                    f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
+                    f"'{assertion.file_hint}' matched {len(files)} files: a hit would name "
+                    f"no particular one. Point the hint at the file the criterion is about."
+                ),
             )
 
         for file_path in files:
@@ -320,6 +363,18 @@ class SpecVerifier:
                 verified=False,
                 discrepancy=True,
                 detail="Unusable regex pattern: invalid, too long, or matches any input",
+            )
+
+        if _unnamed_empty_file(content_pattern, files):
+            return SpecVerificationResult(
+                assertion=assertion,
+                verified=False,
+                discrepancy=True,
+                detail=(
+                    f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
+                    f"'{assertion.file_hint}' matched {len(files)} files: a hit would name "
+                    f"no particular one. Point the hint at the file the criterion is about."
+                ),
             )
 
         for file_path in files:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -206,8 +206,15 @@ def _can_match_nothing(
     for opcode, argument in sequence:  # type: ignore[attr-defined]
         name = getattr(opcode, "name", str(opcode))
         if name in _CONSUMING:
-            return False
-        if name == "AT":
+            # Recorded rather than returned. One consuming atom already settles
+            # this sequence — `_all_empty` answers False as soon as it sees one —
+            # but returning here would stop the walk, and captures written after
+            # it would never be recorded. A conditional outside can still ask
+            # what those captures did, and inside a negative assertion, which is
+            # where such a sequence takes part in a match by failing, the answer
+            # is that they certainly did not.
+            answers.append(False)
+        elif name == "AT":
             anchor = getattr(argument, "name", str(argument))
             if anchor in _ANCHORS_HOLDING_ON_EMPTY:
                 continue
@@ -231,11 +238,18 @@ def _can_match_nothing(
             answers.append(body_empty)
         elif name == "GROUPREF":
             # A backreference repeats whatever its group captured, so it is empty
-            # only when that group can be. If the group never participated the
-            # reference cannot match at all — never empty either. A group not yet
-            # seen (a forward reference) is unknown, and stays unknown.
+            # only when that group can be. A reference to a group that certainly
+            # did not take part refers to nothing captured, and this interpreter
+            # fails such a reference rather than matching nothing with it — so
+            # the sequence around it cannot match at all, empty included. A group
+            # not yet seen (a forward reference) is unknown, and stays unknown.
             seen = groups.get(argument)
-            answers.append(None if seen is None else seen.empty)
+            if seen is None:
+                answers.append(None)
+            elif seen.took_part is False:
+                answers.append(False)
+            else:
+                answers.append(seen.empty)
         elif name == "GROUPREF_EXISTS":
             # `(?(1)yes|no)` runs the arm the group's participation selects. On a
             # match that consumed nothing, a group whose body consumes cannot have

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -12,6 +12,12 @@ import logging
 import os
 import re
 
+# The standard library's own regex parser, so that a pattern can be inspected
+# without being run. Private, but stable across 3.11–3.14 and vendored by every
+# CPython this runs on; the alternative is to hand-write a regex parser, and a
+# second parser that disagrees with the real one in a corner is worse than this.
+from re import _parser as regex_parser
+
 from ouroboros.verification.models import (
     ACVerificationReport,
     SpecAssertion,
@@ -26,6 +32,90 @@ MAX_FILE_SIZE = 50 * 1024  # 50KB per file
 MAX_FILES_PER_HINT = 100
 MAX_PATTERN_LENGTH = 200  # Limit LLM-generated regex length to reduce ReDoS risk
 MAX_SCALAR_LENGTH = 4096
+
+# Whether a pattern can match the empty string is decided by *reading* it, never
+# by running it. Running it is what a hostile pattern is waiting for: `(?:)
+# {100000000}` is fifteen characters, passes the length limit, compiles
+# instantly, and then takes longer than any timeout to match a subject with
+# nothing in it — a stall reached before the verifier has even looked for a file.
+# Capping the pattern's length does not cap a repetition count written inside it,
+# because that count is one number rather than one character each.
+#
+# The parse tree is bounded by the pattern's length, and in it a repetition count
+# is a number that is read rather than a number of steps that are taken. So the
+# analysis is linear in the pattern no matter what the pattern says.
+_MAX_PARSE_DEPTH = 40
+
+# Consumes at least one character, so a sequence containing one cannot be empty.
+_CONSUMING = frozenset({"LITERAL", "NOT_LITERAL", "IN", "ANY", "RANGE", "CATEGORY"})
+# Matches without consuming: `^`, `\A`, `\Z`, `\b`. `\b` cannot actually hold on
+# an empty subject, but calling it zero-width only ever refuses a pattern, and a
+# bare `\b` is vacuous evidence that deserves refusing.
+_ZERO_WIDTH = frozenset({"AT", "GROUPREF"})
+_REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
+
+
+def _can_match_nothing(sequence: object, depth: int = 0) -> bool:
+    """Whether a parsed regex can match the empty string, read rather than run.
+
+    Answers True whenever the answer cannot be worked out — an unknown construct,
+    a tree deeper than this follows. A pattern wrongly called nullable is refused
+    as evidence, which costs an honest criterion a formal failure; one wrongly
+    called discriminating is admitted, and admitting those is the whole defect
+    this file exists to close. So the doubt goes to refusal.
+    """
+    if depth > _MAX_PARSE_DEPTH:
+        return True
+    for opcode, argument in sequence:  # type: ignore[attr-defined]
+        name = getattr(opcode, "name", str(opcode))
+        if name in _ZERO_WIDTH:
+            continue
+        if name in _CONSUMING:
+            return False
+        if name in _REPEATS:
+            minimum, _maximum, item = argument
+            # A repeat that may run zero times is skippable; one that must run
+            # is empty only if what it repeats is. The count itself is never
+            # counted out.
+            if minimum == 0 or _can_match_nothing(item, depth + 1):
+                continue
+            return False
+        if name == "SUBPATTERN":
+            if _can_match_nothing(argument[-1], depth + 1):
+                continue
+            return False
+        if name == "ATOMIC_GROUP":
+            if _can_match_nothing(argument, depth + 1):
+                continue
+            return False
+        if name == "BRANCH":
+            if any(_can_match_nothing(branch, depth + 1) for branch in argument[1]):
+                continue
+            return False
+        if name == "ASSERT":
+            # On a subject with nothing in it there is nothing to either side, so
+            # a lookaround holds exactly when what it looks for can be empty.
+            # `(?=.*foo)` cannot, which is why a lookahead-only pattern stays
+            # admissible evidence.
+            if _can_match_nothing(argument[1], depth + 1):
+                continue
+            return False
+        if name == "ASSERT_NOT":
+            if not _can_match_nothing(argument[1], depth + 1):
+                continue
+            return False
+        return True
+    return True
+
+
+def _matches_the_empty_string(pattern: str, flags: int = 0) -> bool:
+    """Whether `pattern` can match a subject with nothing in it. Never runs it."""
+    try:
+        parsed = regex_parser.parse(pattern, flags)
+    except Exception:  # pragma: no cover - re.compile has already accepted this
+        return True
+    return _can_match_nothing(parsed)
+
 
 # Words that make an acceptance criterion a claim about a file holding nothing.
 # Such a criterion has no content for a regex to find, so every honest way to
@@ -452,7 +542,7 @@ class SpecVerifier:
         compiled = self._compile_or_none(pattern, flags)
         if compiled is None:
             return None
-        if compiled.search("") is not None:
+        if _matches_the_empty_string(pattern, flags):
             # A pattern that hits a file with no content in it hits every file:
             # `.*`, `x?`, `\s*`, `(?:)`, `|` and `^` all compile, and all verified
             # whatever criterion they were handed. A criterion that is genuinely
@@ -484,7 +574,7 @@ class SpecVerifier:
         # path, which can see the content it needs; only one that survives on a file
         # with nothing in it lands here, and that is the pattern this rescue is for.
         compiled = self._compile_or_none(assertion.pattern)
-        if compiled is None or compiled.search("") is None:
+        if compiled is None or not _matches_the_empty_string(assertion.pattern):
             return None
 
         files = self._find_files(assertion.file_hint)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -27,76 +27,44 @@ MAX_FILES_PER_HINT = 100
 MAX_PATTERN_LENGTH = 200  # Limit LLM-generated regex length to reduce ReDoS risk
 MAX_SCALAR_LENGTH = 4096
 
-# Content a pattern is tried against to decide whether matching the empty string
-# is all it can do. Most patterns that match the empty string also match every
-# other file — `.*`, `x?`, `\s*`, `(?:)`, `|`, `^` — so a hit is evidence a file
-# was read, not evidence about the criterion. `\A\Z` is the one that matters on
-# the other side: it matches the empty string and nothing else, which is how
-# "this file MUST remain empty" is written, and refusing it turns an honest
-# criterion into a formal failure.
+# Words that make an acceptance criterion a claim about a file holding nothing.
+# Such a criterion has no content for a regex to find, so every honest way to
+# write it — `\A\Z` and its blank-file variants — is refused by the empty-string
+# rule in `_safe_compile`, and an honest criterion fails formally.
 #
-# A probe added here can only move a pattern out of that exception and into the
-# refusal, never the reverse — the screen must not get weaker as it learns.
-# Deliberately short: these run on every model-supplied pattern, and a long probe
-# is how a guard against ReDoS becomes its own ReDoS.
-_CONTENT_PROBES = ("a", "0\n")
-
-# Inputs carrying no content of their own. A pattern one of these satisfies is
-# saying "this file is empty" — a claim about one named file, not about a set.
-_CONTENTLESS_PROBES = ("", " ", "\n")
+# `_empty_file_criterion_result` answers that one criterion from the file itself.
+# Emptiness is a property of the file, and reading it is ground truth; asking a
+# regex what it *could* match is inference, and inference run against a fixed
+# list of sample strings only ever rejects what the list literally contains.
+_EMPTINESS_WORDS = ("empty", "blank")
 
 
-def _matches_only_empty(compiled: re.Pattern) -> bool:
-    """True for a pattern like `\\A\\Z`, whose only hit means "this file has no content"."""
-    return compiled.search("") is not None and not any(
-        compiled.search(probe) is not None for probe in _CONTENT_PROBES
-    )
+def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> bool:
+    """True when the criterion itself asks whether the file its hint names is empty.
 
-
-def _satisfied_by_an_empty_file(compiled: re.Pattern) -> bool:
-    """True when an empty or blank file alone is enough to make this pattern hit."""
-    return any(compiled.search(probe) is not None for probe in _CONTENTLESS_PROBES)
-
-
-def _hint_names_one_file(file_hint: str, files: list[str]) -> bool:
-    """True when the hint picked out a specific file rather than swept for one.
-
-    A candidate count of one is not the same thing: `**/*.py` returns a single
-    candidate in any package whose only other `.py` files sit under `.venv` or
-    `node_modules`, because `_find_files` drops those. The count is then a
-    property of the project's tree, and a hit still names no file the criterion
-    chose. Only a hint carrying no wildcard names one.
+    Both halves are load-bearing. The hint must name one file, because `\\A\\Z`
+    over `**/*.py` stops at whichever candidate is empty first — in a Python
+    project some package marker no criterion ever mentioned. And the criterion
+    must name that same file, because `pkg/__init__.py` is empty in most
+    repositories, so an exact hint pointed at it would otherwise "verify" a
+    criterion about something else entirely. The hint comes from the same model
+    completion as the pattern and licenses nothing on its own; `ac_text` is the
+    spec's own wording, which the model selects by index but does not write.
     """
-    return bool(file_hint) and not any(c in file_hint for c in "*?[") and len(files) == 1
-
-
-def _unnamed_empty_file(compiled: re.Pattern, file_hint: str, files: list[str]) -> bool:
-    """True when a hit would only say "one of these candidates happens to be empty".
-
-    `\\A\\Z` is honest evidence for "`pkg/__init__.py` MUST remain empty" — but only
-    because that hint names the file the criterion is about. Point the same pattern
-    at `**/*.py` and the search stops at whichever candidate is empty first, which
-    in a Python project is some package marker that no criterion ever mentioned.
-    The pattern discriminates between files; searching a set for *any* hit is what
-    throws that away, so this is a property of the pair, not of the regex.
-    """
-    return _satisfied_by_an_empty_file(compiled) and not _hint_names_one_file(file_hint, files)
-
-
-def _unnamed_empty_file_result(
-    assertion: SpecAssertion, files: list[str]
-) -> SpecVerificationResult:
-    """One refusal for both tiers — a verdict that differs by tier is a hole."""
-    return SpecVerificationResult(
-        assertion=assertion,
-        verified=False,
-        discrepancy=True,
-        detail=(
-            f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
-            f"'{assertion.file_hint}' names no file ({len(files)} candidates): a hit "
-            f"would name no particular one. Point the hint at the file the criterion "
-            f"is about."
-        ),
+    hint = assertion.file_hint
+    if not hint or any(c in hint for c in "*?["):
+        return False
+    ac_text = assertion.ac_text.lower()
+    if not any(word in ac_text for word in _EMPTINESS_WORDS):
+        return False
+    # As a whole token, not a substring: `a.py` sits inside `data.py`, and a
+    # criterion about the latter must not license a hint pointed at the former.
+    return (
+        re.search(
+            rf"(?:\A|[\s'\"`(\[]){re.escape(hint.lower())}(?=\Z|[\s'\"`)\],.;:])",
+            ac_text,
+        )
+        is not None
     )
 
 
@@ -257,30 +225,86 @@ class SpecVerifier:
             project_dir=self.project_dir,
         )
 
-    def _safe_compile(self, pattern: str, flags: int = 0) -> re.Pattern | None:
-        """Compile a model-supplied regex, refusing one that cannot be evidence."""
+    def _compile_or_none(self, pattern: str, flags: int = 0) -> re.Pattern | None:
+        """Compile a model-supplied regex, refusing one that is unusable as a regex."""
         if len(pattern) > MAX_PATTERN_LENGTH:
             logger.warning("Regex pattern too long (%d chars), skipping", len(pattern))
             return None
         try:
-            compiled = re.compile(pattern, flags)
+            return re.compile(pattern, flags)
         except (re.error, OverflowError) as e:
             logger.warning("Invalid regex pattern: %s", e)
             return None
-        if compiled.search("") is not None and not _matches_only_empty(compiled):
-            # A pattern that matches the empty string *and* matches content succeeds
-            # against whatever file it is pointed at. `.*`, `x?`, `\s*`, `(?:)`, `|`
-            # and `^` all compile, and all verified whatever criterion they were
-            # given. `\A\Z` is the carve-out: it matches the empty string and no
-            # content, so it still tells one file from another.
+
+    def _safe_compile(self, pattern: str, flags: int = 0) -> re.Pattern | None:
+        """Compile a model-supplied regex, refusing one that cannot be evidence."""
+        compiled = self._compile_or_none(pattern, flags)
+        if compiled is None:
+            return None
+        if compiled.search("") is not None:
+            # A pattern that hits a file with no content in it hits every file:
+            # `.*`, `x?`, `\s*`, `(?:)`, `|` and `^` all compile, and all verified
+            # whatever criterion they were handed. A criterion that is genuinely
+            # about a file being empty is answered by `_empty_file_criterion_result`
+            # from the file, so nothing honest depends on admitting these here.
             logger.warning(
                 "Regex pattern can match without criterion content, skipping: %r", pattern
             )
             return None
         return compiled
 
+    def _empty_file_criterion_result(
+        self, assertion: SpecAssertion
+    ) -> SpecVerificationResult | None:
+        """Answer an "X MUST remain empty" criterion from the file, not from the pattern.
+
+        Returns None whenever this is not that criterion, leaving the assertion to
+        the ordinary path. Deliberately one gate ahead of the tier split: a verdict
+        that differs between T1 and T2 is a hole, and here that cannot be written.
+        """
+        if assertion.tier not in (VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL):
+            return None
+        if not _asks_whether_a_named_file_is_empty(assertion):
+            return None
+
+        # The pattern still decides which way the criterion is being asked. One that
+        # needs content — `\S` for "MUST NOT be empty" — is answered by the ordinary
+        # path, which can see the content it needs; only one that survives on a file
+        # with nothing in it lands here, and that is the pattern this rescue is for.
+        compiled = self._compile_or_none(assertion.pattern)
+        if compiled is None or compiled.search("") is None:
+            return None
+
+        files = self._find_files(assertion.file_hint)
+        if len(files) != 1:
+            return None
+        content = self._read_file(files[0])
+        if content is None:
+            return None
+
+        # `content.strip()` and not the pattern: a file of one tab is as empty as a
+        # file of zero bytes, and no pattern has to be trusted to agree.
+        empty = not content.strip()
+        basename = os.path.basename(files[0])
+        return SpecVerificationResult(
+            assertion=assertion,
+            verified=empty,
+            file_path=files[0],
+            discrepancy=not empty,
+            detail=(
+                f"Criterion asks whether {basename} is empty; it is empty"
+                if empty
+                else f"Criterion asks whether {basename} is empty; it holds "
+                f"{len(content.strip())} characters of content"
+            ),
+        )
+
     def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult | None:
         """Verify a single assertion. Returns None for skipped tiers."""
+        empty_file = self._empty_file_criterion_result(assertion)
+        if empty_file is not None:
+            return empty_file
+
         if assertion.tier == VerificationTier.T1_CONSTANT:
             return self._verify_constant(assertion)
         elif assertion.tier == VerificationTier.T2_STRUCTURAL:
@@ -316,9 +340,6 @@ class SpecVerifier:
                 discrepancy=True,
                 detail="Unusable regex pattern: invalid, too long, or matches any input",
             )
-
-        if _unnamed_empty_file(pattern, assertion.file_hint, files):
-            return _unnamed_empty_file_result(assertion, files)
 
         for file_path in files:
             content = self._read_file(file_path)
@@ -372,21 +393,6 @@ class SpecVerifier:
 
         files = self._find_files(assertion.file_hint)
 
-        # Both checks below end in a success return, so the screens run ahead of the
-        # first of them. Placed between the two, the empty-file guard would refuse a
-        # pattern on the content path that the filename path had already accepted.
-        content_pattern = self._safe_compile(assertion.pattern)
-        if content_pattern is None:
-            return SpecVerificationResult(
-                assertion=assertion,
-                verified=False,
-                discrepancy=True,
-                detail="Unusable regex pattern: invalid, too long, or matches any input",
-            )
-
-        if _unnamed_empty_file(content_pattern, assertion.file_hint, files):
-            return _unnamed_empty_file_result(assertion, files)
-
         # First check: does the pattern match any filename?
         name_pattern = self._safe_compile(assertion.pattern, re.IGNORECASE)
 
@@ -402,6 +408,14 @@ class SpecVerifier:
                     )
 
         # Second check: search file contents for class/function/interface
+        content_pattern = self._safe_compile(assertion.pattern)
+        if content_pattern is None:
+            return SpecVerificationResult(
+                assertion=assertion,
+                verified=False,
+                discrepancy=True,
+                detail="Unusable regex pattern: invalid, too long, or matches any input",
+            )
 
         for file_path in files:
             content = self._read_file(file_path)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -161,6 +161,24 @@ def _offers_an_alternative_to_emptiness(tokens: list[str], position: int) -> boo
     return False
 
 
+def _names_the_subject(tokens: list[str], position: int) -> bool:
+    """True when nothing turns this mention into the object of a preposition.
+
+    Scans the whole phrase back to the nearest clause boundary rather than the
+    adjacent token, because a preposition can stand any number of modifiers away
+    from the name it governs: in "the status field in the generated marker.txt",
+    two words separate `in` from the file it is still the object of. Stopping at
+    the boundary is what keeps a preposition belonging to an earlier clause —
+    "for the release, marker.txt must be empty" — from disqualifying anything.
+    """
+    for token in reversed(tokens[:position]):
+        if token in _CLAUSE_ENDS:
+            return True
+        if token in _PREPOSITIONS:
+            return False
+    return True
+
+
 def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
     """The emptiness word the criterion predicates of the file, or None.
 
@@ -169,8 +187,9 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     actually asked.
 
     Walks forward from each mention of the file, and returns a word only when
-    every step of the walk holds: the mention is not the object of a preposition,
-    so the file is the subject rather than something the subject lives in; every
+    every step of the walk holds: no preposition governs the mention anywhere in
+    the phrase leading up to it, so the file is the subject rather than something
+    the subject lives in; every
     word between it and the emptiness word belongs to `_PREDICATE_CHAIN`, which
     no negation and no competing noun does; one of them is a copula, without
     which the emptiness is being predicated of something else; the emptiness word
@@ -188,7 +207,7 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     for position, token in enumerate(tokens):
         if token != _FILE_TOKEN:
             continue
-        if position > 0 and tokens[position - 1] in _PREPOSITIONS:
+        if not _names_the_subject(tokens, position):
             continue
         saw_copula = False
         step = position + 1

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -98,26 +98,105 @@ _PREDICATE_CHAIN = _COPULAS | {
     "initially",
     "currently",
 }
-# A file named as the object of a preposition is not the subject of the
-# sentence: "the status field in marker.txt must be empty" is a requirement on
-# the field, and the file it lives in is anything but empty.
-_PREPOSITIONS = frozenset(
+# The only words allowed to stand between the start of a clause and the file
+# that heads it. Anything else means the file is not what the clause is about:
+# a preposition makes it the object of something ("the status field in
+# marker.txt"), a verb makes it the object of that verb ("do not let marker.txt
+# be empty"), and a competing noun makes it a modifier of that noun. This is an
+# allow-list for the same reason the forward chain is — no preposed phrasing can
+# outrun a rule that admits only what it names.
+_CLAUSE_LEAD = frozenset(
     {
-        "in",
-        "inside",
-        "within",
-        "of",
-        "from",
-        "at",
-        "for",
-        "on",
-        "under",
-        "into",
-        "by",
-        "with",
-        "across",
-        "through",
-        "throughout",
+        "the",
+        "a",
+        "an",
+        "this",
+        "that",
+        "these",
+        "those",
+        "each",
+        "every",
+        "its",
+        "their",
+        "our",
+        "my",
+        "your",
+        "we",
+        "file",
+        "files",
+        "filename",
+        "path",
+        "artifact",
+        "output",
+        "document",
+        "log",
+        "report",
+        # Verbs that ask for the clause after them without changing what it
+        # claims: "ensure marker.txt is empty" requires exactly what
+        # "marker.txt is empty" does. Negating one of these negates the
+        # criterion, but the negation is itself a word this set does not admit.
+        "ensure",
+        "ensures",
+        "verify",
+        "verifies",
+        "confirm",
+        "confirms",
+        "require",
+        "requires",
+        "expect",
+        "expects",
+    }
+)
+# A negation can also govern the file from an earlier clause: "do not remove the
+# guard and let marker.txt be empty" carries a clause that, read alone, asks for
+# emptiness. Nothing structural tells that adjunct apart from the innocent "for
+# the release,", so this is a screen and not a proof — it can only ever refuse
+# more. The clause-lead rule above is what makes the direct forms unreachable.
+_NEGATIONS = frozenset(
+    {
+        "not",
+        "never",
+        "no",
+        "none",
+        "nor",
+        "cannot",
+        "cant",
+        "dont",
+        "doesnt",
+        "didnt",
+        "wont",
+        "wouldnt",
+        "shouldnt",
+        "mustnt",
+        "isnt",
+        "arent",
+        "wasnt",
+        "werent",
+        "hasnt",
+        "havent",
+        "hadnt",
+        "couldnt",
+        "avoid",
+        "avoids",
+        "prevent",
+        "prevents",
+        "prohibit",
+        "prohibits",
+        "prohibited",
+        "forbid",
+        "forbids",
+        "forbidden",
+        "disallow",
+        "disallows",
+        "disallowed",
+        "deny",
+        "denies",
+        "refuse",
+        "refuses",
+        "without",
+        "unacceptable",
+        "illegal",
+        "banned",
     }
 )
 # Where the predicate is allowed to stop. An emptiness word followed by anything
@@ -161,22 +240,34 @@ def _offers_an_alternative_to_emptiness(tokens: list[str], position: int) -> boo
     return False
 
 
-def _names_the_subject(tokens: list[str], position: int) -> bool:
-    """True when nothing turns this mention into the object of a preposition.
+def _heads_its_clause(tokens: list[str], position: int) -> bool:
+    """True when the file is what its own clause is about.
 
-    Scans the whole phrase back to the nearest clause boundary rather than the
-    adjacent token, because a preposition can stand any number of modifiers away
-    from the name it governs: in "the status field in the generated marker.txt",
-    two words separate `in` from the file it is still the object of. Stopping at
-    the boundary is what keeps a preposition belonging to an earlier clause —
-    "for the release, marker.txt must be empty" — from disqualifying anything.
+    Reads back to the nearest clause boundary and requires every word in
+    between to be one this can place ahead of a subject. Refusing on anything
+    else is what makes the whole class of preposed government — "the status
+    field in marker.txt", "do not let marker.txt be empty", "never allow
+    marker.txt to remain empty" — unreachable at once, rather than one cited
+    phrasing at a time. Stopping at the boundary is what keeps a word belonging
+    to an earlier clause, as in "for the release, marker.txt must be empty",
+    from disqualifying anything.
     """
     for token in reversed(tokens[:position]):
         if token in _CLAUSE_ENDS:
             return True
-        if token in _PREPOSITIONS:
+        if token not in _CLAUSE_LEAD:
             return False
     return True
+
+
+def _a_negation_governs(tokens: list[str], position: int) -> bool:
+    """True when a negation stands earlier in the same sentence."""
+    for token in reversed(tokens[:position]):
+        if token in _SENTENCE_ENDS:
+            return False
+        if token in _NEGATIONS:
+            return True
+    return False
 
 
 def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
@@ -186,10 +277,10 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     file holding one tab, and the caller has to answer the question that was
     actually asked.
 
-    Walks forward from each mention of the file, and returns a word only when
-    every step of the walk holds: no preposition governs the mention anywhere in
-    the phrase leading up to it, so the file is the subject rather than something
-    the subject lives in; every
+    Walks out from each mention of the file, and returns a word only when every
+    step of the walk holds: the file heads its own clause, so nothing before it
+    governs it and the emptiness is asked of the file rather than of something
+    the file contains; no negation stands earlier in the sentence; every
     word between it and the emptiness word belongs to `_PREDICATE_CHAIN`, which
     no negation and no competing noun does; one of them is a copula, without
     which the emptiness is being predicated of something else; the emptiness word
@@ -207,7 +298,9 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     for position, token in enumerate(tokens):
         if token != _FILE_TOKEN:
             continue
-        if not _names_the_subject(tokens, position):
+        if not _heads_its_clause(tokens, position):
+            continue
+        if _a_negation_governs(tokens, position):
             continue
         saw_copula = False
         step = position + 1

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -51,11 +51,13 @@ _CONSUMING = frozenset({"LITERAL", "NOT_LITERAL", "IN", "ANY", "RANGE", "CATEGOR
 # Matches without consuming: `^`, `\A`, `\Z`, `\b`. `\b` cannot actually hold on
 # an empty subject, but calling it zero-width only ever refuses a pattern, and a
 # bare `\b` is vacuous evidence that deserves refusing.
-_ZERO_WIDTH = frozenset({"AT", "GROUPREF"})
+_ZERO_WIDTH = frozenset({"AT"})
 _REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
 
 
-def _can_match_nothing(sequence: object, depth: int = 0) -> bool:
+def _can_match_nothing(
+    sequence: object, depth: int = 0, groups: dict[int, bool] | None = None
+) -> bool:
     """Whether a parsed regex can match the empty string, read rather than run.
 
     Answers True whenever the answer cannot be worked out — an unknown construct,
@@ -63,7 +65,12 @@ def _can_match_nothing(sequence: object, depth: int = 0) -> bool:
     as evidence, which costs an honest criterion a formal failure; one wrongly
     called discriminating is admitted, and admitting those is the whole defect
     this file exists to close. So the doubt goes to refusal.
+
+    `groups` carries what each capture group, once seen, can itself match, so a
+    backreference can be judged by what it refers to.
     """
+    if groups is None:
+        groups = {}
     if depth > _MAX_PARSE_DEPTH:
         return True
     for opcode, argument in sequence:  # type: ignore[attr-defined]
@@ -74,22 +81,52 @@ def _can_match_nothing(sequence: object, depth: int = 0) -> bool:
             return False
         if name in _REPEATS:
             minimum, _maximum, item = argument
+            # Walked whatever the count, so that groups inside a repeat that may
+            # run zero times are still recorded for a later backreference.
+            item_empty = _can_match_nothing(item, depth + 1, groups)
             # A repeat that may run zero times is skippable; one that must run
             # is empty only if what it repeats is. The count itself is never
             # counted out.
-            if minimum == 0 or _can_match_nothing(item, depth + 1):
+            if minimum == 0 or item_empty:
                 continue
             return False
         if name == "SUBPATTERN":
-            if _can_match_nothing(argument[-1], depth + 1):
+            body_empty = _can_match_nothing(argument[-1], depth + 1, groups)
+            if argument[0] is not None:
+                groups[argument[0]] = body_empty
+            if body_empty:
+                continue
+            return False
+        if name == "GROUPREF":
+            # A backreference repeats whatever its group captured, so it is empty
+            # only when that group can be. If the group never participated the
+            # reference cannot match at all — never empty either. A group not yet
+            # seen (a forward reference) is unknown, and unknown means refuse.
+            if groups.get(argument, True):
+                continue
+            return False
+        if name == "GROUPREF_EXISTS":
+            # `(?(1)yes|no)`: whichever arm runs, it has to be able to be empty.
+            reference, yes_arm, no_arm = argument
+            del reference
+            arms_empty = [_can_match_nothing(yes_arm, depth + 1, groups)]
+            arms_empty.append(
+                True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups)
+            )
+            if any(arms_empty):
                 continue
             return False
         if name == "ATOMIC_GROUP":
-            if _can_match_nothing(argument, depth + 1):
+            if _can_match_nothing(argument, depth + 1, groups):
                 continue
             return False
         if name == "BRANCH":
-            if any(_can_match_nothing(branch, depth + 1) for branch in argument[1]):
+            # Every branch is walked, not just up to the first empty one, so that
+            # groups defined in a later branch are recorded too.
+            branches_empty = [
+                _can_match_nothing(branch, depth + 1, groups) for branch in argument[1]
+            ]
+            if any(branches_empty):
                 continue
             return False
         if name == "ASSERT":
@@ -97,11 +134,11 @@ def _can_match_nothing(sequence: object, depth: int = 0) -> bool:
             # a lookaround holds exactly when what it looks for can be empty.
             # `(?=.*foo)` cannot, which is why a lookahead-only pattern stays
             # admissible evidence.
-            if _can_match_nothing(argument[1], depth + 1):
+            if _can_match_nothing(argument[1], depth + 1, groups):
                 continue
             return False
         if name == "ASSERT_NOT":
-            if not _can_match_nothing(argument[1], depth + 1):
+            if not _can_match_nothing(argument[1], depth + 1, groups):
                 continue
             return False
         return True
@@ -197,8 +234,16 @@ _PREDICATE_CHAIN = _COPULAS | {
 # be empty"), and a competing noun makes it a modifier of that noun. This is an
 # allow-list for the same reason the forward chain is — no preposed phrasing can
 # outrun a rule that admits only what it names.
+#
+# Each word here belongs to one of four classes, and membership is decided by a
+# single test: can putting this word in front of "marker.txt is empty" change
+# what is being claimed about marker.txt? For a determiner, a name for the file
+# itself, a request to see to it, or a politeness or impersonal frame, it cannot.
+# For anything else — every negation, every governing verb, every preposition,
+# every competing noun — it can, and so it is left out and refuses the criterion.
 _CRITERION_LEAD = frozenset(
     {
+        # Determiners and possessives. A closed class in English, listed whole.
         "the",
         "a",
         "an",
@@ -208,12 +253,15 @@ _CRITERION_LEAD = frozenset(
         "those",
         "each",
         "every",
+        "all",
+        "any",
         "its",
         "their",
         "our",
         "my",
         "your",
         "we",
+        # Nouns that name the file rather than something the file contains.
         "file",
         "files",
         "filename",
@@ -229,14 +277,38 @@ _CRITERION_LEAD = frozenset(
         # criterion, but the negation is itself a word this set does not admit.
         "ensure",
         "ensures",
+        "ensured",
         "verify",
         "verifies",
+        "verified",
         "confirm",
         "confirms",
+        "confirmed",
         "require",
         "requires",
+        "required",
         "expect",
         "expects",
+        "expected",
+        "check",
+        "checks",
+        "assert",
+        "asserts",
+        "validate",
+        "validates",
+        "guarantee",
+        "guarantees",
+        "make",
+        "sure",
+        # Politeness and impersonal frames — "please", "it is necessary that".
+        # These carry no claim of their own at all, which is exactly why leaving
+        # them out cost an honest criterion a formal failure.
+        "please",
+        "kindly",
+        "it",
+        "is",
+        "necessary",
+        "mandatory",
     }
 )
 
@@ -543,9 +615,12 @@ class SpecVerifier:
         if compiled is None:
             return None
         if _matches_the_empty_string(pattern, flags):
-            # A pattern that hits a file with no content in it hits every file:
-            # `.*`, `x?`, `\s*`, `(?:)`, `|` and `^` all compile, and all verified
-            # whatever criterion they were handed. A criterion that is genuinely
+            # A pattern that can match a subject with nothing in it proves nothing
+            # about a subject that has something in it either — `\A\Z` matches only
+            # the empty file, `.*` and `x?` and `\s*` and `(?:)` and `|` and `^`
+            # match anywhere in any file, and all of them verified whatever
+            # criterion they were handed. What the two kinds share is that the
+            # match is not evidence of the criterion. A criterion that is genuinely
             # about a file being empty is answered by `_empty_file_criterion_result`
             # from the file, so nothing honest depends on admitting these here.
             logger.warning(
@@ -644,7 +719,7 @@ class SpecVerifier:
                 assertion=assertion,
                 verified=False,
                 discrepancy=True,
-                detail="Unusable regex pattern: invalid, too long, or matches any input",
+                detail="Unusable regex pattern: invalid, too long, or able to match a file with no content",
             )
 
         for file_path in files:
@@ -720,7 +795,7 @@ class SpecVerifier:
                 assertion=assertion,
                 verified=False,
                 discrepancy=True,
-                detail="Unusable regex pattern: invalid, too long, or matches any input",
+                detail="Unusable regex pattern: invalid, too long, or able to match a file with no content",
             )
 
         for file_path in files:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -39,35 +39,18 @@ MAX_SCALAR_LENGTH = 4096
 _EMPTINESS_WORDS = frozenset({"empty", "blank"})
 
 # A criterion that *forbids* emptiness reads almost identically to one that
-# requires it, and the difference is one short word standing before the noun.
-# Polarity has to be read here, from `ac_text`, because the only other thing in
-# the assertion that could carry it is the extracted pattern — and `\A\Z` is
-# what a model writes for both readings.
-_NEGATIONS = frozenset(
-    {
-        "not",
-        "never",
-        "no",
-        "non",
-        "nor",
-        "without",
-        "cannot",
-        "cant",
-        "isnt",
-        "arent",
-        "wasnt",
-        "werent",
-        "doesnt",
-        "dont",
-        "wont",
-        "shouldnt",
-        "mustnt",
-        "neednt",
-    }
-)
-# A copula is what puts the emptiness on the subject. Without one the criterion
-# is saying something else about the file — "MUST contain an empty field" asks
-# about a value nested inside a file that is anything but empty.
+# requires it, and so does one that asks it of something the file merely
+# contains. Both have to be told apart here, from `ac_text`, because the only
+# other thing in the assertion that could carry the difference is the extracted
+# pattern — and `\A\Z` is what a model writes for every one of these readings.
+#
+# The shape that licenses the rescue is narrow on purpose: the file, then a
+# chain of auxiliaries and adverbs, then a copula, then the emptiness word, then
+# the end of the clause. Everything is decided by what may appear *in* that
+# chain rather than by how near some other word happens to fall, because a
+# window has a far side and a criterion can always put its negation past it.
+
+# A copula is what puts the emptiness on the subject.
 _COPULAS = frozenset(
     {
         "be",
@@ -83,32 +66,99 @@ _COPULAS = frozenset(
         "becomes",
     }
 )
-# An article after the copula makes the adjective attributive: "be empty" is a
-# statement about the file, "be an empty JSON object" is a statement about the
-# two bytes it is required to hold.
-_ARTICLES = frozenset({"a", "an", "the"})
+# The only words allowed to stand between the file and the emptiness word.
+# Negations are absent from this set rather than enumerated in one of their own,
+# so "must not be empty" and "must not under any circumstances be empty" are
+# refused by the same rule and no phrasing can outrun it. So is any noun that
+# would move the subject elsewhere — "marker.txt entries must be empty" is about
+# the entries. An unrecognised word means the sentence is not one this can read,
+# which is a reason to fail closed and not a reason to guess.
+_PREDICATE_CHAIN = _COPULAS | {
+    "must",
+    "shall",
+    "should",
+    "will",
+    "would",
+    "has",
+    "have",
+    "had",
+    "needs",
+    "need",
+    "to",
+    "left",
+    "kept",
+    "always",
+    "still",
+    "already",
+    "completely",
+    "entirely",
+    "totally",
+    "fully",
+    "strictly",
+    "initially",
+    "currently",
+}
+# A file named as the object of a preposition is not the subject of the
+# sentence: "the status field in marker.txt must be empty" is a requirement on
+# the field, and the file it lives in is anything but empty.
+_PREPOSITIONS = frozenset(
+    {
+        "in",
+        "inside",
+        "within",
+        "of",
+        "from",
+        "at",
+        "for",
+        "on",
+        "under",
+        "into",
+        "by",
+        "with",
+        "across",
+        "through",
+        "throughout",
+    }
+)
 # Where the predicate is allowed to stop. An emptiness word followed by anything
 # else is qualifying that thing rather than the file.
-_CLAUSE_ENDS = frozenset({".", ",", ";", ":", "and", "or", "but", "then", "while", "unless", "so"})
-# Far enough to cross "must not be", "should never be", "cannot ever be";
-# short enough that a negation belonging to a different clause does not reach.
-_NEGATION_LOOKBACK = 4
+_CLAUSE_ENDS = frozenset({".", ",", ";", ":", "and", "then"})
+# Emptiness offered as one option among several is not a requirement to be
+# empty, and answering it alone would throw away the evidence the other branch
+# names. The ordinary path can weigh a pattern that spells out both.
+_ALTERNATIVES = frozenset({"or", "unless", "otherwise", "either", "alternatively", "except"})
+_SENTENCE_ENDS = frozenset({".", ";"})
+
+
+# Stands in for the file's own name, so that the walk has one token to start
+# from and `empty.txt MUST contain data` stops carrying an emptiness word it
+# never meant. Underscored to keep it out of reach of any English word.
+_FILE_TOKEN = "__the_file__"
 
 
 def _mask_file_hint(ac_text: str, file_hint: str) -> str:
-    """Blank out mentions of the file's own name before the wording is read.
+    """Replace mentions of the file's own name with `_FILE_TOKEN`.
 
-    `empty.txt MUST contain data` says nothing about emptiness; the word is in
-    the filename. Names are matched as whole tokens for the same reason the
-    mention check is — `a.py` sits inside `data.py`.
+    Names are matched as whole tokens for the same reason the mention check is —
+    `a.py` sits inside `data.py`.
     """
     if not file_hint:
         return ac_text
     return re.sub(
         rf"(\A|[\s'\"`(\[]){re.escape(file_hint)}(?=\Z|[\s'\"`)\],.;:])",
-        r"\1__file__",
+        rf"\1{_FILE_TOKEN}",
         ac_text,
     )
+
+
+def _offers_an_alternative_to_emptiness(tokens: list[str], position: int) -> bool:
+    """True when the rest of the sentence lets something other than emptiness satisfy it."""
+    for token in tokens[position + 1 :]:
+        if token in _SENTENCE_ENDS:
+            return False
+        if token in _ALTERNATIVES:
+            return True
+    return False
 
 
 def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
@@ -118,36 +168,41 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     file holding one tab, and the caller has to answer the question that was
     actually asked.
 
-    Four conditions, each closing a way the word can appear without the file
-    being what has to be empty. It is read off words rather than substrings, so
-    `nonempty` is its own word and never an occurrence of `empty`. It is not
-    negated within the lookback, which is what separates "must be empty" from
-    "must not be empty". It follows a copula, without which the criterion is
-    predicating emptiness of something other than its subject. And it ends its
-    clause, because `empty JSON object` describes the contents rather than the
-    file.
+    Walks forward from each mention of the file, and returns a word only when
+    every step of the walk holds: the mention is not the object of a preposition,
+    so the file is the subject rather than something the subject lives in; every
+    word between it and the emptiness word belongs to `_PREDICATE_CHAIN`, which
+    no negation and no competing noun does; one of them is a copula, without
+    which the emptiness is being predicated of something else; the emptiness word
+    ends its clause, because `empty JSON object` describes contents rather than a
+    file; and the sentence offers no alternative to being empty.
 
-    One qualifying occurrence is enough: "must be empty, and must not be
-    deleted" requires emptiness despite carrying a negation elsewhere. Anything
-    this cannot place on the file itself returns None and fails closed.
+    Reading words rather than substrings is what keeps `nonempty` from being an
+    occurrence of `empty`. One qualifying mention is enough: "must be empty, and
+    must not be deleted" requires emptiness despite carrying a negation in its
+    other clause. Anything this cannot place on the file itself returns None,
+    and the criterion fails closed on the ordinary path.
     """
     text = _mask_file_hint(ac_text, file_hint).lower().replace("'", "").replace("’", "")
     tokens = re.findall(r"[a-z_]+|[.,;:]", text)
-    for position, word in enumerate(tokens):
-        if word not in _EMPTINESS_WORDS:
+    for position, token in enumerate(tokens):
+        if token != _FILE_TOKEN:
             continue
-        lookback = tokens[max(0, position - _NEGATION_LOOKBACK) : position]
-        if any(token in _NEGATIONS for token in lookback):
+        if position > 0 and tokens[position - 1] in _PREPOSITIONS:
             continue
-        copulas = [index for index, token in enumerate(lookback) if token in _COPULAS]
-        if not copulas:
+        saw_copula = False
+        step = position + 1
+        while step < len(tokens) and tokens[step] in _PREDICATE_CHAIN:
+            saw_copula = saw_copula or tokens[step] in _COPULAS
+            step += 1
+        if not saw_copula or step >= len(tokens) or tokens[step] not in _EMPTINESS_WORDS:
             continue
-        if any(token in _ARTICLES for token in lookback[copulas[-1] + 1 :]):
-            continue
-        following = tokens[position + 1] if position + 1 < len(tokens) else None
+        following = tokens[step + 1] if step + 1 < len(tokens) else None
         if following is not None and following not in _CLAUSE_ENDS:
             continue
-        return word
+        if _offers_an_alternative_to_emptiness(tokens, step):
+            continue
+        return tokens[step]
     return None
 
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -280,16 +280,30 @@ def _can_match_nothing(
             answers.append(_can_match_nothing(argument, depth + 1, groups, on_path))
         elif name == "BRANCH":
             # Every branch is walked, not just up to the first empty one, so that
-            # groups defined in a later branch are recorded too. Only one of them
-            # runs, so none of them is a path the match had to take.
-            answers.append(
-                _any_empty(
-                    [
-                        _can_match_nothing(branch, depth + 1, groups, _skippable(on_path))
-                        for branch in argument[1]
-                    ]
-                )
-            )
+            # groups defined in a later branch are recorded too.
+            #
+            # Which branch runs is undecidable from outside, but not from inside:
+            # a capture and a conditional reading it that sit in the same branch
+            # stand or fall together, so within a branch the path is the one the
+            # branch inherits. Handing every branch a skippable path instead made
+            # participation unknown for its own captures, and `()(?(1)x|)` — read
+            # correctly on its own — became unreadable the moment an alternative
+            # was written beside it.
+            #
+            # Each branch therefore reads and records over its own copy of the
+            # table, so one branch cannot answer a question about a capture that
+            # only exists in a sibling it does not run with. What a branch
+            # recorded merges back with participation weakened to "may have gone
+            # either way", which is what the alternation makes it for anything
+            # reading that capture from outside.
+            branch_answers: list[bool | None] = []
+            for branch in argument[1]:
+                local = dict(groups)
+                branch_answers.append(_can_match_nothing(branch, depth + 1, local, on_path))
+                for number, group in local.items():
+                    if number not in groups:
+                        groups[number] = _Group(group.empty, _skippable(group.took_part))
+            answers.append(_any_empty(branch_answers))
         elif name == "ASSERT":
             # On a subject with nothing in it there is nothing to either side, so
             # a lookaround holds exactly when what it looks for can be empty.

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -17,6 +17,7 @@ import re
 # CPython this runs on; the alternative is to hand-write a regex parser, and a
 # second parser that disagrees with the real one in a corner is worse than this.
 from re import _parser as regex_parser
+from typing import NamedTuple
 
 from ouroboros.verification.models import (
     ACVerificationReport,
@@ -48,11 +49,53 @@ _MAX_PARSE_DEPTH = 40
 
 # Consumes at least one character, so a sequence containing one cannot be empty.
 _CONSUMING = frozenset({"LITERAL", "NOT_LITERAL", "IN", "ANY", "RANGE", "CATEGORY"})
-# Matches without consuming: `^`, `\A`, `\Z`, `\b`. `\b` cannot actually hold on
-# an empty subject, but calling it zero-width only ever refuses a pattern, and a
-# bare `\b` is vacuous evidence that deserves refusing.
-_ZERO_WIDTH = frozenset({"AT"})
+# Anchors consume nothing, but they still either hold or fail on a subject with
+# nothing in it, and which one it is has to be read off the individual anchor.
+# `^`, `\A`, `$`, `\Z` and `\B` all hold at the sole position of an empty
+# subject; `\b` needs a word character on exactly one side and so can never
+# hold there. Calling `\b` zero-width would be the safe error on its own — a
+# pattern wrongly called nullable is only refused — but `(?!\b)` negates it into
+# the unsafe one, so each anchor is classified by what it actually does.
+_ANCHORS_HOLDING_ON_EMPTY = frozenset(
+    {
+        "AT_BEGINNING",
+        "AT_BEGINNING_STRING",
+        "AT_BEGINNING_LINE",
+        "AT_END",
+        "AT_END_STRING",
+        "AT_END_LINE",
+        "AT_NON_BOUNDARY",
+        "AT_LOC_NON_BOUNDARY",
+        "AT_UNI_NON_BOUNDARY",
+    }
+)
+_ANCHORS_FAILING_ON_EMPTY = frozenset({"AT_BOUNDARY", "AT_LOC_BOUNDARY", "AT_UNI_BOUNDARY"})
 _REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
+
+
+class _Group(NamedTuple):
+    """What a capture group did on a match that consumed nothing."""
+
+    empty: bool | None
+    """Whether the group's own body can match nothing."""
+    took_part: bool | None
+    """Whether the group can have participated in such a match."""
+
+
+def _participation(body_empty: bool | None, optional: bool) -> bool | None:
+    """Whether a group reached here can have taken part in an empty match.
+
+    A group whose body certainly consumes certainly did not take part: had it
+    run, the match would not have been empty. A group whose body can be empty
+    took part only if the path through it is the only path; under a repeat that
+    may run zero times, an alternative, or a lookaround, it may equally have
+    been skipped, and that is not something this reading can settle.
+    """
+    if body_empty is False:
+        return False
+    if body_empty is True and not optional:
+        return True
+    return None
 
 
 def _all_empty(answers: list[bool | None]) -> bool | None:
@@ -95,7 +138,10 @@ def _agreed(answers: list[bool | None]) -> bool | None:
 
 
 def _can_match_nothing(
-    sequence: object, depth: int = 0, groups: dict[int, bool | None] | None = None
+    sequence: object,
+    depth: int = 0,
+    groups: dict[int, _Group] | None = None,
+    optional: bool = False,
 ) -> bool | None:
     """Whether a parsed regex can match the empty string, read rather than run.
 
@@ -113,8 +159,11 @@ def _can_match_nothing(
     strength of not having understood it. None negates to None, so the doubt
     survives the negation and `_matches_the_empty_string` still refuses.
 
-    `groups` carries what each capture group, once seen, can itself match, so a
-    backreference can be judged by what it refers to.
+    `groups` carries, for each capture group once seen, what it can itself match
+    and whether it can have taken part in an empty match — the first so a
+    backreference can be judged by what it refers to, the second so a conditional
+    can be judged by which arm it would run. `optional` says whether the path
+    being walked is one the match could have avoided taking.
     """
     if groups is None:
         groups = {}
@@ -123,46 +172,60 @@ def _can_match_nothing(
     answers: list[bool | None] = []
     for opcode, argument in sequence:  # type: ignore[attr-defined]
         name = getattr(opcode, "name", str(opcode))
-        if name in _ZERO_WIDTH:
-            continue
         if name in _CONSUMING:
             return False
-        if name in _REPEATS:
+        if name == "AT":
+            anchor = getattr(argument, "name", str(argument))
+            if anchor in _ANCHORS_HOLDING_ON_EMPTY:
+                continue
+            answers.append(False if anchor in _ANCHORS_FAILING_ON_EMPTY else None)
+        elif name in _REPEATS:
             minimum, _maximum, item = argument
             # Walked whatever the count, so that groups inside a repeat that may
             # run zero times are still recorded for a later backreference.
-            item_empty = _can_match_nothing(item, depth + 1, groups)
+            item_empty = _can_match_nothing(item, depth + 1, groups, optional or minimum == 0)
             # A repeat that may run zero times is skippable; one that must run
             # is empty only if what it repeats is. The count itself is never
             # counted out.
             answers.append(True if minimum == 0 else item_empty)
         elif name == "SUBPATTERN":
-            body_empty = _can_match_nothing(argument[-1], depth + 1, groups)
-            if argument[0] is not None:
-                groups[argument[0]] = body_empty
+            body_empty = _can_match_nothing(argument[-1], depth + 1, groups, optional)
+            number = argument[0]
+            if number is not None:
+                groups[number] = _Group(body_empty, _participation(body_empty, optional))
             answers.append(body_empty)
         elif name == "GROUPREF":
             # A backreference repeats whatever its group captured, so it is empty
             # only when that group can be. If the group never participated the
             # reference cannot match at all — never empty either. A group not yet
             # seen (a forward reference) is unknown, and stays unknown.
-            answers.append(groups.get(argument))
+            seen = groups.get(argument)
+            answers.append(None if seen is None else seen.empty)
         elif name == "GROUPREF_EXISTS":
-            # `(?(1)yes|no)`: which arm runs depends on whether the group took
-            # part, which this does not track. So the conditional is only certain
-            # when both arms agree, and unknown when they do not.
-            _reference, yes_arm, no_arm = argument
-            arms = [_can_match_nothing(yes_arm, depth + 1, groups)]
-            arms.append(True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups))
-            answers.append(_agreed(arms))
+            # `(?(1)yes|no)` runs the arm the group's participation selects. On a
+            # match that consumed nothing, a group whose body consumes cannot have
+            # taken part, so `(a)?(?(1)|b)` certainly runs `b` and certainly is
+            # not empty. Only when participation itself is undecidable does the
+            # conditional fall back on the arms having to agree.
+            reference, yes_arm, no_arm = argument
+            took_part = groups[reference].took_part if reference in groups else None
+            yes = _can_match_nothing(yes_arm, depth + 1, groups, True)
+            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, True)
+            if took_part is True:
+                answers.append(yes)
+            elif took_part is False:
+                answers.append(no)
+            else:
+                answers.append(_agreed([yes, no]))
         elif name == "ATOMIC_GROUP":
-            answers.append(_can_match_nothing(argument, depth + 1, groups))
+            answers.append(_can_match_nothing(argument, depth + 1, groups, optional))
         elif name == "BRANCH":
             # Every branch is walked, not just up to the first empty one, so that
-            # groups defined in a later branch are recorded too.
+            # groups defined in a later branch are recorded too. Only one of them
+            # runs, so none of them is a path the match had to take.
             answers.append(
                 _any_empty(
-                    [_can_match_nothing(branch, depth + 1, groups) for branch in argument[1]]
+                    [_can_match_nothing(branch, depth + 1, groups, True) for branch in argument[1]]
                 )
             )
         elif name == "ASSERT":
@@ -170,9 +233,9 @@ def _can_match_nothing(
             # a lookaround holds exactly when what it looks for can be empty.
             # `(?=.*foo)` cannot, which is why a lookahead-only pattern stays
             # admissible evidence.
-            answers.append(_can_match_nothing(argument[1], depth + 1, groups))
+            answers.append(_can_match_nothing(argument[1], depth + 1, groups, True))
         elif name == "ASSERT_NOT":
-            inner = _can_match_nothing(argument[1], depth + 1, groups)
+            inner = _can_match_nothing(argument[1], depth + 1, groups, True)
             answers.append(None if inner is None else not inner)
         else:
             answers.append(None)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -44,11 +44,13 @@ _EMPTINESS_WORDS = frozenset({"empty", "blank"})
 # other thing in the assertion that could carry the difference is the extracted
 # pattern — and `\A\Z` is what a model writes for every one of these readings.
 #
-# The shape that licenses the rescue is narrow on purpose: the file, then a
-# chain of auxiliaries and adverbs, then a copula, then the emptiness word, then
-# the end of the clause. Everything is decided by what may appear *in* that
-# chain rather than by how near some other word happens to fall, because a
-# window has a far side and a criterion can always put its negation past it.
+# The shape that licenses the rescue is narrow on purpose, and it is matched
+# against the criterion in full: words that may precede a subject, the file, a
+# chain of auxiliaries and adverbs, a copula, the emptiness word, and then
+# nothing at all. Everything is decided by what may appear *in* that shape
+# rather than by how near some other word happens to fall, because a window has
+# a far side and a criterion can always put a negation, a governing verb or a
+# second obligation past it.
 
 # A copula is what puts the emptiness on the subject.
 _COPULAS = frozenset(
@@ -98,14 +100,14 @@ _PREDICATE_CHAIN = _COPULAS | {
     "initially",
     "currently",
 }
-# The only words allowed to stand between the start of a clause and the file
-# that heads it. Anything else means the file is not what the clause is about:
-# a preposition makes it the object of something ("the status field in
+# The only words allowed to stand between the start of the criterion and the
+# file. Anything else means the file is not what the criterion is about: a
+# preposition makes it the object of something ("the status field in
 # marker.txt"), a verb makes it the object of that verb ("do not let marker.txt
 # be empty"), and a competing noun makes it a modifier of that noun. This is an
 # allow-list for the same reason the forward chain is — no preposed phrasing can
 # outrun a rule that admits only what it names.
-_CLAUSE_LEAD = frozenset(
+_CRITERION_LEAD = frozenset(
     {
         "the",
         "a",
@@ -147,70 +149,9 @@ _CLAUSE_LEAD = frozenset(
         "expects",
     }
 )
-# A negation can also govern the file from an earlier clause: "do not remove the
-# guard and let marker.txt be empty" carries a clause that, read alone, asks for
-# emptiness. Nothing structural tells that adjunct apart from the innocent "for
-# the release,", so this is a screen and not a proof — it can only ever refuse
-# more. The clause-lead rule above is what makes the direct forms unreachable.
-_NEGATIONS = frozenset(
-    {
-        "not",
-        "never",
-        "no",
-        "none",
-        "nor",
-        "cannot",
-        "cant",
-        "dont",
-        "doesnt",
-        "didnt",
-        "wont",
-        "wouldnt",
-        "shouldnt",
-        "mustnt",
-        "isnt",
-        "arent",
-        "wasnt",
-        "werent",
-        "hasnt",
-        "havent",
-        "hadnt",
-        "couldnt",
-        "avoid",
-        "avoids",
-        "prevent",
-        "prevents",
-        "prohibit",
-        "prohibits",
-        "prohibited",
-        "forbid",
-        "forbids",
-        "forbidden",
-        "disallow",
-        "disallows",
-        "disallowed",
-        "deny",
-        "denies",
-        "refuse",
-        "refuses",
-        "without",
-        "unacceptable",
-        "illegal",
-        "banned",
-    }
-)
-# Where the predicate is allowed to stop. An emptiness word followed by anything
-# else is qualifying that thing rather than the file.
-_CLAUSE_ENDS = frozenset({".", ",", ";", ":", "and", "then"})
-# Emptiness offered as one option among several is not a requirement to be
-# empty, and answering it alone would throw away the evidence the other branch
-# names. The ordinary path can weigh a pattern that spells out both.
-_ALTERNATIVES = frozenset({"or", "unless", "otherwise", "either", "alternatively", "except"})
-_SENTENCE_ENDS = frozenset({".", ";"})
 
-
-# Stands in for the file's own name, so that the walk has one token to start
-# from and `empty.txt MUST contain data` stops carrying an emptiness word it
+# Stands in for the file's own name, so that the match has one token to anchor
+# on and `empty.txt MUST contain data` stops carrying an emptiness word it
 # never meant. Underscored to keep it out of reach of any English word.
 _FILE_TOKEN = "__the_file__"
 
@@ -230,46 +171,6 @@ def _mask_file_hint(ac_text: str, file_hint: str) -> str:
     )
 
 
-def _offers_an_alternative_to_emptiness(tokens: list[str], position: int) -> bool:
-    """True when the rest of the sentence lets something other than emptiness satisfy it."""
-    for token in tokens[position + 1 :]:
-        if token in _SENTENCE_ENDS:
-            return False
-        if token in _ALTERNATIVES:
-            return True
-    return False
-
-
-def _heads_its_clause(tokens: list[str], position: int) -> bool:
-    """True when the file is what its own clause is about.
-
-    Reads back to the nearest clause boundary and requires every word in
-    between to be one this can place ahead of a subject. Refusing on anything
-    else is what makes the whole class of preposed government — "the status
-    field in marker.txt", "do not let marker.txt be empty", "never allow
-    marker.txt to remain empty" — unreachable at once, rather than one cited
-    phrasing at a time. Stopping at the boundary is what keeps a word belonging
-    to an earlier clause, as in "for the release, marker.txt must be empty",
-    from disqualifying anything.
-    """
-    for token in reversed(tokens[:position]):
-        if token in _CLAUSE_ENDS:
-            return True
-        if token not in _CLAUSE_LEAD:
-            return False
-    return True
-
-
-def _a_negation_governs(tokens: list[str], position: int) -> bool:
-    """True when a negation stands earlier in the same sentence."""
-    for token in reversed(tokens[:position]):
-        if token in _SENTENCE_ENDS:
-            return False
-        if token in _NEGATIONS:
-            return True
-    return False
-
-
 def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
     """The emptiness word the criterion predicates of the file, or None.
 
@@ -277,45 +178,45 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     file holding one tab, and the caller has to answer the question that was
     actually asked.
 
-    Walks out from each mention of the file, and returns a word only when every
-    step of the walk holds: the file heads its own clause, so nothing before it
-    governs it and the emptiness is asked of the file rather than of something
-    the file contains; no negation stands earlier in the sentence; every
-    word between it and the emptiness word belongs to `_PREDICATE_CHAIN`, which
-    no negation and no competing noun does; one of them is a copula, without
-    which the emptiness is being predicated of something else; the emptiness word
-    ends its clause, because `empty JSON object` describes contents rather than a
-    file; and the sentence offers no alternative to being empty.
+    The criterion has to be this shape and nothing besides::
+
+        <lead>* <file> <chain>* <copula> (empty | blank) ["."]
+
+    every token consumed. Matching the whole of it is what makes the rescue
+    safe to answer, and it is a stronger claim than matching a part: a criterion
+    that says more is also *asking* for more — "must be empty and contain a
+    header" carries a second obligation, and answering only the emptiness half
+    would publish a pass for a requirement nothing checked. Distinguishing a
+    second obligation from a harmless aside means reading English, which is the
+    guessing this exists to avoid. So anything it cannot consume in full returns
+    None and fails closed on the ordinary path, which says plainly that the
+    pattern is unusable rather than authoritatively answering the wrong question.
+
+    Consuming the whole criterion also leaves nowhere to put the words that
+    broke every narrower version of this: a negation, a governing verb, a
+    competing subject and a trailing obligation are all outside the shape, on
+    either side of the name, at any distance.
 
     Reading words rather than substrings is what keeps `nonempty` from being an
-    occurrence of `empty`. One qualifying mention is enough: "must be empty, and
-    must not be deleted" requires emptiness despite carrying a negation in its
-    other clause. Anything this cannot place on the file itself returns None,
-    and the criterion fails closed on the ordinary path.
+    occurrence of `empty`.
     """
     text = _mask_file_hint(ac_text, file_hint).lower().replace("'", "").replace("’", "")
     tokens = re.findall(r"[a-z_]+|[.,;:]", text)
-    for position, token in enumerate(tokens):
-        if token != _FILE_TOKEN:
-            continue
-        if not _heads_its_clause(tokens, position):
-            continue
-        if _a_negation_governs(tokens, position):
-            continue
-        saw_copula = False
-        step = position + 1
-        while step < len(tokens) and tokens[step] in _PREDICATE_CHAIN:
-            saw_copula = saw_copula or tokens[step] in _COPULAS
-            step += 1
-        if not saw_copula or step >= len(tokens) or tokens[step] not in _EMPTINESS_WORDS:
-            continue
-        following = tokens[step + 1] if step + 1 < len(tokens) else None
-        if following is not None and following not in _CLAUSE_ENDS:
-            continue
-        if _offers_an_alternative_to_emptiness(tokens, step):
-            continue
-        return tokens[step]
-    return None
+    if tokens and tokens[-1] == ".":
+        tokens.pop()
+    step = 0
+    while step < len(tokens) and tokens[step] in _CRITERION_LEAD:
+        step += 1
+    if step >= len(tokens) or tokens[step] != _FILE_TOKEN:
+        return None
+    step += 1
+    saw_copula = False
+    while step < len(tokens) and tokens[step] in _PREDICATE_CHAIN:
+        saw_copula = saw_copula or tokens[step] in _COPULAS
+        step += 1
+    if not saw_copula or step != len(tokens) - 1:
+        return None
+    return tokens[step] if tokens[step] in _EMPTINESS_WORDS else None
 
 
 def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> str | None:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -265,11 +265,23 @@ def _can_match_nothing(
             # taken part, so `(a)?(?(1)|b)` certainly runs `b` and certainly is
             # not empty. Only when participation itself is undecidable does the
             # conditional fall back on the arms having to agree.
+            #
+            # Which arm runs is only undecidable while participation is. Once
+            # the group settles it, the selected arm is walked on the path the
+            # conditional itself is on and the other one certainly does not run,
+            # so a capture in the selected arm is as much on the path as the
+            # conditional is — reading both arms as skippable left every such
+            # capture unknown and refused the conditionals reading them.
             reference, yes_arm, no_arm = argument
             took_part = groups[reference].took_part if reference in groups else None
-            arm_path = _skippable(on_path)
-            yes = _can_match_nothing(yes_arm, depth + 1, groups, arm_path)
-            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, arm_path)
+            if took_part is True:
+                yes_path, no_path = on_path, False
+            elif took_part is False:
+                yes_path, no_path = False, on_path
+            else:
+                yes_path = no_path = _skippable(on_path)
+            yes = _can_match_nothing(yes_arm, depth + 1, groups, yes_path)
+            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, no_path)
             if took_part is True:
                 answers.append(yes)
             elif took_part is False:
@@ -296,13 +308,33 @@ def _can_match_nothing(
             # recorded merges back with participation weakened to "may have gone
             # either way", which is what the alternation makes it for anything
             # reading that capture from outside.
-            branch_answers: list[bool | None] = []
+            #
+            # Except when it is not a choice. On a subject with nothing in it
+            # nothing can consume anything, so a branch that cannot match
+            # nothing cannot run at all, and when that leaves a single branch
+            # standing the alternation decides nothing: its captures took part
+            # exactly as much as the alternation itself did. `(?:()|x)(?(1)a|)`
+            # is that shape, and weakening it refused a pattern that plainly
+            # discriminates.
+            walked: list[tuple[bool | None, dict[int, _Group]]] = []
             for branch in argument[1]:
                 local = dict(groups)
-                branch_answers.append(_can_match_nothing(branch, depth + 1, local, on_path))
+                walked.append((_can_match_nothing(branch, depth + 1, local, on_path), local))
+            branch_answers = [answer for answer, _ in walked]
+            settled = branch_answers.count(True) == 1 and all(
+                answer is not None for answer in branch_answers
+            )
+            for answer, local in walked:
                 for number, group in local.items():
-                    if number not in groups:
-                        groups[number] = _Group(group.empty, _skippable(group.took_part))
+                    if number in groups:
+                        continue
+                    if answer is False:
+                        took = False
+                    elif settled:
+                        took = group.took_part
+                    else:
+                        took = _skippable(group.took_part)
+                    groups[number] = _Group(group.empty, took)
             answers.append(_any_empty(branch_answers))
         elif name == "ASSERT":
             # On a subject with nothing in it there is nothing to either side, so
@@ -321,7 +353,21 @@ def _can_match_nothing(
             # subpattern that fails leaves nothing captured behind it. So this is
             # the one path the match certainly did not walk, and every capture
             # inside it certainly did not take part.
-            inner = _can_match_nothing(argument[1], depth + 1, groups, False)
+            #
+            # From outside. The body is still attempted, and while it is being
+            # attempted its captures are as real as any other — a conditional
+            # written inside the body reads the group beside it exactly as it
+            # would anywhere else. Declaring them absent before the body had
+            # been read made `(?!()(?(1)a|))` take its empty arm, so a pattern
+            # that matches every file was admitted as evidence and published as
+            # a formal PASS, which is the defect this file exists to close. So
+            # the body is walked on the path it inherits, over its own copy of
+            # the table, and only what escapes to the outside is `False`.
+            local_to_body = dict(groups)
+            inner = _can_match_nothing(argument[1], depth + 1, local_to_body, on_path)
+            for number, group in local_to_body.items():
+                if number not in groups:
+                    groups[number] = _Group(group.empty, False)
             answers.append(None if inner is None else not inner)
         else:
             answers.append(None)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -196,11 +196,15 @@ class SpecVerifier:
             logger.warning("Invalid regex pattern: %s", e)
             return None
         if compiled.search("") is not None:
-            # A pattern that matches the empty string matches every subject, so a hit
-            # on a real file is not evidence about the criterion — it is evidence that
-            # the file exists. `.*`, `x?`, `\s*`, `(?:)`, `|`, `^` and `\A\Z` all
-            # compile, and all verified whatever criterion they were pointed at.
-            logger.warning("Regex pattern matches any input, skipping: %r", pattern)
+            # A pattern that can match the empty string can succeed without any
+            # criterion-specific content, so a hit is evidence that a file was read,
+            # not evidence about the criterion. `.*`, `x?`, `\s*`, `(?:)`, `|` and `^`
+            # succeed against any file; `\A\Z` succeeds against an empty one, which an
+            # ordinary `__init__.py` supplies. All compile, and all verified whatever
+            # criterion they were pointed at.
+            logger.warning(
+                "Regex pattern can match without criterion content, skipping: %r", pattern
+            )
             return None
         return compiled
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -214,6 +214,15 @@ def _can_match_nothing(
             # where such a sequence takes part in a match by failing, the answer
             # is that they certainly did not.
             answers.append(False)
+        elif name == "FAILURE":
+            # An assertion that can never hold. From 3.13 the parser folds `(?!)`
+            # and `(?!(?:))` into this single opcode; before that the same source
+            # arrives as an `ASSERT_NOT` with an empty body, which this reading
+            # already answered. Nothing matches it, a subject with nothing in it
+            # included, so the answer is the same False — and reading it as an
+            # unknown construct instead refused `(?!)|CameraProvider` on exactly
+            # the interpreters that do the folding and nowhere else.
+            answers.append(False)
         elif name == "AT":
             anchor = getattr(argument, "name", str(argument))
             if anchor in _ANCHORS_HOLDING_ON_EMPTY:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -87,6 +87,20 @@ _ANCHORS_FAILING_ON_EMPTY = _BOUNDARY | (
 )
 _REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
 
+# The two ends of the *subject* a match can be pinned to. Withholding one of
+# them asks a different question of the same pattern: not "can this match
+# nothing" but "can it match at all without that end of the subject".
+#
+# Only `\A` and `\Z` are here, and `^` and `$` are not. The parser emits the
+# same `AT_BEGINNING` for `^` whether or not `re.MULTILINE` is on — it is the
+# compiler, working from flags, that turns it into a line anchor — so a reading
+# that counted `^` as pinned to the file would admit `(?m)^$`, which is
+# satisfied by a blank line inside a file full of content. `^` is therefore
+# read as pinning to nothing at all here, which costs a pattern written that
+# way the same formal failure it already gets today.
+_START_ANCHORS = frozenset({"AT_BEGINNING_STRING"})
+_END_ANCHORS = frozenset({"AT_END_STRING"})
+
 
 class _Group(NamedTuple):
     """What a capture group did on a match that consumed nothing."""
@@ -171,6 +185,8 @@ def _can_match_nothing(
     depth: int = 0,
     groups: dict[int, _Group] | None = None,
     on_path: bool | None = True,
+    withheld: frozenset[str] = frozenset(),
+    porous: bool = False,
 ) -> bool | None:
     """Whether a parsed regex can match the empty string, read rather than run.
 
@@ -197,6 +213,14 @@ def _can_match_nothing(
     three-valued: True for a path the match certainly took, False for one it
     certainly did not — the inside of a negative assertion, which succeeds only
     by failing — and None where it may have gone either way.
+
+    `withheld` names anchors to read as ones that cannot hold, and `porous`
+    reads a consuming atom as something a match can cross rather than something
+    that ends the question. Together they turn this walk into a second question
+    asked of the same tree — "can this match somewhere that is not the start of
+    the subject" — whose answer is what tells a pattern pinned to both ends of
+    the file apart from one that matches anywhere in it. Defaults leave the
+    first question exactly as it was.
     """
     if groups is None:
         groups = {}
@@ -213,7 +237,13 @@ def _can_match_nothing(
             # what those captures did, and inside a negative assertion, which is
             # where such a sequence takes part in a match by failing, the answer
             # is that they certainly did not.
-            answers.append(False)
+            #
+            # Unless the walk was asked to be porous, where a consuming atom is
+            # something the match crosses rather than something that settles it:
+            # the second question is about *where* a match can be, not about how
+            # long it is, and a subject free to hold whatever the atom wants is
+            # a subject the atom does not rule out.
+            answers.append(porous)
         elif name == "FAILURE":
             # An assertion that can never hold. From 3.13 the parser folds `(?!)`
             # and `(?!(?:))` into this single opcode; before that the same source
@@ -225,22 +255,43 @@ def _can_match_nothing(
             answers.append(False)
         elif name == "AT":
             anchor = getattr(argument, "name", str(argument))
-            if anchor in _ANCHORS_HOLDING_ON_EMPTY:
+            # A withheld anchor is read as one that cannot hold. That is not a
+            # claim about the anchor — it is how the second and third walks ask
+            # their narrower question: with the start of the subject withheld,
+            # a `True` answer would mean the pattern can match nothing without
+            # ever pinning to the start, and a `False` means every empty match
+            # it has needs that end.
+            if anchor in withheld:
+                answers.append(False)
+            elif anchor in _ANCHORS_HOLDING_ON_EMPTY:
                 continue
-            answers.append(False if anchor in _ANCHORS_FAILING_ON_EMPTY else None)
+            elif porous:
+                # A word boundary says something about the characters on either
+                # side, and a subject free to hold whatever it likes is free to
+                # hold those. It rules out no position on the porous reading.
+                answers.append(True)
+            else:
+                answers.append(False if anchor in _ANCHORS_FAILING_ON_EMPTY else None)
         elif name in _REPEATS:
             minimum, _maximum, item = argument
             # Walked whatever the count, so that groups inside a repeat that may
             # run zero times are still recorded for a later backreference.
             item_empty = _can_match_nothing(
-                item, depth + 1, groups, _skippable(on_path) if minimum == 0 else on_path
+                item,
+                depth + 1,
+                groups,
+                _skippable(on_path) if minimum == 0 else on_path,
+                withheld,
+                porous,
             )
             # A repeat that may run zero times is skippable; one that must run
             # is empty only if what it repeats is. The count itself is never
             # counted out.
             answers.append(True if minimum == 0 else item_empty)
         elif name == "SUBPATTERN":
-            body_empty = _can_match_nothing(argument[-1], depth + 1, groups, on_path)
+            body_empty = _can_match_nothing(
+                argument[-1], depth + 1, groups, on_path, withheld, porous
+            )
             number = argument[0]
             if number is not None:
                 groups[number] = _Group(body_empty, _participation(body_empty, on_path))
@@ -251,12 +302,17 @@ def _can_match_nothing(
             # did not take part refers to nothing captured, and this interpreter
             # fails such a reference rather than matching nothing with it — so
             # the sequence around it cannot match at all, empty included. A group
-            # not yet seen (a forward reference) is unknown, and stays unknown.
+            # the walk has not reached is one the match has not reached either,
+            # so it has certainly captured nothing here and the reference fails
+            # the same way.
             seen = groups.get(argument)
-            if seen is None:
-                answers.append(None)
-            elif seen.took_part is False:
+            if seen is None or seen.took_part is False:
                 answers.append(False)
+            elif porous:
+                # A reference that resolves repeats text the subject is free to
+                # repeat, so on the porous reading it is crossed like any other
+                # consuming atom rather than being empty.
+                answers.append(True)
             else:
                 answers.append(seen.empty)
         elif name == "GROUPREF_EXISTS":
@@ -272,16 +328,31 @@ def _can_match_nothing(
             # so a capture in the selected arm is as much on the path as the
             # conditional is — reading both arms as skippable left every such
             # capture unknown and refused the conditionals reading them.
+            #
+            # Nor is a group the walk has not reached an open question. A
+            # conditional written before the group it names runs at a point the
+            # match has not yet carried the group into, so nothing can have been
+            # captured in it and the interpreter takes the `no` arm — every
+            # time, on every version. Repetition does not reopen it: a repeat
+            # matches nothing only if each of its runs does, and its first run
+            # always meets the group unreached. Reading a forward reference as
+            # unknown made the arms have to agree, and `(?(1)|a)(a?)` — which
+            # plainly discriminates — was refused as evidence.
             reference, yes_arm, no_arm = argument
-            took_part = groups[reference].took_part if reference in groups else None
+            seen_by_conditional = groups.get(reference)
+            took_part = False if seen_by_conditional is None else seen_by_conditional.took_part
             if took_part is True:
                 yes_path, no_path = on_path, False
             elif took_part is False:
                 yes_path, no_path = False, on_path
             else:
                 yes_path = no_path = _skippable(on_path)
-            yes = _can_match_nothing(yes_arm, depth + 1, groups, yes_path)
-            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, no_path)
+            yes = _can_match_nothing(yes_arm, depth + 1, groups, yes_path, withheld, porous)
+            no = (
+                True
+                if no_arm is None
+                else _can_match_nothing(no_arm, depth + 1, groups, no_path, withheld, porous)
+            )
             if took_part is True:
                 answers.append(yes)
             elif took_part is False:
@@ -289,7 +360,9 @@ def _can_match_nothing(
             else:
                 answers.append(_agreed([yes, no]))
         elif name == "ATOMIC_GROUP":
-            answers.append(_can_match_nothing(argument, depth + 1, groups, on_path))
+            answers.append(
+                _can_match_nothing(argument, depth + 1, groups, on_path, withheld, porous)
+            )
         elif name == "BRANCH":
             # Every branch is walked, not just up to the first empty one, so that
             # groups defined in a later branch are recorded too.
@@ -319,7 +392,9 @@ def _can_match_nothing(
             walked: list[tuple[bool | None, dict[int, _Group]]] = []
             for branch in argument[1]:
                 local = dict(groups)
-                walked.append((_can_match_nothing(branch, depth + 1, local, on_path), local))
+                walked.append(
+                    (_can_match_nothing(branch, depth + 1, local, on_path, withheld, porous), local)
+                )
             branch_answers = [answer for answer, _ in walked]
             settled = branch_answers.count(True) == 1 and all(
                 answer is not None for answer in branch_answers
@@ -347,7 +422,9 @@ def _can_match_nothing(
             # capture inside it took part exactly as much as the same capture
             # written outside it would have. Calling it optional here is what
             # made `(?=())(?(1)x|)` unreadable and refused it as evidence.
-            answers.append(_can_match_nothing(argument[1], depth + 1, groups, on_path))
+            answers.append(
+                _can_match_nothing(argument[1], depth + 1, groups, on_path, withheld, porous)
+            )
         elif name == "ASSERT_NOT":
             # A negative assertion succeeds only where its body fails, and a
             # subpattern that fails leaves nothing captured behind it. So this is
@@ -364,11 +441,21 @@ def _can_match_nothing(
             # the body is walked on the path it inherits, over its own copy of
             # the table, and only what escapes to the outside is `False`.
             local_to_body = dict(groups)
-            inner = _can_match_nothing(argument[1], depth + 1, local_to_body, on_path)
+            inner = _can_match_nothing(
+                argument[1], depth + 1, local_to_body, on_path, withheld, porous
+            )
             for number, group in local_to_body.items():
                 if number not in groups:
                     groups[number] = _Group(group.empty, False)
-            answers.append(None if inner is None else not inner)
+            if porous:
+                # The porous reading asks whether the body can match *somewhere*,
+                # and the negation of "somewhere" is not "nowhere" — `(?!x)` holds
+                # at every position that is not followed by an `x`, however freely
+                # an `x` can appear elsewhere. So only a body that can match
+                # nowhere at all lets this assertion be read with certainty.
+                answers.append(True if inner is False else None)
+            else:
+                answers.append(None if inner is None else not inner)
         else:
             answers.append(None)
     return _all_empty(answers)
@@ -386,299 +473,151 @@ def _matches_the_empty_string(pattern: str, flags: int = 0) -> bool:
     return _can_match_nothing(parsed) is not False
 
 
-# Words that make an acceptance criterion a claim about a file holding nothing.
-# Such a criterion has no content for a regex to find, so every honest way to
-# write it — `\A\Z` and its blank-file variants — is refused by the empty-string
-# rule in `_safe_compile`, and an honest criterion fails formally.
-#
-# `_empty_file_criterion_result` answers that one criterion from the file itself.
-# Emptiness is a property of the file, and reading it is ground truth; asking a
-# regex what it *could* match is inference, and inference run against a fixed
-# list of sample strings only ever rejects what the list literally contains.
-_EMPTINESS_WORDS = frozenset({"empty", "blank"})
+# Whitespace is the one thing a file can hold that no acceptance criterion is
+# about, so it is the one thing a pattern may consume and still be read as a
+# claim that the file holds nothing. `\s` is exactly this class; a literal space,
+# tab or newline is a member of it.
+_BLANK_CATEGORIES = frozenset({"CATEGORY_SPACE"})
 
-# A criterion that *forbids* emptiness reads almost identically to one that
-# requires it, and so does one that asks it of something the file merely
-# contains. Both have to be told apart here, from `ac_text`, because the only
-# other thing in the assertion that could carry the difference is the extracted
-# pattern — and `\A\Z` is what a model writes for every one of these readings.
-#
-# The shape that licenses the rescue is narrow on purpose, and it is matched
-# against the criterion in full: words that may precede a subject, the file, a
-# chain of auxiliaries and adverbs, a copula, the emptiness word, and then
-# nothing at all. Everything is decided by what may appear *in* that shape
-# rather than by how near some other word happens to fall, because a window has
-# a far side and a criterion can always put a negation, a governing verb or a
-# second obligation past it.
-
-# A copula is what puts the emptiness on the subject.
-_COPULAS = frozenset(
-    {
-        "be",
-        "is",
-        "are",
-        "was",
-        "were",
-        "remain",
-        "remains",
-        "stay",
-        "stays",
-        "become",
-        "becomes",
-    }
-)
-# The only words allowed to stand between the file and the emptiness word.
-# Negations are absent from this set rather than enumerated in one of their own,
-# so "must not be empty" and "must not under any circumstances be empty" are
-# refused by the same rule and no phrasing can outrun it. So is any noun that
-# would move the subject elsewhere — "marker.txt entries must be empty" is about
-# the entries. An unrecognised word means the sentence is not one this can read,
-# which is a reason to fail closed and not a reason to guess.
-_PREDICATE_CHAIN = _COPULAS | {
-    "must",
-    "shall",
-    "should",
-    "will",
-    "would",
-    "has",
-    "have",
-    "had",
-    "needs",
-    "need",
-    "to",
-    "left",
-    "kept",
-    "always",
-    "still",
-    "already",
-    "completely",
-    "entirely",
-    "totally",
-    "fully",
-    "strictly",
-    "initially",
-    "currently",
-}
-# The only words allowed to stand between the start of the criterion and the
-# file. Anything else means the file is not what the criterion is about: a
-# preposition makes it the object of something ("the status field in
-# marker.txt"), a verb makes it the object of that verb ("do not let marker.txt
-# be empty"), and a competing noun makes it a modifier of that noun. This is an
-# allow-list for the same reason the forward chain is — no preposed phrasing can
-# outrun a rule that admits only what it names.
-#
-# Each word here belongs to one of four classes, and membership is decided by a
-# single test: can putting this word in front of "marker.txt is empty" change
-# what is being claimed about marker.txt? For a determiner, a name for the file
-# itself, a request to see to it, or a politeness or impersonal frame, it cannot.
-# For anything else — every negation, every governing verb, every preposition,
-# every competing noun — it can, and so it is left out and refuses the criterion.
-_CRITERION_LEAD = frozenset(
-    {
-        # Determiners and possessives. A closed class in English, listed whole.
-        "the",
-        "a",
-        "an",
-        "this",
-        "that",
-        "these",
-        "those",
-        "each",
-        "every",
-        "all",
-        "any",
-        "its",
-        "their",
-        "our",
-        "my",
-        "your",
-        "we",
-        # Nouns that name the file rather than something the file contains.
-        "file",
-        "files",
-        "filename",
-        "path",
-        "artifact",
-        "output",
-        "document",
-        "log",
-        "report",
-        # Verbs that ask for the clause after them without changing what it
-        # claims: "ensure marker.txt is empty" requires exactly what
-        # "marker.txt is empty" does. Negating one of these negates the
-        # criterion, but the negation is itself a word this set does not admit.
-        "ensure",
-        "ensures",
-        "ensured",
-        "verify",
-        "verifies",
-        "verified",
-        "confirm",
-        "confirms",
-        "confirmed",
-        "require",
-        "requires",
-        "required",
-        "expect",
-        "expects",
-        "expected",
-        "check",
-        "checks",
-        "assert",
-        "asserts",
-        "validate",
-        "validates",
-        "guarantee",
-        "guarantees",
-        "make",
-        "sure",
-        # Politeness and impersonal frames — "please", "it is necessary that".
-        # These carry no claim of their own at all, which is exactly why leaving
-        # them out cost an honest criterion a formal failure.
-        "please",
-        "kindly",
-        "it",
-        "is",
-        "necessary",
-        "mandatory",
-    }
-)
-
-# Stands in for the file's own name, so that the match has one token to anchor
-# on and `empty.txt MUST contain data` stops carrying an emptiness word it
-# never meant. Underscored to keep it out of reach of any English word.
-_FILE_TOKEN = "__the_file__"
-
-# Quotes and brackets wrap a name without changing what is claimed about it, and
-# whitespace separates. Everything else in a criterion has to be a word or one of
-# these marks, because a character this cannot read may be the whole of the
-# meaning: `!=` and `≠` invert the very claim they sit in, and a digit or an
-# operator can carry an obligation of its own. So the criterion is consumed
-# character by character and an unreadable one refuses the whole reading — a scan
-# that silently drops what it does not recognise is matching a *part* again, one
-# layer below the tokens.
-_READABLE = re.compile(r"[a-z_]+|[.,;:]|['’\"`()\[\]]|\s+")
-_MARKUP = frozenset("'’\"`()[]")
+# Character ranges are read, not enumerated, past this width. Every run of
+# whitespace codepoints is a handful long — `\t` through `\r` is five — so a
+# wide range is not a blank class that this failed to recognise, it is a class
+# with content in it.
+_MAX_BLANK_RANGE = 64
 
 
-def _criterion_tokens(text: str) -> list[str] | None:
-    """Every word and mark of `text`, or None if any character is unreadable."""
-    tokens: list[str] = []
-    consumed = 0
-    for match in _READABLE.finditer(text):
-        if match.start() != consumed:
-            return None
-        consumed = match.end()
-        token = match.group()
-        if not token.isspace() and token not in _MARKUP:
-            tokens.append(token)
-    return tokens if consumed == len(text) else None
+def _is_blank_codepoint(value: object) -> bool:
+    return isinstance(value, int) and 0 <= value <= 0x10FFFF and chr(value).isspace()
 
 
-def _mask_file_hint(ac_text: str, file_hint: str) -> str:
-    """Replace mentions of the file's own name with `_FILE_TOKEN`.
+def _is_blank_range(bounds: object) -> bool:
+    if not isinstance(bounds, tuple) or len(bounds) != 2:
+        return False
+    low, high = bounds
+    if not isinstance(low, int) or not isinstance(high, int):
+        return False
+    if high - low > _MAX_BLANK_RANGE:
+        return False
+    return all(_is_blank_codepoint(code) for code in range(low, high + 1))
 
-    Names are matched as whole tokens for the same reason the mention check is —
-    `a.py` sits inside `data.py`.
 
-    And case-insensitively for the same reason too. The mention check already
-    ignores case, so `Marker.txt must be empty` against a hint of `marker.txt`
-    reached this function, went unmasked because the substitution did not, and
-    lost the one token the reading anchors on — an ordinary criterion on a file
-    that satisfies it, turned into an authoritative failure by a capital letter.
-    Both places normalize the same way now.
+def _is_blank_class(items: object) -> bool:
+    """Whether a `[...]` class can only ever match whitespace.
+
+    A negated class is not one of them whatever it lists: `[^ ]` is every
+    character that is not a space, which is what content is made of.
     """
-    if not file_hint:
-        return ac_text
-    return re.sub(
-        rf"(\A|[\s'\"`(\[]){re.escape(file_hint)}(?=\Z|[\s'\"`)\],.;:])",
-        rf"\1{_FILE_TOKEN}",
-        ac_text,
-        flags=re.IGNORECASE,
-    )
+    try:
+        members = list(items)  # type: ignore[call-overload]
+    except TypeError:  # pragma: no cover - the parser always hands back a list
+        return False
+    for opcode, argument in members:
+        name = getattr(opcode, "name", str(opcode))
+        if name == "LITERAL":
+            if not _is_blank_codepoint(argument):
+                return False
+        elif name == "RANGE":
+            if not _is_blank_range(argument):
+                return False
+        elif name == "CATEGORY":
+            if getattr(argument, "name", str(argument)) not in _BLANK_CATEGORIES:
+                return False
+        else:
+            return False
+    return True
 
 
-def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | None:
-    """The emptiness word the criterion predicates of the file, or None.
+def _consumes_only_blank(sequence: object, depth: int = 0) -> bool:
+    """Whether nothing this can consume is content.
 
-    Returns `empty` or `blank` because the two do not mean the same thing to a
-    file holding one tab, and the caller has to answer the question that was
-    actually asked.
+    What a lookaround looks at is not consumed and so is never part of what
+    matched; it is skipped here for that reason. A backreference is not, because
+    it repeats whatever its group captured, and a group inside a lookaround can
+    have captured anything at all.
 
-    The criterion has to be this shape and nothing besides::
-
-        <lead>* <file> <chain>* <copula> (empty | blank) ["."]
-
-    every character of it consumed. Matching the whole of it is what makes the rescue
-    safe to answer, and it is a stronger claim than matching a part: a criterion
-    that says more is also *asking* for more — "must be empty and contain a
-    header" carries a second obligation, and answering only the emptiness half
-    would publish a pass for a requirement nothing checked. Distinguishing a
-    second obligation from a harmless aside means reading English, which is the
-    guessing this exists to avoid. So anything it cannot consume in full returns
-    None and fails closed on the ordinary path, which says plainly that the
-    pattern is unusable rather than authoritatively answering the wrong question.
-
-    Consuming the whole criterion also leaves nowhere to put the words that
-    broke every narrower version of this: a negation, a governing verb, a
-    competing subject and a trailing obligation are all outside the shape, on
-    either side of the name, at any distance — and so is a negation written as a
-    symbol, because the reading is over characters and `!=` is not among the ones
-    it can read.
-
-    Reading words rather than substrings is what keeps `nonempty` from being an
-    occurrence of `empty`.
+    False for anything this cannot read, so an unrecognised construct narrows
+    nothing.
     """
-    tokens = _criterion_tokens(_mask_file_hint(ac_text, file_hint).lower())
-    if tokens is None:
-        return None
-    if tokens and tokens[-1] == ".":
-        tokens.pop()
-    step = 0
-    while step < len(tokens) and tokens[step] in _CRITERION_LEAD:
-        step += 1
-    if step >= len(tokens) or tokens[step] != _FILE_TOKEN:
-        return None
-    step += 1
-    saw_copula = False
-    while step < len(tokens) and tokens[step] in _PREDICATE_CHAIN:
-        saw_copula = saw_copula or tokens[step] in _COPULAS
-        step += 1
-    if not saw_copula or step != len(tokens) - 1:
-        return None
-    return tokens[step] if tokens[step] in _EMPTINESS_WORDS else None
+    if depth > _MAX_PARSE_DEPTH:
+        return False
+    try:
+        items = list(sequence)  # type: ignore[call-overload]
+    except TypeError:  # pragma: no cover - the parser always hands back a sequence
+        return False
+    for opcode, argument in items:
+        name = getattr(opcode, "name", str(opcode))
+        if name in ("AT", "ASSERT", "ASSERT_NOT", "FAILURE"):
+            continue
+        if name == "LITERAL":
+            if not _is_blank_codepoint(argument):
+                return False
+        elif name == "IN":
+            if not _is_blank_class(argument):
+                return False
+        elif name == "RANGE":
+            if not _is_blank_range(argument):
+                return False
+        elif name == "CATEGORY":
+            if getattr(argument, "name", str(argument)) not in _BLANK_CATEGORIES:
+                return False
+        elif name in _REPEATS or name == "SUBPATTERN":
+            # Both carry the thing they wrap last: a repeat cannot consume what
+            # its body does not, and a group consumes exactly its body.
+            if not _consumes_only_blank(argument[-1], depth + 1):
+                return False
+        elif name == "ATOMIC_GROUP":
+            if not _consumes_only_blank(argument, depth + 1):
+                return False
+        elif name == "BRANCH":
+            if not all(_consumes_only_blank(branch, depth + 1) for branch in argument[1]):
+                return False
+        elif name == "GROUPREF_EXISTS":
+            _reference, yes_arm, no_arm = argument
+            if not _consumes_only_blank(yes_arm, depth + 1):
+                return False
+            if no_arm is not None and not _consumes_only_blank(no_arm, depth + 1):
+                return False
+        else:
+            return False
+    return True
 
 
-def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> str | None:
-    """The emptiness the criterion asks of the file its hint names, or None.
+def _matches_only_a_blank_subject(pattern: str, flags: int = 0) -> bool:
+    r"""Whether the only file this can match is one with nothing in it.
 
-    All three halves are load-bearing. The hint must name one file, because
-    `\\A\\Z` over `**/*.py` stops at whichever candidate is empty first — in a
-    Python project some package marker no criterion ever mentioned. The
-    criterion must name that same file, because `pkg/__init__.py` is empty in
-    most repositories, so an exact hint pointed at it would otherwise "verify" a
-    criterion about something else entirely. And the criterion must *require*
-    emptiness of that file rather than forbid it, mention it in a filename, or
-    ask it of a value nested inside — an empty file satisfies one reading and
-    violates the others while the pattern looks the same for all of them.
+    `\A\Z` and `\A\s*\Z` match a subject with nothing in it, and the empty-string
+    rule refuses them for it. But the reason that rule exists does not reach
+    them. A pattern that can match nothing *somewhere in the middle* matches
+    every file there is, so its match is evidence of nothing; these match one
+    file and no other, which makes them not the weakest evidence available but
+    the sharpest. Refusing them failed the one criterion they are the right
+    answer to — that a file be left empty — and left it needing a rescue that
+    read the criterion's English instead, which is guesswork this file should
+    not be doing.
 
-    The hint comes from the same model completion as the pattern and licenses
-    nothing on its own; `ac_text` is the spec's own wording, which the model
-    selects by index but does not write. Anything this returns None for falls
-    through to the ordinary path, where `_safe_compile` refuses `\\A\\Z` and the
-    criterion fails closed.
+    Three readings, none of which runs the pattern. Nothing it consumes may be
+    content, or the file it matched had something in it. No match may begin
+    anywhere but the start of the subject, and none may end anywhere but the
+    end, or what matched was a blank stretch inside a file rather than the whole
+    of one — asked by walking the same tree twice more with one end of the
+    subject withheld, which forces every match to justify itself without that
+    end. Both walks answering "cannot" is what says both ends were required.
+
+    Only `\A` and `\Z` count as the ends of the subject, so `\A$` and `(?m)^$`
+    are refused rather than admitted — see `_START_ANCHORS`. That costs a
+    criterion written with `$` the failure it already gets today, and it is the
+    only reading that stays sound without inspecting flags the parser has not
+    applied.
     """
-    hint = assertion.file_hint
-    if not hint or any(c in hint for c in "*?["):
-        return None
-    # As a whole token, not a substring: `a.py` sits inside `data.py`, and a
-    # criterion about the latter must not license a hint pointed at the former.
-    if not re.search(
-        rf"(?:\A|[\s'\"`(\[]){re.escape(hint.lower())}(?=\Z|[\s'\"`)\],.;:])",
-        assertion.ac_text.lower(),
-    ):
-        return None
-    return _emptiness_the_criterion_requires(assertion.ac_text, hint)
+    try:
+        parsed = regex_parser.parse(pattern, flags)
+    except Exception:  # pragma: no cover - re.compile has already accepted this
+        return False
+    if not _consumes_only_blank(parsed):
+        return False
+    unpinned_at_start = _can_match_nothing(parsed, withheld=_START_ANCHORS, porous=True)
+    unpinned_at_end = _can_match_nothing(parsed, withheld=_END_ANCHORS, porous=True)
+    return unpinned_at_start is False and unpinned_at_end is False
 
 
 def _skip_inline_space(text: str, index: int) -> int:
@@ -849,83 +788,50 @@ class SpecVerifier:
             logger.warning("Invalid regex pattern: %s", e)
             return None
 
-    def _safe_compile(self, pattern: str, flags: int = 0) -> re.Pattern | None:
+    def _searches_one_named_file(self, file_hint: str | None, candidates: list[str] | None) -> bool:
+        """Whether this search is about one file the hint named outright.
+
+        A glob is not that, however few files it happens to match today. `\\A\\Z`
+        over `**/*.py` asks whether the project contains *any* empty file, and in
+        a Python project it does — some package marker no criterion mentioned. A
+        hint that names one path asks about that path.
+        """
+        if not file_hint or any(char in file_hint for char in "*?["):
+            return False
+        return candidates is not None and len(candidates) == 1
+
+    def _safe_compile(
+        self,
+        pattern: str,
+        flags: int = 0,
+        file_hint: str | None = None,
+        candidates: list[str] | None = None,
+    ) -> re.Pattern | None:
         """Compile a model-supplied regex, refusing one that cannot be evidence."""
         compiled = self._compile_or_none(pattern, flags)
         if compiled is None:
             return None
         if _matches_the_empty_string(pattern, flags):
-            # A pattern that can match a subject with nothing in it proves nothing
-            # about a subject that has something in it either — `\A\Z` matches only
-            # the empty file, `.*` and `x?` and `\s*` and `(?:)` and `|` and `^`
-            # match anywhere in any file, and all of them verified whatever
-            # criterion they were handed. What the two kinds share is that the
-            # match is not evidence of the criterion. A criterion that is genuinely
-            # about a file being empty is answered by `_empty_file_criterion_result`
-            # from the file, so nothing honest depends on admitting these here.
+            # `.*` and `x?` and `(?:)` and `|` and `^` match anywhere in any file,
+            # so they verified whatever criterion they were handed — the match is
+            # not evidence of the criterion. `\A\Z` shares the empty match and
+            # nothing else: pinned to both ends of the subject and consuming no
+            # content, it holds for a file with nothing in it and fails for every
+            # other, which is discrimination rather than the absence of it. So it
+            # is admitted where it is being asked about one named file, and the
+            # search below answers the criterion from that file directly.
+            if self._searches_one_named_file(file_hint, candidates) and (
+                _matches_only_a_blank_subject(pattern, flags)
+            ):
+                return compiled
             logger.warning(
                 "Regex pattern can match without criterion content, skipping: %r", pattern
             )
             return None
         return compiled
 
-    def _empty_file_criterion_result(
-        self, assertion: SpecAssertion
-    ) -> SpecVerificationResult | None:
-        """Answer an "X MUST remain empty" criterion from the file, not from the pattern.
-
-        Returns None whenever this is not that criterion, leaving the assertion to
-        the ordinary path. Deliberately one gate ahead of the tier split: a verdict
-        that differs between T1 and T2 is a hole, and here that cannot be written.
-        """
-        if assertion.tier not in (VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL):
-            return None
-        requirement = _asks_whether_a_named_file_is_empty(assertion)
-        if requirement is None:
-            return None
-
-        # The pattern still decides which way the criterion is being asked. One that
-        # needs content — `\S` for "MUST NOT be empty" — is answered by the ordinary
-        # path, which can see the content it needs; only one that survives on a file
-        # with nothing in it lands here, and that is the pattern this rescue is for.
-        compiled = self._compile_or_none(assertion.pattern)
-        if compiled is None or not _matches_the_empty_string(assertion.pattern):
-            return None
-
-        files = self._find_files(assertion.file_hint)
-        if len(files) != 1:
-            return None
-        content = self._read_file(files[0])
-        if content is None:
-            return None
-
-        # Which word the criterion used decides the test, because they are not the
-        # same test. A file of one tab is blank and is not empty, and `\A\Z` — the
-        # pattern that motivates this whole path — draws exactly that line.
-        # Answering "empty" with the looser reading would formally approve a file
-        # the criterion rejects.
-        remainder = content if requirement == "empty" else content.strip()
-        satisfied = not remainder
-        basename = os.path.basename(files[0])
-        return SpecVerificationResult(
-            assertion=assertion,
-            verified=satisfied,
-            file_path=files[0],
-            discrepancy=not satisfied,
-            detail=(
-                f"Criterion asks whether {basename} is {requirement}; it is {requirement}"
-                if satisfied
-                else f"Criterion asks whether {basename} is {requirement}; it holds "
-                f"{len(remainder)} characters of content"
-            ),
-        )
-
     def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult | None:
         """Verify a single assertion. Returns None for skipped tiers."""
-        empty_file = self._empty_file_criterion_result(assertion)
-        if empty_file is not None:
-            return empty_file
-
         if assertion.tier == VerificationTier.T1_CONSTANT:
             return self._verify_constant(assertion)
         elif assertion.tier == VerificationTier.T2_STRUCTURAL:
@@ -953,7 +859,9 @@ class SpecVerifier:
                 detail=f"No files matched hint: {assertion.file_hint}",
             )
 
-        pattern = self._safe_compile(assertion.pattern)
+        pattern = self._safe_compile(
+            assertion.pattern, file_hint=assertion.file_hint, candidates=files
+        )
         if pattern is None:
             return SpecVerificationResult(
                 assertion=assertion,
@@ -1029,7 +937,9 @@ class SpecVerifier:
                     )
 
         # Second check: search file contents for class/function/interface
-        content_pattern = self._safe_compile(assertion.pattern)
+        content_pattern = self._safe_compile(
+            assertion.pattern, file_hint=assertion.file_hint, candidates=files
+        )
         if content_pattern is None:
             return SpecVerificationResult(
                 assertion=assertion,

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -36,33 +36,90 @@ MAX_SCALAR_LENGTH = 4096
 # Emptiness is a property of the file, and reading it is ground truth; asking a
 # regex what it *could* match is inference, and inference run against a fixed
 # list of sample strings only ever rejects what the list literally contains.
-_EMPTINESS_WORDS = ("empty", "blank")
+_EMPTINESS_WORDS = frozenset({"empty", "blank"})
+
+# A criterion that *forbids* emptiness reads almost identically to one that
+# requires it, and the difference is one short word standing before the noun.
+# Polarity has to be read here, from `ac_text`, because the only other thing in
+# the assertion that could carry it is the extracted pattern — and `\A\Z` is
+# what a model writes for both readings.
+_NEGATIONS = frozenset(
+    {
+        "not",
+        "never",
+        "no",
+        "non",
+        "nor",
+        "without",
+        "cannot",
+        "cant",
+        "isnt",
+        "arent",
+        "wasnt",
+        "werent",
+        "doesnt",
+        "dont",
+        "wont",
+        "shouldnt",
+        "mustnt",
+        "neednt",
+    }
+)
+# Far enough to cross "must not be", "should never be", "cannot ever be";
+# short enough that a negation belonging to a different clause does not reach.
+_NEGATION_LOOKBACK = 4
+
+
+def _positively_requires_emptiness(ac_text: str) -> bool:
+    """True when the criterion asks for the file to be empty, not for it not to be.
+
+    Read off words, not substrings, so `nonempty` is its own word and never an
+    occurrence of `empty` at all. Hyphenated and spaced forms split into two
+    words, which puts `non` in the lookback where the other negations are.
+
+    One un-negated occurrence is enough: "must be empty, and must not be
+    deleted" requires emptiness despite carrying a negation elsewhere. Every
+    occurrence being negated is what makes the criterion the opposite one.
+    """
+    words = re.findall(r"[a-z]+", ac_text.lower().replace("'", "").replace("’", ""))
+    for position, word in enumerate(words):
+        if word not in _EMPTINESS_WORDS:
+            continue
+        lookback = words[max(0, position - _NEGATION_LOOKBACK) : position]
+        if not any(token in _NEGATIONS for token in lookback):
+            return True
+    return False
 
 
 def _asks_whether_a_named_file_is_empty(assertion: SpecAssertion) -> bool:
     """True when the criterion itself asks whether the file its hint names is empty.
 
-    Both halves are load-bearing. The hint must name one file, because `\\A\\Z`
-    over `**/*.py` stops at whichever candidate is empty first — in a Python
-    project some package marker no criterion ever mentioned. And the criterion
-    must name that same file, because `pkg/__init__.py` is empty in most
-    repositories, so an exact hint pointed at it would otherwise "verify" a
-    criterion about something else entirely. The hint comes from the same model
-    completion as the pattern and licenses nothing on its own; `ac_text` is the
-    spec's own wording, which the model selects by index but does not write.
+    All three halves are load-bearing. The hint must name one file, because
+    `\\A\\Z` over `**/*.py` stops at whichever candidate is empty first — in a
+    Python project some package marker no criterion ever mentioned. The
+    criterion must name that same file, because `pkg/__init__.py` is empty in
+    most repositories, so an exact hint pointed at it would otherwise "verify" a
+    criterion about something else entirely. And the criterion must *require*
+    emptiness rather than forbid it, because an empty file satisfies one reading
+    and violates the other while the pattern looks the same either way.
+
+    The hint comes from the same model completion as the pattern and licenses
+    nothing on its own; `ac_text` is the spec's own wording, which the model
+    selects by index but does not write. Anything this returns False for falls
+    through to the ordinary path, where `_safe_compile` refuses `\\A\\Z` and the
+    criterion fails closed.
     """
     hint = assertion.file_hint
     if not hint or any(c in hint for c in "*?["):
         return False
-    ac_text = assertion.ac_text.lower()
-    if not any(word in ac_text for word in _EMPTINESS_WORDS):
+    if not _positively_requires_emptiness(assertion.ac_text):
         return False
     # As a whole token, not a substring: `a.py` sits inside `data.py`, and a
     # criterion about the latter must not license a hint pointed at the former.
     return (
         re.search(
             rf"(?:\A|[\s'\"`(\[]){re.escape(hint.lower())}(?=\Z|[\s'\"`)\],.;:])",
-            ac_text,
+            assertion.ac_text.lower(),
         )
         is not None
     )

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -51,12 +51,12 @@ _MAX_PARSE_DEPTH = 40
 _CONSUMING = frozenset({"LITERAL", "NOT_LITERAL", "IN", "ANY", "RANGE", "CATEGORY"})
 # Anchors consume nothing, but they still either hold or fail on a subject with
 # nothing in it, and which one it is has to be read off the individual anchor.
-# `^`, `\A`, `$`, `\Z` and `\B` all hold at the sole position of an empty
-# subject; `\b` needs a word character on exactly one side and so can never
-# hold there. Calling `\b` zero-width would be the safe error on its own — a
-# pattern wrongly called nullable is only refused — but `(?!\b)` negates it into
-# the unsafe one, so each anchor is classified by what it actually does.
-_ANCHORS_HOLDING_ON_EMPTY = frozenset(
+# `^`, `\A`, `$` and `\Z` hold at the sole position of an empty subject; `\b`
+# needs a word character on exactly one side and so can never hold there.
+# Calling `\b` zero-width would be the safe error on its own — a pattern wrongly
+# called nullable is only refused — but `(?!\b)` negates it into the unsafe one,
+# so each anchor is classified by what it actually does.
+_ANCHORS_ALWAYS_HOLDING_ON_EMPTY = frozenset(
     {
         "AT_BEGINNING",
         "AT_BEGINNING_STRING",
@@ -64,12 +64,27 @@ _ANCHORS_HOLDING_ON_EMPTY = frozenset(
         "AT_END",
         "AT_END_STRING",
         "AT_END_LINE",
-        "AT_NON_BOUNDARY",
-        "AT_LOC_NON_BOUNDARY",
-        "AT_UNI_NON_BOUNDARY",
     }
 )
-_ANCHORS_FAILING_ON_EMPTY = frozenset({"AT_BOUNDARY", "AT_LOC_BOUNDARY", "AT_UNI_BOUNDARY"})
+_BOUNDARY = frozenset({"AT_BOUNDARY", "AT_LOC_BOUNDARY", "AT_UNI_BOUNDARY"})
+_NON_BOUNDARY = frozenset({"AT_NON_BOUNDARY", "AT_LOC_NON_BOUNDARY", "AT_UNI_NON_BOUNDARY"})
+
+# `\B` is the one anchor whose answer here is not a fact about regular
+# expressions but a fact about this interpreter: before 3.14 it required a
+# position between two characters and so failed on an empty subject; from 3.14
+# the sole position of an empty subject is a non-boundary and it holds. Asking
+# the engine once, with a constant pattern of ours against a constant subject,
+# is both correct on every version this runs on and correct on versions that do
+# not exist yet — which hard-coding a version number is not. Nothing
+# model-supplied is run: the pattern here is two characters and this file's own.
+_NON_BOUNDARY_HOLDS_ON_EMPTY = re.search(r"\B", "") is not None
+
+_ANCHORS_HOLDING_ON_EMPTY = _ANCHORS_ALWAYS_HOLDING_ON_EMPTY | (
+    _NON_BOUNDARY if _NON_BOUNDARY_HOLDS_ON_EMPTY else frozenset()
+)
+_ANCHORS_FAILING_ON_EMPTY = _BOUNDARY | (
+    frozenset() if _NON_BOUNDARY_HOLDS_ON_EMPTY else _NON_BOUNDARY
+)
 _REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
 
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -27,20 +27,30 @@ MAX_FILES_PER_HINT = 100
 MAX_PATTERN_LENGTH = 200  # Limit LLM-generated regex length to reduce ReDoS risk
 MAX_SCALAR_LENGTH = 4096
 
-# Inputs a pattern is tried against to decide whether it discriminates at all. A
-# pattern that matches *every* one of these matches any file it is pointed at.
+# Content a pattern is tried against to decide whether matching the empty string
+# is all it can do. Most patterns that match the empty string also match every
+# other file — `.*`, `x?`, `\s*`, `(?:)`, `|`, `^` — so a hit is evidence a file
+# was read, not evidence about the criterion. `\A\Z` is the one that matters on
+# the other side: it matches the empty string and nothing else, which is how
+# "this file MUST remain empty" is written, and refusing it turns an honest
+# criterion into a formal failure.
 #
-# Empty is one probe among several, not the test on its own: `\A\Z` matches the
-# empty string and nothing else, which is exactly how "this file MUST remain empty"
-# is expressed, and rejecting it turns an honest criterion into a formal failure.
-# The distinction that matters is not "can match nothing" but "cannot tell two
-# files apart". Deliberately short and few — these run on every model-supplied
-# pattern, and a long probe is how a screen against ReDoS becomes its own ReDoS.
-_INDISCRIMINATE_PROBES = ("", "a", "0\n", " ")
+# A probe added here can only move a pattern out of that exception and into the
+# refusal, never the reverse — the screen must not get weaker as it learns.
+# Deliberately short: these run on every model-supplied pattern, and a long probe
+# is how a guard against ReDoS becomes its own ReDoS.
+_CONTENT_PROBES = ("a", "0\n")
 
 # Inputs carrying no content of their own. A pattern one of these satisfies is
 # saying "this file is empty" — a claim about one named file, not about a set.
 _CONTENTLESS_PROBES = ("", " ", "\n")
+
+
+def _matches_only_empty(compiled: re.Pattern) -> bool:
+    """True for a pattern like `\\A\\Z`, whose only hit means "this file has no content"."""
+    return compiled.search("") is not None and not any(
+        compiled.search(probe) is not None for probe in _CONTENT_PROBES
+    )
 
 
 def _satisfied_by_an_empty_file(compiled: re.Pattern) -> bool:
@@ -48,7 +58,19 @@ def _satisfied_by_an_empty_file(compiled: re.Pattern) -> bool:
     return any(compiled.search(probe) is not None for probe in _CONTENTLESS_PROBES)
 
 
-def _unnamed_empty_file(compiled: re.Pattern, files: list[str]) -> bool:
+def _hint_names_one_file(file_hint: str, files: list[str]) -> bool:
+    """True when the hint picked out a specific file rather than swept for one.
+
+    A candidate count of one is not the same thing: `**/*.py` returns a single
+    candidate in any package whose only other `.py` files sit under `.venv` or
+    `node_modules`, because `_find_files` drops those. The count is then a
+    property of the project's tree, and a hit still names no file the criterion
+    chose. Only a hint carrying no wildcard names one.
+    """
+    return bool(file_hint) and not any(c in file_hint for c in "*?[") and len(files) == 1
+
+
+def _unnamed_empty_file(compiled: re.Pattern, file_hint: str, files: list[str]) -> bool:
     """True when a hit would only say "one of these candidates happens to be empty".
 
     `\\A\\Z` is honest evidence for "`pkg/__init__.py` MUST remain empty" — but only
@@ -58,7 +80,24 @@ def _unnamed_empty_file(compiled: re.Pattern, files: list[str]) -> bool:
     The pattern discriminates between files; searching a set for *any* hit is what
     throws that away, so this is a property of the pair, not of the regex.
     """
-    return len(files) > 1 and _satisfied_by_an_empty_file(compiled)
+    return _satisfied_by_an_empty_file(compiled) and not _hint_names_one_file(file_hint, files)
+
+
+def _unnamed_empty_file_result(
+    assertion: SpecAssertion, files: list[str]
+) -> SpecVerificationResult:
+    """One refusal for both tiers — a verdict that differs by tier is a hole."""
+    return SpecVerificationResult(
+        assertion=assertion,
+        verified=False,
+        discrepancy=True,
+        detail=(
+            f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
+            f"'{assertion.file_hint}' names no file ({len(files)} candidates): a hit "
+            f"would name no particular one. Point the hint at the file the criterion "
+            f"is about."
+        ),
+    )
 
 
 def _skip_inline_space(text: str, index: int) -> int:
@@ -228,11 +267,12 @@ class SpecVerifier:
         except (re.error, OverflowError) as e:
             logger.warning("Invalid regex pattern: %s", e)
             return None
-        if all(compiled.search(probe) is not None for probe in _INDISCRIMINATE_PROBES):
-            # A pattern that matches every one of these matches whatever file it is
-            # pointed at, so a hit is evidence that a file was read, not evidence
-            # about the criterion. `.*`, `x?`, `\s*`, `(?:)`, `|` and `^` all compile,
-            # and all verified whatever criterion they were given.
+        if compiled.search("") is not None and not _matches_only_empty(compiled):
+            # A pattern that matches the empty string *and* matches content succeeds
+            # against whatever file it is pointed at. `.*`, `x?`, `\s*`, `(?:)`, `|`
+            # and `^` all compile, and all verified whatever criterion they were
+            # given. `\A\Z` is the carve-out: it matches the empty string and no
+            # content, so it still tells one file from another.
             logger.warning(
                 "Regex pattern can match without criterion content, skipping: %r", pattern
             )
@@ -277,17 +317,8 @@ class SpecVerifier:
                 detail="Unusable regex pattern: invalid, too long, or matches any input",
             )
 
-        if _unnamed_empty_file(pattern, files):
-            return SpecVerificationResult(
-                assertion=assertion,
-                verified=False,
-                discrepancy=True,
-                detail=(
-                    f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
-                    f"'{assertion.file_hint}' matched {len(files)} files: a hit would name "
-                    f"no particular one. Point the hint at the file the criterion is about."
-                ),
-            )
+        if _unnamed_empty_file(pattern, assertion.file_hint, files):
+            return _unnamed_empty_file_result(assertion, files)
 
         for file_path in files:
             content = self._read_file(file_path)
@@ -341,6 +372,21 @@ class SpecVerifier:
 
         files = self._find_files(assertion.file_hint)
 
+        # Both checks below end in a success return, so the screens run ahead of the
+        # first of them. Placed between the two, the empty-file guard would refuse a
+        # pattern on the content path that the filename path had already accepted.
+        content_pattern = self._safe_compile(assertion.pattern)
+        if content_pattern is None:
+            return SpecVerificationResult(
+                assertion=assertion,
+                verified=False,
+                discrepancy=True,
+                detail="Unusable regex pattern: invalid, too long, or matches any input",
+            )
+
+        if _unnamed_empty_file(content_pattern, assertion.file_hint, files):
+            return _unnamed_empty_file_result(assertion, files)
+
         # First check: does the pattern match any filename?
         name_pattern = self._safe_compile(assertion.pattern, re.IGNORECASE)
 
@@ -356,26 +402,6 @@ class SpecVerifier:
                     )
 
         # Second check: search file contents for class/function/interface
-        content_pattern = self._safe_compile(assertion.pattern)
-        if content_pattern is None:
-            return SpecVerificationResult(
-                assertion=assertion,
-                verified=False,
-                discrepancy=True,
-                detail="Unusable regex pattern: invalid, too long, or matches any input",
-            )
-
-        if _unnamed_empty_file(content_pattern, files):
-            return SpecVerificationResult(
-                assertion=assertion,
-                verified=False,
-                discrepancy=True,
-                detail=(
-                    f"Pattern '{assertion.pattern}' is satisfied by an empty file, and hint "
-                    f"'{assertion.file_hint}' matched {len(files)} files: a hit would name "
-                    f"no particular one. Point the hint at the file the criterion is about."
-                ),
-            )
 
         for file_path in files:
             content = self._read_file(file_path)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -186,15 +186,23 @@ class SpecVerifier:
         )
 
     def _safe_compile(self, pattern: str, flags: int = 0) -> re.Pattern | None:
-        """Compile regex with length guard against ReDoS from LLM-generated patterns."""
+        """Compile a model-supplied regex, refusing one that cannot be evidence."""
         if len(pattern) > MAX_PATTERN_LENGTH:
             logger.warning("Regex pattern too long (%d chars), skipping", len(pattern))
             return None
         try:
-            return re.compile(pattern, flags)
+            compiled = re.compile(pattern, flags)
         except (re.error, OverflowError) as e:
             logger.warning("Invalid regex pattern: %s", e)
             return None
+        if compiled.search("") is not None:
+            # A pattern that matches the empty string matches every subject, so a hit
+            # on a real file is not evidence about the criterion — it is evidence that
+            # the file exists. `.*`, `x?`, `\s*`, `(?:)`, `|`, `^` and `\A\Z` all
+            # compile, and all verified whatever criterion they were pointed at.
+            logger.warning("Regex pattern matches any input, skipping: %r", pattern)
+            return None
+        return compiled
 
     def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult | None:
         """Verify a single assertion. Returns None for skipped tiers."""
@@ -231,7 +239,7 @@ class SpecVerifier:
                 assertion=assertion,
                 verified=False,
                 discrepancy=True,
-                detail="Invalid or too-long regex pattern",
+                detail="Unusable regex pattern: invalid, too long, or matches any input",
             )
 
         for file_path in files:
@@ -307,7 +315,7 @@ class SpecVerifier:
                 assertion=assertion,
                 verified=False,
                 discrepancy=True,
-                detail="Invalid or too-long regex pattern",
+                detail="Unusable regex pattern: invalid, too long, or matches any input",
             )
 
         for file_path in files:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -55,16 +55,63 @@ _ZERO_WIDTH = frozenset({"AT"})
 _REPEATS = frozenset({"MAX_REPEAT", "MIN_REPEAT", "POSSESSIVE_REPEAT"})
 
 
+def _all_empty(answers: list[bool | None]) -> bool | None:
+    """Can a run of things, taken together, match nothing?
+
+    Only if each of them can. One that certainly cannot settles it for the whole
+    run; otherwise a single unknown leaves the run unknown.
+    """
+    if any(answer is False for answer in answers):
+        return False
+    if all(answer is True for answer in answers):
+        return True
+    return None
+
+
+def _any_empty(answers: list[bool | None]) -> bool | None:
+    """Can one of a set of alternatives match nothing?
+
+    Yes as soon as one certainly can; no only if every one certainly cannot.
+    """
+    if any(answer is True for answer in answers):
+        return True
+    if all(answer is False for answer in answers):
+        return False
+    return None
+
+
+def _agreed(answers: list[bool | None]) -> bool | None:
+    """The one answer they all give, or unknown if they do not all give it.
+
+    For a construct where which part runs is itself undecidable — a conditional
+    on whether a group took part — the result is only certain when the parts
+    cannot disagree.
+    """
+    if all(answer is True for answer in answers):
+        return True
+    if all(answer is False for answer in answers):
+        return False
+    return None
+
+
 def _can_match_nothing(
-    sequence: object, depth: int = 0, groups: dict[int, bool] | None = None
-) -> bool:
+    sequence: object, depth: int = 0, groups: dict[int, bool | None] | None = None
+) -> bool | None:
     """Whether a parsed regex can match the empty string, read rather than run.
 
-    Answers True whenever the answer cannot be worked out — an unknown construct,
-    a tree deeper than this follows. A pattern wrongly called nullable is refused
-    as evidence, which costs an honest criterion a formal failure; one wrongly
-    called discriminating is admitted, and admitting those is the whole defect
-    this file exists to close. So the doubt goes to refusal.
+    Three answers, not two: True, False, and None for "this reading cannot tell".
+    An unknown construct or a tree deeper than `_MAX_PARSE_DEPTH` is None, and so
+    is anything built out of a None.
+
+    The third answer is what keeps the doubt pointed at refusal. Refusal is the
+    safe direction — a pattern wrongly called nullable costs an honest criterion
+    a formal failure, while one wrongly called discriminating is admitted as
+    evidence, which is the defect this file exists to close — but "safe" is a
+    direction, and `(?!…)` reverses direction. Answering an unreadable inner
+    pattern with a plain True and then negating it produces a confident False:
+    the guard would report *certainty that the pattern discriminates* on the
+    strength of not having understood it. None negates to None, so the doubt
+    survives the negation and `_matches_the_empty_string` still refuses.
 
     `groups` carries what each capture group, once seen, can itself match, so a
     backreference can be judged by what it refers to.
@@ -72,7 +119,8 @@ def _can_match_nothing(
     if groups is None:
         groups = {}
     if depth > _MAX_PARSE_DEPTH:
-        return True
+        return None
+    answers: list[bool | None] = []
     for opcode, argument in sequence:  # type: ignore[attr-defined]
         name = getattr(opcode, "name", str(opcode))
         if name in _ZERO_WIDTH:
@@ -87,71 +135,60 @@ def _can_match_nothing(
             # A repeat that may run zero times is skippable; one that must run
             # is empty only if what it repeats is. The count itself is never
             # counted out.
-            if minimum == 0 or item_empty:
-                continue
-            return False
-        if name == "SUBPATTERN":
+            answers.append(True if minimum == 0 else item_empty)
+        elif name == "SUBPATTERN":
             body_empty = _can_match_nothing(argument[-1], depth + 1, groups)
             if argument[0] is not None:
                 groups[argument[0]] = body_empty
-            if body_empty:
-                continue
-            return False
-        if name == "GROUPREF":
+            answers.append(body_empty)
+        elif name == "GROUPREF":
             # A backreference repeats whatever its group captured, so it is empty
             # only when that group can be. If the group never participated the
             # reference cannot match at all — never empty either. A group not yet
-            # seen (a forward reference) is unknown, and unknown means refuse.
-            if groups.get(argument, True):
-                continue
-            return False
-        if name == "GROUPREF_EXISTS":
-            # `(?(1)yes|no)`: whichever arm runs, it has to be able to be empty.
-            reference, yes_arm, no_arm = argument
-            del reference
-            arms_empty = [_can_match_nothing(yes_arm, depth + 1, groups)]
-            arms_empty.append(
-                True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups)
-            )
-            if any(arms_empty):
-                continue
-            return False
-        if name == "ATOMIC_GROUP":
-            if _can_match_nothing(argument, depth + 1, groups):
-                continue
-            return False
-        if name == "BRANCH":
+            # seen (a forward reference) is unknown, and stays unknown.
+            answers.append(groups.get(argument))
+        elif name == "GROUPREF_EXISTS":
+            # `(?(1)yes|no)`: which arm runs depends on whether the group took
+            # part, which this does not track. So the conditional is only certain
+            # when both arms agree, and unknown when they do not.
+            _reference, yes_arm, no_arm = argument
+            arms = [_can_match_nothing(yes_arm, depth + 1, groups)]
+            arms.append(True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups))
+            answers.append(_agreed(arms))
+        elif name == "ATOMIC_GROUP":
+            answers.append(_can_match_nothing(argument, depth + 1, groups))
+        elif name == "BRANCH":
             # Every branch is walked, not just up to the first empty one, so that
             # groups defined in a later branch are recorded too.
-            branches_empty = [
-                _can_match_nothing(branch, depth + 1, groups) for branch in argument[1]
-            ]
-            if any(branches_empty):
-                continue
-            return False
-        if name == "ASSERT":
+            answers.append(
+                _any_empty(
+                    [_can_match_nothing(branch, depth + 1, groups) for branch in argument[1]]
+                )
+            )
+        elif name == "ASSERT":
             # On a subject with nothing in it there is nothing to either side, so
             # a lookaround holds exactly when what it looks for can be empty.
             # `(?=.*foo)` cannot, which is why a lookahead-only pattern stays
             # admissible evidence.
-            if _can_match_nothing(argument[1], depth + 1, groups):
-                continue
-            return False
-        if name == "ASSERT_NOT":
-            if not _can_match_nothing(argument[1], depth + 1, groups):
-                continue
-            return False
-        return True
-    return True
+            answers.append(_can_match_nothing(argument[1], depth + 1, groups))
+        elif name == "ASSERT_NOT":
+            inner = _can_match_nothing(argument[1], depth + 1, groups)
+            answers.append(None if inner is None else not inner)
+        else:
+            answers.append(None)
+    return _all_empty(answers)
 
 
 def _matches_the_empty_string(pattern: str, flags: int = 0) -> bool:
-    """Whether `pattern` can match a subject with nothing in it. Never runs it."""
+    """Whether `pattern` can match a subject with nothing in it. Never runs it.
+
+    Unknown counts as yes, which refuses the pattern as evidence.
+    """
     try:
         parsed = regex_parser.parse(pattern, flags)
     except Exception:  # pragma: no cover - re.compile has already accepted this
         return True
-    return _can_match_nothing(parsed)
+    return _can_match_nothing(parsed) is not False
 
 
 # Words that make an acceptance criterion a claim about a file holding nothing.
@@ -348,6 +385,13 @@ def _mask_file_hint(ac_text: str, file_hint: str) -> str:
 
     Names are matched as whole tokens for the same reason the mention check is —
     `a.py` sits inside `data.py`.
+
+    And case-insensitively for the same reason too. The mention check already
+    ignores case, so `Marker.txt must be empty` against a hint of `marker.txt`
+    reached this function, went unmasked because the substitution did not, and
+    lost the one token the reading anchors on — an ordinary criterion on a file
+    that satisfies it, turned into an authoritative failure by a capital letter.
+    Both places normalize the same way now.
     """
     if not file_hint:
         return ac_text
@@ -355,6 +399,7 @@ def _mask_file_hint(ac_text: str, file_hint: str) -> str:
         rf"(\A|[\s'\"`(\[]){re.escape(file_hint)}(?=\Z|[\s'\"`)\],.;:])",
         rf"\1{_FILE_TOKEN}",
         ac_text,
+        flags=re.IGNORECASE,
     )
 
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -97,18 +97,32 @@ class _Group(NamedTuple):
     """Whether the group can have participated in such a match."""
 
 
-def _participation(body_empty: bool | None, optional: bool) -> bool | None:
+def _skippable(on_path: bool | None) -> bool | None:
+    """A path the match may have gone around — unless it was never on it at all.
+
+    A repeat that may run zero times, an alternative, and a conditional's arms
+    are all paths the match need not have taken. Inside a negative assertion the
+    answer is already the stronger `False` and stays there: something the match
+    certainly did not walk does not become something it merely might have.
+    """
+    return False if on_path is False else None
+
+
+def _participation(body_empty: bool | None, on_path: bool | None) -> bool | None:
     """Whether a group reached here can have taken part in an empty match.
 
-    A group whose body certainly consumes certainly did not take part: had it
-    run, the match would not have been empty. A group whose body can be empty
-    took part only if the path through it is the only path; under a repeat that
-    may run zero times, an alternative, or a lookaround, it may equally have
-    been skipped, and that is not something this reading can settle.
+    A group the match certainly never walked certainly did not take part, whether
+    or not its body consumes. Otherwise a group whose body certainly consumes
+    certainly did not take part either: had it run, the match would not have been
+    empty. A group whose body can be empty took part only if the path through it
+    is the only path; where the path may have been skipped it may equally have
+    taken part or not, and that is not something this reading can settle.
     """
+    if on_path is False:
+        return False
     if body_empty is False:
         return False
-    if body_empty is True and not optional:
+    if body_empty is True and on_path is True:
         return True
     return None
 
@@ -156,7 +170,7 @@ def _can_match_nothing(
     sequence: object,
     depth: int = 0,
     groups: dict[int, _Group] | None = None,
-    optional: bool = False,
+    on_path: bool | None = True,
 ) -> bool | None:
     """Whether a parsed regex can match the empty string, read rather than run.
 
@@ -177,8 +191,12 @@ def _can_match_nothing(
     `groups` carries, for each capture group once seen, what it can itself match
     and whether it can have taken part in an empty match — the first so a
     backreference can be judged by what it refers to, the second so a conditional
-    can be judged by which arm it would run. `optional` says whether the path
-    being walked is one the match could have avoided taking.
+    can be judged by which arm it would run.
+
+    `on_path` says what the match did with the path being walked, and is itself
+    three-valued: True for a path the match certainly took, False for one it
+    certainly did not — the inside of a negative assertion, which succeeds only
+    by failing — and None where it may have gone either way.
     """
     if groups is None:
         groups = {}
@@ -198,16 +216,18 @@ def _can_match_nothing(
             minimum, _maximum, item = argument
             # Walked whatever the count, so that groups inside a repeat that may
             # run zero times are still recorded for a later backreference.
-            item_empty = _can_match_nothing(item, depth + 1, groups, optional or minimum == 0)
+            item_empty = _can_match_nothing(
+                item, depth + 1, groups, _skippable(on_path) if minimum == 0 else on_path
+            )
             # A repeat that may run zero times is skippable; one that must run
             # is empty only if what it repeats is. The count itself is never
             # counted out.
             answers.append(True if minimum == 0 else item_empty)
         elif name == "SUBPATTERN":
-            body_empty = _can_match_nothing(argument[-1], depth + 1, groups, optional)
+            body_empty = _can_match_nothing(argument[-1], depth + 1, groups, on_path)
             number = argument[0]
             if number is not None:
-                groups[number] = _Group(body_empty, _participation(body_empty, optional))
+                groups[number] = _Group(body_empty, _participation(body_empty, on_path))
             answers.append(body_empty)
         elif name == "GROUPREF":
             # A backreference repeats whatever its group captured, so it is empty
@@ -224,8 +244,9 @@ def _can_match_nothing(
             # conditional fall back on the arms having to agree.
             reference, yes_arm, no_arm = argument
             took_part = groups[reference].took_part if reference in groups else None
-            yes = _can_match_nothing(yes_arm, depth + 1, groups, True)
-            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, True)
+            arm_path = _skippable(on_path)
+            yes = _can_match_nothing(yes_arm, depth + 1, groups, arm_path)
+            no = True if no_arm is None else _can_match_nothing(no_arm, depth + 1, groups, arm_path)
             if took_part is True:
                 answers.append(yes)
             elif took_part is False:
@@ -233,14 +254,17 @@ def _can_match_nothing(
             else:
                 answers.append(_agreed([yes, no]))
         elif name == "ATOMIC_GROUP":
-            answers.append(_can_match_nothing(argument, depth + 1, groups, optional))
+            answers.append(_can_match_nothing(argument, depth + 1, groups, on_path))
         elif name == "BRANCH":
             # Every branch is walked, not just up to the first empty one, so that
             # groups defined in a later branch are recorded too. Only one of them
             # runs, so none of them is a path the match had to take.
             answers.append(
                 _any_empty(
-                    [_can_match_nothing(branch, depth + 1, groups, True) for branch in argument[1]]
+                    [
+                        _can_match_nothing(branch, depth + 1, groups, _skippable(on_path))
+                        for branch in argument[1]
+                    ]
                 )
             )
         elif name == "ASSERT":
@@ -248,9 +272,19 @@ def _can_match_nothing(
             # a lookaround holds exactly when what it looks for can be empty.
             # `(?=.*foo)` cannot, which is why a lookahead-only pattern stays
             # admissible evidence.
-            answers.append(_can_match_nothing(argument[1], depth + 1, groups, True))
+            #
+            # A positive assertion has to hold for the match to happen, so the
+            # path through it is not one the match could have gone around — a
+            # capture inside it took part exactly as much as the same capture
+            # written outside it would have. Calling it optional here is what
+            # made `(?=())(?(1)x|)` unreadable and refused it as evidence.
+            answers.append(_can_match_nothing(argument[1], depth + 1, groups, on_path))
         elif name == "ASSERT_NOT":
-            inner = _can_match_nothing(argument[1], depth + 1, groups, True)
+            # A negative assertion succeeds only where its body fails, and a
+            # subpattern that fails leaves nothing captured behind it. So this is
+            # the one path the match certainly did not walk, and every capture
+            # inside it certainly did not take part.
+            inner = _can_match_nothing(argument[1], depth + 1, groups, False)
             answers.append(None if inner is None else not inner)
         else:
             answers.append(None)

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -155,6 +155,31 @@ _CRITERION_LEAD = frozenset(
 # never meant. Underscored to keep it out of reach of any English word.
 _FILE_TOKEN = "__the_file__"
 
+# Quotes and brackets wrap a name without changing what is claimed about it, and
+# whitespace separates. Everything else in a criterion has to be a word or one of
+# these marks, because a character this cannot read may be the whole of the
+# meaning: `!=` and `≠` invert the very claim they sit in, and a digit or an
+# operator can carry an obligation of its own. So the criterion is consumed
+# character by character and an unreadable one refuses the whole reading — a scan
+# that silently drops what it does not recognise is matching a *part* again, one
+# layer below the tokens.
+_READABLE = re.compile(r"[a-z_]+|[.,;:]|['’\"`()\[\]]|\s+")
+_MARKUP = frozenset("'’\"`()[]")
+
+
+def _criterion_tokens(text: str) -> list[str] | None:
+    """Every word and mark of `text`, or None if any character is unreadable."""
+    tokens: list[str] = []
+    consumed = 0
+    for match in _READABLE.finditer(text):
+        if match.start() != consumed:
+            return None
+        consumed = match.end()
+        token = match.group()
+        if not token.isspace() and token not in _MARKUP:
+            tokens.append(token)
+    return tokens if consumed == len(text) else None
+
 
 def _mask_file_hint(ac_text: str, file_hint: str) -> str:
     """Replace mentions of the file's own name with `_FILE_TOKEN`.
@@ -182,7 +207,7 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
 
         <lead>* <file> <chain>* <copula> (empty | blank) ["."]
 
-    every token consumed. Matching the whole of it is what makes the rescue
+    every character of it consumed. Matching the whole of it is what makes the rescue
     safe to answer, and it is a stronger claim than matching a part: a criterion
     that says more is also *asking* for more — "must be empty and contain a
     header" carries a second obligation, and answering only the emptiness half
@@ -195,13 +220,16 @@ def _emptiness_the_criterion_requires(ac_text: str, file_hint: str) -> str | Non
     Consuming the whole criterion also leaves nowhere to put the words that
     broke every narrower version of this: a negation, a governing verb, a
     competing subject and a trailing obligation are all outside the shape, on
-    either side of the name, at any distance.
+    either side of the name, at any distance — and so is a negation written as a
+    symbol, because the reading is over characters and `!=` is not among the ones
+    it can read.
 
     Reading words rather than substrings is what keeps `nonempty` from being an
     occurrence of `empty`.
     """
-    text = _mask_file_hint(ac_text, file_hint).lower().replace("'", "").replace("’", "")
-    tokens = re.findall(r"[a-z_]+|[.,;:]", text)
+    tokens = _criterion_tokens(_mask_file_hint(ac_text, file_hint).lower())
+    if tokens is None:
+        return None
     if tokens and tokens[-1] == ".":
         tokens.pop()
     step = 0

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -676,6 +676,69 @@ Parallel Execution Verification Report
         [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
         ids=["T1", "T2"],
     )
+    @pytest.mark.parametrize(
+        ("filename", "content", "ac_text"),
+        [
+            ("empty.txt", "", "empty.txt MUST contain data"),
+            ("marker.txt", "", "marker.txt MUST contain an empty JSON string field"),
+            ("marker.txt", "", "marker.txt MUST be an empty JSON object"),
+            ("marker.txt", "  \t\n", "marker.txt MUST be empty"),
+        ],
+        ids=["empty-filename", "nested-value", "attributive", "whitespace-is-not-empty"],
+    )
+    def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(
+        self, tmp_path: Any, tier: VerificationTier, filename: str, content: str, ac_text: str
+    ) -> None:
+        """An emptiness word not predicated of the file must not reach formal approval.
+
+        Three of these require the file to hold content while mentioning emptiness —
+        in the filename, in a nested value, as an adjective on another noun. The
+        fourth is a whitespace-only file against an `empty` criterion, which `\\A\\Z`
+        does not match either. Each produced `final_approved=True`, `score=1.0`,
+        `final_verdict="pass"` at the adapter for a criterion the project violates.
+        """
+        (tmp_path / filename).write_text(content)
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint=filename,
+        )
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content=ac_text,
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is False, f"{ac_text!r} must not be approved"
+        assert summary.ac_results[0].final_verdict != "pass"
+        assert summary.final_approved is False
+        assert summary.score == 0.0
+        assert summary.run_verdict == "FAIL"
+
+    @pytest.mark.parametrize(
+        "tier",
+        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
+        ids=["T1", "T2"],
+    )
     def test_a_forbidden_empty_file_cannot_be_approved_through_the_adapter(
         self, tmp_path: Any, tier: VerificationTier
     ) -> None:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -56,6 +56,7 @@ from ouroboros.verification.models import (
     SpecVerificationSummary,
     VerificationTier,
 )
+from ouroboros.verification.verifier import SpecVerifier
 
 
 class _FakeEventStore:
@@ -668,6 +669,62 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.failure_reason == "1/1 ACs failed (AC 1) [1 spec verification override(s)]"
         assert summary.drift_score is None
+        assert summary.run_verdict == "FAIL"
+
+    @pytest.mark.parametrize(
+        "tier",
+        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
+        ids=["T1", "T2"],
+    )
+    def test_a_forbidden_empty_file_cannot_be_approved_through_the_adapter(
+        self, tmp_path: Any, tier: VerificationTier
+    ) -> None:
+        """A zero-width pattern on an empty file must not approve "MUST NOT be empty".
+
+        This drives the real verifier, not a hand-built report: an extracted
+        pattern of ``\\A\\Z`` matches an empty file, so a verifier that took its
+        polarity from the pattern rather than from the AC text handed the
+        adapter a passing report and the adapter dutifully published
+        final_approved=True / score=1.0 / final_verdict="pass" for a criterion
+        the project violates.
+        """
+        marker = tmp_path / "marker.txt"
+        marker.write_text("")
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST NOT be empty",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="marker.txt",
+        )
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="marker.txt MUST NOT be empty",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].final_verdict != "pass"
+        assert summary.final_approved is False
+        assert summary.score == 0.0
+        assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
     def test_spec_verification_rejects_partial_ac_coverage(self) -> None:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -883,6 +883,9 @@ Parallel Execution Verification Report
             ("", "Please ensure Marker.txt is empty", r"\A\Z"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(a)?(?(1)|a)"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(a?)(?(1)a|)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?=())(?(1)a|)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?<=())(?(1)a|)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!()x)(?(1)|a)"),
         ],
         ids=[
             "politeness-frame",
@@ -896,6 +899,9 @@ Parallel Execution Verification Report
             "capitalized-in-frame",
             "conditional-on-an-absent-group",
             "conditional-on-a-present-group",
+            "conditional-on-a-capture-inside-a-lookahead",
+            "conditional-on-a-capture-inside-a-lookbehind",
+            "conditional-on-a-capture-inside-a-failed-negative-lookahead",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -888,6 +888,8 @@ Parallel Execution Verification Report
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!()x)(?(1)|a)"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!x())(?(1)|a)"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!x())\1|aa"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!)|aa"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"aa(?!)|aa"),
         ],
         ids=[
             "politeness-frame",
@@ -906,6 +908,8 @@ Parallel Execution Verification Report
             "conditional-on-a-capture-inside-a-failed-negative-lookahead",
             "conditional-on-a-capture-after-a-consuming-atom",
             "backreference-to-a-capture-that-did-not-take-part",
+            "branch-that-can-never-be-taken",
+            "branch-that-can-never-be-taken-after-a-literal",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
@@ -927,7 +931,11 @@ Parallel Execution Verification Report
         filename, which the mention check ignored and the masking that follows it
         did not. The last two are conditionals whose arms disagree, refused
         because the reading required agreement instead of asking whether the
-        group could have taken part. Both directions are driven through the real verifier
+        group could have taken part. The last two are the same failure made by
+        the interpreter rather than by the reading: from 3.13 the parser folds
+        `(?!)` into a single opcode this walk did not know, so a pattern with an
+        unreachable branch was evidence on 3.12 and an authoritative failure on
+        3.13 and 3.14. Both directions are driven through the real verifier
         and the real adapter, because the failure only becomes authoritative at
         this boundary.
         """

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -863,6 +863,86 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
+    @pytest.mark.parametrize(
+        "tier",
+        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
+        ids=["T1", "T2"],
+    )
+    @pytest.mark.parametrize(
+        ("content", "ac_text", "pattern"),
+        [
+            ("", "Please ensure marker.txt is empty", r"\A\Z"),
+            ("", "Kindly make sure marker.txt is empty", r"\A\Z"),
+            ("", "It is required that marker.txt be empty", r"\A\Z"),
+            ("", "Check that marker.txt is empty", r"\A\Z"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(a)?\1"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?P<x>a)?(?P=x)"),
+        ],
+        ids=[
+            "politeness-frame",
+            "politeness-and-periphrasis",
+            "impersonal-obligation",
+            "checking-verb",
+            "numbered-backreference",
+            "named-backreference",
+        ],
+    )
+    def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
+        self, tmp_path: Any, tier: VerificationTier, content: str, ac_text: str, pattern: str
+    ) -> None:
+        """Over-rejection is the same blocker seen from the other side.
+
+        Each case here is a project that *meets* its criterion, and each was
+        published as `final_approved=False` / `score=0.0` / `run_verdict="FAIL"`
+        — an authoritative failure manufactured by the guard rather than by the
+        code under test.
+
+        The first four were refused because a word that carries no claim at all
+        was absent from the words known to carry none: `Please ensure marker.txt
+        is empty`, with an empty `marker.txt`, failed on `please`. The last two
+        were refused because every backreference was treated as zero-width, so
+        `(a)?\\1` — which cannot match nothing and does match this file — was
+        called unusable. Both directions are driven through the real verifier
+        and the real adapter, because the failure only becomes authoritative at
+        this boundary.
+        """
+        (tmp_path / "marker.txt").write_text(content)
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content=ac_text,
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is True, f"{ac_text!r} must not be failed"
+        assert summary.ac_results[0].final_verdict == "pass"
+        assert summary.final_approved is True
+        assert summary.score == 1.0
+        assert summary.run_verdict != "FAIL"
+
     def test_spec_verification_rejects_partial_ac_coverage(self) -> None:
         """A subset of verifier reports must not approve unverified ACs."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import UTC, datetime
+import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -1029,6 +1030,71 @@ Parallel Execution Verification Report
         assert summary.final_approved is False
         assert summary.score == 0.0
         assert summary.run_verdict == "FAIL"
+
+    @pytest.mark.parametrize(
+        "tier",
+        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
+        ids=["T1", "T2"],
+    )
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"\B", r"(?!\B)", r"(?<!\B)", r"(?=\B)"],
+        ids=["non-boundary", "negated", "negated-lookbehind", "asserted"],
+    )
+    def test_a_non_boundary_reaches_the_formal_verdict_this_interpreter_justifies(
+        self, tmp_path: Any, tier: VerificationTier, pattern: str
+    ) -> None:
+        """Whether `\\B` holds on an empty subject changed in CPython 3.14.
+
+        Written into the anchor table as a constant, it was right on the
+        interpreter it was written on and wrong on 3.12, where `(?!\\B)` matches
+        every file: an unrelated `marker.txt` was published here as
+        `final_approved=True`, `score=1.0`, `run_verdict="PASS"` for a
+        `CameraProvider` that does not exist. The table now asks the engine, so
+        the assertion is that the formal verdict follows what this interpreter
+        actually does — a pattern that matches nothing at all is refused and
+        fails, one that discriminates is approved — and it pins every version CI
+        runs without naming one.
+        """
+        matches_nothing = re.search(pattern, "") is not None
+        (tmp_path / "marker.txt").write_text("hello\n")
+        ac_text = "marker.txt MUST declare a CameraProvider"
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content=ac_text,
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is not matches_nothing, (
+            f"{pattern!r} matches the empty string here: {matches_nothing}"
+        )
+        assert summary.final_approved is not matches_nothing
+        assert summary.score == (0.0 if matches_nothing else 1.0)
+        assert (summary.run_verdict == "FAIL") is matches_nothing
 
     def test_spec_verification_rejects_partial_ac_coverage(self) -> None:
         """A subset of verifier reports must not approve unverified ACs."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -696,6 +696,10 @@ Parallel Execution Verification Report
                 "marker.txt must be empty, but must also contain generated metadata",
             ),
             ("marker.txt", "", "marker.txt must be deleted, and marker.txt must be empty"),
+            ("marker.txt", "", "marker.txt MUST be != empty"),
+            ("marker.txt", "", "marker.txt MUST be ≠ empty"),
+            ("marker.txt", "", "marker.txt must be empty 100%"),
+            ("marker.txt", "", "marker.txt must be empty > 0 bytes"),
         ],
         ids=[
             "empty-filename",
@@ -711,6 +715,10 @@ Parallel Execution Verification Report
             "compound-modal-obligation",
             "compound-after-comma",
             "obligation-in-preamble",
+            "ascii-symbolic-negation",
+            "unicode-symbolic-negation",
+            "numeric-obligation",
+            "operator-obligation",
         ],
     )
     def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(
@@ -723,12 +731,20 @@ Parallel Execution Verification Report
         the file named as the object of a preposition while some field inside it is
         the subject. One is a whitespace-only file against an `empty` criterion,
         which `\\A\\Z` does not match either, and one puts its negation far enough
-        along that a bounded lookback loses it. The last four are compound: the
-        file may well be empty, but the criterion also demands a header, a
-        deletion or some metadata, and nothing verified those — answering the
-        emptiness half alone publishes a pass for a requirement no one checked.
-        Each produced `final_approved=True`, `score=1.0`, `final_verdict="pass"`
-        at the adapter for a criterion the project violates or has not met.
+        along that a bounded lookback loses it. Four are compound: the file may
+        well be empty, but the criterion also demands a header, a deletion or
+        some metadata, and nothing verified those — answering the emptiness half
+        alone publishes a pass for a requirement no one checked.
+
+        The last four carry their extra meaning in characters rather than words.
+        A tokenizer that keeps only what it recognises deletes the rest, so `!=`
+        and `≠` disappeared and their criteria read as the bare requirement they
+        negate; a trailing `100%` or `> 0 bytes` disappeared the same way. These
+        are here at the formal boundary because deletion at the character level
+        is indistinguishable, from the outside, from the criterion never having
+        said it. Each produced `final_approved=True`, `score=1.0`,
+        `final_verdict="pass"` at the adapter for a criterion the project
+        violates or has not met.
         """
         (tmp_path / filename).write_text(content)
         assertion = SpecAssertion(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -688,6 +688,14 @@ Parallel Execution Verification Report
             ("marker.txt", "", "marker.txt must not under any circumstances be empty."),
             ("marker.txt", "", "The status field in the generated marker.txt must be empty."),
             ("marker.txt", "", "The first record of the newly created marker.txt must be blank"),
+            ("marker.txt", "", "marker.txt must be empty and contain a header"),
+            ("marker.txt", "", "marker.txt must be empty and must be deleted"),
+            (
+                "marker.txt",
+                "",
+                "marker.txt must be empty, but must also contain generated metadata",
+            ),
+            ("marker.txt", "", "marker.txt must be deleted, and marker.txt must be empty"),
         ],
         ids=[
             "empty-filename",
@@ -699,6 +707,10 @@ Parallel Execution Verification Report
             "distant-negation",
             "modifier-separated-preposition",
             "two-modifiers-separated-preposition",
+            "compound-obligation",
+            "compound-modal-obligation",
+            "compound-after-comma",
+            "obligation-in-preamble",
         ],
     )
     def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(
@@ -711,9 +723,12 @@ Parallel Execution Verification Report
         the file named as the object of a preposition while some field inside it is
         the subject. One is a whitespace-only file against an `empty` criterion,
         which `\\A\\Z` does not match either, and one puts its negation far enough
-        along that a bounded lookback loses it. Each produced `final_approved=True`,
-        `score=1.0`, `final_verdict="pass"` at the adapter for a criterion the
-        project violates.
+        along that a bounded lookback loses it. The last four are compound: the
+        file may well be empty, but the criterion also demands a header, a
+        deletion or some metadata, and nothing verified those — answering the
+        emptiness half alone publishes a pass for a requirement no one checked.
+        Each produced `final_approved=True`, `score=1.0`, `final_verdict="pass"`
+        at the adapter for a criterion the project violates or has not met.
         """
         (tmp_path / filename).write_text(content)
         assertion = SpecAssertion(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -880,6 +880,8 @@ Parallel Execution Verification Report
             ("", "Marker.txt must be empty", r"\A\Z"),
             ("", "MARKER.TXT must be empty", r"\A\Z"),
             ("", "Please ensure Marker.txt is empty", r"\A\Z"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(a)?(?(1)|a)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(a?)(?(1)a|)"),
         ],
         ids=[
             "politeness-frame",
@@ -891,6 +893,8 @@ Parallel Execution Verification Report
             "capitalized-mention",
             "shouted-mention",
             "capitalized-in-frame",
+            "conditional-on-an-absent-group",
+            "conditional-on-a-present-group",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
@@ -908,9 +912,11 @@ Parallel Execution Verification Report
         is empty`, with an empty `marker.txt`, failed on `please`. The last two
         were refused because every backreference was treated as zero-width, so
         `(a)?\\1` — which cannot match nothing and does match this file — was
-        called unusable. The last three differ from the hint only in the case of
-        the filename, which the mention check ignored and the masking that
-        follows it did not. Both directions are driven through the real verifier
+        called unusable. Three differ from the hint only in the case of the
+        filename, which the mention check ignored and the masking that follows it
+        did not. The last two are conditionals whose arms disagree, refused
+        because the reading required agreement instead of asking whether the
+        group could have taken part. Both directions are driven through the real verifier
         and the real adapter, because the failure only becomes authoritative at
         this boundary.
         """
@@ -962,8 +968,16 @@ Parallel Execution Verification Report
             r"(?!(a)?(?(1)|c))",
             r"(?!(a)?(?(1)|x)b)",
             "(?!" + "(" * 45 + "x" + ")" * 45 + ")",
+            r"(?!\b)",
+            r"(?<!\b)",
         ],
-        ids=["negated-conditional", "negated-conditional-with-tail", "negated-past-depth-limit"],
+        ids=[
+            "negated-conditional",
+            "negated-conditional-with-tail",
+            "negated-past-depth-limit",
+            "negated-boundary",
+            "negated-lookbehind-boundary",
+        ],
     )
     def test_a_negated_guess_cannot_be_approved_through_the_adapter(
         self, tmp_path: Any, tier: VerificationTier, pattern: str

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -892,6 +892,8 @@ Parallel Execution Verification Report
             ("aa\n", "marker.txt MUST contain a doubled letter", r"aa(?!)|aa"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"()(?(1)Impossible|)|aa"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"aa|()(?(1)Impossible|)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?:()|x)(?(1)a|)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"()(?(1)()|)(?(2)a|)"),
         ],
         ids=[
             "politeness-frame",
@@ -914,6 +916,8 @@ Parallel Execution Verification Report
             "branch-that-can-never-be-taken-after-a-literal",
             "conditional-in-the-first-branch",
             "conditional-in-the-second-branch",
+            "conditional-after-a-branch-only-one-of-which-can-be-empty",
+            "capture-in-the-arm-the-conditional-selects",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
@@ -997,6 +1001,8 @@ Parallel Execution Verification Report
             "(?!" + "(" * 45 + "x" + ")" * 45 + ")",
             r"(?!\b)",
             r"(?<!\b)",
+            r"(?!()(?(1)a|))",
+            r"(?!(?!(a?)(?(1)|a)))",
         ],
         ids=[
             "negated-conditional",
@@ -1004,6 +1010,8 @@ Parallel Execution Verification Report
             "negated-past-depth-limit",
             "negated-boundary",
             "negated-lookbehind-boundary",
+            "negated-conditional-on-a-capture-beside-it",
+            "twice-negated-conditional-on-a-nullable-capture",
         ],
     )
     def test_a_negated_guess_cannot_be_approved_through_the_adapter(
@@ -1018,6 +1026,12 @@ Parallel Execution Verification Report
         confidence that the pattern discriminates. Published here as
         `final_approved=True`, `score=1.0`, `run_verdict="PASS"` for an AC the
         file does not satisfy.
+
+        The last two arrive by a narrower road: the negation was also declaring
+        the captures written inside its own body absent *while that body was
+        still being read*, so a conditional standing beside such a capture took
+        the arm the runtime never takes. The body is an attempt like any other,
+        and what it captured is real to everything inside it.
         """
         (tmp_path / "marker.txt").write_text("hello\n")
         ac_text = "marker.txt MUST declare a CameraProvider"

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -886,6 +886,8 @@ Parallel Execution Verification Report
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?=())(?(1)a|)"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?<=())(?(1)a|)"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!()x)(?(1)|a)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!x())(?(1)|a)"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!x())\1|aa"),
         ],
         ids=[
             "politeness-frame",
@@ -902,6 +904,8 @@ Parallel Execution Verification Report
             "conditional-on-a-capture-inside-a-lookahead",
             "conditional-on-a-capture-inside-a-lookbehind",
             "conditional-on-a-capture-inside-a-failed-negative-lookahead",
+            "conditional-on-a-capture-after-a-consuming-atom",
+            "backreference-to-a-capture-that-did-not-take-part",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -686,6 +686,8 @@ Parallel Execution Verification Report
             ("marker.txt", "", "The status field in marker.txt must be empty."),
             ("marker.txt", "", "marker.txt entries must be empty"),
             ("marker.txt", "", "marker.txt must not under any circumstances be empty."),
+            ("marker.txt", "", "The status field in the generated marker.txt must be empty."),
+            ("marker.txt", "", "The first record of the newly created marker.txt must be blank"),
         ],
         ids=[
             "empty-filename",
@@ -695,6 +697,8 @@ Parallel Execution Verification Report
             "prepositional-subject",
             "competing-noun-subject",
             "distant-negation",
+            "modifier-separated-preposition",
+            "two-modifiers-separated-preposition",
         ],
     )
     def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -877,6 +877,9 @@ Parallel Execution Verification Report
             ("", "Check that marker.txt is empty", r"\A\Z"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(a)?\1"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?P<x>a)?(?P=x)"),
+            ("", "Marker.txt must be empty", r"\A\Z"),
+            ("", "MARKER.TXT must be empty", r"\A\Z"),
+            ("", "Please ensure Marker.txt is empty", r"\A\Z"),
         ],
         ids=[
             "politeness-frame",
@@ -885,6 +888,9 @@ Parallel Execution Verification Report
             "checking-verb",
             "numbered-backreference",
             "named-backreference",
+            "capitalized-mention",
+            "shouted-mention",
+            "capitalized-in-frame",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
@@ -902,7 +908,9 @@ Parallel Execution Verification Report
         is empty`, with an empty `marker.txt`, failed on `please`. The last two
         were refused because every backreference was treated as zero-width, so
         `(a)?\\1` — which cannot match nothing and does match this file — was
-        called unusable. Both directions are driven through the real verifier
+        called unusable. The last three differ from the hint only in the case of
+        the filename, which the mention check ignored and the masking that
+        follows it did not. Both directions are driven through the real verifier
         and the real adapter, because the failure only becomes authoritative at
         this boundary.
         """
@@ -942,6 +950,71 @@ Parallel Execution Verification Report
         assert summary.final_approved is True
         assert summary.score == 1.0
         assert summary.run_verdict != "FAIL"
+
+    @pytest.mark.parametrize(
+        "tier",
+        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
+        ids=["T1", "T2"],
+    )
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            r"(?!(a)?(?(1)|c))",
+            r"(?!(a)?(?(1)|x)b)",
+            "(?!" + "(" * 45 + "x" + ")" * 45 + ")",
+        ],
+        ids=["negated-conditional", "negated-conditional-with-tail", "negated-past-depth-limit"],
+    )
+    def test_a_negated_guess_cannot_be_approved_through_the_adapter(
+        self, tmp_path: Any, tier: VerificationTier, pattern: str
+    ) -> None:
+        """A pattern the analyzer did not understand must not reach formal approval.
+
+        Each of these matches every file, so it verifies whatever it is pointed
+        at — the original defect. Each got there through a negation: the reading
+        sends its doubt to the side that is safe when the answer stands alone,
+        `(?!…)` flips which side that is, and the guess came back out as
+        confidence that the pattern discriminates. Published here as
+        `final_approved=True`, `score=1.0`, `run_verdict="PASS"` for an AC the
+        file does not satisfy.
+        """
+        (tmp_path / "marker.txt").write_text("hello\n")
+        ac_text = "marker.txt MUST declare a CameraProvider"
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content=ac_text,
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is False, f"{pattern!r} must not be approved"
+        assert summary.ac_results[0].final_verdict != "pass"
+        assert summary.final_approved is False
+        assert summary.score == 0.0
+        assert summary.run_verdict == "FAIL"
 
     def test_spec_verification_rejects_partial_ac_coverage(self) -> None:
         """A subset of verifier reports must not approve unverified ACs."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -890,6 +890,8 @@ Parallel Execution Verification Report
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!x())\1|aa"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"(?!)|aa"),
             ("aa\n", "marker.txt MUST contain a doubled letter", r"aa(?!)|aa"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"()(?(1)Impossible|)|aa"),
+            ("aa\n", "marker.txt MUST contain a doubled letter", r"aa|()(?(1)Impossible|)"),
         ],
         ids=[
             "politeness-frame",
@@ -910,6 +912,8 @@ Parallel Execution Verification Report
             "backreference-to-a-capture-that-did-not-take-part",
             "branch-that-can-never-be-taken",
             "branch-that-can-never-be-taken-after-a-literal",
+            "conditional-in-the-first-branch",
+            "conditional-in-the-second-branch",
         ],
     )
     def test_a_satisfied_criterion_is_not_converted_into_a_formal_failure(
@@ -935,7 +939,11 @@ Parallel Execution Verification Report
         the interpreter rather than by the reading: from 3.13 the parser folds
         `(?!)` into a single opcode this walk did not know, so a pattern with an
         unreachable branch was evidence on 3.12 and an authoritative failure on
-        3.13 and 3.14. Both directions are driven through the real verifier
+        3.13 and 3.14. The final two were refused for having an alternative at
+        all: every branch was read as a path that may have been skipped, so a
+        capture and the conditional reading it, written side by side in one
+        branch, could no longer see each other. Both directions are driven
+        through the real verifier
         and the real adapter, because the failure only becomes authoritative at
         this boundary.
         """

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -683,19 +683,33 @@ Parallel Execution Verification Report
             ("marker.txt", "", "marker.txt MUST contain an empty JSON string field"),
             ("marker.txt", "", "marker.txt MUST be an empty JSON object"),
             ("marker.txt", "  \t\n", "marker.txt MUST be empty"),
+            ("marker.txt", "", "The status field in marker.txt must be empty."),
+            ("marker.txt", "", "marker.txt entries must be empty"),
+            ("marker.txt", "", "marker.txt must not under any circumstances be empty."),
         ],
-        ids=["empty-filename", "nested-value", "attributive", "whitespace-is-not-empty"],
+        ids=[
+            "empty-filename",
+            "nested-value",
+            "attributive",
+            "whitespace-is-not-empty",
+            "prepositional-subject",
+            "competing-noun-subject",
+            "distant-negation",
+        ],
     )
     def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(
         self, tmp_path: Any, tier: VerificationTier, filename: str, content: str, ac_text: str
     ) -> None:
         """An emptiness word not predicated of the file must not reach formal approval.
 
-        Three of these require the file to hold content while mentioning emptiness —
-        in the filename, in a nested value, as an adjective on another noun. The
-        fourth is a whitespace-only file against an `empty` criterion, which `\\A\\Z`
-        does not match either. Each produced `final_approved=True`, `score=1.0`,
-        `final_verdict="pass"` at the adapter for a criterion the project violates.
+        Most of these require the file to hold content while mentioning emptiness —
+        in the filename, in a nested value, as an adjective on another noun, or with
+        the file named as the object of a preposition while some field inside it is
+        the subject. One is a whitespace-only file against an `empty` criterion,
+        which `\\A\\Z` does not match either, and one puts its negation far enough
+        along that a bounded lookback loses it. Each produced `final_approved=True`,
+        `score=1.0`, `final_verdict="pass"` at the adapter for a criterion the
+        project violates.
         """
         (tmp_path / filename).write_text(content)
         assertion = SpecAssertion(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -678,82 +678,56 @@ Parallel Execution Verification Report
         ids=["T1", "T2"],
     )
     @pytest.mark.parametrize(
-        ("filename", "content", "ac_text"),
+        ("content", "ac_text", "pattern"),
         [
-            ("empty.txt", "", "empty.txt MUST contain data"),
-            ("marker.txt", "", "marker.txt MUST contain an empty JSON string field"),
-            ("marker.txt", "", "marker.txt MUST be an empty JSON object"),
-            ("marker.txt", "  \t\n", "marker.txt MUST be empty"),
-            ("marker.txt", "", "The status field in marker.txt must be empty."),
-            ("marker.txt", "", "marker.txt entries must be empty"),
-            ("marker.txt", "", "marker.txt must not under any circumstances be empty."),
-            ("marker.txt", "", "The status field in the generated marker.txt must be empty."),
-            ("marker.txt", "", "The first record of the newly created marker.txt must be blank"),
-            ("marker.txt", "", "marker.txt must be empty and contain a header"),
-            ("marker.txt", "", "marker.txt must be empty and must be deleted"),
-            (
-                "marker.txt",
-                "",
-                "marker.txt must be empty, but must also contain generated metadata",
-            ),
-            ("marker.txt", "", "marker.txt must be deleted, and marker.txt must be empty"),
-            ("marker.txt", "", "marker.txt MUST be != empty"),
-            ("marker.txt", "", "marker.txt MUST be ≠ empty"),
-            ("marker.txt", "", "marker.txt must be empty 100%"),
-            ("marker.txt", "", "marker.txt must be empty > 0 bytes"),
+            ("  \t\n", "marker.txt MUST be empty", r"\A\Z"),
+            ("header\n\nbody\n", "marker.txt MUST be empty", r"(?m)^$"),
+            ("header\n\nbody\n", "marker.txt MUST be empty", r"^$"),
+            ("content", "marker.txt MUST be empty", r"\A.*\Z"),
+            ("content", "marker.txt MUST be empty", r"\A\w*\Z"),
+            ("content", "marker.txt MUST contain a header", r".*"),
+            ("content", "marker.txt MUST contain a header", r"x?"),
         ],
         ids=[
-            "empty-filename",
-            "nested-value",
-            "attributive",
             "whitespace-is-not-empty",
-            "prepositional-subject",
-            "competing-noun-subject",
-            "distant-negation",
-            "modifier-separated-preposition",
-            "two-modifiers-separated-preposition",
-            "compound-obligation",
-            "compound-modal-obligation",
-            "compound-after-comma",
-            "obligation-in-preamble",
-            "ascii-symbolic-negation",
-            "unicode-symbolic-negation",
-            "numeric-obligation",
-            "operator-obligation",
+            "multiline-blank-line",
+            "line-anchors",
+            "dot-star-pinned",
+            "word-star-pinned",
+            "matches-anywhere",
+            "optional-atom",
         ],
     )
-    def test_a_misread_emptiness_word_cannot_be_approved_through_the_adapter(
-        self, tmp_path: Any, tier: VerificationTier, filename: str, content: str, ac_text: str
+    def test_a_pattern_that_is_not_evidence_cannot_be_approved_through_the_adapter(
+        self, tmp_path: Any, tier: VerificationTier, content: str, ac_text: str, pattern: str
     ) -> None:
-        """An emptiness word not predicated of the file must not reach formal approval.
+        """A pattern a file with content can satisfy must not reach formal approval.
 
-        Most of these require the file to hold content while mentioning emptiness —
-        in the filename, in a nested value, as an adjective on another noun, or with
-        the file named as the object of a preposition while some field inside it is
-        the subject. One is a whitespace-only file against an `empty` criterion,
-        which `\\A\\Z` does not match either, and one puts its negation far enough
-        along that a bounded lookback loses it. Four are compound: the file may
-        well be empty, but the criterion also demands a header, a deletion or
-        some metadata, and nothing verified those — answering the emptiness half
-        alone publishes a pass for a requirement no one checked.
+        `marker.txt` holds content in every case here, so every one of these is a
+        criterion the project has not met, and each pattern would report a match
+        on it if the verifier admitted the pattern. `.*` and `x?` match anywhere
+        in anything — the original blocker. The rest are the shapes that a guard
+        with an exit for `\\A\\Z` can be talked into admitting: `\\A.*\\Z` and
+        `\\A\\w*\\Z` are pinned to both ends and still swallow a whole file, and
+        `(?m)^$` and `^$` are pinned to the ends of a *line*, which any blank line
+        inside a full file provides.
 
-        The last four carry their extra meaning in characters rather than words.
-        A tokenizer that keeps only what it recognises deletes the rest, so `!=`
-        and `≠` disappeared and their criteria read as the bare requirement they
-        negate; a trailing `100%` or `> 0 bytes` disappeared the same way. These
-        are here at the formal boundary because deletion at the character level
-        is indistinguishable, from the outside, from the criterion never having
-        said it. Each produced `final_approved=True`, `score=1.0`,
+        The first case is the opposite mistake and belongs at the same boundary:
+        a whitespace-only file is blank and is not empty, `\\A\\Z` says so, and the
+        verdict must survive the trip through the adapter rather than being
+        rounded up to a pass.
+
+        Each of these published `final_approved=True`, `score=1.0`,
         `final_verdict="pass"` at the adapter for a criterion the project
         violates or has not met.
         """
-        (tmp_path / filename).write_text(content)
+        (tmp_path / "marker.txt").write_text(content)
         assertion = SpecAssertion(
             ac_index=0,
             ac_text=ac_text,
             tier=tier,
-            pattern=r"\A\Z",
-            file_hint=filename,
+            pattern=pattern,
+            file_hint="marker.txt",
         )
         verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
             (assertion,), agent_results={0: True}
@@ -782,86 +756,6 @@ Parallel Execution Verification Report
         assert summary.ac_results[0].final_verdict != "pass"
         assert summary.final_approved is False
         assert summary.score == 0.0
-        assert summary.run_verdict == "FAIL"
-
-    @pytest.mark.parametrize(
-        "tier",
-        [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
-        ids=["T1", "T2"],
-    )
-    @pytest.mark.parametrize(
-        "ac_text",
-        [
-            "marker.txt MUST NOT be empty",
-            "Do not let marker.txt be empty",
-            "Never allow marker.txt to remain empty",
-            "Do not permit marker.txt to become empty.",
-            "Never, under any reading of this spec, allow marker.txt to be blank",
-            "Do not remove the guard and let marker.txt be empty",
-        ],
-        ids=[
-            "postposed-negation",
-            "preposed-negation",
-            "preposed-negation-infinitive",
-            "preposed-negation-causative",
-            "preposed-negation-past-comma",
-            "preposed-negation-past-conjunction",
-        ],
-    )
-    def test_a_forbidden_empty_file_cannot_be_approved_through_the_adapter(
-        self, tmp_path: Any, tier: VerificationTier, ac_text: str
-    ) -> None:
-        """A zero-width pattern on an empty file must not approve a criterion forbidding it.
-
-        This drives the real verifier, not a hand-built report: an extracted
-        pattern of ``\\A\\Z`` matches an empty file, so a verifier that took its
-        polarity from the pattern rather than from the AC text handed the
-        adapter a passing report and the adapter dutifully published
-        final_approved=True / score=1.0 / final_verdict="pass" for a criterion
-        the project violates.
-
-        The negation is carried both after the filename and ahead of it, because
-        a rule that reads only forward from the file — or only back to the
-        adjacent word — treats "do not let marker.txt be empty" as a requirement
-        to be empty and republishes exactly that false approval.
-        """
-        marker = tmp_path / "marker.txt"
-        marker.write_text("")
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="marker.txt",
-        )
-        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-        mechanical = EvaluationSummary(
-            final_approved=True,
-            highest_stage_passed=2,
-            task_results=(
-                TaskResult(
-                    task_index=0,
-                    task_content=ac_text,
-                    status="completed",
-                    completed=True,
-                    source_ac_index=0,
-                    execution_method="legacy_parallel_report",
-                ),
-            ),
-            execution_completion_status="completed",
-            approval_status="approved",
-        )
-
-        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
-
-        assert summary is not None
-        assert summary.ac_results[0].passed is False
-        assert summary.ac_results[0].final_verdict != "pass"
-        assert summary.final_approved is False
-        assert summary.score == 0.0
-        assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
     @pytest.mark.parametrize(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -757,10 +757,29 @@ Parallel Execution Verification Report
         [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL],
         ids=["T1", "T2"],
     )
+    @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "marker.txt MUST NOT be empty",
+            "Do not let marker.txt be empty",
+            "Never allow marker.txt to remain empty",
+            "Do not permit marker.txt to become empty.",
+            "Never, under any reading of this spec, allow marker.txt to be blank",
+            "Do not remove the guard and let marker.txt be empty",
+        ],
+        ids=[
+            "postposed-negation",
+            "preposed-negation",
+            "preposed-negation-infinitive",
+            "preposed-negation-causative",
+            "preposed-negation-past-comma",
+            "preposed-negation-past-conjunction",
+        ],
+    )
     def test_a_forbidden_empty_file_cannot_be_approved_through_the_adapter(
-        self, tmp_path: Any, tier: VerificationTier
+        self, tmp_path: Any, tier: VerificationTier, ac_text: str
     ) -> None:
-        """A zero-width pattern on an empty file must not approve "MUST NOT be empty".
+        """A zero-width pattern on an empty file must not approve a criterion forbidding it.
 
         This drives the real verifier, not a hand-built report: an extracted
         pattern of ``\\A\\Z`` matches an empty file, so a verifier that took its
@@ -768,12 +787,17 @@ Parallel Execution Verification Report
         adapter a passing report and the adapter dutifully published
         final_approved=True / score=1.0 / final_verdict="pass" for a criterion
         the project violates.
+
+        The negation is carried both after the filename and ahead of it, because
+        a rule that reads only forward from the file — or only back to the
+        adjacent word — treats "do not let marker.txt be empty" as a requirement
+        to be empty and republishes exactly that false approval.
         """
         marker = tmp_path / "marker.txt"
         marker.write_text("")
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text="marker.txt MUST NOT be empty",
+            ac_text=ac_text,
             tier=tier,
             pattern=r"\A\Z",
             file_hint="marker.txt",
@@ -787,7 +811,7 @@ Parallel Execution Verification Report
             task_results=(
                 TaskResult(
                     task_index=0,
-                    task_content="marker.txt MUST NOT be empty",
+                    task_content=ac_text,
                     status="completed",
                     completed=True,
                     source_ac_index=0,

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -883,6 +883,8 @@ class TestSpecVerifier:
             ("marker.txt", "The status field in marker.txt must be empty."),
             ("marker.txt", "Every record within marker.txt must be blank"),
             ("marker.txt", "marker.txt entries must be empty"),
+            ("marker.txt", "The status field in the generated marker.txt must be empty."),
+            ("marker.txt", "The first record of the newly created marker.txt must be blank"),
         ],
         ids=[
             "empty-filename",
@@ -893,6 +895,8 @@ class TestSpecVerifier:
             "prepositional-subject",
             "prepositional-subject-blank",
             "competing-noun-subject",
+            "modifier-separated-preposition",
+            "two-modifiers-separated-preposition",
         ],
     )
     def test_an_emptiness_word_that_is_not_about_the_file_earns_nothing(
@@ -903,9 +907,10 @@ class TestSpecVerifier:
         Each of these mentions emptiness while requiring the file to hold content,
         and each was read as an emptiness requirement: the word sat in the file's own
         name, or described a value nested inside it, or was the adjective on some
-        other noun, or the file was named as the object of a preposition while some
-        field inside it was the actual subject. With `\\A\\Z` and an empty file that
-        produced a formal PASS for a criterion the file plainly violates.
+        other noun, or the file was named as the object of a preposition — directly
+        or with modifiers standing between the two — while some field inside it was
+        the actual subject. With `\\A\\Z` and an empty file that produced a formal
+        PASS for a criterion the file plainly violates.
 
         Everything here falls through to the ordinary path, where `\\A\\Z` is refused
         and the criterion fails closed.
@@ -926,6 +931,48 @@ class TestSpecVerifier:
         assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
         assert summary.discrepancy_count == 1
         assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "marker.txt MUST be empty",
+            "The file marker.txt must be empty",
+            "For the release, marker.txt must be empty",
+            "Run the generator; marker.txt must be empty",
+        ],
+        ids=[
+            "bare",
+            "noun-modifier",
+            "preposition-in-earlier-clause",
+            "preposition-past-semicolon",
+        ],
+    )
+    def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(
+        self, tier: VerificationTier, ac_text: str
+    ) -> None:
+        """A preposition has to actually govern the file, not merely precede it.
+
+        The phrase is scanned back to the nearest clause boundary rather than to
+        the start of the criterion, because failing closed on any earlier `for` or
+        `of` would turn satisfied emptiness ACs into formal failures — the same
+        false-failure this rescue exists to prevent, in a new place.
+        """
+        project = self._create_project({"marker.txt": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is True, f"{ac_text!r} must still verify"
+        assert summary.discrepancy_count == 0
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -456,13 +456,16 @@ class TestSpecVerifier:
         summary = verifier.verify_all((assertion,))
         assert summary.verified_count == 1
 
-    # A pattern that matches the empty string can succeed without any
-    # criterion-specific content, so it verifies whatever it is pointed at. All of
-    # these compile, which is the only question the gate used to ask.
+    # A pattern that matches any input succeeds without any criterion-specific
+    # content, so it verifies whatever it is pointed at. All of these compile, which
+    # is the only question the gate used to ask.
     #
     # Split by which subject exposes each one: the patterns below also match ordinary
     # non-empty files, while `\A\Z` succeeds only against an empty one — so proving
-    # that case needs a project that has such a file.
+    # that case needs a project that has such a file. Matching the empty string is
+    # not itself the defect: `\A\Z` tells an empty file from every other file, which
+    # is exactly what an "MUST remain empty" criterion needs. What fabricates a pass
+    # is searching a *set* of candidates for any hit, so that pair is tested apart.
     @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^"])
     def test_t2_pattern_matching_any_input_is_not_evidence(self, pattern: str) -> None:
         """Such a pattern must not verify an AC the project does not satisfy."""
@@ -502,13 +505,19 @@ class TestSpecVerifier:
         assert summary.reports[0].verified_pass is False
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_anchored_empty_pattern_is_not_evidence(self, tier: VerificationTier) -> None:
+    def test_anchored_empty_pattern_over_a_glob_is_not_evidence(
+        self, tier: VerificationTier
+    ) -> None:
         """`\\A\\Z` succeeds only on an empty file, so only an empty file exposes it.
 
         An empty ``__init__.py`` is ordinary in a Python package, and against it the
         old verifier reported `Pattern found in __init__.py` on both tiers. Against a
         non-empty fixture this pattern matches nothing either way, so a test without
         an empty candidate would pass with the guard removed and prove nothing.
+
+        The hint here sweeps two files and the search stops at the first hit, so a
+        pass names no particular file — the package marker satisfying it is not what
+        the criterion is about. Contrast the exact-hint case below, which is honest.
         """
         project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
         assertion = SpecAssertion(
@@ -525,6 +534,60 @@ class TestSpecVerifier:
 
         assert summary.verified_count == 0
         assert summary.reports[0].verified_pass is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_anchored_empty_pattern_verifies_the_file_its_hint_names(
+        self, tier: VerificationTier
+    ) -> None:
+        """An "MUST remain empty" criterion is real, and `\\A\\Z` is its honest regex.
+
+        Refusing `\\A\\Z` outright reports a project that satisfies its AC as a formal
+        failure, and the adapter downstream reads that as a discrepancy — the guard
+        against fabricated passes manufacturing a fabricated fail instead.
+        """
+        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/__init__.py MUST remain empty",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/__init__.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 1
+        assert summary.reports[0].verified_pass is True
+        assert summary.discrepancy_count == 0
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_anchored_empty_pattern_still_fails_when_the_named_file_has_content(
+        self, tier: VerificationTier
+    ) -> None:
+        """The exact-hint allowance must not become a free pass.
+
+        Same criterion, same pattern, same single-file hint — but the file has content
+        now, and `\\A\\Z` has to report that. This is what makes the test above evidence
+        of discrimination rather than evidence that the guard stopped looking.
+        """
+        project = self._create_project({"pkg/__init__.py": "from .camera import x\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/__init__.py MUST remain empty",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/__init__.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.discrepancy_count == 1
 
     def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:
         """Refusing the pattern must raise a discrepancy, not silently skip the AC.

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -765,8 +765,7 @@ class TestSpecVerifier:
 
         Routing on the word alone would invert this one: the emptiness answer would
         read a file that is correctly non-empty and report a discrepancy against an AC
-        the project satisfies. The pattern carries the polarity — only one that
-        survives on a file with nothing in it needs rescuing.
+        the project satisfies.
         """
         project = self._create_project({"pkg/config.py": "FPS = 60\n"})
         assertion = SpecAssertion(
@@ -782,6 +781,72 @@ class TestSpecVerifier:
         )
 
         assert summary.verified_count == 1
+        assert summary.reports[0].verified_pass is True
+        assert summary.discrepancy_count == 0
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "pkg/config.py MUST NOT be empty",
+            "pkg/config.py must never be empty",
+            "pkg/config.py cannot be blank",
+            "pkg/config.py must not be blank",
+            "pkg/config.py must be non-empty",
+            "pkg/config.py must contain a nonempty value",
+        ],
+        ids=["must-not", "never", "cannot-blank", "not-blank", "hyphenated", "nonempty-word"],
+    )
+    def test_a_criterion_forbidding_emptiness_is_not_satisfied_by_an_empty_file(
+        self, tier: VerificationTier, ac_text: str
+    ) -> None:
+        """The violated reading must not pass, and the pattern cannot tell them apart.
+
+        `\\A\\Z` is what a model writes for "must be empty" and for "must not be
+        empty" alike, so polarity has to be read from `ac_text`. Deciding it from
+        the pattern verified a criterion the file breaks: an empty `config.py`
+        against an AC that requires content.
+
+        `nonempty` is here because reading the word as a substring saw `empty`
+        inside it and called the criterion an emptiness requirement.
+        """
+        project = self._create_project({"pkg/config.py": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/config.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_a_negation_in_another_clause_does_not_disarm_the_requirement(
+        self, tier: VerificationTier
+    ) -> None:
+        """One un-negated occurrence is the requirement; a later `not` is a different clause.
+
+        Failing closed on any `not` anywhere would re-open the original blocker in a
+        narrower form — a satisfied emptiness AC turned into a formal failure.
+        """
+        project = self._create_project({"pkg/marker.txt": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/marker.txt MUST be empty and must not be deleted",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all((assertion,))
+
         assert summary.reports[0].verified_pass is True
         assert summary.discrepancy_count == 0
 

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -802,8 +802,19 @@ class TestSpecVerifier:
             "pkg/config.py must not be blank",
             "pkg/config.py must be non-empty",
             "pkg/config.py must contain a nonempty value",
+            "pkg/config.py must not under any circumstances be empty.",
+            "pkg/config.py should never, under any reading of this spec, be blank",
         ],
-        ids=["must-not", "never", "cannot-blank", "not-blank", "hyphenated", "nonempty-word"],
+        ids=[
+            "must-not",
+            "never",
+            "cannot-blank",
+            "not-blank",
+            "hyphenated",
+            "nonempty-word",
+            "distant-negation",
+            "very-distant-negation",
+        ],
     )
     def test_a_criterion_forbidding_emptiness_is_not_satisfied_by_an_empty_file(
         self, tier: VerificationTier, ac_text: str
@@ -816,7 +827,9 @@ class TestSpecVerifier:
         against an AC that requires content.
 
         `nonempty` is here because reading the word as a substring saw `empty`
-        inside it and called the criterion an emptiness requirement.
+        inside it and called the criterion an emptiness requirement. The distant
+        negations are here because a fixed lookback window has a far side, and a
+        criterion can always put its `not` past it.
         """
         project = self._create_project({"pkg/config.py": ""})
         assertion = SpecAssertion(
@@ -867,8 +880,20 @@ class TestSpecVerifier:
             ("marker.txt", "marker.txt MUST contain an empty JSON string field"),
             ("marker.txt", "marker.txt MUST be an empty JSON object"),
             ("marker.txt", "marker.txt MUST list the empty partitions"),
+            ("marker.txt", "The status field in marker.txt must be empty."),
+            ("marker.txt", "Every record within marker.txt must be blank"),
+            ("marker.txt", "marker.txt entries must be empty"),
         ],
-        ids=["empty-filename", "blank-filename", "nested-value", "attributive", "object-of-verb"],
+        ids=[
+            "empty-filename",
+            "blank-filename",
+            "nested-value",
+            "attributive",
+            "object-of-verb",
+            "prepositional-subject",
+            "prepositional-subject-blank",
+            "competing-noun-subject",
+        ],
     )
     def test_an_emptiness_word_that_is_not_about_the_file_earns_nothing(
         self, tier: VerificationTier, filename: str, ac_text: str
@@ -878,8 +903,9 @@ class TestSpecVerifier:
         Each of these mentions emptiness while requiring the file to hold content,
         and each was read as an emptiness requirement: the word sat in the file's own
         name, or described a value nested inside it, or was the adjective on some
-        other noun. With `\\A\\Z` and an empty file that produced a formal PASS for a
-        criterion the file plainly violates.
+        other noun, or the file was named as the object of a preposition while some
+        field inside it was the actual subject. With `\\A\\Z` and an empty file that
+        produced a formal PASS for a criterion the file plainly violates.
 
         Everything here falls through to the ordinary path, where `\\A\\Z` is refused
         and the criterion fails closed.
@@ -899,6 +925,45 @@ class TestSpecVerifier:
 
         assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
         assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "marker.txt must be empty or contain # generated",
+            "marker.txt must be empty, or contain # generated",
+            "marker.txt must be empty unless the build is incremental",
+        ],
+        ids=["or", "comma-or", "unless"],
+    )
+    def test_emptiness_offered_as_one_option_is_not_an_emptiness_requirement(
+        self, tier: VerificationTier, ac_text: str
+    ) -> None:
+        """A criterion the file can satisfy another way is not this rescue's to answer.
+
+        Answering the emptiness branch alone would throw away the evidence the
+        other branch names and publish an authoritative "the file is not empty"
+        for a criterion that never required it to be. The refusal has to say what
+        it actually is — a pattern that cannot be trusted — so the failure is
+        legible instead of a confident wrong reason.
+        """
+        project = self._create_project({"marker.txt": "# generated\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z|# generated",
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        detail = summary.reports[0].results[0].detail
+        assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
+        assert "regex" in detail.lower()
         assert summary.override_approval is False
 
     def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -859,18 +859,51 @@ class TestSpecVerifier:
         assert summary.override_approval is False
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_a_negation_in_another_clause_does_not_disarm_the_requirement(
-        self, tier: VerificationTier
+    @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "pkg/marker.txt must be empty and contain a header",
+            "pkg/marker.txt must be empty and must be deleted",
+            "pkg/marker.txt must be empty, but must also contain generated metadata",
+            "pkg/marker.txt MUST be empty and must not be deleted",
+            "pkg/marker.txt must be deleted, and pkg/marker.txt must be empty",
+            "pkg/marker.txt must be empty then the build proceeds",
+            "For the release, pkg/marker.txt must be empty",
+            "Run the generator; pkg/marker.txt must be empty",
+        ],
+        ids=[
+            "and-obligation",
+            "and-modal-obligation",
+            "comma-but-also",
+            "and-negated-obligation",
+            "obligation-in-preamble",
+            "trailing-consequence",
+            "preposed-adjunct",
+            "preposed-clause",
+        ],
+    )
+    def test_a_criterion_that_asks_for_more_than_emptiness_is_not_answered_here(
+        self, tier: VerificationTier, ac_text: str
     ) -> None:
-        """One un-negated occurrence is the requirement; a later `not` is a different clause.
+        """Emptiness is only half of a compound criterion, and half is not an answer.
 
-        Failing closed on any `not` anywhere would re-open the original blocker in a
-        narrower form — a satisfied emptiness AC turned into a formal failure.
+        An earlier revision of this test asserted the opposite for the `and must
+        not be deleted` form, on the reasoning that one un-negated occurrence is
+        the requirement. That reasoning was wrong in a way the deletion clause
+        makes obvious: nothing verifies the second obligation, so reporting a
+        pass reports on a criterion that was never checked. The rescue now has
+        to consume the criterion in full, and everything here says something it
+        cannot consume — including the two preposed forms, which it has no way
+        to tell apart from an obligation without reading English.
+
+        Failing closed costs a satisfied emptiness AC its pass, but it costs it
+        an honest `Unusable regex pattern` failure rather than an authoritative
+        wrong answer, which is the trade this whole guard exists to make.
         """
         project = self._create_project({"pkg/marker.txt": ""})
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text="pkg/marker.txt MUST be empty and must not be deleted",
+            ac_text=ac_text,
             tier=tier,
             pattern=r"\A\Z",
             file_hint="pkg/marker.txt",
@@ -878,8 +911,10 @@ class TestSpecVerifier:
 
         summary = SpecVerifier(project_dir=project).verify_all((assertion,))
 
-        assert summary.reports[0].verified_pass is True
-        assert summary.discrepancy_count == 0
+        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
+        detail = summary.reports[0].results[0].detail
+        assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
+        assert "Unusable regex pattern" in detail
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
@@ -947,32 +982,32 @@ class TestSpecVerifier:
         "ac_text",
         [
             "marker.txt MUST be empty",
+            "marker.txt must be empty.",
             "The file marker.txt must be empty",
-            "For the release, marker.txt must be empty",
-            "Run the generator; marker.txt must be empty",
             "Ensure marker.txt is empty",
             "We require marker.txt to be empty",
+            "marker.txt MUST remain empty",
         ],
         ids=[
             "bare",
+            "trailing-period",
             "noun-modifier",
-            "preposition-in-earlier-clause",
-            "preposition-past-semicolon",
             "transparent-verb",
             "transparent-verb-with-subject",
+            "copula-variant",
         ],
     )
     def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(
         self, tier: VerificationTier, ac_text: str
     ) -> None:
-        """A word has to actually govern the file, not merely precede it.
+        """The shapes the rescue must keep answering, pinned against over-tightening.
 
-        The phrase is scanned back to the nearest clause boundary rather than to
-        the start of the criterion, because failing closed on any earlier `for` or
-        `of` would turn satisfied emptiness ACs into formal failures — the same
-        false-failure this rescue exists to prevent, in a new place. `ensure` and
-        `require` ask for the clause after them without changing what it claims,
-        so a criterion that opens with one still says what it says.
+        A guard this strict is one edit away from refusing everything, and a
+        refusal is a formal failure for an AC the project satisfies — the
+        original blocker, relocated. `ensure` and `require` ask for the clause
+        after them without changing what it claims, so a criterion that opens
+        with one still says exactly what it says, and a determiner or a noun for
+        the file itself changes nothing either.
         """
         project = self._create_project({"marker.txt": ""})
         assertion = SpecAssertion(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1481,6 +1481,11 @@ class TestSpecVerifier:
             r"(?=(?=()))(?(1)a|)",
             r"(?!()x)(?(1)|a)",
             r"(?!(a)x)(?(1)|a)",
+            r"(?!x())(?(1)|a)",
+            r"(?!x(a))(?(1)|a)",
+            r"(?!x(a?))(?(1)|a)",
+            r"(?!()x())(?(2)|a)",
+            r"(?!x())\1|aa",
         ],
         ids=[
             "unparticipating-group-runs-the-other-arm",
@@ -1494,6 +1499,11 @@ class TestSpecVerifier:
             "capture-inside-nested-lookaheads",
             "capture-inside-a-failed-negative-lookahead",
             "consuming-capture-inside-a-negative-lookahead",
+            "capture-after-a-consuming-atom",
+            "consuming-capture-after-a-consuming-atom",
+            "nullable-capture-after-a-consuming-atom",
+            "second-capture-after-a-consuming-atom",
+            "backreference-to-a-capture-that-did-not-take-part",
         ],
     )
     def test_a_conditional_is_read_from_whether_its_group_could_have_taken_part(
@@ -1520,6 +1530,13 @@ class TestSpecVerifier:
         capture inside it certainly did not. Reading both as "may have been
         skipped" made every one of these unreadable and refused a criterion the
         source plainly satisfies.
+
+        Knowing that is no use if the walk never reaches the capture. One
+        consuming atom settles whether its own sequence can be empty, but the
+        sequence inside a negative assertion takes part in the match by failing,
+        and a conditional outside still asks what the captures written after that
+        atom did. So the walk records them instead of stopping at the first
+        thing that consumes.
         """
         project = self._create_project({"marker.txt": "aa\n"})
         assertion = SpecAssertion(
@@ -1550,6 +1567,7 @@ class TestSpecVerifier:
             r"(?=(a?))(?(1)|a)",
             r"(?=())?(?(1)a|)",
             r"(?!()x)(?(1)a|)",
+            r"(?!x())(?(1)a|)",
         ],
         ids=[
             "empty-arm-is-the-one-that-runs",
@@ -1560,6 +1578,7 @@ class TestSpecVerifier:
             "nullable-lookahead-capture-empty-arm",
             "lookahead-that-may-be-skipped",
             "failed-negative-lookahead-capture-empty-arm",
+            "capture-after-a-consuming-atom-empty-arm",
         ],
     )
     def test_a_conditional_that_can_run_an_empty_arm_is_still_refused(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -918,6 +918,60 @@ class TestSpecVerifier:
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
+        "ac_text",
+        [
+            "pkg/marker.txt MUST be != empty",
+            "pkg/marker.txt MUST be ≠ empty",
+            "pkg/marker.txt !must be empty",
+            "pkg/marker.txt must be empty 100%",
+            "pkg/marker.txt must be empty > 0 bytes",
+            "pkg/marker.txt must be empty & committed",
+        ],
+        ids=[
+            "ascii-symbolic-negation",
+            "unicode-symbolic-negation",
+            "symbol-before-modal",
+            "numeric-obligation",
+            "operator-obligation",
+            "symbolic-conjunction",
+        ],
+    )
+    def test_a_character_the_reading_cannot_read_refuses_the_whole_criterion(
+        self, tier: VerificationTier, ac_text: str
+    ) -> None:
+        """Consuming every token is not consuming the criterion, if tokens can be dropped.
+
+        The reading used to gather tokens with `findall`, which silently deletes
+        whatever the pattern does not match — so `!=` and `≠` vanished and the
+        criteria here read as bare emptiness requirements, publishing a pass for
+        the exact claim they negate. That is the same defect as matching a part
+        of the criterion, one layer down: a scan over characters that discards
+        the ones it does not recognise is a scan over a part of the characters.
+
+        So the criterion is now consumed character by character, and a character
+        outside words, `.,;:`, quotes, brackets and whitespace refuses the whole
+        reading rather than disappearing from it. An operator or a digit can be
+        the entire meaning, and there is no way to tell the harmless ones apart
+        without reading English.
+        """
+        project = self._create_project({"pkg/marker.txt": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all((assertion,))
+
+        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
+        detail = summary.reports[0].results[0].detail
+        assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
+        assert "Unusable regex pattern" in detail
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
         ("filename", "ac_text"),
         [
             ("empty.txt", "empty.txt MUST contain data"),
@@ -987,6 +1041,8 @@ class TestSpecVerifier:
             "Ensure marker.txt is empty",
             "We require marker.txt to be empty",
             "marker.txt MUST remain empty",
+            "`marker.txt` must be empty",
+            '"marker.txt" must be empty',
         ],
         ids=[
             "bare",
@@ -995,6 +1051,8 @@ class TestSpecVerifier:
             "transparent-verb",
             "transparent-verb-with-subject",
             "copula-variant",
+            "backticked-name",
+            "quoted-name",
         ],
     )
     def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -523,15 +523,15 @@ class TestSpecVerifier:
         non-empty fixture this pattern matches nothing either way, so a test without
         an empty candidate would pass with the guard removed and prove nothing.
 
-        The hint sweeps rather than names, so the search stops at whichever candidate
-        is empty and a pass names no particular file — the package marker satisfying
-        it is not what the criterion is about. Contrast the exact hint below.
+        The criterion here is about a `CameraProvider` and the hint sweeps, so the
+        emptiness answer below is not on offer: the search stops at whichever
+        candidate is empty and a pass names no particular file. Contrast the exact
+        hint and matching criterion in the tests that follow.
 
         Both fixtures use the same wildcard hint and differ only in how many
         candidates survive ``_find_files``: the second's other `.py` sits under
-        `.venv` and is dropped, leaving one. A guard keyed on the candidate *count*
-        passes the first case and fails the second, which is why the count is not
-        the question — the hint still named nothing either time.
+        `.venv` and is dropped, leaving one. Neither the count nor the hint alone
+        may open the allowance, so both must refuse.
         """
         project = self._create_project(files)
         assertion = SpecAssertion(
@@ -558,6 +558,9 @@ class TestSpecVerifier:
         Refusing `\\A\\Z` outright reports a project that satisfies its AC as a formal
         failure, and the adapter downstream reads that as a discrepancy — the guard
         against fabricated passes manufacturing a fabricated fail instead.
+
+        What is verified here is the file, not the pattern: the criterion asks whether
+        `pkg/__init__.py` holds anything, and reading it answers that outright.
         """
         project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
         assertion = SpecAssertion(
@@ -604,7 +607,7 @@ class TestSpecVerifier:
         assert summary.discrepancy_count == 1
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_unnamed_empty_file_refusal_fails_closed_against_an_agent_pass_claim(
+    def test_anchored_empty_refusal_fails_closed_against_an_agent_pass_claim(
         self, tier: VerificationTier
     ) -> None:
         """The refusal has to raise a discrepancy, not merely decline to verify.
@@ -630,74 +633,27 @@ class TestSpecVerifier:
         assert summary.reports[0].verified_pass is False
         assert summary.discrepancy_count == 1
         assert summary.override_approval is False
-        assert "names no file" in summary.reports[0].results[0].detail
+        assert "Unusable regex pattern" in summary.reports[0].results[0].detail
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_filename_exit_obeys_the_empty_file_guard(self, tier: VerificationTier) -> None:
-        """T2 matches basenames before contents, and that exit needs the same guard.
-
-        `.` is satisfied by a blank file, so the guard refuses it under a sweeping
-        hint. Reached through the filename check it used to return `Found file:
-        main.py` instead — the same assertion approved on T2 and refused on T1.
-        """
-        project = self._create_project({"main.py": "print('hello')\n", "pkg/util.py": "x = 1\n"})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
-            tier=tier,
-            pattern=".",
-            file_hint="**/*.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.verified_count == 0
-        assert summary.reports[0].verified_pass is False
-        assert summary.override_approval is False
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_blank_file_pattern_over_a_glob_is_not_evidence(self, tier: VerificationTier) -> None:
-        """A file of whitespace carries no more content than an empty one.
-
-        `\\A[ ]\\Z` never matches the empty string, so a guard that probes only with
-        `""` misses it while a blank `__init__.py` still mints the pass.
-        """
-        project = self._create_project({"pkg/__init__.py": " ", "main.py": "print('hello')\n"})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
-            tier=tier,
-            pattern=r"\A[ ]\Z",
-            file_hint="**/*.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.verified_count == 0
-        assert summary.reports[0].verified_pass is False
-        assert summary.override_approval is False
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_exact_hint_does_not_admit_a_pattern_that_also_matches_content(
+    def test_empty_file_answer_needs_the_criterion_to_name_the_file(
         self, tier: VerificationTier
     ) -> None:
-        """The exact-hint allowance is for patterns whose only hit means "no content".
+        """An exact hint is not consent: `ac_text` has to be about the file too.
 
-        `\\A[0-9\\n]*\\Z` matches the empty string *and* a file of digits, so a hit says
-        nothing about which of the two it found — and the hint being exact does not
-        recover that. Only a pattern content cannot satisfy earns the allowance.
+        `pkg/__init__.py` is empty in most repositories, and both the hint and the
+        pattern come out of the same model completion. Keyed on the hint alone, the
+        allowance lets `\\A\\Z` pointed at any ordinary package marker "verify" a
+        criterion about a camera interface — verbatim the fabrication this change
+        exists to close, re-entered through the door opened for the honest case.
         """
-        project = self._create_project({"pkg/version.py": "123\n"})
+        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text="pkg/version.py MUST remain empty",
+            ac_text="MUST define a CameraProvider interface",
             tier=tier,
-            pattern=r"\A[0-9\n]*\Z",
-            file_hint="pkg/version.py",
+            pattern=r"\A\Z",
+            file_hint="pkg/__init__.py",
         )
 
         summary = SpecVerifier(project_dir=project).verify_all(
@@ -706,7 +662,128 @@ class TestSpecVerifier:
 
         assert summary.verified_count == 0
         assert summary.reports[0].verified_pass is False
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
         assert "Unusable regex pattern" in summary.reports[0].results[0].detail
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_criterion_must_name_the_hinted_file_as_a_whole_token(
+        self, tier: VerificationTier
+    ) -> None:
+        """`a.py` sits inside `data.py`, and a substring test cannot tell them apart.
+
+        The criterion is about `data.py`; the hint points at a different, empty file
+        whose name happens to be a tail of it. Read as a substring, the criterion
+        appears to corroborate a hint it never mentioned.
+        """
+        project = self._create_project({"a.py": "", "data.py": "rows = []\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="data.py MUST remain empty",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="a.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize("blank", ["\t", "  ", "\n\n"], ids=["tab", "spaces", "newlines"])
+    def test_a_file_of_whitespace_satisfies_an_emptiness_criterion(
+        self, tier: VerificationTier, blank: str
+    ) -> None:
+        """The answer comes from the file, so `\\A\\Z` not matching a tab is irrelevant.
+
+        A guard that decided emptiness by trying the pattern against a fixed list of
+        blank strings would have to grow that list once per whitespace character
+        anyone writes. Reading the file has no list to keep up to date.
+        """
+        project = self._create_project({"pkg/__init__.py": blank})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/__init__.py MUST remain empty",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="pkg/__init__.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 1
+        assert summary.reports[0].verified_pass is True
+        assert summary.discrepancy_count == 0
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"\A\Z", r"\A[0-9\n]*\Z", r"\A(?![a0])", r"\A\Z|[\s\S]{3,}", r"\A[A-Z\n]*\Z"],
+        ids=["honest", "digits", "negative-lookahead", "alternation", "upper"],
+    )
+    def test_a_degenerate_pattern_earns_nothing_from_an_emptiness_criterion(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """Every pattern here matches the file; the file is not empty; all must fail.
+
+        `\\A(?![a0])`, `\\A\\Z|[\\s\\S]{3,}` and `\\A[A-Z\\n]*\\Z` are each built to slip past
+        a screen that decides "matches empty and nothing else" by trying a fixed pair
+        of sample strings — they dodge the samples and match every real file. None of
+        that reaches the verdict, because the verdict is `content.strip()`. A screen
+        made of examples only rejects the examples it contains; this one holds
+        whatever the pattern turns out to be.
+        """
+        project = self._create_project({"pkg/__init__.py": "from .camera import x\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/__init__.py MUST remain empty",
+            tier=tier,
+            pattern=pattern,
+            file_hint="pkg/__init__.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_a_must_not_be_empty_criterion_is_left_to_the_ordinary_path(
+        self, tier: VerificationTier
+    ) -> None:
+        """The criterion says "empty", but `\\S` needs content and answers for itself.
+
+        Routing on the word alone would invert this one: the emptiness answer would
+        read a file that is correctly non-empty and report a discrepancy against an AC
+        the project satisfies. The pattern carries the polarity — only one that
+        survives on a file with nothing in it needs rescuing.
+        """
+        project = self._create_project({"pkg/config.py": "FPS = 60\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/config.py MUST NOT be empty",
+            tier=tier,
+            pattern=r"\S",
+            file_hint="pkg/config.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 1
+        assert summary.reports[0].verified_pass is True
+        assert summary.discrepancy_count == 0
 
     def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:
         """Refusing the pattern must raise a discrepancy, not silently skip the AC.

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -505,8 +505,16 @@ class TestSpecVerifier:
         assert summary.reports[0].verified_pass is False
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "files",
+        [
+            {"pkg/__init__.py": "", "main.py": "print('hello')\n"},
+            {"pkg/__init__.py": "", ".venv/lib/site.py": "x = 1\n"},
+        ],
+        ids=["two-candidates", "one-candidate"],
+    )
     def test_anchored_empty_pattern_over_a_glob_is_not_evidence(
-        self, tier: VerificationTier
+        self, tier: VerificationTier, files: dict[str, str]
     ) -> None:
         """`\\A\\Z` succeeds only on an empty file, so only an empty file exposes it.
 
@@ -515,11 +523,17 @@ class TestSpecVerifier:
         non-empty fixture this pattern matches nothing either way, so a test without
         an empty candidate would pass with the guard removed and prove nothing.
 
-        The hint here sweeps two files and the search stops at the first hit, so a
-        pass names no particular file — the package marker satisfying it is not what
-        the criterion is about. Contrast the exact-hint case below, which is honest.
+        The hint sweeps rather than names, so the search stops at whichever candidate
+        is empty and a pass names no particular file — the package marker satisfying
+        it is not what the criterion is about. Contrast the exact hint below.
+
+        Both fixtures use the same wildcard hint and differ only in how many
+        candidates survive ``_find_files``: the second's other `.py` sits under
+        `.venv` and is dropped, leaving one. A guard keyed on the candidate *count*
+        passes the first case and fails the second, which is why the count is not
+        the question — the hint still named nothing either time.
         """
-        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
+        project = self._create_project(files)
         assertion = SpecAssertion(
             ac_index=0,
             ac_text="MUST define a CameraProvider interface",
@@ -588,6 +602,111 @@ class TestSpecVerifier:
         assert summary.verified_count == 0
         assert summary.reports[0].verified_pass is False
         assert summary.discrepancy_count == 1
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_unnamed_empty_file_refusal_fails_closed_against_an_agent_pass_claim(
+        self, tier: VerificationTier
+    ) -> None:
+        """The refusal has to raise a discrepancy, not merely decline to verify.
+
+        With the agent claiming PASS, a refusal that left ``discrepancy=False`` would
+        be indistinguishable from silence: nothing contradicts the self-report and the
+        AC is approved anyway. Both tiers must reach the same verdict here — the guard
+        living on one exit and not its sibling is what let T2 approve what T1 refused.
+        """
+        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="**/*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+        assert "names no file" in summary.reports[0].results[0].detail
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_filename_exit_obeys_the_empty_file_guard(self, tier: VerificationTier) -> None:
+        """T2 matches basenames before contents, and that exit needs the same guard.
+
+        `.` is satisfied by a blank file, so the guard refuses it under a sweeping
+        hint. Reached through the filename check it used to return `Found file:
+        main.py` instead — the same assertion approved on T2 and refused on T1.
+        """
+        project = self._create_project({"main.py": "print('hello')\n", "pkg/util.py": "x = 1\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=tier,
+            pattern=".",
+            file_hint="**/*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_blank_file_pattern_over_a_glob_is_not_evidence(self, tier: VerificationTier) -> None:
+        """A file of whitespace carries no more content than an empty one.
+
+        `\\A[ ]\\Z` never matches the empty string, so a guard that probes only with
+        `""` misses it while a blank `__init__.py` still mints the pass.
+        """
+        project = self._create_project({"pkg/__init__.py": " ", "main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=tier,
+            pattern=r"\A[ ]\Z",
+            file_hint="**/*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_exact_hint_does_not_admit_a_pattern_that_also_matches_content(
+        self, tier: VerificationTier
+    ) -> None:
+        """The exact-hint allowance is for patterns whose only hit means "no content".
+
+        `\\A[0-9\\n]*\\Z` matches the empty string *and* a file of digits, so a hit says
+        nothing about which of the two it found — and the hint being exact does not
+        recover that. Only a pattern content cannot satisfy earns the allowance.
+        """
+        project = self._create_project({"pkg/version.py": "123\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/version.py MUST remain empty",
+            tier=tier,
+            pattern=r"\A[0-9\n]*\Z",
+            file_hint="pkg/version.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert "Unusable regex pattern" in summary.reports[0].results[0].detail
 
     def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:
         """Refusing the pattern must raise a discrepancy, not silently skip the AC.

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1430,17 +1430,17 @@ class TestSpecVerifier:
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
-        ("hint", "ac_text"),
+        ("filename", "hint", "ac_text"),
         [
-            ("marker.txt", "Marker.txt must be empty"),
-            ("marker.txt", "MARKER.TXT must be empty"),
-            ("Marker.txt", "marker.txt must be empty"),
-            ("marker.txt", "Please ensure Marker.txt is empty"),
+            ("marker.txt", "marker.txt", "Marker.txt must be empty"),
+            ("marker.txt", "marker.txt", "MARKER.TXT must be empty"),
+            ("Marker.txt", "Marker.txt", "marker.txt must be empty"),
+            ("marker.txt", "marker.txt", "Please ensure Marker.txt is empty"),
         ],
         ids=["capitalized-mention", "shouted-mention", "capitalized-hint", "capitalized-in-frame"],
     )
     def test_a_capital_letter_in_the_filename_does_not_manufacture_a_failure(
-        self, tier: VerificationTier, hint: str, ac_text: str
+        self, tier: VerificationTier, filename: str, hint: str, ac_text: str
     ) -> None:
         """One normalization, used in both places that read the filename.
 
@@ -1450,7 +1450,7 @@ class TestSpecVerifier:
         token the reading anchors on — an ordinary emptiness requirement on a
         file that satisfies it, failed formally by a capital letter.
         """
-        project = self._create_project({"marker.txt": ""})
+        project = self._create_project({filename: ""})
         assertion = SpecAssertion(
             ac_index=0,
             ac_text=ac_text,

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1532,6 +1532,10 @@ class TestSpecVerifier:
             r"(?!x(a?))(?(1)|a)",
             r"(?!()x())(?(2)|a)",
             r"(?!x())\1|aa",
+            r"()(?(1)Impossible|)|aa",
+            r"aa|()(?(1)Impossible|)",
+            r"x|()(?(1)a|)",
+            r"(?:(a)|b)(?(1)a|b)",
         ],
         ids=[
             "unparticipating-group-runs-the-other-arm",
@@ -1550,6 +1554,10 @@ class TestSpecVerifier:
             "nullable-capture-after-a-consuming-atom",
             "second-capture-after-a-consuming-atom",
             "backreference-to-a-capture-that-did-not-take-part",
+            "capture-and-conditional-in-the-first-branch",
+            "capture-and-conditional-in-the-second-branch",
+            "conditional-in-a-branch-beside-a-consuming-one",
+            "conditional-after-a-branch-that-captures-either-way",
         ],
     )
     def test_a_conditional_is_read_from_whether_its_group_could_have_taken_part(
@@ -1583,6 +1591,13 @@ class TestSpecVerifier:
         and a conditional outside still asks what the captures written after that
         atom did. So the walk records them instead of stopping at the first
         thing that consumes.
+
+        Which branch of an alternation runs is undecidable from outside it, but
+        not from inside: a capture and a conditional written in the same branch
+        stand or fall together. Reading every branch as a path that may have
+        been skipped made `()(?(1)Impossible|)` — read correctly on its own —
+        unreadable the moment an alternative was written beside it, so the last
+        four are the same conditionals with one added.
         """
         project = self._create_project({"marker.txt": "aa\n"})
         assertion = SpecAssertion(
@@ -1614,6 +1629,8 @@ class TestSpecVerifier:
             r"(?=())?(?(1)a|)",
             r"(?!()x)(?(1)a|)",
             r"(?!x())(?(1)a|)",
+            r"(a)b|(?(1)x|)",
+            r"()|(?(1)a|b)",
         ],
         ids=[
             "empty-arm-is-the-one-that-runs",
@@ -1625,6 +1642,8 @@ class TestSpecVerifier:
             "lookahead-that-may-be-skipped",
             "failed-negative-lookahead-capture-empty-arm",
             "capture-after-a-consuming-atom-empty-arm",
+            "conditional-alone-in-its-branch",
+            "empty-branch-beside-the-conditional",
         ],
     )
     def test_a_conditional_that_can_run_an_empty_arm_is_still_refused(
@@ -1640,8 +1659,11 @@ class TestSpecVerifier:
         when the empty arm is the one its participation selects, a capture inside
         a failed negative one still runs the other, and an assertion that is
         itself under a `?` is back to being a path that may have been skipped.
-        Every pattern here matches a subject with nothing in it, so none is
-        evidence of anything.
+        Reading a branch on its own path must not leak the other way either:
+        the last two put the conditional and the capture in *different*
+        branches, where the branch that runs is exactly the one that did not
+        record the capture. Every pattern here matches a subject with nothing in
+        it, so none is evidence of anything.
         """
         project = self._create_project({"marker.txt": "aa\n"})
         assertion = SpecAssertion(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1469,6 +1469,52 @@ class TestSpecVerifier:
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
         "pattern",
+        [r"(?!)|aa", r"(?!(?:))|aa", r"(?!)aa|aa", r"aa(?!)|aa", r"(?!(?!))"],
+        ids=["alternative", "empty-body", "before-the-literal", "after-the-literal", "negated"],
+    )
+    def test_an_assertion_that_can_never_hold_is_read_on_every_supported_parser(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """Which node the parser hands over is a fact about the interpreter.
+
+        `(?!)` is the idiom for a branch that must never be taken. Through 3.12
+        it parses as a negative assertion with an empty body, which this reading
+        already answers: the body matches nothing, so the negation of it matches
+        nothing. From 3.13 the parser folds the whole thing into a single
+        `FAILURE` opcode, which fell through to "unknown construct" and refused
+        the pattern — so `(?!)|CameraProvider` was evidence on 3.12 and an
+        authoritative failure on 3.13 and 3.14, from the same source.
+
+        The assertion is therefore not which node arrives but that the guard
+        agrees with the interpreter that will run it, which pins all three
+        without naming any of them. It has to hold in both directions, so the
+        last case negates the whole thing: `(?!(?!))` matches every file, empty
+        ones included, and stays refused on every parser.
+        """
+        matches_nothing = re.search(pattern, "") is not None
+        assert re.search(pattern, "aa\n"), f"{pattern!r} must be satisfied by the fixture"
+
+        project = self._create_project({"marker.txt": "aa\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a doubled letter",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is not matches_nothing, (
+            f"{pattern!r} matches the empty string here: {matches_nothing}"
+        )
+        assert summary.discrepancy_count == (1 if matches_nothing else 0)
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
         [
             r"(a)?(?(1)|a)",
             r"(a)?(?(1)a|a)",

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1536,6 +1536,9 @@ class TestSpecVerifier:
             r"aa|()(?(1)Impossible|)",
             r"x|()(?(1)a|)",
             r"(?:(a)|b)(?(1)a|b)",
+            r"(?:()|x)(?(1)a|)",
+            r"(?=()|x)(?(1)a|)",
+            r"()(?(1)()|)(?(2)a|)",
         ],
         ids=[
             "unparticipating-group-runs-the-other-arm",
@@ -1558,6 +1561,9 @@ class TestSpecVerifier:
             "capture-and-conditional-in-the-second-branch",
             "conditional-in-a-branch-beside-a-consuming-one",
             "conditional-after-a-branch-that-captures-either-way",
+            "conditional-after-a-branch-only-one-of-which-can-be-empty",
+            "conditional-after-such-a-branch-inside-a-lookahead",
+            "capture-in-the-arm-the-conditional-selects",
         ],
     )
     def test_a_conditional_is_read_from_whether_its_group_could_have_taken_part(
@@ -1597,7 +1603,14 @@ class TestSpecVerifier:
         stand or fall together. Reading every branch as a path that may have
         been skipped made `()(?(1)Impossible|)` — read correctly on its own —
         unreadable the moment an alternative was written beside it, so the last
-        four are the same conditionals with one added.
+        seven are the same conditionals with one added.
+
+        Nor is it always a choice. On a subject with nothing in it nothing can
+        consume anything, so a branch that cannot match nothing cannot run at
+        all, and when that leaves a single branch standing the alternation
+        decides nothing. The same holds one step further in: once participation
+        settles which arm of a conditional runs, a capture written in that arm
+        is as much on the path as the conditional itself.
         """
         project = self._create_project({"marker.txt": "aa\n"})
         assertion = SpecAssertion(
@@ -1689,8 +1702,16 @@ class TestSpecVerifier:
             r"(?!(a)?(?(1)|c))",
             r"(?!(a)?(?(1)|x)b)",
             "(?!" + "(" * 45 + "x" + ")" * 45 + ")",
+            r"(?!()(?(1)a|))",
+            r"(?!(?!(a?)(?(1)|a)))",
         ],
-        ids=["negated-conditional", "negated-conditional-with-tail", "negated-past-depth-limit"],
+        ids=[
+            "negated-conditional",
+            "negated-conditional-with-tail",
+            "negated-past-depth-limit",
+            "negated-conditional-on-a-capture-beside-it",
+            "twice-negated-conditional-on-a-nullable-capture",
+        ],
     )
     def test_doubt_inside_a_negation_does_not_become_confidence_outside_it(
         self, tier: VerificationTier, pattern: str
@@ -1710,6 +1731,14 @@ class TestSpecVerifier:
         which one runs depends on a capture this does not track, the third
         because nesting past `_MAX_PARSE_DEPTH` guessed yes about the inside.
         The answer is a third value — unknown — that negation leaves unknown.
+
+        The last two are not doubt but the opposite mistake: a *confident* wrong
+        answer about the inside. Declaring the body's captures absent before the
+        body had been read made `(?!()(?(1)a|))` take its empty arm, so the
+        negation of a body that cannot match nothing was read as a pattern that
+        discriminates — and it matches every file. What a failed body leaves
+        behind is `False` to the outside; while it is being attempted, a
+        conditional written beside the capture reads it like any other.
         """
         project = self._create_project({"marker.txt": "hello\n"})
         assertion = SpecAssertion(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -640,95 +640,37 @@ class TestSpecVerifier:
         assert "Unusable regex pattern" in summary.reports[0].results[0].detail
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_empty_file_answer_needs_the_criterion_to_name_the_file(
-        self, tier: VerificationTier
-    ) -> None:
-        """An exact hint is not consent: `ac_text` has to be about the file too.
-
-        `pkg/__init__.py` is empty in most repositories, and both the hint and the
-        pattern come out of the same model completion. Keyed on the hint alone, the
-        allowance lets `\\A\\Z` pointed at any ordinary package marker "verify" a
-        criterion about a camera interface — verbatim the fabrication this change
-        exists to close, re-entered through the door opened for the honest case.
-        """
-        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="pkg/__init__.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.verified_count == 0
-        assert summary.reports[0].verified_pass is False
-        assert summary.discrepancy_count == 1
-        assert summary.override_approval is False
-        assert "Unusable regex pattern" in summary.reports[0].results[0].detail
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    def test_criterion_must_name_the_hinted_file_as_a_whole_token(
-        self, tier: VerificationTier
-    ) -> None:
-        """`a.py` sits inside `data.py`, and a substring test cannot tell them apart.
-
-        The criterion is about `data.py`; the hint points at a different, empty file
-        whose name happens to be a tail of it. Read as a substring, the criterion
-        appears to corroborate a hint it never mentioned.
-        """
-        project = self._create_project({"a.py": "", "data.py": "rows = []\n"})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="data.py MUST remain empty",
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="a.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.verified_count == 0
-        assert summary.reports[0].verified_pass is False
-        assert summary.override_approval is False
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize("whitespace", ["\t", "  ", "\n\n"], ids=["tab", "spaces", "newlines"])
     def test_whitespace_is_blank_but_it_is_not_empty(
         self, tier: VerificationTier, whitespace: str
     ) -> None:
-        """The two words ask different questions, and `\\A\\Z` draws exactly that line.
+        """Empty and blank are different questions, and the pattern asks whichever it asks.
 
-        A file of one tab is blank. It is not empty, and the pattern that motivates
-        this whole path says so. Answering an `empty` criterion with the looser
-        reading would hand a formal PASS to a file the criterion rejects, so the
-        word the criterion used has to survive as far as the comparison.
+        A file of one tab is blank and is not empty. `\\A\\Z` draws that line and
+        `\\A\\s*\\Z` does not, so both are admitted and each answers itself — the
+        difference lands in the verdict without anything here reading the
+        criterion's English to find it.
         """
         project = self._create_project({"pkg/__init__.py": whitespace})
 
-        def verify(word: str) -> object:
+        def verify(pattern: str) -> object:
             assertion = SpecAssertion(
                 ac_index=0,
-                ac_text=f"pkg/__init__.py MUST remain {word}",
+                ac_text="pkg/__init__.py MUST remain empty",
                 tier=tier,
-                pattern=r"\A\Z",
+                pattern=pattern,
                 file_hint="pkg/__init__.py",
             )
             return SpecVerifier(project_dir=project).verify_all(
                 (assertion,), agent_results={0: True}
             )
 
-        strict = verify("empty")
+        strict = verify(r"\A\Z")
         assert strict.verified_count == 0
         assert strict.reports[0].verified_pass is False
         assert strict.discrepancy_count == 1
 
-        loose = verify("blank")
+        loose = verify(r"\A\s*\Z")
         assert loose.verified_count == 1
         assert loose.reports[0].verified_pass is True
         assert loose.discrepancy_count == 0
@@ -770,6 +712,57 @@ class TestSpecVerifier:
         assert summary.override_approval is False
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"(?m)^$", r"^$", r"\A.*\Z", r"(?s)\A.*\Z", r"\A\w*\Z", r"\A[^x]*\Z", r"\A\s*", r"\s*\Z"],
+        ids=[
+            "multiline-blank-line",
+            "line-anchors",
+            "dot-star",
+            "dotall-star",
+            "word-star",
+            "negated-class",
+            "start-only",
+            "end-only",
+        ],
+    )
+    def test_a_pattern_a_file_with_content_can_satisfy_is_never_admitted(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """The allowance is for patterns no non-empty file can match — these all can.
+
+        Each of these matches the empty subject, and each also matches this file,
+        which has content in it. Admitting any of them would report `PASS` on a
+        file the criterion rejects, which is the fabricated pass this whole guard
+        exists to stop, arriving through the exit built to rescue honest ACs.
+
+        `(?m)^$` and `^$` are the pair that a naive reading gets wrong: the parser
+        emits the same `AT_BEGINNING` for `^` whether or not `re.MULTILINE` is
+        set — the compiler makes it a line anchor later, from flags — so counting
+        `^` as pinned to the start of the file would admit a pattern that any
+        blank line inside a full file satisfies. `\\A\\s*` and `\\s*\\Z` are pinned at
+        one end only, and match the run of whitespace at whichever end they name.
+        """
+        project = self._create_project({"pkg/__init__.py": "\nfrom .camera import x\n\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="pkg/__init__.py MUST remain empty",
+            tier=tier,
+            pattern=pattern,
+            file_hint="pkg/__init__.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+        assert "Unusable regex pattern" in summary.reports[0].results[0].detail
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     def test_a_must_not_be_empty_criterion_is_left_to_the_ordinary_path(
         self, tier: VerificationTier
     ) -> None:
@@ -795,147 +788,6 @@ class TestSpecVerifier:
         assert summary.verified_count == 1
         assert summary.reports[0].verified_pass is True
         assert summary.discrepancy_count == 0
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    @pytest.mark.parametrize(
-        "ac_text",
-        [
-            "pkg/config.py MUST NOT be empty",
-            "pkg/config.py must never be empty",
-            "pkg/config.py cannot be blank",
-            "pkg/config.py must not be blank",
-            "pkg/config.py must be non-empty",
-            "pkg/config.py must contain a nonempty value",
-            "pkg/config.py must not under any circumstances be empty.",
-            "pkg/config.py should never, under any reading of this spec, be blank",
-            "Do not let pkg/config.py be empty",
-            "Never allow pkg/config.py to remain empty",
-            "Do not permit pkg/config.py to become empty.",
-            "Never, under any reading of this spec, allow pkg/config.py to be blank",
-            "Do not remove the guard and let pkg/config.py be empty",
-            "Please do not let pkg/config.py be empty",
-            "Please ensure pkg/config.py is not empty",
-            "Please avoid leaving pkg/config.py empty",
-            "It is required that pkg/config.py never be empty",
-            "Make sure pkg/config.py is not empty",
-            "It is forbidden that pkg/config.py be empty",
-        ],
-        ids=[
-            "must-not",
-            "never",
-            "cannot-blank",
-            "not-blank",
-            "hyphenated",
-            "nonempty-word",
-            "distant-negation",
-            "very-distant-negation",
-            "preposed-negation",
-            "preposed-negation-infinitive",
-            "preposed-negation-causative",
-            "preposed-negation-past-comma",
-            "preposed-negation-past-conjunction",
-            "politeness-then-negation",
-            "politeness-then-negated-copula",
-            "politeness-then-avoidance",
-            "impersonal-then-negation",
-            "periphrasis-then-negation",
-            "impersonal-prohibition",
-        ],
-    )
-    def test_a_criterion_forbidding_emptiness_is_not_satisfied_by_an_empty_file(
-        self, tier: VerificationTier, ac_text: str
-    ) -> None:
-        """The violated reading must not pass, and the pattern cannot tell them apart.
-
-        `\\A\\Z` is what a model writes for "must be empty" and for "must not be
-        empty" alike, so polarity has to be read from `ac_text`. Deciding it from
-        the pattern verified a criterion the file breaks: an empty `config.py`
-        against an AC that requires content.
-
-        `nonempty` is here because reading the word as a substring saw `empty`
-        inside it and called the criterion an emptiness requirement. The distant
-        negations are here because a fixed lookback window has a far side, and a
-        criterion can always put its `not` past it.
-
-        The politeness and impersonal forms are the other half of admitting
-        `please`, `kindly`, `make sure` and `it is required that` as words that
-        change no claim: each of these opens exactly as an admitted criterion
-        does and then negates it, so widening the lead must not widen this.
-        """
-        project = self._create_project({"pkg/config.py": ""})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="pkg/config.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
-        assert summary.discrepancy_count == 1
-        assert summary.override_approval is False
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    @pytest.mark.parametrize(
-        "ac_text",
-        [
-            "pkg/marker.txt must be empty and contain a header",
-            "pkg/marker.txt must be empty and must be deleted",
-            "pkg/marker.txt must be empty, but must also contain generated metadata",
-            "pkg/marker.txt MUST be empty and must not be deleted",
-            "pkg/marker.txt must be deleted, and pkg/marker.txt must be empty",
-            "pkg/marker.txt must be empty then the build proceeds",
-            "For the release, pkg/marker.txt must be empty",
-            "Run the generator; pkg/marker.txt must be empty",
-        ],
-        ids=[
-            "and-obligation",
-            "and-modal-obligation",
-            "comma-but-also",
-            "and-negated-obligation",
-            "obligation-in-preamble",
-            "trailing-consequence",
-            "preposed-adjunct",
-            "preposed-clause",
-        ],
-    )
-    def test_a_criterion_that_asks_for_more_than_emptiness_is_not_answered_here(
-        self, tier: VerificationTier, ac_text: str
-    ) -> None:
-        """Emptiness is only half of a compound criterion, and half is not an answer.
-
-        An earlier revision of this test asserted the opposite for the `and must
-        not be deleted` form, on the reasoning that one un-negated occurrence is
-        the requirement. That reasoning was wrong in a way the deletion clause
-        makes obvious: nothing verifies the second obligation, so reporting a
-        pass reports on a criterion that was never checked. The rescue now has
-        to consume the criterion in full, and everything here says something it
-        cannot consume — including the two preposed forms, which it has no way
-        to tell apart from an obligation without reading English.
-
-        Failing closed costs a satisfied emptiness AC its pass, but it costs it
-        an honest `Unusable regex pattern` failure rather than an authoritative
-        wrong answer, which is the trade this whole guard exists to make.
-        """
-        project = self._create_project({"pkg/marker.txt": ""})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="pkg/marker.txt",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all((assertion,))
-
-        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
-        detail = summary.reports[0].results[0].detail
-        assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
-        assert "Unusable regex pattern" in detail
 
     def test_a_pattern_is_refused_by_reading_it_and_never_by_running_it(self) -> None:
         """Deciding nullability by execution hands the verifier a denial of service.
@@ -994,121 +846,6 @@ class TestSpecVerifier:
     @pytest.mark.parametrize(
         "ac_text",
         [
-            "pkg/marker.txt MUST be != empty",
-            "pkg/marker.txt MUST be ≠ empty",
-            "pkg/marker.txt !must be empty",
-            "pkg/marker.txt must be empty 100%",
-            "pkg/marker.txt must be empty > 0 bytes",
-            "pkg/marker.txt must be empty & committed",
-        ],
-        ids=[
-            "ascii-symbolic-negation",
-            "unicode-symbolic-negation",
-            "symbol-before-modal",
-            "numeric-obligation",
-            "operator-obligation",
-            "symbolic-conjunction",
-        ],
-    )
-    def test_a_character_the_reading_cannot_read_refuses_the_whole_criterion(
-        self, tier: VerificationTier, ac_text: str
-    ) -> None:
-        """Consuming every token is not consuming the criterion, if tokens can be dropped.
-
-        The reading used to gather tokens with `findall`, which silently deletes
-        whatever the pattern does not match — so `!=` and `≠` vanished and the
-        criteria here read as bare emptiness requirements, publishing a pass for
-        the exact claim they negate. That is the same defect as matching a part
-        of the criterion, one layer down: a scan over characters that discards
-        the ones it does not recognise is a scan over a part of the characters.
-
-        So the criterion is now consumed character by character, and a character
-        outside words, `.,;:`, quotes, brackets and whitespace refuses the whole
-        reading rather than disappearing from it. An operator or a digit can be
-        the entire meaning, and there is no way to tell the harmless ones apart
-        without reading English.
-        """
-        project = self._create_project({"pkg/marker.txt": ""})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="pkg/marker.txt",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all((assertion,))
-
-        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
-        detail = summary.reports[0].results[0].detail
-        assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
-        assert "Unusable regex pattern" in detail
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    @pytest.mark.parametrize(
-        ("filename", "ac_text"),
-        [
-            ("empty.txt", "empty.txt MUST contain data"),
-            ("blank.json", "blank.json MUST hold at least one record"),
-            ("marker.txt", "marker.txt MUST contain an empty JSON string field"),
-            ("marker.txt", "marker.txt MUST be an empty JSON object"),
-            ("marker.txt", "marker.txt MUST list the empty partitions"),
-            ("marker.txt", "The status field in marker.txt must be empty."),
-            ("marker.txt", "Every record within marker.txt must be blank"),
-            ("marker.txt", "marker.txt entries must be empty"),
-            ("marker.txt", "The status field in the generated marker.txt must be empty."),
-            ("marker.txt", "The first record of the newly created marker.txt must be blank"),
-        ],
-        ids=[
-            "empty-filename",
-            "blank-filename",
-            "nested-value",
-            "attributive",
-            "object-of-verb",
-            "prepositional-subject",
-            "prepositional-subject-blank",
-            "competing-noun-subject",
-            "modifier-separated-preposition",
-            "two-modifiers-separated-preposition",
-        ],
-    )
-    def test_an_emptiness_word_that_is_not_about_the_file_earns_nothing(
-        self, tier: VerificationTier, filename: str, ac_text: str
-    ) -> None:
-        """The word has to be predicated of the file, not merely present in the AC.
-
-        Each of these mentions emptiness while requiring the file to hold content,
-        and each was read as an emptiness requirement: the word sat in the file's own
-        name, or described a value nested inside it, or was the adjective on some
-        other noun, or the file was named as the object of a preposition — directly
-        or with modifiers standing between the two — while some field inside it was
-        the actual subject. With `\\A\\Z` and an empty file that produced a formal
-        PASS for a criterion the file plainly violates.
-
-        Everything here falls through to the ordinary path, where `\\A\\Z` is refused
-        and the criterion fails closed.
-        """
-        project = self._create_project({filename: ""})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint=filename,
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
-
-        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
-        assert summary.discrepancy_count == 1
-        assert summary.override_approval is False
-
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    @pytest.mark.parametrize(
-        "ac_text",
-        [
             "marker.txt MUST be empty",
             "marker.txt must be empty.",
             "The file marker.txt must be empty",
@@ -1123,6 +860,10 @@ class TestSpecVerifier:
             "It is necessary that marker.txt remains empty",
             "Check that marker.txt is empty",
             "Please confirm marker.txt is blank",
+            "Verify whether marker.txt is empty",
+            "The marker.txt file must remain empty",
+            "marker.txt는 비어 있어야 한다",
+            "ᛗᚨᚱᚲᛖᚱ",
         ],
         ids=[
             "bare",
@@ -1139,28 +880,30 @@ class TestSpecVerifier:
             "impersonal-necessity",
             "checking-verb",
             "politeness-and-blank",
+            "interrogative",
+            "noun-phrase-subject",
+            "not-english",
+            "names-nothing",
         ],
     )
-    def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(
+    def test_the_wording_of_the_criterion_never_decides_the_verdict(
         self, tier: VerificationTier, ac_text: str
     ) -> None:
-        """The shapes the rescue must keep answering, pinned against over-tightening.
+        """Every wording reaches the same verdict, because none of them is read.
 
-        A guard this strict is one edit away from refusing everything, and a
-        refusal is a formal failure for an AC the project satisfies — the
-        original blocker, relocated. `ensure` and `require` ask for the clause
-        after them without changing what it claims, so a criterion that opens
-        with one still says exactly what it says, and a determiner or a noun for
-        the file itself changes nothing either.
+        An earlier revision recognised a closed sentence shape and let the
+        allowance turn on it, so ordinary criteria — `Verify whether marker.txt
+        is empty`, `The marker.txt file must remain empty` — fell through to the
+        blanket refusal and became formal failures for a project that satisfies
+        them. A word list can always be one word short, and each missing word is
+        another honest AC reported as broken.
 
-        The politeness and impersonal forms are the shapes that were refused —
-        `Please ensure marker.txt is empty` was a formal failure on a project
-        that satisfied it, because `please` names no claim and was not listed as
-        naming none. Every word admitted here answers one question: can it change
-        what is claimed about the file? `please`, `kindly`, `make sure` and `it
-        is required that` cannot, so they are read through. `do not`, `never`,
-        `avoid` and `prevent` can, so they are not — and the paired rejection
-        test pins that.
+        Nothing here parses English any more. The allowance is decided by the
+        pattern (`\\A\\Z` can only match a subject with nothing in it) and the hint
+        (it names one file, and that file is what gets read), so the criterion's
+        wording is free — interrogative, noun-phrase, another language, or text
+        that names nothing at all. All of them verify, because all of them are
+        answered by reading `marker.txt`.
         """
         project = self._create_project({"marker.txt": ""})
         assertion = SpecAssertion(
@@ -1191,13 +934,15 @@ class TestSpecVerifier:
     def test_emptiness_offered_as_one_option_is_not_an_emptiness_requirement(
         self, tier: VerificationTier, ac_text: str
     ) -> None:
-        """A criterion the file can satisfy another way is not this rescue's to answer.
+        """A pattern with a second branch that matches content is not an emptiness test.
 
-        Answering the emptiness branch alone would throw away the evidence the
-        other branch names and publish an authoritative "the file is not empty"
-        for a criterion that never required it to be. The refusal has to say what
-        it actually is — a pattern that cannot be trusted — so the failure is
-        legible instead of a confident wrong reason.
+        `\\A\\Z|# generated` matches the empty subject, so it is refused unless it
+        can only match a subject with nothing in it — and this one plainly can
+        match `# generated`. The alternation is what disqualifies it; that the
+        criterion also offers a second way to be satisfied is a fact about the
+        same pattern, read off the pattern rather than off the prose. The refusal
+        has to say what it actually is — a pattern that cannot be trusted — so
+        the failure is legible instead of a confident wrong reason.
         """
         project = self._create_project({"marker.txt": "# generated\n"})
         assertion = SpecAssertion(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1469,12 +1469,31 @@ class TestSpecVerifier:
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
         "pattern",
-        [r"(a)?(?(1)|a)", r"(a)?(?(1)a|a)", r"(a|b)?(?(1)|a)", r"(a?)(?(1)a|)"],
+        [
+            r"(a)?(?(1)|a)",
+            r"(a)?(?(1)a|a)",
+            r"(a|b)?(?(1)|a)",
+            r"(a?)(?(1)a|)",
+            r"(?=())(?(1)a|)",
+            r"(?<=())(?(1)a|)",
+            r"(?=(a?))(?(1)a|)",
+            r"((?=()))(?(2)a|)",
+            r"(?=(?=()))(?(1)a|)",
+            r"(?!()x)(?(1)|a)",
+            r"(?!(a)x)(?(1)|a)",
+        ],
         ids=[
             "unparticipating-group-runs-the-other-arm",
             "both-arms-consume",
             "branching-group",
             "participating-group-runs-its-own-arm",
+            "capture-inside-a-lookahead",
+            "capture-inside-a-lookbehind",
+            "nullable-capture-inside-a-lookahead",
+            "lookahead-inside-a-capture",
+            "capture-inside-nested-lookaheads",
+            "capture-inside-a-failed-negative-lookahead",
+            "consuming-capture-inside-a-negative-lookahead",
         ],
     )
     def test_a_conditional_is_read_from_whether_its_group_could_have_taken_part(
@@ -1493,6 +1512,14 @@ class TestSpecVerifier:
         certainly consumes certainly did not take part in an empty match. Where
         participation really is undecidable the arms must still agree, and the
         refusal test below keeps that half honest.
+
+        An assertion is not an undecidable path. A positive one has to hold for
+        the match to happen, so a capture inside it took part exactly as much as
+        the same capture written outside it; a negative one succeeds only where
+        its body fails, and a failed subpattern leaves nothing captured, so a
+        capture inside it certainly did not. Reading both as "may have been
+        skipped" made every one of these unreadable and refused a criterion the
+        source plainly satisfies.
         """
         project = self._create_project({"marker.txt": "aa\n"})
         assertion = SpecAssertion(
@@ -1514,11 +1541,25 @@ class TestSpecVerifier:
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
         "pattern",
-        [r"(a)?(?(1)a|)", r"(a?)(?(1)|a)", r"(a?)?(?(1)a|)"],
+        [
+            r"(a)?(?(1)a|)",
+            r"(a?)(?(1)|a)",
+            r"(a?)?(?(1)a|)",
+            r"(?=())(?(1)|a)",
+            r"(?<=())(?(1)|a)",
+            r"(?=(a?))(?(1)|a)",
+            r"(?=())?(?(1)a|)",
+            r"(?!()x)(?(1)a|)",
+        ],
         ids=[
             "empty-arm-is-the-one-that-runs",
             "participating-group-empty-arm",
             "either-arm-may-run",
+            "lookahead-capture-empty-arm",
+            "lookbehind-capture-empty-arm",
+            "nullable-lookahead-capture-empty-arm",
+            "lookahead-that-may-be-skipped",
+            "failed-negative-lookahead-capture-empty-arm",
         ],
     )
     def test_a_conditional_that_can_run_an_empty_arm_is_still_refused(
@@ -1529,7 +1570,12 @@ class TestSpecVerifier:
         The first two are certain the other way — the arm that runs is the empty
         one — and the third is the case participation cannot settle, because the
         group's body can itself match nothing, so it may equally have taken part
-        or been skipped. All three match a subject with nothing in it, so none is
+        or been skipped. Reading assertions accurately has to leave that half
+        intact: a capture inside a positive assertion still runs the empty arm
+        when the empty arm is the one its participation selects, a capture inside
+        a failed negative one still runs the other, and an assertion that is
+        itself under a `?` is back to being a path that may have been skipped.
+        Every pattern here matches a subject with nothing in it, so none is
         evidence of anything.
         """
         project = self._create_project({"marker.txt": "aa\n"})

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -1385,13 +1386,8 @@ class TestSpecVerifier:
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
         "pattern",
-        [r"(?!\b)", r"(?!\bx)", r"(?<!\b)", r"(?=\B)"],
-        ids=[
-            "negated-boundary",
-            "negated-boundary-with-tail",
-            "negated-lookbehind",
-            "non-boundary",
-        ],
+        [r"(?!\b)", r"(?!\bx)", r"(?<!\b)"],
+        ids=["negated-boundary", "negated-boundary-with-tail", "negated-lookbehind"],
     )
     def test_a_word_boundary_is_not_zero_width_once_something_negates_it(
         self, tier: VerificationTier, pattern: str
@@ -1399,8 +1395,8 @@ class TestSpecVerifier:
         """`\\b` consumes nothing, which is not the same as holding on nothing.
 
         Every anchor was treated alike, as a thing that holds wherever it
-        appears. That is true of `^`, `\\A`, `$`, `\\Z` and `\\B` on a subject
-        with nothing in it, and false of `\\b`, which needs a word character on
+        appears. That is true of `^`, `\\A`, `$` and `\\Z` on a subject with
+        nothing in it, and false of `\\b`, which needs a word character on
         exactly one side and so can never hold there. On its own the error was
         the harmless one — a pattern wrongly called nullable is only refused —
         but `(?!\\b)` reverses it: `\\b` fails on an empty subject, so the
@@ -1426,6 +1422,49 @@ class TestSpecVerifier:
         assert summary.reports[0].verified_pass is False, f"{pattern!r} must not be evidence"
         assert summary.discrepancy_count == 1
         assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"\B", r"(?!\B)", r"(?<!\B)", r"(?=\B)"],
+        ids=["non-boundary", "negated", "negated-lookbehind", "asserted"],
+    )
+    def test_a_non_boundary_is_read_from_the_interpreter_that_will_run_it(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """`\\B` on an empty subject is a fact about CPython, not about regexes.
+
+        Before 3.14 it required a position between two characters, of which an
+        empty subject has none; from 3.14 the sole position of an empty subject
+        is a non-boundary and `\\B` holds there. Written into the table as a
+        constant, the entry was right on the interpreter it was written on and
+        wrong on 3.12, where `(?!\\B)` matches every file — an unrelated
+        `marker.txt` verified as evidence and published as a formal PASS — and
+        `(?=\\B)` discriminates but was refused.
+
+        So the assertion here is not which way `\\B` falls, but that the guard
+        falls the same way this interpreter does: what matches a subject with
+        nothing in it is refused, and what does not stays evidence. The same
+        test therefore pins 3.12, 3.13 and 3.14 without naming any of them.
+        """
+        matches_nothing = re.search(pattern, "") is not None
+        project = self._create_project({"marker.txt": "hello\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a CameraProvider declaration",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is not matches_nothing, (
+            f"{pattern!r} matches the empty string here: {matches_nothing}"
+        )
+        assert summary.discrepancy_count == (1 if matches_nothing else 0)
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1382,6 +1382,90 @@ class TestSpecVerifier:
         assert summary.discrepancy_count == 1
         assert summary.override_approval is False
 
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            r"(?!(a)?(?(1)|c))",
+            r"(?!(a)?(?(1)|x)b)",
+            "(?!" + "(" * 45 + "x" + ")" * 45 + ")",
+        ],
+        ids=["negated-conditional", "negated-conditional-with-tail", "negated-past-depth-limit"],
+    )
+    def test_doubt_inside_a_negation_does_not_become_confidence_outside_it(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """A guess that is safe on its own is unsafe once something negates it.
+
+        The reading answers "can this match nothing?" and sends every doubt to
+        the safe side by answering yes, because a pattern wrongly called nullable
+        is only refused. `(?!…)` reverses which side is safe. A guessed yes about
+        the inside becomes a confident *no* about the outside, and the guard then
+        reports that the pattern discriminates on the strength of not having
+        understood it — the fabricated pass this PR exists to stop, produced by
+        the guard itself.
+
+        Each pattern here matches every file, empty or not, and each was admitted
+        as evidence: the first two because the conditional's arms disagree and
+        which one runs depends on a capture this does not track, the third
+        because nesting past `_MAX_PARSE_DEPTH` guessed yes about the inside.
+        The answer is a third value — unknown — that negation leaves unknown.
+        """
+        project = self._create_project({"marker.txt": "hello\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a CameraProvider declaration",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{pattern!r} must not be evidence"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        ("hint", "ac_text"),
+        [
+            ("marker.txt", "Marker.txt must be empty"),
+            ("marker.txt", "MARKER.TXT must be empty"),
+            ("Marker.txt", "marker.txt must be empty"),
+            ("marker.txt", "Please ensure Marker.txt is empty"),
+        ],
+        ids=["capitalized-mention", "shouted-mention", "capitalized-hint", "capitalized-in-frame"],
+    )
+    def test_a_capital_letter_in_the_filename_does_not_manufacture_a_failure(
+        self, tier: VerificationTier, hint: str, ac_text: str
+    ) -> None:
+        """One normalization, used in both places that read the filename.
+
+        The mention check lowered both sides before looking; the masking that
+        follows it did not. So a criterion whose spelling of the name differed
+        only in case got past the check, kept its unmasked name, and lost the one
+        token the reading anchors on — an ordinary emptiness requirement on a
+        file that satisfies it, failed formally by a capital letter.
+        """
+        project = self._create_project({"marker.txt": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint=hint,
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is True, f"{ac_text!r} must still verify"
+        assert summary.discrepancy_count == 0
+
     def test_genuine_constant_match_still_verifies(self) -> None:
         """The same on the T1 path, so the guard is not proven only through T2."""
         project = self._create_project({"config.py": "WARMUP_FRAMES = 10\n"})

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 import tempfile
+import textwrap
 from unittest.mock import AsyncMock
 
 import pytest
@@ -915,6 +918,59 @@ class TestSpecVerifier:
         detail = summary.reports[0].results[0].detail
         assert "empty" not in detail, f"{ac_text!r} must not be answered as an emptiness claim"
         assert "Unusable regex pattern" in detail
+
+    def test_a_pattern_is_refused_by_reading_it_and_never_by_running_it(self) -> None:
+        """Deciding nullability by execution hands the verifier a denial of service.
+
+        Each pattern here is under twenty characters, so the length cap admits
+        it, and each compiles instantly — the cost is all in the matching, which
+        used to happen against `""` before the verifier had even looked for a
+        file. A repetition count is one number in the pattern and two billion
+        steps in the run, so no cap on the pattern's length caps the work. All
+        three run for over twelve seconds under execution and are refused in
+        under a millisecond by reading the parse tree, which is bounded by the
+        pattern's length whatever numbers are written inside it.
+
+        This runs in a child process rather than a thread because a runaway
+        `re.search` holds the GIL for its whole duration: no timeout, alarm or
+        `join` in this process could interrupt one, and a regression would hang
+        interpreter shutdown instead of failing. A child can simply be killed.
+        """
+        project = self._create_project({"marker.txt": "content"})
+        script = textwrap.dedent(
+            f"""
+            from ouroboros.verification.models import SpecAssertion, VerificationTier
+            from ouroboros.verification.verifier import SpecVerifier
+
+            for pattern in [r"(?:){{2000000000}}", r"(?:x?){{2000000000}}", r"(?:\\s*){{2000000000}}"]:
+                for tier in (VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL):
+                    assertion = SpecAssertion(
+                        ac_index=0,
+                        ac_text="marker.txt MUST contain a header",
+                        tier=tier,
+                        pattern=pattern,
+                        file_hint="marker.txt",
+                    )
+                    summary = SpecVerifier(project_dir={project!r}).verify_all(
+                        (assertion,), agent_results={{0: True}}
+                    )
+                    assert summary.reports[0].verified_pass is False
+                    assert summary.override_approval is False
+            """
+        )
+
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail("hostile patterns did not finish — nullability is being decided by running")
+
+        assert completed.returncode == 0, completed.stderr
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1385,6 +1385,134 @@ class TestSpecVerifier:
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
         "pattern",
+        [r"(?!\b)", r"(?!\bx)", r"(?<!\b)", r"(?=\B)"],
+        ids=[
+            "negated-boundary",
+            "negated-boundary-with-tail",
+            "negated-lookbehind",
+            "non-boundary",
+        ],
+    )
+    def test_a_word_boundary_is_not_zero_width_once_something_negates_it(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """`\\b` consumes nothing, which is not the same as holding on nothing.
+
+        Every anchor was treated alike, as a thing that holds wherever it
+        appears. That is true of `^`, `\\A`, `$`, `\\Z` and `\\B` on a subject
+        with nothing in it, and false of `\\b`, which needs a word character on
+        exactly one side and so can never hold there. On its own the error was
+        the harmless one — a pattern wrongly called nullable is only refused —
+        but `(?!\\b)` reverses it: `\\b` fails on an empty subject, so the
+        negation holds, so each of these matches every file including an empty
+        one, and each was admitted as evidence and published as a formal PASS.
+
+        Anchors are now classified one at a time by what they actually do, and
+        `\\bCameraProvider\\b` stays evidence in the acceptance test above.
+        """
+        project = self._create_project({"marker.txt": "hello\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a CameraProvider declaration",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{pattern!r} must not be evidence"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"(a)?(?(1)|a)", r"(a)?(?(1)a|a)", r"(a|b)?(?(1)|a)", r"(a?)(?(1)a|)"],
+        ids=[
+            "unparticipating-group-runs-the-other-arm",
+            "both-arms-consume",
+            "branching-group",
+            "participating-group-runs-its-own-arm",
+        ],
+    )
+    def test_a_conditional_is_read_from_whether_its_group_could_have_taken_part(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """`(?(1)yes|no)` runs one arm, and which one is not a coin toss.
+
+        Requiring both arms to agree refused patterns that plainly discriminate.
+        `(a)?(?(1)|a)` cannot match nothing: on a match that consumed nothing the
+        optional group cannot have taken part — taking part would have consumed
+        the `a` — so the empty arm is exactly the arm that does not run, and the
+        `a` is the arm that does. Refusing it turned a satisfied AC into an
+        authoritative failure.
+
+        Participation is now carried alongside nullability: a group whose body
+        certainly consumes certainly did not take part in an empty match. Where
+        participation really is undecidable the arms must still agree, and the
+        refusal test below keeps that half honest.
+        """
+        project = self._create_project({"marker.txt": "aa\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a doubled letter",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is True, f"{pattern!r} must stay evidence"
+        assert summary.discrepancy_count == 0
+        assert summary.override_approval is None
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"(a)?(?(1)a|)", r"(a?)(?(1)|a)", r"(a?)?(?(1)a|)"],
+        ids=[
+            "empty-arm-is-the-one-that-runs",
+            "participating-group-empty-arm",
+            "either-arm-may-run",
+        ],
+    )
+    def test_a_conditional_that_can_run_an_empty_arm_is_still_refused(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """Reading participation through must not open the hole it was closing.
+
+        The first two are certain the other way — the arm that runs is the empty
+        one — and the third is the case participation cannot settle, because the
+        group's body can itself match nothing, so it may equally have taken part
+        or been skipped. All three match a subject with nothing in it, so none is
+        evidence of anything.
+        """
+        project = self._create_project({"marker.txt": "aa\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a doubled letter",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{pattern!r} must not be evidence"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
         [
             r"(?!(a)?(?(1)|c))",
             r"(?!(a)?(?(1)|x)b)",

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -804,6 +804,11 @@ class TestSpecVerifier:
             "pkg/config.py must contain a nonempty value",
             "pkg/config.py must not under any circumstances be empty.",
             "pkg/config.py should never, under any reading of this spec, be blank",
+            "Do not let pkg/config.py be empty",
+            "Never allow pkg/config.py to remain empty",
+            "Do not permit pkg/config.py to become empty.",
+            "Never, under any reading of this spec, allow pkg/config.py to be blank",
+            "Do not remove the guard and let pkg/config.py be empty",
         ],
         ids=[
             "must-not",
@@ -814,6 +819,11 @@ class TestSpecVerifier:
             "nonempty-word",
             "distant-negation",
             "very-distant-negation",
+            "preposed-negation",
+            "preposed-negation-infinitive",
+            "preposed-negation-causative",
+            "preposed-negation-past-comma",
+            "preposed-negation-past-conjunction",
         ],
     )
     def test_a_criterion_forbidding_emptiness_is_not_satisfied_by_an_empty_file(
@@ -940,23 +950,29 @@ class TestSpecVerifier:
             "The file marker.txt must be empty",
             "For the release, marker.txt must be empty",
             "Run the generator; marker.txt must be empty",
+            "Ensure marker.txt is empty",
+            "We require marker.txt to be empty",
         ],
         ids=[
             "bare",
             "noun-modifier",
             "preposition-in-earlier-clause",
             "preposition-past-semicolon",
+            "transparent-verb",
+            "transparent-verb-with-subject",
         ],
     )
     def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(
         self, tier: VerificationTier, ac_text: str
     ) -> None:
-        """A preposition has to actually govern the file, not merely precede it.
+        """A word has to actually govern the file, not merely precede it.
 
         The phrase is scanned back to the nearest clause boundary rather than to
         the start of the criterion, because failing closed on any earlier `for` or
         `of` would turn satisfied emptiness ACs into formal failures — the same
-        false-failure this rescue exists to prevent, in a new place.
+        false-failure this rescue exists to prevent, in a new place. `ensure` and
+        `require` ask for the clause after them without changing what it claims,
+        so a criterion that opens with one still says what it says.
         """
         project = self._create_project({"marker.txt": ""})
         assertion = SpecAssertion(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -456,10 +456,14 @@ class TestSpecVerifier:
         summary = verifier.verify_all((assertion,))
         assert summary.verified_count == 1
 
-    # A pattern that matches the empty string matches every subject, so it verifies
-    # whatever criterion it is pointed at. All of these compile, which is the only
-    # question the gate used to ask.
-    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^", r"\A\Z"])
+    # A pattern that matches the empty string can succeed without any
+    # criterion-specific content, so it verifies whatever it is pointed at. All of
+    # these compile, which is the only question the gate used to ask.
+    #
+    # Split by which subject exposes each one: the patterns below also match ordinary
+    # non-empty files, while `\A\Z` succeeds only against an empty one — so proving
+    # that case needs a project that has such a file.
+    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^"])
     def test_t2_pattern_matching_any_input_is_not_evidence(self, pattern: str) -> None:
         """Such a pattern must not verify an AC the project does not satisfy."""
         project = self._create_project({"main.py": "print('hello')\n"})
@@ -478,7 +482,7 @@ class TestSpecVerifier:
         assert summary.verified_count == 0
         assert summary.reports[0].verified_pass is False
 
-    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^", r"\A\Z"])
+    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^"])
     def test_t1_pattern_matching_any_input_is_not_evidence(self, pattern: str) -> None:
         """The T1 constant path consumes matches too and needs the same guard."""
         project = self._create_project({"config.py": "FPS = 60\n"})
@@ -488,6 +492,31 @@ class TestSpecVerifier:
             tier=VerificationTier.T1_CONSTANT,
             pattern=pattern,
             file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: False}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    def test_anchored_empty_pattern_is_not_evidence(self, tier: VerificationTier) -> None:
+        """`\\A\\Z` succeeds only on an empty file, so only an empty file exposes it.
+
+        An empty ``__init__.py`` is ordinary in a Python package, and against it the
+        old verifier reported `Pattern found in __init__.py` on both tiers. Against a
+        non-empty fixture this pattern matches nothing either way, so a test without
+        an empty candidate would pass with the guard removed and prove nothing.
+        """
+        project = self._create_project({"pkg/__init__.py": "", "main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint="**/*.py",
         )
 
         summary = SpecVerifier(project_dir=project).verify_all(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -812,6 +812,12 @@ class TestSpecVerifier:
             "Do not permit pkg/config.py to become empty.",
             "Never, under any reading of this spec, allow pkg/config.py to be blank",
             "Do not remove the guard and let pkg/config.py be empty",
+            "Please do not let pkg/config.py be empty",
+            "Please ensure pkg/config.py is not empty",
+            "Please avoid leaving pkg/config.py empty",
+            "It is required that pkg/config.py never be empty",
+            "Make sure pkg/config.py is not empty",
+            "It is forbidden that pkg/config.py be empty",
         ],
         ids=[
             "must-not",
@@ -827,6 +833,12 @@ class TestSpecVerifier:
             "preposed-negation-causative",
             "preposed-negation-past-comma",
             "preposed-negation-past-conjunction",
+            "politeness-then-negation",
+            "politeness-then-negated-copula",
+            "politeness-then-avoidance",
+            "impersonal-then-negation",
+            "periphrasis-then-negation",
+            "impersonal-prohibition",
         ],
     )
     def test_a_criterion_forbidding_emptiness_is_not_satisfied_by_an_empty_file(
@@ -843,6 +855,11 @@ class TestSpecVerifier:
         inside it and called the criterion an emptiness requirement. The distant
         negations are here because a fixed lookback window has a far side, and a
         criterion can always put its `not` past it.
+
+        The politeness and impersonal forms are the other half of admitting
+        `please`, `kindly`, `make sure` and `it is required that` as words that
+        change no claim: each of these opens exactly as an admitted criterion
+        does and then negates it, so widening the lead must not widen this.
         """
         project = self._create_project({"pkg/config.py": ""})
         assertion = SpecAssertion(
@@ -1099,6 +1116,12 @@ class TestSpecVerifier:
             "marker.txt MUST remain empty",
             "`marker.txt` must be empty",
             '"marker.txt" must be empty',
+            "Please ensure marker.txt is empty",
+            "Kindly make sure marker.txt is empty",
+            "It is required that marker.txt be empty",
+            "It is necessary that marker.txt remains empty",
+            "Check that marker.txt is empty",
+            "Please confirm marker.txt is blank",
         ],
         ids=[
             "bare",
@@ -1109,6 +1132,12 @@ class TestSpecVerifier:
             "copula-variant",
             "backticked-name",
             "quoted-name",
+            "politeness-frame",
+            "politeness-and-periphrasis",
+            "impersonal-obligation",
+            "impersonal-necessity",
+            "checking-verb",
+            "politeness-and-blank",
         ],
     )
     def test_the_subject_check_does_not_reject_a_file_it_only_stands_near(
@@ -1122,6 +1151,15 @@ class TestSpecVerifier:
         after them without changing what it claims, so a criterion that opens
         with one still says exactly what it says, and a determiner or a noun for
         the file itself changes nothing either.
+
+        The politeness and impersonal forms are the shapes that were refused —
+        `Please ensure marker.txt is empty` was a formal failure on a project
+        that satisfied it, because `please` names no claim and was not listed as
+        naming none. Every word admitted here answers one question: can it change
+        what is claimed about the file? `please`, `kindly`, `make sure` and `it
+        is required that` cannot, so they are read through. `do not`, `never`,
+        `avoid` and `prevent` can, so they are not — and the paired rejection
+        test pins that.
         """
         project = self._create_project({"marker.txt": ""})
         assertion = SpecAssertion(
@@ -1264,6 +1302,85 @@ class TestSpecVerifier:
         assert summary.verified_count == 1
         assert summary.reports[0].has_discrepancy is False
         assert summary.override_approval is None
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"(a)?\1", r"(?P<x>a)?(?P=x)", r"(a)\1", r"(a)(b)?\1", r"((a))?\2"],
+        ids=[
+            "optional-group-numbered-backreference",
+            "optional-group-named-backreference",
+            "plain-backreference",
+            "unparticipating-optional-group",
+            "nested-group-backreference",
+        ],
+    )
+    def test_a_backreference_is_read_through_to_the_group_it_names(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """A backreference is empty only when the group it refers to can be.
+
+        The reading called every `GROUPREF` zero-width, which is true of the
+        *node* and false of what it matches: `(a)?\\1` matches `aa` and cannot
+        match nothing, because a backreference to a group that never
+        participated fails outright and one to a group that did repeats what it
+        captured. Calling these nullable refused a pattern that genuinely
+        discriminates, so a satisfied AC became an authoritative failure — the
+        blocker this PR opened with, running the other way.
+
+        Each pattern here is now judged from its group: the four with a
+        consuming group are evidence, and `(x?)\\1` in the refusal test below
+        still is not.
+        """
+        project = self._create_project({"marker.txt": "aa\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a doubled letter",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is True, f"{pattern!r} must stay evidence"
+        assert summary.discrepancy_count == 0
+        assert summary.override_approval is None
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [r"(x?)\1", r"(a|)\1", r"(a)?\1{0,3}"],
+        ids=["nullable-group", "empty-branch-group", "optional-backreference"],
+    )
+    def test_a_backreference_to_something_that_can_be_empty_is_still_refused(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        """Reading the group through must not open the hole it was closing.
+
+        Each of these matches a subject with nothing in it, so it verifies any
+        file at all and is not evidence of the criterion — exactly what the
+        earlier blanket treatment of `GROUPREF` let through once a nullable
+        group stood in front of it.
+        """
+        project = self._create_project({"marker.txt": "aa\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="marker.txt MUST contain a doubled letter",
+            tier=tier,
+            pattern=pattern,
+            file_hint="marker.txt",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{pattern!r} must not be evidence"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
 
     def test_genuine_constant_match_still_verifies(self) -> None:
         """The same on the T1 path, so the guard is not proven only through T2."""

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -456,6 +456,150 @@ class TestSpecVerifier:
         summary = verifier.verify_all((assertion,))
         assert summary.verified_count == 1
 
+    # A pattern that matches the empty string matches every subject, so it verifies
+    # whatever criterion it is pointed at. All of these compile, which is the only
+    # question the gate used to ask.
+    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^", r"\A\Z"])
+    def test_t2_pattern_matching_any_input_is_not_evidence(self, pattern: str) -> None:
+        """Such a pattern must not verify an AC the project does not satisfy."""
+        project = self._create_project({"main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=pattern,
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: False}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+
+    @pytest.mark.parametrize("pattern", [".*", "x?", r"\s*", "(?:)", "|", "^", r"\A\Z"])
+    def test_t1_pattern_matching_any_input_is_not_evidence(self, pattern: str) -> None:
+        """The T1 constant path consumes matches too and needs the same guard."""
+        project = self._create_project({"config.py": "FPS = 60\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST set WARMUP_FRAMES to 10",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=pattern,
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: False}
+        )
+
+        assert summary.verified_count == 0
+        assert summary.reports[0].verified_pass is False
+
+    def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:
+        """Refusing the pattern must raise a discrepancy, not silently skip the AC.
+
+        With the agent claiming PASS, a refused pattern has to leave a result behind:
+        an empty report list would make ``verified_pass`` fall back to the agent's own
+        self-report, turning a refused pattern into an unchecked pass.
+        """
+        project = self._create_project({"main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=".*",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        report = summary.reports[0]
+
+        assert report.results, "a refused pattern must still produce a result"
+        assert report.verified_pass is False
+        assert report.has_discrepancy is True
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
+        assert "Unusable regex pattern" in report.results[0].detail
+
+    def test_empty_matching_pattern_does_not_overturn_an_agent_fail(self) -> None:
+        """The spec verifier exists to catch agent lies, not to promote an honest FAIL.
+
+        ``has_discrepancy`` is False here because that flag means "agent claimed PASS
+        but verification disagreed", and there is no such claim to contradict — the
+        point is that ``verified_pass`` stays False instead of overturning the agent.
+        """
+        project = self._create_project({"main.py": "print('hello')\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=".*",
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is False
+        assert report.has_discrepancy is False
+        assert report.results[0].verified is False
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            r"class\s+CameraProvider",
+            r"\bCameraProvider\b",
+            "(?=class CameraProvider)",
+            r"^(?=[\s\S]*CameraProvider)",
+        ],
+    )
+    def test_discriminating_pattern_still_verifies(self, pattern: str) -> None:
+        """The guard must not refuse patterns that really discriminate.
+
+        The lookahead forms matter: they consume nothing, so a guard written in terms
+        of match width would refuse them and report a genuine PASS as a discrepancy —
+        the same failure this change fixes, running the other way.
+        """
+        project = self._create_project({"camera.py": "class CameraProvider:\n    pass\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=pattern,
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.verified_count == 1
+        assert summary.reports[0].has_discrepancy is False
+        assert summary.override_approval is None
+
+    def test_genuine_constant_match_still_verifies(self) -> None:
+        """The same on the T1 path, so the guard is not proven only through T2."""
+        project = self._create_project({"config.py": "WARMUP_FRAMES = 10\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Warmup frames should be 10",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=r"WARMUP_FRAMES\s*=\s*",
+            expected_value="10",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all((assertion,))
+
+        assert summary.verified_count == 1
+
 
 # -- Extractor Tests --
 

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -694,32 +694,40 @@ class TestSpecVerifier:
         assert summary.override_approval is False
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
-    @pytest.mark.parametrize("blank", ["\t", "  ", "\n\n"], ids=["tab", "spaces", "newlines"])
-    def test_a_file_of_whitespace_satisfies_an_emptiness_criterion(
-        self, tier: VerificationTier, blank: str
+    @pytest.mark.parametrize("whitespace", ["\t", "  ", "\n\n"], ids=["tab", "spaces", "newlines"])
+    def test_whitespace_is_blank_but_it_is_not_empty(
+        self, tier: VerificationTier, whitespace: str
     ) -> None:
-        """The answer comes from the file, so `\\A\\Z` not matching a tab is irrelevant.
+        """The two words ask different questions, and `\\A\\Z` draws exactly that line.
 
-        A guard that decided emptiness by trying the pattern against a fixed list of
-        blank strings would have to grow that list once per whitespace character
-        anyone writes. Reading the file has no list to keep up to date.
+        A file of one tab is blank. It is not empty, and the pattern that motivates
+        this whole path says so. Answering an `empty` criterion with the looser
+        reading would hand a formal PASS to a file the criterion rejects, so the
+        word the criterion used has to survive as far as the comparison.
         """
-        project = self._create_project({"pkg/__init__.py": blank})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="pkg/__init__.py MUST remain empty",
-            tier=tier,
-            pattern=r"\A\Z",
-            file_hint="pkg/__init__.py",
-        )
+        project = self._create_project({"pkg/__init__.py": whitespace})
 
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (assertion,), agent_results={0: True}
-        )
+        def verify(word: str) -> object:
+            assertion = SpecAssertion(
+                ac_index=0,
+                ac_text=f"pkg/__init__.py MUST remain {word}",
+                tier=tier,
+                pattern=r"\A\Z",
+                file_hint="pkg/__init__.py",
+            )
+            return SpecVerifier(project_dir=project).verify_all(
+                (assertion,), agent_results={0: True}
+            )
 
-        assert summary.verified_count == 1
-        assert summary.reports[0].verified_pass is True
-        assert summary.discrepancy_count == 0
+        strict = verify("empty")
+        assert strict.verified_count == 0
+        assert strict.reports[0].verified_pass is False
+        assert strict.discrepancy_count == 1
+
+        loose = verify("blank")
+        assert loose.verified_count == 1
+        assert loose.reports[0].verified_pass is True
+        assert loose.discrepancy_count == 0
 
     @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
@@ -849,6 +857,49 @@ class TestSpecVerifier:
 
         assert summary.reports[0].verified_pass is True
         assert summary.discrepancy_count == 0
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        ("filename", "ac_text"),
+        [
+            ("empty.txt", "empty.txt MUST contain data"),
+            ("blank.json", "blank.json MUST hold at least one record"),
+            ("marker.txt", "marker.txt MUST contain an empty JSON string field"),
+            ("marker.txt", "marker.txt MUST be an empty JSON object"),
+            ("marker.txt", "marker.txt MUST list the empty partitions"),
+        ],
+        ids=["empty-filename", "blank-filename", "nested-value", "attributive", "object-of-verb"],
+    )
+    def test_an_emptiness_word_that_is_not_about_the_file_earns_nothing(
+        self, tier: VerificationTier, filename: str, ac_text: str
+    ) -> None:
+        """The word has to be predicated of the file, not merely present in the AC.
+
+        Each of these mentions emptiness while requiring the file to hold content,
+        and each was read as an emptiness requirement: the word sat in the file's own
+        name, or described a value nested inside it, or was the adjective on some
+        other noun. With `\\A\\Z` and an empty file that produced a formal PASS for a
+        criterion the file plainly violates.
+
+        Everything here falls through to the ordinary path, where `\\A\\Z` is refused
+        and the criterion fails closed.
+        """
+        project = self._create_project({filename: ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=tier,
+            pattern=r"\A\Z",
+            file_hint=filename,
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+
+        assert summary.reports[0].verified_pass is False, f"{ac_text!r} must not verify"
+        assert summary.discrepancy_count == 1
+        assert summary.override_approval is False
 
     def test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim(self) -> None:
         """Refusing the pattern must raise a discrepancy, not silently skip the AC.


### PR DESCRIPTION
Refs #1835

## What

`SpecVerifier._safe_compile` asked only whether a model-supplied pattern compiles. A
pattern that matches the empty string matches _every_ subject, so it compiles fine,
matches the first candidate file, and returns `verified=True, detail="Found file:
main.py"` for an acceptance criterion the project does not satisfy.

Reproduced through the public `SpecVerifier.verify_all` on a project containing only
`main.py` (`print('hello')`) and no `CameraProvider` anywhere, with the agent
**honestly reporting AC0 as FAIL**:

| pattern                                | before                                          | after            |
| -------------------------------------- | ----------------------------------------------- | ---------------- |
| `class CameraProvider` (control)       | `verified=False` — "not found in 1 files"       | unchanged        |
| `.*` `x?` `\s*` `(?:)` `\|` `^` `\A\Z` | **`verified_pass=True`**, `Found file: main.py` | `verified=False` |

`ACVerificationReport.verified_pass` feeds `_evaluation_summary_from_spec_verification`
(`mcp/server/adapter.py`), which produces `ACResult(passed=True, score=1.0,
final_verdict="pass", verification_method="spec_verifier")`. The spec verifier exists
to catch agent self-report lies; here it overturned an honest failure into a pass.

## The fix

Refuse the pattern in `_safe_compile` when its compiled form matches `""`.

**Why at the verifier and not at extraction.** A pattern dropped during extraction
produces no report at all, and the adapter reads "no reports" as "nothing to check",
leaving the agent's self-report unexamined — a refusal that silently _removes_ the
check. Refusing at the verifier records a result and raises a discrepancy;
`test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim` pins that,
including `override_approval is False`.

**Why not a match-width rule.** Refusing zero-width _matches_ also refuses
lookahead-only patterns such as `(?=class CameraProvider)`, which genuinely
discriminate — reporting an honest PASS as a discrepancy, i.e. the same failure this
change fixes running the other way. `test_discriminating_pattern_still_verifies` pins
all four lookahead forms. It also keeps the check free of executing the untrusted
pattern against any sentinel string, so it adds no backtracking surface.

## Scope, and what is deliberately left open

This closes the family that matches **any** input. It does not close patterns that
match **unrelated** input — `.`, `.+`, `[\s\S]`, `[A-Z]\w*`, or a bare declaration
keyword like `class\s+\w+` / `interface\s+\w+` / `pub\s+trait\s+\w+` — which are
equally uninformative but require deciding whether a pattern is _about_ its criterion.

I prototyped that broader check as a negative-control corpus (screen the pattern
against nonsense subjects, refuse it if it matches them) and abandoned it. Recording
why, since it is the obvious next idea:

- **Enumeration does not converge.** Five successive hardening rounds each closed the
  family the previous round had probed and left the next one open — `class`, then
  `interface`, then `trait` — and 26 of 26 modifier-prefixed forms
  (`export\s+interface\s+\w+`, `data\s+class\s+\w+`, `async\s+def\s+\w+`, …) survived
  every version. A literal-string corpus is closed under neither modifier prefixes
  nor file formats (SQL, Dockerfile, CSS and TOML shapes escaped too).
- **It makes the screen itself an attack surface.** The untrusted pattern has to run
  against every control, so each control is backtracking bait: one control holding a
  line of code made `(.*)*#` non-terminating on a project with _no candidate files at
  all_, where `main` does no work.
- **The direction is easy to get backwards.** Refusing on "matches every control"
  makes the screen weaker with each control added, since a pattern need only miss one.

The empty-string rule needs no corpus, refuses nothing that discriminates, and is
decidable from the pattern alone. The wider question is recorded on #1835 for separate
design work.

## Tests

Six new test functions in `tests/unit/test_verification.py`, all driving the public
`SpecVerifier.verify_all`:

- `test_t2_pattern_matching_any_input_is_not_evidence` and its T1 twin — the
  regression proof, parametrized over all seven patterns, on both tiers.
- `test_empty_matching_pattern_fails_closed_against_an_agent_pass_claim` — refusal
  must raise a discrepancy, not skip the AC.
- `test_empty_matching_pattern_does_not_overturn_an_agent_fail`.
- `test_discriminating_pattern_still_verifies` — the over-rejection guard, including
  lookahead-only forms.
- `test_genuine_constant_match_still_verifies` — the same on the T1 path.

**Repro proof**, per test node against `origin/main` — 16 of 20 cases fail:

```
16/20 new cases fail at the baseline
   passes at the baseline: test_discriminating_pattern_still_verifies[class\s+CameraProvider]
   passes at the baseline: test_discriminating_pattern_still_verifies[\bCameraProvider\b]
   passes at the baseline: test_discriminating_pattern_still_verifies[^(?=[\s\S]*CameraProvider)]
   passes at the baseline: test_genuine_constant_match_still_verifies
```

The four that pass on both revisions are the over-rejection guards, and that is their
job — they exist to catch the fix refusing patterns that genuinely discriminate, not to
prove the fix. Every case that is offered as a regression proof fails without it.

`\A\Z` needs an empty candidate file to be unsafe at all, so it is tested against a
project carrying an empty `__init__.py` rather than alongside the patterns that succeed
against ordinary files; against a non-empty fixture it matches nothing either way and
would prove nothing.

Sweeping every `pattern=` literal reaching a `SpecAssertion` in `src/` and `tests/`, no
existing pattern is refused.

## Verification

- `pytest tests/unit/test_verification.py` → **61 passed**
- Full suite as CI runs it, `pytest tests/ -n 4 --dist worksteal` → **16457 passed, 19 skipped, 1 xfailed** (9m19s)
- `ruff check`, `ruff format --check`, `mypy` on both changed files → clean
- No file under `src/ouroboros/auto/` is touched
