### PR TITLE
fix(tui): stop reporting pause/resume the monitor cannot perform

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,3 +87,23 @@ jobs:
       - name: Run tests
         run: bun test
         working-directory: src/ouroboros/opencode/plugin
+
+  native-tui:
+    name: Native TUI (Rust)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/ouroboros-tui
+
+      - name: Run tests
+        run: cargo test
+        working-directory: crates/ouroboros-tui

--- a/crates/ouroboros-tui/README.md
+++ b/crates/ouroboros-tui/README.md
@@ -37,4 +37,9 @@ ouroboros-tui --help                    # show all options
 
 ## Keys
 
-`q` quit · `p`/`r` pause/resume · `1-5` screens · `Ctrl+P` command palette · `↑↓` navigate · `Enter` select · mouse click
+`q` quit · `1-5` screens · `Ctrl+P` command palette · `↑↓` navigate · `Enter` select · mouse click
+
+`p`/`r` pause/resume are available in `--mock` demo mode only, where this process owns the
+simulation it is pausing. When monitoring a real database the TUI is an observer with no
+execution owner, so the keys are absent from the footer and the command palette. Use
+`ouroboros cancel execution` to stop a run.

--- a/crates/ouroboros-tui/README.md
+++ b/crates/ouroboros-tui/README.md
@@ -39,7 +39,9 @@ ouroboros-tui --help                    # show all options
 
 `q` quit · `1-5` screens · `Ctrl+P` command palette · `↑↓` navigate · `Enter` select · mouse click
 
-`p`/`r` pause/resume are available in `--mock` demo mode only, where this process owns the
-simulation it is pausing. When monitoring a real database the TUI is an observer with no
-execution owner, so the keys are absent from the footer and the command palette. Use
-`ouroboros cancel execution` to stop a run.
+`p`/`r` pause/resume are available in demo mode only, where this process owns the simulation
+it is pausing. Demo mode is entered with `--mock`, and also as a fallback when the database
+is empty or cannot be opened. When attached to a database with real events the TUI is an
+observer with no execution owner, so the keys are absent from the footer and the command
+palette — use `ouroboros cancel execution` to stop a run. A paused run returns to running on
+its own once persisted progress reports the runtime executing again.

--- a/crates/ouroboros-tui/src/db.rs
+++ b/crates/ouroboros-tui/src/db.rs
@@ -335,11 +335,16 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                     state._start_ts = ts.to_string();
                 }
             }
