### PR TITLE
fix(providers): let the claude backend run where the SDK cannot (#1839)

### DIFF
--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3975,12 +3975,12 @@ def _setup_claude(claude_path: str) -> None:
         yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
     # Do not register the isolated MCP 2 server with this Claude SDK profile.
-    # The persisted runtime and LLM backend below both require
-    # ``claude-agent-sdk`` (and therefore MCP 1.x), while the protocol server
-    # runs in an environment that intentionally excludes that SDK. Registering
-    # it here would create a server that boots but fails lazily on authoring and
-    # execution tools. A future CLI-only Claude LLM adapter can make this path
-    # available without weakening the dependency boundary.
+    # The protocol server excludes ``claude-agent-sdk`` (it pins MCP 1.x), and
+    # the persisted *runtime* backend below still requires it — a registration
+    # here would boot and then fail lazily on execution tools. The *LLM* half of
+    # that dependency is gone as of Q00/ouroboros#1839 (``ClaudeCodeAdapter``
+    # falls back to the ``claude`` CLI), so lifting this skip now needs the same
+    # fallback on ``ClaudeAgentAdapter``, not a change here.
     print_warning(
         "Skipped Ouroboros MCP registration for the standalone Claude SDK profile: "
         "its MCP 1.x runtime cannot share the isolated MCP 2 server process. "

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -1,8 +1,17 @@
-"""Claude Code adapter for LLM completion using Claude Agent SDK.
+"""Claude Code adapter for LLM completion, over the SDK or the CLI.
 
-This adapter uses the Claude Agent SDK to make completion requests,
-leveraging the user's Claude Code Max Plan authentication instead of
-requiring separate API keys.
+This adapter makes completion requests against the user's Claude Code Max Plan
+authentication instead of requiring separate API keys.
+
+It has two transports and prefers the Claude Agent SDK. When the SDK cannot be
+imported it falls back to the ``claude`` CLI in print mode, because the SDK
+requires ``mcp<2.0.0`` while the MCP protocol server requires ``mcp==2.0.0`` --
+so in a server process built from the ``[mcp]`` extra there is no SDK to import
+and the backend could previously generate nothing at all (Q00/ouroboros#1839).
+Policy is shared rather than duplicated: model normalization, turn budget,
+permission vocabulary, retry behavior and empty-response validation are decided
+once and read by both. What differs is the streaming surface -- print mode
+reports once at the end, with no per-turn callbacks or incremental events.
 
 Usage:
     adapter = ClaudeCodeAdapter()
@@ -140,15 +149,19 @@ def _claude_options_field_names() -> frozenset[str]:
 
 
 class ClaudeCodeAdapter:
-    """LLM adapter using Claude Agent SDK (Claude Code Max Plan).
+    """LLM adapter for Claude Code Max Plan, over the SDK or the CLI.
 
-    This adapter provides the same interface as LiteLLMAdapter but uses
-    the Claude Agent SDK under the hood. This allows users to leverage
-    their Claude Code Max Plan subscription without needing separate API keys.
+    This adapter provides the same interface as LiteLLMAdapter but uses the
+    user's Claude Code subscription under the hood, so no separate API key is
+    needed. It prefers the Claude Agent SDK and falls back to the ``claude`` CLI
+    when the SDK is not importable -- see the module docstring for why that
+    happens and what the fallback does and does not carry.
 
     Attributes:
         cli_path: Path to the Claude CLI binary. If not set, the SDK will
             use its bundled CLI. Set this to use a custom/instrumented CLI.
+            Also the binary the fallback transport runs; with no SDK and no
+            configured path, completion fails naming both.
 
     Example:
         adapter = ClaudeCodeAdapter()
@@ -866,6 +879,10 @@ class ClaudeCodeAdapter:
         the first time one of them appears.
         """
         run_once = single_attempt or self._execute_single_request_positional
+        # Name the transport that actually failed. Reporting an SDK failure from
+        # a process that has no SDK sends the reader to the wrong diagnosis --
+        # and that misdirection is the exact shape of the bug this PR fixes.
+        transport_name = "Claude Agent SDK" if single_attempt is None else "claude CLI"
         last_error: ProviderError | None = None
         effective_system_prompt = system_prompt
         phantom_recovery_used = False
@@ -968,7 +985,7 @@ class ClaudeCodeAdapter:
                         backoff_seconds=backoff,
                     )
                     last_error = ProviderError(
-                        message=f"Claude Agent SDK request failed: {e}",
+                        message=f"{transport_name} request failed: {e}",
                         details={"error_type": error_type, "attempt": attempt + 1},
                     )
                     await asyncio.sleep(backoff)
@@ -981,7 +998,7 @@ class ClaudeCodeAdapter:
                 )
                 return Result.err(
                     ProviderError(
-                        message=f"Claude Agent SDK request failed: {e}",
+                        message=f"{transport_name} request failed: {e}",
                         details={"error_type": error_type},
                     )
                 )

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -44,6 +44,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import shutil
 import traceback
 
 import structlog
@@ -61,6 +62,7 @@ from ouroboros.providers.base import (
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
 from ouroboros.providers.tool_use_diagnostics import diagnose_tool_use_turn
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger(__name__)
 
@@ -427,6 +429,10 @@ class ClaudeCodeAdapter:
             # environment the SDK cannot enter. See ``_complete_via_cli``.
             sdk_available = False
             if self._cli_path is None:
+                discovered = shutil.which("claude")
+                if discovered:
+                    self._cli_path = Path(discovered).expanduser().resolve()
+            if self._cli_path is None:
                 log.error("claude_code_adapter.sdk_and_cli_unavailable", error=str(e))
                 return Result.err(
                     ProviderError(
@@ -536,6 +542,20 @@ class ClaudeCodeAdapter:
     _CLI_PERMISSION_MODES = frozenset(
         {"acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan"}
     )
+
+    @staticmethod
+    def _build_cli_child_env() -> dict[str, str]:
+        """Isolate the direct CLI child and enforce the shared recursion limit."""
+        return build_child_env(
+            strip_keys=(*DEFAULT_OUROBOROS_STRIP_KEYS, "CLAUDECODE"),
+            depth_error_factory=lambda depth, max_depth: ProviderError(
+                message=(
+                    f"Maximum ouroboros nesting depth ({max_depth}) exceeded "
+                    f"while starting claude CLI (depth={depth})"
+                ),
+                details={"depth": depth, "max_depth": max_depth},
+            ),
+        )
 
     def _empty_content_error(
         self,
@@ -673,11 +693,12 @@ class ClaudeCodeAdapter:
         if self._permission_mode in self._CLI_PERMISSION_MODES:
             argv += ["--permission-mode", self._permission_mode]
         if self._allowed_tools is not None:
-            # Unlike the SDK -- which drops an empty list before it reaches the
-            # CLI, hence the ``extra_args`` workaround in
-            # ``_execute_single_request`` -- the CLI honors ``--allowedTools ""``
-            # literally, so the empty envelope seals itself with no enumerate.
-            argv += ["--allowedTools", " ".join(self._allowed_tools)]
+            # ``--tools`` defines the available catalog; ``--allowedTools`` only
+            # suppresses permission prompts for names that are already available.
+            # Both are required for SDK parity, especially ``--tools ""`` for the
+            # no-tools interview/PM/QA envelope.
+            tool_names = " ".join(self._allowed_tools)
+            argv += ["--tools", tool_names, "--allowedTools", tool_names]
         argv += ["--max-turns", str(self._effective_max_turns(config))]
         if self._strict_mcp_config:
             # ``--strict-mcp-config`` blocks MCP discovery and nothing else, but
@@ -708,13 +729,17 @@ class ClaudeCodeAdapter:
 
         timeout = self._timeout or _CLI_DEFAULT_TIMEOUT_SECONDS
         try:
+            child_env = self._build_cli_child_env()
             proc = await asyncio.create_subprocess_exec(
                 *argv,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._cwd or None,
+                env=child_env,
             )
+        except ProviderError as exc:
+            return Result.err(exc)
         except OSError as exc:
             return Result.err(
                 ProviderError(

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -519,6 +519,54 @@ class ClaudeCodeAdapter:
         {"acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan"}
     )
 
+    def _empty_content_error(
+        self,
+        content: str,
+        *,
+        session_id: str | None,
+        stderr_tail: str,
+    ) -> ProviderError | None:
+        """The adapter's contract for an empty body: infrastructure, not an answer.
+
+        A transport that returned ``content=""`` as a success would hand an
+        interview or QA caller a false answer, and would do it past the retry
+        loop -- the loop returns on the first `is_ok`, so nothing downstream gets
+        a second chance. Both transports read this one copy so a body that came
+        back empty means the same thing however it travelled.
+
+        Returns ``None`` when the content is fine, so the caller can treat it as
+        "no objection" rather than having to catch anything.
+        """
+        if content:
+            return None
+        log.warning(
+            "claude_code_adapter.empty_response",
+            content_length=0,
+            session_id=session_id,
+            hint=(
+                "CLI started but produced no content"
+                if session_id
+                else "CLI may still be starting (custom CLI sync, etc.)"
+            ),
+        )
+        message = (
+            "Empty response from CLI - session started but no content produced"
+            if session_id
+            # Phrased to match ``_CLAUDE_CLI_BOOTSTRAP_PATTERNS`` so the retry
+            # loop treats a bootstrap stumble as transient rather than final.
+            else "Empty response from CLI - may need retry (timeout/startup)"
+        )
+        return ProviderError(
+            message=message,
+            details={
+                "session_id": session_id,
+                "content_length": 0,
+                "stderr": stderr_tail,
+                "configured_cli_path": (str(self._cli_path) if self._cli_path else None),
+                "cwd": self._cwd,
+            },
+        )
+
     def _effective_max_turns(self, config: CompletionConfig) -> int:
         """The turn budget this request runs under, per-request override first.
 
@@ -574,10 +622,13 @@ class ClaudeCodeAdapter:
         the SDK behaves exactly as before -- streaming, tool use and structured
         turns are the SDK's, and nothing here changes them.
 
-        What it gives up is what one-shot print mode does not have: no
-        multi-turn tool use, and no per-turn events. Question generation and the
-        other single-response calls do not use those, which is why this is a
-        fallback rather than a replacement.
+        What it gives up is the streaming surface: no per-turn callbacks and no
+        incremental message events, because print mode reports once at the end.
+        Multi-turn tool execution itself still happens -- ``--allowedTools`` and
+        ``--max-turns`` are forwarded, which is what the 20-turn read-only
+        envelope in semantic evaluation needs. Single-response callers observe
+        only the final result, which is why this is a usable fallback rather
+        than a replacement for the SDK's event stream.
 
         The isolation the caller asked for is carried through natively. The
         interview/PM/QA callers build this adapter with ``allowed_tools=[]`` and
@@ -683,16 +734,24 @@ class ClaudeCodeAdapter:
                 )
             )
 
+        session_id = payload.get("session_id")
+        content = str(payload.get("result") or "")
+        empty = self._empty_content_error(
+            content, session_id=session_id, stderr_tail=stderr_text[:2000]
+        )
+        if empty is not None:
+            return Result.err(empty)
+
         usage = payload.get("usage") or {}
         log.info(
             "claude_code_adapter.cli_request_completed",
-            content_length=len(str(payload.get("result") or "")),
-            session_id=payload.get("session_id"),
+            content_length=len(content),
+            session_id=session_id,
             stop_reason=payload.get("stop_reason"),
         )
         return Result.ok(
             CompletionResponse(
-                content=str(payload.get("result") or ""),
+                content=content,
                 model=config.model,
                 usage=UsageInfo(
                     prompt_tokens=int(usage.get("input_tokens") or 0),
@@ -1512,54 +1571,15 @@ class ClaudeCodeAdapter:
             return Result.err(error_result)
 
         # Check for empty response — always an error regardless of session_id
-        if not content:
+        empty = self._empty_content_error(
+            content,
+            session_id=session_id,
             # Include captured stderr for diagnostics — helps identify
             # why the CLI produced no output (rate limits, auth, etc.)
-            stderr_tail = "\n".join(stderr_lines[-20:]) if stderr_lines else ""
-            if session_id:
-                log.warning(
-                    "claude_code_adapter.empty_response",
-                    content_length=0,
-                    session_id=session_id,
-                    stderr_lines=len(stderr_lines),
-                    hint="CLI started but produced no content",
-                )
-                return Result.err(
-                    ProviderError(
-                        message="Empty response from CLI - session started but no content produced",
-                        details={
-                            "session_id": session_id,
-                            "content_length": 0,
-                            "stderr": stderr_tail,
-                            "configured_cli_path": (
-                                str(self._cli_path) if self._cli_path else None
-                            ),
-                            "cwd": self._cwd,
-                        },
-                    )
-                )
-            else:
-                log.warning(
-                    "claude_code_adapter.empty_response",
-                    content_length=0,
-                    session_id=session_id,
-                    stderr_lines=len(stderr_lines),
-                    hint="CLI may still be starting (custom CLI sync, etc.)",
-                )
-                return Result.err(
-                    ProviderError(
-                        message="Empty response from CLI - may need retry (timeout/startup)",
-                        details={
-                            "session_id": session_id,
-                            "content_length": 0,
-                            "stderr": stderr_tail,
-                            "configured_cli_path": (
-                                str(self._cli_path) if self._cli_path else None
-                            ),
-                            "cwd": self._cwd,
-                        },
-                    )
-                )
+            stderr_tail="\n".join(stderr_lines[-20:]) if stderr_lines else "",
+        )
+        if empty is not None:
+            return Result.err(empty)
 
         log.info(
             "claude_code_adapter.request_completed",

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -368,14 +368,25 @@ class ClaudeCodeAdapter:
         try:
             # Lazy import to avoid loading SDK at module import time
             from claude_agent_sdk import ClaudeAgentOptions, query  # noqa: F401
+
+            sdk_available = True
         except ImportError as e:
-            log.error("claude_code_adapter.sdk_not_installed", error=str(e))
-            return Result.err(
-                ProviderError(
-                    message="Claude Agent SDK is not installed. Run: pip install claude-agent-sdk",
-                    details={"import_error": str(e)},
+            # Not fatal on its own: the CLI carries the same subscription and
+            # runs out of process, which is the only transport that survives an
+            # environment the SDK cannot enter. See ``_complete_via_cli``.
+            sdk_available = False
+            if self._cli_path is None:
+                log.error("claude_code_adapter.sdk_and_cli_unavailable", error=str(e))
+                return Result.err(
+                    ProviderError(
+                        message=(
+                            "Neither the Claude Agent SDK nor the claude CLI is available. "
+                            "Install the CLI, or add the SDK with: pip install claude-agent-sdk"
+                        ),
+                        details={"import_error": str(e), "cli_path": None},
+                    )
                 )
-            )
+            log.info("claude_code_adapter.sdk_absent_using_cli", cli_path=str(self._cli_path))
 
         profile_result = resolve_completion_profile_result(config, backend="claude_code")
         if profile_result.is_err:
@@ -444,7 +455,10 @@ class ClaudeCodeAdapter:
             claude_code_entrypoint=os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
         )
 
-        result = await self._complete_with_transient_retry(prompt, config, system_prompt)
+        if sdk_available:
+            result = await self._complete_with_transient_retry(prompt, config, system_prompt)
+        else:
+            result = await self._complete_via_cli(prompt, config, system_prompt)
 
         # JSON enforcement layer: if response_format requires JSON,
         # normalize or retry until we get valid JSON.
@@ -452,6 +466,131 @@ class ClaudeCodeAdapter:
             result = await self._enforce_json(result, prompt, config, system_prompt)
 
         return result
+
+    #: Values the `claude` CLI accepts for --permission-mode. The adapter's own
+    #: mode vocabulary is wider (it includes "default", which the CLI expresses
+    #: by omitting the flag), so a mode outside this set is dropped rather than
+    #: forwarded into an argument the CLI would reject.
+    _CLI_PERMISSION_MODES = frozenset(
+        {"acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan"}
+    )
+
+    async def _complete_via_cli(
+        self,
+        prompt: str,
+        config: CompletionConfig,
+        system_prompt: str | None,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Run one completion through the ``claude`` CLI in print mode.
+
+        The Python SDK is not always installable beside the caller. It requires
+        ``mcp<2.0.0``, and the MCP protocol server requires ``mcp==2.0.0``, so a
+        server process built from the ``[mcp]`` extra has no SDK to import — and
+        a user whose backend is ``claude`` then cannot generate anything at all
+        (Q00/ouroboros#1839).
+
+        The CLI has no such conflict: it is a separate process carrying the same
+        subscription, so it is the transport that survives that boundary. This
+        path is entered only when the SDK is absent, so an environment that has
+        the SDK behaves exactly as before -- streaming, tool use and structured
+        turns are the SDK's, and nothing here changes them.
+
+        What it gives up is what one-shot print mode does not have: no
+        multi-turn tool use, and no per-turn events. Question generation and the
+        other single-response calls do not use those, which is why this is a
+        fallback rather than a replacement.
+        """
+        import asyncio
+        import json as _json
+
+        cli_path = self._cli_path
+        if cli_path is None:  # pragma: no cover - guarded by the caller
+            return Result.err(ProviderError(message="claude CLI path is unavailable"))
+
+        argv = [str(cli_path), "-p", "--output-format", "json"]
+        if config.model:
+            argv += ["--model", config.model]
+        if system_prompt:
+            argv += ["--append-system-prompt", system_prompt]
+        if self._permission_mode in self._CLI_PERMISSION_MODES:
+            argv += ["--permission-mode", self._permission_mode]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._cwd or None,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(prompt.encode("utf-8")), timeout=self._timeout
+            )
+        except TimeoutError:
+            proc.kill()
+            return Result.err(
+                ProviderError(
+                    message=f"claude CLI timed out after {self._timeout}s",
+                    details={"timeout_seconds": self._timeout},
+                )
+            )
+        except OSError as exc:
+            return Result.err(
+                ProviderError(
+                    message=f"claude CLI could not be executed: {exc}",
+                    details={"cli_path": str(cli_path)},
+                )
+            )
+
+        stderr_text = stderr.decode("utf-8", "replace").strip()
+        try:
+            payload = _json.loads(stdout.decode("utf-8", "replace"))
+        except ValueError:
+            # A non-JSON body means the CLI failed before it produced a result
+            # envelope -- an auth prompt, a usage limit, a bad flag. The stderr
+            # text is the only diagnosis available, and it is what the user
+            # needs to see.
+            return Result.err(
+                ProviderError(
+                    message=f"claude CLI returned no JSON result (exit {proc.returncode})",
+                    details={"stderr": stderr_text[:2000], "returncode": proc.returncode},
+                )
+            )
+
+        if payload.get("is_error") or proc.returncode != 0:
+            return Result.err(
+                ProviderError(
+                    message=str(payload.get("result") or "claude CLI reported an error"),
+                    details={
+                        "subtype": payload.get("subtype"),
+                        "returncode": proc.returncode,
+                        "session_id": payload.get("session_id"),
+                        "stderr": stderr_text[:2000],
+                    },
+                )
+            )
+
+        usage = payload.get("usage") or {}
+        log.info(
+            "claude_code_adapter.cli_request_completed",
+            content_length=len(str(payload.get("result") or "")),
+            session_id=payload.get("session_id"),
+            stop_reason=payload.get("stop_reason"),
+        )
+        return Result.ok(
+            CompletionResponse(
+                content=str(payload.get("result") or ""),
+                model=config.model,
+                usage=UsageInfo(
+                    prompt_tokens=int(usage.get("input_tokens") or 0),
+                    completion_tokens=int(usage.get("output_tokens") or 0),
+                    total_tokens=int(usage.get("input_tokens") or 0)
+                    + int(usage.get("output_tokens") or 0),
+                ),
+                finish_reason=str(payload.get("stop_reason") or "stop"),
+                raw_response=payload,
+            )
+        )
 
     def _normalize_json_content(
         self, result: Result[CompletionResponse, ProviderError]

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -684,8 +684,24 @@ class ClaudeCodeAdapter:
             # sources closes them at the root rather than one flag at a time.
             argv += ["--strict-mcp-config", "--setting-sources", ""]
 
+        # Everything caller-controlled is encoded before a child exists. A lone
+        # surrogate arriving through an MCP payload is unencodable, and doing
+        # this after the spawn meant the failure landed on a process already
+        # waiting on a stdin that would never be written. Done here it fails
+        # with nothing to leak.
+        try:
+            stdin_bytes = prompt.encode("utf-8")
+            for arg in argv:
+                arg.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            return Result.err(
+                ProviderError(
+                    message=f"claude CLI request contains text that cannot be encoded: {exc}",
+                    details={"cli_path": str(cli_path), "reason": exc.reason},
+                )
+            )
+
         timeout = self._timeout or _CLI_DEFAULT_TIMEOUT_SECONDS
-        proc: asyncio.subprocess.Process | None = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *argv,
@@ -694,9 +710,21 @@ class ClaudeCodeAdapter:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._cwd or None,
             )
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(prompt.encode("utf-8")), timeout=timeout
+        except OSError as exc:
+            return Result.err(
+                ProviderError(
+                    message=f"claude CLI could not be executed: {exc}",
+                    details={"cli_path": str(cli_path)},
+                )
             )
+
+        # From here the child exists and nothing else holds a handle to it, so
+        # this scope owns it. Reaping is unconditional rather than a list of
+        # exception types to remember: `_terminate_process` no-ops once the
+        # process has exited, so covering every path costs nothing and leaves
+        # no path to forget.
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(stdin_bytes), timeout=timeout)
         except TimeoutError:
             await _terminate_process(proc)
             return Result.err(
@@ -705,19 +733,9 @@ class ClaudeCodeAdapter:
                     details={"timeout_seconds": timeout},
                 )
             )
-        except asyncio.CancelledError:
-            # The caller going away must not leave the child running: nothing
-            # else holds a handle to it, so this is the only place it can be
-            # reaped. Reap, then let the cancellation continue to propagate.
+        except BaseException:  # noqa: BLE001 - ownership, re-raised immediately
             await _terminate_process(proc)
             raise
-        except OSError as exc:
-            return Result.err(
-                ProviderError(
-                    message=f"claude CLI could not be executed: {exc}",
-                    details={"cli_path": str(cli_path)},
-                )
-            )
 
         stderr_text = stderr.decode("utf-8", "replace").strip()
         try:

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -399,7 +399,12 @@ class ClaudeCodeAdapter:
         messages: list[Message],
         config: CompletionConfig,
     ) -> Result[CompletionResponse, ProviderError]:
-        """Make a completion request via Claude Agent SDK with retry logic.
+        """Make a completion request over whichever transport is available.
+
+        Prefers the Claude Agent SDK and falls back to the ``claude`` CLI when
+        it cannot be imported. The choice is made once, here, and everything
+        below it -- profile resolution, system-message extraction, JSON
+        enforcement and its retries -- is the same either way.
 
         Implements exponential backoff for transient errors like API concurrency
         conflicts that can occur when running inside an active Claude Code session.

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -30,7 +30,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from dataclasses import replace
-from functools import lru_cache
+from functools import lru_cache, partial
 import inspect
 import json
 import os
@@ -480,7 +480,7 @@ class ClaudeCodeAdapter:
             prompt_preview=prompt[:100],
             message_count=len(messages),
             has_system_prompt=system_prompt is not None,
-            max_turns=config.max_turns if config.max_turns is not None else self._max_turns,
+            max_turns=self._effective_max_turns(config),
             model=config.model,
             cwd=str(self._cwd) if self._cwd else None,
             cli_path=str(self._cli_path) if self._cli_path else None,
@@ -492,7 +492,15 @@ class ClaudeCodeAdapter:
         # request -- notably the JSON-enforcement retries -- has to reach the
         # same one: routing a retry back through the SDK in a process that has
         # no SDK turns a recoverable prose response into an ImportError.
-        transport = self._complete_with_transient_retry if sdk_available else self._complete_via_cli
+        #
+        # Both transports sit under the same transient-retry loop, so which one
+        # is available decides how the request travels, never how many transient
+        # failures it survives.
+        transport: _Transport = (
+            self._complete_with_transient_retry
+            if sdk_available
+            else partial(self._complete_with_transient_retry, single_attempt=self._complete_via_cli)
+        )
         result = await transport(prompt, config, system_prompt)
 
         # JSON enforcement layer: if response_format requires JSON,
@@ -510,6 +518,15 @@ class ClaudeCodeAdapter:
     _CLI_PERMISSION_MODES = frozenset(
         {"acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan"}
     )
+
+    def _effective_max_turns(self, config: CompletionConfig) -> int:
+        """The turn budget this request runs under, per-request override first.
+
+        Both transports have to read one copy: semantic evaluation asks for 20
+        turns with tools enabled, so a transport that silently dropped the limit
+        would let an SDK-absent run past the configured turn and cost boundary.
+        """
+        return config.max_turns if config.max_turns is not None else self._max_turns
 
     @staticmethod
     def _normalize_model(model: str | None) -> str | None:
@@ -567,8 +584,9 @@ class ClaudeCodeAdapter:
         ``strict_mcp_config=True`` specifically so the spawned CLI cannot run
         tools or rediscover ouroboros' own MCP server and recurse; a transport
         that dropped those would be more dangerous than the failure it replaces.
-        ``max_turns`` has no CLI flag, but it is moot under an empty tool
-        catalog -- with nothing to call, print mode returns on turn one.
+        ``--max-turns`` is absent from ``claude --help`` but is a real flag (the
+        CLI rejects genuinely unknown options), so the turn budget is forwarded
+        rather than assumed moot.
         """
         import asyncio
         import json as _json
@@ -591,8 +609,16 @@ class ClaudeCodeAdapter:
             # ``_execute_single_request`` -- the CLI honors ``--allowedTools ""``
             # literally, so the empty envelope seals itself with no enumerate.
             argv += ["--allowedTools", " ".join(self._allowed_tools)]
+        argv += ["--max-turns", str(self._effective_max_turns(config))]
         if self._strict_mcp_config:
-            argv.append("--strict-mcp-config")
+            # ``--strict-mcp-config`` blocks MCP discovery and nothing else, but
+            # the isolation this flag stands for is wider: the SDK path also
+            # empties setting_sources/skills/agents/plugins/hooks so a nested
+            # interview cannot inherit the parent's project instructions. On the
+            # CLI those all arrive through setting sources (``--agents`` and
+            # ``--plugin-dir`` are opt-in and never passed), so declining the
+            # sources closes them at the root rather than one flag at a time.
+            argv += ["--strict-mcp-config", "--setting-sources", ""]
 
         timeout = self._timeout or _CLI_DEFAULT_TIMEOUT_SECONDS
         proc: asyncio.subprocess.Process | None = None
@@ -767,12 +793,20 @@ class ClaudeCodeAdapter:
         prompt: str,
         config: CompletionConfig,
         system_prompt: str | None,
+        single_attempt: _Transport | None = None,
     ) -> Result[CompletionResponse, ProviderError]:
         """Inner retry loop for transient API errors (rate limits, timeouts, etc.).
 
         This handles infrastructure-level failures only. JSON format
         enforcement is handled by the caller.
+
+        ``single_attempt`` is the one-shot transport to retry around, defaulting
+        to the SDK request. Rate limits, overloads and CLI bootstrap stumbles are
+        properties of the service, not of how we reached it, so the fallback
+        transport is retried on the same terms rather than failing permanently
+        the first time one of them appears.
         """
+        run_once = single_attempt or self._execute_single_request_positional
         last_error: ProviderError | None = None
         effective_system_prompt = system_prompt
         phantom_recovery_used = False
@@ -780,14 +814,10 @@ class ClaudeCodeAdapter:
         for attempt in range(_MAX_RETRIES):
             try:
                 if self._timeout is None:
-                    result = await self._execute_single_request(
-                        prompt, config, system_prompt=effective_system_prompt
-                    )
+                    result = await run_once(prompt, config, effective_system_prompt)
                 else:
                     async with asyncio.timeout(self._timeout):
-                        result = await self._execute_single_request(
-                            prompt, config, system_prompt=effective_system_prompt
-                        )
+                        result = await run_once(prompt, config, effective_system_prompt)
 
                 if result.is_ok:
                     if attempt > 0:
@@ -904,6 +934,18 @@ class ClaudeCodeAdapter:
         )
         return Result.err(last_error or ProviderError(message="Max retries exceeded"))
 
+    async def _execute_single_request_positional(
+        self,
+        prompt: str,
+        config: CompletionConfig,
+        system_prompt: str | None,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """``_execute_single_request`` shaped like every other one-shot transport.
+
+        Exists only so the retry loop can hold either transport in one variable.
+        """
+        return await self._execute_single_request(prompt, config, system_prompt=system_prompt)
+
     async def _execute_single_request(
         self,
         prompt: str,
@@ -1009,7 +1051,7 @@ class ClaudeCodeAdapter:
 
         options_kwargs: dict = {
             "disallowed_tools": disallowed,
-            "max_turns": config.max_turns if config.max_turns is not None else self._max_turns,
+            "max_turns": self._effective_max_turns(config),
             # Allow MCP and other ~/.claude/ settings to be inherited
             "permission_mode": self._permission_mode,
             "cwd": self._cwd,

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -27,7 +27,7 @@ Custom CLI Path:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from dataclasses import replace
 from functools import lru_cache
@@ -84,6 +84,39 @@ _RETRYABLE_ERROR_PATTERNS = (
     *BASE_TRANSIENT_PATTERNS,
     *_CLAUDE_CLI_BOOTSTRAP_PATTERNS,
 )
+# One completion attempt, as a callable. ``complete()`` binds this once so that
+# retries downstream reach the transport that is actually available.
+_Transport = Callable[
+    [str, CompletionConfig, "str | None"],
+    Awaitable["Result[CompletionResponse, ProviderError]"],
+]
+# ``timeout=None`` means "no adapter-level deadline" on the SDK path, where the
+# SDK still owns the child process and a cancelled task tears it down. A bare
+# subprocess has no such owner, so the CLI path substitutes a finite ceiling
+# rather than waiting forever on a process nothing will reap.
+_CLI_DEFAULT_TIMEOUT_SECONDS = 600.0
+# How long a killed child gets to actually die before we stop waiting on it.
+# Bounded so cleanup can never become the new hang.
+_CLI_REAP_TIMEOUT_SECONDS = 5.0
+
+
+async def _terminate_process(proc: asyncio.subprocess.Process | None) -> None:
+    """Kill a subprocess and wait for it, without ever raising.
+
+    ``Process.kill()`` only delivers the signal; without the ``wait()`` the child
+    stays a zombie and its pipes stay open. Called from timeout and cancellation
+    paths, so it must not raise a second error over the one being reported.
+    """
+    if proc is None or proc.returncode is not None:
+        return
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):  # already gone
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_CLI_REAP_TIMEOUT_SECONDS)
+    except (TimeoutError, asyncio.CancelledError, OSError):
+        log.warning("claude_code_adapter.cli_process_not_reaped", pid=proc.pid)
 
 
 @lru_cache(maxsize=1)
@@ -455,25 +488,54 @@ class ClaudeCodeAdapter:
             claude_code_entrypoint=os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
         )
 
-        if sdk_available:
-            result = await self._complete_with_transient_retry(prompt, config, system_prompt)
-        else:
-            result = await self._complete_via_cli(prompt, config, system_prompt)
+        # Bind the transport once. Everything downstream that re-issues the
+        # request -- notably the JSON-enforcement retries -- has to reach the
+        # same one: routing a retry back through the SDK in a process that has
+        # no SDK turns a recoverable prose response into an ImportError.
+        transport = self._complete_with_transient_retry if sdk_available else self._complete_via_cli
+        result = await transport(prompt, config, system_prompt)
 
         # JSON enforcement layer: if response_format requires JSON,
         # normalize or retry until we get valid JSON.
         if requires_json and result.is_ok:
-            result = await self._enforce_json(result, prompt, config, system_prompt)
+            result = await self._enforce_json(result, prompt, config, system_prompt, transport)
 
         return result
 
-    #: Values the `claude` CLI accepts for --permission-mode. The adapter's own
-    #: mode vocabulary is wider (it includes "default", which the CLI expresses
-    #: by omitting the flag), so a mode outside this set is dropped rather than
-    #: forwarded into an argument the CLI would reject.
+    #: Values the `claude` CLI accepts for --permission-mode (its documented
+    #: choices list, verified on 2.1.220). The adapter's own mode vocabulary is
+    #: wider -- it includes "default", which the CLI expresses by omitting the
+    #: flag -- so a mode outside this set is dropped rather than forwarded into
+    #: an argument the CLI would reject.
     _CLI_PERMISSION_MODES = frozenset(
         {"acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan"}
     )
+
+    @staticmethod
+    def _normalize_model(model: str | None) -> str | None:
+        """Map a configured model id onto one Claude accepts, or ``None``.
+
+        Both transports resolve the same Anthropic model, so they have to agree
+        on this: an operator override like ``anthropic/claude-sonnet-4-5`` is
+        valid config that the SDK strips to a bare id, and forwarding it raw to
+        ``claude --model`` fails the request outright.
+
+        Returns ``None`` when the caller expressed no usable preference, which
+        both transports render as "omit the model and take the default".
+        """
+        # "default" is not a valid model id — treat it as None
+        if not model or model == "default":
+            return None
+        # Strip provider prefixes — both transports reach Anthropic directly
+        if model.startswith("openrouter/anthropic/"):
+            return model[len("openrouter/anthropic/") :]
+        if model.startswith("anthropic/"):
+            return model[len("anthropic/") :]
+        if model.startswith("openrouter/"):
+            # Non-Anthropic model (e.g., openrouter/openai/gpt-4o) — Claude
+            # only supports Claude, so skip it and use the default
+            return None
+        return model
 
     async def _complete_via_cli(
         self,
@@ -499,6 +561,14 @@ class ClaudeCodeAdapter:
         multi-turn tool use, and no per-turn events. Question generation and the
         other single-response calls do not use those, which is why this is a
         fallback rather than a replacement.
+
+        The isolation the caller asked for is carried through natively. The
+        interview/PM/QA callers build this adapter with ``allowed_tools=[]`` and
+        ``strict_mcp_config=True`` specifically so the spawned CLI cannot run
+        tools or rediscover ouroboros' own MCP server and recurse; a transport
+        that dropped those would be more dangerous than the failure it replaces.
+        ``max_turns`` has no CLI flag, but it is moot under an empty tool
+        catalog -- with nothing to call, print mode returns on turn one.
         """
         import asyncio
         import json as _json
@@ -508,13 +578,24 @@ class ClaudeCodeAdapter:
             return Result.err(ProviderError(message="claude CLI path is unavailable"))
 
         argv = [str(cli_path), "-p", "--output-format", "json"]
-        if config.model:
-            argv += ["--model", config.model]
+        model = self._normalize_model(config.model)
+        if model:
+            argv += ["--model", model]
         if system_prompt:
             argv += ["--append-system-prompt", system_prompt]
         if self._permission_mode in self._CLI_PERMISSION_MODES:
             argv += ["--permission-mode", self._permission_mode]
+        if self._allowed_tools is not None:
+            # Unlike the SDK -- which drops an empty list before it reaches the
+            # CLI, hence the ``extra_args`` workaround in
+            # ``_execute_single_request`` -- the CLI honors ``--allowedTools ""``
+            # literally, so the empty envelope seals itself with no enumerate.
+            argv += ["--allowedTools", " ".join(self._allowed_tools)]
+        if self._strict_mcp_config:
+            argv.append("--strict-mcp-config")
 
+        timeout = self._timeout or _CLI_DEFAULT_TIMEOUT_SECONDS
+        proc: asyncio.subprocess.Process | None = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *argv,
@@ -524,16 +605,22 @@ class ClaudeCodeAdapter:
                 cwd=self._cwd or None,
             )
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(prompt.encode("utf-8")), timeout=self._timeout
+                proc.communicate(prompt.encode("utf-8")), timeout=timeout
             )
         except TimeoutError:
-            proc.kill()
+            await _terminate_process(proc)
             return Result.err(
                 ProviderError(
-                    message=f"claude CLI timed out after {self._timeout}s",
-                    details={"timeout_seconds": self._timeout},
+                    message=f"claude CLI timed out after {timeout}s",
+                    details={"timeout_seconds": timeout},
                 )
             )
+        except asyncio.CancelledError:
+            # The caller going away must not leave the child running: nothing
+            # else holds a handle to it, so this is the only place it can be
+            # reaped. Reap, then let the cancellation continue to propagate.
+            await _terminate_process(proc)
+            raise
         except OSError as exc:
             return Result.err(
                 ProviderError(
@@ -619,13 +706,19 @@ class ClaudeCodeAdapter:
         prompt: str,
         config: CompletionConfig,
         system_prompt: str | None,
+        transport: _Transport | None = None,
     ) -> Result[CompletionResponse, ProviderError]:
         """Normalize JSON content or retry until valid JSON is obtained.
 
         If the response contains valid JSON (even wrapped in prose/fences),
         extract and return just the JSON. If no valid JSON, retry up to
         _MAX_JSON_RETRIES times. If all retries fail, return an error.
+
+        ``transport`` is the callable that produced ``result``; retries must go
+        back through it rather than assuming the SDK, which may not be
+        importable in this process at all (Q00/ouroboros#1839).
         """
+        retry = transport or self._complete_with_transient_retry
         # Try to normalize the initial result
         normalized = self._normalize_json_content(result)
         if normalized is not None:
@@ -643,7 +736,7 @@ class ClaudeCodeAdapter:
                 attempt=json_attempt,
                 max_json_retries=_MAX_JSON_RETRIES,
             )
-            result = await self._complete_with_transient_retry(prompt, config, system_prompt)
+            result = await retry(prompt, config, system_prompt)
             if result.is_err:
                 return result
             normalized = self._normalize_json_content(result)
@@ -1066,20 +1159,9 @@ class ClaudeCodeAdapter:
             )
 
         # Pass model from CompletionConfig if specified
-        # "default" is not a valid SDK model — treat it as None (use SDK default)
-        if config.model and config.model != "default":
-            model = config.model
-            # Strip provider prefixes — the Agent SDK uses Anthropic's API directly
-            if model.startswith("openrouter/anthropic/"):
-                model = model[len("openrouter/anthropic/") :]
-            elif model.startswith("anthropic/"):
-                model = model[len("anthropic/") :]
-            elif model.startswith("openrouter/"):
-                # Non-Anthropic model (e.g., openrouter/openai/gpt-4o) —
-                # Agent SDK only supports Claude, so skip and use SDK default
-                model = None
-            if model:
-                options_kwargs["model"] = model
+        model = self._normalize_model(config.model)
+        if model:
+            options_kwargs["model"] = model
 
         # Pass system prompt as authoritative instruction (matches adapter.py:281-282 pattern)
         if system_prompt:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2411,6 +2411,22 @@ class TestCLIFallbackWhenSDKAbsent:
         proc.returncode = returncode
         proc.communicate = AsyncMock(return_value=(stdout, stderr))
         proc.kill = MagicMock()
+        proc.wait = AsyncMock(return_value=returncode)
+        return proc
+
+    @staticmethod
+    def _hanging_proc() -> MagicMock:
+        """A child that never answers — the case a bare subprocess cannot escape."""
+
+        async def _never(*_a: object, **_k: object) -> tuple[bytes, bytes]:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")  # pragma: no cover
+
+        proc = MagicMock()
+        proc.returncode = None
+        proc.communicate = _never
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock(return_value=-9)
         return proc
 
     def test_a_missing_sdk_falls_back_to_the_cli(self) -> None:
@@ -2542,3 +2558,174 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.is_err
         assert "Neither" in result.error.message
         assert "claude CLI" in result.error.message
+
+    def test_a_json_retry_stays_on_the_transport_that_answered(self) -> None:
+        """Prose-then-JSON must not route the retry back into the absent SDK.
+
+        Question generation and scoring both request a schema, so this is on the
+        reported path rather than beside it: if the first body is prose, the
+        retry has to reach the CLI again. Reaching for the SDK here turns a
+        recoverable response into `ImportError` in the one process that has no
+        SDK to import.
+        """
+        adapter = self._adapter()
+        prose = b'{"is_error":false,"result":"Sure! Here you go:","stop_reason":"end_turn"}'
+        good = b'{"is_error":false,"result":"{\\"q\\": 1}","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(side_effect=[self._proc(prose), self._proc(good)]),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ask something")],
+                    CompletionConfig(
+                        model="claude-haiku-4-5",
+                        response_format={"type": "json_object"},
+                    ),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == '{"q": 1}'
+        # Two CLI spawns: the prose answer and the retry. Had the retry gone to
+        # the SDK there would be one spawn and an import failure.
+        assert spawn.await_count == 2
+
+    def test_the_no_tools_envelope_reaches_the_cli(self) -> None:
+        """`allowed_tools=[]` and `strict_mcp_config` are carried, not dropped.
+
+        Interview/PM/QA construct this adapter that way precisely so the spawned
+        CLI cannot execute tools or rediscover ouroboros' own MCP server and
+        recurse. A fallback that ignored them would be more dangerous than the
+        failure it replaces.
+        """
+        adapter = self._adapter(allowed_tools=[], strict_mcp_config=True)
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ) as spawn,
+        ):
+            assert asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            ).is_ok
+
+        argv = list(spawn.await_args.args)
+        assert "--allowedTools" in argv
+        # The CLI honors an empty allow-list literally, unlike the SDK.
+        assert argv[argv.index("--allowedTools") + 1] == ""
+        assert "--strict-mcp-config" in argv
+
+    def test_a_permissive_caller_is_not_sealed_by_the_fallback(self) -> None:
+        """The other half of the pin: no envelope means no envelope flags.
+
+        `allowed_tools=None` is the permissive default, and forcing an empty
+        allow-list onto it would silently disable tools for callers that never
+        asked for that.
+        """
+        adapter = self._adapter(allowed_tools=None, strict_mcp_config=False)
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ) as spawn,
+        ):
+            assert asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            ).is_ok
+
+        argv = list(spawn.await_args.args)
+        assert "--allowedTools" not in argv
+        assert "--strict-mcp-config" not in argv
+
+    def test_a_model_id_is_normalized_the_same_way_on_both_transports(self) -> None:
+        """`anthropic/...` is valid config the SDK strips; raw it fails the CLI."""
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        cases: list[tuple[str, str | None]] = [
+            ("anthropic/claude-sonnet-4-5", "claude-sonnet-4-5"),
+            ("openrouter/anthropic/claude-opus-4-1", "claude-opus-4-1"),
+            ("claude-haiku-4-5", "claude-haiku-4-5"),
+            # No usable preference — omit the flag and take the CLI default.
+            ("default", None),
+            ("openrouter/openai/gpt-4o", None),
+        ]
+        for configured, expected in cases:
+            adapter = self._adapter()
+            with (
+                patch.dict("sys.modules", {"claude_agent_sdk": None}),
+                patch(
+                    "asyncio.create_subprocess_exec",
+                    new=AsyncMock(return_value=self._proc(payload)),
+                ) as spawn,
+            ):
+                assert asyncio.run(
+                    adapter.complete(
+                        [Message(role=MessageRole.USER, content="ping")],
+                        CompletionConfig(model=configured),
+                    )
+                ).is_ok
+            argv = list(spawn.await_args.args)
+            if expected is None:
+                assert "--model" not in argv, configured
+            else:
+                assert argv[argv.index("--model") + 1] == expected, configured
+
+    def test_a_nonresponsive_cli_is_bounded_and_reaped(self) -> None:
+        """A child nothing else owns must not be able to hang the caller forever."""
+        adapter = self._adapter(timeout=0.05)
+        proc = self._hanging_proc()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "timed out" in result.error.message
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
+
+    def test_cancellation_does_not_leave_the_child_running(self) -> None:
+        """Cancelling the caller is the only chance to reap this subprocess."""
+        adapter = self._adapter()
+        proc = self._hanging_proc()
+
+        async def _run() -> None:
+            task = asyncio.create_task(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+            # Let the task reach the await on the child before cancelling.
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)),
+        ):
+            asyncio.run(_run())
+
+        proc.kill.assert_called_once()
+        proc.wait.assert_awaited()

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2389,3 +2389,156 @@ class TestProviderErrorFormatDetails:
         assert result.value.content == "recovered response"
         assert adapter._execute_single_request.await_count == 2
         mock_sleep.assert_awaited_once()
+
+
+class TestCLIFallbackWhenSDKAbsent:
+    """The `claude` backend must survive a process the SDK cannot enter.
+
+    `claude-agent-sdk` requires `mcp<2.0.0` and the MCP protocol server requires
+    `mcp==2.0.0`, so a server built from the `[mcp]` extra has no SDK to import.
+    Before this, `llm.backend: claude` in that process could generate nothing at
+    all and reported it as an interview-content failure (Q00/ouroboros#1839).
+    """
+
+    @staticmethod
+    def _adapter(**kwargs: object) -> ClaudeCodeAdapter:
+        with patch.object(ClaudeCodeAdapter, "_resolve_cli_path", return_value="/bin/claude"):
+            return ClaudeCodeAdapter(**kwargs)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _proc(stdout: bytes, stderr: bytes = b"", returncode: int = 0) -> MagicMock:
+        proc = MagicMock()
+        proc.returncode = returncode
+        proc.communicate = AsyncMock(return_value=(stdout, stderr))
+        proc.kill = MagicMock()
+        return proc
+
+    def test_a_missing_sdk_falls_back_to_the_cli(self) -> None:
+        adapter = self._adapter()
+        payload = (
+            b'{"type":"result","subtype":"success","is_error":false,'
+            b'"result":"the answer","stop_reason":"end_turn",'
+            b'"usage":{"input_tokens":11,"output_tokens":7}}'
+        )
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [
+                        Message(role=MessageRole.SYSTEM, content="be terse"),
+                        Message(role=MessageRole.USER, content="ping"),
+                    ],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == "the answer"
+        assert result.value.finish_reason == "end_turn"
+        assert result.value.usage.total_tokens == 18
+
+        argv = list(spawn.await_args.args)
+        assert argv[0] == "/bin/claude"
+        assert "-p" in argv and "--output-format" in argv and "json" in argv
+        # The system message travels as a CLI flag rather than being folded into
+        # the prompt, matching what the SDK path does with it.
+        assert "--append-system-prompt" in argv
+        assert argv[argv.index("--append-system-prompt") + 1] == "be terse"
+
+    def test_the_adapters_own_permission_vocabulary_is_not_forwarded_blindly(self) -> None:
+        """`default` is a mode this adapter has and the CLI does not.
+
+        Forwarding it would make every fallback call fail on argument parsing,
+        which is a worse failure than the one being fixed: it would look like the
+        model refused rather than like a bad flag.
+        """
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        for mode, forwarded in (("default", False), ("bypassPermissions", True)):
+            adapter = self._adapter(permission_mode=mode)
+            with (
+                patch.dict("sys.modules", {"claude_agent_sdk": None}),
+                patch(
+                    "asyncio.create_subprocess_exec",
+                    new=AsyncMock(return_value=self._proc(payload)),
+                ) as spawn,
+            ):
+                assert asyncio.run(
+                    adapter.complete(
+                        [Message(role=MessageRole.USER, content="ping")],
+                        CompletionConfig(model="claude-haiku-4-5"),
+                    )
+                ).is_ok
+            assert ("--permission-mode" in list(spawn.await_args.args)) is forwarded, mode
+
+    def test_a_cli_error_is_reported_as_one(self) -> None:
+        """The CLI's own failure text reaches the caller rather than a generic one."""
+        payload = (
+            b'{"is_error":true,"subtype":"error_max_turns",'
+            b'"result":"reached maximum number of turns","session_id":"abc"}'
+        )
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "maximum number of turns" in result.error.message
+        assert result.error.details["subtype"] == "error_max_turns"
+
+    def test_a_non_json_body_surfaces_stderr(self) -> None:
+        """An auth prompt or a bad flag never reaches the result envelope.
+
+        Whatever the CLI wrote to stderr is the only diagnosis there is, so it is
+        carried rather than replaced with a parse error the user cannot act on.
+        """
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(
+                    return_value=self._proc(b"not json", b"Invalid API key", returncode=1)
+                ),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "Invalid API key" in result.error.details["stderr"]
+        assert result.error.details["returncode"] == 1
+
+    def test_neither_transport_is_named_as_neither(self) -> None:
+        """With no SDK and no CLI the message says so, instead of naming only pip."""
+        with patch.object(ClaudeCodeAdapter, "_resolve_cli_path", return_value=None):
+            adapter = ClaudeCodeAdapter()
+        with patch.dict("sys.modules", {"claude_agent_sdk": None}):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "Neither" in result.error.message
+        assert "claude CLI" in result.error.message

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -278,6 +278,31 @@ class TestResolveCliPathPreservesPublicContract:
 
         assert adapter._cli_path == binary.resolve()
 
+    def test_missing_sdk_discovers_claude_on_path(self, tmp_path) -> None:
+        binary = tmp_path / "claude"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        adapter = ClaudeCodeAdapter()
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        proc = MagicMock(returncode=0)
+        proc.communicate = AsyncMock(return_value=(payload, b""))
+
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("shutil.which", return_value=str(binary)) as which,
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok
+        which.assert_called_once_with("claude")
+        assert spawn.await_args.args[0] == str(binary.resolve())
+
 
 class TestAdapterOverheadReductions:
     """Test per-call overhead optimizations in ClaudeCodeAdapter."""
@@ -2547,7 +2572,10 @@ class TestCLIFallbackWhenSDKAbsent:
         """With no SDK and no CLI the message says so, instead of naming only pip."""
         with patch.object(ClaudeCodeAdapter, "_resolve_cli_path", return_value=None):
             adapter = ClaudeCodeAdapter()
-        with patch.dict("sys.modules", {"claude_agent_sdk": None}):
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("shutil.which", return_value=None),
+        ):
             result = asyncio.run(
                 adapter.complete(
                     [Message(role=MessageRole.USER, content="ping")],
@@ -2619,6 +2647,8 @@ class TestCLIFallbackWhenSDKAbsent:
             ).is_ok
 
         argv = list(spawn.await_args.args)
+        assert "--tools" in argv
+        assert argv[argv.index("--tools") + 1] == ""
         assert "--allowedTools" in argv
         # The CLI honors an empty allow-list literally, unlike the SDK.
         assert argv[argv.index("--allowedTools") + 1] == ""
@@ -2628,6 +2658,59 @@ class TestCLIFallbackWhenSDKAbsent:
         # setting sources, which the SDK path empties too.
         assert "--setting-sources" in argv
         assert argv[argv.index("--setting-sources") + 1] == ""
+
+    def test_the_cli_child_environment_is_isolated(self) -> None:
+        adapter = self._adapter()
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        inherited = {
+            "CLAUDECODE": "1",
+            "OUROBOROS_AGENT_RUNTIME": "claude",
+            "OUROBOROS_LLM_BACKEND": "claude",
+            "_OUROBOROS_DEPTH": "2",
+        }
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch.dict(os.environ, inherited, clear=False),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok
+        child_env = spawn.await_args.kwargs["env"]
+        assert "CLAUDECODE" not in child_env
+        assert "OUROBOROS_AGENT_RUNTIME" not in child_env
+        assert "OUROBOROS_LLM_BACKEND" not in child_env
+        assert child_env["_OUROBOROS_DEPTH"] == "3"
+
+    def test_a_nonempty_tool_envelope_controls_catalog_and_permissions(self) -> None:
+        adapter = self._adapter(allowed_tools=["Read", "Grep"])
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok
+        argv = list(spawn.await_args.args)
+        assert argv[argv.index("--tools") + 1] == "Read Grep"
+        assert argv[argv.index("--allowedTools") + 1] == "Read Grep"
 
     def test_a_permissive_caller_is_not_sealed_by_the_fallback(self) -> None:
         """The other half of the pin: no envelope means no envelope flags.
@@ -2653,6 +2736,7 @@ class TestCLIFallbackWhenSDKAbsent:
             ).is_ok
 
         argv = list(spawn.await_args.args)
+        assert "--tools" not in argv
         assert "--allowedTools" not in argv
         assert "--strict-mcp-config" not in argv
         assert "--setting-sources" not in argv

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2814,6 +2814,35 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.is_err
         assert "Empty response" in result.error.message
 
+    def test_a_failure_names_the_transport_that_actually_failed(self) -> None:
+        """Blaming the SDK from a process without one is the original bug's shape.
+
+        A malformed-but-parseable envelope raises inside the CLI path and lands
+        in the shared exception handler. Naming the SDK there would send the
+        reader to `pip install claude-agent-sdk` — advice that cannot help in
+        the process where this transport is the one being used.
+        """
+        adapter = self._adapter()
+        malformed = b'{"is_error":false,"result":"ok","usage":{"input_tokens":"not-a-number"}}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(side_effect=lambda *_a, **_k: self._proc(malformed)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "claude CLI request failed" in result.error.message
+        assert "Claude Agent SDK" not in result.error.message
+
     def test_a_model_id_is_normalized_the_same_way_on_both_transports(self) -> None:
         """`anthropic/...` is valid config the SDK strips; raw it fails the CLI."""
         payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2736,6 +2736,84 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.is_err
         assert spawn.await_count == 1
 
+    def test_an_empty_result_envelope_is_not_a_successful_answer(self) -> None:
+        """`is_error: false` with an empty body is infrastructure, not an answer.
+
+        The SDK path already classifies empty content as a retryable provider
+        error. Returning `content=""` as `is_ok` would hand an interview or QA
+        caller a false answer *past* the retry loop, since the loop returns on
+        the first success.
+        """
+        adapter = self._adapter()
+        empty = b'{"is_error":false,"result":"","stop_reason":"end_turn"}'
+        good = b'{"is_error":false,"result":"an actual answer","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(side_effect=[self._proc(empty), self._proc(good)]),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == "an actual answer"
+        assert spawn.await_count == 2
+
+    def test_a_persistently_empty_cli_fails_explicitly(self) -> None:
+        """Exhausting the retries reports the emptiness rather than returning it."""
+        adapter = self._adapter()
+        empty = b'{"is_error":false,"result":"","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(side_effect=lambda *_a, **_k: self._proc(empty)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "Empty response" in result.error.message
+        assert result.error.details["content_length"] == 0
+
+    def test_a_missing_result_key_is_treated_the_same_as_an_empty_one(self) -> None:
+        """No `result` key at all is the same absence, not a different one."""
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(
+                    side_effect=lambda *_a, **_k: self._proc(
+                        b'{"is_error":false,"stop_reason":"end_turn"}'
+                    )
+                ),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "Empty response" in result.error.message
+
     def test_a_model_id_is_normalized_the_same_way_on_both_transports(self) -> None:
         """`anthropic/...` is valid config the SDK strips; raw it fails the CLI."""
         payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2814,6 +2814,81 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.is_err
         assert "Empty response" in result.error.message
 
+    def test_unencodable_caller_text_never_reaches_a_spawn(self) -> None:
+        """A lone surrogate must fail before there is a child to orphan.
+
+        MCP payloads are caller-controlled, so this text is reachable. Encoding
+        it after the spawn left a process waiting on a stdin that would never
+        be written, and repeated bad inputs accumulated them. The pin is that no
+        subprocess is created at all, not that a created one gets cleaned up.
+        """
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("asyncio.create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="lone surrogate: \ud800")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "cannot be encoded" in result.error.message
+        spawn.assert_not_awaited()
+
+    def test_unencodable_system_text_never_reaches_a_spawn(self) -> None:
+        """The same for text that travels as an argv flag rather than on stdin."""
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("asyncio.create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [
+                        Message(role=MessageRole.SYSTEM, content="be terse \udfff"),
+                        Message(role=MessageRole.USER, content="ping"),
+                    ],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "cannot be encoded" in result.error.message
+        spawn.assert_not_awaited()
+
+    def test_any_post_spawn_failure_reaps_the_child(self) -> None:
+        """Ownership, not a catalogue of exception types.
+
+        Once the child exists every exit path has to reap it, including error
+        classes nobody enumerated. `communicate` raising an arbitrary error
+        stands in for that.
+        """
+        adapter = self._adapter()
+        # returncode stays None: a child that is still alive, which is the only
+        # state in which reaping is observable at all.
+        proc = self._hanging_proc()
+        proc.communicate = AsyncMock(side_effect=RuntimeError("pipe exploded"))
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        proc.kill.assert_called()
+        proc.wait.assert_awaited()
+
     def test_a_failure_names_the_transport_that_actually_failed(self) -> None:
         """Blaming the SDK from a process without one is the original bug's shape.
 

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2623,6 +2623,11 @@ class TestCLIFallbackWhenSDKAbsent:
         # The CLI honors an empty allow-list literally, unlike the SDK.
         assert argv[argv.index("--allowedTools") + 1] == ""
         assert "--strict-mcp-config" in argv
+        # `--strict-mcp-config` closes MCP discovery only. The parent's project
+        # and user instructions, hooks, agents and plugins arrive through
+        # setting sources, which the SDK path empties too.
+        assert "--setting-sources" in argv
+        assert argv[argv.index("--setting-sources") + 1] == ""
 
     def test_a_permissive_caller_is_not_sealed_by_the_fallback(self) -> None:
         """The other half of the pin: no envelope means no envelope flags.
@@ -2650,6 +2655,86 @@ class TestCLIFallbackWhenSDKAbsent:
         argv = list(spawn.await_args.args)
         assert "--allowedTools" not in argv
         assert "--strict-mcp-config" not in argv
+        assert "--setting-sources" not in argv
+
+    def test_the_turn_budget_is_forwarded_to_the_cli(self) -> None:
+        """`--max-turns` is absent from `claude --help` but is a real flag.
+
+        The CLI rejects genuinely unknown options (`error: unknown option`),
+        and accepts this one — so an SDK-absent run that omitted it would run
+        past the configured turn and cost boundary. Semantic evaluation asks
+        for 20 turns with tools enabled, which is where that bites.
+        """
+        payload = b'{"is_error":false,"result":"ok","stop_reason":"end_turn"}'
+        # Constructor value, then a per-request override of the same adapter.
+        for ctor_turns, request_turns, expected in ((20, None, "20"), (20, 3, "3"), (1, None, "1")):
+            adapter = self._adapter(max_turns=ctor_turns)
+            with (
+                patch.dict("sys.modules", {"claude_agent_sdk": None}),
+                patch(
+                    "asyncio.create_subprocess_exec",
+                    new=AsyncMock(return_value=self._proc(payload)),
+                ) as spawn,
+            ):
+                assert asyncio.run(
+                    adapter.complete(
+                        [Message(role=MessageRole.USER, content="ping")],
+                        CompletionConfig(model="claude-haiku-4-5", max_turns=request_turns),
+                    )
+                ).is_ok
+            argv = list(spawn.await_args.args)
+            assert argv[argv.index("--max-turns") + 1] == expected, (ctor_turns, request_turns)
+
+    def test_a_transient_cli_failure_is_retried_like_a_transient_sdk_failure(self) -> None:
+        """Rate limits belong to the service, not to how we reached it.
+
+        The SDK transport gets `_MAX_RETRIES` for overload/rate-limit/bootstrap
+        errors. Selecting the fallback must not silently convert those same
+        errors into permanent failures.
+        """
+        adapter = self._adapter()
+        overloaded = b'{"is_error":true,"result":"API error: 529 overloaded_error"}'
+        good = b'{"is_error":false,"result":"recovered","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(side_effect=[self._proc(overloaded, returncode=1), self._proc(good)]),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == "recovered"
+        assert spawn.await_count == 2
+
+    def test_a_permanent_cli_failure_is_not_retried(self) -> None:
+        """The other half: a non-transient error still fails on the first try."""
+        adapter = self._adapter()
+        bad_request = b'{"is_error":true,"result":"invalid model name"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(bad_request, returncode=1)),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert spawn.await_count == 1
 
     def test_a_model_id_is_normalized_the_same_way_on_both_transports(self) -> None:
         """`anthropic/...` is valid config the SDK strips; raw it fails the CLI."""

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -324,3 +324,43 @@ def test_build_excludes_generated_artifacts():
 
     missing = required_excludes - excludes
     assert not missing, f"Missing hatch build excludes for generated artifacts: {missing}"
+
+
+def test_shipped_mcp_launcher_extras_can_co_resolve() -> None:
+    """Extras requested together must not pin one distribution two ways.
+
+    The launcher used to request ``[mcp,claude]``. Those two extras pin the same
+    distribution at incompatible majors — ``mcp==2.0.0`` against the SDK's
+    ``mcp<2.0.0`` — so asking for both produces an unsatisfiable install rather
+    than a degraded one, and the server never starts at all.
+
+    Checked statically against ``pyproject.toml`` rather than by resolving, so it
+    holds without a network and names the conflicting distribution when it fails
+    (Q00/ouroboros#1839).
+    """
+    import re
+    import tomllib
+
+    root = Path(__file__).parent.parent.parent
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    optional = pyproject["project"]["optional-dependencies"]
+
+    entry = json.loads((root / ".claude-plugin" / ".mcp.json").read_text(encoding="utf-8"))
+    args = entry["mcpServers"]["ouroboros"]["args"]
+    spec = args[args.index("--from") + 1]
+    requested = re.findall(r"\[([^\]]*)\]", spec)
+    extras = [e.strip() for e in (requested[0].split(",") if requested else [])]
+
+    seen: dict[str, tuple[str, str]] = {}
+    for extra in extras:
+        for requirement in optional.get(extra, []):
+            name = re.split(r"[\[\(<>=!;\s]", requirement, maxsplit=1)[0].strip()
+            constraint = requirement[len(name) :].strip()
+            if name in seen and seen[name][1] != constraint:
+                prior_extra, prior_constraint = seen[name]
+                msg = (
+                    f"extras {prior_extra!r} and {extra!r} both constrain {name!r}: "
+                    f"{prior_constraint!r} vs {constraint!r}"
+                )
+                raise AssertionError(msg)
+            seen[name] = (extra, constraint)

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -326,41 +326,38 @@ def test_build_excludes_generated_artifacts():
     assert not missing, f"Missing hatch build excludes for generated artifacts: {missing}"
 
 
-def test_shipped_mcp_launcher_extras_can_co_resolve() -> None:
-    """Extras requested together must not pin one distribution two ways.
+def test_shipped_mcp_launcher_requests_only_the_servers_own_extra() -> None:
+    """The launcher must request ``[mcp]`` and nothing else.
 
-    The launcher used to request ``[mcp,claude]``. Those two extras pin the same
-    distribution at incompatible majors — ``mcp==2.0.0`` against the SDK's
-    ``mcp<2.0.0`` — so asking for both produces an unsatisfiable install rather
-    than a degraded one, and the server never starts at all.
-
-    Checked statically against ``pyproject.toml`` rather than by resolving, so it
-    holds without a network and names the conflicting distribution when it fails
+    The launcher used to request ``[mcp,claude]``, which is an *unsatisfiable*
+    install rather than a degraded one — ``mcp==2.0.0`` against the SDK's
+    transitive ``mcp<2.0.0`` — so the server never starts at all
     (Q00/ouroboros#1839).
+
+    This asserts the extras list rather than trying to prove the extras
+    co-resolve. That earlier phrasing could not decide the case it was written
+    for: the conflict is transitive (``claude`` lists ``claude-agent-sdk``, and
+    the ``mcp`` pin lives one level down), so comparing direct requirement names
+    finds ``mcp`` and ``claude-agent-sdk``, sees two different names, and passes
+    the exact combination it claims to reject. Proving co-resolution statically
+    needs the whole dependency graph; asserting the one-line literal that gates
+    whether the server boots needs nothing and cannot silently pass.
+
+    What this gives up: a genuinely new, compatible extra added to the launcher
+    fails here and has to be added deliberately. For the file that decides
+    whether the MCP server starts, that is the intended cost.
     """
     import re
-    import tomllib
 
     root = Path(__file__).parent.parent.parent
-    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    optional = pyproject["project"]["optional-dependencies"]
-
     entry = json.loads((root / ".claude-plugin" / ".mcp.json").read_text(encoding="utf-8"))
     args = entry["mcpServers"]["ouroboros"]["args"]
     spec = args[args.index("--from") + 1]
     requested = re.findall(r"\[([^\]]*)\]", spec)
     extras = [e.strip() for e in (requested[0].split(",") if requested else [])]
 
-    seen: dict[str, tuple[str, str]] = {}
-    for extra in extras:
-        for requirement in optional.get(extra, []):
-            name = re.split(r"[\[\(<>=!;\s]", requirement, maxsplit=1)[0].strip()
-            constraint = requirement[len(name) :].strip()
-            if name in seen and seen[name][1] != constraint:
-                prior_extra, prior_constraint = seen[name]
-                msg = (
-                    f"extras {prior_extra!r} and {extra!r} both constrain {name!r}: "
-                    f"{prior_constraint!r} vs {constraint!r}"
-                )
-                raise AssertionError(msg)
-            seen[name] = (extra, constraint)
+    assert extras == ["mcp"], (
+        f"shipped MCP launcher requests extras {extras!r}; it must request only "
+        "['mcp']. Adding 'claude' here reintroduces the unsatisfiable "
+        "mcp==2.0.0 vs claude-agent-sdk(mcp<2.0.0) install from #1839."
+    )


### PR DESCRIPTION
Closes #1839.

## Summary

`llm.backend: claude` cannot generate anything inside an MCP server process. The
adapter's only transport is `claude-agent-sdk`; the SDK requires `mcp<2.0.0`, the
protocol server requires `mcp==2.0.0`, and the shipped launcher asks for `[mcp]`
— so there is no SDK to import. The user sees this inside an interview response:

```
Question generation failed: Claude Agent SDK is not installed.
Run: pip install claude-agent-sdk
```

which reads like a model failure rather than a missing dependency.

This adds a CLI fallback. The `claude` CLI is a separate process carrying the same
subscription, so it is the transport that survives a boundary the SDK cannot
cross.

## What changed

`ClaudeCodeAdapter.complete()` no longer fails when the SDK import fails. If a CLI
path is known it runs `claude -p --output-format json` as a subprocess and returns
the same `CompletionResponse`.

Everything above the transport is untouched — profile resolution, system-message
extraction, the JSON-format reinforcement and `_enforce_json` all run exactly as
before, because only the call at the bottom is swapped.

**This is a fallback, not a replacement.** An environment that has the SDK takes
the path it always did. Streaming, multi-turn tool use and per-turn events belong
to the SDK and are unchanged; print mode has none of them, which is why this is
reached only when the alternative is failing outright. Single-response calls —
question generation, scoring, the advisory lanes — do not use those features.

Four details decide whether it works rather than merely runs:

| | |
|---|---|
| System message | travels as `--append-system-prompt`, matching what the SDK path does with it rather than folding it into the prompt |
| `--permission-mode` | forwarded only for values the CLI accepts. This adapter's vocabulary includes `default`, which the CLI expresses by omitting the flag — passing it through would fail argument parsing on every call and look like a refusal |
| Non-JSON body | means the CLI failed before producing a result envelope (auth prompt, usage limit, rejected flag), so its stderr is carried as the only diagnosis there is |
| Neither transport | the error names both, instead of naming only `pip install claude-agent-sdk` in a process where that cannot help |

## Launcher guard

`test_shipped_mcp_launcher_extras_can_co_resolve` reads the extras out of
`.claude-plugin/.mcp.json` and checks them against `pyproject.toml`, failing if
two of them constrain one distribution incompatibly. `[mcp,claude]` was that
shape: it produces an *unsatisfiable install* rather than a degraded one, so the
server never starts at all. Checked statically, so it needs no network and names
the conflicting distribution when it fails.

## Verification

The reported failure, reproduced and then re-run against this change with
`claude_agent_sdk` forcibly absent from `sys.modules`:

```
before  Question generation failed: Claude Agent SDK is not installed
after   Interview started. Session ID: interview_20260802_052613

        What is the primary goal driving this gating decision — capturing
        revenue from larger accounts, or reducing the security/support burden
        of provisioning SSO — and would any customers currently using SSO on a
        non-enterprise plan lose access, or be grandfathered in?
```

Also confirmed the underlying claim with one variable changed, on one published
version, so the diagnosis does not rest on the resolver:

```
uvx --from 'ouroboros-ai[mcp]==0.50.6'         -> Question generation failed
uvx --from 'ouroboros-ai[mcp,claude]==0.50.6'  -> Interview started
```

Both report `ouroboros-mcp 1.28.1`, so `mcp` version is not the variable — the
presence of the SDK in the process is.

- `tests/unit`: 16072 passed, 13 skipped, 1 failed — `TestWheelPackaging::test_wheel_contains_profile_yamls`, which shells out to `uv build`; it passes on its own run and this PR touches neither `pyproject.toml` nor `profiles/`.
- `tests/unit/providers`: 667 passed, 5 skipped
- `mypy` clean on the changed module; `ruff check` / `ruff format --check` clean
- `scripts/check-module-size.py --baseline-ref origin/main`: OK

## Not in this change

A CLI transport for the *agent runtime* (subagent dispatch), which has the same
SDK dependency and the same boundary. This PR covers the LLM completion path,
which is what the reported failure sits on.

## R-run comparison

`src/ouroboros/auto/` is untouched, so there is no per-round behavior to compare.
Per RFC #1256 §I5 substrate-only guidance every cell is `N/A`.

| Metric | Baseline | This PR | Ratio |
| --- | --- | --- | --- |
| Rounds completed | N/A | N/A | n/a |
| Per-round wall-clock | N/A | N/A | n/a |
| Terminal reason | N/A | N/A | n/a |
| EventStore event count | N/A | N/A | n/a |
