### PR TITLE
fix(config): pin UTF-8 on config and credentials YAML I/O

### DIFF
--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -500,7 +500,7 @@ def create_default_config(
     # Create config.yaml
     default_config = get_default_config()
     config_dict = _model_to_yaml_dict(default_config)
-    with config_path.open("w") as f:
+    with config_path.open("w", encoding="utf-8") as f:
         yaml.dump(
             config_dict,
             f,
@@ -512,7 +512,7 @@ def create_default_config(
     # Create credentials.yaml with secure permissions
     default_credentials = get_default_credentials()
     credentials_dict = _model_to_yaml_dict(default_credentials)
-    with credentials_path.open("w") as f:
+    with credentials_path.open("w", encoding="utf-8") as f:
         yaml.dump(
             credentials_dict,
             f,
@@ -553,9 +553,9 @@ def load_config(config_path: Path | None = None) -> OuroborosConfig:
         )
 
     try:
-        with config_path.open() as f:
+        with config_path.open(encoding="utf-8") as f:
             config_dict = yaml.safe_load(f)
-    except yaml.YAMLError as e:
+    except (UnicodeDecodeError, yaml.YAMLError) as e:
         raise ConfigError(
             f"Failed to parse configuration file: {e}",
             config_file=str(config_path),
@@ -626,9 +626,9 @@ def load_credentials(credentials_path: Path | None = None) -> CredentialsConfig:
         pass
 
     try:
-        with credentials_path.open() as f:
+        with credentials_path.open(encoding="utf-8") as f:
             credentials_dict = yaml.safe_load(f)
-    except yaml.YAMLError as e:
+    except (UnicodeDecodeError, yaml.YAMLError) as e:
         raise ConfigError(
             f"Failed to parse credentials file: {e}",
             config_file=str(credentials_path),
@@ -1126,9 +1126,9 @@ def get_usage_limit_pause_seconds() -> int:
         return int(_DEFAULT_USAGE_LIMIT_PAUSE_HOURS * _SECONDS_PER_HOUR)
 
     try:
-        with config_path.open() as f:
+        with config_path.open(encoding="utf-8") as f:
             config_dict = yaml.safe_load(f)
-    except yaml.YAMLError as e:
+    except (UnicodeDecodeError, yaml.YAMLError) as e:
         raise ConfigError(
             f"Failed to parse configuration file: {e}",
             config_file=str(config_path),
@@ -1197,9 +1197,9 @@ def get_max_parallel_workers() -> int:
         return _DEFAULT_MAX_PARALLEL_WORKERS
 
     try:
-        with config_path.open() as f:
+        with config_path.open(encoding="utf-8") as f:
             config_dict = yaml.safe_load(f)
-    except yaml.YAMLError as e:
+    except (UnicodeDecodeError, yaml.YAMLError) as e:
         raise ConfigError(
             f"Failed to parse configuration file: {e}",
             config_file=str(config_path),

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -887,8 +887,8 @@ def resolve_event_store_path(config_path: Path | None = None) -> Path:
         return config_path.parent / "ouroboros.db"
 
     try:
-        loaded = yaml.safe_load(config_path.read_text()) or {}
-    except (OSError, yaml.YAMLError):
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
         raise ValueError("invalid EventStore configuration") from None
     if not isinstance(loaded, Mapping):
         raise ValueError("invalid EventStore configuration")

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -2389,8 +2389,13 @@ class TestConfigEncodingLocaleIndependence:
             if not key.startswith(("PYTHON", "OUROBOROS", "LC_", "LANG"))
         }
         env.update({"PYTHONUTF8": "0", "LC_ALL": "C", "LANG": "C"})
+        # The program goes through a UTF-8 script file, not -c: under the C
+        # locale the child cannot even decode a non-ASCII command line, while
+        # Python source files are UTF-8 by default regardless of locale.
+        script_path = tmp_path / "locale_repro.py"
+        script_path.write_text(script, encoding="utf-8")
         result = subprocess.run(
-            [sys.executable, "-c", script, str(tmp_path / "config")],
+            [sys.executable, str(script_path), str(tmp_path / "config")],
             capture_output=True,
             text=True,
             env=env,

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -3,6 +3,9 @@
 import os
 from pathlib import Path
 import stat
+import subprocess
+import sys
+import textwrap
 from unittest.mock import patch
 
 import pytest
@@ -60,6 +63,7 @@ from ouroboros.config.models import (
     ResilienceConfig,
     RuntimeControlsConfig,
     RuntimeProfileConfig,
+    resolve_event_store_path,
 )
 from ouroboros.core.errors import ConfigError
 
@@ -2331,3 +2335,85 @@ class TestGetExecutionModel:
             return_value=OuroborosConfig(execution=ExecutionConfig(default_model=value)),
         ):
             assert get_execution_model() is None
+
+
+class TestConfigEncodingLocaleIndependence:
+    """#1831: config/credentials I/O must not depend on the process locale."""
+
+    def test_utf8_config_round_trips_under_non_utf8_locale(self, tmp_path: Path) -> None:
+        """Create, rewrite with Korean content, and load back under LC_ALL=C.
+
+        The subprocess disables Python UTF-8 mode so the platform default
+        encoding really is ASCII; every canonical config operation has to
+        keep working because each pins UTF-8 explicitly.
+        """
+        script = textwrap.dedent(
+            """
+            import locale
+            from pathlib import Path
+            import sys
+
+            import yaml
+
+            preferred = locale.getpreferredencoding(False)
+            if "utf" in preferred.lower():
+                print(f"BADENV preferred={preferred}")
+                sys.exit(2)
+
+            from ouroboros.config import loader
+            from ouroboros.config.models import resolve_event_store_path
+
+            config_dir = Path(sys.argv[1])
+            config_path, credentials_path = loader.create_default_config(
+                config_dir=config_dir
+            )
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            data.setdefault("project", {})["name"] = "한국어 프로젝트"
+            data.setdefault("persistence", {})["database_path"] = str(
+                config_dir / "데이터" / "ouroboros.db"
+            )
+            with config_path.open("w", encoding="utf-8") as f:
+                yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
+
+            config = loader.load_config(config_path)
+            assert config is not None
+            loader.load_credentials(credentials_path)
+            resolved = resolve_event_store_path(config_path)
+            assert "데이터" in str(resolved), resolved
+            print("OK")
+            """
+        )
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("PYTHON", "OUROBOROS", "LC_", "LANG"))
+        }
+        env.update({"PYTHONUTF8": "0", "LC_ALL": "C", "LANG": "C"})
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(tmp_path / "config")],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0 and "OK" in result.stdout, (
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    def test_invalidly_encoded_files_fail_through_domain_errors(self, tmp_path: Path) -> None:
+        """A non-UTF-8 file must surface the documented error, not a codec leak."""
+        garbage = b"project:\n  name: \xff\xfe broken\n"
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_bytes(garbage)
+        with pytest.raises(ConfigError):
+            load_config(config_path)
+
+        credentials_path = tmp_path / "credentials.yaml"
+        credentials_path.write_bytes(garbage)
+        credentials_path.chmod(0o600)
+        with pytest.raises(ConfigError):
+            load_credentials(credentials_path)
+
+        with pytest.raises(ValueError, match="invalid EventStore configuration"):
+            resolve_event_store_path(config_path)


### PR DESCRIPTION
Closes #1831.

## Problem

The canonical config/credentials operations opened their files with the platform default encoding. With Python UTF-8 mode disabled under a non-UTF-8 locale (`PYTHONUTF8=0 LC_ALL=C`), loading a valid UTF-8 config containing non-ASCII values raised `UnicodeDecodeError` from `load_config`, `load_credentials`, and the independent EventStore-path reader — the exact failure in the issue's diagnostic — so the application could not start at all on such hosts. The EventStore-path reader also leaked the raw codec exception because its error boundary caught only `OSError` and `yaml.YAMLError`.

## Fix

All five operations named in the issue now pass `encoding="utf-8"` explicitly: both writers in `create_default_config`, both loaders, and `resolve_event_store_path`'s `read_text`. The load boundaries treat a decoding failure the same way as malformed YAML: the loaders raise their documented `ConfigError`, and the EventStore-path reader raises its documented `ValueError("invalid EventStore configuration")`, so an invalidly encoded file can no longer leak an unhandled codec exception.

## Tests

- `test_utf8_config_round_trips_under_non_utf8_locale` runs the full round trip in a subprocess with `PYTHONUTF8=0 LC_ALL=C LANG=C`: the script refuses to run if the preferred encoding still reports UTF-8 (so a broken environment cannot produce a vacuous pass), creates the default config through the real writers, rewrites it with Korean YAML content, and loads everything back through `load_config`, `load_credentials`, and `resolve_event_store_path`. Verified failing on the baseline with the issue's `UnicodeDecodeError`.
- `test_invalidly_encoded_files_fail_through_domain_errors` feeds non-UTF-8 bytes to all three readers and requires the documented domain errors; the EventStore case matches on the documented message, which a leaked `UnicodeDecodeError` (itself a `ValueError`) cannot satisfy. Verified failing on the baseline.

Config suite (489) and persistence suite pass; ruff, mypy, and the module-size gate are clean.