### PR TITLE
fix(interview): gate the branches the echo actually arrives on (#1754)

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -1247,10 +1247,13 @@ def _extract_interview_question(
     ``directive_was_appended`` so the gate and the renderer share one condition.
     Cutting on shape alone truncated
     a question that quoted the sentinel whenever no directive was there to
-    find — on ``PLUGIN_PASSIVE``, where the response is deliberately left
-    unchanged, that is every turn. Auto would then answer, and persist, a
-    question the server never asked. The producer knows whether it appended;
-    asking it is cheaper and surer than inferring from the text.
+    find — on ``PLUGIN_PASSIVE``, where the server appends none, that is every
+    turn. Auto would then answer, and persist, a question the server never
+    asked. The producer knows whether it appended; asking it is cheaper and
+    surer than inferring from the text. It is also the only honest question to
+    ask, since the server is no longer the only producer that writes into that
+    text: the OpenCode bridge appends to it too, and this gate speaks only for
+    ours.
     """
     if dispatch_appended:
         text = split_appended_dispatch(text)

--- a/src/ouroboros/mcp/tools/advisory_dispatch.py
+++ b/src/ouroboros/mcp/tools/advisory_dispatch.py
@@ -57,10 +57,11 @@ _SEQUENTIAL_HOST_ACTION = "process_payloads_sequentially"
 #: where it is parsed.
 QUESTION_ADVISORY_DISPATCH_MARKER = "<!-- ouroboros-question-advisory-dispatch-v1 -->"
 
-#: The first words of the directive that always follows the marker. Recognising
-#: the pair is what lets the strip tell its own output from a question that
-#: merely quotes the marker; written once here so the emitter and the stripper
-#: cannot drift into disagreeing about what a directive looks like.
+#: The first words of the directive this module appends after the marker.
+#: Recognising the pair is what lets a reader tell an append from a question
+#: that merely quotes the marker; written once here so the emitter and the
+#: readers cannot drift into disagreeing about what a directive looks like.
+#: One of two openings — see :data:`_DIRECTIVE_OPENINGS`.
 _HOST_DIRECTIVE_OPENING = "> **Host action — "
 
 #: The OpenCode bridge's opening. It is a *second* producer appending to the
@@ -115,9 +116,14 @@ def directive_was_appended(meta: dict[str, Any]) -> bool:
 
     The renderer's own condition, named once so a reader of the response cannot
     disagree with the writer of it about whether there is anything to strip.
-    ``PLUGIN_PASSIVE`` stamps no host action and leaves content unchanged, so
-    this is false there and `auto` cuts nothing — the same reason
-    ``_HOST_DIRECTIVE_OPENING`` is a shared constant rather than two copies.
+    ``PLUGIN_PASSIVE`` stamps no host action, so this is false there and `auto`
+    cuts nothing.
+
+    *This module* leaves the content unchanged there; the response a host sees
+    does not, because the bridge stamps its own notice onto it afterwards. The
+    distinction is the whole point of asking the producer instead of the text:
+    what this answers is whether **we** appended, which is the only thing our
+    gate is entitled to speak for.
     """
     payloads = meta.get(_PAYLOADS_KEY)
     return bool(meta.get(_HOST_ACTION_KEY)) and isinstance(payloads, list) and bool(payloads)
@@ -285,14 +291,17 @@ def split_appended_dispatch(text: str) -> str:
 
     **Only call this when the server appended a directive**, which
     :func:`directive_was_appended` answers from the same response. With none
-    present the last marker in the text belongs to the question, and cutting
-    there destroys it — on ``PLUGIN_PASSIVE``, where content is left unchanged
-    by design, that would be every turn.
+    present a marker in the text belongs to the question, and cutting there
+    destroys it — on ``PLUGIN_PASSIVE``, where this module appends nothing,
+    that would be every turn.
 
     The gate is also what retires the residual an earlier version of this
-    docstring accepted. A directive is always appended last, so once one exists
-    the last marker is ours and a question quoting the sentinel survives in
-    front of the cut.
+    docstring accepted: with a directive known to be present, a question merely
+    quoting the sentinel survives in front of the cut. That version went on to
+    say the *last* marker is therefore ours. It was ours while we were the only
+    producer. The bridge now declares with the same marker and appends after us,
+    so the search is for the last marker of the opening this function names —
+    which is what the ``openings`` argument to :func:`_directive_at` is for.
 
     The shape question itself is asked in one place, :func:`_directive_at`, and
     both readers of a response ask it. What differs is the warrant each side has
@@ -318,6 +327,32 @@ def split_appended_dispatch(text: str) -> str:
     return text if cut < 0 else text[:cut].strip()
 
 
+def strip_declared_append(text: Any) -> Any:
+    """Return *text* without a declared append, for a caller holding no record.
+
+    :func:`echo_carries_dispatch` answers a caller that has the issued question
+    and can simply prefer it. Two branches have no such record: the plugin path
+    persists no question-only round, so its answer branch is *always* the one
+    with nothing stored, and the reopen branch is answering a probe the server
+    never issued. There, refusing an echo does not keep the right question —
+    there is no right question to keep, and the round would record a placeholder
+    instead. Refusing would trade a leak for the damage ``last_question`` exists
+    to repair.
+
+    So this cuts rather than refuses, and cutting is warranted by the same thing
+    that makes the echo path work: the producer declared where its own text
+    begins. That is a statement, not an inference from prose — which is what
+    separates this from the shape-matching that kept truncating questions. What
+    remains is the residual the whole grammar carries: a question reproducing a
+    complete declared append, marker and opening together, is cut at it. That is
+    narrower than the text this otherwise writes into the transcript verbatim.
+    """
+    if not isinstance(text, str):
+        return text
+    cut = _directive_at(text)
+    return text if cut < 0 else text[:cut].strip()
+
+
 __all__ = [
     "QUESTION_ADVISORY_DISPATCH_MARKER",
     "append_lateral_review_notice",
@@ -325,4 +360,5 @@ __all__ = [
     "directive_was_appended",
     "echo_carries_dispatch",
     "split_appended_dispatch",
+    "strip_declared_append",
 ]

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -62,6 +62,7 @@ from ouroboros.mcp.tools.advisory_dispatch import (
     append_lateral_review_notice,
     append_question_advisory_dispatch,
     echo_carries_dispatch,
+    strip_declared_append,
 )
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
@@ -2382,20 +2383,20 @@ class InterviewHandler:
                 # provenance where the answer arrives either way.
                 has_pending = bool(state.rounds) and state.rounds[-1].user_response is None
                 if has_pending:
-                    # The subprocess path's gatekeeper, asked here too — and this
-                    # is the path the bridge's append actually reaches, since only
-                    # ``PLUGIN_PASSIVE`` lets a second producer stamp the visible
-                    # question. An echo carrying a directive is not a repair.
+                    # Only reachable from state a subprocess turn persisted; an
+                    # echo carrying a directive is not a repair, so prefer ours.
                     issued = state.rounds[-1].question
                     question_text = (
-                        issued
-                        if echo_carries_dispatch(last_question)
-                        else (last_question or issued)
+                        issued if echo_carries_dispatch(last_question) else (last_question or issued)
                     )
                 else:
-                    # Fall back to a descriptive placeholder for backward
-                    # compatibility (callers that don't supply last_question).
-                    question_text = last_question if last_question else "(continued from subagent)"
+                    # The branch plugin mode takes every turn: it persists no
+                    # question-only round, so there is never a record to prefer
+                    # and refusing the echo would store the placeholder instead
+                    # of the question. Cut the declared append, not the question.
+                    question_text = (
+                        strip_declared_append(last_question) or "(continued from subagent)"
+                    )
                 plugin_intent_guard_report = _guard_interview_answer(
                     state=state,
                     question=question_text,
@@ -3145,7 +3146,8 @@ class InterviewHandler:
                 )
 
             if not state.rounds and last_question:
-                pending_question = last_question
+                # No round to prefer: cut the append, refusing records nothing.
+                pending_question = strip_declared_append(last_question)
             elif not state.rounds:
                 return Result.err(
                     MCPToolError(
@@ -3204,7 +3206,8 @@ class InterviewHandler:
                             tool_name="ouroboros_interview",
                         )
                     )
-                pending_question = last_question
+                # The reopen probe is the caller's, never ours: same cut.
+                pending_question = strip_declared_append(last_question)
 
             intent_guard_report = _guard_interview_answer(
                 state=state,

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -1219,8 +1219,10 @@ describe("bridge appends declare themselves", () => {
   //
   // Three paths append: dispatch, dedupe, and pre-dispatch failure. Only the
   // first was declared when this was found, which is why the declaration now
-  // lives in `stampBridge` rather than at each call site. These tests pin all
-  // three, so a fourth path that bypasses the helper is a failing test.
+  // lives in `stampBridge` rather than at each call site. The three behavioural
+  // tests below pin what each path emits; the source test pins that they are
+  // the only writers, since `stamp` stays exported and a fourth call site could
+  // otherwise bypass the helper and pass all three.
   const DECLARATION = `\n\n${OUROBOROS_DISPATCH_MARKER}\n\n${BRIDGE_NOTICE_OPENING}\n`
 
   function expectDeclaredAfter(text: string, question: string): void {
@@ -1267,6 +1269,17 @@ describe("bridge appends declare themselves", () => {
   }
 
   const QUESTION = "Session sess-1\n\nHow do you define completion?"
+
+  test("stampBridge is the only writer that appends to a response", async () => {
+    // The behavioural tests above cannot see a fourth call site; this can.
+    // `stamp` is the primitive and stays exported, so the invariant worth
+    // pinning is that nothing inside the hook reaches past `stampBridge`.
+    const source = await Bun.file(new URL("./ouroboros-bridge.ts", import.meta.url)).text()
+    const body = source.slice(source.indexOf("export function stampBridge"))
+    const direct = body.match(/(?<!stampB)\bstamp\(/g) ?? []
+    // The one inside stampBridge itself is the intended delegation.
+    expect(direct.length).toBe(1)
+  })
 
   test("stampBridge declares, with or without a question in front", () => {
     const withQuestion = { content: [{ type: "text", text: "x" }] }

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
@@ -326,7 +326,9 @@ export function stamp(r: Output, msg: string): void {
 // call site. Passing `original` is what says "a question is in front of this".
 export function stampBridge(r: Output, original: string | undefined, body: string): void {
   const declared = `${OUROBOROS_DISPATCH_MARKER}\n\n${BRIDGE_NOTICE_OPENING}\n${body}`
-  stamp(r, original === undefined ? declared : `${original}\n\n${declared}`)
+  // Falsy, not `undefined`: readText() returns "" for a metadata-only response,
+  // and prefixing that would open the text with two blank lines.
+  stamp(r, original ? `${original}\n\n${declared}` : declared)
 }
 
 export interface OkResult {
@@ -729,7 +731,7 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         const banner = notify(ok, failed.map((f) => f.sub), [])
         // Preserve response_shape in text so the LLM can read contract fields
         // (session_id, job_id, status) that build_subagent_result() provides.
-        // Without this, stamp() replaces the JSON and the LLM loses these values.
+        // Without this the stamp replaces the JSON and the LLM loses these values.
         const shapeSuffix = Object.keys(responseShape).length > 0
           ? "\n\n```json\n" + JSON.stringify(responseShape, null, 2) + "\n```"
           : ""

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -1123,19 +1123,24 @@ def _bridge_echo(issued: str) -> str:
 
 
 async def test_a_bridge_mutated_echo_does_not_reach_the_plugin_transcript(tmp_path) -> None:
-    """The plugin path, with the exact shape the bridge produces.
+    """The plugin handler's pending branch, with the shape the bridge produces.
 
-    **This is the path the bridge's append actually reaches.** `handle()` returns
-    to `_handle_plugin_dispatch` before `_handle_answer` is entered, so the
-    gatekeeper the subprocess path asks was never on the plugin round-trip — and
-    plugin-passive is the only transport where the bridge stamps anything. A
-    gatekeeper that recognised the bridge's grammar while sitting on the other
-    branch would have read as a fix and persisted the banner anyway.
+    `handle()` returns into `_handle_plugin_dispatch` before `_handle_answer` is
+    entered, so the subprocess gatekeeper is not on the plugin round-trip at all
+    and this branch needs its own.
 
-    So this drives the real handler against a real state directory rather than a
-    mocked engine: the plugin path loads and saves state itself, and a mock of
-    `InterviewEngine` is simply not consulted here. What the round remembers
-    asking is read back off disk.
+    **The fixture is the caveat.** A question-only pending round is state plugin
+    mode does not produce on its own — it reaches this branch only from a
+    session a subprocess turn persisted. The branch plugin mode takes every turn
+    is the sibling below, covered by
+    ``test_the_plugin_branch_that_actually_runs_records_only_the_question``,
+    which builds no state by hand. This test was written believing it covered
+    that path, and passed while the live path leaked; the pair is split so the
+    fixture cannot stand in for the transport again.
+
+    It drives the real handler against a real state directory rather than a
+    mocked engine: the plugin path loads and saves state itself, so a mock of
+    `InterviewEngine` is never consulted here.
     """
     from ouroboros.mcp.tools.advisory_dispatch import (
         QUESTION_ADVISORY_DISPATCH_MARKER as marker,
@@ -1267,3 +1272,128 @@ def test_two_declared_appends_cut_at_the_server_s_own_directive() -> None:
     )
     # The echo path still recognises it — it accepts either producer.
     assert echo_carries_dispatch(both)
+
+
+async def test_the_plugin_branch_that_actually_runs_records_only_the_question(tmp_path) -> None:
+    """Driven start -> answer, never by hand-built state.
+
+    The earlier plugin regression seeded a question-only pending round, and that
+    is the one state shape plugin mode does not produce: the child asks the
+    questions and the server only ever records answers, so `record_answer`
+    appends a complete round and `has_pending` is false on every turn. The gate
+    written for the pending branch was therefore never reached here, and the
+    test that was supposed to prove otherwise passed because its fixture stood
+    in for a state the transport cannot reach.
+
+    So this one asks the handler for a session and answers it, three times,
+    reading each round back off disk.
+    """
+    from ouroboros.mcp.tools.advisory_dispatch import (
+        QUESTION_ADVISORY_DISPATCH_MARKER as marker,
+    )
+
+    issued = "How do you define completion?"
+    handler = InterviewHandler(
+        data_dir=tmp_path, agent_runtime_backend="opencode", opencode_mode="plugin"
+    )
+    started = await handler.handle(
+        {
+            "action": "start",
+            "initial_context": "Build a data-aware interview lane for Ouroboros.",
+            "cwd": str(tmp_path),
+        }
+    )
+    assert started.is_ok
+    session_id = started.value.meta["session_id"]
+    state_file = tmp_path / f"interview_{session_id}.json"
+
+    for turn in range(3):
+        before = json.loads(state_file.read_text(encoding="utf-8"))["rounds"]
+        assert not (before and before[-1]["user_response"] is None), (
+            "plugin mode is not expected to persist a question-only round"
+        )
+        result = await handler.handle(
+            {
+                "session_id": session_id,
+                "answer": f"A{turn}",
+                "last_question": _bridge_echo(issued),
+            }
+        )
+        assert result.is_ok
+
+    for round_data in json.loads(state_file.read_text(encoding="utf-8"))["rounds"]:
+        assert round_data["question"] == issued
+        assert marker not in round_data["question"]
+        assert "fanout_abc123" not in round_data["question"]
+
+
+async def test_a_new_session_and_a_reopen_record_only_the_question() -> None:
+    """The two subprocess branches with no round to prefer.
+
+    Neither has a stored question — one has no rounds at all, the other is a
+    Seed-ready-challenge reopen answering a probe the server never issued. So
+    neither can prefer the record, and refusing the echo would leave the round
+    with nothing. They cut the declared append instead, and the directive here
+    is the server's own, built by the renderer rather than written by hand.
+    """
+    from ouroboros.mcp.tools.advisory_dispatch import (
+        QUESTION_ADVISORY_DISPATCH_MARKER as marker,
+    )
+
+    question = "How do you define completion?"
+    meta = {
+        "question_advisory_host_action": "spawn_subagents",
+        "question_advisory_subagents": [
+            {
+                "tool_name": "ouroboros_interview",
+                "title": "Interview advisory: data_context",
+                "agent": "general",
+                "prompt": "Measure it.",
+                "context": {"lane_id": "data_context", "required": True},
+            }
+        ],
+        "question_advisory_fanout_id": "fanout_server_leak",
+    }
+    echoed = append_question_advisory_dispatch(question, meta)
+    assert directive_was_appended(meta)
+
+    for label, rounds in (
+        ("no rounds yet", []),
+        (
+            "reopen after an answered round",
+            [InterviewRound(round_number=1, question="Q1?", user_response="A1")],
+        ),
+    ):
+        state = InterviewState(interview_id="sess-nb", rounds=list(rounds))
+
+        async def record(
+            current: InterviewState, answer: str, question_text: str
+        ) -> Result[InterviewState, object]:
+            current.rounds.append(
+                InterviewRound(
+                    round_number=current.current_round_number,
+                    question=question_text,
+                    user_response=answer,
+                )
+            )
+            return Result.ok(current)
+
+        engine = MagicMock()
+        engine.load_state = AsyncMock(return_value=Result.ok(state))
+        engine.record_response = AsyncMock(side_effect=record)
+        engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+        engine.ask_next_question = AsyncMock(return_value=Result.ok("Next?"))
+
+        handler = InterviewHandler(interview_engine=engine, agent_runtime_backend="claude")
+        handler.llm_adapter = MagicMock()
+        handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+        handler._score_interview_state = AsyncMock(return_value=_score(0.35))  # type: ignore[method-assign]
+
+        result = await handler.handle(
+            {"session_id": "sess-nb", "answer": "A", "last_question": echoed}
+        )
+        assert result.is_ok, label
+        recorded = engine.record_response.await_args.args[2]
+        assert recorded == question, label
+        assert marker not in recorded, label
+        assert "fanout_server_leak" not in recorded, label


### PR DESCRIPTION
Stacked on #1825 (base: `feat/data-context-lane`) so that PR's approval is preserved. Merge #1825 first; GitHub will retarget this to `main`.

## What this fixes

#1825 added a gatekeeper to the pending-round branch of both interview handlers and reported the plugin-passive echo leak closed. **It is not closed.** The branch it gates is dead on the transport that produces the leak.

Plugin mode never persists a question-only round: the child asks the questions and the server only records answers, so `record_answer` appends a complete round and `has_pending` is `False` on every turn. Control always falls to the ungated `else`.

Driving the real handler `start → answer → answer → answer` against a real state directory, reading each round back off disk at `2f2e96d9`:

| turn | `has_pending` | fan-out id in the persisted question |
|---|---|---|
| 1 | False | **yes** |
| 2 | False | **yes** |
| 3 | False | **yes** |

The marker, the bridge banner and `question_advisory_fanout_id` all persist, every turn. After this PR, all three are absent and the round records the issued question.

The regression in #1825 that was supposed to prove otherwise seeded a question-only pending round **by hand** — the one state shape plugin mode cannot reach — so it passed while the live path leaked. That fixture, not the code, is what the previous round verified.

## Two more writers with the same shape

Both on the subprocess path, carrying the *server's own* directive rather than the bridge's. Probed with a directive built by the real renderer, not hand-written; both recorded it whole:

- a session with no rounds yet (`last_question` is the only question there is);
- the Seed-ready-challenge reopen, which is a normal user action.

## Why these cut rather than prefer the record

None of the three has a stored question, so the gate used in #1825 does not transfer. Refusing the echo there records a placeholder instead of what the user was asked — trading a leak for exactly the damage `last_question` exists to repair.

So they cut the producer's declared append. Cutting is warranted by the same thing that makes the echo path work: the producer declared where its own text begins, which is a statement rather than an inference from prose. That is what separates it from the shape-matching that kept truncating questions in earlier rounds. `strip_declared_append` carries the residual in its docstring — a question reproducing a *whole* declared append, marker and opening together, is cut at it, which is narrower than the text this branch otherwise writes into the transcript verbatim.

## Also here, because the same round introduced or exposed them

- `stampBridge` branched on `original === undefined`, so a metadata-only response whose text is `""` gained two leading blank lines. Falsy, not undefined.
- A source-level test pins that `stampBridge` is the only writer appending to a response. The behavioural tests cannot see a fourth call site, and the comment claiming they could was false while `stamp` stays exported.
- Comments this branch falsified: *"the last marker is ours"* (true only while we were the only producer), *"PLUGIN_PASSIVE leaves content unchanged"* in three places (this module appends nothing there — the response a host sees changes anyway), and `_HOST_DIRECTIVE_OPENING` described as *the* opening rather than one of two.

## Verification

`tests/unit/mcp` + `tests/unit/auto` 2923 passed; bridge `bun test` 118 pass; `bunx tsc --noEmit` clean; `mypy src/ouroboros` clean (493 files); `ruff check` / `ruff format --check` clean; `check-module-size.py --baseline-ref origin/main` OK; `check-auto-boundary.py` OK.

New regressions: the driven plugin flow (builds no state by hand), the two subprocess branches, and the bridge source invariant. The #1825 plugin test is kept and its docstring corrected to say what its fixture actually reaches, so it cannot stand in for the transport again.

Refs #1754