+            // Terminal events clear `is_paused` as well as setting the status,
+            // matching the Python monitor. Leaving the flag set would let a
+            // late progress event lift a run that has already ended.
             "orchestrator.session.completed" => {
                 state.status = ExecutionStatus::Completed;
+                state.is_paused = false;
             }
             "orchestrator.session.failed" => {
                 state.status = ExecutionStatus::Failed;
+                state.is_paused = false;
             }
             "orchestrator.session.paused" => {
                 state.status = ExecutionStatus::Paused;
@@ -347,6 +352,7 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
             }
             "orchestrator.session.cancelled" => {
                 state.status = ExecutionStatus::Cancelled;
+                state.is_paused = false;
             }
             "execution.phase.completed" => {
                 if let Some(phase_str) = ev.payload.get("phase").and_then(|v| v.as_str()) {
@@ -409,7 +415,9 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                 // reporting the runtime is executing again is the only signal
                 // that can lift a paused display. It never authors a status
                 // otherwise.
-                if state.is_paused && progress_acknowledges_running(&ev.payload) {
+                if state.status == ExecutionStatus::Paused
+                    && progress_acknowledges_running(&ev.payload)
+                {
                     state.is_paused = false;
                     state.status = ExecutionStatus::Running;
                 }
@@ -925,7 +933,9 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                     });
             }
             "orchestrator.progress.updated" => {
-                if state.is_paused && progress_acknowledges_running(&ev.payload) {
+                if state.status == ExecutionStatus::Paused
+                    && progress_acknowledges_running(&ev.payload)
+                {
                     state.is_paused = false;
                     state.status = ExecutionStatus::Running;
                 }
@@ -1182,6 +1192,33 @@ mod tests {
 
             assert!(state.is_paused, "{terminal} cleared the paused display");
             assert_eq!(state.status, ExecutionStatus::Paused, "{terminal}");
+        }
+    }
+
+    #[test]
+    fn late_running_progress_cannot_revive_a_terminal_run() {
+        // paused -> completed -> stale progress(running). The terminal event is
+        // authoritative; delayed progress must not walk it back.
+        for (terminal_event, expected) in [
+            ("orchestrator.session.completed", ExecutionStatus::Completed),
+            ("orchestrator.session.failed", ExecutionStatus::Failed),
+            ("orchestrator.session.cancelled", ExecutionStatus::Cancelled),
+        ] {
+            let mut state = paused_state();
+
+            populate_state_from_events(&mut state, &[event(terminal_event, json!({}))]);
+            assert!(!state.is_paused, "{terminal_event} left is_paused set");
+
+            populate_state_from_events(
+                &mut state,
+                &[event(
+                    "workflow.progress.updated",
+                    json!({"last_update": {"runtime_status": "running"}}),
+                )],
+            );
+
+            assert_eq!(state.status, expected, "{terminal_event} was walked back");
+            assert!(!state.is_paused);
         }
     }
 

--- a/crates/ouroboros-tui/src/db.rs
+++ b/crates/ouroboros-tui/src/db.rs
@@ -405,6 +405,14 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                 }
             }
             "workflow.progress.updated" => {
+                // There is no `orchestrator.session.resumed` event; progress
+                // reporting the runtime is executing again is the only signal
+                // that can lift a paused display. It never authors a status
+                // otherwise.
+                if state.is_paused && progress_acknowledges_running(&ev.payload) {
+                    state.is_paused = false;
+                    state.status = ExecutionStatus::Running;
+                }
                 if let Some(phase_str) = ev.payload.get("current_phase").and_then(|v| v.as_str()) {
                     state.current_phase = match phase_str.to_lowercase().as_str() {
                         "discover" => Phase::Discover,
@@ -917,6 +925,10 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                     });
             }
             "orchestrator.progress.updated" => {
+                if state.is_paused && progress_acknowledges_running(&ev.payload) {
+                    state.is_paused = false;
+                    state.status = ExecutionStatus::Running;
+                }
                 state._msg_count += 1;
                 if let Some(preview) = ev.payload.get("content_preview").and_then(|v| v.as_str()) {
                     state.add_log(
@@ -1006,6 +1018,34 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
     state.rebuild_tree_state();
 }
 
+/// Whether a progress payload acknowledges the run is executing again.
+///
+/// Mirrors the Python monitor's `_progress_acknowledges_running`. Deliberately
+/// narrow: only `running` counts. `runtime_status` is per-runtime-turn
+/// metadata — messages such as `result.completed` project to `"completed"` —
+/// so honouring terminal values here would let an unfinished run advertise a
+/// terminal state. Global paused/terminal status stays with
+/// `orchestrator.session.*`.
+///
+/// The two producers nest the value differently: `orchestrator.progress.updated`
+/// wraps it in `progress`, `workflow.progress.updated` carries it in
+/// `last_update`.
+fn progress_acknowledges_running(payload: &Value) -> bool {
+    for container in ["progress", "last_update"] {
+        if let Some(status) = payload
+            .get(container)
+            .and_then(|v| v.get("runtime_status"))
+            .and_then(|v| v.as_str())
+        {
+            return status.trim().eq_ignore_ascii_case("running");
+        }
+    }
+    payload
+        .get("runtime_status")
+        .and_then(|v| v.as_str())
+        .is_some_and(|status| status.trim().eq_ignore_ascii_case("running"))
+}
+
 fn short_payload(payload: &Value) -> String {
     let s = payload.to_string();
     if s.chars().count() > 500 {
@@ -1055,5 +1095,109 @@ fn compute_elapsed(start: &str, end: &str) -> Option<String> {
         Some(format!("{hours:02}:{mins:02}:{secs:02}"))
     } else {
         Some(format!("{mins:02}:{secs:02}"))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(event_type: &str, payload: Value) -> EventRow {
+        EventRow {
+            id: "1".into(),
+            aggregate_type: "session".into(),
+            aggregate_id: "sess_1833".into(),
+            event_type: event_type.into(),
+            payload,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    fn paused_state() -> AppState {
+        let mut state = AppState::new();
+        populate_state_from_events(
+            &mut state,
+            &[event(
+                "orchestrator.session.paused",
+                json!({"reason": "usage limit"}),
+            )],
+        );
+        assert!(state.is_paused, "fixture did not reach the paused state");
+        state
+    }
+
+    #[test]
+    fn workflow_progress_running_lifts_a_paused_display() {
+        // Q00/ouroboros#1833: with `r` inert in observer mode, a durable resume
+        // signal is the only way back out of `paused`.
+        let mut state = paused_state();
+
+        populate_state_from_events(
+            &mut state,
+            &[event(
+                "workflow.progress.updated",
+                json!({"last_update": {"runtime_status": "running"}}),
+            )],
+        );
+
+        assert!(!state.is_paused);
+        assert_eq!(state.status, ExecutionStatus::Running);
+    }
+
+    #[test]
+    fn orchestrator_progress_running_lifts_a_paused_display() {
+        let mut state = paused_state();
+
+        populate_state_from_events(
+            &mut state,
+            &[event(
+                "orchestrator.progress.updated",
+                json!({"progress": {"runtime_status": "running"}}),
+            )],
+        );
+
+        assert!(!state.is_paused);
+        assert_eq!(state.status, ExecutionStatus::Running);
+    }
+
+    #[test]
+    fn per_turn_terminal_runtime_status_is_not_global_lifecycle() {
+        // `runtime_status` describes the latest agent turn — `result.completed`
+        // projects to "completed" — so it must not end the run.
+        for terminal in ["completed", "failed", "cancelled"] {
+            let mut state = paused_state();
+
+            populate_state_from_events(
+                &mut state,
+                &[event(
+                    "workflow.progress.updated",
+                    json!({"last_update": {"runtime_status": terminal}}),
+                )],
+            );
+
+            assert!(state.is_paused, "{terminal} cleared the paused display");
+            assert_eq!(state.status, ExecutionStatus::Paused, "{terminal}");
+        }
+    }
+
+    #[test]
+    fn progress_without_runtime_status_does_not_lift_paused() {
+        let mut state = paused_state();
+
+        populate_state_from_events(
+            &mut state,
+            &[event(
+                "workflow.progress.updated",
+                json!({"completed_count": 1, "total_count": 3}),
+            )],
+        );
+
+        assert!(state.is_paused);
+        assert_eq!(state.status, ExecutionStatus::Paused);
     }
 }

--- a/crates/ouroboros-tui/src/main.rs
+++ b/crates/ouroboros-tui/src/main.rs
@@ -249,6 +249,10 @@ fn main() -> std::io::Result<()> {
                                 if let Some(ref mut conn) = ouro_db {
                                     // Reset state for new session
                                     let mut new_state = AppState::new();
+                                    // Execution ownership belongs to how this
+                                    // process attached, not to the session being
+                                    // viewed — it must survive the rebuild.
+                                    new_state.inherit_capabilities_from(&state);
                                     // Preserve sessions list and table
                                     new_state.sessions = state.sessions.clone();
                                     new_state.session_table = slt::TableState::new(

--- a/crates/ouroboros-tui/src/main.rs
+++ b/crates/ouroboros-tui/src/main.rs
@@ -179,6 +179,14 @@ fn main() -> std::io::Result<()> {
                         );
                         db::populate_state_from_events(&mut state, &lineage_events);
                     }
+                    // Attached to a real execution: this process observes it but
+                    // does not own it, so lifecycle controls must not be offered.
+                    state.disable_lifecycle_controls();
+                    state.add_log(
+                        LogLevel::Info,
+                        "tui",
+                        "Observer mode — pause/resume unavailable; use 'ouroboros cancel execution'",
+                    );
                     ouro_db = Some(conn);
                 }
             }
@@ -199,20 +207,28 @@ fn main() -> std::io::Result<()> {
             handle_global_keys(ui, &mut state);
 
             if let Some(cmd_idx) = ui.command_palette(&mut state.command_palette) {
-                match cmd_idx {
-                    0 => state.tabs.selected = 0, // Dashboard
-                    1 => state.tabs.selected = 1, // Execution
-                    2 => state.tabs.selected = 2, // Lineage
-                    3 => state.tabs.selected = 3, // Sessions
-                    4 => {
+                // Dispatch by label: the Pause/Resume entries are removed in
+                // observer mode, so positional indices are not stable.
+                let label = state
+                    .command_palette
+                    .commands
+                    .get(cmd_idx)
+                    .map(|command| command.label.clone())
+                    .unwrap_or_default();
+                match label.as_str() {
+                    "Dashboard" => state.tabs.selected = 0,
+                    "Execution" => state.tabs.selected = 1,
+                    "Lineage" => state.tabs.selected = 2,
+                    "Sessions" => state.tabs.selected = 3,
+                    "Pause" if state.lifecycle_controls_enabled => {
                         state.is_paused = true;
                         state.status = ExecutionStatus::Paused;
                     }
-                    5 => {
+                    "Resume" if state.lifecycle_controls_enabled => {
                         state.is_paused = false;
                         state.status = ExecutionStatus::Running;
                     }
-                    6 => ui.quit(),
+                    "Quit" => ui.quit(),
                     _ => {}
                 }
             }
@@ -300,12 +316,17 @@ fn handle_global_keys(ui: &mut Context, state: &mut AppState) {
     if ui.key_mod('p', KeyModifiers::CONTROL) {
         state.command_palette.open = !state.command_palette.open;
     }
-    if ui.key('p') && !state.command_palette.open && !log_input_active {
+    // Only the mock simulation is owned by this process. Attached to a real
+    // database the TUI is an observer, and flipping local state would report a
+    // pause/resume the execution never made (Q00/ouroboros#1833).
+    let lifecycle_key_active =
+        state.lifecycle_controls_enabled && !state.command_palette.open && !log_input_active;
+    if ui.key('p') && lifecycle_key_active {
         state.is_paused = true;
         state.status = ExecutionStatus::Paused;
         state.add_log(LogLevel::Info, "tui", "Execution paused by user");
     }
-    if ui.key('r') && !state.command_palette.open && !log_input_active {
+    if ui.key('r') && lifecycle_key_active {
         state.is_paused = false;
         state.status = ExecutionStatus::Running;
         state.add_log(LogLevel::Info, "tui", "Execution resumed");
@@ -470,9 +491,17 @@ fn render_footer(ui: &mut Context, state: &AppState) {
         Screen::SessionSelector => &[("Enter", "Load session"), ("←→", "Page"), ("Esc", "Back")],
     };
 
+    // Pause/Resume is advertised only when this process owns the execution
+    // (mock/demo). An observer attached to a real database cannot control it.
+    let global_keys: &[(&str, &str)] = if state.lifecycle_controls_enabled {
+        &[("q", "Quit"), ("p/r", "Pause/Resume"), ("^P", "Palette")]
+    } else {
+        &[("q", "Quit"), ("^P", "Palette")]
+    };
+
     ui.container().bg(surface).px(3).py(0).row(|ui| {
         // Global keys
-        for (key, desc) in &[("q", "Quit"), ("p/r", "Pause/Resume"), ("^P", "Palette")] {
+        for (key, desc) in global_keys {
             ui.text(*key).fg(accent);
             ui.text(format!(" {}  ", desc)).fg(dim);
         }

--- a/crates/ouroboros-tui/src/state.rs
+++ b/crates/ouroboros-tui/src/state.rs
@@ -350,6 +350,14 @@ pub struct AppState {
     // Mock simulation
     pub mock_tick: u64,
     pub auto_simulate: bool,
+
+    /// Whether `p`/`r` may change lifecycle state.
+    ///
+    /// Only the mock/demo simulation is owned by this process. When attached to
+    /// a real database the TUI is an observer with no execution owner, so
+    /// pausing locally would report a transition the run never made
+    /// (Q00/ouroboros#1833).
+    pub lifecycle_controls_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -450,7 +458,16 @@ impl AppState {
 
             mock_tick: 0,
             auto_simulate: true,
+            lifecycle_controls_enabled: true,
         }
+    }
+
+    /// Drop to observer mode: no execution owner, so no lifecycle controls.
+    pub fn disable_lifecycle_controls(&mut self) {
+        self.lifecycle_controls_enabled = false;
+        self.command_palette
+            .commands
+            .retain(|command| !matches!(command.label.as_str(), "Pause" | "Resume"));
     }
 
     /// Find an AC node by ID across the tree.
@@ -672,4 +689,58 @@ fn chrono_lite_now() -> String {
     let m = (secs / 60) % 60;
     let s = secs % 60;
     format!("{h:02}:{m:02}:{s:02}")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn palette_labels(state: &AppState) -> Vec<&str> {
+        state
+            .command_palette
+            .commands
+            .iter()
+            .map(|command| command.label.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn mock_mode_offers_lifecycle_controls() {
+        let state = AppState::new();
+
+        assert!(state.lifecycle_controls_enabled);
+        assert!(palette_labels(&state).contains(&"Pause"));
+        assert!(palette_labels(&state).contains(&"Resume"));
+    }
+
+    #[test]
+    fn observer_mode_withdraws_lifecycle_controls() {
+        // Q00/ouroboros#1833: attached to a real database the TUI owns no
+        // execution, so it must not advertise or perform pause/resume.
+        let mut state = AppState::new();
+
+        state.disable_lifecycle_controls();
+
+        assert!(!state.lifecycle_controls_enabled);
+        assert!(!palette_labels(&state).contains(&"Pause"));
+        assert!(!palette_labels(&state).contains(&"Resume"));
+    }
+
+    #[test]
+    fn observer_mode_keeps_navigation_commands_dispatchable() {
+        // Dispatch is by label, so removing two entries must not strand the
+        // commands that used to sit after them.
+        let mut state = AppState::new();
+
+        state.disable_lifecycle_controls();
+
+        let labels = palette_labels(&state);
+        for expected in ["Dashboard", "Execution", "Lineage", "Sessions", "Quit"] {
+            assert!(labels.contains(&expected), "missing {expected}");
+        }
+    }
 }

--- a/crates/ouroboros-tui/src/state.rs
+++ b/crates/ouroboros-tui/src/state.rs
@@ -470,6 +470,18 @@ impl AppState {
             .retain(|command| !matches!(command.label.as_str(), "Pause" | "Resume"));
     }
 
+    /// Carry execution-ownership capability across a state rebuild.
+    ///
+    /// Ownership is a property of how this process attached — mock simulation
+    /// versus an observed database — not of the session being viewed. Switching
+    /// sessions rebuilds `AppState` from `new()`, which would otherwise restore
+    /// owner-only controls to an observer (Q00/ouroboros#1833).
+    pub fn inherit_capabilities_from(&mut self, previous: &AppState) {
+        if !previous.lifecycle_controls_enabled {
+            self.disable_lifecycle_controls();
+        }
+    }
+
     /// Find an AC node by ID across the tree.
     pub fn find_node(&self, id: &str) -> Option<&ACNode> {
         fn search<'a>(nodes: &'a [ACNode], id: &str) -> Option<&'a ACNode> {
@@ -728,6 +740,33 @@ mod tests {
         assert!(!state.lifecycle_controls_enabled);
         assert!(!palette_labels(&state).contains(&"Pause"));
         assert!(!palette_labels(&state).contains(&"Resume"));
+    }
+
+    #[test]
+    fn observer_mode_survives_a_session_switch() {
+        // Switching sessions rebuilds AppState from new(); the observer
+        // capability must not come back with it.
+        let mut attached = AppState::new();
+        attached.disable_lifecycle_controls();
+
+        let mut after_switch = AppState::new();
+        after_switch.inherit_capabilities_from(&attached);
+
+        assert!(!after_switch.lifecycle_controls_enabled);
+        assert!(!palette_labels(&after_switch).contains(&"Pause"));
+        assert!(!palette_labels(&after_switch).contains(&"Resume"));
+    }
+
+    #[test]
+    fn mock_mode_keeps_its_controls_across_a_session_switch() {
+        // The inverse: a process that does own its simulation keeps the controls.
+        let owning = AppState::new();
+
+        let mut after_switch = AppState::new();
+        after_switch.inherit_capabilities_from(&owning);
+
+        assert!(after_switch.lifecycle_controls_enabled);
+        assert!(palette_labels(&after_switch).contains(&"Pause"));
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1006,9 +1006,14 @@ ouroboros tui monitor --backend slt
 | `s` | Session Selector |
 | `e` | Lineage view |
 | `q` | Quit |
-| `p` | Pause execution |
-| `r` | Resume execution |
+| `p` | Pause execution — hidden in `tui monitor` |
+| `r` | Resume execution — hidden in `tui monitor` |
 | Up/Down | Scroll |
+
+> **Note**: `ouroboros tui monitor` observes the event store and does not own
+> the running execution, so the pause/resume bindings are hidden there.
+> Use `ouroboros cancel execution` to stop a run. See
+> [TUI Usage](./guides/tui-usage.md#keyboard-shortcuts) for details.
 
 ---
 

--- a/docs/guides/tui-usage.md
+++ b/docs/guides/tui-usage.md
@@ -130,8 +130,20 @@ View evolutionary lineage across generations when using evolutionary loops (`ooo
 | `s` | Session Selector |
 | `e` | Lineage view |
 | `q` | Quit the TUI |
-| `r` | Resume execution |
-| `p` | Pause execution |
+| `p` | Pause execution — only when an execution owner is connected (see below) |
+| `r` | Resume execution — only when an execution owner is connected (see below) |
+
+> **Note**: `ouroboros tui monitor` attaches to the event store as an observer
+> and does not own the running execution, so `p` and `r` are hidden from the
+> footer and do nothing there. Use `ouroboros cancel execution` to stop a run.
+>
+> The bindings appear only when an embedding caller connects an execution owner
+> via `OuroborosTUI.set_pause_callback()` / `set_resume_callback()`. Even then,
+> the displayed lifecycle status changes only after the execution control path
+> persists an acknowledged lifecycle event — `orchestrator.session.paused` for a
+> pause, and progress carrying `runtime_status: running` for a resume. A request
+> that is unavailable or fails is reported as a warning/error and leaves the
+> status unchanged.
 
 ### Navigation
 
@@ -180,7 +192,12 @@ Key message types:
 
 **AC tree doesn't update**
 - The TUI polls every 0.5s; brief delays are expected
-- Press `r` to resume execution if paused
+- If the run is paused, resume it from the process that owns the execution;
+  `ouroboros tui monitor` cannot resume a run
+
+**`p` / `r` do nothing**
+- Expected in `ouroboros tui monitor` — it does not own the execution, so the
+  bindings are hidden. Use `ouroboros cancel execution` to stop a run.
 
 **Display issues**
 - Ensure your terminal supports 256 colors and Unicode

--- a/docs/guides/tui-usage.md
+++ b/docs/guides/tui-usage.md
@@ -145,7 +145,8 @@ View evolutionary lineage across generations when using evolutionary loops (`ooo
 > persists an acknowledged lifecycle event — `orchestrator.session.paused` for a
 > pause, and progress carrying `runtime_status: running` for a resume. A request
 > that is unavailable or fails is reported as a warning/error and leaves the
-> status unchanged.
+> status unchanged. Both backends project that same acknowledgement, so a paused
+> display recovers on its own once the execution really resumes.
 
 ### Navigation
 

--- a/docs/guides/tui-usage.md
+++ b/docs/guides/tui-usage.md
@@ -135,7 +135,9 @@ View evolutionary lineage across generations when using evolutionary loops (`ooo
 
 > **Note**: `ouroboros tui monitor` attaches to the event store as an observer
 > and does not own the running execution, so `p` and `r` are hidden from the
-> footer and do nothing there. Use `ouroboros cancel execution` to stop a run.
+> footer and do nothing there. This applies to both backends — the `slt` backend
+> offers them only in `--mock` demo mode, where it owns the simulation it is
+> pausing. Use `ouroboros cancel execution` to stop a run.
 >
 > The bindings appear only when an embedding caller connects an execution owner
 > via `OuroborosTUI.set_pause_callback()` / `set_resume_callback()`. Even then,

--- a/src/ouroboros/cli/commands/tui.py
+++ b/src/ouroboros/cli/commands/tui.py
@@ -60,19 +60,19 @@ def monitor_command(
     database. You can then select a session to monitor in real-time.
 
     The monitor attaches to the event store as an observer and does not own the
-    running execution, so pause/resume controls are not offered. Use
-    `ouroboros cancel execution` to stop a run.
+    running execution, so pause/resume controls are not offered on either
+    backend. Use `ouroboros cancel execution` to stop a run.
     """
     resolved_db_path = db_path or _resolve_event_store_path_or_exit()
+    print_info(
+        "This monitor does not own the execution: pause/resume are not available here. "
+        "Use 'ouroboros cancel execution' to stop a run."
+    )
     if backend == "slt":
         _run_slt_backend(resolved_db_path)
         return
 
     print_info(f"Connecting to database: {resolved_db_path}")
-    print_info(
-        "This monitor does not own the execution: pause/resume are not available here. "
-        "Use 'ouroboros cancel execution' to stop a run."
-    )
 
     try:
         from ouroboros.tui import OuroborosTUI

--- a/src/ouroboros/cli/commands/tui.py
+++ b/src/ouroboros/cli/commands/tui.py
@@ -58,6 +58,10 @@ def monitor_command(
 
     Starts a terminal UI that shows a list of all sessions found in the
     database. You can then select a session to monitor in real-time.
+
+    The monitor attaches to the event store as an observer and does not own the
+    running execution, so pause/resume controls are not offered. Use
+    `ouroboros cancel execution` to stop a run.
     """
     resolved_db_path = db_path or _resolve_event_store_path_or_exit()
     if backend == "slt":
@@ -65,6 +69,10 @@ def monitor_command(
         return
 
     print_info(f"Connecting to database: {resolved_db_path}")
+    print_info(
+        "This monitor does not own the execution: pause/resume are not available here. "
+        "Use 'ouroboros cancel execution' to stop a run."
+    )
 
     try:
         from ouroboros.tui import OuroborosTUI

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -334,6 +334,7 @@ class OuroborosTUI(App[None]):
         self._is_paused = False
         self._pause_callback: Any | None = None
         self._resume_callback: Any | None = None
+        self._control_requests: dict[tuple[str, str], asyncio.Task[None]] = {}
 
     @property
     def state(self) -> TUIState:
@@ -529,12 +530,15 @@ class OuroborosTUI(App[None]):
         elif event_type == "orchestrator.session.completed":
             self._state.status = "completed"
             self._state.is_paused = False
+            self._acknowledge_all_controls(self._state.execution_id)
         elif event_type == "orchestrator.session.failed":
             self._state.status = "failed"
             self._state.is_paused = False
+            self._acknowledge_all_controls(self._state.execution_id)
         elif event_type == "orchestrator.session.cancelled":
             self._state.status = "cancelled"
             self._state.is_paused = False
+            self._acknowledge_all_controls(self._state.execution_id)
         elif event_type == "execution.terminal":
             # Mirror event from the execution stream — ensures TUI sees
             # terminal transitions even when only polling "execution".
@@ -542,9 +546,11 @@ class OuroborosTUI(App[None]):
             if terminal_status in {"completed", "failed", "cancelled", "paused"}:
                 self._state.status = terminal_status
                 self._state.is_paused = terminal_status == "paused"
+                self._acknowledge_all_controls(self._state.execution_id)
         elif event_type == "orchestrator.session.paused":
             self._state.status = "paused"
             self._state.is_paused = True
+            self._acknowledge_control("pause", self._state.execution_id)
         elif event_type in {"orchestrator.progress.updated", "workflow.progress.updated"}:
             # There is no `orchestrator.session.resumed` event, so progress
             # reporting the runtime is executing again is the only signal that
@@ -557,6 +563,7 @@ class OuroborosTUI(App[None]):
             if self._state.status == "paused" and _progress_acknowledges_running(data):
                 self._state.status = "running"
                 self._state.is_paused = False
+                self._acknowledge_control("resume", self._state.execution_id)
         elif event_type == "execution.phase.completed":
             self._state.current_phase = data.get("phase", "")
             self._state.iteration = data.get("iteration", 0)
@@ -612,6 +619,7 @@ class OuroborosTUI(App[None]):
 
     def set_execution(self, execution_id: str, session_id: str = "") -> None:
         """Set the execution to monitor."""
+        self._cancel_control_requests()
         self._execution_id = execution_id
         self._state.execution_id = execution_id
         self._state.session_id = session_id
@@ -662,6 +670,12 @@ class OuroborosTUI(App[None]):
         self._state.session_id = message.session_id
         self._state.status = message.status
         self._state.is_paused = message.status == "paused"
+        if message.status == "paused":
+            self._acknowledge_control("pause", message.execution_id)
+        elif message.status == "running":
+            self._acknowledge_control("resume", message.execution_id)
+        elif message.status in {"completed", "failed", "cancelled"}:
+            self._acknowledge_all_controls(message.execution_id)
         self._forward_to_dashboard("on_execution_updated", message)
 
     def on_phase_changed(self, message: PhaseChanged) -> None:
@@ -1074,7 +1088,10 @@ class OuroborosTUI(App[None]):
         if self._pause_callback is None:
             self._report_control_unavailable("Pause", message.execution_id)
             return
-        asyncio.create_task(self._call_pause_callback(message.execution_id))
+        if not self._begin_control_request(
+            "pause", message.execution_id, self._call_pause_callback(message.execution_id)
+        ):
+            return
         self._state.add_log(
             "info", "tui.control", f"Pause requested for execution {message.execution_id}"
         )
@@ -1088,7 +1105,10 @@ class OuroborosTUI(App[None]):
         if self._resume_callback is None:
             self._report_control_unavailable("Resume", message.execution_id)
             return
-        asyncio.create_task(self._call_resume_callback(message.execution_id))
+        if not self._begin_control_request(
+            "resume", message.execution_id, self._call_resume_callback(message.execution_id)
+        ):
+            return
         self._state.add_log(
             "info", "tui.control", f"Resume requested for execution {message.execution_id}"
         )
@@ -1122,6 +1142,7 @@ class OuroborosTUI(App[None]):
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
+                self._acknowledge_control("pause", execution_id)
                 self._report_control_failure("Pause", e)
 
     async def _call_resume_callback(self, execution_id: str) -> None:
@@ -1131,7 +1152,33 @@ class OuroborosTUI(App[None]):
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
+                self._acknowledge_control("resume", execution_id)
                 self._report_control_failure("Resume", e)
+
+    def _begin_control_request(self, action: str, execution_id: str, request: Any) -> bool:
+        """Start one lifecycle request per action/execution until acknowledged."""
+        key = (action, execution_id)
+        if execution_id != self._state.execution_id or key in self._control_requests:
+            request.close()
+            return False
+        self._control_requests[key] = asyncio.create_task(request)
+        return True
+
+    def _acknowledge_control(self, action: str, execution_id: str) -> None:
+        """Release an in-flight gate after failure or authoritative state."""
+        self._control_requests.pop((action, execution_id), None)
+
+    def _acknowledge_all_controls(self, execution_id: str) -> None:
+        for action in ("pause", "resume"):
+            self._acknowledge_control(action, execution_id)
+
+    def _cancel_control_requests(self) -> None:
+        """Cancel callbacks owned by the previous monitored execution."""
+        requests = tuple(self._control_requests.values())
+        self._control_requests.clear()
+        for request in requests:
+            if not request.done():
+                request.cancel()
 
     @property
     def pause_control_available(self) -> bool:
@@ -1152,20 +1199,41 @@ class OuroborosTUI(App[None]):
         disabled *and* hidden, while ``None`` would leave the key greyed out in
         the footer — still advertised.
         """
-        if action == "pause" and not self.pause_control_available:
-            return False
-        if action == "resume" and not self.resume_control_available:
-            return False
+        execution_id = self._state.execution_id
+        if action == "pause":
+            if (
+                not self.pause_control_available
+                or ("pause", execution_id) in self._control_requests
+            ):
+                return False
+        if action == "resume":
+            if (
+                not self.resume_control_available
+                or (
+                    "resume",
+                    execution_id,
+                )
+                in self._control_requests
+            ):
+                return False
         return super().check_action(action, parameters)
 
     def action_pause(self) -> None:
         # `check_action` already makes the key inert without a connected owner;
         # a request that still gets here is refused by `on_pause_requested`.
-        if self._state.execution_id and not self._state.is_paused:
+        if (
+            self._state.execution_id
+            and not self._state.is_paused
+            and ("pause", self._state.execution_id) not in self._control_requests
+        ):
             self.post_message(PauseRequested(self._state.execution_id))
 
     def action_resume(self) -> None:
-        if self._state.execution_id and self._state.is_paused:
+        if (
+            self._state.execution_id
+            and self._state.is_paused
+            and ("resume", self._state.execution_id) not in self._control_requests
+        ):
             self.post_message(ResumeRequested(self._state.execution_id))
 
     def action_show_dashboard(self) -> None:

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -88,15 +88,23 @@ _RUNTIME_LIFECYCLE_STATUSES = frozenset({"running", "paused", "completed", "fail
 def _runtime_status_from_progress(data: object) -> str | None:
     """Extract an authoritative runtime status from a progress event payload.
 
-    Mirrors ``SessionRepository._status_from_event``: the status may sit under
-    ``progress.runtime_status`` or at the payload root.
+    The two progress producers nest it differently:
+
+    - ``orchestrator.progress.updated`` (``SessionRepository.track_progress``)
+      wraps the payload in ``progress``, matching
+      ``SessionRepository._status_from_event`` and the
+      ``$.progress.runtime_status`` / ``$.runtime_status`` snapshot query.
+    - ``workflow.progress.updated`` (``create_workflow_progress_event``) carries
+      it in ``last_update``, where ``WorkflowState`` writes it
+      (``workflow_state.py`` ``last_update["runtime_status"]``).
     """
     if not isinstance(data, dict):
         return None
-    progress = data.get("progress")
     candidates = []
-    if isinstance(progress, dict):
-        candidates.append(progress.get("runtime_status"))
+    for container_key in ("progress", "last_update"):
+        container = data.get(container_key)
+        if isinstance(container, dict):
+            candidates.append(container.get("runtime_status"))
     candidates.append(data.get("runtime_status"))
     for candidate in candidates:
         status = _coerce_non_empty_string(candidate)
@@ -398,10 +406,15 @@ class OuroborosTUI(App[None]):
         except Exception:
             pass
 
+        # State projection must not depend on whether a Textual message exists
+        # for the event type. `orchestrator.progress.updated` has no message
+        # mapping, and it is the acknowledgement that clears a paused display —
+        # gating the projection on `message is not None` made it unreachable.
+        self._update_state_from_event(event)
+
         message = create_message_from_event(event)
         if message is not None:
             self.post_message(message)
-            self._update_state_from_event(event)
 
         # Fold provider identity through the SHARED board derivation (the exact
         # rules the web Kanban's reduce_board applies). Additive: it only annotates

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -82,24 +82,30 @@ def _coerce_non_empty_string(value: object) -> str | None:
     return None
 
 
-_RUNTIME_LIFECYCLE_STATUSES = frozenset({"running", "paused", "completed", "failed", "cancelled"})
+def _progress_acknowledges_running(data: object) -> bool:
+    """Whether a progress payload acknowledges the run is executing again.
 
+    Deliberately narrow: only ``running`` is honoured, because that is the one
+    transition no other event can supply — there is no
+    ``orchestrator.session.resumed``. ``runtime_status`` is per-runtime-turn
+    metadata, and ``derive_runtime_signal`` maps messages such as
+    ``result.completed`` / ``turn.completed`` to ``"completed"``. Those describe
+    the latest agent turn, not the orchestration, so treating them as global
+    lifecycle would let an unfinished run advertise a terminal state. Global
+    paused/terminal status stays with ``orchestrator.session.*`` and
+    ``execution.terminal``.
 
-def _runtime_status_from_progress(data: object) -> str | None:
-    """Extract an authoritative runtime status from a progress event payload.
-
-    The two progress producers nest it differently:
+    The two producers nest the value differently:
 
     - ``orchestrator.progress.updated`` (``SessionRepository.track_progress``)
       wraps the payload in ``progress``, matching
       ``SessionRepository._status_from_event`` and the
       ``$.progress.runtime_status`` / ``$.runtime_status`` snapshot query.
     - ``workflow.progress.updated`` (``create_workflow_progress_event``) carries
-      it in ``last_update``, where ``WorkflowState`` writes it
-      (``workflow_state.py`` ``last_update["runtime_status"]``).
+      it in ``last_update``, where ``WorkflowState`` writes it.
     """
     if not isinstance(data, dict):
-        return None
+        return False
     candidates = []
     for container_key in ("progress", "last_update"):
         container = data.get(container_key)
@@ -108,9 +114,9 @@ def _runtime_status_from_progress(data: object) -> str | None:
     candidates.append(data.get("runtime_status"))
     for candidate in candidates:
         status = _coerce_non_empty_string(candidate)
-        if status is not None and status.lower() in _RUNTIME_LIFECYCLE_STATUSES:
-            return status.lower()
-    return None
+        if status is not None:
+            return status.lower() == "running"
+    return False
 
 
 def _coerce_int(value: object, default: int) -> int:
@@ -540,16 +546,14 @@ class OuroborosTUI(App[None]):
             self._state.status = "paused"
             self._state.is_paused = True
         elif event_type in {"orchestrator.progress.updated", "workflow.progress.updated"}:
-            # There is no `orchestrator.session.resumed` event; a resumed run is
-            # acknowledged by progress carrying a runtime status. This reads the
-            # same two payload locations as the durable projections
-            # (`SessionRepository._status_from_event` and the
-            # `$.progress.runtime_status` / `$.runtime_status` snapshot query),
-            # so a paused display recovers only on an authoritative signal.
-            runtime_status = _runtime_status_from_progress(data)
-            if runtime_status is not None:
-                self._state.status = runtime_status
-                self._state.is_paused = runtime_status == "paused"
+            # There is no `orchestrator.session.resumed` event, so progress
+            # reporting the runtime is executing again is the only signal that
+            # can clear a paused display. Scope is exactly that: it never sets
+            # a status, only lifts `paused`. Progress is per-turn runtime
+            # metadata and must not advertise global paused/terminal state.
+            if self._state.is_paused and _progress_acknowledges_running(data):
+                self._state.status = "running"
+                self._state.is_paused = False
         elif event_type == "execution.phase.completed":
             self._state.current_phase = data.get("phase", "")
             self._state.iteration = data.get("iteration", 0)

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -551,7 +551,10 @@ class OuroborosTUI(App[None]):
             # can clear a paused display. Scope is exactly that: it never sets
             # a status, only lifts `paused`. Progress is per-turn runtime
             # metadata and must not advertise global paused/terminal state.
-            if self._state.is_paused and _progress_acknowledges_running(data):
+            # Gate on the status, not just the flag: a terminal event clears
+            # `is_paused`, so keying off the status keeps late or out-of-order
+            # progress from resurrecting a run that already ended.
+            if self._state.status == "paused" and _progress_acknowledges_running(data):
                 self._state.status = "running"
                 self._state.is_paused = False
         elif event_type == "execution.phase.completed":

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -4,7 +4,14 @@ OuroborosTUI is the main application class that:
 - Manages screens (session selector, dashboard, execution, logs, debug)
 - Handles global keybindings
 - Subscribes to EventStore for live updates
-- Provides pause/resume execution control
+- Optionally forwards pause/resume requests to an execution owner
+
+Pause/resume are only offered when an embedding caller connects an execution
+owner via :meth:`OuroborosTUI.set_pause_callback` /
+:meth:`OuroborosTUI.set_resume_callback`. Without one the bindings are hidden.
+Even with an owner connected, the displayed lifecycle status changes only when
+an acknowledged lifecycle event arrives — the TUI never optimistically reports
+a transition the execution never made.
 """
 
 from __future__ import annotations
@@ -16,6 +23,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.app import App
 from textual.binding import Binding
+from textual.notifications import SeverityLevel
 
 from ouroboros.dashboard.board import ProviderLedger, fold_provider_event
 from ouroboros.tui.events import (
@@ -71,6 +79,29 @@ def _coerce_non_empty_string(value: object) -> str | None:
         stripped = value.strip()
         if stripped:
             return stripped
+    return None
+
+
+_RUNTIME_LIFECYCLE_STATUSES = frozenset({"running", "paused", "completed", "failed", "cancelled"})
+
+
+def _runtime_status_from_progress(data: object) -> str | None:
+    """Extract an authoritative runtime status from a progress event payload.
+
+    Mirrors ``SessionRepository._status_from_event``: the status may sit under
+    ``progress.runtime_status`` or at the payload root.
+    """
+    if not isinstance(data, dict):
+        return None
+    progress = data.get("progress")
+    candidates = []
+    if isinstance(progress, dict):
+        candidates.append(progress.get("runtime_status"))
+    candidates.append(data.get("runtime_status"))
+    for candidate in candidates:
+        status = _coerce_non_empty_string(candidate)
+        if status is not None and status.lower() in _RUNTIME_LIFECYCLE_STATUSES:
+            return status.lower()
     return None
 
 
@@ -495,6 +526,17 @@ class OuroborosTUI(App[None]):
         elif event_type == "orchestrator.session.paused":
             self._state.status = "paused"
             self._state.is_paused = True
+        elif event_type in {"orchestrator.progress.updated", "workflow.progress.updated"}:
+            # There is no `orchestrator.session.resumed` event; a resumed run is
+            # acknowledged by progress carrying a runtime status. This reads the
+            # same two payload locations as the durable projections
+            # (`SessionRepository._status_from_event` and the
+            # `$.progress.runtime_status` / `$.runtime_status` snapshot query),
+            # so a paused display recovers only on an authoritative signal.
+            runtime_status = _runtime_status_from_progress(data)
+            if runtime_status is not None:
+                self._state.status = runtime_status
+                self._state.is_paused = runtime_status == "paused"
         elif event_type == "execution.phase.completed":
             self._state.current_phase = data.get("phase", "")
             self._state.iteration = data.get("iteration", 0)
@@ -1001,22 +1043,57 @@ class OuroborosTUI(App[None]):
             pass  # Screen might not be ready
 
     def on_pause_requested(self, message: PauseRequested) -> None:
-        self._state.is_paused = True
-        self._state.status = "paused"
-        if self._pause_callback is not None:
-            asyncio.create_task(self._call_pause_callback(message.execution_id))
+        """Forward a pause request to the execution owner.
+
+        Lifecycle display state is never changed here. ``paused`` is only
+        rendered once the authoritative execution control path acknowledges
+        the transition via ``orchestrator.session.paused`` (or a terminal
+        ``execution.terminal`` mirror), so the monitor cannot claim a
+        transition the execution never reached.
+        """
+        if self._pause_callback is None:
+            self._report_control_unavailable("Pause", message.execution_id)
+            return
+        asyncio.create_task(self._call_pause_callback(message.execution_id))
         self._state.add_log(
             "info", "tui.control", f"Pause requested for execution {message.execution_id}"
         )
 
     def on_resume_requested(self, message: ResumeRequested) -> None:
-        self._state.is_paused = False
-        self._state.status = "running"
-        if self._resume_callback is not None:
-            asyncio.create_task(self._call_resume_callback(message.execution_id))
+        """Forward a resume request to the execution owner.
+
+        As with :meth:`on_pause_requested`, the displayed lifecycle status is
+        left untouched until an acknowledged lifecycle event arrives.
+        """
+        if self._resume_callback is None:
+            self._report_control_unavailable("Resume", message.execution_id)
+            return
+        asyncio.create_task(self._call_resume_callback(message.execution_id))
         self._state.add_log(
             "info", "tui.control", f"Resume requested for execution {message.execution_id}"
         )
+
+    def _report_control_unavailable(self, action: str, execution_id: str) -> None:
+        """Log and surface that a lifecycle control is not wired up."""
+        detail = (
+            f"{action} is unavailable in this monitor: no execution control is "
+            f"connected for execution {execution_id}."
+        )
+        self._state.add_log("warning", "tui.control", detail)
+        self._notify(detail, severity="warning")
+
+    def _report_control_failure(self, action: str, error: Exception) -> None:
+        """Log and surface that a lifecycle control request failed."""
+        detail = f"{action} callback failed: {error}"
+        self._state.add_log("error", "tui.control", detail)
+        self._notify(detail, severity="error")
+
+    def _notify(self, message: str, *, severity: SeverityLevel) -> None:
+        """Best-effort user notification that tolerates a not-yet-running app."""
+        try:
+            self.notify(message, severity=severity, markup=False)
+        except Exception:
+            pass  # App may not be running (offline/embedded construction)
 
     async def _call_pause_callback(self, execution_id: str) -> None:
         if self._pause_callback is not None:
@@ -1025,7 +1102,7 @@ class OuroborosTUI(App[None]):
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
-                self._state.add_log("error", "tui.control", f"Pause callback failed: {e}")
+                self._report_control_failure("Pause", e)
 
     async def _call_resume_callback(self, execution_id: str) -> None:
         if self._resume_callback is not None:
@@ -1034,9 +1111,36 @@ class OuroborosTUI(App[None]):
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
-                self._state.add_log("error", "tui.control", f"Resume callback failed: {e}")
+                self._report_control_failure("Resume", e)
+
+    @property
+    def pause_control_available(self) -> bool:
+        """Whether a pause owner is connected to this monitor."""
+        return self._pause_callback is not None
+
+    @property
+    def resume_control_available(self) -> bool:
+        """Whether a resume owner is connected to this monitor."""
+        return self._resume_callback is not None
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Hide the pause/resume bindings when no execution owner is connected.
+
+        ``ouroboros tui monitor`` attaches to the event store as an observer and
+        owns no execution, so advertising `p`/`r` there would promise control it
+        cannot exercise. ``False`` is deliberate: Textual treats ``False`` as
+        disabled *and* hidden, while ``None`` would leave the key greyed out in
+        the footer — still advertised.
+        """
+        if action == "pause" and not self.pause_control_available:
+            return False
+        if action == "resume" and not self.resume_control_available:
+            return False
+        return super().check_action(action, parameters)
 
     def action_pause(self) -> None:
+        # `check_action` already makes the key inert without a connected owner;
+        # a request that still gets here is refused by `on_pause_requested`.
         if self._state.execution_id and not self._state.is_paused:
             self.post_message(PauseRequested(self._state.execution_id))
 
@@ -1085,9 +1189,18 @@ class OuroborosTUI(App[None]):
 
     def set_pause_callback(self, callback: Any) -> None:
         self._pause_callback = callback
+        self._refresh_control_bindings()
 
     def set_resume_callback(self, callback: Any) -> None:
         self._resume_callback = callback
+        self._refresh_control_bindings()
+
+    def _refresh_control_bindings(self) -> None:
+        """Re-evaluate `check_action` so the footer reflects a late-connected owner."""
+        try:
+            self.refresh_bindings()
+        except Exception:
+            pass  # App may not be mounted yet; check_action runs fresh on mount
 
     def update_ac_tree(self, tree_data: dict[str, Any]) -> None:
         self._state.ac_tree = tree_data

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -1096,6 +1096,16 @@ class DashboardScreenV3(Screen[None]):
     # Actions
     # ─────────────────────────────────────────────────────────────────────────
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Defer `p`/`r` availability to the app that owns the execution.
+
+        Screen bindings shadow app bindings, so the dashboard must apply the
+        same gate; otherwise `ouroboros tui monitor`, which owns no execution,
+        would keep advertising controls it cannot exercise. Delegating keeps one
+        source of truth instead of a second copy of the rule.
+        """
+        return self.app.check_action(action, parameters)
+
     def action_pause(self) -> None:
         if self._state and self._state.execution_id:
             self.post_message(PauseRequested(self._state.execution_id))

--- a/tests/integration/tui/__init__.py
+++ b/tests/integration/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the production TUI monitor wiring."""

--- a/tests/integration/tui/test_monitor_lifecycle_controls.py
+++ b/tests/integration/tui/test_monitor_lifecycle_controls.py
@@ -291,6 +291,82 @@ class TestAcknowledgedDurableControlPath:
         assert tui.state.status == "running"
         assert tui.state.is_paused is False
 
+    @pytest.mark.parametrize("terminal_runtime_status", ["completed", "failed", "cancelled"])
+    async def test_per_turn_terminal_runtime_status_is_not_global_lifecycle(
+        self, event_store: EventStore, terminal_runtime_status: str
+    ) -> None:
+        """Progress metadata must not advertise a terminal run.
+
+        `runtime_status` describes the latest agent turn: `derive_runtime_signal`
+        maps runtime messages such as `result.completed` / `turn.completed` to
+        `"completed"`, and the runner persists that workflow-progress event
+        immediately. With 0 of 3 ACs done the orchestration is plainly not
+        finished, so honouring it would recreate the reporting problem this PR
+        exists to fix, only with terminal states.
+        """
+        tui = OuroborosTUI()
+        tui.set_execution("exec_turn", "sess_turn")
+        tui.state.status = "paused"
+        tui.state.is_paused = True
+
+        workflow_event = create_workflow_progress_event(
+            execution_id="exec_turn",
+            session_id="sess_turn",
+            acceptance_criteria=[],
+            completed_count=0,
+            total_count=3,
+            current_ac_index=1,
+            current_phase="Discover",
+            activity="working",
+            activity_detail="",
+            elapsed_display="00:10",
+            estimated_remaining="00:20",
+            messages_count=4,
+            tool_calls_count=2,
+            estimated_tokens=100,
+            estimated_cost_usd=0.01,
+            last_update={"runtime_status": terminal_runtime_status},
+        )
+        await event_store.append(workflow_event)
+
+        tui._process_subscription_event(workflow_event)
+
+        assert tui.state.status == "paused"
+        assert tui.state.is_paused is True
+
+    async def test_progress_does_not_override_a_running_display(
+        self, event_store: EventStore
+    ) -> None:
+        """Progress only lifts `paused`; it never authors a status otherwise."""
+        tui = OuroborosTUI()
+        tui.set_execution("exec_live", "sess_live")
+        assert tui.state.status == "running"
+
+        workflow_event = create_workflow_progress_event(
+            execution_id="exec_live",
+            session_id="sess_live",
+            acceptance_criteria=[],
+            completed_count=0,
+            total_count=3,
+            current_ac_index=1,
+            current_phase="Discover",
+            activity="working",
+            activity_detail="",
+            elapsed_display="00:10",
+            estimated_remaining="00:20",
+            messages_count=4,
+            tool_calls_count=2,
+            estimated_tokens=100,
+            estimated_cost_usd=0.01,
+            last_update={"runtime_status": "completed"},
+        )
+        await event_store.append(workflow_event)
+
+        tui._process_subscription_event(workflow_event)
+
+        assert tui.state.status == "running"
+        assert tui.state.is_paused is False
+
     async def test_progress_without_runtime_status_does_not_clear_paused(
         self, event_store: EventStore
     ) -> None:

--- a/tests/integration/tui/test_monitor_lifecycle_controls.py
+++ b/tests/integration/tui/test_monitor_lifecycle_controls.py
@@ -20,6 +20,7 @@ import pytest
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.tui import app as tui_app
+from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.events import create_workflow_progress_event
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore, sqlite_database_url
@@ -333,6 +334,61 @@ class TestAcknowledgedDurableControlPath:
 
         assert tui.state.status == "paused"
         assert tui.state.is_paused is True
+
+    @pytest.mark.parametrize(
+        "terminal_event",
+        [
+            "orchestrator.session.completed",
+            "orchestrator.session.failed",
+            "orchestrator.session.cancelled",
+        ],
+    )
+    async def test_late_running_progress_cannot_revive_a_terminal_run(
+        self, event_store: EventStore, terminal_event: str
+    ) -> None:
+        """paused -> terminal -> stale progress(running) must not walk it back."""
+        expected_status = terminal_event.rsplit(".", 1)[-1]
+
+        tui = OuroborosTUI()
+        tui.set_execution("exec_stale", "sess_stale")
+        tui.state.status = "paused"
+        tui.state.is_paused = True
+
+        tui._process_subscription_event(
+            BaseEvent(
+                type=terminal_event,
+                aggregate_type="session",
+                aggregate_id="sess_stale",
+                data={},
+            )
+        )
+        assert tui.state.status == expected_status
+        assert tui.state.is_paused is False
+
+        workflow_event = create_workflow_progress_event(
+            execution_id="exec_stale",
+            session_id="sess_stale",
+            acceptance_criteria=[],
+            completed_count=3,
+            total_count=3,
+            current_ac_index=3,
+            current_phase="Deliver",
+            activity="working",
+            activity_detail="",
+            elapsed_display="00:10",
+            estimated_remaining="00:00",
+            messages_count=4,
+            tool_calls_count=2,
+            estimated_tokens=100,
+            estimated_cost_usd=0.01,
+            last_update={"runtime_status": "running"},
+        )
+        await event_store.append(workflow_event)
+
+        tui._process_subscription_event(workflow_event)
+
+        assert tui.state.status == expected_status
+        assert tui.state.is_paused is False
 
     async def test_progress_does_not_override_a_running_display(
         self, event_store: EventStore

--- a/tests/integration/tui/test_monitor_lifecycle_controls.py
+++ b/tests/integration/tui/test_monitor_lifecycle_controls.py
@@ -1,0 +1,315 @@
+"""Integration coverage for `ouroboros tui monitor` lifecycle controls.
+
+The monitor observes the event store and owns no execution, so it must never
+report a pause/resume transition the execution never reached
+(Q00/ouroboros#1833). These tests exercise the production `tui monitor` wiring,
+the footer bindings a user actually sees, and the durable control path an
+embedding caller drives — including the round trip back out of `paused`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+import re
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.tui import app as tui_app
+from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.persistence.event_store import EventStore, sqlite_database_url
+from ouroboros.tui.app import OuroborosTUI
+from ouroboros.tui.events import PauseRequested
+
+runner = CliRunner()
+
+
+@pytest.fixture
+async def event_store(tmp_path: Path):
+    """Real SQLite-backed event store for the durable control path."""
+    store = EventStore(sqlite_database_url(tmp_path / "ouroboros.db"))
+    await store.initialize()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+async def _drain_control_tasks(action: Callable[[], None]) -> None:
+    """Run ``action`` and await the control task its message handler spawns.
+
+    The snapshot and the diff are taken with no ``await`` in between, so the
+    difference is exactly what ``action`` created. Only call this on an app that
+    is not running under ``run_test`` — a running app owns long-lived tasks that
+    would never complete.
+    """
+    before = asyncio.all_tasks()
+    action()
+    for task in asyncio.all_tasks() - before:
+        await task
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+_PANEL_CHROME = re.compile(r"[│╭╮╰╯─]")
+
+
+def _plain(output: str) -> str:
+    """Flatten a Rich panel back to a single searchable line."""
+    return " ".join(_PANEL_CHROME.sub(" ", _ANSI.sub("", output)).split())
+
+
+def _launch_monitor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[OuroborosTUI, Any]:
+    """Run the production `tui monitor` command and capture its TUI instance."""
+    captured: list[OuroborosTUI] = []
+
+    async def fake_run_async(self: OuroborosTUI, *args: Any, **kwargs: Any) -> None:
+        captured.append(self)
+
+    monkeypatch.setattr(OuroborosTUI, "run_async", fake_run_async)
+
+    result = runner.invoke(tui_app, ["monitor", "--db-path", str(tmp_path / "ouroboros.db")])
+
+    assert result.exit_code == 0, result.output
+    assert captured, "monitor_command did not construct a TUI"
+    return captured[0], result
+
+
+class TestProductionMonitorOwnsNoExecution:
+    """`ouroboros tui monitor` must not advertise controls it cannot exercise."""
+
+    def test_monitor_connects_no_execution_owner(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        tui, _ = _launch_monitor(monkeypatch, tmp_path)
+
+        assert tui.pause_control_available is False
+        assert tui.resume_control_available is False
+
+    def test_monitor_states_that_controls_are_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _, result = _launch_monitor(monkeypatch, tmp_path)
+
+        assert "pause/resume are not available here" in _plain(result.output)
+        assert "ouroboros cancel execution" in _plain(result.output)
+
+    async def test_footer_does_not_advertise_pause_or_resume(self) -> None:
+        """The user-visible surface: `p`/`r` must be absent from the bindings.
+
+        Textual keeps a `None` binding in `active_bindings` (greyed out but
+        still shown); only `False` removes it. Asserting on `active_bindings`
+        rather than on `check_action` keeps that distinction honest.
+        """
+        tui = OuroborosTUI()
+        async with tui.run_test() as pilot:
+            await pilot.pause()
+
+            assert "p" not in tui.screen.active_bindings
+            assert "r" not in tui.screen.active_bindings
+            assert "q" in tui.screen.active_bindings
+
+    async def test_footer_advertises_controls_once_an_owner_connects(self) -> None:
+        tui = OuroborosTUI()
+        tui.set_pause_callback(MagicMock())
+        tui.set_resume_callback(MagicMock())
+        async with tui.run_test() as pilot:
+            await pilot.pause()
+
+            assert "p" in tui.screen.active_bindings
+            assert "r" in tui.screen.active_bindings
+
+    async def test_pressing_p_without_an_owner_does_not_pause(self) -> None:
+        """End-to-end: the key must not fake a lifecycle transition."""
+        tui = OuroborosTUI()
+        async with tui.run_test() as pilot:
+            await pilot.pause()
+            tui.set_execution("exec_keypress", "sess_keypress")
+
+            await pilot.press("p")
+            await pilot.pause()
+
+            assert tui.state.status == "running"
+            assert tui.state.is_paused is False
+
+    async def test_pressing_p_with_an_owner_reaches_the_owner(self) -> None:
+        """With an owner connected, `p` forwards the request but does not fake state."""
+        requested: list[str] = []
+
+        tui = OuroborosTUI()
+        tui.set_pause_callback(requested.append)
+        async with tui.run_test() as pilot:
+            await pilot.pause()
+            tui.set_execution("exec_keypress", "sess_keypress")
+
+            await pilot.press("p")
+            await pilot.pause()
+
+            assert requested == ["exec_keypress"]
+            # Still no optimistic transition — only an acknowledged event flips it.
+            assert tui.state.status == "running"
+            assert tui.state.is_paused is False
+
+
+class TestAcknowledgedDurableControlPath:
+    """A connected owner drives the display only via persisted lifecycle events."""
+
+    async def test_pause_reaches_event_store_and_status_follows_acknowledgement(
+        self, event_store: EventStore
+    ) -> None:
+        repository = SessionRepository(event_store)
+        created = await repository.create_session(
+            execution_id="exec_1833",
+            seed_id="seed_1833",
+            session_id="sess_1833",
+        )
+        assert created.is_ok, created.error
+
+        # No event_store on the app: this test drives projection explicitly so the
+        # 0.5s poller cannot race the "not yet acknowledged" assertion.
+        tui = OuroborosTUI()
+        tui.set_execution("exec_1833", "sess_1833")
+
+        async def pause_owner(_execution_id: str) -> None:
+            result = await repository.mark_paused(
+                "sess_1833",
+                reason="Paused from TUI monitor",
+            )
+            assert result.is_ok, result.error
+
+        tui.set_pause_callback(pause_owner)
+
+        # The request alone must not move the display; the durable control path
+        # runs in the task the handler spawns.
+        await _drain_control_tasks(lambda: tui.on_pause_requested(PauseRequested("exec_1833")))
+        assert tui.state.status == "running"
+        assert tui.state.is_paused is False
+
+        events, _ = await event_store.get_recent_aggregate_events(
+            "session",
+            "sess_1833",
+            event_types={"orchestrator.session.paused"},
+        )
+        assert [event.type for event in events] == ["orchestrator.session.paused"]
+
+        # Only the acknowledged lifecycle event flips the display.
+        tui._update_state_from_event(events[0])
+        assert tui.state.status == "paused"
+        assert tui.state.is_paused is True
+
+    async def test_resume_is_acknowledged_by_progress_runtime_status(
+        self, event_store: EventStore
+    ) -> None:
+        """A paused display must be able to get back to running.
+
+        There is no `orchestrator.session.resumed` event; a resumed run is
+        acknowledged by progress carrying `runtime_status`. Without projecting
+        it, a monitor that stops writing state optimistically would be stuck on
+        `paused` for the rest of the run.
+        """
+        repository = SessionRepository(event_store)
+        created = await repository.create_session(
+            execution_id="exec_resume",
+            seed_id="seed_resume",
+            session_id="sess_resume",
+        )
+        assert created.is_ok, created.error
+
+        paused = await repository.mark_paused("sess_resume", reason="Paused from TUI monitor")
+        assert paused.is_ok, paused.error
+
+        tui = OuroborosTUI()
+        tui.set_execution("exec_resume", "sess_resume")
+
+        paused_events, _ = await event_store.get_recent_aggregate_events(
+            "session",
+            "sess_resume",
+            event_types={"orchestrator.session.paused"},
+        )
+        tui._update_state_from_event(paused_events[0])
+        assert tui.state.is_paused is True
+
+        # The execution really resumes and reports it through progress.
+        tracked = await repository.track_progress(
+            "sess_resume",
+            {"runtime_status": "running", "completed_count": 1, "total_count": 3},
+        )
+        assert tracked.is_ok, tracked.error
+
+        progress_events, _ = await event_store.get_recent_aggregate_events(
+            "session",
+            "sess_resume",
+            event_types={"orchestrator.progress.updated"},
+        )
+        assert progress_events, "no progress event was persisted"
+        for event in progress_events:
+            tui._update_state_from_event(event)
+
+        assert tui.state.status == "running"
+        assert tui.state.is_paused is False
+
+    async def test_progress_without_runtime_status_does_not_clear_paused(
+        self, event_store: EventStore
+    ) -> None:
+        """Ordinary progress is not a resume acknowledgement."""
+        repository = SessionRepository(event_store)
+        created = await repository.create_session(
+            execution_id="exec_quiet",
+            seed_id="seed_quiet",
+            session_id="sess_quiet",
+        )
+        assert created.is_ok, created.error
+
+        tui = OuroborosTUI()
+        tui.set_execution("exec_quiet", "sess_quiet")
+        tui.state.status = "paused"
+        tui.state.is_paused = True
+
+        tracked = await repository.track_progress(
+            "sess_quiet", {"completed_count": 1, "total_count": 3}
+        )
+        assert tracked.is_ok, tracked.error
+
+        progress_events, _ = await event_store.get_recent_aggregate_events(
+            "session",
+            "sess_quiet",
+            event_types={"orchestrator.progress.updated"},
+        )
+        for event in progress_events:
+            tui._update_state_from_event(event)
+
+        assert tui.state.status == "paused"
+        assert tui.state.is_paused is True
+
+    async def test_unacknowledged_pause_persists_nothing_and_keeps_running(
+        self, event_store: EventStore
+    ) -> None:
+        repository = SessionRepository(event_store)
+        created = await repository.create_session(
+            execution_id="exec_noack",
+            seed_id="seed_noack",
+            session_id="sess_noack",
+        )
+        assert created.is_ok, created.error
+
+        tui = OuroborosTUI()
+        tui.set_execution("exec_noack", "sess_noack")
+
+        async def rejecting_owner(_execution_id: str) -> None:
+            raise RuntimeError("owner refused the pause")
+
+        tui.set_pause_callback(rejecting_owner)
+        await _drain_control_tasks(lambda: tui.on_pause_requested(PauseRequested("exec_noack")))
+
+        events, _ = await event_store.get_recent_aggregate_events(
+            "session",
+            "sess_noack",
+            event_types={"orchestrator.session.paused"},
+        )
+        assert events == []
+        assert tui.state.status == "running"
+        assert tui.state.is_paused is False
+        assert tui.state.logs[-1]["level"] == "error"

--- a/tests/integration/tui/test_monitor_lifecycle_controls.py
+++ b/tests/integration/tui/test_monitor_lifecycle_controls.py
@@ -20,6 +20,7 @@ import pytest
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.tui import app as tui_app
+from ouroboros.orchestrator.events import create_workflow_progress_event
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore, sqlite_database_url
 from ouroboros.tui.app import OuroborosTUI
@@ -196,7 +197,7 @@ class TestAcknowledgedDurableControlPath:
         assert [event.type for event in events] == ["orchestrator.session.paused"]
 
         # Only the acknowledged lifecycle event flips the display.
-        tui._update_state_from_event(events[0])
+        tui._process_subscription_event(events[0])
         assert tui.state.status == "paused"
         assert tui.state.is_paused is True
 
@@ -229,7 +230,7 @@ class TestAcknowledgedDurableControlPath:
             "sess_resume",
             event_types={"orchestrator.session.paused"},
         )
-        tui._update_state_from_event(paused_events[0])
+        tui._process_subscription_event(paused_events[0])
         assert tui.state.is_paused is True
 
         # The execution really resumes and reports it through progress.
@@ -246,7 +247,46 @@ class TestAcknowledgedDurableControlPath:
         )
         assert progress_events, "no progress event was persisted"
         for event in progress_events:
-            tui._update_state_from_event(event)
+            tui._process_subscription_event(event)
+
+        assert tui.state.status == "running"
+        assert tui.state.is_paused is False
+
+    async def test_resume_is_acknowledged_by_workflow_progress_last_update(
+        self, event_store: EventStore
+    ) -> None:
+        """The other producer nests `runtime_status` under `last_update`.
+
+        `create_workflow_progress_event` carries the status where
+        `WorkflowState` writes it, not under `progress`. Built from the real
+        event factory so the payload shape cannot drift away from production.
+        """
+        tui = OuroborosTUI()
+        tui.set_execution("exec_wf", "sess_wf")
+        tui.state.status = "paused"
+        tui.state.is_paused = True
+
+        workflow_event = create_workflow_progress_event(
+            execution_id="exec_wf",
+            session_id="sess_wf",
+            acceptance_criteria=[],
+            completed_count=1,
+            total_count=3,
+            current_ac_index=1,
+            current_phase="Discover",
+            activity="working",
+            activity_detail="",
+            elapsed_display="00:10",
+            estimated_remaining="00:20",
+            messages_count=4,
+            tool_calls_count=2,
+            estimated_tokens=100,
+            estimated_cost_usd=0.01,
+            last_update={"runtime_status": "running"},
+        )
+        await event_store.append(workflow_event)
+
+        tui._process_subscription_event(workflow_event)
 
         assert tui.state.status == "running"
         assert tui.state.is_paused is False
@@ -279,7 +319,7 @@ class TestAcknowledgedDurableControlPath:
             event_types={"orchestrator.progress.updated"},
         )
         for event in progress_events:
-            tui._update_state_from_event(event)
+            tui._process_subscription_event(event)
 
         assert tui.state.status == "paused"
         assert tui.state.is_paused is True

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -664,8 +664,8 @@ class TestOuroborosTUIMessageHandlers:
         assert nodes["node_child"]["parent_id"] == "node_root"
         assert nodes["node_root"]["content"] == "Canonical root AC"
 
-    def test_on_pause_requested(self) -> None:
-        """Test handling PauseRequested message."""
+    def test_on_pause_requested_without_owner_keeps_status(self) -> None:
+        """A pause request with no execution owner must not claim 'paused'."""
         app = OuroborosTUI()
         app.set_execution("exec_123")
         initial_log_count = len(app.state.logs)
@@ -673,14 +673,14 @@ class TestOuroborosTUIMessageHandlers:
 
         app.on_pause_requested(msg)
 
-        assert app.state.is_paused is True
-        assert app.state.status == "paused"
-        # Check log was added (one more than before)
+        assert app.state.is_paused is False
+        assert app.state.status == "running"
         assert len(app.state.logs) == initial_log_count + 1
-        assert "Pause requested" in app.state.logs[-1]["message"]
+        assert app.state.logs[-1]["level"] == "warning"
+        assert "unavailable" in app.state.logs[-1]["message"]
 
-    def test_on_resume_requested(self) -> None:
-        """Test handling ResumeRequested message."""
+    def test_on_resume_requested_without_owner_keeps_status(self) -> None:
+        """A resume request with no execution owner must not claim 'running'."""
         app = OuroborosTUI()
         app.set_execution("exec_123")
         app._state.is_paused = True
@@ -690,11 +690,11 @@ class TestOuroborosTUIMessageHandlers:
 
         app.on_resume_requested(msg)
 
-        assert app.state.is_paused is False
-        assert app.state.status == "running"
-        # Check log was added (one more than before)
+        assert app.state.is_paused is True
+        assert app.state.status == "paused"
         assert len(app.state.logs) == initial_log_count + 1
-        assert "Resume requested" in app.state.logs[-1]["message"]
+        assert app.state.logs[-1]["level"] == "warning"
+        assert "unavailable" in app.state.logs[-1]["message"]
 
 
 class TestOuroborosTUIActions:
@@ -703,6 +703,7 @@ class TestOuroborosTUIActions:
     def test_action_pause_posts_message(self) -> None:
         """Test pause action posts message when execution active."""
         app = OuroborosTUI()
+        app.set_pause_callback(MagicMock())
         app.set_execution("exec_123")
         app.post_message = MagicMock()  # type: ignore
 
@@ -717,6 +718,7 @@ class TestOuroborosTUIActions:
     def test_action_pause_no_execution(self) -> None:
         """Test pause action does nothing without execution."""
         app = OuroborosTUI()
+        app.set_pause_callback(MagicMock())
         app.post_message = MagicMock()  # type: ignore
 
         app.action_pause()
@@ -726,6 +728,7 @@ class TestOuroborosTUIActions:
     def test_action_pause_already_paused(self) -> None:
         """Test pause action does nothing when already paused."""
         app = OuroborosTUI()
+        app.set_pause_callback(MagicMock())
         app.set_execution("exec_123")
         app._state.is_paused = True
         app.post_message = MagicMock()  # type: ignore
@@ -734,9 +737,16 @@ class TestOuroborosTUIActions:
 
         app.post_message.assert_not_called()
 
+    def test_pause_binding_is_hidden_without_owner(self) -> None:
+        """`False` (hidden), not `None` (greyed out but still advertised)."""
+        app = OuroborosTUI()
+
+        assert app.check_action("pause", ()) is False
+
     def test_action_resume_posts_message(self) -> None:
         """Test resume action posts message when paused."""
         app = OuroborosTUI()
+        app.set_resume_callback(MagicMock())
         app.set_execution("exec_123")
         app._state.is_paused = True
         app.post_message = MagicMock()  # type: ignore
@@ -750,6 +760,7 @@ class TestOuroborosTUIActions:
     def test_action_resume_not_paused(self) -> None:
         """Test resume action does nothing when not paused."""
         app = OuroborosTUI()
+        app.set_resume_callback(MagicMock())
         app.set_execution("exec_123")
         app._state.is_paused = False
         app.post_message = MagicMock()  # type: ignore
@@ -757,6 +768,28 @@ class TestOuroborosTUIActions:
         app.action_resume()
 
         app.post_message.assert_not_called()
+
+    def test_resume_binding_is_hidden_without_owner(self) -> None:
+        """`False` (hidden), not `None` (greyed out but still advertised)."""
+        app = OuroborosTUI()
+
+        assert app.check_action("resume", ()) is False
+
+    def test_check_action_shows_controls_when_owner_connected(self) -> None:
+        """Bindings are advertised once an execution owner is connected."""
+        app = OuroborosTUI()
+        app.set_pause_callback(MagicMock())
+        app.set_resume_callback(MagicMock())
+
+        assert app.check_action("pause", ()) is True
+        assert app.check_action("resume", ()) is True
+
+    def test_check_action_leaves_unrelated_actions_alone(self) -> None:
+        """Only the lifecycle bindings are gated."""
+        app = OuroborosTUI()
+
+        assert app.check_action("quit", ()) is True
+        assert app.check_action("show_logs", ()) is True
 
 
 class TestOuroborosTUIEventSubscription:

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -791,6 +791,78 @@ class TestOuroborosTUIActions:
         assert app.check_action("quit", ()) is True
         assert app.check_action("show_logs", ()) is True
 
+    @pytest.mark.asyncio
+    async def test_pause_key_spam_starts_one_request_until_acknowledged(self) -> None:
+        app = OuroborosTUI()
+        release = asyncio.Event()
+
+        async def _blocked_pause(_execution_id: str) -> None:
+            await release.wait()
+
+        callback = AsyncMock(side_effect=_blocked_pause)
+        app.set_pause_callback(callback)
+        app.set_execution("exec_123")
+        message = PauseRequested("exec_123")
+
+        app.on_pause_requested(message)
+        app.on_pause_requested(message)
+        app.on_pause_requested(message)
+        await asyncio.sleep(0)
+
+        callback.assert_awaited_once_with("exec_123")
+        assert app.check_action("pause", ()) is False
+
+        release.set()
+        await asyncio.sleep(0)
+        app._update_state_from_event(
+            BaseEvent(
+                type="orchestrator.session.paused",
+                aggregate_type="session",
+                aggregate_id="sess_123",
+                data={"execution_id": "exec_123"},
+            )
+        )
+
+        assert ("pause", "exec_123") not in app._control_requests
+
+    @pytest.mark.asyncio
+    async def test_control_failure_releases_gate_for_retry(self) -> None:
+        app = OuroborosTUI()
+        callback = AsyncMock(side_effect=RuntimeError("owner unavailable"))
+        app.set_resume_callback(callback)
+        app.set_execution("exec_123")
+        app._state.status = "paused"
+        app._state.is_paused = True
+        message = ResumeRequested("exec_123")
+
+        app.on_resume_requested(message)
+        await asyncio.sleep(0)
+        app.on_resume_requested(message)
+        await asyncio.sleep(0)
+
+        assert callback.await_count == 2
+        assert ("resume", "exec_123") not in app._control_requests
+
+    @pytest.mark.asyncio
+    async def test_session_switch_cancels_pending_control(self) -> None:
+        app = OuroborosTUI()
+        release = asyncio.Event()
+
+        async def _blocked_pause(_execution_id: str) -> None:
+            await release.wait()
+
+        callback = AsyncMock(side_effect=_blocked_pause)
+        app.set_pause_callback(callback)
+        app.set_execution("exec_old")
+        app.on_pause_requested(PauseRequested("exec_old"))
+        await asyncio.sleep(0)
+
+        app.set_execution("exec_new")
+        await asyncio.sleep(0)
+
+        assert not app._control_requests
+        assert app.state.execution_id == "exec_new"
+
 
 class TestOuroborosTUIEventSubscription:
     """Tests for event store subscription."""


### PR DESCRIPTION
## Summary

`ouroboros tui monitor` advertised `p`/`r` as pause/resume controls, but `monitor_command` never connects an execution owner. Both handlers wrote `state.is_paused` / `state.status` *before* checking their callback, so the monitor could report `paused` or `running` when no lifecycle command was ever sent or persisted — an operator could believe a costly run had paused while it was still executing.

The monitor observes the event store and does not own the running execution, and there is no cross-process pause/resume control channel (cancellation has one, via `orchestrator.heartbeat`; pause/resume do not). This PR takes the second option from #1833 for the production surface — stop offering controls it cannot exercise — and makes the shared app honest for embedding callers that *do* connect an owner.

## What changed

- **No optimistic lifecycle writes.** `on_pause_requested` / `on_resume_requested` no longer touch `status` / `is_paused`. The display changes only on an acknowledged lifecycle event.
- **Explicit failure feedback.** A request with no connected owner is refused with a warning log + notification; a failing owner callback reports an error. Neither leaves the display in a state the execution never reached.
- **Bindings hidden when no owner is connected.** `check_action` returns `False` — Textual treats `False` as disabled *and hidden*, while `None` would leave `p Pause` greyed out but still advertised in the footer. `DashboardScreenV3` delegates to the app's gate, because screen bindings shadow app bindings and the dashboard declares its own `p`/`r`.
- **`set_pause_callback` / `set_resume_callback` refresh the bindings**, so an owner connected after mount shows up in the footer.
- **`tui monitor` says so**, and points at `ouroboros cancel execution`.

### Resume needed an acknowledgement path to exist at all

Worth a reviewer's eye, since it goes slightly beyond the issue text. There is no `orchestrator.session.resumed` event, and the TUI projected nothing that could clear `is_paused`. Simply deleting the optimistic write would have stranded a paused display for the rest of the run — and because `action_pause` is guarded on `not is_paused`, pause would have gone permanently dead too. Trading an optimistic bug for a stuck-forever bug is not a fix.

So `_update_state_from_event` now projects `runtime_status` from `orchestrator.progress.updated` / `workflow.progress.updated`, reading the same two payload locations the durable projections already use — `SessionRepository._status_from_event` and the `$.progress.runtime_status` / `$.runtime_status` snapshot query in `event_store.py`. No new event type, no new rule.

## Test plan

- [x] `uv run pytest tests/ -q -n 4 --dist worksteal` — **16514 passed, 15 skipped, 1 xfailed** (env matched CI: `uv sync --python 3.13 --dev --group mcp-test --group litellm-test`)
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/ouroboros` clean (487 files)
- [x] `python3 scripts/check-module-size.py` and `python3 scripts/check-auto-boundary.py` clean
- [x] Docs updated per CONTRIBUTING's TUI → doc mapping (`BINDINGS` changed): `docs/guides/tui-usage.md`, `docs/cli-reference.md`

New coverage in `tests/integration/tui/test_monitor_lifecycle_controls.py`:

- production `tui monitor` wiring connects no owner and says so
- the footer surface a user actually sees — asserted via `screen.active_bindings`, not `check_action`, so the `False`/`None` distinction can't silently regress
- real `p` key presses through the dashboard bindings, with and without an owner
- callback-unavailable and callback-failure cases
- durable path against a real SQLite event store and `SessionRepository`: the pause acknowledgement, the resume round trip, and that ordinary progress without a `runtime_status` does *not* clear `paused`

## Scope

TUI app + dashboard screen + the `tui monitor` command, plus tests and docs. No changes to the orchestrator, persistence, or any public API.

Note for a follow-up (happy to file separately): the Rust `--backend slt` TUI has the same pattern — `crates/ouroboros-tui/src/main.rs` sets `state.is_paused` / `ExecutionStatus::Paused` directly on `p`/`r` while attached to a database, where only the mock `auto_simulate` mode can legitimately pause locally. I left it out to keep this PR to one language and one reviewable change.

## Related issues

Closes #1833
