### PR TITLE
feat(evolve): converge on active acceptance criteria

### DIFF
--- a/docs/contributing/control-contract.md
+++ b/docs/contributing/control-contract.md
@@ -87,6 +87,7 @@ authority for `StepAction` outcomes:
 |---|---|---|
 | `StepAction.CONTINUE` | no directive emission | No-op continuation; `lineage.generation.completed` already records progress. |
 | `StepAction.CONVERGED` | `CONVERGE` | Terminal success. |
+| `StepAction.ONTOLOGY_STABLE` | `EVALUATE` | Non-terminal handoff. The caller must run the same lineage with `execute=true` so Execute→Evaluate can establish verified convergence. |
 | `StepAction.STAGNATED` | `UNSTUCK` | Non-terminal recovery path; never terminal success. |
 | `StepAction.EXHAUSTED` | `CANCEL` | Terminal stop without claiming convergence. |
 | `StepAction.INTERRUPTED` | `CANCEL` | Current runtime stops the interrupted step and relies on resume state for continuation. |

--- a/scripts/check-module-size.py
+++ b/scripts/check-module-size.py
@@ -99,7 +99,7 @@ GRANDFATHERED: dict[str, int] = {
     "src/ouroboros/orchestrator/codex_cli_runtime.py": 4140,
     "src/ouroboros/mcp/tools/authoring_handlers.py": 3780,
     "src/ouroboros/orchestrator/execution_authority.py": 3449,
-    "src/ouroboros/mcp/tools/subagent.py": 2787,  # was 3163
+    "src/ouroboros/mcp/tools/subagent.py": 2786,  # was 3163
     "src/ouroboros/persistence/event_store.py": 3102,
     "src/ouroboros/cli/commands/plugin.py": 3053,
     "src/ouroboros/mcp/job_manager.py": 2950,

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -38,7 +38,7 @@ Options:
   --seed-file PATH       Seed YAML for Gen 1
   --max-cycles N         Max loop iterations (default: 30)
   --max-retries N        Lateral-think retries per stagnation (default: 2)
-  --no-execute           Ontology-only evolution (skip execution)
+  --no-execute           Explore ontology only, then verify a stable Seed
   --no-parallel          Sequential AC execution (slower, more stable)
   --no-qa                Skip post-execution QA evaluation
   --server-command CMD   MCP server executable (default: ouroboros)
@@ -250,6 +250,11 @@ while (( cycle < MAX_CYCLES )); do
 
     case "$action" in
         continue)
+            stagnation_count=0
+            ;;
+        ontology_stable)
+            log "ONTOLOGY STABLE — switching same lineage to Execute→Evaluate"
+            NO_EXECUTE=false
             stagnation_count=0
             ;;
         converged)

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -86,13 +86,23 @@ documented fallback / Path B instead of retrying the failing call.
    - `continue` → Inspect `active_ac_indices`, then call `ouroboros_evolve_step`
      again with just `lineage_id`. Only active failed/reopened nodes evolve;
      frozen PASS nodes stay immutable and are boundary-reverified.
+   - `ontology_stable` → This is not success. Call `ouroboros_evolve_step`
+     again for the same `lineage_id` with `execute: true` so the stable Seed
+     goes through Execute→Evaluate. Do not call standalone evaluate or report
+     convergence before that step returns `converged`.
    - `converged` → Evolution complete! Display final ontology
    - `stagnated` → Ontology unchanged for 3+ gens. Consider `ouroboros_lateral_think`
    - `exhausted` → Max 30 generations reached. Display best result
-   - `failed` → Check error, possibly retry
-7. **Repeat step 6** until action ≠ `continue`
+   - `failed` → Check error, possibly retry. If the error reports an expired
+     lineage owner, first confirm that the prior owner process is dead, then
+     make one explicit recovery call with `recover_expired_claim: true`.
+     Never set this flag for a merely slow or still-running owner.
+7. **Repeat step 6** while action is `continue`. Treat `ontology_stable` as the
+   explicit transition above, then process the `execute: true` response using
+   step 6. Stop only on `converged`, `stagnated`, `exhausted`, or `failed`.
 8. When the loop terminates, display a result summary with next step:
    - `converged`: `◆ Current state → next: Ontology converged! Run ooo evaluate for formal verification`
+   - `ontology_stable`: `◆ Current state → next: Run the same lineage with execute=true for Execute→Evaluate; this is not verified convergence yet`
    - `stagnated`: `◆ Current state → next: ooo unstuck to break through, then ooo evolve --status <lineage_id> to resume`
    - `exhausted`: `◆ Current state → next: ooo evaluate to check best result — or ooo unstuck to try a new approach`
    - `failed`: `◆ Current state → next: Check the error above. ooo status to inspect session, or ooo unstuck if blocked`
@@ -124,9 +134,11 @@ Then add to your runtime's MCP configuration (e.g., `~/.claude/mcp.json` for Cla
   to identify ontological gaps and hidden assumptions
 - **Reflect**: "How should the ontology evolve?" - proposes specific
   mutations to fields, acceptance criteria, and constraints
-- **Convergence**: Loop stops when ontology similarity ≥ 0.95 between
-  consecutive generations, when the independently verified outcome passes,
-  when judge scores plateau for 3 generations, or after 30 generations max
+- **Convergence**: Verified success requires the independently evaluated
+  outcome to pass. In ontology-only mode, similarity ≥ 0.95 returns the
+  non-success `ontology_stable` handoff and the same lineage must run once with
+  `execute: true`. Judge-score plateau and the 30-generation cap are also
+  non-success stops.
 - **Focused evolution**: Gen 1 establishes the baseline. Gen 2+ derives an
   active node set from failed/regressed verifier results. Only those nodes are
   open to Wonder, Reflect, and execution; PASS nodes are frozen. The active
@@ -143,7 +155,9 @@ Then add to your runtime's MCP configuration (e.g., `~/.claude/mcp.json` for Cla
   Ralph integration — state is fully reconstructed from events between calls
 - **execute flag**: `true` (default) runs full Execute→Evaluate each generation.
   `false` skips execution for fast ontology exploration. Previous generation's
-  execution output is fed into Wonder/Reflect for informed evolution
+  execution output is fed into Wonder/Reflect for informed evolution. An
+  `ontology_stable` response from `execute: false` must be followed by the same
+  lineage with `execute: true`; ontology stability alone is never convergence.
 - **QA verdict**: Each generation's response includes a QA Verdict section
   (when `execute=true` and `skip_qa` is not set). Use the QA score to track
   quality progression across generations. Pass `skip_qa: true` to disable

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -11,10 +11,11 @@ refines the ontology and acceptance criteria across generations until convergenc
 
 ## Flow
 ```
-Gen 1: Interview → Seed(O₁) → Execute → Evaluate
-Gen 2: Wonder → Reflect → Seed(O₂) → Execute → Evaluate
-Gen 3: Wonder → Reflect → Seed(O₃) → Execute → Evaluate
-...until ontology converges (similarity ≥ 0.95) or max 30 generations
+Gen 1: Seed(O₁) → Execute(all nodes) → Judge → Gate
+Gen 2: Wonder(failed nodes) → Reflect(active nodes only) → Execute(active) → Gate(all)
+Gen 3: Repeat with a smaller active set; frozen PASS nodes are reverified, not regenerated
+...until the outcome gate passes, the working set stagnates, ontology converges,
+or max 30 generations is reached
 ```
 
 ## Usage
@@ -82,7 +83,9 @@ documented fallback / Path B instead of retrying the failing call.
    - `execute`: `true` (default) for full Execute→Evaluate pipeline,
      `false` for fast ontology-only evolution (no seed execution)
 6. Check the `action` in the response:
-   - `continue` → Call `ouroboros_evolve_step` again with just `lineage_id`
+   - `continue` → Inspect `active_ac_indices`, then call `ouroboros_evolve_step`
+     again with just `lineage_id`. Only active failed/reopened nodes evolve;
+     frozen PASS nodes stay immutable and are boundary-reverified.
    - `converged` → Evolution complete! Display final ontology
    - `stagnated` → Ontology unchanged for 3+ gens. Consider `ouroboros_lateral_think`
    - `exhausted` → Max 30 generations reached. Display best result
@@ -122,7 +125,18 @@ Then add to your runtime's MCP configuration (e.g., `~/.claude/mcp.json` for Cla
 - **Reflect**: "How should the ontology evolve?" - proposes specific
   mutations to fields, acceptance criteria, and constraints
 - **Convergence**: Loop stops when ontology similarity ≥ 0.95 between
-  consecutive generations, or after 30 generations max
+  consecutive generations, when the independently verified outcome passes,
+  when judge scores plateau for 3 generations, or after 30 generations max
+- **Focused evolution**: Gen 1 establishes the baseline. Gen 2+ derives an
+  active node set from failed/regressed verifier results. Only those nodes are
+  open to Wonder, Reflect, and execution; PASS nodes are frozen. The active
+  output should shrink toward zero rather than feeding the full graph back.
+- **Judge/Gate split**: Evaluation records score and evidence; deterministic
+  convergence logic decides accept/continue/stagnate. A passing Gen 1 may end
+  immediately—minimum-generation churn is not required after the gate passes.
+- **No-drift stop**: If rejected evaluation scores move by less than 0.01 for
+  the 3-generation window, stop as `stagnated` and hand off to `ooo unstuck`
+  instead of spending the 30-generation cap.
 - **Rewind**: Each generation is a snapshot. You can rewind to any
   generation and branch evolution from there
 - **evolve_step**: Runs exactly ONE generation per call. Designed for

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -53,6 +53,7 @@ from ouroboros.core.seed import (
     parse_expected_artifact_list,
 )
 from ouroboros.core.types import Result
+from ouroboros.evolution.acceptance_contracts import evolve_seed_contract_fields
 from ouroboros.providers.base import CompletionConfig, LLMAdapter, Message, MessageRole
 
 log = structlog.get_logger()
@@ -1872,17 +1873,10 @@ class SeedGenerator:
         parent_seed: Seed,
         reflect_output: Any,
     ) -> Result[Seed, ValidationError | ProviderError]:
-        """Generate a new Seed from ReflectOutput (Gen 2+ path).
+        """Generate a successor Seed while preserving structured AC authority.
 
-        Applies ontology mutations to parent's schema and uses refined
-        ACs from the reflect phase. No ambiguity gating needed.
-
-        Args:
-            parent_seed: The parent seed to evolve from.
-            reflect_output: ReflectOutput with refined goal/constraints/ACs/mutations.
-
-        Returns:
-            Result containing the evolved Seed.
+        Reflect applies ontology and prose deltas without Gen-1 ambiguity
+        gating; mechanical AC contracts remain intact across the boundary.
         """
         log.info(
             "seed.generation.from_reflect",
@@ -1908,11 +1902,11 @@ class SeedGenerator:
                 task_type=parent_seed.task_type,
                 brownfield_context=parent_seed.brownfield_context,
                 constraints=reflect_output.refined_constraints,
-                acceptance_criteria=reflect_output.refined_acs,
                 ontology_schema=new_ontology,
                 evaluation_principles=parent_seed.evaluation_principles,
                 exit_conditions=parent_seed.exit_conditions,
                 metadata=metadata,
+                **evolve_seed_contract_fields(parent_seed, reflect_output.refined_acs),
             )
 
             log.info(

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -1875,8 +1875,9 @@ class SeedGenerator:
     ) -> Result[Seed, ValidationError | ProviderError]:
         """Generate a successor Seed while preserving structured AC authority.
 
-        Reflect applies ontology and prose deltas without Gen-1 ambiguity
-        gating; mechanical AC contracts remain intact across the boundary.
+        Reflect applies ontology and identity-bearing prose deltas without
+        Gen-1 ambiguity gating. Mechanical AC contracts cross only explicit
+        keeps; description changes require a future replacement-contract patch.
         """
         log.info(
             "seed.generation.from_reflect",

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -1897,6 +1897,9 @@ class SeedGenerator:
                 parent_seed_id=parent_seed.metadata.seed_id,
             )
 
+            refined_patches = (
+                reflect_output.ac_patches if reflect_output.ac_patch_identity_explicit else None
+            )
             seed = Seed(
                 goal=reflect_output.refined_goal,
                 task_type=parent_seed.task_type,
@@ -1906,7 +1909,9 @@ class SeedGenerator:
                 evaluation_principles=parent_seed.evaluation_principles,
                 exit_conditions=parent_seed.exit_conditions,
                 metadata=metadata,
-                **evolve_seed_contract_fields(parent_seed, reflect_output.refined_acs),
+                **evolve_seed_contract_fields(
+                    parent_seed, reflect_output.refined_acs, refined_patches
+                ),
             )
 
             log.info(

--- a/src/ouroboros/core/directive.py
+++ b/src/ouroboros/core/directive.py
@@ -36,6 +36,7 @@ disappear when this vocabulary lands. The first reference migration maps
 
     StepAction.STAGNATED  -> Directive.UNSTUCK
     StepAction.CONVERGED  -> Directive.CONVERGE
+    StepAction.ONTOLOGY_STABLE -> Directive.EVALUATE
     StepAction.FAILED     -> Directive.RETRY  or Directive.CANCEL   (budget-dependent)
 
 Later migrations follow the same pattern so callers can be converted one

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -355,6 +355,8 @@ class GenerationRecord(BaseModel, frozen=True):
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     seed_json: str | None = None
     execution_output: str | None = None
+    active_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
+    frozen_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     seed_quality_canary_feedback: tuple[FeedbackMetadata, ...] = Field(
         default_factory=tuple,
         description=(

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -87,6 +87,35 @@ class ACResult(BaseModel, frozen=True):
         return self.final_verdict.upper()
 
     @property
+    def verdict_is_authoritative(self) -> bool:
+        """Whether this result records a completed evaluator/verifier verdict."""
+        if self.ac_verdict_state == "evaluated":
+            return True
+        if self.ac_verdict_state != "overridden":
+            return False
+        method = self.verification_method.strip().lower()
+        return bool(method and method != "unknown" and self.evidence.strip())
+
+    @property
+    def authoritative_pass(self) -> bool:
+        """Whether this AC may be consumed as proven passing evidence."""
+        return self.passed and self.verdict_is_authoritative
+
+    @property
+    def unresolved(self) -> bool:
+        """Whether this AC must remain in the evolution working set."""
+        return not self.authoritative_pass
+
+    @property
+    def authority_state(self) -> str:
+        """Return ``pass``, ``fail``, or ``unresolved`` at the authority boundary."""
+        if self.authoritative_pass:
+            return "pass"
+        if self.verdict_is_authoritative:
+            return "fail"
+        return "unresolved"
+
+    @property
     def provisional_verdict(self) -> str:
         """What the evaluator originally said before any override."""
         # If overridden, the original was the opposite
@@ -208,9 +237,17 @@ class EvaluationSummary(BaseModel, frozen=True):
     def _reconcile_approval_with_ac_results(self) -> EvaluationSummary:
         """Eagerly reconcile approval fields with AC results at construction time."""
         if self.ac_results:
-            ac_passed = all(ac.passed for ac in self.ac_results)
+            ac_passed = all(ac.authoritative_pass for ac in self.ac_results)
             execution_completed = self.execution_completion_status == "completed"
-            final_approved = ac_passed and execution_completed
+            # Detailed AC results may veto approval, never mint it. Final
+            # approval is an independent authority gate (RFC #1888), so an
+            # explicitly rejected consensus cannot be upgraded by AC PASSes.
+            final_approved = (
+                self.final_approved
+                and self.approval_status == "approved"
+                and ac_passed
+                and execution_completed
+            )
             expected_status = "approved" if final_approved else "rejected"
             if self.approval_status != expected_status:
                 object.__setattr__(self, "approval_status", expected_status)
@@ -227,11 +264,11 @@ class EvaluationSummary(BaseModel, frozen=True):
         """
         if self.execution_completion_status != "completed":
             return False
-        if self.ac_results:
-            return all(ac.passed for ac in self.ac_results)
-        if self.approval_status != "approved":
+        if not self.final_approved or self.approval_status != "approved":
             return False
-        return self.final_approved
+        if self.ac_results:
+            return all(ac.authoritative_pass for ac in self.ac_results)
+        return True
 
     @property
     def run_verdict(self) -> str:
@@ -358,6 +395,7 @@ class GenerationRecord(BaseModel, frozen=True):
     execution_output: str | None = None
     active_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     frozen_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
+    verification_handoff_pending: bool = False
     seed_quality_canary_feedback: tuple[FeedbackMetadata, ...] = Field(
         default_factory=tuple,
         description=(
@@ -422,6 +460,7 @@ class ControlDirectiveEmission(BaseModel, frozen=True):
     generation_number: int | None = None
     phase: str | None = None
     is_terminal: bool = False
+    step_action: str | None = None
     parent_directive_id: str | None = None
     idempotency_key: str | None = None
 
@@ -452,6 +491,31 @@ class OntologyLineage(BaseModel, frozen=True):
     def current_ontology(self) -> OntologySchema | None:
         """Return the latest ontology snapshot, or None if no generations."""
         return self.generations[-1].ontology_snapshot if self.generations else None
+
+    @property
+    def verification_handoff_pending(self) -> bool:
+        """Whether the latest completed generation requested evaluation."""
+        previous = next(
+            (
+                record
+                for record in reversed(self.generations)
+                if record.phase == GenerationPhase.COMPLETED
+            ),
+            None,
+        )
+        if previous is None:
+            return False
+        if previous.verification_handoff_pending:
+            return True
+        # Legacy events stored the handoff only in the audit directive. Keep
+        # that replay fallback while new completions carry atomic authority.
+        for emission in reversed(self.directive_emissions):
+            if emission.generation_number != previous.generation_number:
+                continue
+            if emission.emitted_by != "evolver" or emission.timestamp < previous.created_at:
+                continue
+            return emission.step_action == "ontology_stable"
+        return False
 
     def with_generation(self, record: GenerationRecord) -> OntologyLineage:
         """Return new lineage with appended or replaced generation.

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -55,7 +55,7 @@ class MutationAction(StrEnum):
 class ACResult(BaseModel, frozen=True):
     """Result of evaluating a single acceptance criterion."""
 
-    ac_index: int
+    ac_index: int = Field(strict=True, ge=0)
     ac_content: str
     semantic_ac_key: str | None = Field(default=None, pattern=r"^ac_[a-f0-9]{16}$")
     passed: bool

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -57,6 +57,7 @@ class ACResult(BaseModel, frozen=True):
 
     ac_index: int
     ac_content: str
+    semantic_ac_key: str | None = Field(default=None, pattern=r"^ac_[a-f0-9]{16}$")
     passed: bool
     score: float | None = None
     evidence: str = ""

--- a/src/ouroboros/events/lineage.py
+++ b/src/ouroboros/events/lineage.py
@@ -30,17 +30,21 @@ def lineage_generation_started(
     generation_number: int,
     phase: str,
     seed_id: str | None = None,
+    seed_json: str | None = None,
 ) -> BaseEvent:
     """Create event when a generation begins."""
+    data = {
+        "generation_number": generation_number,
+        "phase": phase,
+        "seed_id": seed_id,
+    }
+    if seed_json is not None:
+        data["seed_json"] = seed_json
     return BaseEvent(
         type="lineage.generation.started",
         aggregate_type="lineage",
         aggregate_id=lineage_id,
-        data={
-            "generation_number": generation_number,
-            "phase": phase,
-            "seed_id": seed_id,
-        },
+        data=data,
     )
 
 
@@ -57,6 +61,7 @@ def lineage_generation_completed(
     seed_quality_canary_feedback: list[dict] | None = None,
     active_ac_indices: list[int] | None = None,
     frozen_ac_indices: list[int] | None = None,
+    verification_handoff_pending: bool = False,
 ) -> BaseEvent:
     """Create event when a generation completes successfully."""
     data = {
@@ -65,6 +70,7 @@ def lineage_generation_completed(
         "ontology_snapshot": ontology_snapshot,
         "evaluation_summary": evaluation_summary,
         "wonder_questions": wonder_questions or [],
+        "verification_handoff_pending": verification_handoff_pending,
     }
     if seed_quality_canary_feedback is not None:
         data["seed_quality_canary_feedback"] = seed_quality_canary_feedback

--- a/src/ouroboros/events/lineage.py
+++ b/src/ouroboros/events/lineage.py
@@ -7,6 +7,8 @@ These events carry enough data to reconstruct OntologyLineage state via
 LineageProjector.project().
 """
 
+from typing import Any
+
 from ouroboros.events.base import BaseEvent
 
 
@@ -96,13 +98,33 @@ def lineage_generation_phase_changed(
     lineage_id: str,
     generation_number: int,
     phase: str,
+    *,
+    last_completed_phase: str | None = None,
+    seed_id: str | None = None,
+    seed_json: str | None = None,
+    partial_state: dict[str, Any] | None = None,
+    active_ac_indices: list[int] | None = None,
+    frozen_ac_indices: list[int] | None = None,
 ) -> BaseEvent:
-    """Create event when a generation transitions to a new phase."""
+    """Create a phase transition with an optional durable recovery checkpoint."""
+    data: dict[str, Any] = {"generation_number": generation_number, "phase": phase}
+    if last_completed_phase is not None:
+        data["last_completed_phase"] = last_completed_phase
+    if seed_id is not None:
+        data["seed_id"] = seed_id
+    if seed_json is not None:
+        data["seed_json"] = seed_json
+    if partial_state is not None:
+        data["partial_state"] = partial_state
+    if active_ac_indices is not None:
+        data["active_ac_indices"] = active_ac_indices
+    if frozen_ac_indices is not None:
+        data["frozen_ac_indices"] = frozen_ac_indices
     return BaseEvent(
         type="lineage.generation.phase_changed",
         aggregate_type="lineage",
         aggregate_id=lineage_id,
-        data={"generation_number": generation_number, "phase": phase},
+        data=data,
     )
 
 

--- a/src/ouroboros/events/lineage.py
+++ b/src/ouroboros/events/lineage.py
@@ -55,6 +55,8 @@ def lineage_generation_completed(
     execution_output: str | None = None,
     parent_seed_id: str | None = None,
     seed_quality_canary_feedback: list[dict] | None = None,
+    active_ac_indices: list[int] | None = None,
+    frozen_ac_indices: list[int] | None = None,
 ) -> BaseEvent:
     """Create event when a generation completes successfully."""
     data = {
@@ -66,6 +68,10 @@ def lineage_generation_completed(
     }
     if seed_quality_canary_feedback is not None:
         data["seed_quality_canary_feedback"] = seed_quality_canary_feedback
+    if active_ac_indices is not None:
+        data["active_ac_indices"] = active_ac_indices
+    if frozen_ac_indices is not None:
+        data["frozen_ac_indices"] = frozen_ac_indices
     if parent_seed_id is not None:
         data["parent_seed_id"] = parent_seed_id
     if seed_json is not None:

--- a/src/ouroboros/evolution/acceptance_contracts.py
+++ b/src/ouroboros/evolution/acceptance_contracts.py
@@ -17,9 +17,11 @@ def evolve_acceptance_contracts(
     Reflect intentionally reasons over human-readable descriptions.  Existing
     mechanical verification and investment fields remain authoritative and are
     carried forward by position.  A revised description receives a fresh
-    semantic key; missing reflected entries cannot silently delete a contract.
+    semantic key.  Ambiguous deletion and reordering are rejected before they
+    can rebind structured authority to a different criterion.
     """
     refined = tuple(refined_descriptions)
+    _reject_ambiguous_structured_rewrite(parent_criteria, refined)
     evolved: list[AcceptanceCriterionSpec] = []
     for index, parent in enumerate(parent_criteria):
         if index >= len(refined) or refined[index] == parent.description:
@@ -38,6 +40,35 @@ def evolve_acceptance_contracts(
         for description in refined[len(parent_criteria) :]
     )
     return tuple(evolved)
+
+
+def _reject_ambiguous_structured_rewrite(
+    parent_criteria: tuple[AcceptanceCriterionSpec, ...],
+    refined_descriptions: tuple[str, ...],
+) -> None:
+    """Reject legacy prose rewrites that cannot preserve structured identity."""
+    has_structured_authority = any(
+        criterion.has_success_contract or criterion.investment is not None
+        for criterion in parent_criteria
+    )
+    if not has_structured_authority:
+        return
+
+    if len(refined_descriptions) < len(parent_criteria):
+        raise ValueError(
+            "shorter refined_acs cannot preserve structured acceptance contracts; "
+            "explicit stable AC identity is required"
+        )
+
+    parent_descriptions = tuple(criterion.description for criterion in parent_criteria)
+    for index, description in enumerate(refined_descriptions[: len(parent_criteria)]):
+        if description == parent_descriptions[index]:
+            continue
+        if description in parent_descriptions:
+            raise ValueError(
+                "refined_acs reorders structured acceptance contracts; "
+                "explicit stable AC identity is required"
+            )
 
 
 def evolve_seed_contract_fields(

--- a/src/ouroboros/evolution/acceptance_contracts.py
+++ b/src/ouroboros/evolution/acceptance_contracts.py
@@ -1,0 +1,59 @@
+"""Preserve structured acceptance authority across evolution generations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ouroboros.core.seed import AcceptanceCriterionSpec, Seed
+
+
+def evolve_acceptance_contracts(
+    parent_criteria: tuple[AcceptanceCriterionSpec, ...],
+    refined_descriptions: Sequence[str],
+) -> tuple[AcceptanceCriterionSpec, ...]:
+    """Apply reflected prose without reducing structured ACs back to strings.
+
+    Reflect intentionally reasons over human-readable descriptions.  Existing
+    mechanical verification and investment fields remain authoritative and are
+    carried forward by position.  A revised description receives a fresh
+    semantic key; missing reflected entries cannot silently delete a contract.
+    """
+    refined = tuple(refined_descriptions)
+    evolved: list[AcceptanceCriterionSpec] = []
+    for index, parent in enumerate(parent_criteria):
+        if index >= len(refined) or refined[index] == parent.description:
+            evolved.append(parent)
+            continue
+        evolved.append(
+            parent.model_copy(
+                update={
+                    "description": refined[index],
+                    "semantic_ac_key": None,
+                }
+            )
+        )
+    evolved.extend(
+        AcceptanceCriterionSpec(description=description)
+        for description in refined[len(parent_criteria) :]
+    )
+    return tuple(evolved)
+
+
+def evolve_seed_contract_fields(
+    parent_seed: Seed,
+    refined_descriptions: Sequence[str],
+) -> dict[str, Any]:
+    """Return successor ACs plus thawed plugin-owned Seed fields."""
+    serialized_parent = parent_seed.to_dict()
+    extra_fields = {key: serialized_parent[key] for key in (parent_seed.model_extra or {})}
+    return {
+        "acceptance_criteria": evolve_acceptance_contracts(
+            parent_seed.acceptance_criteria,
+            refined_descriptions,
+        ),
+        **extra_fields,
+    }
+
+
+__all__ = ["evolve_acceptance_contracts", "evolve_seed_contract_fields"]

--- a/src/ouroboros/evolution/acceptance_contracts.py
+++ b/src/ouroboros/evolution/acceptance_contracts.py
@@ -3,14 +3,26 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Protocol
 
 from ouroboros.core.seed import AcceptanceCriterionSpec, Seed
+
+
+class _AcceptancePatch(Protocol):
+    @property
+    def op(self) -> str: ...
+
+    @property
+    def index(self) -> int | None: ...
+
+    @property
+    def content(self) -> str | None: ...
 
 
 def evolve_acceptance_contracts(
     parent_criteria: tuple[AcceptanceCriterionSpec, ...],
     refined_descriptions: Sequence[str],
+    refined_patches: Sequence[_AcceptancePatch] = (),
 ) -> tuple[AcceptanceCriterionSpec, ...]:
     """Apply reflected prose without reducing structured ACs back to strings.
 
@@ -20,16 +32,26 @@ def evolve_acceptance_contracts(
     semantic key.  Ambiguous deletion and reordering are rejected before they
     can rebind structured authority to a different criterion.
     """
-    refined = tuple(refined_descriptions)
-    _reject_ambiguous_structured_rewrite(parent_criteria, refined)
+    refined = tuple(_validated_description(description) for description in refined_descriptions)
+    identity_is_explicit = _validate_explicit_patch_identity(
+        parent_criteria,
+        refined,
+        refined_patches,
+    )
+    _reject_ambiguous_structured_rewrite(
+        parent_criteria,
+        refined,
+        identity_is_explicit=identity_is_explicit,
+    )
     evolved: list[AcceptanceCriterionSpec] = []
     for index, parent in enumerate(parent_criteria):
         if index >= len(refined) or refined[index] == parent.description:
             evolved.append(parent)
             continue
         evolved.append(
-            parent.model_copy(
-                update={
+            AcceptanceCriterionSpec.model_validate(
+                {
+                    **parent.model_dump(mode="python"),
                     "description": refined[index],
                     "semantic_ac_key": None,
                 }
@@ -42,9 +64,51 @@ def evolve_acceptance_contracts(
     return tuple(evolved)
 
 
+def _validated_description(description: Any) -> str:
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError("refined acceptance criteria must be non-empty strings")
+    stripped = description.strip()
+    if any(ord(character) < 32 or ord(character) == 127 for character in stripped):
+        raise ValueError("refined acceptance criteria cannot contain control characters")
+    return stripped
+
+
+def _validate_explicit_patch_identity(
+    parent_criteria: tuple[AcceptanceCriterionSpec, ...],
+    refined_descriptions: tuple[str, ...],
+    refined_patches: Sequence[_AcceptancePatch],
+) -> bool:
+    if not refined_patches:
+        return False
+    if len(refined_patches) != len(refined_descriptions):
+        raise ValueError("ac_patches must identify every refined acceptance criterion")
+
+    parent_count = len(parent_criteria)
+    for position, (description, patch) in enumerate(
+        zip(refined_descriptions, refined_patches, strict=True)
+    ):
+        op = getattr(patch, "op", None)
+        index = getattr(patch, "index", None)
+        content = getattr(patch, "content", None)
+        if position < parent_count:
+            parent = parent_criteria[position]
+            if index != position or op not in ("keep", "revise"):
+                raise ValueError("ac_patches do not preserve acceptance criterion identity")
+            if op == "keep" and description != parent.description:
+                raise ValueError("keep patch changed an acceptance criterion")
+            if op == "revise" and _validated_description(content) != description:
+                raise ValueError("revise patch content does not match refined_acs")
+            continue
+        if op != "add" or index is not None or _validated_description(content) != description:
+            raise ValueError("add patch does not match the appended refined_acs entry")
+    return True
+
+
 def _reject_ambiguous_structured_rewrite(
     parent_criteria: tuple[AcceptanceCriterionSpec, ...],
     refined_descriptions: tuple[str, ...],
+    *,
+    identity_is_explicit: bool,
 ) -> None:
     """Reject legacy prose rewrites that cannot preserve structured identity."""
     has_structured_authority = any(
@@ -54,6 +118,9 @@ def _reject_ambiguous_structured_rewrite(
     if not has_structured_authority:
         return
 
+    if identity_is_explicit:
+        return
+
     if len(refined_descriptions) < len(parent_criteria):
         raise ValueError(
             "shorter refined_acs cannot preserve structured acceptance contracts; "
@@ -61,19 +128,26 @@ def _reject_ambiguous_structured_rewrite(
         )
 
     parent_descriptions = tuple(criterion.description for criterion in parent_criteria)
+    changed_count = 0
     for index, description in enumerate(refined_descriptions[: len(parent_criteria)]):
         if description == parent_descriptions[index]:
             continue
+        changed_count += 1
         if description in parent_descriptions:
             raise ValueError(
                 "refined_acs reorders structured acceptance contracts; "
                 "explicit stable AC identity is required"
             )
+    if changed_count > 1:
+        raise ValueError(
+            "multiple structured acceptance contract revisions require explicit stable AC identity"
+        )
 
 
 def evolve_seed_contract_fields(
     parent_seed: Seed,
     refined_descriptions: Sequence[str],
+    refined_patches: Sequence[_AcceptancePatch] = (),
 ) -> dict[str, Any]:
     """Return successor ACs plus thawed plugin-owned Seed fields."""
     serialized_parent = parent_seed.to_dict()
@@ -82,6 +156,7 @@ def evolve_seed_contract_fields(
         "acceptance_criteria": evolve_acceptance_contracts(
             parent_seed.acceptance_criteria,
             refined_descriptions,
+            refined_patches,
         ),
         **extra_fields,
     }

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -17,7 +17,10 @@ from ouroboros.core.lineage import (
     OntologyDelta,
     OntologyLineage,
 )
+from ouroboros.core.seed import Seed
+from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
 from ouroboros.evolution.regression import RegressionDetector
+from ouroboros.evolution.validation_result import validation_passed
 from ouroboros.evolution.wonder import WonderOutput
 
 
@@ -30,6 +33,7 @@ class ConvergenceSignal:
     ontology_similarity: float
     generation: int
     failed_acs: tuple[int, ...] = ()
+    should_stop: bool = False
 
 
 @dataclass
@@ -65,6 +69,8 @@ class ConvergenceCriteria:
         latest_wonder: WonderOutput | None = None,
         latest_evaluation: EvaluationSummary | None = None,
         validation_output: str | None = None,
+        latest_seed: Seed | None = None,
+        validation_expected: bool = False,
     ) -> ConvergenceSignal:
         """Check if the loop should terminate.
 
@@ -79,15 +85,6 @@ class ConvergenceCriteria:
         num_completed = len(completed)
         current_gen = lineage.current_generation
 
-        # Signal 4: Hard cap (only count completed generations)
-        if num_completed >= self.max_generations:
-            return ConvergenceSignal(
-                converged=True,
-                reason=f"Max generations reached ({self.max_generations})",
-                ontology_similarity=self._latest_similarity(lineage),
-                generation=current_gen,
-            )
-
         # Loop-engineering exit gate: a convergence loop is finished when its
         # independently checked outcome passes.  Requiring ontology churn after
         # that point spends generations optimizing the loop rather than the
@@ -98,6 +95,8 @@ class ConvergenceCriteria:
                 lineage,
                 latest_evaluation,
                 validation_output,
+                latest_seed,
+                validation_expected,
             )
             if outcome_block is None:
                 score = latest_evaluation.score
@@ -107,7 +106,19 @@ class ConvergenceCriteria:
                     reason=f"Outcome gate passed: evaluation approved ({score_text})",
                     ontology_similarity=self._latest_similarity(lineage),
                     generation=current_gen,
+                    should_stop=True,
                 )
+
+        # Signal 4: hard cap after the verified outcome gate, so a first PASS
+        # on the final allowed generation is recorded as success, not exhaustion.
+        if num_completed >= self.max_generations:
+            return ConvergenceSignal(
+                converged=False,
+                reason=f"Max generations reached ({self.max_generations})",
+                ontology_similarity=self._latest_similarity(lineage),
+                generation=current_gen,
+                should_stop=True,
+            )
 
         # Need at least min_generations completed before checking other signals
         if num_completed < self.min_generations:
@@ -125,31 +136,73 @@ class ConvergenceCriteria:
         latest_sim = self._latest_similarity(lineage)
         stable_block: ConvergenceSignal | None = None
         if latest_sim >= self.convergence_threshold:
-            # Eval gate: block convergence if evaluation is unsatisfactory
-            if self.eval_gate_enabled and latest_evaluation is not None:
-                eval_blocks = not latest_evaluation.final_approved or (
-                    latest_evaluation.score is not None
-                    and latest_evaluation.score < self.eval_min_score
-                )
-                if eval_blocks:
+            # Eval gate: missing authority is not satisfactory authority.
+            if self.eval_gate_enabled:
+                if latest_evaluation is None:
                     stable_block = ConvergenceSignal(
                         converged=False,
                         reason=(
                             f"Ontology stable (similarity {latest_sim:.3f}) "
-                            f"but evaluation unsatisfactory"
+                            "but evaluation unavailable"
                         ),
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                     )
+                else:
+                    eval_blocks = not latest_evaluation.final_approved or (
+                        latest_evaluation.score is not None
+                        and latest_evaluation.score < self.eval_min_score
+                    )
+                    if eval_blocks:
+                        stable_block = ConvergenceSignal(
+                            converged=False,
+                            reason=(
+                                f"Ontology stable (similarity {latest_sim:.3f}) "
+                                "but evaluation unsatisfactory"
+                            ),
+                            ontology_similarity=latest_sim,
+                            generation=current_gen,
+                        )
 
-            # Per-AC gate: block convergence if individual ACs are failing
+            # Coverage is an authority requirement, not a configurable pass
+            # policy.  Even ``ac_gate_mode=off`` cannot turn partial evidence
+            # into verified stability convergence.
+            if stable_block is None:
+                if latest_evaluation is None:
+                    stable_block = ConvergenceSignal(
+                        converged=False,
+                        reason=(
+                            f"Ontology stable (similarity {latest_sim:.3f}) "
+                            "but evaluation unavailable"
+                        ),
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                    )
+                elif latest_seed is None:
+                    stable_block = ConvergenceSignal(
+                        converged=False,
+                        reason="Per-AC gate: current Seed unavailable for coverage validation",
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                    )
+                else:
+                    coverage = validate_seed_ac_coverage(latest_seed, latest_evaluation)
+                    if not coverage.complete:
+                        stable_block = ConvergenceSignal(
+                            converged=False,
+                            reason=f"Per-AC gate: {coverage.reason}",
+                            ontology_similarity=latest_sim,
+                            generation=current_gen,
+                        )
+
+            # Per-AC policy: complete evidence may still be rejected when
+            # individual ACs fail the configured all/ratio threshold.
             if stable_block is None and (
                 self.eval_gate_enabled
                 and self.ac_gate_mode != "off"
                 and latest_evaluation is not None
-                and latest_evaluation.ac_results
             ):
-                ac_block = self._check_ac_gate(latest_evaluation)
+                ac_block = self._check_ac_gate(latest_evaluation, latest_seed)
                 if ac_block is not None:
                     failed_indices, reason = ac_block
                     stable_block = ConvergenceSignal(
@@ -195,12 +248,18 @@ class ConvergenceCriteria:
                     generation=current_gen,
                 )
 
-            # Validation gate: block convergence if validation was skipped or failed
-            if stable_block is None and self.validation_gate_enabled and validation_output:
-                if "skipped" in validation_output.lower() or "error" in validation_output.lower():
+            # A configured validator must produce explicit, non-error evidence.
+            if stable_block is None and self.validation_gate_enabled:
+                if (validation_expected or validation_output is not None) and not validation_passed(
+                    validation_output
+                ):
+                    rendered = (validation_output or "").strip()
                     stable_block = ConvergenceSignal(
                         converged=False,
-                        reason=(f"Validation gate blocked: {validation_output}"),
+                        reason=(
+                            "Validation gate blocked: "
+                            f"{rendered or 'configured validator returned no result'}"
+                        ),
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                     )
@@ -214,6 +273,7 @@ class ConvergenceCriteria:
                     ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    should_stop=True,
                 )
 
         # Signal 2: Stagnation (unchanged for N consecutive gens)
@@ -221,13 +281,14 @@ class ConvergenceCriteria:
             stagnant = self._check_stagnation(lineage)
             if stagnant:
                 return ConvergenceSignal(
-                    converged=True,
+                    converged=False,
                     reason=(
                         f"Stagnation detected: ontology unchanged for "
                         f"{self.stagnation_window} consecutive generations"
                     ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    should_stop=True,
                 )
 
         # Signal 2.25: the judge score has stopped moving.  This is the
@@ -237,7 +298,7 @@ class ConvergenceCriteria:
         if self._check_evaluation_plateau(lineage):
             scores = self._recent_evaluation_scores(lineage)
             return ConvergenceSignal(
-                converged=True,
+                converged=False,
                 reason=(
                     "Stagnation detected: evaluation score plateau over "
                     f"{self.stagnation_window} generations "
@@ -245,6 +306,7 @@ class ConvergenceCriteria:
                 ),
                 ontology_similarity=latest_sim,
                 generation=current_gen,
+                should_stop=True,
             )
 
         # Signal 2.5: Oscillation detection (A→B→A→B cycling)
@@ -252,10 +314,11 @@ class ConvergenceCriteria:
             oscillating = self._check_oscillation(lineage)
             if oscillating:
                 return ConvergenceSignal(
-                    converged=True,
+                    converged=False,
                     reason=("Oscillation detected: ontology is cycling between similar states"),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    should_stop=True,
                 )
 
         # Signal 3: Repetitive wonder questions
@@ -263,10 +326,13 @@ class ConvergenceCriteria:
             repetitive = self._check_repetitive_feedback(lineage, latest_wonder)
             if repetitive:
                 return ConvergenceSignal(
-                    converged=True,
-                    reason="Repetitive feedback: wonder questions are repeating across generations",
+                    converged=False,
+                    reason=(
+                        "Stagnation detected: repetitive feedback questions across generations"
+                    ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    should_stop=True,
                 )
 
         if stable_block is not None:
@@ -285,17 +351,25 @@ class ConvergenceCriteria:
         lineage: OntologyLineage,
         evaluation: EvaluationSummary,
         validation_output: str | None,
+        latest_seed: Seed | None,
+        validation_expected: bool,
     ) -> str | None:
         """Return why the deterministic outcome gate cannot end the loop."""
+        if latest_seed is None:
+            return "current Seed unavailable for per-AC coverage validation"
+        coverage = validate_seed_ac_coverage(latest_seed, evaluation)
+        if not coverage.complete:
+            return coverage.reason
         if not evaluation.run_verdict_passed:
             return "evaluation rejected"
         if evaluation.score is not None and evaluation.score < self.eval_min_score:
             return "evaluation score below threshold"
-        if self.ac_gate_mode != "off" and self._check_ac_gate(evaluation) is not None:
+        if self.ac_gate_mode != "off" and self._check_ac_gate(evaluation, latest_seed) is not None:
             return "per-AC gate rejected"
-        if self.validation_gate_enabled and validation_output:
-            lowered = validation_output.lower()
-            if "skipped" in lowered or "error" in lowered:
+        if self.validation_gate_enabled:
+            if (validation_expected or validation_output is not None) and not validation_passed(
+                validation_output
+            ):
                 return "validation gate rejected"
         if self.regression_gate_enabled:
             completed = self._completed_generations(lineage)
@@ -375,8 +449,14 @@ class ConvergenceCriteria:
     def _check_ac_gate(
         self,
         evaluation: EvaluationSummary,
+        seed: Seed | None = None,
     ) -> tuple[tuple[int, ...], str] | None:
         """Check per-AC gate. Returns (failed_ac_indices, reason) if blocked, None if OK."""
+        if seed is None:
+            return (), "Per-AC gate: current Seed unavailable for coverage validation"
+        coverage = validate_seed_ac_coverage(seed, evaluation)
+        if not coverage.complete:
+            return (), f"Per-AC gate: {coverage.reason}"
         if not evaluation.ac_results:
             return None
 

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -34,6 +34,7 @@ class ConvergenceSignal:
     generation: int
     failed_acs: tuple[int, ...] = ()
     should_stop: bool = False
+    ontology_stable: bool = False
 
 
 @dataclass
@@ -54,6 +55,9 @@ class ConvergenceCriteria:
     min_generations: int = 2
     max_generations: int = 30
     enable_oscillation_detection: bool = True
+    # Backward-compatible optional evaluation policy gate.  Disabling it may
+    # skip score/ratio thresholds, but never the authoritative approval,
+    # Seed-wide coverage, or all-AC-PASS requirements below.
     eval_gate_enabled: bool = False
     eval_min_score: float = 0.7
     outcome_gate_enabled: bool = True
@@ -92,12 +96,7 @@ class ConvergenceCriteria:
         # that point spends generations optimizing the loop rather than the
         # product.  This gate deliberately precedes ``min_generations`` so a
         # correct Gen 1 can stop after one expensive Execute→Evaluate cycle.
-        if (
-            self.outcome_gate_enabled
-            and self.eval_gate_enabled
-            and evaluation_expected
-            and latest_evaluation is not None
-        ):
+        if self.outcome_gate_enabled and evaluation_expected and latest_evaluation is not None:
             outcome_block = self._outcome_gate_block(
                 lineage,
                 latest_evaluation,
@@ -143,8 +142,10 @@ class ConvergenceCriteria:
         latest_sim = self._latest_similarity(lineage)
         stable_block: ConvergenceSignal | None = None
         if latest_sim >= self.convergence_threshold:
-            # Eval gate: missing authority is not satisfactory authority.
-            if evaluation_expected and self.eval_gate_enabled:
+            # Approval is convergence authority, not an optional policy dial.
+            # Evaluation-backed modes must never converge from rejected or
+            # absent evidence even when ``eval_gate_enabled`` is false.
+            if evaluation_expected:
                 if latest_evaluation is None:
                     stable_block = ConvergenceSignal(
                         converged=False,
@@ -156,11 +157,34 @@ class ConvergenceCriteria:
                         generation=current_gen,
                     )
                 else:
-                    eval_blocks = not latest_evaluation.final_approved or (
-                        latest_evaluation.score is not None
-                        and latest_evaluation.score < self.eval_min_score
+                    failed_indices = tuple(
+                        result.ac_index
+                        for result in latest_evaluation.ac_results
+                        if result.unresolved
                     )
-                    if eval_blocks:
+                    eval_blocks = (
+                        not latest_evaluation.final_approved
+                        or not latest_evaluation.run_verdict_passed
+                    )
+                    if self.eval_gate_enabled:
+                        eval_blocks = eval_blocks or (
+                            latest_evaluation.score is not None
+                            and latest_evaluation.score < self.eval_min_score
+                        )
+                    if failed_indices:
+                        failed_display = ", ".join(str(index + 1) for index in failed_indices)
+                        stable_block = ConvergenceSignal(
+                            converged=False,
+                            reason=(
+                                "Per-AC authority: "
+                                f"{len(failed_indices)} AC(s) still unresolved "
+                                f"(AC {failed_display})"
+                            ),
+                            ontology_similarity=latest_sim,
+                            generation=current_gen,
+                            failed_acs=failed_indices,
+                        )
+                    elif eval_blocks:
                         stable_block = ConvergenceSignal(
                             converged=False,
                             reason=(
@@ -202,8 +226,8 @@ class ConvergenceCriteria:
                             generation=current_gen,
                         )
 
-            # Per-AC policy: complete evidence may still be rejected when
-            # individual ACs fail the configured all/ratio threshold.
+            # Optional per-AC policy: complete passing evidence may still be
+            # subject to configured thresholds while the policy gate is on.
             if stable_block is None and (
                 evaluation_expected
                 and self.eval_gate_enabled
@@ -244,7 +268,7 @@ class ConvergenceCriteria:
             # preserving a well-performing ontology, or Wonder/Reflect encountered
             # errors. Either way, withhold convergence until genuine evolution occurs.
             evolved_count = self._count_evolved_generations(lineage)
-            if stable_block is None and evolved_count == 0:
+            if stable_block is None and evaluation_expected and evolved_count == 0:
                 stable_block = ConvergenceSignal(
                     converged=False,
                     reason=(
@@ -273,6 +297,19 @@ class ConvergenceCriteria:
                     )
 
             if stable_block is None:
+                if not evaluation_expected:
+                    return ConvergenceSignal(
+                        converged=False,
+                        reason=(
+                            f"Ontology stable: similarity {latest_sim:.3f} "
+                            f">= threshold {self.convergence_threshold}; "
+                            "execution and evaluation are required for verified convergence"
+                        ),
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                        should_stop=True,
+                        ontology_stable=True,
+                    )
                 return ConvergenceSignal(
                     converged=True,
                     reason=(
@@ -368,11 +405,21 @@ class ConvergenceCriteria:
         coverage = validate_seed_ac_coverage(latest_seed, evaluation)
         if not coverage.complete:
             return coverage.reason
-        if not evaluation.run_verdict_passed:
+        if not evaluation.final_approved or not evaluation.run_verdict_passed:
             return "evaluation rejected"
-        if evaluation.score is not None and evaluation.score < self.eval_min_score:
+        if any(result.unresolved for result in evaluation.ac_results):
+            return "per-AC authority rejected"
+        if (
+            self.eval_gate_enabled
+            and evaluation.score is not None
+            and evaluation.score < self.eval_min_score
+        ):
             return "evaluation score below threshold"
-        if self.ac_gate_mode != "off" and self._check_ac_gate(evaluation, latest_seed) is not None:
+        if (
+            self.eval_gate_enabled
+            and self.ac_gate_mode != "off"
+            and self._check_ac_gate(evaluation, latest_seed) is not None
+        ):
             return "per-AC gate rejected"
         if self.validation_gate_enabled:
             if (validation_expected or validation_output is not None) and not validation_passed(
@@ -468,7 +515,7 @@ class ConvergenceCriteria:
         if not evaluation.ac_results:
             return None
 
-        failed = tuple(ac.ac_index for ac in evaluation.ac_results if not ac.passed)
+        failed = tuple(ac.ac_index for ac in evaluation.ac_results if ac.unresolved)
         if not failed:
             return None
 
@@ -479,7 +526,7 @@ class ConvergenceCriteria:
         if self.ac_gate_mode == "all":
             failed_display = ", ".join(str(i + 1) for i in failed)
             return failed, (
-                f"Per-AC gate (mode=all): {len(failed)} AC(s) still failing (AC {failed_display})"
+                f"Per-AC gate (mode=all): {len(failed)} AC(s) still unresolved (AC {failed_display})"
             )
         elif self.ac_gate_mode == "ratio":
             if ratio < self.ac_min_pass_ratio:

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -1,11 +1,9 @@
 """Convergence criteria for the evolutionary loop.
 
-Determines when the loop should terminate. v1 uses 3 signals:
-1. Ontology stability (similarity >= threshold)
-2. Stagnation detection (unchanged ontology for N consecutive gens)
-3. max_generations hard cap
-
-v1.1 will add drift-trend and evaluation-satisfaction signals.
+Determines when the loop should terminate using outcome satisfaction, ontology
+stability, no-drift/stagnation detection, oscillation, and a hard generation
+cap.  The outcome gate is checked before the minimum-generation guard so a
+verified first generation does not pay for unnecessary evolutionary churn.
 """
 
 from __future__ import annotations
@@ -54,6 +52,8 @@ class ConvergenceCriteria:
     enable_oscillation_detection: bool = True
     eval_gate_enabled: bool = False
     eval_min_score: float = 0.7
+    outcome_gate_enabled: bool = True
+    evaluation_plateau_epsilon: float = 0.01
     ac_gate_mode: str = "all"  # "all" | "ratio" | "off"
     ac_min_pass_ratio: float = 1.0  # for "ratio" mode
     regression_gate_enabled: bool = True
@@ -88,6 +88,27 @@ class ConvergenceCriteria:
                 generation=current_gen,
             )
 
+        # Loop-engineering exit gate: a convergence loop is finished when its
+        # independently checked outcome passes.  Requiring ontology churn after
+        # that point spends generations optimizing the loop rather than the
+        # product.  This gate deliberately precedes ``min_generations`` so a
+        # correct Gen 1 can stop after one expensive Execute→Evaluate cycle.
+        if self.outcome_gate_enabled and self.eval_gate_enabled and latest_evaluation is not None:
+            outcome_block = self._outcome_gate_block(
+                lineage,
+                latest_evaluation,
+                validation_output,
+            )
+            if outcome_block is None:
+                score = latest_evaluation.score
+                score_text = "unscored" if score is None else f"score {score:.3f}"
+                return ConvergenceSignal(
+                    converged=True,
+                    reason=f"Outcome gate passed: evaluation approved ({score_text})",
+                    ontology_similarity=self._latest_similarity(lineage),
+                    generation=current_gen,
+                )
+
         # Need at least min_generations completed before checking other signals
         if num_completed < self.min_generations:
             return ConvergenceSignal(
@@ -97,8 +118,12 @@ class ConvergenceCriteria:
                 generation=current_gen,
             )
 
-        # Signal 1: Ontology stability (latest two generations)
+        # Signal 1: Ontology stability (latest two generations).  A blocked
+        # stable candidate is retained while no-progress detectors run below;
+        # returning immediately here used to bypass stagnation and burn all 30
+        # generations on the same failing output.
         latest_sim = self._latest_similarity(lineage)
+        stable_block: ConvergenceSignal | None = None
         if latest_sim >= self.convergence_threshold:
             # Eval gate: block convergence if evaluation is unsatisfactory
             if self.eval_gate_enabled and latest_evaluation is not None:
@@ -107,7 +132,7 @@ class ConvergenceCriteria:
                     and latest_evaluation.score < self.eval_min_score
                 )
                 if eval_blocks:
-                    return ConvergenceSignal(
+                    stable_block = ConvergenceSignal(
                         converged=False,
                         reason=(
                             f"Ontology stable (similarity {latest_sim:.3f}) "
@@ -118,7 +143,7 @@ class ConvergenceCriteria:
                     )
 
             # Per-AC gate: block convergence if individual ACs are failing
-            if (
+            if stable_block is None and (
                 self.eval_gate_enabled
                 and self.ac_gate_mode != "off"
                 and latest_evaluation is not None
@@ -127,7 +152,7 @@ class ConvergenceCriteria:
                 ac_block = self._check_ac_gate(latest_evaluation)
                 if ac_block is not None:
                     failed_indices, reason = ac_block
-                    return ConvergenceSignal(
+                    stable_block = ConvergenceSignal(
                         converged=False,
                         reason=reason,
                         ontology_similarity=latest_sim,
@@ -136,14 +161,14 @@ class ConvergenceCriteria:
                     )
 
             # Signal 5: Regression gate — block convergence if ACs regressed
-            if self.regression_gate_enabled:
+            if stable_block is None and self.regression_gate_enabled:
                 # Pass only completed generations to regression detector
                 completed_lineage = lineage.model_copy(update={"generations": completed})
                 regression_report = RegressionDetector().detect(completed_lineage)
                 if regression_report.has_regressions:
                     regressed = regression_report.regressed_ac_indices
                     display = ", ".join(str(i + 1) for i in regressed)
-                    return ConvergenceSignal(
+                    stable_block = ConvergenceSignal(
                         converged=False,
                         reason=(
                             f"Regression detected: {len(regressed)} AC(s) regressed (AC {display})"
@@ -158,8 +183,8 @@ class ConvergenceCriteria:
             # preserving a well-performing ontology, or Wonder/Reflect encountered
             # errors. Either way, withhold convergence until genuine evolution occurs.
             evolved_count = self._count_evolved_generations(lineage)
-            if evolved_count == 0:
-                return ConvergenceSignal(
+            if stable_block is None and evolved_count == 0:
+                stable_block = ConvergenceSignal(
                     converged=False,
                     reason=(
                         f"Convergence withheld: similarity {latest_sim:.3f} "
@@ -171,24 +196,25 @@ class ConvergenceCriteria:
                 )
 
             # Validation gate: block convergence if validation was skipped or failed
-            if self.validation_gate_enabled and validation_output:
+            if stable_block is None and self.validation_gate_enabled and validation_output:
                 if "skipped" in validation_output.lower() or "error" in validation_output.lower():
-                    return ConvergenceSignal(
+                    stable_block = ConvergenceSignal(
                         converged=False,
                         reason=(f"Validation gate blocked: {validation_output}"),
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                     )
 
-            return ConvergenceSignal(
-                converged=True,
-                reason=(
-                    f"Ontology converged: similarity {latest_sim:.3f} "
-                    f">= threshold {self.convergence_threshold}"
-                ),
-                ontology_similarity=latest_sim,
-                generation=current_gen,
-            )
+            if stable_block is None:
+                return ConvergenceSignal(
+                    converged=True,
+                    reason=(
+                        f"Ontology converged: similarity {latest_sim:.3f} "
+                        f">= threshold {self.convergence_threshold}"
+                    ),
+                    ontology_similarity=latest_sim,
+                    generation=current_gen,
+                )
 
         # Signal 2: Stagnation (unchanged for N consecutive gens)
         if num_completed >= self.stagnation_window:
@@ -203,6 +229,23 @@ class ConvergenceCriteria:
                     ontology_similarity=latest_sim,
                     generation=current_gen,
                 )
+
+        # Signal 2.25: the judge score has stopped moving.  This is the
+        # learning-loop stop rule from loop engineering: when the last N
+        # rejected candidates differ by less than epsilon, another full run has
+        # negative expected value and should hand off to ``unstuck``.
+        if self._check_evaluation_plateau(lineage):
+            scores = self._recent_evaluation_scores(lineage)
+            return ConvergenceSignal(
+                converged=True,
+                reason=(
+                    "Stagnation detected: evaluation score plateau over "
+                    f"{self.stagnation_window} generations "
+                    f"(scores={', '.join(f'{score:.3f}' for score in scores)})"
+                ),
+                ontology_similarity=latest_sim,
+                generation=current_gen,
+            )
 
         # Signal 2.5: Oscillation detection (A→B→A→B cycling)
         if self.enable_oscillation_detection and num_completed >= 3:
@@ -226,12 +269,68 @@ class ConvergenceCriteria:
                     generation=current_gen,
                 )
 
+        if stable_block is not None:
+            return stable_block
+
         # Not converged
         return ConvergenceSignal(
             converged=False,
             reason=f"Continuing: similarity {latest_sim:.3f} < {self.convergence_threshold}",
             ontology_similarity=latest_sim,
             generation=current_gen,
+        )
+
+    def _outcome_gate_block(
+        self,
+        lineage: OntologyLineage,
+        evaluation: EvaluationSummary,
+        validation_output: str | None,
+    ) -> str | None:
+        """Return why the deterministic outcome gate cannot end the loop."""
+        if not evaluation.run_verdict_passed:
+            return "evaluation rejected"
+        if evaluation.score is not None and evaluation.score < self.eval_min_score:
+            return "evaluation score below threshold"
+        if self.ac_gate_mode != "off" and self._check_ac_gate(evaluation) is not None:
+            return "per-AC gate rejected"
+        if self.validation_gate_enabled and validation_output:
+            lowered = validation_output.lower()
+            if "skipped" in lowered or "error" in lowered:
+                return "validation gate rejected"
+        if self.regression_gate_enabled:
+            completed = self._completed_generations(lineage)
+            completed_lineage = lineage.model_copy(update={"generations": completed})
+            if RegressionDetector().detect(completed_lineage).has_regressions:
+                return "regression gate rejected"
+        return None
+
+    def _recent_evaluation_scores(self, lineage: OntologyLineage) -> tuple[float, ...]:
+        """Return the bounded score window used by no-drift detection."""
+        completed = self._completed_generations(lineage)
+        recent = completed[-self.stagnation_window :]
+        return tuple(
+            float(generation.evaluation_summary.score)
+            for generation in recent
+            if generation.evaluation_summary is not None
+            and generation.evaluation_summary.score is not None
+        )
+
+    def _check_evaluation_plateau(self, lineage: OntologyLineage) -> bool:
+        """Detect N rejected generations with no meaningful score movement."""
+        completed = self._completed_generations(lineage)
+        if len(completed) < self.stagnation_window:
+            return False
+        recent = completed[-self.stagnation_window :]
+        summaries = [generation.evaluation_summary for generation in recent]
+        if any(summary is None or summary.score is None for summary in summaries):
+            return False
+        typed = [summary for summary in summaries if summary is not None]
+        if any(summary.run_verdict_passed for summary in typed):
+            return False
+        scores = [float(summary.score) for summary in typed if summary.score is not None]
+        return all(
+            abs(scores[index] - scores[index - 1]) < self.evaluation_plateau_epsilon
+            for index in range(1, len(scores))
         )
 
     def _completed_generations(self, lineage: OntologyLineage) -> tuple[GenerationRecord, ...]:

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -70,6 +70,7 @@ class ConvergenceCriteria:
         latest_evaluation: EvaluationSummary | None = None,
         validation_output: str | None = None,
         latest_seed: Seed | None = None,
+        evaluation_expected: bool = True,
         validation_expected: bool = False,
     ) -> ConvergenceSignal:
         """Check if the loop should terminate.
@@ -77,6 +78,7 @@ class ConvergenceCriteria:
         Args:
             lineage: Current lineage with all generation records.
             latest_wonder: Latest wonder output (for repetitive feedback check).
+            evaluation_expected: Whether this mode executes and evaluates the Seed.
 
         Returns:
             ConvergenceSignal with convergence status and reason.
@@ -90,7 +92,12 @@ class ConvergenceCriteria:
         # that point spends generations optimizing the loop rather than the
         # product.  This gate deliberately precedes ``min_generations`` so a
         # correct Gen 1 can stop after one expensive Execute→Evaluate cycle.
-        if self.outcome_gate_enabled and self.eval_gate_enabled and latest_evaluation is not None:
+        if (
+            self.outcome_gate_enabled
+            and self.eval_gate_enabled
+            and evaluation_expected
+            and latest_evaluation is not None
+        ):
             outcome_block = self._outcome_gate_block(
                 lineage,
                 latest_evaluation,
@@ -137,7 +144,7 @@ class ConvergenceCriteria:
         stable_block: ConvergenceSignal | None = None
         if latest_sim >= self.convergence_threshold:
             # Eval gate: missing authority is not satisfactory authority.
-            if self.eval_gate_enabled:
+            if evaluation_expected and self.eval_gate_enabled:
                 if latest_evaluation is None:
                     stable_block = ConvergenceSignal(
                         converged=False,
@@ -167,7 +174,7 @@ class ConvergenceCriteria:
             # Coverage is an authority requirement, not a configurable pass
             # policy.  Even ``ac_gate_mode=off`` cannot turn partial evidence
             # into verified stability convergence.
-            if stable_block is None:
+            if stable_block is None and evaluation_expected:
                 if latest_evaluation is None:
                     stable_block = ConvergenceSignal(
                         converged=False,
@@ -198,7 +205,8 @@ class ConvergenceCriteria:
             # Per-AC policy: complete evidence may still be rejected when
             # individual ACs fail the configured all/ratio threshold.
             if stable_block is None and (
-                self.eval_gate_enabled
+                evaluation_expected
+                and self.eval_gate_enabled
                 and self.ac_gate_mode != "off"
                 and latest_evaluation is not None
             ):

--- a/src/ouroboros/evolution/directive_mapping.py
+++ b/src/ouroboros/evolution/directive_mapping.py
@@ -71,6 +71,7 @@ def step_action_to_directive(
     ============================  ==================================
     ``CONTINUE``                  ``None`` (no emission)
     ``CONVERGED``                 ``CONVERGE``
+    ``ONTOLOGY_STABLE``           ``EVALUATE``
     ``STAGNATED``                 ``UNSTUCK``
     ``EXHAUSTED``                 ``CANCEL``
     ``FAILED`` (budget > 0)       ``RETRY``
@@ -83,6 +84,8 @@ def step_action_to_directive(
         return None
     if value == "converged":
         return Directive.CONVERGE
+    if value == "ontology_stable":
+        return Directive.EVALUATE
     if value == "stagnated":
         return Directive.UNSTUCK
     if value == "exhausted":

--- a/src/ouroboros/evolution/evaluation_coverage.py
+++ b/src/ouroboros/evolution/evaluation_coverage.py
@@ -1,0 +1,105 @@
+"""Authoritative Seed-wide acceptance-verdict coverage checks.
+
+Per-AC consumers must not infer completeness from a non-empty tuple.  The
+evaluator contract is complete only when every current Seed criterion appears
+exactly once, at the expected index, with the expected human-readable content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.core.lineage import EvaluationSummary
+from ouroboros.core.seed import Seed, ac_texts
+
+
+@dataclass(frozen=True, slots=True)
+class ACVerdictCoverage:
+    """Result of validating one evaluation against its Seed contract."""
+
+    complete: bool
+    reason: str
+    expected_indices: tuple[int, ...]
+    reported_indices: tuple[int, ...]
+
+
+def validate_seed_ac_coverage(
+    seed: Seed,
+    evaluation: EvaluationSummary,
+) -> ACVerdictCoverage:
+    """Require complete, unique, in-range verdicts for the current Seed."""
+    expected_acs = ac_texts(seed.acceptance_criteria)
+    expected_indices = tuple(range(len(expected_acs)))
+    reported_indices = tuple(result.ac_index for result in evaluation.ac_results)
+
+    if len(reported_indices) != len(set(reported_indices)):
+        return ACVerdictCoverage(
+            complete=False,
+            reason="duplicate per-AC verdict indices",
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    out_of_range = tuple(
+        index for index in reported_indices if index < 0 or index >= len(expected_acs)
+    )
+    if out_of_range:
+        return ACVerdictCoverage(
+            complete=False,
+            reason=f"out-of-range per-AC verdict indices: {list(out_of_range)}",
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    if set(reported_indices) != set(expected_indices):
+        missing = sorted(set(expected_indices) - set(reported_indices))
+        return ACVerdictCoverage(
+            complete=False,
+            reason=f"missing per-AC verdict indices: {missing}",
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    mismatched = tuple(
+        result.ac_index
+        for result in evaluation.ac_results
+        if result.ac_content.strip() != expected_acs[result.ac_index].strip()
+    )
+    if mismatched:
+        return ACVerdictCoverage(
+            complete=False,
+            reason=f"per-AC verdict content differs from Seed at indices: {list(mismatched)}",
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    identity_mismatched = tuple(
+        result.ac_index
+        for result in evaluation.ac_results
+        if result.semantic_ac_key != seed.acceptance_criteria[result.ac_index].semantic_ac_key
+        and (
+            seed.acceptance_criteria[result.ac_index].has_success_contract
+            or seed.acceptance_criteria[result.ac_index].investment is not None
+            or result.semantic_ac_key is not None
+        )
+    )
+    if identity_mismatched:
+        return ACVerdictCoverage(
+            complete=False,
+            reason=(
+                "per-AC verdict semantic identity differs from Seed at indices: "
+                f"{list(identity_mismatched)}"
+            ),
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    return ACVerdictCoverage(
+        complete=True,
+        reason="complete Seed-wide per-AC verdict coverage",
+        expected_indices=expected_indices,
+        reported_indices=reported_indices,
+    )
+
+
+__all__ = ["ACVerdictCoverage", "validate_seed_ac_coverage"]

--- a/src/ouroboros/evolution/evaluation_coverage.py
+++ b/src/ouroboros/evolution/evaluation_coverage.py
@@ -26,8 +26,15 @@ class ACVerdictCoverage:
 def validate_seed_ac_coverage(
     seed: Seed,
     evaluation: EvaluationSummary,
+    *,
+    require_authoritative: bool = True,
 ) -> ACVerdictCoverage:
-    """Require complete, unique, in-range verdicts for the current Seed."""
+    """Require complete, unique, current verdicts for the current Seed.
+
+    Convergence callers use the authoritative default. Working-set selection
+    may validate structural coverage alone, then keep each non-authoritative
+    criterion active while still freezing unrelated authoritative passes.
+    """
     expected_acs = ac_texts(seed.acceptance_criteria)
     expected_indices = tuple(range(len(expected_acs)))
     reported_indices = tuple(result.ac_index for result in evaluation.ac_results)
@@ -89,6 +96,19 @@ def validate_seed_ac_coverage(
             reason=(
                 "per-AC verdict semantic identity differs from Seed at indices: "
                 f"{list(identity_mismatched)}"
+            ),
+            expected_indices=expected_indices,
+            reported_indices=reported_indices,
+        )
+
+    non_authoritative = tuple(
+        result.ac_index for result in evaluation.ac_results if not result.verdict_is_authoritative
+    )
+    if require_authoritative and non_authoritative:
+        return ACVerdictCoverage(
+            complete=False,
+            reason=(
+                f"non-authoritative per-AC verdict states at indices: {list(non_authoritative)}"
             ),
             expected_indices=expected_indices,
             reported_indices=reported_indices,

--- a/src/ouroboros/evolution/focus.py
+++ b/src/ouroboros/evolution/focus.py
@@ -1,0 +1,215 @@
+"""Deterministic working-set selection for focused evolution.
+
+Loop engineering converges by shrinking the work that remains.  This module
+turns the previous generation's verification evidence into an explicit AC
+working set: failed, changed, challenged, regressed, and newly-added nodes stay
+active; proven passing nodes are frozen and only reverified at the boundary.
+
+The selector is deliberately independent of LLM output such as
+``ReflectOutput.settled_ac_indices``.  A model may propose a change, but it does
+not decide which already-passing nodes are safe to rerun.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+import logging
+from typing import Any
+
+from ouroboros.core.lineage import EvaluationSummary
+from ouroboros.core.seed import Seed, ac_texts
+from ouroboros.evolution.regression import RegressionReport
+from ouroboros.evolution.wonder import WonderOutput
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class EvolutionFocus:
+    """The AC nodes open for mutation and the nodes frozen by evidence."""
+
+    active_ac_indices: tuple[int, ...]
+    frozen_ac_indices: tuple[int, ...]
+    reason: str
+
+    @property
+    def is_scoped(self) -> bool:
+        """Whether this generation can skip at least one proven node."""
+        return bool(self.frozen_ac_indices)
+
+    def externally_satisfied_acs(self) -> dict[int, dict[str, str]]:
+        """Build the executor contract for nodes frozen by the prior gate."""
+        return {
+            index: {
+                "reason": (
+                    "frozen by prior PASS evidence; excluded from evolve and "
+                    "reverified at the final boundary"
+                )
+            }
+            for index in self.frozen_ac_indices
+        }
+
+    def log_selection(self, generation_number: int) -> None:
+        """Emit the selected working set without burdening the orchestrator."""
+        logger.info(
+            "evolution.generation.focus_selected",
+            extra={
+                "generation": generation_number,
+                "active_ac_indices": self.active_ac_indices,
+                "frozen_ac_indices": self.frozen_ac_indices,
+                "reason": self.reason,
+            },
+        )
+
+
+def initial_evolution_focus(seed: Seed) -> EvolutionFocus:
+    """Keep every AC active until a verifier has produced node evidence."""
+    return EvolutionFocus(
+        active_ac_indices=tuple(range(len(getattr(seed, "acceptance_criteria", ())))),
+        frozen_ac_indices=(),
+        reason="initial/full generation",
+    )
+
+
+def callable_accepts_keyword(
+    callable_obj: Any,
+    keyword: str,
+    signature_getter: Any = inspect.signature,
+) -> bool:
+    """Return whether a callable supports a keyword or arbitrary keywords."""
+    try:
+        signature = signature_getter(callable_obj)
+    except (TypeError, ValueError):
+        return False
+    return keyword in signature.parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+async def call_executor(
+    executor: Any,
+    seed: Seed,
+    *,
+    parallel: bool,
+    execution_id: str | None,
+    externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
+) -> Any:
+    """Invoke an executor while negotiating optional evolve context."""
+    kwargs: dict[str, Any] = {"parallel": parallel}
+    if execution_id is not None and callable_accepts_keyword(executor, "execution_id"):
+        kwargs["execution_id"] = execution_id
+    if externally_satisfied_acs and callable_accepts_keyword(executor, "externally_satisfied_acs"):
+        kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+    return await executor(seed, **kwargs)
+
+
+def add_active_focus(
+    kwargs: dict[str, Any],
+    callable_obj: Any,
+    focus: EvolutionFocus,
+) -> None:
+    """Pass the active set only to focus-aware Wonder/Reflect implementations."""
+    if focus.is_scoped and callable_accepts_keyword(callable_obj, "active_ac_indices"):
+        kwargs["active_ac_indices"] = focus.active_ac_indices
+
+
+def select_externally_satisfied_acs(
+    *,
+    scoped_reexecution: bool,
+    focused_evolution: bool,
+    focus: EvolutionFocus,
+    settled_ac_indices: tuple[int, ...],
+    reflect_ran_fresh: bool,
+) -> dict[int, dict[str, str]] | None:
+    """Map frozen nodes to the executor while retaining legacy opt-out behavior."""
+    if not scoped_reexecution or not reflect_ran_fresh:
+        return None
+    if focused_evolution and focus.is_scoped:
+        return focus.externally_satisfied_acs()
+    if focused_evolution or not settled_ac_indices:
+        return None
+    return {
+        index: {
+            "reason": "satisficed: passed previously; not challenged or regressed",
+        }
+        for index in settled_ac_indices
+    }
+
+
+def select_evolution_focus(
+    parent_seed: Seed,
+    candidate_seed: Seed,
+    evaluation: EvaluationSummary | None,
+    *,
+    wonder: WonderOutput | None = None,
+    regression_report: RegressionReport | None = None,
+    enabled: bool = True,
+) -> EvolutionFocus:
+    """Select the smallest evidence-backed AC working set.
+
+    Scoping is fail-closed.  Without per-AC verdicts, or when every reported AC
+    passed but the aggregate gate still did not end the lineage, every node
+    remains active.  This avoids treating missing evidence as a PASS.
+    """
+    parent_acs = ac_texts(parent_seed.acceptance_criteria)
+    candidate_acs = ac_texts(candidate_seed.acceptance_criteria)
+    all_candidate = set(range(len(candidate_acs)))
+
+    if not enabled or evaluation is None or not evaluation.ac_results:
+        return EvolutionFocus(
+            active_ac_indices=tuple(sorted(all_candidate)),
+            frozen_ac_indices=(),
+            reason="full generation: no per-AC PASS evidence available",
+        )
+
+    passed = {
+        result.ac_index
+        for result in evaluation.ac_results
+        if result.passed and 0 <= result.ac_index < len(parent_acs)
+    }
+    failed = {
+        result.ac_index
+        for result in evaluation.ac_results
+        if not result.passed and 0 <= result.ac_index < len(parent_acs)
+    }
+
+    # If the aggregate run failed without naming a failed AC, the failure sits
+    # outside the addressable node set (for example execution/validation).  A
+    # node-focused retry would have no honest target, so keep the full graph open.
+    if not failed:
+        return EvolutionFocus(
+            active_ac_indices=tuple(sorted(all_candidate)),
+            frozen_ac_indices=(),
+            reason="full generation: aggregate gate has no failed AC target",
+        )
+
+    challenged: set[int] = set()
+    if wonder is not None:
+        for question in wonder.grounded_questions:
+            if question.kind == "challenge":
+                challenged.update(question.ac_indices)
+
+    regressed = (
+        set(regression_report.regressed_ac_indices) if regression_report is not None else set()
+    )
+    changed = {
+        index
+        for index in range(min(len(parent_acs), len(candidate_acs)))
+        if parent_acs[index] != candidate_acs[index]
+    }
+    added = set(range(len(parent_acs), len(candidate_acs)))
+    reopened = challenged | regressed | changed | added
+
+    frozen = {index for index in passed - reopened if index in all_candidate}
+    active = all_candidate - frozen
+
+    return EvolutionFocus(
+        active_ac_indices=tuple(sorted(active)),
+        frozen_ac_indices=tuple(sorted(frozen)),
+        reason=(
+            f"focused generation: {len(active)} active / {len(frozen)} frozen "
+            "from prior per-AC gate"
+        ),
+    )

--- a/src/ouroboros/evolution/focus.py
+++ b/src/ouroboros/evolution/focus.py
@@ -125,11 +125,15 @@ def select_externally_satisfied_acs(
     reflect_ran_fresh: bool,
 ) -> dict[int, dict[str, str]] | None:
     """Map frozen nodes to the executor while retaining legacy opt-out behavior."""
-    if not scoped_reexecution or not reflect_ran_fresh:
+    if not scoped_reexecution:
         return None
-    if focused_evolution and focus.is_scoped:
-        return focus.externally_satisfied_acs()
-    if focused_evolution or not settled_ac_indices:
+    if focused_evolution:
+        # Focus is reconstructed deterministically from the prior authoritative
+        # evaluation and the persisted candidate Seed.  Unlike legacy
+        # ``settled_ac_indices`` it remains authoritative when Reflect was
+        # restored from an interruption checkpoint rather than run afresh.
+        return focus.externally_satisfied_acs() if focus.is_scoped else None
+    if not reflect_ran_fresh or not settled_ac_indices:
         return None
     return {
         index: {
@@ -165,7 +169,11 @@ def select_evolution_focus(
             reason="full generation: no per-AC PASS evidence available",
         )
 
-    coverage = validate_seed_ac_coverage(parent_seed, evaluation)
+    coverage = validate_seed_ac_coverage(
+        parent_seed,
+        evaluation,
+        require_authoritative=False,
+    )
     if not coverage.complete:
         return EvolutionFocus(
             active_ac_indices=tuple(sorted(all_candidate)),
@@ -176,12 +184,12 @@ def select_evolution_focus(
     passed = {
         result.ac_index
         for result in evaluation.ac_results
-        if result.passed and 0 <= result.ac_index < len(parent_acs)
+        if result.authoritative_pass and 0 <= result.ac_index < len(parent_acs)
     }
     failed = {
         result.ac_index
         for result in evaluation.ac_results
-        if not result.passed and 0 <= result.ac_index < len(parent_acs)
+        if result.unresolved and 0 <= result.ac_index < len(parent_acs)
     }
 
     # If the aggregate run failed without naming a failed AC, the failure sits

--- a/src/ouroboros/evolution/focus.py
+++ b/src/ouroboros/evolution/focus.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from ouroboros.core.lineage import EvaluationSummary
 from ouroboros.core.seed import Seed, ac_texts
+from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
 from ouroboros.evolution.regression import RegressionReport
 from ouroboros.evolution.wonder import WonderOutput
 
@@ -162,6 +163,14 @@ def select_evolution_focus(
             active_ac_indices=tuple(sorted(all_candidate)),
             frozen_ac_indices=(),
             reason="full generation: no per-AC PASS evidence available",
+        )
+
+    coverage = validate_seed_ac_coverage(parent_seed, evaluation)
+    if not coverage.complete:
+        return EvolutionFocus(
+            active_ac_indices=tuple(sorted(all_candidate)),
+            frozen_ac_indices=(),
+            reason=f"full generation: {coverage.reason}",
         )
 
     passed = {

--- a/src/ouroboros/evolution/focus.py
+++ b/src/ouroboros/evolution/focus.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any
 
 from ouroboros.core.lineage import EvaluationSummary
-from ouroboros.core.seed import Seed, ac_texts
+from ouroboros.core.seed import Seed
 from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
 from ouroboros.evolution.regression import RegressionReport
 from ouroboros.evolution.wonder import WonderOutput
@@ -154,8 +154,8 @@ def select_evolution_focus(
     passed but the aggregate gate still did not end the lineage, every node
     remains active.  This avoids treating missing evidence as a PASS.
     """
-    parent_acs = ac_texts(parent_seed.acceptance_criteria)
-    candidate_acs = ac_texts(candidate_seed.acceptance_criteria)
+    parent_acs = parent_seed.acceptance_criteria
+    candidate_acs = candidate_seed.acceptance_criteria
     all_candidate = set(range(len(candidate_acs)))
 
     if not enabled or evaluation is None or not evaluation.ac_results:
@@ -206,6 +206,9 @@ def select_evolution_focus(
     changed = {
         index
         for index in range(min(len(parent_acs), len(candidate_acs)))
+        # Display prose is not the authority boundary. Reopen whenever any
+        # structured verifier, artifact, assertion, investment, or semantic
+        # identity field changed beneath the previously passing verdict.
         if parent_acs[index] != candidate_acs[index]
     }
     added = set(range(len(parent_acs), len(candidate_acs)))

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -1480,7 +1480,15 @@ class EvolutionaryLoop:
                     )
                 if _should_skip("reflecting") and ps.get("reflect_output"):
                     try:
-                        reflect_output = ReflectOutput.model_validate(ps["reflect_output"])
+                        restored_reflect_output = ReflectOutput.model_validate(ps["reflect_output"])
+                        if restored_reflect_output.ac_patches:
+                            # Parser-issued patch provenance is intentionally not
+                            # serialized. Re-run Reflect rather than trusting a
+                            # replay payload to preserve authority-bearing fields.
+                            resume_after_phase = "wondering"
+                            reflect_output = None
+                        else:
+                            reflect_output = restored_reflect_output
                     except Exception as e:
                         logger.warning(
                             "evolution.resume.reflect_output_restore_failed",

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -599,6 +599,7 @@ class EvolutionaryLoop:
                 latest_evaluation=result.evaluation_summary,
                 validation_output=result.validation_output,
                 latest_seed=result.seed,
+                evaluation_expected=True,
                 validation_expected=self.validator is not None,
             )
 
@@ -1103,7 +1104,8 @@ class EvolutionaryLoop:
                 latest_evaluation=result.evaluation_summary,
                 validation_output=result.validation_output,
                 latest_seed=result.seed,
-                validation_expected=self.validator is not None,
+                evaluation_expected=execute,
+                validation_expected=execute and self.validator is not None,
             )
 
             action = StepAction.CONTINUE

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -46,7 +46,6 @@ from ouroboros.events.lineage import (
     lineage_generation_failed,
     lineage_generation_interrupted,
     lineage_generation_phase_changed,
-    lineage_generation_started,
     lineage_ontology_evolved,
     lineage_stagnated,
     lineage_wonder_degraded,
@@ -55,7 +54,6 @@ from ouroboros.evolution import focus, loop_support
 from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
 from ouroboros.evolution.directive_mapping import (
     is_terminal_directive,
-    step_action_to_directive,
     watchdog_timeout_to_directive,
 )
 from ouroboros.evolution.projector import LineageProjector
@@ -144,6 +142,7 @@ class StepAction(StrEnum):
 
     CONTINUE = "continue"
     CONVERGED = "converged"
+    ONTOLOGY_STABLE = "ontology_stable"
     STAGNATED = "stagnated"
     EXHAUSTED = "exhausted"
     FAILED = "failed"
@@ -171,21 +170,6 @@ class _StepResultContainer:
     """Mutable container for passing StepResult out of AgentProcess work."""
 
     result: Result[StepResult, OuroborosError] | None = None
-
-
-def _watchdog_timeout_step_action(timeout_kind: str) -> StepAction:
-    """Return the public ``evolve_step`` action matching a watchdog directive."""
-    directive = watchdog_timeout_to_directive(timeout_kind)
-    if directive is None:
-        return StepAction.FAILED
-    if is_terminal_directive(directive):
-        return StepAction.EXHAUSTED
-    return StepAction.STAGNATED
-
-
-def _watchdog_timeout_has_directive_metadata(exc: GenerationWatchdogTimeout) -> bool:
-    """Return True when a timeout came from the watchdog directive path."""
-    return isinstance(exc.details.get("execution_id"), str) and bool(exc.details["execution_id"])
 
 
 class EvolutionaryLoop:
@@ -305,55 +289,6 @@ class EvolutionaryLoop:
         """Restore the previous task-local project directory context."""
         self._project_dir_context.reset(token)
 
-    async def _emit_step_directive(
-        self,
-        action: StepAction,
-        *,
-        lineage_id: str,
-        generation_number: int,
-        phase: str,
-        reason: str,
-        retry_budget_remaining: int = 1,
-    ) -> None:
-        """Emit ``control.directive.emitted`` at a ``StepAction`` decision point.
-
-        Slice 1 of #472 — translates the local ``StepAction`` outcome onto
-        the shared :class:`Directive` vocabulary and persists the
-        translation so projectors (#514) can render the decision lane
-        alongside ``lineage.*`` state events. ``StepAction.CONTINUE``
-        deliberately produces no event (the underlying
-        ``lineage.generation.completed`` event already records the
-        no-op continuation; emitting on every CONTINUE would flood the
-        journal).
-
-        Args:
-            action: Outcome being returned to the caller.
-            lineage_id: Target aggregate id (required by the factory).
-            generation_number: Correlation field for projector
-                interleaving.
-            phase: Current pipeline phase string for the projector.
-            reason: Short audit-level rationale.
-            retry_budget_remaining: Forwarded to
-                :func:`step_action_to_directive` for the
-                ``StepAction.FAILED`` branch.
-        """
-        directive = step_action_to_directive(action, retry_budget_remaining=retry_budget_remaining)
-        if directive is None:
-            return
-        await self.event_store.append(
-            create_control_directive_emitted_event(
-                target_type="lineage",
-                target_id=lineage_id,
-                emitted_by="evolver",
-                directive=directive,
-                reason=reason,
-                lineage_id=lineage_id,
-                generation_number=generation_number,
-                phase=phase,
-                extra={"step_action": str(action), "is_terminal": is_terminal_directive(directive)},
-            )
-        )
-
     async def _emit_watchdog_timeout_directive(
         self,
         exc: GenerationWatchdogTimeout,
@@ -386,41 +321,6 @@ class EvolutionaryLoop:
                 },
             )
         )
-
-    async def _phase_for_failed_step_directive(
-        self,
-        *,
-        lineage_id: str,
-        generation_number: int,
-    ) -> str:
-        """Return the phase recorded by the generation failure event.
-
-        ``evolve_step`` emits its StepAction-level directive after
-        ``_run_generation`` has already emitted the phase-specific
-        ``lineage.generation.failed`` event. Replaying that last failure
-        preserves the real phase (wondering/reflecting/seeding/etc.)
-        instead of stamping every failed step as ``executing``.
-        """
-        events = await self.event_store.replay_lineage(lineage_id)
-        saw_cancelled_failure = False
-        for event in reversed(events):
-            if event.data.get("generation_number") != generation_number:
-                continue
-            if event.type == "lineage.generation.failed":
-                phase = event.data.get("phase")
-                if isinstance(phase, str) and phase:
-                    if phase != GenerationPhase.CANCELLED.value:
-                        return phase
-                    saw_cancelled_failure = True
-                    continue
-            if saw_cancelled_failure and event.type in {
-                "lineage.generation.phase_changed",
-                "lineage.generation.started",
-            }:
-                phase = event.data.get("phase")
-                if isinstance(phase, str) and phase:
-                    return phase
-        return GenerationPhase.FAILED.value
 
     async def run(
         self,
@@ -499,16 +399,19 @@ class EvolutionaryLoop:
                         "details": gen_result.error.details,
                     },
                 )
-                if _watchdog_timeout_has_directive_metadata(gen_result.error):
+                if loop_support.watchdog_has_directive_metadata(gen_result.error.details):
                     await self._emit_watchdog_timeout_directive(
                         gen_result.error,
                         lineage_id=lineage.lineage_id,
                         generation_number=generation_number,
-                        phase=await self._phase_for_failed_step_directive(
+                        phase=await loop_support.phase_for_failed_step_directive(
+                            self.event_store,
                             lineage_id=lineage.lineage_id,
                             generation_number=generation_number,
                         ),
-                        action=_watchdog_timeout_step_action(gen_result.error.timeout_kind),
+                        action=StepAction(
+                            loop_support.watchdog_timeout_action(gen_result.error.timeout_kind)
+                        ),
                     )
                 break
 
@@ -681,21 +584,64 @@ class EvolutionaryLoop:
         parallel: bool = True,
         conductor_directive: ConductorDirective | None = None,
     ) -> Result[StepResult, OuroborosError]:
-        """Run exactly one generation of the evolutionary loop.
+        """Advance one lineage exactly once while concurrent retries coalesce.
 
-        Stateless between calls: all state is reconstructed from EventStore
-        via LineageProjector. Designed for Ralph integration where each call
-        may happen in a different session context.
-
-        Args:
-            lineage_id: Lineage ID to continue (or new ID for Gen 1).
-            initial_seed: Seed for Gen 1 (required if no events exist).
-                          Omit for Gen 2+ (reconstructed from events).
-
-        Returns:
-            Result containing StepResult with generation result, convergence
-            signal, and action (CONTINUE/CONVERGED/STAGNATED/EXHAUSTED/FAILED).
+        The replay that chooses a generation number and the provider-backed work
+        that completes it form one lineage-owned critical section.  A concurrent
+        caller with the same request observes the winner's result; a different
+        request waits and then replays the durable winner. Completed tasks remove
+        their single-flight entry so the registry remains bounded.
         """
+        from ouroboros.evolution.step_receipt import decode_step_result, encode_step_result
+
+        while True:
+            generation_number = await loop_support.planned_evolve_generation(
+                self.event_store,
+                lineage_id,
+                execute=execute,
+            )
+            request_key = loop_support.evolve_request_key(
+                initial_seed,
+                execute=execute,
+                parallel=parallel,
+                conductor_directive=conductor_directive,
+                project_dir=self.get_project_dir(),
+                generation_number=generation_number,
+            )
+            try:
+                return await loop_support.run_lineage_single_flight(
+                    self.event_store,
+                    lineage_id,
+                    request_key,
+                    lambda: loop_support.run_durable_lineage_single_flight(
+                        self.event_store,
+                        lineage_id,
+                        request_key,
+                        lambda: self._evolve_step_once(
+                            lineage_id,
+                            initial_seed=initial_seed,
+                            execute=execute,
+                            parallel=parallel,
+                            conductor_directive=conductor_directive,
+                        ),
+                        generation_number=generation_number,
+                        encode=encode_step_result,
+                        decode=lambda payload: decode_step_result(self.event_store, payload),
+                    ),
+                    replan_on_different=True,
+                )
+            except loop_support.LineageWinnerAdvanced:
+                continue
+
+    async def _evolve_step_once(
+        self,
+        lineage_id: str,
+        initial_seed: Seed | None = None,
+        execute: bool = True,
+        parallel: bool = True,
+        conductor_directive: ConductorDirective | None = None,
+    ) -> Result[StepResult, OuroborosError]:
+        """Run one event-reconstructed generation under lineage ownership."""
         projector = LineageProjector()
 
         # Step 1: Replay events to reconstruct state
@@ -745,7 +691,7 @@ class EvolutionaryLoop:
                 generation_number = last_gen + 1
 
             # Reconstruct seed — prefer interrupted gen's seed_json (has evolved state)
-            if initial_seed is not None:
+            if initial_seed is not None and not lineage.verification_handoff_pending:
                 # Caller provided seed explicitly (e.g., after rewind)
                 current_seed = initial_seed
             elif last_phase == GenerationPhase.INTERRUPTED:
@@ -842,6 +788,37 @@ class EvolutionaryLoop:
             else:
                 return Result.err(OuroborosError("Events exist but no completed generations found"))
 
+        if lineage.verification_handoff_pending and not execute:
+            previous = next(
+                record
+                for record in reversed(lineage.generations)
+                if record.phase == GenerationPhase.COMPLETED
+            )
+            reason = "Stable Seed is awaiting Execute -> Evaluate verification"
+            return Result.ok(
+                StepResult(
+                    generation_result=GenerationResult(
+                        generation_number=previous.generation_number,
+                        seed=current_seed,
+                        execution_output=previous.execution_output,
+                        evaluation_summary=previous.evaluation_summary,
+                        active_ac_indices=previous.active_ac_indices,
+                        frozen_ac_indices=previous.frozen_ac_indices,
+                    ),
+                    convergence_signal=ConvergenceSignal(
+                        converged=False,
+                        reason=reason,
+                        ontology_similarity=1.0,
+                        generation=previous.generation_number,
+                        should_stop=True,
+                        ontology_stable=True,
+                    ),
+                    lineage=lineage,
+                    action=StepAction.ONTOLOGY_STABLE,
+                    next_generation=generation_number,
+                )
+            )
+
         approved_seed = current_seed
         if conductor_directive is not None:
             current_seed = Seed.from_dict(
@@ -883,7 +860,8 @@ class EvolutionaryLoop:
                         ontology_similarity=0.0,
                         generation=generation_number,
                     )
-                    await self._emit_step_directive(
+                    await loop_support.emit_step_directive(
+                        self.event_store,
                         StepAction.INTERRUPTED,
                         lineage_id=lineage.lineage_id,
                         generation_number=generation_number,
@@ -894,7 +872,7 @@ class EvolutionaryLoop:
                         StepResult(
                             generation_result=interrupted_before_start,
                             convergence_signal=conv_signal,
-                            lineage=lineage,
+                            lineage=await loop_support.refresh_lineage(self.event_store, lineage),
                             action=StepAction.INTERRUPTED,
                             next_generation=generation_number,
                         )
@@ -927,13 +905,16 @@ class EvolutionaryLoop:
                     ontology_similarity=0.0,
                     generation=generation_number,
                 )
-                if _watchdog_timeout_has_directive_metadata(gen_result.error):
-                    watchdog_action = _watchdog_timeout_step_action(gen_result.error.timeout_kind)
+                if loop_support.watchdog_has_directive_metadata(gen_result.error.details):
+                    watchdog_action = StepAction(
+                        loop_support.watchdog_timeout_action(gen_result.error.timeout_kind)
+                    )
                     await self._emit_watchdog_timeout_directive(
                         gen_result.error,
                         lineage_id=lineage.lineage_id,
                         generation_number=generation_number,
-                        phase=await self._phase_for_failed_step_directive(
+                        phase=await loop_support.phase_for_failed_step_directive(
+                            self.event_store,
                             lineage_id=lineage.lineage_id,
                             generation_number=generation_number,
                         ),
@@ -945,7 +926,7 @@ class EvolutionaryLoop:
                     StepResult(
                         generation_result=failed_gen,
                         convergence_signal=conv_signal,
-                        lineage=lineage,
+                        lineage=await loop_support.refresh_lineage(self.event_store, lineage),
                         action=watchdog_action,
                         next_generation=generation_number,
                     )
@@ -967,11 +948,13 @@ class EvolutionaryLoop:
                     ontology_similarity=0.0,
                     generation=generation_number,
                 )
-                await self._emit_step_directive(
+                await loop_support.emit_step_directive(
+                    self.event_store,
                     StepAction.FAILED,
                     lineage_id=lineage.lineage_id,
                     generation_number=generation_number,
-                    phase=await self._phase_for_failed_step_directive(
+                    phase=await loop_support.phase_for_failed_step_directive(
+                        self.event_store,
                         lineage_id=lineage.lineage_id,
                         generation_number=generation_number,
                     ),
@@ -981,7 +964,7 @@ class EvolutionaryLoop:
                     StepResult(
                         generation_result=failed_gen,
                         convergence_signal=conv_signal,
-                        lineage=lineage,
+                        lineage=await loop_support.refresh_lineage(self.event_store, lineage),
                         action=StepAction.FAILED,
                         next_generation=generation_number,
                     )
@@ -1026,7 +1009,8 @@ class EvolutionaryLoop:
                     ontology_similarity=0.0,
                     generation=generation_number,
                 )
-                await self._emit_step_directive(
+                await loop_support.emit_step_directive(
+                    self.event_store,
                     StepAction.INTERRUPTED,
                     lineage_id=lineage.lineage_id,
                     generation_number=generation_number,
@@ -1037,7 +1021,7 @@ class EvolutionaryLoop:
                     StepResult(
                         generation_result=result,
                         convergence_signal=conv_signal,
-                        lineage=lineage,
+                        lineage=await loop_support.refresh_lineage(self.event_store, lineage),
                         action=StepAction.INTERRUPTED,
                         next_generation=generation_number,
                     )
@@ -1063,7 +1047,19 @@ class EvolutionaryLoop:
                 frozen_ac_indices=result.frozen_ac_indices,
             )
             nonlocal_lineage = nonlocal_lineage.with_generation(record)
-
+            # Persist the stable Seed and its verification handoff atomically.
+            conv_signal = self._convergence.evaluate(
+                nonlocal_lineage,
+                result.wonder_output,
+                latest_evaluation=result.evaluation_summary,
+                validation_output=result.validation_output,
+                latest_seed=result.seed,
+                evaluation_expected=execute,
+                validation_expected=execute and self.validator is not None,
+            )
+            if conv_signal.ontology_stable:
+                record = record.model_copy(update={"verification_handoff_pending": True})
+                nonlocal_lineage = nonlocal_lineage.with_generation(record)
             await self.event_store.append(
                 lineage_generation_completed(
                     nonlocal_lineage.lineage_id,
@@ -1084,9 +1080,9 @@ class EvolutionaryLoop:
                     or None,
                     active_ac_indices=list(result.active_ac_indices),
                     frozen_ac_indices=list(result.frozen_ac_indices),
+                    verification_handoff_pending=record.verification_handoff_pending,
                 )
             )
-
             # Emit ontology evolved event if delta exists.
             if result.ontology_delta and result.ontology_delta.similarity < 1.0:
                 await self.event_store.append(
@@ -1096,18 +1092,6 @@ class EvolutionaryLoop:
                         result.ontology_delta.model_dump(mode="json"),
                     )
                 )
-
-            # Step 4: Check convergence.
-            conv_signal = self._convergence.evaluate(
-                nonlocal_lineage,
-                result.wonder_output,
-                latest_evaluation=result.evaluation_summary,
-                validation_output=result.validation_output,
-                latest_seed=result.seed,
-                evaluation_expected=execute,
-                validation_expected=execute and self.validator is not None,
-            )
-
             action = StepAction.CONTINUE
             if conv_signal.should_stop:
                 if conv_signal.converged:
@@ -1121,6 +1105,8 @@ class EvolutionaryLoop:
                     )
                     nonlocal_lineage = nonlocal_lineage.with_status(LineageStatus.CONVERGED)
                     action = StepAction.CONVERGED
+                elif conv_signal.ontology_stable:
+                    action = StepAction.ONTOLOGY_STABLE
                 elif generation_number >= self.config.max_generations:
                     await self.event_store.append(
                         lineage_exhausted(
@@ -1144,13 +1130,19 @@ class EvolutionaryLoop:
                     # Directive contract maps STAGNATED to UNSTUCK, so keep the
                     # lineage resumable for the lateral-thinking recovery path.
                     action = StepAction.STAGNATED
-            await self._emit_step_directive(
-                action,
-                lineage_id=nonlocal_lineage.lineage_id,
-                generation_number=generation_number,
-                phase=str(result.phase),
-                reason=conv_signal.reason,
-            )
+            try:
+                await loop_support.emit_step_directive(
+                    self.event_store,
+                    action,
+                    lineage_id=nonlocal_lineage.lineage_id,
+                    generation_number=generation_number,
+                    phase=str(result.phase),
+                    reason=conv_signal.reason,
+                )
+            except Exception:
+                if action is not StepAction.ONTOLOGY_STABLE:
+                    raise
+                logger.warning("evolution.ontology_stable.directive_emit_failed", exc_info=True)
             container.result = Result.ok(
                 StepResult(
                     generation_result=result,
@@ -1509,13 +1501,21 @@ class EvolutionaryLoop:
                 if _should_skip("evaluating") and ps.get("validation_output"):
                     restored_validation_output = ps["validation_output"]
 
-        # Gen 2+: Wonder and Reflect phases
-        if generation_number > 1 and lineage.generations:
-            prev_gen = next(
+        prev_gen = (
+            next(
                 (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
                 lineage.generations[-1],  # fallback if no completed gen exists
             )
-
+            if generation_number > 1 and lineage.generations
+            else None
+        )
+        try:
+            # The previous evaluation belongs to the completed parent, not an
+            # interrupted generation's candidate Seed.
+            generation_parent_seed = loop_support.generation_parent_seed(current_seed, prev_gen)
+        except ValueError as exc:
+            return Result.err(OuroborosError(str(exc)))
+        if prev_gen is not None and not (execute and lineage.verification_handoff_pending):
             regression_report: RegressionReport = RegressionDetector().detect(lineage)
             generation_focus = focus.select_evolution_focus(
                 generation_parent_seed,
@@ -1526,12 +1526,12 @@ class EvolutionaryLoop:
             )
 
             # Emit generation started
-            await self.event_store.append(
-                lineage_generation_started(
-                    lineage.lineage_id,
-                    generation_number,
-                    GenerationPhase.WONDERING.value,
-                )
+            await loop_support.emit_generation_started_once(
+                self.event_store,
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase=GenerationPhase.WONDERING.value,
+                seed=current_seed,
             )
 
             # Wonder phase (skip if already completed before interruption)
@@ -1551,7 +1551,11 @@ class EvolutionaryLoop:
                 wonder_result = await self.wonder_engine.wonder(**wonder_kwargs)
                 if wonder_result.is_ok:
                     wonder_output = wonder_result.value
-                    if not wonder_output.should_continue and not wonder_output.questions:
+                    if (
+                        not execute
+                        and not wonder_output.should_continue
+                        and not wonder_output.questions
+                    ):
                         # Only early-return if Wonder has NO questions at all.
                         # If questions exist, we must continue to Reflect even if
                         # should_continue=false, because the questions represent
@@ -1616,7 +1620,7 @@ class EvolutionaryLoop:
             if (
                 self.reflect_engine
                 and wonder_output
-                and prev_gen.evaluation_summary
+                and (wonder_output.should_continue or wonder_output.questions)
                 and not _should_skip("reflecting")
             ):
                 max_reflect_attempts = 2
@@ -1771,17 +1775,16 @@ class EvolutionaryLoop:
                     current_seed = new_seed
 
         else:
-            # Gen 1: just emit started event
-            await self.event_store.append(
-                lineage_generation_started(
-                    lineage.lineage_id,
-                    generation_number,
-                    GenerationPhase.EXECUTING.value,
-                    current_seed.metadata.seed_id,
-                )
+            # Gen 1, or a Gen 2+ ontology-stable verification handoff.
+            await loop_support.emit_generation_started_once(
+                self.event_store,
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase=GenerationPhase.EXECUTING.value,
+                seed=current_seed,
             )
 
-        if generation_number > 1 and lineage.generations:
+        if prev_gen is not None and not (execute and lineage.verification_handoff_pending):
             generation_focus = focus.select_evolution_focus(
                 generation_parent_seed,
                 current_seed,

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -1437,12 +1437,29 @@ class EvolutionaryLoop:
         ontology_delta: OntologyDelta | None = None
         generation_parent_seed = current_seed
         generation_focus = focus.initial_evolution_focus(current_seed)
-        restored = loop_support.restore_phase_state(
-            lineage,
-            generation_number,
-            current_seed,
-            resume_after_phase,
+        prev_gen = (
+            next(
+                (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
+                lineage.generations[-1],  # fallback if no completed gen exists
+            )
+            if generation_number > 1 and lineage.generations
+            else None
         )
+        try:
+            # Previous evaluation belongs to the completed parent, not the interrupted candidate.
+            generation_parent_seed = loop_support.generation_parent_seed(current_seed, prev_gen)
+        except ValueError as exc:
+            return Result.err(OuroborosError(str(exc)))
+        try:
+            restored = loop_support.restore_phase_state(
+                lineage,
+                generation_number,
+                current_seed,
+                generation_parent_seed,
+                resume_after_phase,
+            )
+        except ValueError as exc:
+            return Result.err(OuroborosError(str(exc)))
         resume_after_phase = restored.resume_after_phase
         wonder_output = restored.wonder_output
         reflect_output = restored.reflect_output
@@ -1454,21 +1471,6 @@ class EvolutionaryLoop:
         checkpoint_focus = restored.checkpoint_focus
         if checkpoint_focus is not None:
             generation_focus = checkpoint_focus
-
-        prev_gen = (
-            next(
-                (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
-                lineage.generations[-1],  # fallback if no completed gen exists
-            )
-            if generation_number > 1 and lineage.generations
-            else None
-        )
-        try:
-            # The previous evaluation belongs to the completed parent, not an
-            # interrupted generation's candidate Seed.
-            generation_parent_seed = loop_support.generation_parent_seed(current_seed, prev_gen)
-        except ValueError as exc:
-            return Result.err(OuroborosError(str(exc)))
         if prev_gen is not None and not (execute and lineage.verification_handoff_pending):
             regression_report: RegressionReport = RegressionDetector().detect(lineage)
             generation_focus = focus.select_evolution_focus(
@@ -1479,7 +1481,6 @@ class EvolutionaryLoop:
                 enabled=self.config.focused_evolution,
             )
 
-            # Emit generation started
             await loop_support.emit_generation_started_once(
                 self.event_store,
                 lineage_id=lineage.lineage_id,

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -1932,7 +1932,7 @@ class EvolutionaryLoop:
         # Evaluate phase (placeholder - actual evaluation via EvaluationPipeline)
         # Skip if already completed before interruption (use restored summary)
         evaluation_summary: EvaluationSummary | None = restored_evaluation_summary
-        if evaluation_summary and _should_skip("evaluating"):
+        if _should_skip("evaluating"):
             logger.info(
                 "evolution.generation.evaluation_restored_from_checkpoint",
                 extra={"generation": generation_number},

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -607,6 +607,7 @@ class EvolutionaryLoop:
                 conductor_directive=conductor_directive,
                 project_dir=self.get_project_dir(),
                 generation_number=generation_number,
+                execution_policy=loop_support.evolution_execution_policy(self.config),
             )
             try:
                 return await loop_support.run_lineage_single_flight(
@@ -684,14 +685,15 @@ class EvolutionaryLoop:
             # Determine resume point
             last_gen, last_phase, interrupted_at_phase = projector.find_resume_point(events)
 
-            if last_phase in (GenerationPhase.FAILED, GenerationPhase.INTERRUPTED):
-                # Resume the failed/interrupted generation
-                generation_number = last_gen
-            else:
-                generation_number = last_gen + 1
-
-            # Reconstruct seed — prefer interrupted gen's seed_json (has evolved state)
-            if initial_seed is not None and not lineage.verification_handoff_pending:
+            try:
+                generation_number, recovered_seed = loop_support.recovery_plan(
+                    lineage, last_gen, last_phase
+                )
+            except ValueError as exc:
+                return Result.err(OuroborosError(str(exc)))
+            if recovered_seed is not None:
+                current_seed = recovered_seed
+            elif initial_seed is not None and not lineage.verification_handoff_pending:
                 # Caller provided seed explicitly (e.g., after rewind)
                 current_seed = initial_seed
             elif last_phase == GenerationPhase.INTERRUPTED:
@@ -828,9 +830,7 @@ class EvolutionaryLoop:
                 }
             )
 
-        # Step 2: Run one generation wrapped in AgentProcess for pause/cancel/replay
-        # primitives. State reconstruction above is outside the process boundary
-        # so that replays start with a clean slate.
+        # Run one generation in AgentProcess; replayed state stays outside its boundary.
         resume_after_phase = (
             interrupted_at_phase if last_phase == GenerationPhase.INTERRUPTED else None
         )
@@ -839,9 +839,7 @@ class EvolutionaryLoop:
         async def _generation_work(handle: AgentProcessHandle) -> None:
             self._install_sigint_handler()
             try:
-                # Cooperative checkpoint before generation phases begin. Route
-                # through the normal shutdown checkpoint so pause, cancel, and
-                # SIGINT all persist a lineage interruption consistently.
+                # Persist pause, cancel, and SIGINT through the normal shutdown checkpoint.
                 interrupted_before_start = await self._check_shutdown(
                     lineage.lineage_id,
                     generation_number,

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -51,6 +51,7 @@ from ouroboros.events.lineage import (
     lineage_stagnated,
     lineage_wonder_degraded,
 )
+from ouroboros.evolution import focus, loop_support
 from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
 from ouroboros.evolution.directive_mapping import (
     is_terminal_directive,
@@ -75,40 +76,8 @@ from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessHandl
 from ouroboros.persistence.event_store import EventStore
 
 logger = logging.getLogger(__name__)
-
-
-def _default_runtime_controls() -> RuntimeControlsConfig:
-    """Load runtime controls through the config/env compatibility layer."""
-    from ouroboros.config.loader import get_runtime_controls_config
-
-    return get_runtime_controls_config()
-
-
-def _conductor_preservation_error(
-    approved: Seed,
-    successor: Seed,
-    directive: ConductorDirective | None,
-) -> str | None:
-    """Return a fail-closed invariant error for an unauthorized direction change."""
-    if directive is None:
-        return None
-    changed: list[str] = []
-    if directive.preserve_goal and approved.goal != successor.goal:
-        changed.append("goal")
-    if (
-        directive.preserve_acceptance_criteria
-        and approved.acceptance_criteria != successor.acceptance_criteria
-    ):
-        changed.append("acceptance_criteria")
-    if directive.preserve_constraints and approved.constraints != successor.constraints:
-        changed.append("constraints")
-    if directive.preserve_non_goals and approved.to_dict().get(
-        "non_goals"
-    ) != successor.to_dict().get("non_goals"):
-        changed.append("non_goals")
-    if not changed:
-        return None
-    return "Conductor successor changed preserved direction fields: " + ", ".join(changed)
+_default_runtime_controls = loop_support.default_runtime_controls
+_conductor_preservation_error = loop_support.conductor_preservation_error
 
 
 @dataclass
@@ -124,7 +93,10 @@ class EvolutionaryLoopConfig:
     enable_oscillation_detection: bool = True
     eval_gate_enabled: bool = True
     eval_min_score: float = 0.7
+    outcome_gate_enabled: bool = True
+    evaluation_plateau_epsilon: float = 0.01
     scoped_reexecution: bool = True
+    focused_evolution: bool = True
 
     def __post_init__(self) -> None:
         """Map legacy generation_timeout_seconds onto no-progress detection."""
@@ -149,6 +121,8 @@ class GenerationResult:
     reflect_output: ReflectOutput | None = None
     ontology_delta: OntologyDelta | None = None
     validation_output: str | None = None
+    active_ac_indices: tuple[int, ...] = ()
+    frozen_ac_indices: tuple[int, ...] = ()
     phase: GenerationPhase = GenerationPhase.COMPLETED
     success: bool = True
 
@@ -272,6 +246,8 @@ class EvolutionaryLoop:
             enable_oscillation_detection=self.config.enable_oscillation_detection,
             eval_gate_enabled=self.config.eval_gate_enabled,
             eval_min_score=self.config.eval_min_score,
+            outcome_gate_enabled=self.config.outcome_gate_enabled,
+            evaluation_plateau_epsilon=self.config.evaluation_plateau_epsilon,
         )
 
     def _install_sigint_handler(self) -> None:
@@ -574,6 +550,8 @@ class EvolutionaryLoop:
                 wonder_questions=result.wonder_output.questions if result.wonder_output else (),
                 phase=result.phase,
                 execution_output=result.execution_output,
+                active_ac_indices=result.active_ac_indices,
+                frozen_ac_indices=result.frozen_ac_indices,
             )
             lineage = lineage.with_generation(record)
 
@@ -596,6 +574,8 @@ class EvolutionaryLoop:
                         for feedback in record.seed_quality_canary_feedback
                     ]
                     or None,
+                    active_ac_indices=list(result.active_ac_indices),
+                    frozen_ac_indices=list(result.frozen_ac_indices),
                 )
             )
 
@@ -1072,6 +1052,8 @@ class EvolutionaryLoop:
                 phase=result.phase,
                 seed_json=json.dumps(result.seed.to_dict()),
                 execution_output=result.execution_output,
+                active_ac_indices=result.active_ac_indices,
+                frozen_ac_indices=result.frozen_ac_indices,
             )
             nonlocal_lineage = nonlocal_lineage.with_generation(record)
 
@@ -1093,6 +1075,8 @@ class EvolutionaryLoop:
                         for feedback in record.seed_quality_canary_feedback
                     ]
                     or None,
+                    active_ac_indices=list(result.active_ac_indices),
+                    frozen_ac_indices=list(result.frozen_ac_indices),
                 )
             )
 
@@ -1266,7 +1250,7 @@ class EvolutionaryLoop:
         conductor_directive: ConductorDirective | None = None,
     ) -> Result[GenerationResult, OuroborosError]:
         """Run one generation under progress-aware liveness controls."""
-        execution_id = self._generation_execution_id(lineage.lineage_id, generation_number)
+        execution_id = loop_support.generation_execution_id(lineage.lineage_id, generation_number)
         watchdog = GenerationProgressWatchdog(
             event_store=self.event_store,
             lineage_id=lineage.lineage_id,
@@ -1291,11 +1275,6 @@ class EvolutionaryLoop:
         except GenerationWatchdogTimeout as exc:
             return Result.err(exc)
 
-    @staticmethod
-    def _generation_execution_id(lineage_id: str, generation_number: int) -> str:
-        """Build the deterministic execution ID for an evolve generation."""
-        return f"evolve:{lineage_id}:generation:{generation_number}"
-
     async def _call_executor(
         self,
         seed: Seed,
@@ -1305,31 +1284,18 @@ class EvolutionaryLoop:
         externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Any:
         """Call the configured executor with optional execution_id support."""
-        kwargs: dict[str, Any] = {"parallel": parallel}
-        if execution_id is not None and self._callable_accepts_keyword(
+        return await focus.call_executor(
             self.executor,
-            "execution_id",
-        ):
-            kwargs["execution_id"] = execution_id
-        if externally_satisfied_acs and self._callable_accepts_keyword(
-            self.executor,
-            "externally_satisfied_acs",
-        ):
-            kwargs["externally_satisfied_acs"] = externally_satisfied_acs
-        return await self.executor(seed, **kwargs)
+            seed,
+            parallel=parallel,
+            execution_id=execution_id,
+            externally_satisfied_acs=externally_satisfied_acs,
+        )
 
     @staticmethod
     def _callable_accepts_keyword(callable_obj: Any, keyword: str) -> bool:
         """Return True when *callable_obj* accepts *keyword*."""
-        try:
-            signature = inspect.signature(callable_obj)
-        except (TypeError, ValueError):
-            return False
-
-        for parameter in signature.parameters.values():
-            if parameter.kind == inspect.Parameter.VAR_KEYWORD:
-                return True
-        return keyword in signature.parameters
+        return focus.callable_accepts_keyword(callable_obj, keyword, inspect.signature)
 
     async def _check_shutdown(
         self,
@@ -1476,6 +1442,8 @@ class EvolutionaryLoop:
         restored_execution_output: str | None = None
         restored_evaluation_summary: EvaluationSummary | None = None
         restored_validation_output: str | None = None
+        generation_parent_seed = current_seed
+        generation_focus = focus.initial_evolution_focus(current_seed)
 
         # Restore partial state from interrupted generation if resuming
         if resume_after_phase and lineage.generations:
@@ -1526,16 +1494,19 @@ class EvolutionaryLoop:
 
         # Gen 2+: Wonder and Reflect phases
         if generation_number > 1 and lineage.generations:
-            # Use last COMPLETED generation for context (evaluation, execution output).
-            # The tail may be an interrupted/failed record which lacks these fields.
             prev_gen = next(
                 (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
                 lineage.generations[-1],  # fallback if no completed gen exists
             )
 
-            # Compute regressions once and reuse for both Reflect's prompt and its
-            # deterministic satisficing backstop (a regressed AC is never settled).
             regression_report: RegressionReport = RegressionDetector().detect(lineage)
+            generation_focus = focus.select_evolution_focus(
+                generation_parent_seed,
+                current_seed,
+                prev_gen.evaluation_summary,
+                regression_report=regression_report,
+                enabled=self.config.focused_evolution,
+            )
 
             # Emit generation started
             await self.event_store.append(
@@ -1548,13 +1519,19 @@ class EvolutionaryLoop:
 
             # Wonder phase (skip if already completed before interruption)
             if self.wonder_engine and not _should_skip("wondering"):
-                wonder_result = await self.wonder_engine.wonder(
-                    current_ontology=current_seed.ontology_schema,
-                    evaluation_summary=prev_gen.evaluation_summary,
-                    execution_output=prev_gen.execution_output,
-                    lineage=lineage,
-                    seed=current_seed,
+                wonder_kwargs: dict[str, Any] = {
+                    "current_ontology": current_seed.ontology_schema,
+                    "evaluation_summary": prev_gen.evaluation_summary,
+                    "execution_output": prev_gen.execution_output,
+                    "lineage": lineage,
+                    "seed": current_seed,
+                }
+                focus.add_active_focus(
+                    wonder_kwargs,
+                    self.wonder_engine.wonder,
+                    generation_focus,
                 )
+                wonder_result = await self.wonder_engine.wonder(**wonder_kwargs)
                 if wonder_result.is_ok:
                     wonder_output = wonder_result.value
                     if not wonder_output.should_continue and not wonder_output.questions:
@@ -1568,6 +1545,8 @@ class EvolutionaryLoop:
                                 generation_number=generation_number,
                                 seed=current_seed,
                                 wonder_output=wonder_output,
+                                active_ac_indices=generation_focus.active_ac_indices,
+                                frozen_ac_indices=generation_focus.frozen_ac_indices,
                                 phase=GenerationPhase.COMPLETED,
                                 success=True,
                             )
@@ -1625,15 +1604,21 @@ class EvolutionaryLoop:
             ):
                 max_reflect_attempts = 2
                 for attempt in range(max_reflect_attempts):
-                    reflect_result = await self.reflect_engine.reflect(
-                        current_seed=current_seed,
-                        execution_output=prev_gen.execution_output or "",
-                        evaluation_summary=prev_gen.evaluation_summary,
-                        wonder_output=wonder_output,
-                        lineage=lineage,
-                        regression_report=regression_report,
-                        conductor_directive=conductor_directive,
+                    reflect_kwargs: dict[str, Any] = {
+                        "current_seed": current_seed,
+                        "execution_output": prev_gen.execution_output or "",
+                        "evaluation_summary": prev_gen.evaluation_summary,
+                        "wonder_output": wonder_output,
+                        "lineage": lineage,
+                        "regression_report": regression_report,
+                        "conductor_directive": conductor_directive,
+                    }
+                    focus.add_active_focus(
+                        reflect_kwargs,
+                        self.reflect_engine.reflect,
+                        generation_focus,
                     )
+                    reflect_result = await self.reflect_engine.reflect(**reflect_kwargs)
 
                     if reflect_result.is_ok:
                         break
@@ -1779,6 +1764,17 @@ class EvolutionaryLoop:
                 )
             )
 
+        if generation_number > 1 and lineage.generations:
+            generation_focus = focus.select_evolution_focus(
+                generation_parent_seed,
+                current_seed,
+                prev_gen.evaluation_summary,
+                wonder=wonder_output,
+                regression_report=regression_report,
+                enabled=self.config.focused_evolution,
+            )
+            generation_focus.log_selection(generation_number)
+
         # Check for graceful shutdown before executing.
         # Derive the actual last completed phase from what ran:
         # - reflect_output set → seeding completed
@@ -1820,25 +1816,15 @@ class EvolutionaryLoop:
                 extra={"generation": generation_number},
             )
         elif execute and self.executor:
-            # AC-scoped re-execution: skip ACs that satisficed last generation
-            # (passed AND not challenged AND not regressed). Only when Reflect ran
-            # fresh this invocation — resume paths pass nothing (conservative full
-            # run). Verification still runs over ALL ACs downstream.
-            externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
-            if (
-                self.config.scoped_reexecution
-                and reflect_output is not None
-                and reflect_output.settled_ac_indices
-                and not _should_skip("reflecting")
-            ):
-                externally_satisfied_acs = {
-                    i: {
-                        "reason": (
-                            "satisficed: passed in previous generation; not challenged or regressed"
-                        )
-                    }
-                    for i in reflect_output.settled_ac_indices
-                }
+            externally_satisfied_acs = focus.select_externally_satisfied_acs(
+                scoped_reexecution=self.config.scoped_reexecution,
+                focused_evolution=self.config.focused_evolution,
+                focus=generation_focus,
+                settled_ac_indices=(
+                    reflect_output.settled_ac_indices if reflect_output is not None else ()
+                ),
+                reflect_ran_fresh=not _should_skip("reflecting"),
+            )
             try:
                 exec_result = await self._call_executor(
                     current_seed,
@@ -2020,6 +2006,8 @@ class EvolutionaryLoop:
                 reflect_output=reflect_output,
                 ontology_delta=ontology_delta,
                 validation_output=validation_output,
+                active_ac_indices=generation_focus.active_ac_indices,
+                frozen_ac_indices=generation_focus.frozen_ac_indices,
                 phase=GenerationPhase.COMPLETED,
                 success=True,
             )

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -66,6 +66,7 @@ from ouroboros.evolution.rewind import (
     NoOpRewindObserver,
     RewindObserver,
 )
+from ouroboros.evolution.validation_result import normalize_validation_result
 from ouroboros.evolution.watchdog import (
     GenerationProgressWatchdog,
     GenerationWatchdogTimeout,
@@ -541,6 +542,7 @@ class EvolutionaryLoop:
             generation_results.append(result)
 
             # Record generation in lineage
+            seed_json = json.dumps(result.seed.to_dict())
             record = GenerationRecord(
                 generation_number=generation_number,
                 seed_id=result.seed.metadata.seed_id,
@@ -549,6 +551,7 @@ class EvolutionaryLoop:
                 evaluation_summary=result.evaluation_summary,
                 wonder_questions=result.wonder_output.questions if result.wonder_output else (),
                 phase=result.phase,
+                seed_json=seed_json,
                 execution_output=result.execution_output,
                 active_ac_indices=result.active_ac_indices,
                 frozen_ac_indices=result.frozen_ac_indices,
@@ -566,7 +569,7 @@ class EvolutionaryLoop:
                     if result.evaluation_summary
                     else None,
                     list(result.wonder_output.questions) if result.wonder_output else None,
-                    seed_json=json.dumps(result.seed.to_dict()),
+                    seed_json=seed_json,
                     execution_output=result.execution_output,
                     parent_seed_id=result.seed.metadata.parent_seed_id,
                     seed_quality_canary_feedback=[
@@ -595,21 +598,34 @@ class EvolutionaryLoop:
                 result.wonder_output,
                 latest_evaluation=result.evaluation_summary,
                 validation_output=result.validation_output,
+                latest_seed=result.seed,
+                validation_expected=self.validator is not None,
             )
 
-            if conv_signal.converged:
+            if conv_signal.should_stop:
                 logger.info(
-                    "evolution.converged",
+                    "evolution.converged" if conv_signal.converged else "evolution.stopped",
                     extra={
                         "lineage_id": lineage.lineage_id,
                         "generation": generation_number,
                         "reason": conv_signal.reason,
                         "similarity": conv_signal.ontology_similarity,
+                        "converged": conv_signal.converged,
                     },
                 )
 
                 # Emit appropriate termination event
-                if generation_number >= self.config.max_generations:
+                if conv_signal.converged:
+                    await self.event_store.append(
+                        lineage_converged(
+                            lineage.lineage_id,
+                            generation_number,
+                            conv_signal.reason,
+                            conv_signal.ontology_similarity,
+                        )
+                    )
+                    lineage = lineage.with_status(LineageStatus.CONVERGED)
+                elif generation_number >= self.config.max_generations:
                     await self.event_store.append(
                         lineage_exhausted(
                             lineage.lineage_id,
@@ -618,7 +634,7 @@ class EvolutionaryLoop:
                         )
                     )
                     lineage = lineage.with_status(LineageStatus.EXHAUSTED)
-                elif "Stagnation" in conv_signal.reason or "Oscillation" in conv_signal.reason:
+                else:
                     await self.event_store.append(
                         lineage_stagnated(
                             lineage.lineage_id,
@@ -630,17 +646,6 @@ class EvolutionaryLoop:
                     # Stagnation is a non-terminal control handoff: the shared
                     # Directive contract maps STAGNATED to UNSTUCK, so keep the
                     # lineage resumable for the lateral-thinking recovery path.
-                else:
-                    await self.event_store.append(
-                        lineage_converged(
-                            lineage.lineage_id,
-                            generation_number,
-                            conv_signal.reason,
-                            conv_signal.ontology_similarity,
-                        )
-                    )
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
-
                 break
 
             # Prepare for next generation
@@ -1042,6 +1047,7 @@ class EvolutionaryLoop:
 
             # Step 3: Emit generation completed event (with seed_json).
             nonlocal_lineage = lineage
+            seed_json = json.dumps(result.seed.to_dict())
             record = GenerationRecord(
                 generation_number=generation_number,
                 seed_id=result.seed.metadata.seed_id,
@@ -1050,7 +1056,7 @@ class EvolutionaryLoop:
                 evaluation_summary=result.evaluation_summary,
                 wonder_questions=result.wonder_output.questions if result.wonder_output else (),
                 phase=result.phase,
-                seed_json=json.dumps(result.seed.to_dict()),
+                seed_json=seed_json,
                 execution_output=result.execution_output,
                 active_ac_indices=result.active_ac_indices,
                 frozen_ac_indices=result.frozen_ac_indices,
@@ -1067,7 +1073,7 @@ class EvolutionaryLoop:
                     if result.evaluation_summary
                     else None,
                     list(result.wonder_output.questions) if result.wonder_output else None,
-                    seed_json=json.dumps(result.seed.to_dict()),
+                    seed_json=seed_json,
                     execution_output=result.execution_output,
                     parent_seed_id=result.seed.metadata.parent_seed_id,
                     seed_quality_canary_feedback=[
@@ -1096,11 +1102,24 @@ class EvolutionaryLoop:
                 result.wonder_output,
                 latest_evaluation=result.evaluation_summary,
                 validation_output=result.validation_output,
+                latest_seed=result.seed,
+                validation_expected=self.validator is not None,
             )
 
             action = StepAction.CONTINUE
-            if conv_signal.converged:
-                if generation_number >= self.config.max_generations:
+            if conv_signal.should_stop:
+                if conv_signal.converged:
+                    await self.event_store.append(
+                        lineage_converged(
+                            nonlocal_lineage.lineage_id,
+                            generation_number,
+                            conv_signal.reason,
+                            conv_signal.ontology_similarity,
+                        )
+                    )
+                    nonlocal_lineage = nonlocal_lineage.with_status(LineageStatus.CONVERGED)
+                    action = StepAction.CONVERGED
+                elif generation_number >= self.config.max_generations:
                     await self.event_store.append(
                         lineage_exhausted(
                             nonlocal_lineage.lineage_id,
@@ -1110,7 +1129,7 @@ class EvolutionaryLoop:
                     )
                     nonlocal_lineage = nonlocal_lineage.with_status(LineageStatus.EXHAUSTED)
                     action = StepAction.EXHAUSTED
-                elif "Stagnation" in conv_signal.reason or "Oscillation" in conv_signal.reason:
+                else:
                     await self.event_store.append(
                         lineage_stagnated(
                             nonlocal_lineage.lineage_id,
@@ -1123,18 +1142,6 @@ class EvolutionaryLoop:
                     # Directive contract maps STAGNATED to UNSTUCK, so keep the
                     # lineage resumable for the lateral-thinking recovery path.
                     action = StepAction.STAGNATED
-                else:
-                    await self.event_store.append(
-                        lineage_converged(
-                            nonlocal_lineage.lineage_id,
-                            generation_number,
-                            conv_signal.reason,
-                            conv_signal.ontology_similarity,
-                        )
-                    )
-                    nonlocal_lineage = nonlocal_lineage.with_status(LineageStatus.CONVERGED)
-                    action = StepAction.CONVERGED
-
             await self._emit_step_directive(
                 action,
                 lineage_id=nonlocal_lineage.lineage_id,
@@ -1887,15 +1894,7 @@ class EvolutionaryLoop:
         elif execute and execution_output and self.validator:
             try:
                 validation_result = await self.validator(current_seed, execution_output)
-                if isinstance(validation_result, str):
-                    validation_output = validation_result
-                elif hasattr(validation_result, "is_ok"):
-                    if validation_result.is_ok:
-                        validation_output = str(validation_result.value)
-                    else:
-                        validation_output = f"Validation error: {validation_result.error}"
-                else:
-                    validation_output = str(validation_result)
+                validation_output = normalize_validation_result(validation_result)
                 if validation_output and "skipped" in validation_output.lower():
                     logger.warning(
                         "evolution.generation.validation_skipped",

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -45,7 +45,6 @@ from ouroboros.events.lineage import (
     lineage_generation_completed,
     lineage_generation_failed,
     lineage_generation_interrupted,
-    lineage_generation_phase_changed,
     lineage_ontology_evolved,
     lineage_stagnated,
     lineage_wonder_degraded,
@@ -69,7 +68,7 @@ from ouroboros.evolution.watchdog import (
     GenerationProgressWatchdog,
     GenerationWatchdogTimeout,
 )
-from ouroboros.evolution.wonder import WonderEngine, WonderOutput, ground_questions
+from ouroboros.evolution.wonder import WonderEngine, WonderOutput
 from ouroboros.observability.drift import DriftMeasuredEvent, DriftMeasurement
 from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessHandle
 from ouroboros.persistence.event_store import EventStore
@@ -644,6 +643,7 @@ class EvolutionaryLoop:
     ) -> Result[StepResult, OuroborosError]:
         """Run one event-reconstructed generation under lineage ownership."""
         projector = LineageProjector()
+        hard_crash_record: GenerationRecord | None = None
 
         # Step 1: Replay events to reconstruct state
         events = await self.event_store.replay_lineage(lineage_id)
@@ -691,6 +691,14 @@ class EvolutionaryLoop:
                 )
             except ValueError as exc:
                 return Result.err(OuroborosError(str(exc)))
+            hard_crash_record, recovery_error = loop_support.hard_crash_recovery(
+                lineage,
+                generation_number,
+                last_phase,
+                execute=execute,
+            )
+            if recovery_error is not None:
+                return Result.err(OuroborosError(recovery_error))
             if recovered_seed is not None:
                 current_seed = recovered_seed
             elif initial_seed is not None and not lineage.verification_handoff_pending:
@@ -831,9 +839,11 @@ class EvolutionaryLoop:
             )
 
         # Run one generation in AgentProcess; replayed state stays outside its boundary.
-        resume_after_phase = (
-            interrupted_at_phase if last_phase == GenerationPhase.INTERRUPTED else None
-        )
+        resume_after_phase = None
+        if last_phase == GenerationPhase.INTERRUPTED:
+            resume_after_phase = interrupted_at_phase
+        elif hard_crash_record is not None:
+            resume_after_phase = hard_crash_record.last_completed_phase
         container = _StepResultContainer()
 
         async def _generation_work(handle: AgentProcessHandle) -> None:
@@ -1343,21 +1353,23 @@ class EvolutionaryLoop:
             },
         )
 
-        # Build partial state from whatever we have so far
-        partial_state: dict[str, Any] = {}
         try:
-            if wonder_output:
-                partial_state["wonder_questions"] = list(wonder_output.questions)
-            if reflect_output:
-                partial_state["reflect_output"] = reflect_output.model_dump(mode="json")
-            if execution_output:
-                partial_state["execution_output"] = execution_output[:10_000]
-            if evaluation_summary:
-                partial_state["evaluation_summary"] = evaluation_summary.model_dump(mode="json")
-            if validation_output:
-                partial_state["validation_output"] = validation_output[:5_000]
+            execution_completed = last_completed_phase in {
+                GenerationPhase.EXECUTING.value,
+                GenerationPhase.EVALUATING.value,
+            }
+            partial_state = loop_support.generation_partial_state(
+                wonder_output=wonder_output,
+                reflect_output=reflect_output,
+                execution_output=execution_output,
+                execution_boundary_completed=execution_completed,
+                validation_output=validation_output,
+                validation_boundary_completed=execution_completed,
+                evaluation_summary=evaluation_summary,
+            )
         except (TypeError, ValueError, KeyError):
             logger.warning("evolution.generation.partial_state_build_failed", exc_info=True)
+            partial_state = {}
 
         try:
             try:
@@ -1417,87 +1429,31 @@ class EvolutionaryLoop:
 
         Separated from _run_generation to allow CancelledError guard at the
         outer level without deeply nesting the entire method body.
-
-        Args:
-            resume_after_phase: If set, skip phases that were already completed
-                before interruption. Phase order: wondering → reflecting →
-                seeding → executing → evaluating.
         """
-        # Phase ordering for resume skip logic
-        _PHASE_ORDER = ["wondering", "reflecting", "seeding", "executing", "evaluating"]
 
         def _should_skip(phase: str) -> bool:
-            """Return True if this phase was already completed before interruption."""
-            if resume_after_phase is None:
-                return False
-            try:
-                return _PHASE_ORDER.index(phase) <= _PHASE_ORDER.index(resume_after_phase)
-            except ValueError:
-                return False
+            return loop_support.phase_should_skip(phase, resume_after_phase)
 
-        wonder_output: WonderOutput | None = None
-        reflect_output: ReflectOutput | None = None
         ontology_delta: OntologyDelta | None = None
-        restored_execution_output: str | None = None
-        restored_evaluation_summary: EvaluationSummary | None = None
-        restored_validation_output: str | None = None
         generation_parent_seed = current_seed
         generation_focus = focus.initial_evolution_focus(current_seed)
-
-        # Restore partial state from interrupted generation if resuming
-        if resume_after_phase and lineage.generations:
-            interrupted_gen = next(
-                (
-                    g
-                    for g in reversed(lineage.generations)
-                    if g.phase == GenerationPhase.INTERRUPTED
-                ),
-                None,
-            )
-            if interrupted_gen and interrupted_gen.partial_state:
-                ps = interrupted_gen.partial_state
-                if _should_skip("wondering") and ps.get("wonder_questions"):
-                    # partial_state persists only plain strings — re-ground them
-                    # via the deterministic regex so a restored challenge is not
-                    # silently demoted to a gap (which would over-protect its AC).
-                    restored_questions = tuple(ps["wonder_questions"])
-                    wonder_output = WonderOutput(
-                        questions=restored_questions,
-                        grounded_questions=ground_questions(
-                            restored_questions, len(current_seed.acceptance_criteria)
-                        ),
-                        should_continue=True,
-                    )
-                if _should_skip("reflecting") and ps.get("reflect_output"):
-                    try:
-                        restored_reflect_output = ReflectOutput.model_validate(ps["reflect_output"])
-                        if restored_reflect_output.ac_patches:
-                            # Parser-issued patch provenance is intentionally not
-                            # serialized. Re-run Reflect rather than trusting a
-                            # replay payload to preserve authority-bearing fields.
-                            resume_after_phase = "wondering"
-                            reflect_output = None
-                        else:
-                            reflect_output = restored_reflect_output
-                    except Exception as e:
-                        logger.warning(
-                            "evolution.resume.reflect_output_restore_failed",
-                            extra={"error": str(e)},
-                        )
-                if _should_skip("executing") and ps.get("execution_output"):
-                    restored_execution_output = ps["execution_output"]
-                if _should_skip("evaluating") and ps.get("evaluation_summary"):
-                    try:
-                        restored_evaluation_summary = EvaluationSummary.model_validate(
-                            ps["evaluation_summary"]
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "evolution.resume.evaluation_summary_restore_failed",
-                            extra={"error": str(e)},
-                        )
-                if _should_skip("evaluating") and ps.get("validation_output"):
-                    restored_validation_output = ps["validation_output"]
+        restored = loop_support.restore_phase_state(
+            lineage,
+            generation_number,
+            current_seed,
+            resume_after_phase,
+        )
+        resume_after_phase = restored.resume_after_phase
+        wonder_output = restored.wonder_output
+        reflect_output = restored.reflect_output
+        restored_execution_output = restored.execution_output
+        restored_execution_boundary_completed = restored.execution_boundary_completed
+        restored_evaluation_summary = restored.evaluation_summary
+        restored_validation_output = restored.validation_output
+        restored_validation_boundary_completed = restored.validation_boundary_completed
+        checkpoint_focus = restored.checkpoint_focus
+        if checkpoint_focus is not None:
+            generation_focus = checkpoint_focus
 
         prev_gen = (
             next(
@@ -1532,7 +1488,6 @@ class EvolutionaryLoop:
                 seed=current_seed,
             )
 
-            # Wonder phase (skip if already completed before interruption)
             if self.wonder_engine and not _should_skip("wondering"):
                 wonder_kwargs: dict[str, Any] = {
                     "current_ontology": current_seed.ontology_schema,
@@ -1589,7 +1544,6 @@ class EvolutionaryLoop:
                         )
                     )
 
-            # Check for graceful shutdown after Wonder phase
             post_wonder_phase = (
                 GenerationPhase.WONDERING.value if wonder_output is not None else None
             )
@@ -1604,17 +1558,21 @@ class EvolutionaryLoop:
             if interrupted:
                 return Result.ok(interrupted)
 
-            # Phase transition: wondering → reflecting
-            await self.event_store.append(
-                lineage_generation_phase_changed(
-                    lineage.lineage_id,
-                    generation_number,
-                    GenerationPhase.REFLECTING.value,
+            if not _should_skip("reflecting"):
+                # Phase transition: wondering → reflecting
+                await self.event_store.append(
+                    loop_support.generation_phase_checkpoint(
+                        lineage_id=lineage.lineage_id,
+                        generation_number=generation_number,
+                        phase=GenerationPhase.REFLECTING,
+                        last_completed_phase=GenerationPhase.WONDERING.value,
+                        seed=current_seed,
+                        active_ac_indices=generation_focus.active_ac_indices,
+                        frozen_ac_indices=generation_focus.frozen_ac_indices,
+                        wonder_output=wonder_output,
+                    )
                 )
-            )
 
-            # Reflect phase (with retry on parse failure)
-            # Skip if already completed before interruption
             if (
                 self.reflect_engine
                 and wonder_output
@@ -1715,10 +1673,16 @@ class EvolutionaryLoop:
             elif reflect_output and not _should_skip("seeding"):
                 # Phase transition: reflecting → seeding
                 await self.event_store.append(
-                    lineage_generation_phase_changed(
-                        lineage.lineage_id,
-                        generation_number,
-                        GenerationPhase.SEEDING.value,
+                    loop_support.generation_phase_checkpoint(
+                        lineage_id=lineage.lineage_id,
+                        generation_number=generation_number,
+                        phase=GenerationPhase.SEEDING,
+                        last_completed_phase=GenerationPhase.REFLECTING.value,
+                        seed=current_seed,
+                        active_ac_indices=generation_focus.active_ac_indices,
+                        frozen_ac_indices=generation_focus.frozen_ac_indices,
+                        wonder_output=wonder_output,
+                        reflect_output=reflect_output,
                     )
                 )
 
@@ -1791,6 +1755,8 @@ class EvolutionaryLoop:
                 regression_report=regression_report,
                 enabled=self.config.focused_evolution,
             )
+            if checkpoint_focus is not None:
+                generation_focus = checkpoint_focus
             generation_focus.log_selection(generation_number)
 
         # Check for graceful shutdown before executing.
@@ -1816,19 +1782,24 @@ class EvolutionaryLoop:
         if interrupted:
             return Result.ok(interrupted)
 
-        # Phase transition: → executing
-        await self.event_store.append(
-            lineage_generation_phase_changed(
-                lineage.lineage_id,
-                generation_number,
-                GenerationPhase.EXECUTING.value,
+        if not _should_skip("executing"):
+            # Phase transition: → executing
+            await self.event_store.append(
+                loop_support.generation_phase_checkpoint(
+                    lineage_id=lineage.lineage_id,
+                    generation_number=generation_number,
+                    phase=GenerationPhase.EXECUTING,
+                    last_completed_phase=pre_exec_phase,
+                    seed=current_seed,
+                    active_ac_indices=generation_focus.active_ac_indices,
+                    frozen_ac_indices=generation_focus.frozen_ac_indices,
+                    wonder_output=wonder_output,
+                    reflect_output=reflect_output,
+                )
             )
-        )
 
-        # Execute phase (placeholder - actual execution via OrchestratorRunner)
-        # Skip if already completed before interruption (use restored output)
         execution_output: str | None = restored_execution_output
-        if execution_output and _should_skip("executing"):
+        if restored_execution_boundary_completed and _should_skip("executing"):
             logger.info(
                 "evolution.generation.execution_restored_from_checkpoint",
                 extra={"generation": generation_number},
@@ -1897,7 +1868,7 @@ class EvolutionaryLoop:
         # Validate phase - reconcile parallel execution artifacts
         # Skip if restored from checkpoint (resume after evaluating)
         validation_output: str | None = restored_validation_output
-        if validation_output and _should_skip("evaluating"):
+        if restored_validation_boundary_completed and _should_skip("executing"):
             logger.info(
                 "evolution.generation.validation_restored_from_checkpoint",
                 extra={"generation": generation_number},
@@ -1937,14 +1908,25 @@ class EvolutionaryLoop:
         if interrupted:
             return Result.ok(interrupted)
 
-        # Phase transition: → evaluating
-        await self.event_store.append(
-            lineage_generation_phase_changed(
-                lineage.lineage_id,
-                generation_number,
-                GenerationPhase.EVALUATING.value,
+        if not _should_skip("evaluating"):
+            # Phase transition: → evaluating
+            await self.event_store.append(
+                loop_support.generation_phase_checkpoint(
+                    lineage_id=lineage.lineage_id,
+                    generation_number=generation_number,
+                    phase=GenerationPhase.EVALUATING,
+                    last_completed_phase=GenerationPhase.EXECUTING.value,
+                    seed=current_seed,
+                    active_ac_indices=generation_focus.active_ac_indices,
+                    frozen_ac_indices=generation_focus.frozen_ac_indices,
+                    wonder_output=wonder_output,
+                    reflect_output=reflect_output,
+                    execution_output=execution_output,
+                    execution_boundary_completed=True,
+                    validation_output=validation_output,
+                    validation_boundary_completed=True,
+                )
             )
-        )
 
         # Evaluate phase (placeholder - actual evaluation via EvaluationPipeline)
         # Skip if already completed before interruption (use restored summary)
@@ -1966,6 +1948,25 @@ class EvolutionaryLoop:
                     "evolution.evaluation.failed",
                     extra={"error": str(e), "generation": generation_number},
                 )
+
+        await self.event_store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase=GenerationPhase.EVALUATING,
+                last_completed_phase=GenerationPhase.EVALUATING.value,
+                seed=current_seed,
+                active_ac_indices=generation_focus.active_ac_indices,
+                frozen_ac_indices=generation_focus.frozen_ac_indices,
+                wonder_output=wonder_output,
+                reflect_output=reflect_output,
+                execution_output=execution_output,
+                execution_boundary_completed=True,
+                validation_output=validation_output,
+                validation_boundary_completed=True,
+                evaluation_summary=evaluation_summary,
+            )
+        )
 
         # Measure drift after evaluation
         if execution_output:

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -161,13 +161,19 @@ def generation_partial_state(
     partial_state: dict[str, Any] = {
         "execution_boundary_completed": execution_boundary_completed,
         "validation_boundary_completed": validation_boundary_completed,
+        "wonder_output_complete": True,
+        "reflect_output_complete": True,
     }
     if focus_checkpointed:
         partial_state["focus_checkpointed"] = True
     if wonder_output is not None:
         partial_state["wonder_questions"] = list(wonder_output.questions)
+        partial_state["wonder_output"] = wonder_output.model_dump(mode="json")
     if reflect_output is not None:
         partial_state["reflect_output"] = reflect_output.model_dump(mode="json")
+        partial_state["reflect_patch_identity_explicit"] = bool(
+            reflect_output.ac_patch_identity_explicit
+        )
     if execution_output is not None:
         partial_state["execution_output"] = execution_output[:10_000]
         partial_state["execution_output_complete"] = len(execution_output) <= 10_000
@@ -216,6 +222,27 @@ def hard_crash_recovery(
             "Cannot safely redispatch a hard-crashed executing generation; reconcile the "
             "external execution before retrying"
         )
+    if last_phase != GenerationPhase.WONDERING:
+        assert record is not None
+        partial_state = record.partial_state
+        assert partial_state is not None
+        if partial_state.get("wonder_output_complete") is not True:
+            return record, (
+                "Cannot safely recover hard-crashed generation: complete Wonder output is "
+                "unavailable"
+            )
+        if record.last_completed_phase in {
+            GenerationPhase.REFLECTING.value,
+            GenerationPhase.SEEDING.value,
+        } and (
+            partial_state.get("reflect_output_complete") is not True
+            or not isinstance(partial_state.get("reflect_output"), Mapping)
+            or not isinstance(partial_state.get("reflect_patch_identity_explicit"), bool)
+        ):
+            return record, (
+                "Cannot safely recover hard-crashed generation: complete Reflect output and "
+                "patch provenance are unavailable"
+            )
     if last_phase == GenerationPhase.EVALUATING and execute:
         assert partial_state is not None
         if partial_state.get("execution_boundary_completed") is not True or (
@@ -255,6 +282,7 @@ def restore_phase_state(
     lineage: OntologyLineage,
     generation_number: int,
     current_seed: Seed,
+    generation_parent_seed: Seed,
     resume_after_phase: str | None,
 ) -> RestoredPhaseState:
     """Restore checkpointed outputs without trusting them across unfinished boundaries."""
@@ -300,13 +328,20 @@ def restore_phase_state(
                 reason="restored durable phase checkpoint",
             )
     wonder_output = None
-    if should_skip("wondering") and partial_state.get("wonder_questions"):
+    if should_skip("wondering") and partial_state.get("wonder_output_complete") is True:
+        checkpointed_wonder = partial_state.get("wonder_output")
+        if checkpointed_wonder is not None:
+            try:
+                wonder_output = WonderOutput.model_validate(checkpointed_wonder)
+            except Exception as exc:
+                raise ValueError(f"Failed to restore complete Wonder checkpoint: {exc}") from exc
+    elif should_skip("wondering") and "wonder_questions" in partial_state:
         questions = tuple(partial_state["wonder_questions"])
         wonder_output = WonderOutput(
             questions=questions,
             grounded_questions=ground_questions(
                 questions,
-                len(current_seed.acceptance_criteria),
+                len(generation_parent_seed.acceptance_criteria),
             ),
             should_continue=True,
         )
@@ -314,17 +349,39 @@ def restore_phase_state(
     if should_skip("reflecting") and partial_state.get("reflect_output"):
         try:
             restored_reflect_output = ReflectOutput.model_validate(partial_state["reflect_output"])
-            if restored_reflect_output.ac_patches and not should_skip("seeding"):
+            durable_reflect = partial_state.get("reflect_output_complete") is True
+            explicit_patch_identity = partial_state.get("reflect_patch_identity_explicit")
+            if durable_reflect and not isinstance(explicit_patch_identity, bool):
+                raise ValueError("Complete Reflect checkpoint lacks patch provenance")
+            if durable_reflect and explicit_patch_identity is True:
+                restored_reflect_output.restore_durable_patch_identity(generation_parent_seed)
+            if (
+                restored_reflect_output.ac_patches
+                and not restored_reflect_output.ac_patch_identity_explicit
+                and not durable_reflect
+                and not should_skip("seeding")
+            ):
                 resume_after_phase = "wondering"
             else:
                 reflect_output = restored_reflect_output
         except Exception as exc:
+            if partial_state.get("reflect_output_complete") is True:
+                raise ValueError(f"Failed to restore complete Reflect checkpoint: {exc}") from exc
             logger.warning(
                 "evolution.resume.reflect_output_restore_failed",
                 extra={"error": str(exc)},
             )
-    execution_boundary_completed = (
-        should_skip("executing") and partial_state.get("execution_boundary_completed") is True
+    # Graceful-interruption events written before durable phase checkpoints
+    # carried ``last_completed_phase`` but no explicit boundary marker.  That
+    # event is itself an authoritative acknowledgement that the boundary
+    # completed.  Hard-crash records must still carry the explicit marker and
+    # therefore remain fail-closed.
+    graceful_execution_completed = record.phase == GenerationPhase.INTERRUPTED and (
+        record.last_completed_phase
+        in {GenerationPhase.EXECUTING.value, GenerationPhase.EVALUATING.value}
+    )
+    execution_boundary_completed = should_skip("executing") and (
+        partial_state.get("execution_boundary_completed") is True or graceful_execution_completed
     )
     execution_output = (
         partial_state.get("execution_output") if execution_boundary_completed else None
@@ -342,8 +399,8 @@ def restore_phase_state(
                 "evolution.resume.evaluation_summary_restore_failed",
                 extra={"error": str(exc)},
             )
-    validation_boundary_completed = (
-        should_skip("executing") and partial_state.get("validation_boundary_completed") is True
+    validation_boundary_completed = should_skip("executing") and (
+        partial_state.get("validation_boundary_completed") is True or graceful_execution_completed
     )
     validation_output = (
         partial_state.get("validation_output") if validation_boundary_completed else None

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -682,8 +682,29 @@ async def run_durable_lineage_single_flight[T](
             await asyncio.sleep(0.01)
             continue
 
+        waiter_id = claim.waiter_id
+        if waiter_id is None:
+            raise RuntimeError("Durable lineage waiter registration has no identity")
+        waiter_heartbeat = asyncio.create_task(
+            _renew_waiter_until_cancelled(
+                event_store,
+                scope=scope,
+                lineage_id=lineage_id,
+                owner_id=claim.owner_id,
+                waiter_id=waiter_id,
+            )
+        )
         try:
             while True:
+                if waiter_heartbeat.done():
+                    heartbeat_error = (
+                        None if waiter_heartbeat.cancelled() else waiter_heartbeat.exception()
+                    )
+                    if heartbeat_error is not None:
+                        raise RuntimeError(
+                            "Durable lineage waiter heartbeat failed before receipt replay"
+                        ) from heartbeat_error
+                    raise RuntimeError("Lost durable lineage waiter registration")
                 winner = await lineage_claims.observe(
                     event_store,
                     scope=scope,
@@ -703,11 +724,19 @@ async def run_durable_lineage_single_flight[T](
                     raise LineageWinnerAdvanced
                 await asyncio.sleep(0.01)
         finally:
+            waiter_heartbeat.cancel()
+            try:
+                await waiter_heartbeat
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
             await lineage_claims.acknowledge_waiter(
                 event_store,
                 scope=scope,
                 lineage_id=lineage_id,
                 owner_id=claim.owner_id,
+                waiter_id=waiter_id,
             )
 
 
@@ -729,6 +758,29 @@ async def _renew_claim_until_cancelled(
             owner_id=owner_id,
         ):
             raise RuntimeError("Lost durable lineage advancement claim during renewal")
+
+
+async def _renew_waiter_until_cancelled(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+    waiter_id: str,
+) -> None:
+    """Heartbeat one waiter registration until its winner receipt is consumed."""
+    from ouroboros.persistence import lineage_claims
+
+    while True:
+        await asyncio.sleep(lineage_claims.WAITER_LEASE_SECONDS / 3)
+        if not await lineage_claims.renew_waiter(
+            event_store,
+            scope=scope,
+            lineage_id=lineage_id,
+            owner_id=owner_id,
+            waiter_id=waiter_id,
+        ):
+            raise RuntimeError("Lost durable lineage waiter registration during renewal")
 
 
 async def planned_evolve_generation(

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -1,0 +1,46 @@
+"""Small deterministic helpers shared by the evolution loop."""
+
+from __future__ import annotations
+
+from ouroboros.config.models import RuntimeControlsConfig
+from ouroboros.core.conductor import ConductorDirective
+from ouroboros.core.seed import Seed
+
+
+def default_runtime_controls() -> RuntimeControlsConfig:
+    """Load runtime controls through the config/env compatibility layer."""
+    from ouroboros.config.loader import get_runtime_controls_config
+
+    return get_runtime_controls_config()
+
+
+def generation_execution_id(lineage_id: str, generation_number: int) -> str:
+    """Build the deterministic execution ID for an evolve generation."""
+    return f"evolve:{lineage_id}:generation:{generation_number}"
+
+
+def conductor_preservation_error(
+    approved: Seed,
+    successor: Seed,
+    directive: ConductorDirective | None,
+) -> str | None:
+    """Return a fail-closed invariant error for an unauthorized direction change."""
+    if directive is None:
+        return None
+    changed: list[str] = []
+    if directive.preserve_goal and approved.goal != successor.goal:
+        changed.append("goal")
+    if (
+        directive.preserve_acceptance_criteria
+        and approved.acceptance_criteria != successor.acceptance_criteria
+    ):
+        changed.append("acceptance_criteria")
+    if directive.preserve_constraints and approved.constraints != successor.constraints:
+        changed.append("constraints")
+    if directive.preserve_non_goals and approved.to_dict().get(
+        "non_goals"
+    ) != successor.to_dict().get("non_goals"):
+        changed.append("non_goals")
+    if not changed:
+        return None
+    return "Conductor successor changed preserved direction fields: " + ", ".join(changed)

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -163,6 +163,7 @@ def generation_partial_state(
         "validation_boundary_completed": validation_boundary_completed,
         "wonder_output_complete": True,
         "reflect_output_complete": True,
+        "evaluation_summary_complete": True,
     }
     if focus_checkpointed:
         partial_state["focus_checkpointed"] = True
@@ -234,6 +235,14 @@ def hard_crash_recovery(
         if record.last_completed_phase in {
             GenerationPhase.REFLECTING.value,
             GenerationPhase.SEEDING.value,
+        } and not isinstance(partial_state.get("wonder_output"), Mapping):
+            return record, (
+                "Cannot safely recover hard-crashed generation: complete Wonder output is "
+                "unavailable"
+            )
+        if record.last_completed_phase in {
+            GenerationPhase.REFLECTING.value,
+            GenerationPhase.SEEDING.value,
         } and (
             partial_state.get("reflect_output_complete") is not True
             or not isinstance(partial_state.get("reflect_output"), Mapping)
@@ -242,6 +251,14 @@ def hard_crash_recovery(
             return record, (
                 "Cannot safely recover hard-crashed generation: complete Reflect output and "
                 "patch provenance are unavailable"
+            )
+        if (
+            record.last_completed_phase == GenerationPhase.EVALUATING.value
+            and partial_state.get("evaluation_summary_complete") is not True
+        ):
+            return record, (
+                "Cannot safely recover hard-crashed generation: complete evaluation summary "
+                "is unavailable"
             )
     if last_phase == GenerationPhase.EVALUATING and execute:
         assert partial_state is not None
@@ -395,6 +412,10 @@ def restore_phase_state(
                 partial_state["evaluation_summary"]
             )
         except Exception as exc:
+            if partial_state.get("evaluation_summary_complete") is True:
+                raise ValueError(
+                    f"Failed to restore complete evaluation checkpoint: {exc}"
+                ) from exc
             logger.warning(
                 "evolution.resume.evaluation_summary_restore_failed",
                 extra={"error": str(exc)},

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -326,7 +326,9 @@ def restore_phase_state(
     execution_boundary_completed = (
         should_skip("executing") and partial_state.get("execution_boundary_completed") is True
     )
-    execution_output = partial_state.get("execution_output")
+    execution_output = (
+        partial_state.get("execution_output") if execution_boundary_completed else None
+    )
     if not isinstance(execution_output, str):
         execution_output = None
     evaluation_summary = None
@@ -343,7 +345,9 @@ def restore_phase_state(
     validation_boundary_completed = (
         should_skip("executing") and partial_state.get("validation_boundary_completed") is True
     )
-    validation_output = partial_state.get("validation_output")
+    validation_output = (
+        partial_state.get("validation_output") if validation_boundary_completed else None
+    )
     if not isinstance(validation_output, str):
         validation_output = None
     return RestoredPhaseState(

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -7,25 +7,45 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, fields, is_dataclass
 import inspect
 import json
+import logging
 import time
 from typing import Any
 from uuid import uuid4
 
 from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.conductor import ConductorDirective, stable_payload_digest
-from ouroboros.core.lineage import GenerationPhase, GenerationRecord, OntologyLineage
+from ouroboros.core.lineage import (
+    EvaluationSummary,
+    GenerationPhase,
+    GenerationRecord,
+    OntologyLineage,
+)
 from ouroboros.core.seed import Seed
+from ouroboros.events.base import BaseEvent
 from ouroboros.events.control import create_control_directive_emitted_event
-from ouroboros.events.lineage import lineage_generation_started
+from ouroboros.events.lineage import lineage_generation_phase_changed, lineage_generation_started
 from ouroboros.evolution.directive_mapping import (
     is_terminal_directive,
     step_action_to_directive,
 )
 from ouroboros.persistence.event_store import EventStore
 
+logger = logging.getLogger(__name__)
+_PHASE_ORDER = ("wondering", "reflecting", "seeding", "executing", "evaluating")
+
 
 class LineageWinnerAdvanced(RuntimeError):
     """The caller must recompute its request from the durable winner state."""
+
+
+def phase_should_skip(phase: str, resume_after_phase: str | None) -> bool:
+    """Return whether a phase completed before the durable resume boundary."""
+    if resume_after_phase is None:
+        return False
+    try:
+        return _PHASE_ORDER.index(phase) <= _PHASE_ORDER.index(resume_after_phase)
+    except ValueError:
+        return False
 
 
 @dataclass(slots=True)
@@ -83,6 +103,260 @@ def evolution_execution_policy(config: Any | None) -> dict[str, Any] | None:
     if not isinstance(projected, dict):
         raise TypeError("Evolution execution policy must project to an object")
     return projected
+
+
+def generation_phase_checkpoint(
+    *,
+    lineage_id: str,
+    generation_number: int,
+    phase: GenerationPhase,
+    last_completed_phase: str | None,
+    seed: Seed,
+    active_ac_indices: tuple[int, ...],
+    frozen_ac_indices: tuple[int, ...],
+    wonder_output: Any | None = None,
+    reflect_output: Any | None = None,
+    execution_output: str | None = None,
+    execution_boundary_completed: bool = False,
+    validation_output: str | None = None,
+    validation_boundary_completed: bool = False,
+    evaluation_summary: Any | None = None,
+) -> BaseEvent:
+    """Persist bounded state needed to resume without replaying prior side effects."""
+    partial_state = generation_partial_state(
+        wonder_output=wonder_output,
+        reflect_output=reflect_output,
+        execution_output=execution_output,
+        execution_boundary_completed=execution_boundary_completed,
+        validation_output=validation_output,
+        validation_boundary_completed=validation_boundary_completed,
+        evaluation_summary=evaluation_summary,
+        focus_checkpointed=True,
+    )
+    return lineage_generation_phase_changed(
+        lineage_id,
+        generation_number,
+        phase.value,
+        last_completed_phase=last_completed_phase,
+        seed_id=seed.metadata.seed_id,
+        seed_json=json.dumps(seed.to_dict()),
+        partial_state=partial_state,
+        active_ac_indices=list(active_ac_indices),
+        frozen_ac_indices=list(frozen_ac_indices),
+    )
+
+
+def generation_partial_state(
+    *,
+    wonder_output: Any | None = None,
+    reflect_output: Any | None = None,
+    execution_output: str | None = None,
+    execution_boundary_completed: bool = False,
+    validation_output: str | None = None,
+    validation_boundary_completed: bool = False,
+    evaluation_summary: Any | None = None,
+    focus_checkpointed: bool = False,
+) -> dict[str, Any]:
+    """Serialize bounded phase outputs with explicit completeness markers."""
+    partial_state: dict[str, Any] = {
+        "execution_boundary_completed": execution_boundary_completed,
+        "validation_boundary_completed": validation_boundary_completed,
+    }
+    if focus_checkpointed:
+        partial_state["focus_checkpointed"] = True
+    if wonder_output is not None:
+        partial_state["wonder_questions"] = list(wonder_output.questions)
+    if reflect_output is not None:
+        partial_state["reflect_output"] = reflect_output.model_dump(mode="json")
+    if execution_output is not None:
+        partial_state["execution_output"] = execution_output[:10_000]
+        partial_state["execution_output_complete"] = len(execution_output) <= 10_000
+    if validation_output is not None:
+        partial_state["validation_output"] = validation_output[:5_000]
+        partial_state["validation_output_complete"] = len(validation_output) <= 5_000
+    if evaluation_summary is not None:
+        partial_state["evaluation_summary"] = evaluation_summary.model_dump(mode="json")
+    return partial_state
+
+
+def hard_crash_recovery(
+    lineage: OntologyLineage,
+    generation_number: int,
+    last_phase: GenerationPhase,
+    *,
+    execute: bool,
+) -> tuple[GenerationRecord | None, str | None]:
+    """Validate whether a nonterminal generation has enough authority to resume."""
+    if last_phase in {
+        GenerationPhase.COMPLETED,
+        GenerationPhase.FAILED,
+        GenerationPhase.INTERRUPTED,
+    }:
+        return None, None
+    record = next(
+        (
+            generation
+            for generation in reversed(lineage.generations)
+            if generation.generation_number == generation_number
+        ),
+        None,
+    )
+    partial_state = record.partial_state if record is not None else None
+    if last_phase != GenerationPhase.WONDERING and (
+        record is None
+        or record.last_completed_phase is None
+        or not partial_state
+        or partial_state.get("focus_checkpointed") is not True
+    ):
+        return record, (
+            "Cannot safely recover hard-crashed generation: durable phase checkpoint is unavailable"
+        )
+    if last_phase == GenerationPhase.EXECUTING and execute:
+        return record, (
+            "Cannot safely redispatch a hard-crashed executing generation; reconcile the "
+            "external execution before retrying"
+        )
+    if last_phase == GenerationPhase.EVALUATING and execute:
+        assert partial_state is not None
+        if partial_state.get("execution_boundary_completed") is not True or (
+            "execution_output" in partial_state
+            and partial_state.get("execution_output_complete") is not True
+        ):
+            return record, (
+                "Cannot safely recover evaluation: durable execution output is unavailable "
+                "or incomplete"
+            )
+        if (
+            "validation_output" in partial_state
+            and partial_state.get("validation_output_complete") is not True
+        ):
+            return record, (
+                "Cannot safely recover evaluation: durable validation output is incomplete"
+            )
+    return record, None
+
+
+@dataclass(frozen=True, slots=True)
+class RestoredPhaseState:
+    """Typed in-memory projection of one durable nonterminal phase checkpoint."""
+
+    resume_after_phase: str | None
+    wonder_output: Any | None = None
+    reflect_output: Any | None = None
+    execution_output: str | None = None
+    execution_boundary_completed: bool = False
+    evaluation_summary: EvaluationSummary | None = None
+    validation_output: str | None = None
+    validation_boundary_completed: bool = False
+    checkpoint_focus: Any | None = None
+
+
+def restore_phase_state(
+    lineage: OntologyLineage,
+    generation_number: int,
+    current_seed: Seed,
+    resume_after_phase: str | None,
+) -> RestoredPhaseState:
+    """Restore checkpointed outputs without trusting them across unfinished boundaries."""
+    if not resume_after_phase or not lineage.generations:
+        return RestoredPhaseState(resume_after_phase=resume_after_phase)
+    from ouroboros.evolution import focus
+    from ouroboros.evolution.reflect import ReflectOutput
+    from ouroboros.evolution.wonder import WonderOutput, ground_questions
+
+    phase_order = ["wondering", "reflecting", "seeding", "executing", "evaluating"]
+
+    def should_skip(phase: str) -> bool:
+        try:
+            return phase_order.index(phase) <= phase_order.index(resume_after_phase)
+        except ValueError:
+            return False
+
+    record = next(
+        (
+            generation
+            for generation in reversed(lineage.generations)
+            if generation.generation_number == generation_number
+        ),
+        None,
+    )
+    if record is None or not record.partial_state:
+        return RestoredPhaseState(resume_after_phase=resume_after_phase)
+    partial_state = record.partial_state
+    checkpoint_focus = None
+    if partial_state.get("focus_checkpointed") is True:
+        active = record.active_ac_indices
+        frozen = record.frozen_ac_indices
+        expected = set(range(len(current_seed.acceptance_criteria)))
+        if (
+            len(active) == len(set(active))
+            and len(frozen) == len(set(frozen))
+            and not set(active) & set(frozen)
+            and set(active) | set(frozen) == expected
+        ):
+            checkpoint_focus = focus.EvolutionFocus(
+                active_ac_indices=active,
+                frozen_ac_indices=frozen,
+                reason="restored durable phase checkpoint",
+            )
+    wonder_output = None
+    if should_skip("wondering") and partial_state.get("wonder_questions"):
+        questions = tuple(partial_state["wonder_questions"])
+        wonder_output = WonderOutput(
+            questions=questions,
+            grounded_questions=ground_questions(
+                questions,
+                len(current_seed.acceptance_criteria),
+            ),
+            should_continue=True,
+        )
+    reflect_output = None
+    if should_skip("reflecting") and partial_state.get("reflect_output"):
+        try:
+            restored_reflect_output = ReflectOutput.model_validate(partial_state["reflect_output"])
+            if restored_reflect_output.ac_patches and not should_skip("seeding"):
+                resume_after_phase = "wondering"
+            else:
+                reflect_output = restored_reflect_output
+        except Exception as exc:
+            logger.warning(
+                "evolution.resume.reflect_output_restore_failed",
+                extra={"error": str(exc)},
+            )
+    execution_boundary_completed = (
+        should_skip("executing") and partial_state.get("execution_boundary_completed") is True
+    )
+    execution_output = partial_state.get("execution_output")
+    if not isinstance(execution_output, str):
+        execution_output = None
+    evaluation_summary = None
+    if should_skip("evaluating") and partial_state.get("evaluation_summary"):
+        try:
+            evaluation_summary = EvaluationSummary.model_validate(
+                partial_state["evaluation_summary"]
+            )
+        except Exception as exc:
+            logger.warning(
+                "evolution.resume.evaluation_summary_restore_failed",
+                extra={"error": str(exc)},
+            )
+    validation_boundary_completed = (
+        should_skip("executing") and partial_state.get("validation_boundary_completed") is True
+    )
+    validation_output = partial_state.get("validation_output")
+    if not isinstance(validation_output, str):
+        validation_output = None
+    return RestoredPhaseState(
+        resume_after_phase=resume_after_phase,
+        wonder_output=wonder_output,
+        reflect_output=reflect_output,
+        execution_output=execution_output,
+        execution_boundary_completed=execution_boundary_completed,
+        evaluation_summary=evaluation_summary,
+        validation_output=validation_output,
+        validation_boundary_completed=validation_boundary_completed,
+        checkpoint_focus=checkpoint_focus,
+    )
 
 
 async def emit_generation_started_once(

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -2,9 +2,47 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+import inspect
+import json
+import time
+from typing import Any
+from uuid import uuid4
+
 from ouroboros.config.models import RuntimeControlsConfig
-from ouroboros.core.conductor import ConductorDirective
+from ouroboros.core.conductor import ConductorDirective, stable_payload_digest
+from ouroboros.core.lineage import GenerationPhase, GenerationRecord, OntologyLineage
 from ouroboros.core.seed import Seed
+from ouroboros.events.control import create_control_directive_emitted_event
+from ouroboros.events.lineage import lineage_generation_started
+from ouroboros.evolution.directive_mapping import (
+    is_terminal_directive,
+    step_action_to_directive,
+)
+from ouroboros.persistence.event_store import EventStore
+
+
+class LineageWinnerAdvanced(RuntimeError):
+    """The caller must recompute its request from the durable winner state."""
+
+
+@dataclass(slots=True)
+class _LineageFlight[T]:
+    request_key: str
+    task: asyncio.Task[T]
+    waiters: int = 0
+
+
+_lineage_flights: dict[str, dict[tuple[str, str], _LineageFlight[Any]]] = {}
+
+
+def _event_store_authority(event_store: EventStore) -> str:
+    database_url = getattr(event_store, "_database_url", None)
+    if isinstance(database_url, str) and ":memory:" not in database_url:
+        return f"database:{database_url}"
+    return f"object:{id(event_store)}"
 
 
 def default_runtime_controls() -> RuntimeControlsConfig:
@@ -17,6 +55,418 @@ def default_runtime_controls() -> RuntimeControlsConfig:
 def generation_execution_id(lineage_id: str, generation_number: int) -> str:
     """Build the deterministic execution ID for an evolve generation."""
     return f"evolve:{lineage_id}:generation:{generation_number}"
+
+
+async def emit_generation_started_once(
+    event_store: EventStore,
+    *,
+    lineage_id: str,
+    generation_number: int,
+    phase: str,
+    seed: Seed,
+) -> None:
+    """Persist the sole started event while allowing later attempts to resume."""
+    events = await event_store.replay_lineage(lineage_id)
+    if any(
+        event.type == "lineage.generation.started"
+        and event.data.get("generation_number") == generation_number
+        for event in events
+    ):
+        return
+    await event_store.append(
+        lineage_generation_started(
+            lineage_id,
+            generation_number,
+            phase,
+            seed.metadata.seed_id,
+            json.dumps(seed.to_dict()),
+        )
+    )
+
+
+def evolve_request_key(
+    initial_seed: Seed | None,
+    *,
+    execute: bool,
+    parallel: bool,
+    conductor_directive: ConductorDirective | None,
+    project_dir: str | None = None,
+    generation_number: int | None = None,
+) -> str:
+    """Identify inputs whose concurrent callers may share one evolve result."""
+    return stable_payload_digest(
+        {
+            "initial_seed": initial_seed.to_dict() if initial_seed is not None else None,
+            "execute": execute,
+            "parallel": parallel,
+            "project_dir": project_dir,
+            "generation_number": generation_number,
+            "conductor_directive": (
+                conductor_directive.to_event_data() if conductor_directive is not None else None
+            ),
+        }
+    )
+
+
+def _release_lineage_flight(
+    authority: str,
+    flight_key: tuple[str, str],
+    flight: _LineageFlight[Any],
+) -> None:
+    flights = _lineage_flights.get(authority)
+    if flights is None or flights.get(flight_key) is not flight:
+        return
+    flights.pop(flight_key, None)
+    if not flights:
+        _lineage_flights.pop(authority, None)
+
+
+def _finish_lineage_flight(
+    task: asyncio.Task[Any],
+    authority: str,
+    flight_key: tuple[str, str],
+    flight: _LineageFlight[Any],
+) -> None:
+    _release_lineage_flight(authority, flight_key, flight)
+    if not task.cancelled():
+        task.exception()
+
+
+async def _await_lineage_flight[T](flight: _LineageFlight[T]) -> T:
+    """Await a shared task while preserving sole-caller cancellation."""
+    flight.waiters += 1
+    caller_cancelled = False
+    try:
+        return await asyncio.shield(flight.task)
+    except asyncio.CancelledError as cancellation:
+        caller_cancelled = True
+        flight.waiters -= 1
+        if flight.waiters == 0 and not flight.task.done():
+            flight.task.cancel()
+            while not flight.task.done():
+                try:
+                    await asyncio.shield(flight.task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+        raise cancellation
+    finally:
+        if not caller_cancelled:
+            flight.waiters -= 1
+
+
+async def run_lineage_single_flight[T](
+    event_store: EventStore,
+    lineage_id: str,
+    request_key: str,
+    operation: Callable[[], Awaitable[T]],
+    *,
+    scope: str = "evolve-core",
+    replan_on_different: bool = False,
+) -> T:
+    """Run one process-local writer per lineage and coalesce identical calls.
+
+    A caller with identical inputs observes the winner's exact result. A caller
+    with different inputs waits for the durable winner, then retries against the
+    newly replayable lineage state. Shielding prevents one duplicate caller from
+    cancelling provider work shared with the others.
+    """
+    authority = _event_store_authority(event_store)
+    flight_key = (scope, lineage_id)
+    while True:
+        flights = _lineage_flights.setdefault(authority, {})
+        current = flights.get(flight_key)
+        if current is None:
+            task: asyncio.Task[T] = asyncio.create_task(operation())
+            current = _LineageFlight(request_key=request_key, task=task)
+            flights[flight_key] = current
+            task.add_done_callback(
+                lambda completed, flight=current: _finish_lineage_flight(
+                    completed, authority, flight_key, flight
+                )
+            )
+            return await _await_lineage_flight(current)
+
+        if current.request_key == request_key:
+            return await _await_lineage_flight(current)
+
+        try:
+            await asyncio.shield(current.task)
+        except asyncio.CancelledError:
+            if not current.task.cancelled():
+                raise
+        except Exception:
+            pass
+        _release_lineage_flight(authority, flight_key, current)
+        if replan_on_different:
+            raise LineageWinnerAdvanced
+
+
+async def run_durable_lineage_single_flight[T](
+    event_store: EventStore,
+    lineage_id: str,
+    request_key: str,
+    operation: Callable[[], Awaitable[T]],
+    *,
+    generation_number: int,
+    encode: Callable[[T], dict[str, Any]],
+    decode: Callable[[Mapping[str, Any]], T | Awaitable[T]],
+    scope: str = "evolve-core",
+) -> T:
+    """Coordinate one lineage writer across EventStore instances and processes."""
+    from ouroboros.persistence import lineage_claims
+
+    if not lineage_claims.supports_durable_claims(event_store):
+        return await operation()
+    await event_store.initialize()
+    while True:
+        owner_id = str(uuid4())
+        claim = await lineage_claims.try_acquire(
+            event_store,
+            scope=scope,
+            lineage_id=lineage_id,
+            generation_number=generation_number,
+            owner_id=owner_id,
+            request_key=request_key,
+        )
+        if claim is None:  # pragma: no cover - production claims fail closed.
+            raise RuntimeError("Durable lineage claim acquisition returned no authority")
+        if claim.completed:
+            if (
+                claim.generation_number == generation_number
+                and claim.request_key == request_key
+                and claim.result_payload is not None
+            ):
+                decoded = decode(claim.result_payload)
+                return await decoded if inspect.isawaitable(decoded) else decoded
+            if claim.generation_number == generation_number:
+                raise LineageWinnerAdvanced
+            await asyncio.sleep(0.01)
+            continue
+        if claim.acquired:
+            heartbeat = asyncio.create_task(
+                _renew_claim_until_cancelled(
+                    event_store,
+                    scope=scope,
+                    lineage_id=lineage_id,
+                    owner_id=owner_id,
+                )
+            )
+            try:
+                result = await operation()
+                if heartbeat.done():
+                    heartbeat_error = None if heartbeat.cancelled() else heartbeat.exception()
+                    if heartbeat_error is not None:
+                        raise RuntimeError(
+                            "Durable lineage claim heartbeat failed before completion"
+                        ) from heartbeat_error
+                    raise RuntimeError("Lost durable lineage advancement claim before completion")
+                published = await lineage_claims.complete(
+                    event_store,
+                    scope=scope,
+                    lineage_id=lineage_id,
+                    owner_id=owner_id,
+                    result_payload=encode(result),
+                )
+                if not published:
+                    raise RuntimeError("Lost durable lineage advancement claim before completion")
+                return result
+            except BaseException:
+                await lineage_claims.release(
+                    event_store,
+                    scope=scope,
+                    lineage_id=lineage_id,
+                    owner_id=owner_id,
+                )
+                raise
+            finally:
+                heartbeat.cancel()
+                try:
+                    await heartbeat
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    # A committed receipt is authoritative. A heartbeat failure
+                    # observed before commit is raised above; one racing after a
+                    # successful commit must not replace that durable outcome.
+                    pass
+
+        if not claim.waiter_registered:
+            await asyncio.sleep(0.01)
+            continue
+
+        try:
+            while True:
+                winner = await lineage_claims.observe(
+                    event_store,
+                    scope=scope,
+                    lineage_id=lineage_id,
+                )
+                if winner is None or winner.owner_id != claim.owner_id:
+                    raise LineageWinnerAdvanced
+                if not winner.completed and winner.lease_expires_at_ms <= int(time.time() * 1000):
+                    raise RuntimeError(
+                        "Durable lineage owner lease expired; confirm the owner process is dead, "
+                        "then rerun ouroboros_evolve_step with recover_expired_claim=true"
+                    )
+                if winner.completed:
+                    if winner.request_key == request_key and winner.result_payload is not None:
+                        decoded = decode(winner.result_payload)
+                        return await decoded if inspect.isawaitable(decoded) else decoded
+                    raise LineageWinnerAdvanced
+                await asyncio.sleep(0.01)
+        finally:
+            await lineage_claims.acknowledge_waiter(
+                event_store,
+                scope=scope,
+                lineage_id=lineage_id,
+                owner_id=claim.owner_id,
+            )
+
+
+async def _renew_claim_until_cancelled(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+) -> None:
+    from ouroboros.persistence import lineage_claims
+
+    while True:
+        await asyncio.sleep(lineage_claims.DEFAULT_LEASE_SECONDS / 3)
+        if not await lineage_claims.renew(
+            event_store,
+            scope=scope,
+            lineage_id=lineage_id,
+            owner_id=owner_id,
+        ):
+            raise RuntimeError("Lost durable lineage advancement claim during renewal")
+
+
+async def planned_evolve_generation(
+    event_store: EventStore,
+    lineage_id: str,
+    *,
+    execute: bool,
+) -> int:
+    """Return the generation identity a fresh evolve request would advance."""
+    from ouroboros.core.lineage import GenerationPhase, LineageStatus
+    from ouroboros.evolution.projector import LineageProjector
+
+    events = await event_store.replay_lineage(lineage_id)
+    if not events:
+        return 1
+    projector = LineageProjector()
+    lineage = projector.project(events)
+    if lineage is None:
+        raise ValueError("Failed to project lineage for advancement claim")
+    if lineage.status in {LineageStatus.CONVERGED, LineageStatus.EXHAUSTED}:
+        return lineage.current_generation
+    last_generation, last_phase, _ = projector.find_resume_point(events)
+    if lineage.verification_handoff_pending and not execute:
+        return lineage.current_generation
+    if last_phase != GenerationPhase.COMPLETED:
+        return last_generation
+    return last_generation + 1
+
+
+async def refresh_lineage(
+    event_store: EventStore,
+    fallback: OntologyLineage,
+) -> OntologyLineage:
+    """Project the durable state written by a failed or interrupted generation."""
+    from ouroboros.evolution.projector import LineageProjector
+
+    projected = LineageProjector().project(await event_store.replay_lineage(fallback.lineage_id))
+    return projected or fallback
+
+
+def generation_parent_seed(current_seed: Seed, previous: GenerationRecord | None) -> Seed:
+    """Restore the completed parent that owns the previous evaluation."""
+    if previous is None or not isinstance(previous.seed_json, str) or not previous.seed_json:
+        return current_seed
+    try:
+        return Seed.from_dict(json.loads(previous.seed_json))
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to reconstruct generation parent Seed from seed_json: {exc}"
+        ) from exc
+
+
+def watchdog_timeout_action(timeout_kind: str) -> str:
+    """Map a watchdog timeout to its public evolve action value."""
+    from ouroboros.evolution.directive_mapping import watchdog_timeout_to_directive
+
+    directive = watchdog_timeout_to_directive(timeout_kind)
+    if directive is None:
+        return "failed"
+    return "exhausted" if is_terminal_directive(directive) else "stagnated"
+
+
+def watchdog_has_directive_metadata(details: Mapping[str, object]) -> bool:
+    """Return whether watchdog evidence identifies the claimed execution."""
+    execution_id = details.get("execution_id")
+    return isinstance(execution_id, str) and bool(execution_id)
+
+
+async def phase_for_failed_step_directive(
+    event_store: EventStore,
+    *,
+    lineage_id: str,
+    generation_number: int,
+) -> str:
+    """Recover the real failed phase, looking past watchdog cancellation."""
+    events = await event_store.replay_lineage(lineage_id)
+    saw_cancelled_failure = False
+    for event in reversed(events):
+        if event.data.get("generation_number") != generation_number:
+            continue
+        if event.type == "lineage.generation.failed":
+            phase = event.data.get("phase")
+            if isinstance(phase, str) and phase:
+                if phase != GenerationPhase.CANCELLED.value:
+                    return phase
+                saw_cancelled_failure = True
+                continue
+        if saw_cancelled_failure and event.type in {
+            "lineage.generation.phase_changed",
+            "lineage.generation.started",
+        }:
+            phase = event.data.get("phase")
+            if isinstance(phase, str) and phase:
+                return phase
+    return GenerationPhase.FAILED.value
+
+
+async def emit_step_directive(
+    event_store: EventStore,
+    action: str,
+    *,
+    lineage_id: str,
+    generation_number: int,
+    phase: str,
+    reason: str,
+    retry_budget_remaining: int = 1,
+) -> None:
+    """Persist the shared control directive for one evolution outcome."""
+    directive = step_action_to_directive(action, retry_budget_remaining=retry_budget_remaining)
+    if directive is None:
+        return
+    await event_store.append(
+        create_control_directive_emitted_event(
+            target_type="lineage",
+            target_id=lineage_id,
+            emitted_by="evolver",
+            directive=directive,
+            reason=reason,
+            lineage_id=lineage_id,
+            generation_number=generation_number,
+            phase=phase,
+            extra={"step_action": action, "is_terminal": is_terminal_directive(directive)},
+        )
+    )
 
 
 def conductor_preservation_error(

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, fields, is_dataclass
 import inspect
 import json
 import time
@@ -57,6 +57,34 @@ def generation_execution_id(lineage_id: str, generation_number: int) -> str:
     return f"evolve:{lineage_id}:generation:{generation_number}"
 
 
+def _execution_policy_value(value: Any) -> Any:
+    """Project nested config values into a stable, field-complete JSON tree."""
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _execution_policy_value(model_dump(mode="json"))
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            item.name: _execution_policy_value(getattr(value, item.name)) for item in fields(value)
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _execution_policy_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_execution_policy_value(item) for item in value]
+    raise TypeError(f"Unsupported evolution execution-policy value: {type(value).__qualname__}")
+
+
+def evolution_execution_policy(config: Any | None) -> dict[str, Any] | None:
+    """Return every declared evolution config field for durable request identity."""
+    if config is None:
+        return None
+    projected = _execution_policy_value(config)
+    if not isinstance(projected, dict):
+        raise TypeError("Evolution execution policy must project to an object")
+    return projected
+
+
 async def emit_generation_started_once(
     event_store: EventStore,
     *,
@@ -92,6 +120,7 @@ def evolve_request_key(
     conductor_directive: ConductorDirective | None,
     project_dir: str | None = None,
     generation_number: int | None = None,
+    execution_policy: Mapping[str, Any] | None = None,
 ) -> str:
     """Identify inputs whose concurrent callers may share one evolve result."""
     return stable_payload_digest(
@@ -101,6 +130,7 @@ def evolve_request_key(
             "parallel": parallel,
             "project_dir": project_dir,
             "generation_number": generation_number,
+            "execution_policy": dict(execution_policy) if execution_policy is not None else None,
             "conductor_directive": (
                 conductor_directive.to_event_data() if conductor_directive is not None else None
             ),
@@ -393,6 +423,44 @@ def generation_parent_seed(current_seed: Seed, previous: GenerationRecord | None
         raise ValueError(
             f"Failed to reconstruct generation parent Seed from seed_json: {exc}"
         ) from exc
+
+
+def unfinished_generation_seed(
+    lineage: OntologyLineage,
+    generation_number: int,
+) -> Seed:
+    """Restore the durable starting Seed for a hard-crashed generation."""
+    unfinished = next(
+        (
+            generation
+            for generation in reversed(lineage.generations)
+            if generation.generation_number == generation_number
+        ),
+        None,
+    )
+    if unfinished is None or not unfinished.seed_json:
+        raise ValueError(
+            "Cannot recover unfinished generation: its durable starting Seed is unavailable"
+        )
+    try:
+        return Seed.from_dict(json.loads(unfinished.seed_json))
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to reconstruct unfinished generation seed from seed_json: {exc}"
+        ) from exc
+
+
+def recovery_plan(
+    lineage: OntologyLineage,
+    last_generation: int,
+    last_phase: GenerationPhase,
+) -> tuple[int, Seed | None]:
+    """Keep unfinished generation identity and recover hard-crash Seed authority."""
+    if last_phase == GenerationPhase.COMPLETED:
+        return last_generation + 1, None
+    if last_phase in {GenerationPhase.FAILED, GenerationPhase.INTERRUPTED}:
+        return last_generation, None
+    return last_generation, unfinished_generation_seed(lineage, last_generation)
 
 
 def watchdog_timeout_action(timeout_kind: str) -> str:

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -102,6 +102,8 @@ class LineageProjector:
                     created_at=event.timestamp,
                     seed_json=data.get("seed_json"),
                     execution_output=data.get("execution_output"),
+                    active_ac_indices=tuple(data.get("active_ac_indices", [])),
+                    frozen_ac_indices=tuple(data.get("frozen_ac_indices", [])),
                 )
                 generations[gen_num] = record
 

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -78,6 +78,7 @@ class LineageProjector:
                         ontology_snapshot=_PENDING_ONTOLOGY,
                         phase=phase,
                         created_at=event.timestamp,
+                        seed_json=data.get("seed_json"),
                     )
 
             elif event.type == "lineage.generation.completed":
@@ -104,6 +105,11 @@ class LineageProjector:
                     execution_output=data.get("execution_output"),
                     active_ac_indices=tuple(data.get("active_ac_indices", [])),
                     frozen_ac_indices=tuple(data.get("frozen_ac_indices", [])),
+                    verification_handoff_pending=(
+                        data.get("verification_handoff_pending", False)
+                        if isinstance(data.get("verification_handoff_pending", False), bool)
+                        else False
+                    ),
                 )
                 generations[gen_num] = record
 
@@ -243,6 +249,12 @@ class LineageProjector:
                 is_terminal = data.get("is_terminal", False)
                 if not isinstance(is_terminal, bool):
                     continue
+                extra = data.get("extra")
+                step_action = None
+                if isinstance(extra, dict):
+                    raw_step_action = extra.get("step_action")
+                    if isinstance(raw_step_action, str) and raw_step_action.strip():
+                        step_action = raw_step_action
                 parent_directive_id = data.get("parent_directive_id")
                 if parent_directive_id is not None and (
                     not isinstance(parent_directive_id, str) or not parent_directive_id.strip()
@@ -265,6 +277,7 @@ class LineageProjector:
                         generation_number=generation_number,
                         phase=phase,
                         is_terminal=is_terminal,
+                        step_action=step_action,
                         parent_directive_id=parent_directive_id,
                         idempotency_key=idempotency_key,
                     )

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -122,7 +122,21 @@ class LineageProjector:
                     except ValueError:
                         continue  # Skip events with invalid/legacy phase values
                     old = generations[gen_num]
-                    generations[gen_num] = old.model_copy(update={"phase": phase})
+                    update: dict = {"phase": phase}
+                    for field_name in (
+                        "last_completed_phase",
+                        "seed_json",
+                        "partial_state",
+                    ):
+                        if field_name in data:
+                            update[field_name] = data[field_name]
+                    if "seed_id" in data:
+                        update["seed_id"] = data["seed_id"] or old.seed_id
+                    if "active_ac_indices" in data:
+                        update["active_ac_indices"] = tuple(data["active_ac_indices"])
+                    if "frozen_ac_indices" in data:
+                        update["frozen_ac_indices"] = tuple(data["frozen_ac_indices"])
+                    generations[gen_num] = old.model_copy(update=update)
 
             elif event.type == "lineage.generation.failed":
                 data = event.data

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -213,6 +213,8 @@ def _apply_satisficing_backstop(
     patches: list[ACPatch],
     protected: set[int],
     passed_indices: set[int],
+    *,
+    allow_additions: bool = True,
 ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
     """Deterministically enforce the satisficing invariant.
 
@@ -230,6 +232,12 @@ def _apply_satisficing_backstop(
 
     for patch in patches:
         if patch.op == "add":
+            if not allow_additions:
+                logger.info(
+                    "reflect.patch.dropped",
+                    extra={"reason": "focused_evolution_disallows_new_node"},
+                )
+                continue
             if not patch.content:
                 logger.warning("reflect.patch.dropped", extra={"reason": "add_without_content"})
                 continue
@@ -414,6 +422,7 @@ class ReflectEngine:
         lineage: OntologyLineage,
         regression_report: RegressionReport | None = None,
         conductor_directive: ConductorDirective | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> Result[ReflectOutput, ProviderError]:
         """Reflect on execution results and propose evolution.
 
@@ -441,6 +450,7 @@ class ReflectEngine:
             lineage,
             regression_report,
             conductor_directive,
+            active_ac_indices,
         )
 
         messages = [
@@ -478,6 +488,7 @@ class ReflectEngine:
             evaluation_summary,
             wonder_output,
             regression_report,
+            active_ac_indices,
         )
         if parsed is None:
             return Result.err(
@@ -534,6 +545,9 @@ Guidelines:
 - If evaluation score < 0.8 or not approved, propose more aggressive mutations to address failures
 - Each mutation must have a clear reason tied to evaluation findings or wonder questions
 - Patches should address the wonder questions and ontology tensions
+- When an "Evolution Focus" is present, only ACTIVE AC indices may be revised.
+  Keep every frozen node verbatim, do not add ACs, and do not rewrite the goal
+  or constraints. The next generation's working set must not expand.
 - Do NOT change things that are working well -- only evolve what needs evolution
 - action must be exactly one of: "add", "modify", "remove"
 - An empty ontology_mutations list is ONLY acceptable when there are no Wonder questions
@@ -548,11 +562,24 @@ Guidelines:
         lineage: OntologyLineage,
         regression_report: RegressionReport,
         conductor_directive: ConductorDirective | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> str:
         parts = ["## Current Seed"]
         parts.append(f"Goal: {seed.goal}")
         parts.append(f"Constraints: {list(seed.constraints)}")
-        parts.append(f"Acceptance Criteria: {list(ac_texts(seed.acceptance_criteria))}")
+        seed_acs = ac_texts(seed.acceptance_criteria)
+        focused = active_ac_indices is not None
+        active = set(active_ac_indices or ())
+        if focused:
+            parts.append(
+                f"Evolution Focus: {len(active)} active / {len(seed_acs) - len(active)} frozen"
+            )
+            parts.append("Only these nodes may change; all omitted nodes are immutable:")
+            for index in sorted(active):
+                if 0 <= index < len(seed_acs):
+                    parts.append(f"  ACTIVE AC {index + 1}: {seed_acs[index]}")
+        else:
+            parts.append(f"Acceptance Criteria: {list(seed_acs)}")
 
         if conductor_directive is not None:
             parts.append("\n## Active Conductor Successor Directive")
@@ -601,10 +628,13 @@ Guidelines:
                 )
         if eval_summary.ac_results:
             parts.append("\n  Per-AC Breakdown:")
-            for ac in eval_summary.ac_results:
+            visible_results = [
+                ac for ac in eval_summary.ac_results if not focused or ac.ac_index in active
+            ]
+            for ac in visible_results:
                 status = "PASS" if ac.passed else "FAIL"
                 parts.append(f"    AC {ac.ac_index + 1} [{status}]: {ac.ac_content}")
-            failed_acs = [ac for ac in eval_summary.ac_results if not ac.passed]
+            failed_acs = [ac for ac in visible_results if not ac.passed]
             if failed_acs:
                 parts.append(
                     f"\n  PRIORITY: Fix {len(failed_acs)} failing AC(s) while preserving passing ones."
@@ -641,7 +671,22 @@ Guidelines:
             for t in wonder.ontology_tensions:
                 parts.append(f"  - {t}")
 
-        truncated = truncate_head_tail(execution_output)
+        evidence = []
+        if focused:
+            evidence = [
+                f"AC {result.ac_index + 1}: {result.evidence}"
+                for result in eval_summary.ac_results
+                if result.ac_index in active and result.evidence
+            ]
+        truncated = (
+            "\n".join(evidence)
+            if evidence
+            else truncate_head_tail(
+                execution_output,
+                head=200 if focused else 500,
+                tail=800 if focused else 2000,
+            )
+        )
         parts.append(f"\n## Execution Output (truncated)\n{truncated}")
 
         if len(lineage.generations) > 1:
@@ -691,6 +736,7 @@ Guidelines:
         evaluation_summary: EvaluationSummary,
         wonder_output: WonderOutput,
         regression_report: RegressionReport,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> ReflectOutput | None:
         """Parse LLM response into ReflectOutput.
 
@@ -718,6 +764,7 @@ Guidelines:
                 evaluation_summary,
                 wonder_output,
                 regression_report,
+                active_ac_indices,
             )
             refined_goal = data.get("refined_goal", current_seed.goal)
             if not isinstance(refined_goal, str):
@@ -735,6 +782,11 @@ Guidelines:
                 _clean_required_text(constraint, "refined constraint")
                 for constraint in raw_refined_constraints
             )
+            if active_ac_indices is not None:
+                # Node-focused evolution cannot drift global direction while
+                # repairing a bounded AC working set.
+                refined_goal = current_seed.goal
+                refined_constraints = current_seed.constraints
             reasoning = data.get("reasoning", "")
             if not isinstance(reasoning, str):
                 raise TypeError("Expected reasoning to be a string")
@@ -765,6 +817,7 @@ Guidelines:
         evaluation_summary: EvaluationSummary,
         wonder_output: WonderOutput,
         regression_report: RegressionReport,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
         """Compose the next AC list from LLM patches under the satisficing backstop."""
         passed_indices = {ac.ac_index for ac in evaluation_summary.ac_results if ac.passed}
@@ -781,11 +834,21 @@ Guidelines:
         # Invariant: a regressed AC is never settled, even if kept — subtract it
         # from the settleable set before the backstop decides settling.
         settleable = passed_indices - regressed
+        if active_ac_indices is not None:
+            active = {index for index in active_ac_indices if 0 <= index < len(parent_acs)}
+            protected.update(set(range(len(parent_acs))) - active)
+            settleable -= challenged
 
         if "ac_patches" in data:
             raw_patches = data["ac_patches"]
             patches = _parse_ac_patches(raw_patches)
-            return _apply_satisficing_backstop(parent_acs, patches, protected, settleable)
+            return _apply_satisficing_backstop(
+                parent_acs,
+                patches,
+                protected,
+                settleable,
+                allow_additions=active_ac_indices is None,
+            )
 
         # Legacy full-list shape: derive patches by positional diff.
         raw_refined_acs = data.get("refined_acs", list(parent_acs))
@@ -800,8 +863,16 @@ Guidelines:
         if legacy_patches is None:
             # Shorter list → full-rewrite semantics: use the LLM list as-is with
             # no settled indices and no patches (do not guess at deletions).
-            return llm_refined_acs, (), ()
-        return _apply_satisficing_backstop(parent_acs, legacy_patches, protected, settleable)
+            if active_ac_indices is None:
+                return llm_refined_acs, (), ()
+            legacy_patches = [ACPatch(op="keep", index=index) for index in range(len(parent_acs))]
+        return _apply_satisficing_backstop(
+            parent_acs,
+            legacy_patches,
+            protected,
+            settleable,
+            allow_additions=active_ac_indices is None,
+        )
 
 
 def _adapter_rebuild_kwargs(adapter: LLMAdapter) -> dict[str, object]:

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -25,7 +25,7 @@ from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDelta, OntologyLineage
-from ouroboros.core.seed import Seed, ac_texts
+from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
 from ouroboros.evolution.regression import RegressionDetector, RegressionReport
@@ -88,6 +88,7 @@ class ReflectOutput(BaseModel, frozen=True):
     refined_constraints: tuple[str, ...] = Field(default_factory=tuple)
     refined_acs: tuple[str, ...] = Field(default_factory=tuple)
     ac_patches: tuple[ACPatch, ...] = Field(default_factory=tuple)
+    ac_patch_identity_explicit: bool = False
     settled_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     ontology_mutations: tuple[OntologyMutation, ...] = Field(default_factory=tuple)
     reasoning: str = ""
@@ -96,7 +97,19 @@ class ReflectOutput(BaseModel, frozen=True):
     @classmethod
     def _coerce_refined_acs(cls, value: object) -> object:
         if isinstance(value, list | tuple):
-            return ac_texts(value)
+            if any(not isinstance(item, str | AcceptanceCriterionSpec) for item in value):
+                raise TypeError("Expected refined acceptance criteria to contain strings")
+            descriptions = tuple(
+                _clean_required_text(description, "refined acceptance criterion")
+                for description in ac_texts(value)
+            )
+            if any(
+                ord(character) < 32 or ord(character) == 127
+                for description in descriptions
+                for character in description
+            ):
+                raise TypeError("Expected refined acceptance criteria without control characters")
+            return descriptions
         return value
 
 
@@ -796,6 +809,7 @@ Guidelines:
                 refined_constraints=refined_constraints,
                 refined_acs=refined_acs,
                 ac_patches=ac_patches,
+                ac_patch_identity_explicit="ac_patches" in data,
                 settled_ac_indices=settled,
                 ontology_mutations=tuple(mutations),
                 reasoning=reasoning,

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -108,6 +108,33 @@ class ReflectOutput(BaseModel, frozen=True):
         """Whether this output carries parser-issued, non-serialized patch provenance."""
         return self._ac_patch_provenance == (self.refined_acs, self.ac_patches)
 
+    def restore_durable_patch_identity(self, parent_seed: Seed) -> None:
+        """Restore explicit identity from a complete, trusted phase checkpoint.
+
+        Generic model serialization intentionally cannot manufacture parser
+        provenance.  The evolution checkpoint boundary persists that provenance
+        separately and calls this method only after replay.  Revalidate the
+        complete patch mapping against the durable parent Seed before restoring
+        it so corrupt or mismatched checkpoint data still fails closed.
+        """
+        raw_patches = [patch.model_dump(mode="python") for patch in self.ac_patches]
+        parent_acs = ac_texts(parent_seed.acceptance_criteria)
+        _validate_explicit_ac_patch_identity(raw_patches, len(parent_acs))
+
+        parent_patches = {
+            patch.index: patch for patch in self.ac_patches if patch.op in {"keep", "revise"}
+        }
+        restored_acs = list(parent_acs)
+        for index in range(len(parent_acs)):
+            patch = parent_patches[index]
+            if patch.op == "revise":
+                assert patch.content is not None
+                restored_acs[index] = patch.content
+        restored_acs.extend(patch.content or "" for patch in self.ac_patches if patch.op == "add")
+        if tuple(restored_acs) != self.refined_acs:
+            raise ValueError("Durable ac_patches conflict with refined_acs")
+        self._ac_patch_provenance = (self.refined_acs, self.ac_patches)
+
     @field_validator("refined_acs", mode="before")
     @classmethod
     def _coerce_refined_acs(cls, value: object) -> object:

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -76,6 +76,14 @@ class ACPatch(BaseModel, frozen=True):
     content: str | None = None
     reason: str = ""
 
+    @field_validator("index", mode="before")
+    @classmethod
+    def _normalize_index(cls, value: object) -> int | None:
+        """Match persisted patch coercion to the strict fresh-response parser."""
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        return None
+
 
 class ReflectOutput(BaseModel, frozen=True):
     """Output of the Reflect phase -- feeds directly into SeedGenerator.
@@ -252,11 +260,15 @@ def _derive_legacy_patches(
     """Derive patches from a full refined-AC list (old JSON shape).
 
     Verbatim positional diff: identical text → keep, different → revise, extra
-    tail entries → add. A *shorter* list returns None to signal full-rewrite
-    semantics (the caller uses ``refined_acs`` as-is with no settled indices)
-    rather than guessing at deletions.
+    tail entries → add. A shorter list or an entry moved from another parent
+    position returns None because positional identity would be ambiguous.
     """
     if len(refined_acs) < len(parent_acs):
+        return None
+    if any(
+        new_text != parent_acs[index] and new_text in parent_acs
+        for index, new_text in enumerate(refined_acs[: len(parent_acs)])
+    ) or any(new_text in parent_acs for new_text in refined_acs[len(parent_acs) :]):
         return None
     patches: list[ACPatch] = []
     for i, parent_text in enumerate(parent_acs):
@@ -277,6 +289,7 @@ def _apply_satisficing_backstop(
     passed_indices: set[int],
     *,
     allow_additions: bool = True,
+    reject_ambiguous_identity: bool = False,
 ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
     """Deterministically enforce the satisficing invariant.
 
@@ -284,7 +297,10 @@ def _apply_satisficing_backstop(
     challenged AND not regressed) are forced to verbatim keep. Missing indices
     keep implicitly. Malformed/duplicate/out-of-range patches are dropped so the
     composed list holds every parent index exactly once (keeps/revises in place,
-    adds appended in order), preserving positional AC identity.
+    adds appended in order), preserving positional AC identity. Fresh Reflect
+    output rejects patches that reuse a parent identity so the provider retry
+    boundary can recover. Persisted legacy output instead drops those unsafe
+    patches and falls back to an implicit keep, preserving replayability.
 
     Returns ``(refined_acs, final_patches, settled_ac_indices)``.
     """
@@ -303,6 +319,20 @@ def _apply_satisficing_backstop(
             if not patch.content:
                 logger.warning("reflect.patch.dropped", extra={"reason": "add_without_content"})
                 continue
+            if patch.content in parent_acs:
+                if reject_ambiguous_identity:
+                    raise ValueError("acceptance criterion patch reuses another parent identity")
+                logger.warning(
+                    "reflect.patch.dropped",
+                    extra={"reason": "add_reuses_parent_identity"},
+                )
+                continue
+            if patch.index is not None:
+                logger.info(
+                    "reflect.patch.normalized",
+                    extra={"reason": "add_index_removed", "index": patch.index},
+                )
+                patch = patch.model_copy(update={"index": None})
             adds.append(patch)
             continue
         # keep / revise must target a valid, not-yet-seen parent index.
@@ -316,6 +346,18 @@ def _apply_satisficing_backstop(
             logger.warning(
                 "reflect.patch.dropped",
                 extra={"reason": "revise_without_content", "index": patch.index},
+            )
+            continue
+        if (
+            patch.op == "revise"
+            and patch.content != parent_acs[patch.index]
+            and patch.content in parent_acs
+        ):
+            if reject_ambiguous_identity:
+                raise ValueError("acceptance criterion patch reuses another parent identity")
+            logger.warning(
+                "reflect.patch.dropped",
+                extra={"reason": "revise_reuses_parent_identity", "index": patch.index},
             )
             continue
         if patch.index in keep_revise:
@@ -479,7 +521,7 @@ class ReflectEngine:
         self,
         current_seed: Seed,
         execution_output: str,
-        evaluation_summary: EvaluationSummary,
+        evaluation_summary: EvaluationSummary | None,
         wonder_output: WonderOutput,
         lineage: OntologyLineage,
         regression_report: RegressionReport | None = None,
@@ -491,7 +533,9 @@ class ReflectEngine:
         Args:
             current_seed: The seed that was executed.
             execution_output: What was actually produced.
-            evaluation_summary: How the execution was evaluated.
+            evaluation_summary: How the execution was evaluated, or ``None``
+                during ontology-only exploration. Missing evaluation never
+                creates PASS, protection, or settling authority.
             wonder_output: What we still don't know (from WonderEngine).
             lineage: Full lineage for cross-generation context.
             regression_report: Precomputed regressions (from the loop). When
@@ -603,6 +647,8 @@ SATISFICING DELTA — patch the AC list, do NOT rewrite it:
 
 Guidelines:
 - If Wonder questions exist, you MUST propose at least one ontology_mutation that addresses them
+- If Evaluation Results says "Not evaluated", do not infer PASS, protection, or
+  settlement for any AC; evolve only from Wonder questions and ontology context.
 - If evaluation score >= 0.8 and approved, keep changes focused but still evolve the ontology based on Wonder insights
 - If evaluation score < 0.8 or not approved, propose more aggressive mutations to address failures
 - Each mutation must have a clear reason tied to evaluation findings or wonder questions
@@ -619,7 +665,7 @@ Guidelines:
         self,
         seed: Seed,
         execution_output: str,
-        eval_summary: EvaluationSummary,
+        eval_summary: EvaluationSummary | None,
         wonder: WonderOutput,
         lineage: OntologyLineage,
         regression_report: RegressionReport,
@@ -668,39 +714,46 @@ Guidelines:
             parts.append(f"  - {f.name} ({f.field_type}): {f.description}")
 
         parts.append("\n## Evaluation Results")
-        parts.append(f"  Approved: {eval_summary.final_approved}")
-        parts.append(f"  Score: {eval_summary.score}")
-        parts.append(f"  Drift: {eval_summary.drift_score}")
-        if eval_summary.failure_reason:
-            parts.append(f"  Failure: {eval_summary.failure_reason}")
-        if eval_summary.feedback_metadata:
-            parts.append("  Feedback Signals:")
-            for feedback in eval_summary.feedback_metadata:
-                details: list[str] = []
-                max_depth = feedback.details.get("max_depth")
-                if isinstance(max_depth, int):
-                    details.append(f"max_depth={max_depth}")
-                affected_count = feedback.details.get("affected_count")
-                if isinstance(affected_count, int):
-                    details.append(f"affected_count={affected_count}")
-                detail_suffix = f" ({', '.join(details)})" if details else ""
-                parts.append(
-                    f"    - [{feedback.severity.upper()}] {feedback.code}: "
-                    f"{feedback.message}{detail_suffix}"
-                )
-        if eval_summary.ac_results:
-            parts.append("\n  Per-AC Breakdown:")
-            visible_results = [
-                ac for ac in eval_summary.ac_results if not focused or ac.ac_index in active
-            ]
-            for ac in visible_results:
-                status = "PASS" if ac.passed else "FAIL"
-                parts.append(f"    AC {ac.ac_index + 1} [{status}]: {ac.ac_content}")
-            failed_acs = [ac for ac in visible_results if not ac.passed]
-            if failed_acs:
-                parts.append(
-                    f"\n  PRIORITY: Fix {len(failed_acs)} failing AC(s) while preserving passing ones."
-                )
+        if eval_summary is None:
+            parts.append("  Not evaluated (ontology-only exploration).")
+            parts.append(
+                "  No AC has PASS, protection, or settling authority; use only "
+                "the Wonder questions and ontology context."
+            )
+        else:
+            parts.append(f"  Approved: {eval_summary.final_approved}")
+            parts.append(f"  Score: {eval_summary.score}")
+            parts.append(f"  Drift: {eval_summary.drift_score}")
+            if eval_summary.failure_reason:
+                parts.append(f"  Failure: {eval_summary.failure_reason}")
+            if eval_summary.feedback_metadata:
+                parts.append("  Feedback Signals:")
+                for feedback in eval_summary.feedback_metadata:
+                    details: list[str] = []
+                    max_depth = feedback.details.get("max_depth")
+                    if isinstance(max_depth, int):
+                        details.append(f"max_depth={max_depth}")
+                    affected_count = feedback.details.get("affected_count")
+                    if isinstance(affected_count, int):
+                        details.append(f"affected_count={affected_count}")
+                    detail_suffix = f" ({', '.join(details)})" if details else ""
+                    parts.append(
+                        f"    - [{feedback.severity.upper()}] {feedback.code}: "
+                        f"{feedback.message}{detail_suffix}"
+                    )
+            if eval_summary.ac_results:
+                parts.append("\n  Per-AC Breakdown:")
+                visible_results = [
+                    ac for ac in eval_summary.ac_results if not focused or ac.ac_index in active
+                ]
+                for ac in visible_results:
+                    status = ac.authority_state.upper()
+                    parts.append(f"    AC {ac.ac_index + 1} [{status}]: {ac.ac_content}")
+                unresolved_acs = [ac for ac in visible_results if ac.unresolved]
+                if unresolved_acs:
+                    parts.append(
+                        f"\n  PRIORITY: Resolve {len(unresolved_acs)} open AC(s) while preserving passing ones."
+                    )
 
         # Regression context (precomputed once by the caller and reused here).
         if regression_report.has_regressions:
@@ -734,7 +787,7 @@ Guidelines:
                 parts.append(f"  - {t}")
 
         evidence = []
-        if focused:
+        if focused and eval_summary is not None:
             evidence = [
                 f"AC {result.ac_index + 1}: {result.evidence}"
                 for result in eval_summary.ac_results
@@ -795,7 +848,7 @@ Guidelines:
         self,
         content: str,
         current_seed: Seed,
-        evaluation_summary: EvaluationSummary,
+        evaluation_summary: EvaluationSummary | None,
         wonder_output: WonderOutput,
         regression_report: RegressionReport,
         active_ac_indices: tuple[int, ...] | None = None,
@@ -894,13 +947,17 @@ Guidelines:
     def _compose_acs(
         data: dict[str, object],
         parent_acs: tuple[str, ...],
-        evaluation_summary: EvaluationSummary,
+        evaluation_summary: EvaluationSummary | None,
         wonder_output: WonderOutput,
         regression_report: RegressionReport,
         active_ac_indices: tuple[int, ...] | None = None,
     ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
         """Compose the next AC list from LLM patches under the satisficing backstop."""
-        passed_indices = {ac.ac_index for ac in evaluation_summary.ac_results if ac.passed}
+        passed_indices = (
+            {ac.ac_index for ac in evaluation_summary.ac_results if ac.authoritative_pass}
+            if evaluation_summary is not None
+            else set()
+        )
         challenged: set[int] = set()
         for gq in wonder_output.grounded_questions:
             if gq.kind == "challenge":
@@ -913,11 +970,10 @@ Guidelines:
         }
         # Invariant: a regressed AC is never settled, even if kept — subtract it
         # from the settleable set before the backstop decides settling.
-        settleable = passed_indices - regressed
+        settleable = passed_indices - regressed - challenged
         if active_ac_indices is not None:
             active = {index for index in active_ac_indices if 0 <= index < len(parent_acs)}
             protected.update(set(range(len(parent_acs))) - active)
-            settleable -= challenged
 
         if "ac_patches" in data:
             raw_patches = data["ac_patches"]
@@ -928,6 +984,7 @@ Guidelines:
                 protected,
                 settleable,
                 allow_additions=active_ac_indices is None,
+                reject_ambiguous_identity=True,
             )
 
         # Legacy full-list shape: derive patches by positional diff.
@@ -941,11 +998,9 @@ Guidelines:
         )
         legacy_patches = _derive_legacy_patches(llm_refined_acs, parent_acs)
         if legacy_patches is None:
-            # Shorter list → full-rewrite semantics: use the LLM list as-is with
-            # no settled indices and no patches (do not guess at deletions).
-            if active_ac_indices is None:
-                return llm_refined_acs, (), ()
-            legacy_patches = [ACPatch(op="keep", index=index) for index in range(len(parent_acs))]
+            raise ValueError(
+                "legacy refined_acs cannot delete or reorder parent criteria; use ac_patches"
+            )
         return _apply_satisficing_backstop(
             parent_acs,
             legacy_patches,

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -197,6 +197,48 @@ def _parse_ac_patches(raw_patches: object) -> list[ACPatch]:
     return patches
 
 
+def _validate_explicit_ac_patch_identity(raw_patches: object, parent_count: int) -> None:
+    """Require a complete, unique parent-index map before trusting patch provenance."""
+    if not isinstance(raw_patches, list):
+        raise TypeError("Expected ac_patches to be a list")
+
+    seen_parent_indices: set[int] = set()
+    for item in raw_patches:
+        if not isinstance(item, dict):
+            raise TypeError("Expected each ac_patch to be an object")
+        op = item.get("op")
+        if op in ("keep", "revise"):
+            index = item.get("index")
+            if isinstance(index, bool) or not isinstance(index, int):
+                raise TypeError("Expected keep/revise ac_patch index to be an integer")
+            if index < 0 or index >= parent_count:
+                raise ValueError("Explicit ac_patch index is outside the parent AC range")
+            if index in seen_parent_indices:
+                raise ValueError("Explicit ac_patches contain a duplicate parent AC index")
+            seen_parent_indices.add(index)
+            if op == "keep":
+                if item.get("content") is not None:
+                    raise ValueError("Explicit keep ac_patch cannot carry replacement content")
+            else:
+                content = item.get("content")
+                if not isinstance(content, str):
+                    raise TypeError("Expected revise ac_patch content to be a string")
+                _clean_required_text(content, "acceptance criterion patch content")
+            continue
+        if op == "add":
+            if item.get("index") is not None:
+                raise ValueError("Explicit add ac_patch cannot carry a parent AC index")
+            content = item.get("content")
+            if not isinstance(content, str):
+                raise TypeError("Expected add ac_patch content to be a string")
+            _clean_required_text(content, "acceptance criterion patch content")
+            continue
+        raise ValueError("Explicit ac_patch op must be keep, revise, or add")
+
+    if seen_parent_indices != set(range(parent_count)):
+        raise ValueError("Explicit ac_patches must identify every parent AC exactly once")
+
+
 def _derive_legacy_patches(
     refined_acs: tuple[str, ...], parent_acs: tuple[str, ...]
 ) -> list[ACPatch] | None:
@@ -771,6 +813,9 @@ Guidelines:
             mutations = _parse_ontology_mutations(data)
 
             parent_acs = ac_texts(current_seed.acceptance_criteria)
+            explicit_patch_identity = "ac_patches" in data
+            if explicit_patch_identity:
+                _validate_explicit_ac_patch_identity(data["ac_patches"], len(parent_acs))
             refined_acs, ac_patches, settled = self._compose_acs(
                 data,
                 parent_acs,
@@ -809,7 +854,7 @@ Guidelines:
                 refined_constraints=refined_constraints,
                 refined_acs=refined_acs,
                 ac_patches=ac_patches,
-                ac_patch_identity_explicit="ac_patches" in data,
+                ac_patch_identity_explicit=explicit_patch_identity,
                 settled_ac_indices=settled,
                 ontology_mutations=tuple(mutations),
                 reasoning=reasoning,

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -18,7 +18,7 @@ import json
 import logging
 from typing import Literal
 
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, PrivateAttr, ValidationError, field_validator
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.conductor import ConductorDirective
@@ -88,10 +88,17 @@ class ReflectOutput(BaseModel, frozen=True):
     refined_constraints: tuple[str, ...] = Field(default_factory=tuple)
     refined_acs: tuple[str, ...] = Field(default_factory=tuple)
     ac_patches: tuple[ACPatch, ...] = Field(default_factory=tuple)
-    ac_patch_identity_explicit: bool = False
     settled_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     ontology_mutations: tuple[OntologyMutation, ...] = Field(default_factory=tuple)
     reasoning: str = ""
+    _ac_patch_provenance: tuple[tuple[str, ...], tuple[ACPatch, ...]] | None = PrivateAttr(
+        default=None
+    )
+
+    @property
+    def ac_patch_identity_explicit(self) -> bool:
+        """Whether this output carries parser-issued, non-serialized patch provenance."""
+        return self._ac_patch_provenance == (self.refined_acs, self.ac_patches)
 
     @field_validator("refined_acs", mode="before")
     @classmethod
@@ -824,6 +831,18 @@ Guidelines:
                 regression_report,
                 active_ac_indices,
             )
+            if explicit_patch_identity and "refined_acs" in data:
+                raw_refined_acs = data["refined_acs"]
+                if not isinstance(raw_refined_acs, list | tuple) or not all(
+                    isinstance(criterion, str) for criterion in raw_refined_acs
+                ):
+                    raise TypeError("Expected refined_acs to be a list of strings")
+                supplied_refined_acs = tuple(
+                    _clean_required_text(criterion, "refined acceptance criterion")
+                    for criterion in raw_refined_acs
+                )
+                if supplied_refined_acs != refined_acs:
+                    raise ValueError("Explicit ac_patches conflict with refined_acs")
             refined_goal = data.get("refined_goal", current_seed.goal)
             if not isinstance(refined_goal, str):
                 raise TypeError("Expected refined_goal to be a string")
@@ -849,16 +868,18 @@ Guidelines:
             if not isinstance(reasoning, str):
                 raise TypeError("Expected reasoning to be a string")
 
-            return ReflectOutput(
+            output = ReflectOutput(
                 refined_goal=refined_goal,
                 refined_constraints=refined_constraints,
                 refined_acs=refined_acs,
                 ac_patches=ac_patches,
-                ac_patch_identity_explicit=explicit_patch_identity,
                 settled_ac_indices=settled,
                 ontology_mutations=tuple(mutations),
                 reasoning=reasoning,
             )
+            if explicit_patch_identity:
+                output._ac_patch_provenance = (output.refined_acs, output.ac_patches)
+            return output
         except (ValueError, KeyError, TypeError, ValidationError) as e:
             logger.warning(
                 "reflect.parse_failed",

--- a/src/ouroboros/evolution/regression.py
+++ b/src/ouroboros/evolution/regression.py
@@ -69,11 +69,13 @@ class RegressionDetector:
             if not gen.evaluation_summary or not gen.evaluation_summary.ac_results:
                 continue
             for ac in gen.evaluation_summary.ac_results:
-                ac_history.setdefault(ac.ac_index, []).append((gen.generation_number, ac.passed))
+                ac_history.setdefault(ac.ac_index, []).append(
+                    (gen.generation_number, ac.authoritative_pass)
+                )
 
         regressions: list[ACRegression] = []
         for ac in latest.evaluation_summary.ac_results:
-            if ac.passed:
+            if ac.authoritative_pass:
                 continue
 
             history = ac_history.get(ac.ac_index, [])

--- a/src/ouroboros/evolution/step_receipt.py
+++ b/src/ouroboros/evolution/step_receipt.py
@@ -20,6 +20,7 @@ from ouroboros.persistence.event_store import EventStore
 
 MAX_RECEIPT_TEXT = 2_000
 MAX_VALIDATION_TEXT = 5_000
+MAX_EXECUTION_TEXT = 50_000
 
 
 def _bounded(value: str | None, limit: int) -> str | None:
@@ -57,6 +58,11 @@ def encode_step_result(result: Result[StepResult, OuroborosError]) -> dict[str, 
             generation.reflect_output.ac_patch_identity_explicit
             if generation.reflect_output is not None
             else None
+        ),
+        "execution_output": _bounded(generation.execution_output, MAX_EXECUTION_TEXT),
+        "execution_output_complete": (
+            generation.execution_output is None
+            or len(generation.execution_output) <= MAX_EXECUTION_TEXT
         ),
         "validation_output": _bounded(generation.validation_output, MAX_VALIDATION_TEXT),
         "ontology_delta": (
@@ -148,7 +154,21 @@ async def decode_step_result(
         if previous is not None and previous.seed_json:
             parent_seed = Seed.from_dict(json.loads(previous.seed_json))
         reflect.restore_durable_patch_identity(parent_seed)
-    execution_output = partial_state.get("execution_output", record.execution_output)
+    if "execution_output_complete" in payload:
+        if payload.get("execution_output_complete") is not True:
+            raise ValueError(
+                "Durable evolve receipt execution output is incomplete; handler evidence "
+                "cannot be rematerialized safely"
+            )
+        execution_output = payload.get("execution_output")
+        if execution_output is not None and not isinstance(execution_output, str):
+            raise ValueError("Durable evolve receipt execution output must be text or null")
+    else:
+        execution_output = partial_state.get("execution_output", record.execution_output)
+        if execution_output is not None:
+            raise ValueError(
+                "Legacy durable evolve receipt cannot prove execution-output completeness"
+            )
     evaluation_data = partial_state.get("evaluation_summary")
     evaluation_summary = (
         EvaluationSummary.model_validate(evaluation_data)

--- a/src/ouroboros/evolution/step_receipt.py
+++ b/src/ouroboros/evolution/step_receipt.py
@@ -43,9 +43,19 @@ def encode_step_result(result: Result[StepResult, OuroborosError]) -> dict[str, 
         "generation_success": generation.success,
         "action": step.action.value,
         "next_generation": step.next_generation,
-        "wonder_should_continue": (
-            generation.wonder_output.should_continue
+        "wonder_output": (
+            generation.wonder_output.model_dump(mode="json")
             if generation.wonder_output is not None
+            else None
+        ),
+        "reflect_output": (
+            generation.reflect_output.model_dump(mode="json")
+            if generation.reflect_output is not None
+            else None
+        ),
+        "reflect_patch_identity_explicit": (
+            generation.reflect_output.ac_patch_identity_explicit
+            if generation.reflect_output is not None
             else None
         ),
         "validation_output": _bounded(generation.validation_output, MAX_VALIDATION_TEXT),
@@ -97,31 +107,47 @@ async def decode_step_result(
         raise ValueError("Durable evolve receipt generation has no structured Seed")
     seed = Seed.from_dict(json.loads(record.seed_json))
     partial_state = record.partial_state if isinstance(record.partial_state, Mapping) else {}
-    partial_questions = partial_state.get("wonder_questions")
-    wonder_questions = (
-        tuple(str(question) for question in partial_questions)
-        if isinstance(partial_questions, (list, tuple))
-        else record.wonder_questions
-    )
-    should_continue = payload.get("wonder_should_continue")
-    wonder = (
-        WonderOutput(
-            questions=wonder_questions,
-            grounded_questions=ground_questions(wonder_questions, len(seed.acceptance_criteria)),
-            should_continue=bool(should_continue),
-            reasoning="replayed from durable generation receipt",
+    wonder_data = payload.get("wonder_output")
+    if isinstance(wonder_data, Mapping):
+        wonder = WonderOutput.model_validate(wonder_data)
+    else:
+        partial_questions = partial_state.get("wonder_questions")
+        wonder_questions = (
+            tuple(str(question) for question in partial_questions)
+            if isinstance(partial_questions, (list, tuple))
+            else record.wonder_questions
         )
-        if wonder_questions or should_continue is not None
-        else None
-    )
-    reflect_data = partial_state.get("reflect_output")
+        should_continue = payload.get("wonder_should_continue")
+        wonder = (
+            WonderOutput(
+                questions=wonder_questions,
+                grounded_questions=ground_questions(
+                    wonder_questions, len(seed.acceptance_criteria)
+                ),
+                should_continue=bool(should_continue),
+                reasoning="replayed from legacy durable generation receipt",
+            )
+            if wonder_questions or should_continue is not None
+            else None
+        )
+    reflect_data = payload.get("reflect_output", partial_state.get("reflect_output"))
     reflect = (
         ReflectOutput.model_validate(reflect_data) if isinstance(reflect_data, Mapping) else None
     )
-    if reflect is not None and reflect.ac_patches:
-        # Explicit parser provenance is process-local by design. A durable
-        # waiter must not turn serialized patches back into identity authority.
-        reflect = None
+    if reflect is not None and payload.get("reflect_patch_identity_explicit") is True:
+        previous = next(
+            (
+                generation
+                for generation in reversed(lineage.generations)
+                if generation.generation_number < generation_number
+                and generation.phase == GenerationPhase.COMPLETED
+            ),
+            None,
+        )
+        parent_seed = seed
+        if previous is not None and previous.seed_json:
+            parent_seed = Seed.from_dict(json.loads(previous.seed_json))
+        reflect.restore_durable_patch_identity(parent_seed)
     execution_output = partial_state.get("execution_output", record.execution_output)
     evaluation_data = partial_state.get("evaluation_summary")
     evaluation_summary = (

--- a/src/ouroboros/evolution/step_receipt.py
+++ b/src/ouroboros/evolution/step_receipt.py
@@ -1,0 +1,167 @@
+"""Bounded durable references for cross-process evolve waiters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Any
+
+from ouroboros.core.errors import OuroborosError
+from ouroboros.core.lineage import EvaluationSummary, GenerationPhase, OntologyDelta
+from ouroboros.core.seed import Seed
+from ouroboros.core.text import truncate_head_tail
+from ouroboros.core.types import Result
+from ouroboros.evolution.convergence import ConvergenceSignal
+from ouroboros.evolution.loop import GenerationResult, StepAction, StepResult
+from ouroboros.evolution.projector import LineageProjector
+from ouroboros.evolution.reflect import ReflectOutput
+from ouroboros.evolution.wonder import WonderOutput, ground_questions
+from ouroboros.persistence.event_store import EventStore
+
+MAX_RECEIPT_TEXT = 2_000
+MAX_VALIDATION_TEXT = 5_000
+
+
+def _bounded(value: str | None, limit: int) -> str | None:
+    if value is None or len(value) <= limit:
+        return value
+    return truncate_head_tail(value, head=limit // 2, tail=limit // 2)
+
+
+def encode_step_result(result: Result[StepResult, OuroborosError]) -> dict[str, Any]:
+    """Persist only bounded decision metadata and durable event references."""
+    if result.is_err:
+        return {"ok": False, "error": _bounded(str(result.error), MAX_RECEIPT_TEXT)}
+    step = result.value
+    generation = step.generation_result
+    signal = step.convergence_signal
+    return {
+        "ok": True,
+        "lineage_id": step.lineage.lineage_id,
+        "generation_number": generation.generation_number,
+        "generation_phase": generation.phase.value,
+        "generation_success": generation.success,
+        "action": step.action.value,
+        "next_generation": step.next_generation,
+        "wonder_should_continue": (
+            generation.wonder_output.should_continue
+            if generation.wonder_output is not None
+            else None
+        ),
+        "validation_output": _bounded(generation.validation_output, MAX_VALIDATION_TEXT),
+        "ontology_delta": (
+            generation.ontology_delta.model_dump(mode="json")
+            if generation.ontology_delta is not None
+            else None
+        ),
+        "signal": {
+            "converged": signal.converged,
+            "reason": _bounded(signal.reason, MAX_RECEIPT_TEXT),
+            "ontology_similarity": signal.ontology_similarity,
+            "generation": signal.generation,
+            "failed_acs": list(signal.failed_acs),
+            "should_stop": signal.should_stop,
+            "ontology_stable": signal.ontology_stable,
+        },
+    }
+
+
+def _mapping(value: object, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Durable evolve receipt {field} must be an object")
+    return value
+
+
+async def decode_step_result(
+    event_store: EventStore,
+    payload: Mapping[str, Any],
+) -> Result[StepResult, OuroborosError]:
+    """Rebuild the winner from its durable generation events and bounded receipt."""
+    if not bool(payload.get("ok")):
+        return Result.err(OuroborosError(str(payload.get("error") or "evolve_step failed")))
+    lineage_id = str(payload["lineage_id"])
+    generation_number = int(payload["generation_number"])
+    events = await event_store.replay_lineage(lineage_id)
+    lineage = LineageProjector().project(events)
+    if lineage is None:
+        raise ValueError("Durable evolve receipt lineage cannot be projected")
+    record = next(
+        (
+            generation
+            for generation in reversed(lineage.generations)
+            if generation.generation_number == generation_number
+        ),
+        None,
+    )
+    if record is None or not record.seed_json:
+        raise ValueError("Durable evolve receipt generation has no structured Seed")
+    seed = Seed.from_dict(json.loads(record.seed_json))
+    partial_state = record.partial_state if isinstance(record.partial_state, Mapping) else {}
+    partial_questions = partial_state.get("wonder_questions")
+    wonder_questions = (
+        tuple(str(question) for question in partial_questions)
+        if isinstance(partial_questions, (list, tuple))
+        else record.wonder_questions
+    )
+    should_continue = payload.get("wonder_should_continue")
+    wonder = (
+        WonderOutput(
+            questions=wonder_questions,
+            grounded_questions=ground_questions(wonder_questions, len(seed.acceptance_criteria)),
+            should_continue=bool(should_continue),
+            reasoning="replayed from durable generation receipt",
+        )
+        if wonder_questions or should_continue is not None
+        else None
+    )
+    reflect_data = partial_state.get("reflect_output")
+    reflect = (
+        ReflectOutput.model_validate(reflect_data) if isinstance(reflect_data, Mapping) else None
+    )
+    if reflect is not None and reflect.ac_patches:
+        # Explicit parser provenance is process-local by design. A durable
+        # waiter must not turn serialized patches back into identity authority.
+        reflect = None
+    execution_output = partial_state.get("execution_output", record.execution_output)
+    evaluation_data = partial_state.get("evaluation_summary")
+    evaluation_summary = (
+        EvaluationSummary.model_validate(evaluation_data)
+        if isinstance(evaluation_data, Mapping)
+        else record.evaluation_summary
+    )
+    delta_data = payload.get("ontology_delta")
+    signal_data = _mapping(payload.get("signal"), "signal")
+    generation = GenerationResult(
+        generation_number=generation_number,
+        seed=seed,
+        execution_output=(execution_output if isinstance(execution_output, str) else None),
+        evaluation_summary=evaluation_summary,
+        wonder_output=wonder,
+        reflect_output=reflect,
+        ontology_delta=(
+            OntologyDelta.model_validate(delta_data) if delta_data is not None else None
+        ),
+        validation_output=payload.get("validation_output"),
+        active_ac_indices=record.active_ac_indices,
+        frozen_ac_indices=record.frozen_ac_indices,
+        phase=GenerationPhase(str(payload["generation_phase"])),
+        success=bool(payload["generation_success"]),
+    )
+    signal = ConvergenceSignal(
+        converged=bool(signal_data["converged"]),
+        reason=str(signal_data["reason"]),
+        ontology_similarity=float(signal_data["ontology_similarity"]),
+        generation=int(signal_data["generation"]),
+        failed_acs=tuple(int(value) for value in signal_data["failed_acs"]),
+        should_stop=bool(signal_data["should_stop"]),
+        ontology_stable=bool(signal_data["ontology_stable"]),
+    )
+    return Result.ok(
+        StepResult(
+            generation_result=generation,
+            convergence_signal=signal,
+            lineage=lineage,
+            action=StepAction(str(payload["action"])),
+            next_generation=int(payload["next_generation"]),
+        )
+    )

--- a/src/ouroboros/evolution/step_receipt.py
+++ b/src/ouroboros/evolution/step_receipt.py
@@ -65,6 +65,10 @@ def encode_step_result(result: Result[StepResult, OuroborosError]) -> dict[str, 
             or len(generation.execution_output) <= MAX_EXECUTION_TEXT
         ),
         "validation_output": _bounded(generation.validation_output, MAX_VALIDATION_TEXT),
+        "validation_output_complete": (
+            generation.validation_output is None
+            or len(generation.validation_output) <= MAX_VALIDATION_TEXT
+        ),
         "ontology_delta": (
             generation.ontology_delta.model_dump(mode="json")
             if generation.ontology_delta is not None
@@ -169,6 +173,14 @@ async def decode_step_result(
             raise ValueError(
                 "Legacy durable evolve receipt cannot prove execution-output completeness"
             )
+    validation_output = payload.get("validation_output")
+    if validation_output is not None and not isinstance(validation_output, str):
+        raise ValueError("Durable evolve receipt validation output must be text or null")
+    if payload.get("validation_output_complete") is not True and validation_output is not None:
+        raise ValueError(
+            "Durable evolve receipt validation output is incomplete; public result cannot "
+            "be reconstructed safely"
+        )
     evaluation_data = partial_state.get("evaluation_summary")
     evaluation_summary = (
         EvaluationSummary.model_validate(evaluation_data)
@@ -187,7 +199,7 @@ async def decode_step_result(
         ontology_delta=(
             OntologyDelta.model_validate(delta_data) if delta_data is not None else None
         ),
-        validation_output=payload.get("validation_output"),
+        validation_output=validation_output,
         active_ac_indices=record.active_ac_indices,
         frozen_ac_indices=record.frozen_ac_indices,
         phase=GenerationPhase(str(payload["generation_phase"])),

--- a/src/ouroboros/evolution/validation_result.py
+++ b/src/ouroboros/evolution/validation_result.py
@@ -1,0 +1,27 @@
+"""Normalize optional validator results without inventing success evidence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_validation_result(result: Any) -> str | None:
+    """Preserve missing values so configured validation can fail closed."""
+    if result is None or isinstance(result, str):
+        return result
+    if isinstance(result, bool):
+        verdict = "passed" if result else "failed"
+        return f"Validation {verdict}: typed validator returned {str(result).lower()}"
+    if hasattr(result, "is_ok"):
+        if result.is_ok:
+            return normalize_validation_result(result.value)
+        return f"Validation error: {result.error}"
+    return str(result)
+
+
+def validation_passed(output: str | None) -> bool:
+    """Accept only an explicit validator success receipt."""
+    return bool(output and output.strip().lower().startswith("validation passed"))
+
+
+__all__ = ["normalize_validation_result", "validation_passed"]

--- a/src/ouroboros/evolution/validation_result.py
+++ b/src/ouroboros/evolution/validation_result.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
+
+BUILTIN_COLLECTION_ATTEMPT_LIMIT = 3
+_TYPED_SUCCESS_RECEIPT = "Validation passed: typed validator returned true"
+_COLLECTION_ATTEMPT_RECEIPT = re.compile(
+    r"Validation passed \(attempt (?P<attempt>[1-9][0-9]*)/(?P<limit>[1-9][0-9]*)\)"
+)
+_COLLECTION_REPAIR_RECEIPT = re.compile(
+    r"Validation passed after (?P<attempts>[1-9][0-9]*) fix attempts"
+)
 
 
 def normalize_validation_result(result: Any) -> str | None:
@@ -20,8 +30,30 @@ def normalize_validation_result(result: Any) -> str | None:
 
 
 def validation_passed(output: str | None) -> bool:
-    """Accept only an explicit validator success receipt."""
-    return bool(output and output.strip().lower().startswith("validation passed"))
+    """Accept only a complete, unambiguous validator success receipt.
+
+    Validator output is persisted as text, so success must use one of the
+    closed receipt forms emitted by this module or the built-in collection
+    validator.  Prefix matching is deliberately forbidden: it turns
+    contradictory or appended error text into success evidence.
+    """
+    if output == _TYPED_SUCCESS_RECEIPT:
+        return True
+
+    attempt_match = _COLLECTION_ATTEMPT_RECEIPT.fullmatch(output or "")
+    if attempt_match is not None:
+        attempt = int(attempt_match.group("attempt"))
+        limit = int(attempt_match.group("limit"))
+        return limit == BUILTIN_COLLECTION_ATTEMPT_LIMIT and attempt <= limit
+
+    repair_match = _COLLECTION_REPAIR_RECEIPT.fullmatch(output or "")
+    return bool(
+        repair_match and int(repair_match.group("attempts")) == BUILTIN_COLLECTION_ATTEMPT_LIMIT
+    )
 
 
-__all__ = ["normalize_validation_result", "validation_passed"]
+__all__ = [
+    "BUILTIN_COLLECTION_ATTEMPT_LIMIT",
+    "normalize_validation_result",
+    "validation_passed",
+]

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -412,12 +412,12 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                 visible_results = [
                     ac for ac in eval_summary.ac_results if not focused or ac.ac_index in active
                 ]
-                failed_acs = [ac for ac in visible_results if not ac.passed]
-                if failed_acs:
-                    parts.append(f"\n  Active failed ACs ({len(failed_acs)}):")
-                    for ac in failed_acs:
+                unresolved_acs = [ac for ac in visible_results if ac.unresolved]
+                if unresolved_acs:
+                    parts.append(f"\n  Active unresolved ACs ({len(unresolved_acs)}):")
+                    for ac in unresolved_acs:
                         parts.append(f"    - AC {ac.ac_index + 1}: {ac.ac_content}")
-                passed_count = sum(1 for ac in visible_results if ac.passed)
+                passed_count = sum(1 for ac in visible_results if ac.authoritative_pass)
                 parts.append(f"  Visible AC pass rate: {passed_count}/{len(visible_results)}")
 
         # Regression context

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -237,6 +237,7 @@ class WonderEngine:
         execution_output: str | None,
         lineage: OntologyLineage,
         seed: Seed | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> Result[WonderOutput, ProviderError]:
         """Generate wonder output for the next generation.
 
@@ -251,7 +252,12 @@ class WonderEngine:
             Result containing WonderOutput or ProviderError.
         """
         prompt = self._build_prompt(
-            current_ontology, evaluation_summary, execution_output, lineage, seed
+            current_ontology,
+            evaluation_summary,
+            execution_output,
+            lineage,
+            seed,
+            active_ac_indices,
         )
 
         messages = [
@@ -275,9 +281,16 @@ class WonderEngine:
                 "WonderEngine LLM call failed, using degraded mode: %s",
                 result.error,
             )
-            return Result.ok(self._degraded_output(evaluation_summary, current_ontology, seed))
+            return Result.ok(
+                self._degraded_output(
+                    evaluation_summary,
+                    current_ontology,
+                    seed,
+                    active_ac_indices,
+                )
+            )
 
-        return Result.ok(self._parse_response(result.value.content, seed))
+        return Result.ok(self._parse_response(result.value.content, seed, active_ac_indices))
 
     def _system_prompt(self) -> str:
         return """You are the Wonder Engine of Ouroboros, an evolutionary development system.
@@ -320,6 +333,9 @@ SCOPE GUARD — this is critical:
 - An ontology is ALWAYS incomplete — that is normal, not a gap to fill.
 - "This concept is not modeled" is NOT a valid tension unless the seed requires it (explicitly or implicitly).
 - Prefer deepening existing fields over adding new ones.
+- When an "Evolution Focus" is present, ONLY its active AC nodes may be
+  questioned or changed. Do not reopen frozen ACs, emit unscoped gap questions,
+  or add a new AC. The working set must shrink toward zero.
 - If the current ontology covers the seed's acceptance criteria AND evaluation shows no regressions or failures, set should_continue to false.
 
 Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions (how to code it)."""
@@ -331,8 +347,11 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
         execution_output: str | None,
         lineage: OntologyLineage,
         seed: Seed | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> str:
         parts: list[str] = []
+        focused = active_ac_indices is not None
+        active = set(active_ac_indices or ())
 
         # Seed scope comes first — this is the boundary for all questions
         if seed:
@@ -343,9 +362,22 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                 for c in seed.constraints:
                     parts.append(f"  - {c}")
             if seed.acceptance_criteria:
-                parts.append(f"Acceptance Criteria: {len(seed.acceptance_criteria)}")
-                for i, ac in enumerate(ac_texts(seed.acceptance_criteria), 1):
-                    parts.append(f"  AC {i}: {ac}")
+                seed_acs = ac_texts(seed.acceptance_criteria)
+                if focused:
+                    parts.append(
+                        f"Evolution Focus: {len(active)} active / "
+                        f"{len(seed_acs) - len(active)} frozen AC nodes"
+                    )
+                    parts.append(
+                        "Frozen nodes are immutable in this generation and are omitted below."
+                    )
+                    for index in sorted(active):
+                        if 0 <= index < len(seed_acs):
+                            parts.append(f"  ACTIVE AC {index + 1}: {seed_acs[index]}")
+                else:
+                    parts.append(f"Acceptance Criteria: {len(seed_acs)}")
+                    for i, ac in enumerate(seed_acs, 1):
+                        parts.append(f"  AC {i}: {ac}")
             parts.append("")
 
         parts.append(f"## Current Ontology: {ontology.name}")
@@ -377,13 +409,16 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                         f"{feedback.message}{detail_suffix}"
                     )
             if eval_summary.ac_results:
-                failed_acs = [ac for ac in eval_summary.ac_results if not ac.passed]
+                visible_results = [
+                    ac for ac in eval_summary.ac_results if not focused or ac.ac_index in active
+                ]
+                failed_acs = [ac for ac in visible_results if not ac.passed]
                 if failed_acs:
-                    parts.append(f"\n  Failed ACs ({len(failed_acs)}):")
+                    parts.append(f"\n  Active failed ACs ({len(failed_acs)}):")
                     for ac in failed_acs:
                         parts.append(f"    - AC {ac.ac_index + 1}: {ac.ac_content}")
-                passed_count = sum(1 for ac in eval_summary.ac_results if ac.passed)
-                parts.append(f"  AC pass rate: {passed_count}/{len(eval_summary.ac_results)}")
+                passed_count = sum(1 for ac in visible_results if ac.passed)
+                parts.append(f"  Visible AC pass rate: {passed_count}/{len(visible_results)}")
 
         # Regression context
         if lineage and len(lineage.generations) >= 2:
@@ -399,7 +434,25 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                 parts.append("  WHY did these previously-passing ACs start failing?")
 
         if execution_output:
-            truncated = truncate_head_tail(execution_output)
+            # Focused generations prefer verifier evidence attached to the open
+            # nodes.  The full prior transcript would re-expand context with
+            # already-settled work and defeat working-set convergence.
+            evidence = []
+            if focused and eval_summary is not None:
+                evidence = [
+                    f"AC {result.ac_index + 1}: {result.evidence}"
+                    for result in eval_summary.ac_results
+                    if result.ac_index in active and result.evidence
+                ]
+            truncated = (
+                "\n".join(evidence)
+                if evidence
+                else truncate_head_tail(
+                    execution_output,
+                    head=200 if focused else 500,
+                    tail=800 if focused else 2000,
+                )
+            )
             parts.append(f"\n## Execution Output (truncated)\n{truncated}")
 
         if lineage.generations:
@@ -421,7 +474,12 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
 
         return "\n".join(parts)
 
-    def _parse_response(self, content: str, seed: Seed | None = None) -> WonderOutput:
+    def _parse_response(
+        self,
+        content: str,
+        seed: Seed | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
+    ) -> WonderOutput:
         """Parse LLM response into WonderOutput."""
         total_acs = len(seed.acceptance_criteria) if seed else None
         try:
@@ -452,6 +510,33 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
             reasoning = data.get("reasoning", "")
             if not isinstance(reasoning, str):
                 raise TypeError("Expected reasoning to be a string")
+            if active_ac_indices is not None:
+                active = set(active_ac_indices)
+                grounded = tuple(
+                    GroundedQuestion(
+                        question=question.question,
+                        kind="challenge",
+                        ac_indices=tuple(i for i in question.ac_indices if i in active),
+                    )
+                    for question in grounded
+                    if question.kind == "challenge"
+                    and any(i in active for i in question.ac_indices)
+                )
+                # An empty focused response cannot justify a full-graph retry.
+                # Keep one concrete open-node question so Reflect receives a
+                # bounded target rather than inventing a new gap.
+                if not grounded and active:
+                    target = min(active)
+                    text = f"What blocks ACTIVE AC {target + 1} from passing its verifier?"
+                    grounded = (
+                        GroundedQuestion(
+                            question=text,
+                            kind="challenge",
+                            ac_indices=(target,),
+                        ),
+                    )
+                ontology_tensions = []
+                should_continue = bool(grounded)
             return WonderOutput(
                 # ``questions`` stays a flat string tuple for events, lineage, and
                 # the repetitive-feedback convergence check (unchanged contract).
@@ -463,6 +548,22 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
             )
         except (ValueError, KeyError, TypeError, ValidationError) as e:
             logger.warning("Failed to parse WonderEngine response: %s", e)
+            if active_ac_indices:
+                target = min(active_ac_indices)
+                fallback = f"What blocks ACTIVE AC {target + 1} from passing its verifier?"
+                return WonderOutput(
+                    questions=(fallback,),
+                    grounded_questions=(
+                        GroundedQuestion(
+                            question=fallback,
+                            kind="challenge",
+                            ac_indices=(target,),
+                        ),
+                    ),
+                    ontology_tensions=(),
+                    should_continue=True,
+                    reasoning=f"Parse error, using focused fallback: {e}",
+                )
             scope_hint = f" for goal: {seed.goal}" if seed else ""
             fallback = f"What assumptions remain untested{scope_hint}?"
             return WonderOutput(
@@ -511,8 +612,25 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
         eval_summary: EvaluationSummary | None,
         ontology: OntologySchema,
         seed: Seed | None = None,
+        active_ac_indices: tuple[int, ...] | None = None,
     ) -> WonderOutput:
         """Generate fallback output when LLM fails (degraded mode)."""
+        if active_ac_indices:
+            target = min(active_ac_indices)
+            question = f"What blocks ACTIVE AC {target + 1} from passing its verifier?"
+            return WonderOutput(
+                questions=(question,),
+                grounded_questions=(
+                    GroundedQuestion(
+                        question=question,
+                        kind="challenge",
+                        ac_indices=(target,),
+                    ),
+                ),
+                ontology_tensions=(),
+                should_continue=True,
+                reasoning="Degraded mode: using the verifier-selected active node",
+            )
         questions: list[str] = []
         tensions: list[str] = []
         scope_hint = f" (within scope: {seed.goal})" if seed else ""

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -641,18 +641,19 @@ def _agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
 def _evaluation_summary_from_spec_verification(
     mechanical: Any,
     verification_summary: Any,
+    seed: Any | None = None,
 ) -> Any | None:
-    """Promote complete verifier coverage into formal AC verdict results.
-
-    Spec verification may only return reports for ACs that produced extractable
-    assertions. Missing reports and reports with no concrete verification
-    results are not formal approval: they become failed/not-evaluated AC
-    results so a partial verifier pass cannot approve the whole run.
-    """
+    """Promote complete verifier coverage into Seed-bound formal AC verdicts."""
     from ouroboros.core.lineage import ACResult, EvaluationSummary
 
     reports = tuple(getattr(verification_summary, "reports", ()) or ())
     if not reports:
+        return None
+    seed_criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+
+    def semantic_key(ac_index: int) -> str | None:
+        if 0 <= ac_index < len(seed_criteria):
+            return getattr(seed_criteria[ac_index], "semantic_ac_key", None)
         return None
 
     expected_ac_content: dict[int, str] = {
@@ -682,6 +683,7 @@ def _evaluation_summary_from_spec_verification(
                     ac_content=expected_ac_content.get(
                         ac_index, f"Acceptance criterion {ac_index + 1}"
                     ),
+                    semantic_ac_key=semantic_key(ac_index),
                     passed=False,
                     score=0.0,
                     evidence="No spec verification report was produced for this AC.",
@@ -713,6 +715,7 @@ def _evaluation_summary_from_spec_verification(
             ACResult(
                 ac_index=report.ac_index,
                 ac_content=report.ac_text,
+                semantic_ac_key=semantic_key(report.ac_index),
                 passed=passed,
                 score=1.0 if passed else 0.0,
                 evidence=evidence,
@@ -1990,7 +1993,6 @@ def create_ouroboros_server(
         if not seed_id:
             return None
 
-        # Extract assertions from ACs (cached by seed_id)
         extract_result = await spec_extractor.extract(seed_id, ac_texts(seed_acs))
         if extract_result.is_err:
             log.warning("spec_verification.extraction_failed", error=str(extract_result.error))
@@ -2000,10 +2002,8 @@ def create_ouroboros_server(
         if not assertions:
             return None
 
-        # Build agent results map from formal AC results or legacy task completion.
         agent_results = _agent_results_from_execution_summary(mechanical)
 
-        # Run verification
         verifier = SpecVerifier(project_dir=project_dir)
         summary = verifier.verify_all(assertions, agent_results)
 
@@ -2014,7 +2014,7 @@ def create_ouroboros_server(
                 project_dir=project_dir,
             )
 
-        return _evaluation_summary_from_spec_verification(mechanical, summary)
+        return _evaluation_summary_from_spec_verification(mechanical, summary, seed)
 
     async def _evolution_evaluator(seed: Any, execution_output: str | None) -> EvaluationSummary:
         await _ensure_evolution_store_initialized()

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -2096,6 +2096,8 @@ def create_ouroboros_server(
         import re
         import subprocess  # noqa: S404  # nosec
 
+        from ouroboros.evolution.validation_result import BUILTIN_COLLECTION_ATTEMPT_LIMIT
+
         project_dir = _extract_project_dir(execution_output or "", seed=seed)
 
         if not project_dir:
@@ -2123,7 +2125,7 @@ def create_ouroboros_server(
                 timeout=60,
             )
 
-        max_attempts = 3
+        max_attempts = BUILTIN_COLLECTION_ATTEMPT_LIMIT
         # Use Sonnet for validation fixes — import error resolution doesn't need Opus
         validation_model = os.environ.get("OUROBOROS_VALIDATION_MODEL") or execution_model
         if validation_model is None and execute_runtime_backend == "claude":

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -629,7 +629,7 @@ def _agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
     ``source_ac_index`` so skipped/unverifiable assertions do not convert a
     worker-reported failure into formal approval.
     """
-    agent_results = {ac.ac_index: ac.passed for ac in mechanical.ac_results}
+    agent_results = {ac.ac_index: ac.authoritative_pass for ac in mechanical.ac_results}
     for task in mechanical.task_results:
         source_ac_index = task.source_ac_index
         if source_ac_index is None:
@@ -727,7 +727,7 @@ def _evaluation_summary_from_spec_verification(
         )
 
     total = len(ac_results)
-    passed_count = sum(1 for result in ac_results if result.passed)
+    passed_count = sum(1 for result in ac_results if result.authoritative_pass)
     score = passed_count / total if total > 0 else 0.0
     complete_coverage = bool(expected_indices) and expected_indices.issubset(reports_by_index)
     execution_completed = mechanical.execution_completion_status == "completed"
@@ -735,7 +735,7 @@ def _evaluation_summary_from_spec_verification(
 
     failure_reason = None
     if not approved:
-        failed_indices = [result.ac_index + 1 for result in ac_results if not result.passed]
+        failed_indices = [result.ac_index + 1 for result in ac_results if result.unresolved]
         discrepancy_count = getattr(verification_summary, "discrepancy_count", 0)
         reason_parts = []
         if failed_indices:

--- a/src/ouroboros/mcp/tools/dashboard.py
+++ b/src/ouroboros/mcp/tools/dashboard.py
@@ -32,7 +32,7 @@ def _extract_ac_history(
         for ac in es.ac_results:
             if ac.ac_index not in history:
                 history[ac.ac_index] = []
-            history[ac.ac_index].append((gen.generation_number, ac.passed))
+            history[ac.ac_index].append((gen.generation_number, ac.authoritative_pass))
 
     return history
 
@@ -119,7 +119,7 @@ def format_summary(lineage: OntologyLineage) -> str:
             stable_count += 1
             continue
 
-        status = "PASS" if ac.passed else "FAIL"
+        status = ac.authority_state.upper()
         desc = ac.ac_content[:50] + ("..." if len(ac.ac_content) > 50 else "")
         trend = _trend_dots(ac_history) if ac_history else "-"
         lines.append(f"| {ac.ac_index + 1} | {status} | {desc} | {trend} |")

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -679,7 +679,6 @@ class EvolveStepHandler(BridgeAwareMixin):
             "generation": gen.generation_number,
             "action": step.action.value,
             "similarity": sig.ontology_similarity,
-            "converged": sig.converged,
             "next_generation": step.next_generation,
             "executed": execute,
             "qa_attempted": qa_attempted,
@@ -696,6 +695,10 @@ class EvolveStepHandler(BridgeAwareMixin):
             meta["worktree_branch"] = workspace.branch
         if qa_meta:
             meta["qa"] = qa_meta
+
+        from ouroboros.evolution.loop import StepAction
+
+        meta["converged"] = step.action is StepAction.CONVERGED
 
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -536,6 +536,20 @@ class EvolveStepHandler(BridgeAwareMixin):
             f"**Lineage**: {step.lineage.lineage_id} ({step.lineage.current_generation} generations)",
             f"**Next generation**: {step.next_generation}",
         ]
+        if gen.frozen_ac_indices:
+            active_labels = ", ".join(str(index + 1) for index in gen.active_ac_indices) or "none"
+            frozen_labels = ", ".join(str(index + 1) for index in gen.frozen_ac_indices)
+            text_lines.extend(
+                [
+                    f"**Active evolve nodes**: {active_labels}",
+                    f"**Frozen nodes**: {frozen_labels}",
+                    (
+                        "**Working set**: "
+                        f"{len(gen.active_ac_indices)} active / "
+                        f"{len(gen.frozen_ac_indices)} frozen"
+                    ),
+                ]
+            )
         if workspace is not None:
             text_lines.extend(
                 [
@@ -547,7 +561,11 @@ class EvolveStepHandler(BridgeAwareMixin):
         if gen.execution_output:
             text_lines.append("")
             text_lines.append("### Execution output")
-            output_preview = truncate_head_tail(gen.execution_output)
+            output_preview = truncate_head_tail(
+                gen.execution_output,
+                head=150 if gen.frozen_ac_indices else 500,
+                tail=650 if gen.frozen_ac_indices else 2000,
+            )
             text_lines.append(output_preview)
 
         if gen.evaluation_summary:
@@ -562,9 +580,22 @@ class EvolveStepHandler(BridgeAwareMixin):
             if es.ac_results:
                 text_lines.append("")
                 text_lines.append("#### Per-AC Results")
-                for ac in es.ac_results:
+                active = set(gen.active_ac_indices)
+                visible_results = [
+                    ac
+                    for ac in es.ac_results
+                    if not gen.frozen_ac_indices or ac.ac_index in active or not ac.passed
+                ]
+                for ac in visible_results:
                     status = "PASS" if ac.passed else "FAIL"
                     text_lines.append(f"- AC {ac.ac_index + 1}: [{status}] {ac.ac_content[:80]}")
+                frozen_passes = sum(
+                    1 for ac in es.ac_results if ac.ac_index in gen.frozen_ac_indices and ac.passed
+                )
+                if frozen_passes:
+                    text_lines.append(
+                        f"- {frozen_passes} frozen node(s): [PASS] boundary reverified"
+                    )
 
         checkpoint_commits, checkpoint_attempted_ac_ids = _checkpoint_passed_generation_acs(
             arguments,
@@ -653,6 +684,10 @@ class EvolveStepHandler(BridgeAwareMixin):
             "executed": execute,
             "qa_attempted": qa_attempted,
             "has_execution_output": gen.execution_output is not None,
+            "active_ac_indices": list(gen.active_ac_indices),
+            "frozen_ac_indices": list(gen.frozen_ac_indices),
+            "active_node_count": len(gen.active_ac_indices),
+            "frozen_node_count": len(gen.frozen_ac_indices),
             "checkpoint_commits": checkpoint_commits,
             "checkpoint_attempted_ac_ids": checkpoint_attempted_ac_ids,
         }

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -676,13 +676,22 @@ class EvolveStepHandler(BridgeAwareMixin):
         normalized_project_dir = (
             project_dir if isinstance(project_dir, str) and project_dir else None
         )
+        configured_project_dir = self.evolutionary_loop.get_project_dir()
+        normalized_configured_project_dir = (
+            configured_project_dir
+            if isinstance(configured_project_dir, str) and configured_project_dir
+            else None
+        )
+        effective_source_project_dir = normalized_project_dir or normalized_configured_project_dir
         workspace: TaskWorkspace | None = None
-        if execute and (normalized_project_dir is None or is_git_repo(normalized_project_dir)):
+        if execute and (
+            effective_source_project_dir is None or is_git_repo(effective_source_project_dir)
+        ):
             try:
                 workspace = maybe_restore_task_workspace(
                     lineage_id,
                     persisted=None,
-                    fallback_source_cwd=normalized_project_dir or os.getcwd(),
+                    fallback_source_cwd=effective_source_project_dir or os.getcwd(),
                 )
             except WorktreeError as e:
                 return Result.err(
@@ -693,7 +702,7 @@ class EvolveStepHandler(BridgeAwareMixin):
                 )
 
         project_dir_token = self.evolutionary_loop.set_project_dir(
-            workspace.effective_cwd if workspace else normalized_project_dir
+            workspace.effective_cwd if workspace else effective_source_project_dir
         )
         resolved_verification_working_dir = Path.cwd()
         workspace_evidence_pending = False
@@ -718,7 +727,7 @@ class EvolveStepHandler(BridgeAwareMixin):
                     workspace,
                     _resolve_evolve_verification_working_dir(
                         normalized_project_dir,
-                        self.evolutionary_loop.get_project_dir(),
+                        normalized_configured_project_dir,
                         getattr(step.generation_result, "seed", None),
                         initial_seed,
                     ),

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -108,19 +108,16 @@ def _evolve_handler_request_key(
         if isinstance(project_dir, str) and project_dir
         else None
     )
-    normalized["project_dir"] = (
-        str(resolved_project_dir) if resolved_project_dir is not None else None
-    )
     configured = (
         resolve_path_against_base(configured_project_dir, stable_base=fallback_cwd)
         if configured_project_dir
         else None
     )
+    effective_project_dir = resolved_project_dir or configured or fallback_cwd
+    normalized["project_dir"] = str(effective_project_dir)
     return stable_payload_digest(
         {
             "arguments": normalized,
-            "configured_project_dir": str(configured) if configured is not None else None,
-            "fallback_cwd": str(fallback_cwd),
             "execution_policy": execution_policy,
         }
     )

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -85,6 +85,7 @@ def _evolve_handler_request_key(
     *,
     configured_project_dir: str | None,
     fallback_cwd: Path,
+    execution_policy: dict[str, Any] | None = None,
 ) -> str:
     """Canonicalize semantically equivalent public retries before hashing."""
     normalized = dict(arguments)
@@ -120,6 +121,7 @@ def _evolve_handler_request_key(
             "arguments": normalized,
             "configured_project_dir": str(configured) if configured is not None else None,
             "fallback_cwd": str(fallback_cwd),
+            "execution_policy": execution_policy,
         }
     )
 
@@ -472,6 +474,9 @@ class EvolveStepHandler(BridgeAwareMixin):
             arguments,
             configured_project_dir=configured_project_dir,
             fallback_cwd=Path.cwd().resolve(),
+            execution_policy=loop_support.evolution_execution_policy(
+                getattr(self.evolutionary_loop, "config", None)
+            ),
         )
         recovered_generation: int | None = None
         recovered_evolve_result: Any | None = None

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -10,6 +10,7 @@ Contains handlers for evolutionary loop operations:
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
+import time
 from typing import Any
 
 import structlog
@@ -20,6 +21,7 @@ from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState
 from ouroboros.config import get_runtime_controls_config
 from ouroboros.core.conductor import (
     ConductorDirective,
+    stable_payload_digest,
     validate_conductor_successor_authorization,
 )
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
@@ -35,6 +37,7 @@ from ouroboros.core.worktree import (
 )
 from ouroboros.evaluation.verification_artifacts import build_verification_artifacts
 from ouroboros.events.conductor import create_conductor_directive_attached_event
+from ouroboros.evolution import loop_support
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools.background import start_background_tool_job
@@ -58,6 +61,67 @@ from ouroboros.mcp.types import (
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
+
+_EVOLVE_HANDLER_DEFAULTS: dict[str, object] = {
+    "seed_content": None,
+    "execute": True,
+    "parallel": True,
+    "skip_qa": False,
+    "project_dir": None,
+    "commit_policy": None,
+    "auto_session_id": None,
+    "execution_id": None,
+    "checkpoint_commits": [],
+    "checkpoint_attempted_ac_ids": [],
+    "conductor_decision_id": None,
+    "predecessor_execution_id": None,
+    "conductor_directive": None,
+    "recover_expired_claim": False,
+}
+
+
+def _evolve_handler_request_key(
+    arguments: dict[str, Any],
+    *,
+    configured_project_dir: str | None,
+    fallback_cwd: Path,
+) -> str:
+    """Canonicalize semantically equivalent public retries before hashing."""
+    normalized = dict(arguments)
+    for name, default in _EVOLVE_HANDLER_DEFAULTS.items():
+        normalized.setdefault(name, default)
+    # Recovery authorizes takeover of an expired owner; it does not change the
+    # generation operation whose durable request identity must still match.
+    normalized["recover_expired_claim"] = False
+    seed_content = normalized["seed_content"]
+    if isinstance(seed_content, str) and seed_content:
+        try:
+            normalized["seed_content"] = Seed.from_dict(yaml.safe_load(seed_content)).to_dict()
+        except Exception:
+            pass
+    elif not seed_content:
+        normalized["seed_content"] = None
+    project_dir = normalized["project_dir"]
+    resolved_project_dir = (
+        resolve_path_against_base(project_dir, stable_base=fallback_cwd)
+        if isinstance(project_dir, str) and project_dir
+        else None
+    )
+    normalized["project_dir"] = (
+        str(resolved_project_dir) if resolved_project_dir is not None else None
+    )
+    configured = (
+        resolve_path_against_base(configured_project_dir, stable_base=fallback_cwd)
+        if configured_project_dir
+        else None
+    )
+    return stable_payload_digest(
+        {
+            "arguments": normalized,
+            "configured_project_dir": str(configured) if configured is not None else None,
+            "fallback_cwd": str(fallback_cwd),
+        }
+    )
 
 
 async def _resolve_conductor_directive(
@@ -259,7 +323,9 @@ class EvolveStepHandler(BridgeAwareMixin):
                 "For Gen 1: provide lineage_id and seed_content (YAML). "
                 "For Gen 2+: provide lineage_id only (state reconstructed from events). "
                 "Returns generation result, convergence signal, and next action "
-                "(continue/converged/stagnated/exhausted/failed)."
+                "(continue/converged/ontology_stable/stagnated/exhausted/failed). "
+                "ontology_stable is a non-success handoff; rerun the same lineage "
+                "with execute=true to perform Execute→Evaluate."
             ),
             parameters=(
                 MCPToolParameter(
@@ -307,6 +373,16 @@ class EvolveStepHandler(BridgeAwareMixin):
                     name="skip_qa",
                     type=ToolInputType.BOOLEAN,
                     description="Skip post-execution QA evaluation. Default: false",
+                    required=False,
+                    default=False,
+                ),
+                MCPToolParameter(
+                    name="recover_expired_claim",
+                    type=ToolInputType.BOOLEAN,
+                    description=(
+                        "Explicitly recover an expired lineage writer claim after confirming "
+                        "the prior owner process is dead. Default: false"
+                    ),
                     required=False,
                     default=False,
                 ),
@@ -374,7 +450,7 @@ class EvolveStepHandler(BridgeAwareMixin):
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
-        """Handle an evolve_step request."""
+        """Coalesce the complete public request before workspace acquisition."""
         lineage_id = arguments.get("lineage_id")
         if not lineage_id:
             return Result.err(
@@ -383,6 +459,150 @@ class EvolveStepHandler(BridgeAwareMixin):
                     tool_name="ouroboros_evolve_step",
                 )
             )
+        event_store = self.event_store or getattr(self.evolutionary_loop, "event_store", None)
+        if not isinstance(event_store, EventStore):
+            return await self._handle_once(dict(arguments))
+        configured_project_dir = (
+            self.evolutionary_loop.get_project_dir()
+            if self.evolutionary_loop is not None
+            and callable(getattr(self.evolutionary_loop, "get_project_dir", None))
+            else None
+        )
+        request_key = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=configured_project_dir,
+            fallback_cwd=Path.cwd().resolve(),
+        )
+        recovered_generation: int | None = None
+        recovered_evolve_result: Any | None = None
+        if arguments.get("recover_expired_claim") is True:
+            from ouroboros.evolution.step_receipt import decode_step_result
+            from ouroboros.persistence import lineage_claims
+
+            await event_store.initialize()
+            stale_handler = await lineage_claims.observe(
+                event_store,
+                scope="evolve-handler",
+                lineage_id=str(lineage_id),
+            )
+            if (
+                stale_handler is not None
+                and not stale_handler.completed
+                and stale_handler.lease_expires_at_ms <= int(time.time() * 1000)
+            ):
+                if stale_handler.request_key != request_key:
+                    return Result.err(
+                        MCPToolError(
+                            "Expired evolve handler must be recovered with its original request",
+                            tool_name="ouroboros_evolve_step",
+                        )
+                    )
+                recovered_generation = stale_handler.generation_number
+                core_receipt = await lineage_claims.observe(
+                    event_store,
+                    scope="evolve-core",
+                    lineage_id=str(lineage_id),
+                )
+                if (
+                    core_receipt is not None
+                    and core_receipt.completed
+                    and core_receipt.generation_number != recovered_generation
+                ):
+                    return Result.err(
+                        MCPToolError(
+                            "Expired evolve handler disagrees with the durable core generation",
+                            tool_name="ouroboros_evolve_step",
+                        )
+                    )
+                if (
+                    core_receipt is not None
+                    and core_receipt.completed
+                    and core_receipt.generation_number == recovered_generation
+                ):
+                    if core_receipt.result_payload is None:
+                        return Result.err(
+                            MCPToolError(
+                                "Expired evolve handler has no durable core result to recover",
+                                tool_name="ouroboros_evolve_step",
+                            )
+                        )
+                    try:
+                        recovered_evolve_result = await decode_step_result(
+                            event_store,
+                            core_receipt.result_payload,
+                        )
+                    except (KeyError, TypeError, ValueError) as exc:
+                        return Result.err(
+                            MCPToolError(
+                                f"Failed to recover durable evolve result: {exc}",
+                                tool_name="ouroboros_evolve_step",
+                            )
+                        )
+            for scope in ("evolve-handler", "evolve-core"):
+                await lineage_claims.recover_expired(
+                    event_store,
+                    scope=scope,
+                    lineage_id=str(lineage_id),
+                )
+        durable_public_result = not should_dispatch_via_plugin(
+            self.agent_runtime_backend,
+            self.opencode_mode,
+        )
+
+        async def run_public_request() -> Result[MCPToolResult, MCPServerError]:
+            if not durable_public_result:
+                return await self._handle_once(dict(arguments))
+            from ouroboros.mcp.tools.evolve_handler_receipt import (
+                decode_evolve_handler_result,
+                encode_evolve_handler_result,
+            )
+
+            async def run_bounded_handler() -> Result[MCPToolResult, MCPServerError]:
+                raw_result = await self._handle_once(
+                    dict(arguments),
+                    recovered_evolve_result=recovered_evolve_result,
+                )
+                return decode_evolve_handler_result(encode_evolve_handler_result(raw_result))
+
+            while True:
+                generation_number = recovered_generation
+                if generation_number is None:
+                    generation_number = await loop_support.planned_evolve_generation(
+                        event_store,
+                        str(lineage_id),
+                        execute=bool(arguments.get("execute", True)),
+                    )
+                try:
+                    return await loop_support.run_durable_lineage_single_flight(
+                        event_store,
+                        str(lineage_id),
+                        request_key,
+                        run_bounded_handler,
+                        generation_number=generation_number,
+                        encode=encode_evolve_handler_result,
+                        decode=decode_evolve_handler_result,
+                        scope="evolve-handler",
+                    )
+                except loop_support.LineageWinnerAdvanced:
+                    continue
+
+        return await loop_support.run_lineage_single_flight(
+            event_store,
+            str(lineage_id),
+            request_key,
+            run_public_request,
+            scope="evolve-handler",
+        )
+
+    async def _handle_once(
+        self,
+        arguments: dict[str, Any],
+        *,
+        recovered_evolve_result: Any | None = None,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Run one complete evolve handler request under public ownership."""
+        lineage_id = arguments.get("lineage_id")
+        assert lineage_id
 
         directive_result = await _resolve_conductor_directive(
             arguments=arguments,
@@ -474,6 +694,7 @@ class EvolveStepHandler(BridgeAwareMixin):
             workspace.effective_cwd if workspace else normalized_project_dir
         )
         resolved_verification_working_dir = Path.cwd()
+        workspace_evidence_pending = False
 
         try:
             # Ensure event store is initialized before evolve_step accesses it
@@ -482,19 +703,25 @@ class EvolveStepHandler(BridgeAwareMixin):
             evolve_kwargs: dict[str, Any] = {"execute": execute, "parallel": parallel}
             if conductor_directive is not None:
                 evolve_kwargs["conductor_directive"] = conductor_directive
-            result = await self.evolutionary_loop.evolve_step(
-                lineage_id,
-                initial_seed,
-                **evolve_kwargs,
-            )
+            result = recovered_evolve_result
+            if result is None:
+                result = await self.evolutionary_loop.evolve_step(
+                    lineage_id,
+                    initial_seed,
+                    **evolve_kwargs,
+                )
             if result.is_ok:
                 step = result.value
-                resolved_verification_working_dir = _resolve_evolve_verification_working_dir(
-                    normalized_project_dir,
-                    self.evolutionary_loop.get_project_dir(),
-                    getattr(step.generation_result, "seed", None),
-                    initial_seed,
+                resolved_verification_working_dir = _resolve_checkpoint_working_dir(
+                    workspace,
+                    _resolve_evolve_verification_working_dir(
+                        normalized_project_dir,
+                        self.evolutionary_loop.get_project_dir(),
+                        getattr(step.generation_result, "seed", None),
+                        initial_seed,
+                    ),
                 )
+                workspace_evidence_pending = True
         except Exception as e:
             log.error("mcp.tool.evolve_step.error", error=str(e))
             return Result.err(
@@ -505,7 +732,7 @@ class EvolveStepHandler(BridgeAwareMixin):
             )
         finally:
             self.evolutionary_loop.reset_project_dir(project_dir_token)
-            if workspace is not None:
+            if workspace is not None and not workspace_evidence_pending:
                 release_lock(workspace.lock_path)
 
         if result.is_err:
@@ -517,6 +744,19 @@ class EvolveStepHandler(BridgeAwareMixin):
             )
 
         step = result.value
+        (
+            checkpoint_commits,
+            checkpoint_attempted_ac_ids,
+            qa_attempted,
+            artifact,
+            reference,
+        ) = await _materialize_locked_evolve_evidence(
+            arguments=arguments,
+            step=step,
+            execute=execute,
+            workspace=workspace,
+            verification_working_dir=resolved_verification_working_dir,
+        )
         gen = step.generation_result
         sig = step.convergence_signal
 
@@ -584,24 +824,21 @@ class EvolveStepHandler(BridgeAwareMixin):
                 visible_results = [
                     ac
                     for ac in es.ac_results
-                    if not gen.frozen_ac_indices or ac.ac_index in active or not ac.passed
+                    if not gen.frozen_ac_indices or ac.ac_index in active or ac.unresolved
                 ]
                 for ac in visible_results:
-                    status = "PASS" if ac.passed else "FAIL"
+                    status = ac.authority_state.upper()
                     text_lines.append(f"- AC {ac.ac_index + 1}: [{status}] {ac.ac_content[:80]}")
                 frozen_passes = sum(
-                    1 for ac in es.ac_results if ac.ac_index in gen.frozen_ac_indices and ac.passed
+                    1
+                    for ac in es.ac_results
+                    if ac.ac_index in gen.frozen_ac_indices and ac.authoritative_pass
                 )
                 if frozen_passes:
                     text_lines.append(
                         f"- {frozen_passes} frozen node(s): [PASS] boundary reverified"
                     )
 
-        checkpoint_commits, checkpoint_attempted_ac_ids = _checkpoint_passed_generation_acs(
-            arguments,
-            gen.evaluation_summary,
-            _resolve_checkpoint_working_dir(workspace, resolved_verification_working_dir),
-        )
         if checkpoint_commits:
             text_lines.append("")
             text_lines.append("### Checkpoint commits")
@@ -633,38 +870,27 @@ class EvolveStepHandler(BridgeAwareMixin):
 
         # Post-execution QA
         qa_meta = None
-        skip_qa = arguments.get("skip_qa", False)
-        qa_attempted = step.action.value in ("continue", "converged") and execute and not skip_qa
         if qa_attempted:
             from ouroboros.mcp.tools.qa import QAHandler
 
+            assert artifact is not None
+            assert reference is not None
             qa_handler = QAHandler()
-            quality_bar = "Generation must improve upon previous generation."
-            if initial_seed:
-                ac_lines = [f"- {ac}" for ac in ac_texts(initial_seed.acceptance_criteria)]
-                quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
-                    ac_lines
-                )
+            ac_lines = [f"- {ac}" for ac in ac_texts(gen.seed.acceptance_criteria)]
+            quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
+                ac_lines
+            )
+            canonical_seed_content = yaml.safe_dump(
+                gen.seed.to_dict(), sort_keys=False, allow_unicode=True
+            )
 
-            execution_artifact = gen.execution_output or "\n".join(text_lines)
-            try:
-                verification = await build_verification_artifacts(
-                    f"{step.lineage.lineage_id}-gen-{gen.generation_number}",
-                    execution_artifact,
-                    resolved_verification_working_dir,
-                )
-                artifact = verification.artifact
-                reference = verification.reference
-            except Exception as e:
-                artifact = execution_artifact
-                reference = f"Verification artifact generation failed: {e}"
             qa_result = await qa_handler.handle(
                 {
                     "artifact": artifact,
                     "artifact_type": "test_output",
                     "quality_bar": quality_bar,
                     "reference": reference,
-                    "seed_content": seed_content or "",
+                    "seed_content": canonical_seed_content,
                     "pass_threshold": 0.80,
                 }
             )
@@ -709,6 +935,67 @@ class EvolveStepHandler(BridgeAwareMixin):
         )
 
 
+async def _materialize_locked_evolve_evidence(
+    *,
+    arguments: dict[str, Any],
+    step: Any,
+    execute: bool,
+    workspace: TaskWorkspace | None,
+    verification_working_dir: Path,
+) -> tuple[list[dict[str, Any]], list[str], bool, str | None, str | None]:
+    """Materialize every filesystem-dependent receipt before releasing the workspace.
+
+    The generation Seed and its verification artifact must describe one filesystem
+    epoch.  A managed task worktree can be reused by the next generation as soon as
+    its durable lock is released, so checkpointing and mechanical verification run
+    while that lock is still held.  QA runs later from the returned strings and does
+    not need to retain the lock across provider latency.
+    """
+    try:
+        gen = step.generation_result
+        checkpoint_commits, checkpoint_attempted_ac_ids = _checkpoint_passed_generation_acs(
+            arguments,
+            gen.evaluation_summary,
+            verification_working_dir,
+        )
+        skip_qa = arguments.get("skip_qa", False)
+        qa_attempted = step.action.value in ("continue", "converged") and execute and not skip_qa
+        if not qa_attempted:
+            return (
+                checkpoint_commits,
+                checkpoint_attempted_ac_ids,
+                False,
+                None,
+                None,
+            )
+
+        execution_artifact = gen.execution_output or (
+            f"Generation {gen.generation_number}: action={step.action.value}; "
+            f"reason={step.convergence_signal.reason}"
+        )
+        try:
+            verification = await build_verification_artifacts(
+                f"{step.lineage.lineage_id}-gen-{gen.generation_number}",
+                execution_artifact,
+                verification_working_dir,
+            )
+            artifact = verification.artifact
+            reference = verification.reference
+        except Exception as exc:
+            artifact = execution_artifact
+            reference = f"Verification artifact generation failed: {exc}"
+        return (
+            checkpoint_commits,
+            checkpoint_attempted_ac_ids,
+            True,
+            artifact,
+            reference,
+        )
+    finally:
+        if workspace is not None:
+            release_lock(workspace.lock_path)
+
+
 def _checkpoint_passed_generation_acs(
     arguments: dict[str, Any],
     evaluation_summary: Any,
@@ -742,7 +1029,7 @@ def _checkpoint_passed_generation_acs(
     state.checkpoint_commits = list(existing)
     state.checkpoint_attempted_ac_ids = list(attempted)
     for ac in evaluation_summary.ac_results:
-        if not getattr(ac, "passed", False):
+        if not bool(getattr(ac, "authoritative_pass", False)):
             continue
         ac_id = f"AC-{int(getattr(ac, 'ac_index', 0)) + 1}"
         ac_text = str(getattr(ac, "ac_content", ac_id))

--- a/src/ouroboros/mcp/tools/evolve_handler_receipt.py
+++ b/src/ouroboros/mcp/tools/evolve_handler_receipt.py
@@ -1,0 +1,93 @@
+"""Bounded durable receipts for complete evolve MCP handler calls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ouroboros.core.text import truncate_head_tail
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+MAX_HANDLER_TEXT = 50_000
+MAX_HANDLER_ERROR = 2_000
+
+
+def _bounded(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return truncate_head_tail(value, head=limit // 2, tail=limit // 2)
+
+
+def encode_evolve_handler_result(
+    result: Result[MCPToolResult, MCPServerError],
+) -> dict[str, Any]:
+    """Encode the public result needed by a cross-process duplicate."""
+    if result.is_err:
+        return {
+            "ok": False,
+            "error": _bounded(str(result.error), MAX_HANDLER_ERROR),
+            "is_retriable": result.error.is_retriable,
+        }
+    tool_result = result.value
+    content: list[dict[str, Any]] = []
+    for item in tool_result.content:
+        if item.type is not ContentType.TEXT:
+            raise ValueError("Evolve handler durable receipt supports text content only")
+        content.append(
+            {
+                "type": item.type.value,
+                "text": _bounded(item.text or "", MAX_HANDLER_TEXT),
+                "meta": item.meta,
+            }
+        )
+    action = tool_result.meta.get("action")
+    return {
+        "ok": True,
+        "action": action if isinstance(action, str) else None,
+        "content": content,
+        "is_error": tool_result.is_error,
+        "meta": tool_result.meta,
+        "structured_content": tool_result.structured_content,
+        "result_type": tool_result.result_type,
+    }
+
+
+def decode_evolve_handler_result(
+    payload: Mapping[str, Any],
+) -> Result[MCPToolResult, MCPServerError]:
+    """Decode the durable public result without rerunning evidence or QA."""
+    if not bool(payload.get("ok")):
+        return Result.err(
+            MCPToolError(
+                str(payload.get("error") or "evolve_step failed"),
+                tool_name="ouroboros_evolve_step",
+                is_retriable=bool(payload.get("is_retriable")),
+            )
+        )
+    raw_content = payload.get("content")
+    if not isinstance(raw_content, list):
+        raise ValueError("Durable evolve handler receipt content must be a list")
+    content: list[MCPContentItem] = []
+    for raw_item in raw_content:
+        if not isinstance(raw_item, Mapping) or raw_item.get("type") != ContentType.TEXT.value:
+            raise ValueError("Durable evolve handler receipt contains invalid content")
+        raw_meta = raw_item.get("meta")
+        content.append(
+            MCPContentItem(
+                type=ContentType.TEXT,
+                text=str(raw_item.get("text") or ""),
+                meta=dict(raw_meta) if isinstance(raw_meta, Mapping) else {},
+            )
+        )
+    raw_meta = payload.get("meta")
+    return Result.ok(
+        MCPToolResult(
+            content=tuple(content),
+            is_error=bool(payload.get("is_error")),
+            meta=dict(raw_meta) if isinstance(raw_meta, Mapping) else {},
+            structured_content=payload.get("structured_content"),
+            result_type=str(payload.get("result_type") or "complete"),
+        )
+    )

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -2180,21 +2180,20 @@ Gen 1 lifecycle (seed provided):
 3. Record generation, report convergence signal.
 
 Gen 2+ lifecycle (no seed — reconstruct from prior generation):
-1. Wonder(ontology, evaluation) → open questions
-2. Reflect(seed, output, evaluation, wonder) → ontology mutations
-3. Generate next Seed from reflect output
-4. Execute(Seed) → execution_output
-5. Evaluate(execution_output) → evaluation summary
-6. Record generation, report convergence signal.
+1. Derive active nodes from failed/regressed AC verdicts; freeze prior PASS nodes
+2. Wonder(active nodes, focused evidence) → grounded open questions
+3. Reflect(active nodes only) → bounded ontology/AC mutations; do not add scope
+4. Generate next Seed while keeping frozen nodes verbatim
+5. Execute active nodes only; boundary-reverify every frozen node
+6. Evaluate the shrinking active output and record active/frozen indices
+7. Report the convergence signal.
 
 ## Lineage ID
 {lineage_id}
 {seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{conductor_note}
-Return a generation report containing: generation number, phase, action
-(continue / converged / stagnated / exhausted / failed), ontology similarity,
-evaluation verdict, and any ontology delta (added / removed / modified
-fields). Stop after one generation — the orchestrator decides whether to
-call you again."""
+Return a generation report: generation, phase, action, ontology similarity,
+evaluation verdict, active/frozen AC indices, and ontology delta. Report
+converged immediately on verified PASS; stop after one generation."""
 
     context: dict[str, Any] = {
         "lineage_id": lineage_id,

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -2166,8 +2166,8 @@ def build_evolve_subagent(
     else:
         mode_note = (
             "\n## Mode\nOntology-only: skip execution and evaluation. Perform "
-            "Wonder → Reflect to evolve the ontology from prior generation "
-            "state.\n"
+            "Wonder → Reflect; return ontology_stable, never converged, when stable. "
+            "The caller must rerun the same lineage with execute=true.\n"
         )
 
     prompt = f"""## Your Task
@@ -2192,8 +2192,8 @@ Gen 2+ lifecycle (no seed — reconstruct from prior generation):
 {lineage_id}
 {seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{conductor_note}
 Return a generation report: generation, phase, action, ontology similarity,
-evaluation verdict, active/frozen AC indices, and ontology delta. Report
-converged immediately on verified PASS; stop after one generation."""
+evaluation verdict, active/frozen AC indices, and ontology delta. Report only
+verified convergence; ontology-only stability is ontology_stable. Stop after one generation."""
 
     context: dict[str, Any] = {
         "lineage_id": lineage_id,
@@ -2322,7 +2322,7 @@ def build_ralph_subagent(
         if execute
         else (
             "\n## Mode\nOntology-only: skip execution/evaluation and evolve "
-            "from prior generation state.\n"
+            "from prior state. On ontology_stable, rerun the same lineage with execute=true.\n"
         )
     )
 
@@ -2410,7 +2410,7 @@ Run a Ralph loop for the given lineage inside this OpenCode child session.
 
 Repeat one evolutionary generation at a time until one stop condition is met:
 - QA passes
-- action is converged
+- action is converged (ontology_stable must first rerun the same lineage with execute=true)
 - action is failed / interrupted / exhausted / stagnated
 - max_generations is reached
 - total elapsed time exceeds max_total_seconds (when supplied) — return

--- a/src/ouroboros/persistence/lineage_claims.py
+++ b/src/ouroboros/persistence/lineage_claims.py
@@ -105,11 +105,14 @@ async def try_acquire(
                     .mappings()
                     .first()
                 )
-                now_ms = _now_ms()
                 waiter_count = int(row["waiter_count"]) if row is not None else 0
-                receipt_drained = row is not None and (
-                    waiter_count == 0 or int(row["lease_expires_at_ms"]) <= now_ms
-                )
+                # A completed receipt is exact winner authority for every
+                # caller that registered while its owner was active.  Time
+                # alone cannot revoke that authority: a live waiter may be
+                # descheduled or blocked on the database beyond the short
+                # receipt lease.  Only its atomic acknowledgement drains the
+                # receipt for ordinary next-generation acquisition.
+                receipt_drained = row is not None and waiter_count == 0
                 replaceable = row is None or (
                     bool(row["completed"])
                     and receipt_drained

--- a/src/ouroboros/persistence/lineage_claims.py
+++ b/src/ouroboros/persistence/lineage_claims.py
@@ -6,15 +6,19 @@ from dataclasses import dataclass
 import time
 from typing import Any
 
-from sqlalchemy import delete, insert, select, update
+from sqlalchemy import delete, func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.persistence.event_store import EventStore
-from ouroboros.persistence.schema import lineage_advancement_claims_table
+from ouroboros.persistence.schema import (
+    lineage_advancement_claims_table,
+    lineage_advancement_waiters_table,
+)
 
 DEFAULT_LEASE_SECONDS = 120.0
+WAITER_LEASE_SECONDS = 120.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +29,7 @@ class ClaimObservation:
     acquired: bool
     lease_expires_at_ms: int
     waiter_registered: bool = False
+    waiter_id: str | None = None
     completed: bool = False
     result_payload: dict[str, Any] | None = None
 
@@ -36,6 +41,10 @@ def _now_ms() -> int:
 def _lease_ms(seconds: float | None = None) -> int:
     duration = DEFAULT_LEASE_SECONDS if seconds is None else seconds
     return _now_ms() + max(1, int(duration * 1000))
+
+
+def _waiter_lease_ms() -> int:
+    return _now_ms() + max(1, int(WAITER_LEASE_SECONDS * 1000))
 
 
 def _engine(event_store: EventStore) -> AsyncEngine | None:
@@ -69,6 +78,48 @@ async def _commit(connection: AsyncConnection, transaction: Any) -> None:
         await connection.commit()
     elif transaction is not None:
         await transaction.commit()
+
+
+async def _prune_and_count_waiters(
+    connection: AsyncConnection,
+    *,
+    scope: str,
+    lineage_id: str,
+    claim_owner_id: str,
+) -> int:
+    """Remove expired registrations and return the live waiter cardinality."""
+    await connection.execute(
+        delete(lineage_advancement_waiters_table).where(
+            lineage_advancement_waiters_table.c.scope == scope,
+            lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+            lineage_advancement_waiters_table.c.claim_owner_id == claim_owner_id,
+            lineage_advancement_waiters_table.c.lease_expires_at_ms <= _now_ms(),
+        )
+    )
+    count = await connection.scalar(
+        select(func.count())
+        .select_from(lineage_advancement_waiters_table)
+        .where(
+            lineage_advancement_waiters_table.c.scope == scope,
+            lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+            lineage_advancement_waiters_table.c.claim_owner_id == claim_owner_id,
+        )
+    )
+    return int(count or 0)
+
+
+async def _delete_claim_waiters(
+    connection: AsyncConnection,
+    *,
+    scope: str,
+    lineage_id: str,
+) -> None:
+    await connection.execute(
+        delete(lineage_advancement_waiters_table).where(
+            lineage_advancement_waiters_table.c.scope == scope,
+            lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+        )
+    )
 
 
 async def try_acquire(
@@ -105,13 +156,28 @@ async def try_acquire(
                     .mappings()
                     .first()
                 )
-                waiter_count = int(row["waiter_count"]) if row is not None else 0
-                # A completed receipt is exact winner authority for every
-                # caller that registered while its owner was active.  Time
-                # alone cannot revoke that authority: a live waiter may be
-                # descheduled or blocked on the database beyond the short
-                # receipt lease.  Only its atomic acknowledgement drains the
-                # receipt for ordinary next-generation acquisition.
+                waiter_count = 0
+                if row is not None:
+                    waiter_count = await _prune_and_count_waiters(
+                        connection,
+                        scope=scope,
+                        lineage_id=lineage_id,
+                        claim_owner_id=str(row["owner_id"]),
+                    )
+                    if waiter_count != int(row["waiter_count"]):
+                        await connection.execute(
+                            update(lineage_advancement_claims_table)
+                            .where(
+                                lineage_advancement_claims_table.c.scope == scope,
+                                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                                lineage_advancement_claims_table.c.owner_id == row["owner_id"],
+                            )
+                            .values(waiter_count=waiter_count)
+                        )
+                # A completed receipt is exact winner authority for every live
+                # waiter registered on its owner.  Short receipt-lease expiry
+                # alone cannot revoke it; individually leased waiter rows
+                # distinguish a delayed live process from a hard-crashed one.
                 receipt_drained = row is not None and waiter_count == 0
                 replaceable = row is None or (
                     bool(row["completed"])
@@ -133,6 +199,11 @@ async def try_acquire(
                     "result_payload": None,
                 }
                 if replaceable:
+                    await _delete_claim_waiters(
+                        connection,
+                        scope=scope,
+                        lineage_id=lineage_id,
+                    )
                     if row is None:
                         await connection.execute(
                             insert(lineage_advancement_claims_table).values(
@@ -162,13 +233,22 @@ async def try_acquire(
                 assert row is not None
                 if not bool(row["completed"]):
                     await connection.execute(
+                        insert(lineage_advancement_waiters_table).values(
+                            scope=scope,
+                            lineage_id=lineage_id,
+                            claim_owner_id=row["owner_id"],
+                            waiter_id=owner_id,
+                            lease_expires_at_ms=_waiter_lease_ms(),
+                        )
+                    )
+                    await connection.execute(
                         update(lineage_advancement_claims_table)
                         .where(
                             lineage_advancement_claims_table.c.scope == scope,
                             lineage_advancement_claims_table.c.lineage_id == lineage_id,
                             lineage_advancement_claims_table.c.owner_id == row["owner_id"],
                         )
-                        .values(waiter_count=lineage_advancement_claims_table.c.waiter_count + 1)
+                        .values(waiter_count=waiter_count + 1)
                     )
                     await _commit(connection, transaction)
                     return ClaimObservation(
@@ -178,6 +258,7 @@ async def try_acquire(
                         acquired=False,
                         lease_expires_at_ms=int(row["lease_expires_at_ms"]),
                         waiter_registered=True,
+                        waiter_id=owner_id,
                     )
 
                 await _commit(connection, transaction)
@@ -280,17 +361,29 @@ async def complete(
     async with engine.connect() as connection:
         transaction = await _begin_write(connection)
         row = (
-            await connection.execute(
-                select(lineage_advancement_claims_table.c.waiter_count).where(
-                    lineage_advancement_claims_table.c.scope == scope,
-                    lineage_advancement_claims_table.c.lineage_id == lineage_id,
-                    lineage_advancement_claims_table.c.owner_id == owner_id,
+            (
+                await connection.execute(
+                    select(lineage_advancement_claims_table)
+                    .where(
+                        lineage_advancement_claims_table.c.scope == scope,
+                        lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                        lineage_advancement_claims_table.c.owner_id == owner_id,
+                    )
+                    .with_for_update()
                 )
             )
-        ).first()
+            .mappings()
+            .first()
+        )
         if row is None:
             await _commit(connection, transaction)
             return False
+        waiter_count = await _prune_and_count_waiters(
+            connection,
+            scope=scope,
+            lineage_id=lineage_id,
+            claim_owner_id=owner_id,
+        )
         result = await connection.execute(
             update(lineage_advancement_claims_table)
             .where(
@@ -304,6 +397,7 @@ async def complete(
                 completed=True,
                 result_payload=result_payload,
                 lease_expires_at_ms=_lease_ms(5.0),
+                waiter_count=waiter_count,
             )
         )
         await _commit(connection, transaction)
@@ -322,7 +416,7 @@ async def release(
     if engine is None:
         return
     async with engine.begin() as connection:
-        await connection.execute(
+        removed = await connection.execute(
             delete(lineage_advancement_claims_table).where(
                 lineage_advancement_claims_table.c.scope == scope,
                 lineage_advancement_claims_table.c.lineage_id == lineage_id,
@@ -330,6 +424,14 @@ async def release(
                 lineage_advancement_claims_table.c.completed.is_(False),
             )
         )
+        if removed.rowcount:
+            await connection.execute(
+                delete(lineage_advancement_waiters_table).where(
+                    lineage_advancement_waiters_table.c.scope == scope,
+                    lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+                    lineage_advancement_waiters_table.c.claim_owner_id == owner_id,
+                )
+            )
 
 
 async def recover_expired(
@@ -351,6 +453,39 @@ async def recover_expired(
                 lineage_advancement_claims_table.c.lease_expires_at_ms <= _now_ms(),
             )
         )
+        if result.rowcount:
+            await _delete_claim_waiters(
+                connection,
+                scope=scope,
+                lineage_id=lineage_id,
+            )
+    return bool(result.rowcount)
+
+
+async def renew_waiter(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+    waiter_id: str,
+) -> bool:
+    """Renew one live waiter's independent receipt-registration lease."""
+    engine = _engine(event_store)
+    if engine is None:
+        return False
+    async with engine.begin() as connection:
+        result = await connection.execute(
+            update(lineage_advancement_waiters_table)
+            .where(
+                lineage_advancement_waiters_table.c.scope == scope,
+                lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+                lineage_advancement_waiters_table.c.claim_owner_id == owner_id,
+                lineage_advancement_waiters_table.c.waiter_id == waiter_id,
+                lineage_advancement_waiters_table.c.lease_expires_at_ms > _now_ms(),
+            )
+            .values(lease_expires_at_ms=_waiter_lease_ms())
+        )
     return bool(result.rowcount)
 
 
@@ -360,19 +495,44 @@ async def acknowledge_waiter(
     scope: str,
     lineage_id: str,
     owner_id: str,
+    waiter_id: str,
 ) -> None:
-    """Atomically consume one registered waiter without a lost update."""
+    """Atomically consume one exact waiter registration without a lost update."""
     engine = _engine(event_store)
     if engine is None:
         return
-    async with engine.begin() as connection:
+    async with engine.connect() as connection:
+        transaction = await _begin_write(connection)
+        await connection.execute(
+            select(lineage_advancement_claims_table.c.owner_id)
+            .where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.owner_id == owner_id,
+            )
+            .with_for_update()
+        )
+        await connection.execute(
+            delete(lineage_advancement_waiters_table).where(
+                lineage_advancement_waiters_table.c.scope == scope,
+                lineage_advancement_waiters_table.c.lineage_id == lineage_id,
+                lineage_advancement_waiters_table.c.claim_owner_id == owner_id,
+                lineage_advancement_waiters_table.c.waiter_id == waiter_id,
+            )
+        )
+        waiter_count = await _prune_and_count_waiters(
+            connection,
+            scope=scope,
+            lineage_id=lineage_id,
+            claim_owner_id=owner_id,
+        )
         await connection.execute(
             update(lineage_advancement_claims_table)
             .where(
                 lineage_advancement_claims_table.c.scope == scope,
                 lineage_advancement_claims_table.c.lineage_id == lineage_id,
                 lineage_advancement_claims_table.c.owner_id == owner_id,
-                lineage_advancement_claims_table.c.waiter_count > 0,
             )
-            .values(waiter_count=lineage_advancement_claims_table.c.waiter_count - 1)
+            .values(waiter_count=waiter_count)
         )
+        await _commit(connection, transaction)

--- a/src/ouroboros/persistence/lineage_claims.py
+++ b/src/ouroboros/persistence/lineage_claims.py
@@ -1,0 +1,375 @@
+"""Durable same-lineage advancement claims shared by EventStore instances."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Any
+
+from sqlalchemy import delete, insert, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+from ouroboros.core.errors import PersistenceError
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.schema import lineage_advancement_claims_table
+
+DEFAULT_LEASE_SECONDS = 120.0
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimObservation:
+    generation_number: int
+    owner_id: str
+    request_key: str
+    acquired: bool
+    lease_expires_at_ms: int
+    waiter_registered: bool = False
+    completed: bool = False
+    result_payload: dict[str, Any] | None = None
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _lease_ms(seconds: float | None = None) -> int:
+    duration = DEFAULT_LEASE_SECONDS if seconds is None else seconds
+    return _now_ms() + max(1, int(duration * 1000))
+
+
+def _engine(event_store: EventStore) -> AsyncEngine | None:
+    engine = getattr(event_store, "_engine", None)
+    return engine if isinstance(engine, AsyncEngine) else None
+
+
+def supports_durable_claims(event_store: object) -> bool:
+    """Return whether this is the production EventStore authority."""
+    return isinstance(event_store, EventStore)
+
+
+def _receipt_allows_retry(payload: object) -> bool:
+    """Return whether a completed receipt represents resumable work."""
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("ok") is False:
+        return True
+    return payload.get("action") in {"failed", "interrupted"}
+
+
+async def _begin_write(connection: AsyncConnection) -> Any:
+    if connection.dialect.name == "sqlite":
+        await connection.exec_driver_sql("BEGIN IMMEDIATE")
+        return None
+    return await connection.begin()
+
+
+async def _commit(connection: AsyncConnection, transaction: Any) -> None:
+    if connection.dialect.name == "sqlite":
+        await connection.commit()
+    elif transaction is not None:
+        await transaction.commit()
+
+
+async def try_acquire(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    generation_number: int,
+    owner_id: str,
+    request_key: str,
+) -> ClaimObservation | None:
+    """Acquire a lineage claim or register as a waiter on its active owner."""
+    engine = _engine(event_store)
+    if engine is None:
+        raise PersistenceError(
+            "EventStore must be initialized before lineage claim acquisition",
+            operation="claim_lineage_advancement",
+        )
+    for _attempt in range(3):
+        try:
+            async with engine.connect() as connection:
+                transaction = await _begin_write(connection)
+                row = (
+                    (
+                        await connection.execute(
+                            select(lineage_advancement_claims_table)
+                            .where(
+                                lineage_advancement_claims_table.c.scope == scope,
+                                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                            )
+                            .with_for_update()
+                        )
+                    )
+                    .mappings()
+                    .first()
+                )
+                now_ms = _now_ms()
+                waiter_count = int(row["waiter_count"]) if row is not None else 0
+                receipt_drained = row is not None and (
+                    waiter_count == 0 or int(row["lease_expires_at_ms"]) <= now_ms
+                )
+                replaceable = row is None or (
+                    bool(row["completed"])
+                    and receipt_drained
+                    and (
+                        _receipt_allows_retry(row["result_payload"])
+                        or int(row["generation_number"]) != generation_number
+                        or str(row["request_key"]) != request_key
+                    )
+                )
+                lease_expires_at_ms = _lease_ms()
+                values = {
+                    "owner_id": owner_id,
+                    "generation_number": generation_number,
+                    "request_key": request_key,
+                    "lease_expires_at_ms": lease_expires_at_ms,
+                    "waiter_count": 0,
+                    "completed": False,
+                    "result_payload": None,
+                }
+                if replaceable:
+                    if row is None:
+                        await connection.execute(
+                            insert(lineage_advancement_claims_table).values(
+                                scope=scope,
+                                lineage_id=lineage_id,
+                                **values,
+                            )
+                        )
+                    else:
+                        await connection.execute(
+                            update(lineage_advancement_claims_table)
+                            .where(
+                                lineage_advancement_claims_table.c.scope == scope,
+                                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                            )
+                            .values(**values)
+                        )
+                    await _commit(connection, transaction)
+                    return ClaimObservation(
+                        generation_number,
+                        owner_id,
+                        request_key,
+                        acquired=True,
+                        lease_expires_at_ms=lease_expires_at_ms,
+                    )
+
+                assert row is not None
+                if not bool(row["completed"]):
+                    await connection.execute(
+                        update(lineage_advancement_claims_table)
+                        .where(
+                            lineage_advancement_claims_table.c.scope == scope,
+                            lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                            lineage_advancement_claims_table.c.owner_id == row["owner_id"],
+                        )
+                        .values(waiter_count=lineage_advancement_claims_table.c.waiter_count + 1)
+                    )
+                    await _commit(connection, transaction)
+                    return ClaimObservation(
+                        int(row["generation_number"]),
+                        str(row["owner_id"]),
+                        str(row["request_key"]),
+                        acquired=False,
+                        lease_expires_at_ms=int(row["lease_expires_at_ms"]),
+                        waiter_registered=True,
+                    )
+
+                await _commit(connection, transaction)
+                return ClaimObservation(
+                    int(row["generation_number"]),
+                    str(row["owner_id"]),
+                    str(row["request_key"]),
+                    acquired=False,
+                    lease_expires_at_ms=int(row["lease_expires_at_ms"]),
+                    completed=True,
+                    result_payload=(
+                        dict(row["result_payload"])
+                        if isinstance(row["result_payload"], dict)
+                        else None
+                    ),
+                )
+        except IntegrityError:
+            continue
+    raise PersistenceError(
+        "Could not acquire durable lineage advancement claim",
+        operation="claim_lineage_advancement",
+        details={"scope": scope, "lineage_id": lineage_id},
+    )
+
+
+async def renew(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+) -> bool:
+    """Renew an active claim lease owned by this caller."""
+    engine = _engine(event_store)
+    if engine is None:
+        return False
+    async with engine.begin() as connection:
+        result = await connection.execute(
+            update(lineage_advancement_claims_table)
+            .where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.owner_id == owner_id,
+                lineage_advancement_claims_table.c.completed.is_(False),
+            )
+            .values(lease_expires_at_ms=_lease_ms())
+        )
+    return bool(result.rowcount)
+
+
+async def observe(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+) -> ClaimObservation | None:
+    """Read the current owner and optional completed result."""
+    engine = _engine(event_store)
+    if engine is None:
+        return None
+    async with engine.connect() as connection:
+        row = (
+            (
+                await connection.execute(
+                    select(lineage_advancement_claims_table).where(
+                        lineage_advancement_claims_table.c.scope == scope,
+                        lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                    )
+                )
+            )
+            .mappings()
+            .first()
+        )
+    if row is None:
+        return None
+    payload = row["result_payload"]
+    return ClaimObservation(
+        int(row["generation_number"]),
+        str(row["owner_id"]),
+        str(row["request_key"]),
+        acquired=False,
+        lease_expires_at_ms=int(row["lease_expires_at_ms"]),
+        completed=bool(row["completed"]),
+        result_payload=dict(payload) if isinstance(payload, dict) else None,
+    )
+
+
+async def complete(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+    result_payload: dict[str, Any],
+) -> bool:
+    """Publish a result only when registered waiters need to replay it."""
+    engine = _engine(event_store)
+    if engine is None:
+        return False
+    async with engine.connect() as connection:
+        transaction = await _begin_write(connection)
+        row = (
+            await connection.execute(
+                select(lineage_advancement_claims_table.c.waiter_count).where(
+                    lineage_advancement_claims_table.c.scope == scope,
+                    lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                    lineage_advancement_claims_table.c.owner_id == owner_id,
+                )
+            )
+        ).first()
+        if row is None:
+            await _commit(connection, transaction)
+            return False
+        result = await connection.execute(
+            update(lineage_advancement_claims_table)
+            .where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.owner_id == owner_id,
+                lineage_advancement_claims_table.c.completed.is_(False),
+                lineage_advancement_claims_table.c.lease_expires_at_ms > _now_ms(),
+            )
+            .values(
+                completed=True,
+                result_payload=result_payload,
+                lease_expires_at_ms=_lease_ms(5.0),
+            )
+        )
+        await _commit(connection, transaction)
+    return bool(result.rowcount)
+
+
+async def release(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+) -> None:
+    """Release an unfinished owner claim after failure or cancellation."""
+    engine = _engine(event_store)
+    if engine is None:
+        return
+    async with engine.begin() as connection:
+        await connection.execute(
+            delete(lineage_advancement_claims_table).where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.owner_id == owner_id,
+                lineage_advancement_claims_table.c.completed.is_(False),
+            )
+        )
+
+
+async def recover_expired(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+) -> bool:
+    """Explicitly clear an expired unfinished claim after operator confirmation."""
+    engine = _engine(event_store)
+    if engine is None:
+        return False
+    async with engine.begin() as connection:
+        result = await connection.execute(
+            delete(lineage_advancement_claims_table).where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.completed.is_(False),
+                lineage_advancement_claims_table.c.lease_expires_at_ms <= _now_ms(),
+            )
+        )
+    return bool(result.rowcount)
+
+
+async def acknowledge_waiter(
+    event_store: EventStore,
+    *,
+    scope: str,
+    lineage_id: str,
+    owner_id: str,
+) -> None:
+    """Atomically consume one registered waiter without a lost update."""
+    engine = _engine(event_store)
+    if engine is None:
+        return
+    async with engine.begin() as connection:
+        await connection.execute(
+            update(lineage_advancement_claims_table)
+            .where(
+                lineage_advancement_claims_table.c.scope == scope,
+                lineage_advancement_claims_table.c.lineage_id == lineage_id,
+                lineage_advancement_claims_table.c.owner_id == owner_id,
+                lineage_advancement_claims_table.c.waiter_count > 0,
+            )
+            .values(waiter_count=lineage_advancement_claims_table.c.waiter_count - 1)
+        )

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -117,6 +118,22 @@ ac_acceptance_guards_table = Table(
         default=lambda: datetime.now(UTC),
         server_default=text("CURRENT_TIMESTAMP"),
     ),
+)
+
+# One cross-process advancement owner per lineage/scope. Results are retained
+# only while already-registered waiters replay the winner, then deleted.
+lineage_advancement_claims_table = Table(
+    "lineage_advancement_claims",
+    metadata,
+    Column("scope", String(64), primary_key=True),
+    Column("lineage_id", String(256), primary_key=True),
+    Column("generation_number", Integer, nullable=False),
+    Column("owner_id", String(36), nullable=False),
+    Column("request_key", String(64), nullable=False),
+    Column("lease_expires_at_ms", BigInteger, nullable=False),
+    Column("waiter_count", Integer, nullable=False, default=0, server_default=text("0")),
+    Column("completed", Boolean, nullable=False, default=False, server_default=text("0")),
+    Column("result_payload", JSON, nullable=True),
 )
 
 # Brownfield repos table - registered repositories/worktrees from brownfield scan.

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -136,6 +136,20 @@ lineage_advancement_claims_table = Table(
     Column("result_payload", JSON, nullable=True),
 )
 
+# Individually leased waiter registrations let completed lineage receipts retain
+# exact winner authority for live callers without being pinned forever by a
+# process that died before acknowledgement.  The claim owner ID binds each
+# waiter to one immutable receipt generation.
+lineage_advancement_waiters_table = Table(
+    "lineage_advancement_waiters",
+    metadata,
+    Column("scope", String(64), primary_key=True),
+    Column("lineage_id", String(256), primary_key=True),
+    Column("claim_owner_id", String(36), primary_key=True),
+    Column("waiter_id", String(36), primary_key=True),
+    Column("lease_expires_at_ms", BigInteger, nullable=False),
+)
+
 # Brownfield repos table - registered repositories/worktrees from brownfield scan.
 # Filesystem discovery is bounded to the scan root. Normal repo roots can add
 # Git-reported linked worktrees outside that root, but linked worktree seeds are

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -150,6 +150,7 @@ class RalphLoopRunner:
         loop_start_monotonic = time.monotonic()
         checkpoint_commits = list(config.checkpoint_commits)
         checkpoint_attempted_ac_ids = list(config.checkpoint_attempted_ac_ids)
+        execute_current = config.execute
 
         for iteration_index in range(1, config.max_generations + 1):
             if (
@@ -185,7 +186,7 @@ class RalphLoopRunner:
 
             arguments: dict[str, Any] = {
                 "lineage_id": config.lineage_id,
-                "execute": config.execute,
+                "execute": execute_current,
                 "parallel": config.parallel,
                 "skip_qa": config.skip_qa,
             }
@@ -314,6 +315,14 @@ class RalphLoopRunner:
                 status = "failed"
                 stop_reason = action
                 break
+            if action == "ontology_stable":
+                if iteration_index >= config.max_generations:
+                    status = "failed"
+                    stop_reason = "max_generations reached"
+                    break
+                execute_current = True
+                seed_content = None
+                continue
 
             if _is_oscillating(iterations, config.oscillation_window):
                 status = "failed"

--- a/tests/unit/core/test_lineage.py
+++ b/tests/unit/core/test_lineage.py
@@ -176,8 +176,8 @@ class TestEvaluationSummary:
             "decomposition_depth_warning"
         ]
 
-    def test_run_verdict_prefers_ac_results_over_final_approved(self) -> None:
-        """Summary verdict should follow the detailed AC verdict source."""
+    def test_ac_results_cannot_override_final_rejection(self) -> None:
+        """Detailed AC PASSes are necessary but cannot mint final approval."""
         summary = EvaluationSummary(
             final_approved=False,
             highest_stage_passed=2,
@@ -193,10 +193,9 @@ class TestEvaluationSummary:
             ),
         )
 
-        assert summary.run_verdict_passed is True
-        assert summary.run_verdict == "PASS"
-        # approval_status must be reconciled to avoid contradictory serialization
-        assert summary.approval_status == "approved"
+        assert summary.run_verdict_passed is False
+        assert summary.run_verdict == "FAIL"
+        assert summary.approval_status == "rejected"
 
     def test_run_verdict_uses_canonical_final_verdict_over_legacy_passed_flag(self) -> None:
         """Summary verdict should aggregate from final_verdict even for legacy-shaped inputs."""
@@ -257,8 +256,8 @@ class TestEvaluationSummary:
         assert summary.run_verdict_passed is False
         assert summary.run_verdict == "FAIL"
 
-    def test_run_verdict_reconciles_approval_when_acs_override(self) -> None:
-        """When AC results all pass, approval_status must be reconciled to 'approved'."""
+    def test_run_verdict_preserves_rejection_when_acs_pass(self) -> None:
+        """AC results may veto but cannot upgrade the independent final gate."""
         summary = EvaluationSummary(
             final_approved=False,
             highest_stage_passed=2,
@@ -276,9 +275,9 @@ class TestEvaluationSummary:
             ),
         )
 
-        assert summary.run_verdict_passed is True
-        assert summary.run_verdict == "PASS"
-        assert summary.approval_status == "approved"
+        assert summary.run_verdict_passed is False
+        assert summary.run_verdict == "FAIL"
+        assert summary.approval_status == "rejected"
 
     def test_run_verdict_reconciles_approval_when_acs_fail(self) -> None:
         """When AC results fail, approval_status must be reconciled to 'rejected'."""
@@ -304,8 +303,8 @@ class TestEvaluationSummary:
         assert summary.run_verdict == "FAIL"
         assert summary.approval_status == "rejected"
 
-    def test_approval_reconciled_at_construction_not_lazily(self) -> None:
-        """model_dump() must show reconciled approval_status without reading run_verdict first."""
+    def test_rejection_preserved_at_construction_not_lazily(self) -> None:
+        """model_dump() must preserve the final gate without lazy property access."""
         summary = EvaluationSummary(
             final_approved=False,
             highest_stage_passed=2,
@@ -323,8 +322,8 @@ class TestEvaluationSummary:
 
         # Deliberately do NOT access run_verdict_passed before serializing
         payload = summary.model_dump(mode="json")
-        assert payload["approval_status"] == "approved"
-        assert payload["final_approved"] is True
+        assert payload["approval_status"] == "rejected"
+        assert payload["final_approved"] is False
 
     def test_serialized_approval_is_execution_aware_with_passing_acs(self) -> None:
         """model_dump() must not expose approved legacy fields after execution failure."""
@@ -370,6 +369,73 @@ class TestACResult:
         assert result.override_reason == "Spec verification override: hidden regression"
         assert result.final_verdict == "fail"
         assert result.rendered_verdict == "FAIL"
+
+    def test_not_evaluated_pass_is_not_authoritative_approval(self) -> None:
+        """A contradictory PASS label cannot upgrade unknown evidence to approval."""
+        summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Ship feature",
+                    passed=True,
+                    ac_verdict_state="not_evaluated",
+                    verification_method="unknown",
+                ),
+            ),
+        )
+
+        assert summary.ac_results[0].passed is True
+        assert not summary.ac_results[0].verdict_is_authoritative
+        assert not summary.ac_results[0].authoritative_pass
+        assert summary.ac_results[0].unresolved
+        assert summary.ac_results[0].authority_state == "unresolved"
+        assert not summary.final_approved
+        assert summary.approval_status == "rejected"
+        assert not summary.run_verdict_passed
+
+    def test_opaque_override_cannot_mint_approval(self) -> None:
+        """An override needs a concrete verifier source and reason."""
+        result = ACResult(
+            ac_index=0,
+            ac_content="Ship feature",
+            passed=True,
+            ac_verdict_state="overridden",
+            verification_method="unknown",
+            evidence="",
+        )
+        summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(result,),
+        )
+
+        assert not result.verdict_is_authoritative
+        assert not summary.final_approved
+        assert not summary.run_verdict_passed
+
+    def test_ac_passes_cannot_upgrade_explicit_final_rejection(self) -> None:
+        """Final approval and AC approval are conjunctive authorities."""
+        summary = EvaluationSummary(
+            final_approved=False,
+            approval_status="rejected",
+            highest_stage_passed=3,
+            failure_reason="Stage 3 consensus rejected the artifact",
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Ship feature",
+                    passed=True,
+                    verification_method="semantic",
+                ),
+            ),
+        )
+
+        assert not summary.final_approved
+        assert summary.approval_status == "rejected"
+        assert summary.failure_reason == "Stage 3 consensus rejected the artifact"
+        assert not summary.run_verdict_passed
 
     def test_verdict_label_ignores_stale_rendered_verdict(self) -> None:
         """Rendered labels should keep following final_verdict once normalized."""

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -199,7 +199,8 @@ class TestEvolutionBackendDrift:
             "fresh",
             content=(
                 '{"refined_goal": "Build a login system", "refined_constraints": [], '
-                '"refined_acs": [], "ontology_mutations": [], "reasoning": "ok"}'
+                '"refined_acs": ["User can log in"], '
+                '"ontology_mutations": [], "reasoning": "ok"}'
             ),
         )
         engine = ReflectEngine(
@@ -374,7 +375,8 @@ class TestEvolutionExplicitModelOverride:
             "fresh",
             content=(
                 '{"refined_goal": "Build a login system", "refined_constraints": [], '
-                '"refined_acs": [], "ontology_mutations": [], "reasoning": "ok"}'
+                '"refined_acs": ["User can log in"], '
+                '"ontology_mutations": [], "reasoning": "ok"}'
             ),
         )
         engine = ReflectEngine(

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -29,6 +29,12 @@ class TestStepActionMapping:
     def test_converged_maps_to_converge(self) -> None:
         assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
 
+    def test_ontology_stable_maps_to_nonterminal_evaluate(self) -> None:
+        directive = step_action_to_directive(StepAction.ONTOLOGY_STABLE)
+
+        assert directive == Directive.EVALUATE
+        assert directive.is_terminal is False
+
     def test_stagnated_maps_to_unstuck_not_terminal_success(self) -> None:
         directive = step_action_to_directive(StepAction.STAGNATED)
 
@@ -57,6 +63,7 @@ class TestStepActionMapping:
     def test_string_value_accepted(self) -> None:
         """The function accepts the StepAction value verbatim (StrEnum semantics)."""
         assert step_action_to_directive("converged") == Directive.CONVERGE
+        assert step_action_to_directive("ontology_stable") == Directive.EVALUATE
         assert step_action_to_directive("stagnated") == Directive.UNSTUCK
         assert step_action_to_directive("continue") is None
 

--- a/tests/unit/evolution/test_evolve_step_agent_process_integration.py
+++ b/tests/unit/evolution/test_evolve_step_agent_process_integration.py
@@ -16,12 +16,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from ouroboros.core.lineage import (
+    ACResult,
     EvaluationSummary,
     GenerationPhase,
     OntologyLineage,
     OntologySchema,
 )
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import AcceptanceCriterionSpec, Seed
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.lineage import lineage_created, lineage_generation_interrupted
@@ -66,6 +67,7 @@ def _make_seed(seed_id: str = "seed-1") -> Seed:
     seed.metadata.seed_id = seed_id
     seed.metadata.parent_seed_id = None
     seed.ontology_schema = ontology
+    seed.acceptance_criteria = (AcceptanceCriterionSpec(description="Works"),)
     seed.to_dict.return_value = {"seed_id": seed_id}
     return seed
 
@@ -88,6 +90,7 @@ def _make_generation_result(
             score=0.8,
             final_approved=True,
             highest_stage_passed=1,
+            ac_results=(ACResult(ac_index=0, ac_content="Works", passed=True),),
         ),
         wonder_output=wonder_output,
         phase=phase,

--- a/tests/unit/evolution/test_focus.py
+++ b/tests/unit/evolution/test_focus.py
@@ -3,7 +3,14 @@
 import pytest
 
 from ouroboros.core.lineage import ACResult, EvaluationSummary
-from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    InvestmentSpec,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
 from ouroboros.events.lineage import lineage_created, lineage_generation_completed
 from ouroboros.evolution.focus import select_evolution_focus
 from ouroboros.evolution.projector import LineageProjector
@@ -11,7 +18,7 @@ from ouroboros.evolution.regression import RegressionReport
 from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
 
 
-def _seed(*acs: str) -> Seed:
+def _seed(*acs: str | AcceptanceCriterionSpec) -> Seed:
     return Seed(
         metadata=SeedMetadata(ambiguity_score=0.1),
         goal="Build the product",
@@ -34,6 +41,7 @@ def _evaluation(seed: Seed, *passed: bool) -> EvaluationSummary:
             ACResult(
                 ac_index=index,
                 ac_content=seed.acceptance_criteria[index].description,
+                semantic_ac_key=seed.acceptance_criteria[index].semantic_ac_key,
                 passed=value,
             )
             for index, value in enumerate(passed)
@@ -94,6 +102,96 @@ def test_new_candidate_node_is_active_not_silently_frozen() -> None:
 
     assert focus.active_ac_indices == (1, 2)
     assert focus.frozen_ac_indices == (0,)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("description", "passed with revised prose"),
+        ("semantic_ac_key", "ac_0000000000000000"),
+        ("verify_command", "python -m pytest new.py"),
+        ("expected_artifacts", ("new-report.json",)),
+        ("output_assertion", "2 passed"),
+        (
+            "investment",
+            InvestmentSpec(
+                difficulty="medium",
+                stakes="low",
+                provenance="declared",
+                confidence="low",
+            ),
+        ),
+        (
+            "investment",
+            InvestmentSpec(
+                difficulty="low",
+                stakes="medium",
+                provenance="declared",
+                confidence="low",
+            ),
+        ),
+        (
+            "investment",
+            InvestmentSpec(
+                difficulty="low",
+                stakes="low",
+                provenance="measured",
+                confidence="low",
+            ),
+        ),
+        (
+            "investment",
+            InvestmentSpec(
+                difficulty="low",
+                stakes="low",
+                provenance="declared",
+                confidence="high",
+            ),
+        ),
+    ],
+    ids=(
+        "description",
+        "semantic-key",
+        "verify-command",
+        "expected-artifacts",
+        "output-assertion",
+        "investment-difficulty",
+        "investment-stakes",
+        "investment-provenance",
+        "investment-confidence",
+    ),
+)
+def test_any_structured_contract_change_reopens_prior_pass(
+    field: str,
+    value: object,
+) -> None:
+    parent = _seed(
+        AcceptanceCriterionSpec(
+            description="passed",
+            verify_command="python -m pytest old.py",
+            expected_artifacts=("old-report.json",),
+            output_assertion="1 passed",
+            investment=InvestmentSpec(
+                difficulty="low",
+                stakes="low",
+                provenance="declared",
+                confidence="low",
+            ),
+        ),
+        "failed",
+    )
+    revised = parent.acceptance_criteria[0].model_copy(update={field: value})
+    candidate = _seed(revised, parent.acceptance_criteria[1])
+
+    focus = select_evolution_focus(
+        parent,
+        candidate,
+        _evaluation(parent, True, False),
+        regression_report=RegressionReport(),
+    )
+
+    assert focus.active_ac_indices == (0, 1)
+    assert focus.frozen_ac_indices == ()
 
 
 def test_missing_per_ac_evidence_keeps_full_graph_open() -> None:

--- a/tests/unit/evolution/test_focus.py
+++ b/tests/unit/evolution/test_focus.py
@@ -1,5 +1,7 @@
 """Focused evolution selects a shrinking, evidence-backed AC working set."""
 
+import pytest
+
 from ouroboros.core.lineage import ACResult, EvaluationSummary
 from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
 from ouroboros.events.lineage import lineage_created, lineage_generation_completed
@@ -23,13 +25,17 @@ def _seed(*acs: str) -> Seed:
     )
 
 
-def _evaluation(*passed: bool) -> EvaluationSummary:
+def _evaluation(seed: Seed, *passed: bool) -> EvaluationSummary:
     return EvaluationSummary(
         final_approved=all(passed),
         highest_stage_passed=2,
         score=sum(passed) / len(passed),
         ac_results=tuple(
-            ACResult(ac_index=index, ac_content=f"AC {index}", passed=value)
+            ACResult(
+                ac_index=index,
+                ac_content=seed.acceptance_criteria[index].description,
+                passed=value,
+            )
             for index, value in enumerate(passed)
         ),
     )
@@ -41,7 +47,7 @@ def test_only_failed_node_stays_active() -> None:
     focus = select_evolution_focus(
         seed,
         seed,
-        _evaluation(True, False, True),
+        _evaluation(seed, True, False, True),
         regression_report=RegressionReport(),
     )
 
@@ -66,7 +72,7 @@ def test_challenge_reopens_a_previously_passing_node() -> None:
     focus = select_evolution_focus(
         seed,
         seed,
-        _evaluation(True, False),
+        _evaluation(seed, True, False),
         wonder=wonder,
         regression_report=RegressionReport(),
     )
@@ -82,7 +88,7 @@ def test_new_candidate_node_is_active_not_silently_frozen() -> None:
     focus = select_evolution_focus(
         parent,
         candidate,
-        _evaluation(True, False),
+        _evaluation(parent, True, False),
         regression_report=RegressionReport(),
     )
 
@@ -104,6 +110,42 @@ def test_missing_per_ac_evidence_keeps_full_graph_open() -> None:
     assert focus.frozen_ac_indices == ()
 
 
+@pytest.mark.parametrize(
+    "results",
+    [
+        (ACResult(ac_index=0, ac_content="one", passed=True),),
+        (
+            ACResult(ac_index=0, ac_content="one", passed=True),
+            ACResult(ac_index=0, ac_content="one", passed=False),
+        ),
+        (
+            ACResult(ac_index=0, ac_content="one", passed=True),
+            ACResult(ac_index=2, ac_content="outside", passed=False),
+        ),
+        (
+            ACResult(ac_index=0, ac_content="not one", passed=True),
+            ACResult(ac_index=1, ac_content="two", passed=False),
+        ),
+    ],
+    ids=("missing", "duplicate", "out-of-range", "content-mismatch"),
+)
+def test_incomplete_or_invalid_verdict_coverage_keeps_full_graph_open(
+    results: tuple[ACResult, ...],
+) -> None:
+    seed = _seed("one", "two")
+    evaluation = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=1,
+        score=0.0,
+        ac_results=results,
+    )
+
+    focus = select_evolution_focus(seed, seed, evaluation)
+
+    assert focus.active_ac_indices == (0, 1)
+    assert focus.frozen_ac_indices == ()
+
+
 def test_focus_is_persisted_in_lineage_trace() -> None:
     seed = _seed("passed", "failed")
     events = [
@@ -113,7 +155,7 @@ def test_focus_is_persisted_in_lineage_trace() -> None:
             1,
             seed.metadata.seed_id,
             seed.ontology_schema.model_dump(mode="json"),
-            _evaluation(True, False).model_dump(mode="json"),
+            _evaluation(seed, True, False).model_dump(mode="json"),
             active_ac_indices=[1],
             frozen_ac_indices=[0],
         ),

--- a/tests/unit/evolution/test_focus.py
+++ b/tests/unit/evolution/test_focus.py
@@ -64,6 +64,50 @@ def test_only_failed_node_stays_active() -> None:
     assert set(focus.externally_satisfied_acs()) == {0, 2}
 
 
+def test_not_evaluated_pass_is_active_not_frozen() -> None:
+    seed = _seed("unknown 0", "failed 1")
+    evaluation = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=1,
+        ac_results=(
+            ACResult(
+                ac_index=0,
+                ac_content="unknown 0",
+                passed=True,
+                ac_verdict_state="not_evaluated",
+            ),
+            ACResult(ac_index=1, ac_content="failed 1", passed=False),
+        ),
+    )
+
+    focus = select_evolution_focus(seed, seed, evaluation)
+
+    assert focus.active_ac_indices == (0, 1)
+    assert focus.frozen_ac_indices == ()
+
+
+def test_unknown_node_stays_active_while_authoritative_pass_freezes() -> None:
+    seed = _seed("passed 0", "unknown 1")
+    evaluation = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=1,
+        ac_results=(
+            ACResult(ac_index=0, ac_content="passed 0", passed=True),
+            ACResult(
+                ac_index=1,
+                ac_content="unknown 1",
+                passed=True,
+                ac_verdict_state="not_evaluated",
+            ),
+        ),
+    )
+
+    focus = select_evolution_focus(seed, seed, evaluation)
+
+    assert focus.active_ac_indices == (1,)
+    assert focus.frozen_ac_indices == (0,)
+
+
 def test_challenge_reopens_a_previously_passing_node() -> None:
     seed = _seed("passed but challenged", "failed")
     wonder = WonderOutput(

--- a/tests/unit/evolution/test_focus.py
+++ b/tests/unit/evolution/test_focus.py
@@ -1,0 +1,126 @@
+"""Focused evolution selects a shrinking, evidence-backed AC working set."""
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.events.lineage import lineage_created, lineage_generation_completed
+from ouroboros.evolution.focus import select_evolution_focus
+from ouroboros.evolution.projector import LineageProjector
+from ouroboros.evolution.regression import RegressionReport
+from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
+
+
+def _seed(*acs: str) -> Seed:
+    return Seed(
+        metadata=SeedMetadata(ambiguity_score=0.1),
+        goal="Build the product",
+        constraints=("keep scope",),
+        acceptance_criteria=acs,
+        ontology_schema=OntologySchema(
+            name="product",
+            description="product",
+            fields=(OntologyField(name="item", field_type="entity", description="item"),),
+        ),
+    )
+
+
+def _evaluation(*passed: bool) -> EvaluationSummary:
+    return EvaluationSummary(
+        final_approved=all(passed),
+        highest_stage_passed=2,
+        score=sum(passed) / len(passed),
+        ac_results=tuple(
+            ACResult(ac_index=index, ac_content=f"AC {index}", passed=value)
+            for index, value in enumerate(passed)
+        ),
+    )
+
+
+def test_only_failed_node_stays_active() -> None:
+    seed = _seed("passed 0", "failed 1", "passed 2")
+
+    focus = select_evolution_focus(
+        seed,
+        seed,
+        _evaluation(True, False, True),
+        regression_report=RegressionReport(),
+    )
+
+    assert focus.active_ac_indices == (1,)
+    assert focus.frozen_ac_indices == (0, 2)
+    assert set(focus.externally_satisfied_acs()) == {0, 2}
+
+
+def test_challenge_reopens_a_previously_passing_node() -> None:
+    seed = _seed("passed but challenged", "failed")
+    wonder = WonderOutput(
+        questions=("Challenge AC 1",),
+        grounded_questions=(
+            GroundedQuestion(
+                question="Challenge AC 1",
+                kind="challenge",
+                ac_indices=(0,),
+            ),
+        ),
+    )
+
+    focus = select_evolution_focus(
+        seed,
+        seed,
+        _evaluation(True, False),
+        wonder=wonder,
+        regression_report=RegressionReport(),
+    )
+
+    assert focus.active_ac_indices == (0, 1)
+    assert focus.frozen_ac_indices == ()
+
+
+def test_new_candidate_node_is_active_not_silently_frozen() -> None:
+    parent = _seed("passed", "failed")
+    candidate = _seed("passed", "failed revised", "new")
+
+    focus = select_evolution_focus(
+        parent,
+        candidate,
+        _evaluation(True, False),
+        regression_report=RegressionReport(),
+    )
+
+    assert focus.active_ac_indices == (1, 2)
+    assert focus.frozen_ac_indices == (0,)
+
+
+def test_missing_per_ac_evidence_keeps_full_graph_open() -> None:
+    seed = _seed("one", "two")
+    evaluation = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=1,
+        score=0.0,
+    )
+
+    focus = select_evolution_focus(seed, seed, evaluation)
+
+    assert focus.active_ac_indices == (0, 1)
+    assert focus.frozen_ac_indices == ()
+
+
+def test_focus_is_persisted_in_lineage_trace() -> None:
+    seed = _seed("passed", "failed")
+    events = [
+        lineage_created("lin_focus_trace", seed.goal),
+        lineage_generation_completed(
+            "lin_focus_trace",
+            1,
+            seed.metadata.seed_id,
+            seed.ontology_schema.model_dump(mode="json"),
+            _evaluation(True, False).model_dump(mode="json"),
+            active_ac_indices=[1],
+            frozen_ac_indices=[0],
+        ),
+    ]
+
+    lineage = LineageProjector().project(events)
+
+    assert lineage is not None
+    assert lineage.generations[0].active_ac_indices == (1,)
+    assert lineage.generations[0].frozen_ac_indices == (0,)

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -22,6 +22,7 @@ from ouroboros.core.seed import (
 from ouroboros.core.types import Result
 from ouroboros.events.lineage import (
     lineage_created,
+    lineage_generation_completed,
     lineage_generation_failed,
     lineage_generation_interrupted,
     lineage_generation_started,
@@ -31,9 +32,9 @@ from ouroboros.evolution.convergence import ConvergenceSignal
 from ouroboros.evolution.loop import GenerationResult, StepAction, StepResult
 from ouroboros.evolution.loop_support import run_durable_lineage_single_flight
 from ouroboros.evolution.projector import LineageProjector
-from ouroboros.evolution.reflect import ReflectOutput
+from ouroboros.evolution.reflect import ACPatch, ReflectOutput
 from ouroboros.evolution.step_receipt import decode_step_result, encode_step_result
-from ouroboros.evolution.wonder import WonderOutput
+from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
 from ouroboros.persistence import lineage_claims
 from ouroboros.persistence.event_store import EventStore
 
@@ -582,13 +583,23 @@ async def test_interrupted_step_receipt_replays_partial_generation(tmp_path: Pat
     seed = _seed()
     lineage_id = "interrupted-lineage"
     questions = ("[AC 1] What writer evidence remains unresolved?",)
-    wonder = WonderOutput(questions=questions, should_continue=True, reasoning="challenge")
+    wonder = WonderOutput(
+        questions=questions,
+        grounded_questions=(
+            GroundedQuestion(question=questions[0], kind="challenge", ac_indices=(0,)),
+        ),
+        ontology_tensions=("owner and waiter observe one contract",),
+        should_continue=True,
+        reasoning="challenge",
+    )
     reflect = ReflectOutput(
         refined_goal=seed.goal,
         refined_constraints=seed.constraints,
         refined_acs=("One generation has one writer",),
+        ac_patches=(ACPatch(op="keep", index=0, reason="preserve identity"),),
         reasoning="preserve the partial reflection",
     )
+    reflect.restore_durable_patch_identity(seed)
     try:
         await writer.append(lineage_created(lineage_id, seed.goal))
         await writer.append(
@@ -644,12 +655,84 @@ async def test_interrupted_step_receipt_replays_partial_generation(tmp_path: Pat
         generation = replayed.value.generation_result
         assert replayed.value.action is StepAction.INTERRUPTED
         assert generation.phase is GenerationPhase.INTERRUPTED
-        assert generation.wonder_output is not None
-        assert generation.wonder_output.questions == questions
+        assert generation.wonder_output == wonder
+        assert generation.reflect_output == reflect
         assert generation.reflect_output is not None
-        assert generation.reflect_output.reasoning == reflect.reasoning
+        assert generation.reflect_output.ac_patch_identity_explicit is True
         assert generation.execution_output == "partial execution"
         assert not generation.success
+    finally:
+        await writer.close()
+        await reader.close()
+
+
+@pytest.mark.asyncio
+async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_path: Path) -> None:
+    """Completed projection cannot erase the winner result observed by a waiter."""
+    writer, reader = await _stores(tmp_path / "completed-structured-receipt.db")
+    seed = _seed()
+    lineage_id = "completed-structured-lineage"
+    wonder = WonderOutput(
+        questions=(),
+        grounded_questions=(),
+        ontology_tensions=("empty questions still carry a tension",),
+        should_continue=True,
+        reasoning="authoritative empty-question result",
+    )
+    reflect = ReflectOutput(
+        refined_goal=seed.goal,
+        refined_constraints=seed.constraints,
+        refined_acs=("One generation has one writer",),
+        ac_patches=(ACPatch(op="keep", index=0, reason="stable contract"),),
+        settled_ac_indices=(0,),
+        reasoning="parser-issued keep",
+    )
+    reflect.restore_durable_patch_identity(seed)
+    try:
+        await writer.append(lineage_created(lineage_id, seed.goal))
+        await writer.append(
+            lineage_generation_completed(
+                lineage_id,
+                generation_number=1,
+                seed_id=seed.metadata.seed_id,
+                ontology_snapshot=seed.ontology_schema.model_dump(mode="json"),
+                wonder_questions=[],
+                seed_json=json.dumps(seed.to_dict()),
+            )
+        )
+        lineage = LineageProjector().project(await writer.replay_lineage(lineage_id))
+        assert lineage is not None
+        assert lineage.generations[-1].partial_state is None
+        winner = Result.ok(
+            StepResult(
+                generation_result=GenerationResult(
+                    generation_number=1,
+                    seed=seed,
+                    wonder_output=wonder,
+                    reflect_output=reflect,
+                    phase=GenerationPhase.COMPLETED,
+                    success=True,
+                ),
+                convergence_signal=ConvergenceSignal(
+                    converged=False,
+                    reason="continue",
+                    ontology_similarity=0.0,
+                    generation=1,
+                ),
+                lineage=lineage,
+                action=StepAction.CONTINUE,
+                next_generation=2,
+            )
+        )
+
+        replayed = await decode_step_result(reader, encode_step_result(winner))
+
+        assert replayed.is_ok
+        waiter_generation = replayed.value.generation_result
+        assert waiter_generation.wonder_output == wonder
+        assert waiter_generation.reflect_output == reflect
+        assert waiter_generation.reflect_output is not None
+        assert waiter_generation.reflect_output.ac_patch_identity_explicit is True
     finally:
         await writer.close()
         await reader.close()

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -33,7 +33,11 @@ from ouroboros.evolution.loop import GenerationResult, StepAction, StepResult
 from ouroboros.evolution.loop_support import run_durable_lineage_single_flight
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ACPatch, ReflectOutput
-from ouroboros.evolution.step_receipt import decode_step_result, encode_step_result
+from ouroboros.evolution.step_receipt import (
+    MAX_EXECUTION_TEXT,
+    decode_step_result,
+    encode_step_result,
+)
 from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
 from ouroboros.persistence import lineage_claims
 from ouroboros.persistence.event_store import EventStore
@@ -688,6 +692,7 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
         reasoning="parser-issued keep",
     )
     reflect.restore_durable_patch_identity(seed)
+    execution_output = "execution-start\n" + ("x" * 12_000) + "\nTRAILING FAILURE MARKER"
     try:
         await writer.append(lineage_created(lineage_id, seed.goal))
         await writer.append(
@@ -698,6 +703,7 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
                 ontology_snapshot=seed.ontology_schema.model_dump(mode="json"),
                 wonder_questions=[],
                 seed_json=json.dumps(seed.to_dict()),
+                execution_output=execution_output,
             )
         )
         lineage = LineageProjector().project(await writer.replay_lineage(lineage_id))
@@ -710,6 +716,7 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
                     seed=seed,
                     wonder_output=wonder,
                     reflect_output=reflect,
+                    execution_output=execution_output,
                     phase=GenerationPhase.COMPLETED,
                     success=True,
                 ),
@@ -733,6 +740,59 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
         assert waiter_generation.reflect_output == reflect
         assert waiter_generation.reflect_output is not None
         assert waiter_generation.reflect_output.ac_patch_identity_explicit is True
+        assert waiter_generation.execution_output == execution_output
+        assert waiter_generation.execution_output.endswith("TRAILING FAILURE MARKER")
+    finally:
+        await writer.close()
+        await reader.close()
+
+
+@pytest.mark.asyncio
+async def test_step_receipt_fails_closed_when_execution_output_exceeds_cap(
+    tmp_path: Path,
+) -> None:
+    """Incomplete bounded evidence never becomes a handler verification artifact."""
+    writer, reader = await _stores(tmp_path / "oversized-execution-receipt.db")
+    seed = _seed()
+    lineage_id = "oversized-execution-lineage"
+    execution_output = "x" * (MAX_EXECUTION_TEXT + 1)
+    try:
+        await writer.append(lineage_created(lineage_id, seed.goal))
+        await writer.append(
+            lineage_generation_completed(
+                lineage_id,
+                generation_number=1,
+                seed_id=seed.metadata.seed_id,
+                ontology_snapshot=seed.ontology_schema.model_dump(mode="json"),
+                seed_json=json.dumps(seed.to_dict()),
+                execution_output=execution_output,
+            )
+        )
+        lineage = LineageProjector().project(await writer.replay_lineage(lineage_id))
+        assert lineage is not None
+        winner = Result.ok(
+            StepResult(
+                generation_result=GenerationResult(
+                    generation_number=1,
+                    seed=seed,
+                    execution_output=execution_output,
+                ),
+                convergence_signal=ConvergenceSignal(
+                    converged=False,
+                    reason="continue",
+                    ontology_similarity=0.0,
+                    generation=1,
+                ),
+                lineage=lineage,
+                action=StepAction.CONTINUE,
+                next_generation=2,
+            )
+        )
+        payload = encode_step_result(winner)
+        assert payload["execution_output_complete"] is False
+
+        with pytest.raises(ValueError, match="execution output is incomplete"):
+            await decode_step_result(reader, payload)
     finally:
         await writer.close()
         await reader.close()

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -224,6 +224,117 @@ async def test_durable_claim_coalesces_distinct_event_store_instances(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_completed_receipt_waits_for_delayed_waiter_acknowledgement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A short receipt lease cannot move a registered waiter into the next generation."""
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'delayed-waiter.db'}"
+    owner_store = EventStore(database_url)
+    waiter_store = EventStore(database_url)
+    next_store = EventStore(database_url)
+    for store in (owner_store, waiter_store, next_store):
+        await store.initialize()
+
+    clock_ms = 1_000
+    monkeypatch.setattr(lineage_claims, "_now_ms", lambda: clock_ms)
+    owner_entered = asyncio.Event()
+    release_owner = asyncio.Event()
+    waiter_observing = asyncio.Event()
+    release_waiter = asyncio.Event()
+    next_attempted = asyncio.Event()
+    calls: list[str] = []
+    original_observe = lineage_claims.observe
+    original_try_acquire = lineage_claims.try_acquire
+
+    async def delay_waiter_observation(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args and args[0] is waiter_store and not release_waiter.is_set():
+            waiter_observing.set()
+            await release_waiter.wait()
+        return await original_observe(*args, **kwargs)
+
+    monkeypatch.setattr(lineage_claims, "observe", delay_waiter_observation)
+
+    async def track_next_acquisition(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args and args[0] is next_store:
+            next_attempted.set()
+        return await original_try_acquire(*args, **kwargs)
+
+    monkeypatch.setattr(lineage_claims, "try_acquire", track_next_acquisition)
+
+    async def generation_one() -> str:
+        calls.append("generation-1")
+        owner_entered.set()
+        await release_owner.wait()
+        return "generation-1-winner"
+
+    async def forbidden_duplicate() -> str:
+        calls.append("duplicate")
+        return "duplicate"
+
+    async def generation_two() -> str:
+        calls.append("generation-2")
+        return "generation-2-winner"
+
+    encode = lambda value: {"value": value}  # noqa: E731
+    decode = lambda payload: str(payload["value"])  # noqa: E731
+    try:
+        owner = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                owner_store,
+                "lineage",
+                "request-1",
+                generation_one,
+                generation_number=1,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await owner_entered.wait()
+        waiter = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                waiter_store,
+                "lineage",
+                "request-1",
+                forbidden_duplicate,
+                generation_number=1,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await waiter_observing.wait()
+        release_owner.set()
+        assert await owner == "generation-1-winner"
+
+        # The completed receipt has a five-second cleanup lease.  Advancing
+        # beyond it must not revoke the registered waiter's winner authority.
+        clock_ms = 7_000
+        next_generation = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                next_store,
+                "lineage",
+                "request-2",
+                generation_two,
+                generation_number=2,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await next_attempted.wait()
+        await asyncio.sleep(0)
+        assert not next_generation.done()
+        assert calls == ["generation-1"]
+
+        release_waiter.set()
+        assert await waiter == "generation-1-winner"
+        assert await next_generation == "generation-2-winner"
+        assert calls == ["generation-1", "generation-2"]
+    finally:
+        for store in (owner_store, waiter_store, next_store):
+            await store.close()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("retryable_action", ["failed", "interrupted"])
 async def test_retryable_receipt_replays_waiters_but_allows_later_attempt(
     tmp_path: Path,

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -1,0 +1,655 @@
+"""Durable lineage-writer regressions for evolve retries."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import multiprocessing
+from pathlib import Path
+import time
+
+import pytest
+
+from ouroboros.core.lineage import GenerationPhase
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.core.types import Result
+from ouroboros.events.lineage import (
+    lineage_created,
+    lineage_generation_failed,
+    lineage_generation_interrupted,
+    lineage_generation_started,
+)
+from ouroboros.evolution import loop_support
+from ouroboros.evolution.convergence import ConvergenceSignal
+from ouroboros.evolution.loop import GenerationResult, StepAction, StepResult
+from ouroboros.evolution.loop_support import run_durable_lineage_single_flight
+from ouroboros.evolution.projector import LineageProjector
+from ouroboros.evolution.reflect import ReflectOutput
+from ouroboros.evolution.step_receipt import decode_step_result, encode_step_result
+from ouroboros.evolution.wonder import WonderOutput
+from ouroboros.persistence import lineage_claims
+from ouroboros.persistence.event_store import EventStore
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Prove one durable evolve writer",
+        task_type="code",
+        constraints=("Keep retries idempotent",),
+        acceptance_criteria=("One generation has one writer",),
+        ontology_schema=OntologySchema(
+            name="LineageWriter",
+            description="Durable generation authority",
+            fields=(
+                OntologyField(
+                    name="owner",
+                    field_type="string",
+                    description="The generation writer",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="single_writer",
+                description="Provider work executes once",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="one_receipt",
+                description="Every waiter observes the winner",
+                evaluation_criteria="Exactly one operation call",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id="seed_single_writer", ambiguity_score=0.0),
+    )
+
+
+async def _stores(db_path: Path) -> tuple[EventStore, EventStore]:
+    database_url = f"sqlite+aiosqlite:///{db_path}"
+    first = EventStore(database_url)
+    second = EventStore(database_url)
+    await first.initialize()
+    await second.initialize()
+    return first, second
+
+
+def _run_process_claim(
+    database_url: str,
+    label: str,
+    marker_path: str,
+    owner_ready_path: str,
+    release_path: str,
+    process_started_path: str,
+    result_queue: multiprocessing.Queue,
+) -> None:
+    """Run one standalone process against the shared lineage claim table."""
+
+    async def run() -> None:
+        store = EventStore(database_url)
+        await store.initialize()
+        Path(process_started_path).write_text(label, encoding="utf-8")
+
+        async def operation() -> str:
+            Path(owner_ready_path).write_text(label, encoding="utf-8")
+            while not Path(release_path).exists():
+                await asyncio.sleep(0.01)
+            with Path(marker_path).open("a", encoding="utf-8") as marker:
+                marker.write(f"{label}\n")
+            return label
+
+        try:
+            value = await run_durable_lineage_single_flight(
+                store,
+                "cross-process-lineage",
+                "same-request",
+                operation,
+                generation_number=3,
+                encode=lambda result: {"value": result},
+                decode=lambda payload: str(payload["value"]),
+            )
+            result_queue.put(("ok", value))
+        except BaseException as exc:
+            result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+        finally:
+            await store.close()
+
+    asyncio.run(run())
+
+
+def _wait_for_path(path: Path, *, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"Timed out waiting for {path.name}")
+        time.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_durable_claim_coalesces_distinct_event_store_instances(tmp_path: Path) -> None:
+    """The database claim, not the process registry, owns one generation."""
+    first_store, second_store = await _stores(tmp_path / "lineage-writer.db")
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    async def winner() -> str:
+        calls.append("generation-3")
+        entered.set()
+        await release.wait()
+        return "generation-3-winner"
+
+    async def forbidden_duplicate() -> str:
+        calls.append("duplicate")
+        return "duplicate"
+
+    encode = lambda value: {"value": value}  # noqa: E731
+    decode = lambda payload: str(payload["value"])  # noqa: E731
+    try:
+        owner = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                first_store,
+                "lineage",
+                "request-3",
+                winner,
+                generation_number=3,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await entered.wait()
+        waiter = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                second_store,
+                "lineage",
+                "request-3",
+                forbidden_duplicate,
+                generation_number=3,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not waiter.done()
+        release.set()
+
+        assert await asyncio.gather(owner, waiter) == [
+            "generation-3-winner",
+            "generation-3-winner",
+        ]
+        assert calls == ["generation-3"]
+
+        late_retry = await run_durable_lineage_single_flight(
+            second_store,
+            "lineage",
+            "request-3",
+            forbidden_duplicate,
+            generation_number=3,
+            encode=encode,
+            decode=decode,
+        )
+        assert late_retry == "generation-3-winner"
+
+        async def next_generation() -> str:
+            calls.append("generation-4")
+            return "generation-4-winner"
+
+        advanced = await run_durable_lineage_single_flight(
+            first_store,
+            "lineage",
+            "request-4",
+            next_generation,
+            generation_number=4,
+            encode=encode,
+            decode=decode,
+        )
+        assert advanced == "generation-4-winner"
+        assert calls == ["generation-3", "generation-4"]
+    finally:
+        await first_store.close()
+        await second_store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retryable_action", ["failed", "interrupted"])
+async def test_retryable_receipt_replays_waiters_but_allows_later_attempt(
+    tmp_path: Path,
+    retryable_action: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure receipts deduplicate overlap without pinning later recovery forever."""
+    writer, retry_store = await _stores(tmp_path / f"retry-{retryable_action}.db")
+    calls: list[str] = []
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    waiter_registered = asyncio.Event()
+    original_try_acquire = lineage_claims.try_acquire
+
+    async def observe_waiter(*args, **kwargs):  # type: ignore[no-untyped-def]
+        claim = await original_try_acquire(*args, **kwargs)
+        if claim is not None and claim.waiter_registered:
+            waiter_registered.set()
+        return claim
+
+    monkeypatch.setattr(lineage_claims, "try_acquire", observe_waiter)
+
+    async def failed_attempt() -> str:
+        calls.append(retryable_action)
+        entered.set()
+        await release.wait()
+        return retryable_action
+
+    async def forbidden_duplicate() -> str:
+        calls.append("duplicate")
+        return "duplicate"
+
+    async def recovered_attempt() -> str:
+        calls.append("continue")
+        return "continue"
+
+    def encode(action: str) -> dict[str, object]:
+        return {"ok": True, "action": action}
+
+    try:
+        owner = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                writer,
+                "lineage",
+                "same-request",
+                failed_attempt,
+                generation_number=2,
+                encode=encode,
+                decode=lambda payload: str(payload["action"]),
+            )
+        )
+        await entered.wait()
+        waiter = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                retry_store,
+                "lineage",
+                "same-request",
+                forbidden_duplicate,
+                generation_number=2,
+                encode=encode,
+                decode=lambda payload: str(payload["action"]),
+            )
+        )
+        await waiter_registered.wait()
+        release.set()
+        assert await asyncio.gather(owner, waiter) == [
+            retryable_action,
+            retryable_action,
+        ]
+
+        recovered = await run_durable_lineage_single_flight(
+            retry_store,
+            "lineage",
+            "same-request",
+            recovered_attempt,
+            generation_number=2,
+            encode=encode,
+            decode=lambda payload: str(payload["action"]),
+        )
+
+        assert recovered == "continue"
+        assert calls == [retryable_action, "continue"]
+    finally:
+        await writer.close()
+        await retry_store.close()
+
+
+def test_durable_claim_coalesces_distinct_processes(tmp_path: Path) -> None:
+    """Separate interpreters still execute the generation operation exactly once."""
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'cross-process.db'}"
+    initializer = EventStore(database_url)
+    asyncio.run(initializer.initialize())
+    asyncio.run(initializer.close())
+
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    marker = tmp_path / "operation-calls.txt"
+    owner_ready = tmp_path / "owner-ready"
+    release = tmp_path / "release-owner"
+    first_started = tmp_path / "first-started"
+    second_started = tmp_path / "second-started"
+    common = (database_url, "process-a", str(marker), str(owner_ready), str(release))
+    first = context.Process(
+        target=_run_process_claim,
+        args=(*common, str(first_started), result_queue),
+    )
+    second = context.Process(
+        target=_run_process_claim,
+        args=(
+            database_url,
+            "process-b",
+            str(marker),
+            str(owner_ready),
+            str(release),
+            str(second_started),
+            result_queue,
+        ),
+    )
+    first.start()
+    try:
+        _wait_for_path(first_started)
+        _wait_for_path(owner_ready)
+        second.start()
+        _wait_for_path(second_started)
+        time.sleep(0.1)
+        release.write_text("release", encoding="utf-8")
+        first.join(timeout=10)
+        second.join(timeout=10)
+        assert first.exitcode == 0
+        assert second.exitcode == 0
+        results = sorted([result_queue.get(timeout=1), result_queue.get(timeout=1)])
+        assert results == [("ok", "process-a"), ("ok", "process-a")]
+        assert marker.read_text(encoding="utf-8").splitlines() == ["process-a"]
+    finally:
+        for process in (first, second):
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=2)
+        result_queue.close()
+
+
+@pytest.mark.asyncio
+async def test_expired_owner_fails_closed_without_implicit_takeover(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crashed writer requires recovery instead of silently duplicating work."""
+    first_store, second_store = await _stores(tmp_path / "expired-writer.db")
+    monkeypatch.setattr(lineage_claims, "DEFAULT_LEASE_SECONDS", 0.03)
+    executed = False
+
+    async def forbidden_operation() -> str:
+        nonlocal executed
+        executed = True
+        return "must-not-run"
+
+    try:
+        claim = await lineage_claims.try_acquire(
+            first_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            generation_number=2,
+            owner_id="crashed-owner",
+            request_key="request-2",
+        )
+        assert claim is not None and claim.acquired
+
+        with pytest.raises(RuntimeError, match="recover_expired_claim=true"):
+            await asyncio.wait_for(
+                run_durable_lineage_single_flight(
+                    second_store,
+                    "lineage",
+                    "request-2",
+                    forbidden_operation,
+                    generation_number=2,
+                    encode=lambda value: {"value": value},
+                    decode=lambda payload: str(payload["value"]),
+                ),
+                timeout=1.0,
+            )
+        assert not executed
+        assert await lineage_claims.recover_expired(
+            second_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+        )
+        recovered = await run_durable_lineage_single_flight(
+            second_store,
+            "lineage",
+            "request-2",
+            forbidden_operation,
+            generation_number=2,
+            encode=lambda value: {"value": value},
+            decode=lambda payload: str(payload["value"]),
+        )
+        assert recovered == "must-not-run"
+        assert executed
+    finally:
+        await lineage_claims.release(
+            first_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            owner_id="crashed-owner",
+        )
+        await first_store.close()
+        await second_store.close()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_failure_before_completion_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lost renewal cannot be hidden behind a successful provider result."""
+    store, reader = await _stores(tmp_path / "heartbeat-loss.db")
+
+    async def failed_heartbeat(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("database renewal failed")
+
+    async def operation() -> str:
+        await asyncio.sleep(0)
+        return "unowned-result"
+
+    monkeypatch.setattr(loop_support, "_renew_claim_until_cancelled", failed_heartbeat)
+    try:
+        with pytest.raises(RuntimeError, match="heartbeat failed before completion"):
+            await run_durable_lineage_single_flight(
+                store,
+                "lineage",
+                "request",
+                operation,
+                generation_number=1,
+                encode=lambda value: {"value": value},
+                decode=lambda payload: str(payload["value"]),
+            )
+        assert (
+            await lineage_claims.observe(
+                reader,
+                scope="evolve-core",
+                lineage_id="lineage",
+            )
+            is None
+        )
+    finally:
+        await store.close()
+        await reader.close()
+
+
+@pytest.mark.asyncio
+async def test_post_commit_heartbeat_error_does_not_override_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the receipt commits, a racing heartbeat exception is no longer authoritative."""
+    writer, reader = await _stores(tmp_path / "heartbeat-after-commit.db")
+    committed = asyncio.Event()
+    original_complete = lineage_claims.complete
+
+    async def heartbeat(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        await committed.wait()
+        raise RuntimeError("late heartbeat failure")
+
+    async def complete_then_fail_heartbeat(*args, **kwargs):  # type: ignore[no-untyped-def]
+        published = await original_complete(*args, **kwargs)
+        committed.set()
+        await asyncio.sleep(0)
+        return published
+
+    monkeypatch.setattr(loop_support, "_renew_claim_until_cancelled", heartbeat)
+    monkeypatch.setattr(lineage_claims, "complete", complete_then_fail_heartbeat)
+    try:
+        result = await run_durable_lineage_single_flight(
+            writer,
+            "lineage",
+            "request",
+            lambda: asyncio.sleep(0, result="committed-result"),
+            generation_number=1,
+            encode=lambda value: {"value": value},
+            decode=lambda payload: str(payload["value"]),
+        )
+        assert result == "committed-result"
+
+        replayed = await run_durable_lineage_single_flight(
+            reader,
+            "lineage",
+            "request",
+            lambda: asyncio.sleep(0, result="duplicate"),
+            generation_number=1,
+            encode=lambda value: {"value": value},
+            decode=lambda payload: str(payload["value"]),
+        )
+        assert replayed == "committed-result"
+    finally:
+        await writer.close()
+        await reader.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_step_receipt_replays_seed_from_started_event(tmp_path: Path) -> None:
+    """Cross-process waiters reproduce a failed winner without inventing a Seed."""
+    writer, reader = await _stores(tmp_path / "failed-receipt.db")
+    seed = _seed()
+    lineage_id = "failed-lineage"
+    try:
+        await writer.append(lineage_created(lineage_id, seed.goal))
+        await writer.append(
+            lineage_generation_started(
+                lineage_id,
+                1,
+                GenerationPhase.EXECUTING.value,
+                seed.metadata.seed_id,
+                json.dumps(seed.to_dict()),
+            )
+        )
+        await writer.append(
+            lineage_generation_failed(
+                lineage_id,
+                1,
+                GenerationPhase.EXECUTING.value,
+                "provider failed",
+            )
+        )
+        lineage = LineageProjector().project(await writer.replay_lineage(lineage_id))
+        assert lineage is not None
+        result = Result.ok(
+            StepResult(
+                generation_result=GenerationResult(
+                    generation_number=1,
+                    seed=seed,
+                    phase=GenerationPhase.FAILED,
+                    success=False,
+                ),
+                convergence_signal=ConvergenceSignal(
+                    converged=False,
+                    reason="provider failed",
+                    ontology_similarity=0.0,
+                    generation=1,
+                ),
+                lineage=lineage,
+                action=StepAction.FAILED,
+                next_generation=1,
+            )
+        )
+
+        replayed = await decode_step_result(reader, encode_step_result(result))
+
+        assert replayed.is_ok
+        assert replayed.value.action is StepAction.FAILED
+        assert replayed.value.generation_result.seed == seed
+        assert replayed.value.generation_result.phase is GenerationPhase.FAILED
+        assert not replayed.value.generation_result.success
+    finally:
+        await writer.close()
+        await reader.close()
+
+
+@pytest.mark.asyncio
+async def test_interrupted_step_receipt_replays_partial_generation(tmp_path: Path) -> None:
+    """A waiter recovers interrupted Wonder/Reflect evidence from the durable checkpoint."""
+    writer, reader = await _stores(tmp_path / "interrupted-receipt.db")
+    seed = _seed()
+    lineage_id = "interrupted-lineage"
+    questions = ("[AC 1] What writer evidence remains unresolved?",)
+    wonder = WonderOutput(questions=questions, should_continue=True, reasoning="challenge")
+    reflect = ReflectOutput(
+        refined_goal=seed.goal,
+        refined_constraints=seed.constraints,
+        refined_acs=("One generation has one writer",),
+        reasoning="preserve the partial reflection",
+    )
+    try:
+        await writer.append(lineage_created(lineage_id, seed.goal))
+        await writer.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                seed.metadata.seed_id,
+                json.dumps(seed.to_dict()),
+            )
+        )
+        await writer.append(
+            lineage_generation_interrupted(
+                lineage_id,
+                2,
+                last_completed_phase=GenerationPhase.EXECUTING.value,
+                partial_state={
+                    "wonder_questions": list(questions),
+                    "reflect_output": reflect.model_dump(mode="json"),
+                    "execution_output": "partial execution",
+                },
+                seed_json=json.dumps(seed.to_dict()),
+            )
+        )
+        lineage = LineageProjector().project(await writer.replay_lineage(lineage_id))
+        assert lineage is not None
+        result = Result.ok(
+            StepResult(
+                generation_result=GenerationResult(
+                    generation_number=2,
+                    seed=seed,
+                    wonder_output=wonder,
+                    reflect_output=reflect,
+                    execution_output="partial execution",
+                    phase=GenerationPhase.INTERRUPTED,
+                    success=False,
+                ),
+                convergence_signal=ConvergenceSignal(
+                    converged=False,
+                    reason="Generation interrupted by SIGINT",
+                    ontology_similarity=0.0,
+                    generation=2,
+                ),
+                lineage=lineage,
+                action=StepAction.INTERRUPTED,
+                next_generation=2,
+            )
+        )
+
+        replayed = await decode_step_result(reader, encode_step_result(result))
+
+        assert replayed.is_ok
+        generation = replayed.value.generation_result
+        assert replayed.value.action is StepAction.INTERRUPTED
+        assert generation.phase is GenerationPhase.INTERRUPTED
+        assert generation.wonder_output is not None
+        assert generation.wonder_output.questions == questions
+        assert generation.reflect_output is not None
+        assert generation.reflect_output.reasoning == reflect.reasoning
+        assert generation.execution_output == "partial execution"
+        assert not generation.success
+    finally:
+        await writer.close()
+        await reader.close()

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -324,6 +324,14 @@ async def test_completed_receipt_waits_for_delayed_waiter_acknowledgement(
         await asyncio.sleep(0)
         assert not next_generation.done()
         assert calls == ["generation-1"]
+        retained = await lineage_claims.observe(
+            next_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+        )
+        assert retained is not None
+        assert retained.generation_number == 1
+        assert retained.completed
 
         release_waiter.set()
         assert await waiter == "generation-1-winner"
@@ -332,6 +340,217 @@ async def test_completed_receipt_waits_for_delayed_waiter_acknowledgement(
     finally:
         for store in (owner_store, waiter_store, next_store):
             await store.close()
+
+
+@pytest.mark.asyncio
+async def test_waiter_heartbeat_extends_lease_and_retains_winner_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live waiter's heartbeat prevents a later generation from displacing it."""
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'waiter-heartbeat.db'}"
+    owner_store = EventStore(database_url)
+    waiter_store = EventStore(database_url)
+    next_store = EventStore(database_url)
+    for store in (owner_store, waiter_store, next_store):
+        await store.initialize()
+
+    clock_ms = 1_000
+    monkeypatch.setattr(lineage_claims, "_now_ms", lambda: clock_ms)
+    monkeypatch.setattr(lineage_claims, "WAITER_LEASE_SECONDS", 0.03)
+    owner_entered = asyncio.Event()
+    release_owner = asyncio.Event()
+    waiter_observing = asyncio.Event()
+    release_waiter = asyncio.Event()
+    waiter_renewed = asyncio.Event()
+    next_attempted = asyncio.Event()
+    calls: list[str] = []
+    original_observe = lineage_claims.observe
+    original_renew_waiter = lineage_claims.renew_waiter
+    original_try_acquire = lineage_claims.try_acquire
+
+    async def delay_waiter_observation(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args and args[0] is waiter_store and not release_waiter.is_set():
+            waiter_observing.set()
+            await release_waiter.wait()
+        return await original_observe(*args, **kwargs)
+
+    async def track_waiter_renewal(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal clock_ms
+        if args and args[0] is waiter_store and not waiter_renewed.is_set():
+            clock_ms = 1_020
+        renewed = await original_renew_waiter(*args, **kwargs)
+        if args and args[0] is waiter_store and renewed:
+            waiter_renewed.set()
+        return renewed
+
+    async def track_next_acquisition(*args, **kwargs):  # type: ignore[no-untyped-def]
+        if args and args[0] is next_store:
+            next_attempted.set()
+        return await original_try_acquire(*args, **kwargs)
+
+    monkeypatch.setattr(lineage_claims, "observe", delay_waiter_observation)
+    monkeypatch.setattr(lineage_claims, "renew_waiter", track_waiter_renewal)
+    monkeypatch.setattr(lineage_claims, "try_acquire", track_next_acquisition)
+
+    async def generation_one() -> str:
+        calls.append("generation-1")
+        owner_entered.set()
+        await release_owner.wait()
+        return "generation-1-winner"
+
+    async def forbidden_duplicate() -> str:
+        calls.append("duplicate")
+        return "duplicate"
+
+    async def generation_two() -> str:
+        calls.append("generation-2")
+        return "generation-2-winner"
+
+    encode = lambda value: {"value": value}  # noqa: E731
+    decode = lambda payload: str(payload["value"])  # noqa: E731
+    try:
+        owner = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                owner_store,
+                "lineage",
+                "request-1",
+                generation_one,
+                generation_number=1,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await owner_entered.wait()
+        waiter = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                waiter_store,
+                "lineage",
+                "request-1",
+                forbidden_duplicate,
+                generation_number=1,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await waiter_observing.wait()
+        release_owner.set()
+        assert await owner == "generation-1-winner"
+        await asyncio.wait_for(waiter_renewed.wait(), timeout=1.0)
+
+        # Move past the registration's original t=1,030 lease, but remain
+        # inside the heartbeat-renewed t=1,050 lease.
+        clock_ms = 1_040
+        next_generation = asyncio.create_task(
+            run_durable_lineage_single_flight(
+                next_store,
+                "lineage",
+                "request-2",
+                generation_two,
+                generation_number=2,
+                encode=encode,
+                decode=decode,
+            )
+        )
+        await next_attempted.wait()
+        await asyncio.sleep(0)
+        assert not next_generation.done()
+        assert calls == ["generation-1"]
+
+        release_waiter.set()
+        assert await waiter == "generation-1-winner"
+        assert await next_generation == "generation-2-winner"
+        assert calls == ["generation-1", "generation-2"]
+    finally:
+        release_owner.set()
+        release_waiter.set()
+        for store in (owner_store, waiter_store, next_store):
+            await store.close()
+
+
+@pytest.mark.asyncio
+async def test_hard_crashed_waiter_expires_without_pinning_next_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An orphaned waiter lease expires so a later generation can acquire."""
+    owner_store, waiter_store = await _stores(tmp_path / "crashed-waiter.db")
+    next_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'crashed-waiter.db'}")
+    await next_store.initialize()
+    clock_ms = 1_000
+    monkeypatch.setattr(lineage_claims, "_now_ms", lambda: clock_ms)
+    monkeypatch.setattr(lineage_claims, "WAITER_LEASE_SECONDS", 1.0)
+    calls: list[str] = []
+    try:
+        owner = await lineage_claims.try_acquire(
+            owner_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            generation_number=1,
+            owner_id="generation-1-owner",
+            request_key="request-1",
+        )
+        assert owner is not None and owner.acquired
+        crashed_waiter = await lineage_claims.try_acquire(
+            waiter_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            generation_number=1,
+            owner_id="crashed-waiter",
+            request_key="request-1",
+        )
+        assert crashed_waiter is not None and crashed_waiter.waiter_registered
+        assert crashed_waiter.waiter_id == "crashed-waiter"
+        assert await lineage_claims.complete(
+            owner_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            owner_id="generation-1-owner",
+            result_payload={"value": "generation-1-winner"},
+        )
+
+        # Simulate the waiter process disappearing without its heartbeat or
+        # finally acknowledgement, then move beyond both bounded leases.
+        clock_ms = 7_000
+
+        async def generation_two() -> str:
+            calls.append("generation-2")
+            return "generation-2-winner"
+
+        advanced = await asyncio.wait_for(
+            run_durable_lineage_single_flight(
+                next_store,
+                "lineage",
+                "request-2",
+                generation_two,
+                generation_number=2,
+                encode=lambda value: {"value": value},
+                decode=lambda payload: str(payload["value"]),
+            ),
+            timeout=1.0,
+        )
+        assert advanced == "generation-2-winner"
+        assert calls == ["generation-2"]
+        assert not await lineage_claims.renew_waiter(
+            waiter_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+            owner_id="generation-1-owner",
+            waiter_id="crashed-waiter",
+        )
+
+        current = await lineage_claims.observe(
+            next_store,
+            scope="evolve-core",
+            lineage_id="lineage",
+        )
+        assert current is not None
+        assert current.generation_number == 2
+        assert current.completed
+    finally:
+        await owner_store.close()
+        await waiter_store.close()
+        await next_store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evolution/test_lineage_single_writer.py
+++ b/tests/unit/evolution/test_lineage_single_writer.py
@@ -693,6 +693,7 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
     )
     reflect.restore_durable_patch_identity(seed)
     execution_output = "execution-start\n" + ("x" * 12_000) + "\nTRAILING FAILURE MARKER"
+    validation_output = "validation-start\n" + ("v" * 4_000) + "\nVALIDATION TAIL"
     try:
         await writer.append(lineage_created(lineage_id, seed.goal))
         await writer.append(
@@ -717,6 +718,7 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
                     wonder_output=wonder,
                     reflect_output=reflect,
                     execution_output=execution_output,
+                    validation_output=validation_output,
                     phase=GenerationPhase.COMPLETED,
                     success=True,
                 ),
@@ -742,6 +744,8 @@ async def test_completed_step_receipt_preserves_structured_phase_outputs(tmp_pat
         assert waiter_generation.reflect_output.ac_patch_identity_explicit is True
         assert waiter_generation.execution_output == execution_output
         assert waiter_generation.execution_output.endswith("TRAILING FAILURE MARKER")
+        assert waiter_generation.validation_output == validation_output
+        assert waiter_generation.validation_output.endswith("VALIDATION TAIL")
     finally:
         await writer.close()
         await reader.close()

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -97,11 +97,17 @@ def _compose(
     passed: dict[int, bool] | None = None,
     challenge: tuple[int, ...] = (),
     regressed: tuple[int, ...] = (),
+    active: tuple[int, ...] | None = None,
 ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
     if passed is None:
         passed = {0: True, 1: True, 2: True}
     return ReflectEngine._compose_acs(
-        data, parent, _summary(passed), _wonder(challenge), _regression(regressed)
+        data,
+        parent,
+        _summary(passed),
+        _wonder(challenge),
+        _regression(regressed),
+        active,
     )
 
 
@@ -172,6 +178,35 @@ class TestComposition:
         # only the 3 implicit keeps remain
         assert len(refined) == 3
         assert all(p.op == "keep" for p in patches)
+
+    def test_focused_evolution_drops_new_nodes(self) -> None:
+        refined, patches, _ = _compose(
+            {
+                "ac_patches": [
+                    {"op": "revise", "index": 1, "content": "target fixed"},
+                    {"op": "add", "content": "scope expansion"},
+                ]
+            },
+            passed={0: True, 1: False, 2: False},
+            active=(1,),
+        )
+
+        assert refined == ("AC zero", "target fixed", "AC two")
+        assert all(patch.op != "add" for patch in patches)
+
+    def test_focused_evolution_forces_non_target_failed_node_to_keep(self) -> None:
+        refined, _, _ = _compose(
+            {
+                "ac_patches": [
+                    {"op": "revise", "index": 1, "content": "target fixed"},
+                    {"op": "revise", "index": 2, "content": "not targeted"},
+                ]
+            },
+            passed={0: True, 1: False, 2: False},
+            active=(1,),
+        )
+
+        assert refined == ("AC zero", "target fixed", "AC two")
 
 
 class TestSatisficingBackstop:

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -16,10 +16,18 @@ import pytest
 
 from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.core.lineage import ACResult, EvaluationSummary, OntologyLineage
-from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    InvestmentSpec,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
 from ouroboros.evolution.reflect import (
     ACPatch,
     ReflectEngine,
+    ReflectOutput,
     _apply_satisficing_backstop,
     _derive_legacy_patches,
     _parse_ac_patches,
@@ -30,7 +38,10 @@ from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
 PARENT_ACS = ("AC zero", "AC one", "AC two")
 
 
-def _seed(acs: tuple[str, ...] = PARENT_ACS) -> Seed:
+def _seed(
+    acs: tuple[str | AcceptanceCriterionSpec, ...] = PARENT_ACS,
+    **extra_fields: object,
+) -> Seed:
     return Seed(
         metadata=SeedMetadata(ambiguity_score=0.1),
         goal="Build a thing",
@@ -41,6 +52,7 @@ def _seed(acs: tuple[str, ...] = PARENT_ACS) -> Seed:
             description="d",
             fields=(OntologyField(name="f", field_type="entity", description="a field"),),
         ),
+        **extra_fields,
     )
 
 
@@ -530,6 +542,52 @@ class TestReflectEndToEnd:
         assert fields["f"].field_type == "object"
         assert fields["f"].description == "a field"
         assert "obsolete" not in fields
+
+    def test_seed_generation_preserves_structured_ac_contracts(self) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="AC zero",
+                    verify_command="pytest -q tests/test_zero.py",
+                    expected_artifacts=("dist/zero.json",),
+                    output_assertion="1 passed",
+                    investment=InvestmentSpec(
+                        difficulty="high",
+                        stakes="medium",
+                        confidence="high",
+                    ),
+                ),
+                "AC one",
+                "AC two",
+            ),
+            plugin_contract={"items": ["one", {"nested": ["two"]}]},
+        )
+        original = parent.acceptance_criteria[0]
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=("AC zero revised", "AC one", "AC two"),
+            ac_patches=(
+                ACPatch(op="revise", index=0, content="AC zero revised"),
+                ACPatch(op="keep", index=1),
+                ACPatch(op="keep", index=2),
+            ),
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_ok
+        revised = result.value.acceptance_criteria[0]
+        assert revised.description == "AC zero revised"
+        assert revised.verify_command == original.verify_command
+        assert revised.expected_artifacts == original.expected_artifacts
+        assert revised.output_assertion == original.output_assertion
+        assert revised.investment == original.investment
+        assert revised.semantic_ac_key != original.semantic_ac_key
+        assert result.value.to_dict()["plugin_contract"] == {"items": ["one", {"nested": ["two"]}]}
 
 
 class _FakeAdapter:

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -589,6 +589,52 @@ class TestReflectEndToEnd:
         assert revised.semantic_ac_key != original.semantic_ac_key
         assert result.value.to_dict()["plugin_contract"] == {"items": ["one", {"nested": ["two"]}]}
 
+    @pytest.mark.parametrize(
+        ("refined_acs", "expected_reason"),
+        [
+            (("AC one",), "shorter"),
+            (("AC one", "AC zero"), "reorders"),
+        ],
+        ids=("deletion", "reordering"),
+    )
+    def test_seed_generation_rejects_ambiguous_structured_contract_rewrites(
+        self,
+        refined_acs: tuple[str, ...],
+        expected_reason: str,
+    ) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="AC zero",
+                    verify_command="python verify_zero.py",
+                    expected_artifacts=("dist/zero.json",),
+                    output_assertion="zero passed",
+                    investment=InvestmentSpec(difficulty="high", stakes="medium"),
+                ),
+                AcceptanceCriterionSpec(
+                    description="AC one",
+                    verify_command="python verify_one.py",
+                    expected_artifacts=("dist/one.json",),
+                    output_assertion="one passed",
+                    investment=InvestmentSpec(difficulty="medium", stakes="high"),
+                ),
+            )
+        )
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=refined_acs,
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_err
+        assert expected_reason in str(result.error)
+        assert "structured acceptance contracts" in str(result.error)
+
 
 class _FakeAdapter:
     def __init__(self, content: str) -> None:

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -224,6 +224,34 @@ class TestComposition:
         assert len(refined) == 3
         assert all(p.op == "keep" for p in patches)
 
+    def test_add_index_is_normalized_before_seed_materialization(self) -> None:
+        refined, patches, _ = _compose(
+            {"ac_patches": [{"op": "add", "index": 99, "content": "brand new"}]}
+        )
+
+        addition = patches[-1]
+        assert refined[-1] == "brand new"
+        assert addition.op == "add"
+        assert addition.index is None
+
+    @pytest.mark.parametrize(
+        "patches",
+        [
+            [
+                {"op": "revise", "index": 0, "content": "AC one"},
+                {"op": "revise", "index": 1, "content": "AC zero"},
+            ],
+            [{"op": "add", "content": "AC one"}],
+        ],
+        ids=["semantic-swap", "add-parent-identity"],
+    )
+    def test_fresh_parent_identity_reuse_is_rejected_for_reflect_retry(
+        self,
+        patches: list[dict[str, object]],
+    ) -> None:
+        with pytest.raises(ValueError, match="reuses another parent identity"):
+            _compose({"ac_patches": patches})
+
     def test_focused_evolution_drops_new_nodes(self) -> None:
         refined, patches, _ = _compose(
             {
@@ -255,6 +283,33 @@ class TestComposition:
 
 
 class TestSatisficingBackstop:
+    def test_non_authoritative_pass_is_revisable_and_never_settled(self) -> None:
+        summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content=PARENT_ACS[0],
+                    passed=True,
+                    ac_verdict_state="not_evaluated",
+                ),
+            ),
+        )
+
+        refined, patches, settled = ReflectEngine._compose_acs(
+            {"ac_patches": [{"op": "revise", "index": 0, "content": "verified AC zero"}]},
+            PARENT_ACS,
+            summary,
+            _wonder(),
+            _regression(),
+            (0,),
+        )
+
+        assert refined[0] == "verified AC zero"
+        assert patches[0].op == "revise"
+        assert 0 not in settled
+
     def test_forces_keep_on_protected(self) -> None:
         # AC 0 passed, unchallenged, unregressed → protected. LLM tries to revise.
         patches = [ACPatch(op="revise", index=0, content="sneaky rewrite")]
@@ -273,6 +328,13 @@ class TestSatisficingBackstop:
         )
         assert refined[1] == "challenged fix"
         assert 1 not in settled  # revised, not kept
+
+    def test_challenged_ac_is_not_settled_when_kept(self) -> None:
+        _, _, settled = _compose(
+            {"ac_patches": [{"op": "keep", "index": 1}]},
+            challenge=(1,),
+        )
+        assert 1 not in settled
 
     def test_failed_ac_may_revise(self) -> None:
         refined, _, settled = _compose(
@@ -298,6 +360,24 @@ class TestSatisficingBackstop:
             regressed=(1,),
         )
         assert 1 not in settled
+
+    def test_missing_evaluation_mints_no_protection_or_settlement(self) -> None:
+        refined, _, settled = ReflectEngine._compose_acs(
+            {
+                "ac_patches": [
+                    {"op": "revise", "index": 0, "content": "ontology revision"},
+                    {"op": "keep", "index": 1},
+                    {"op": "keep", "index": 2},
+                ]
+            },
+            PARENT_ACS,
+            None,
+            _wonder(),
+            _regression(),
+        )
+
+        assert refined[0] == "ontology revision"
+        assert settled == ()
 
 
 class TestSettledIndices:
@@ -328,12 +408,15 @@ class TestLegacyFallbackDiff:
         assert ops == ["keep", "revise", "keep", "add"]
         assert set(settled) == {0, 2}  # kept + passed; index 1 revised
 
-    def test_shorter_list_full_rewrite_semantics(self) -> None:
+    def test_shorter_list_is_rejected_as_identity_ambiguous(self) -> None:
         data = {"refined_acs": ["only one"]}
-        refined, patches, settled = _compose(data)
-        assert refined == ("only one",)
-        assert patches == ()
-        assert settled == ()
+        with pytest.raises(ValueError, match="cannot delete or reorder"):
+            _compose(data)
+
+    def test_reordered_list_is_rejected_as_identity_ambiguous(self) -> None:
+        data = {"refined_acs": ["AC one", "AC zero", "AC two"]}
+        with pytest.raises(ValueError, match="cannot delete or reorder"):
+            _compose(data)
 
     def test_derive_legacy_patches_shorter_returns_none(self) -> None:
         assert _derive_legacy_patches(("a",), ("a", "b", "c")) is None
@@ -383,6 +466,43 @@ class TestMalformedPatches:
 
 
 class TestReflectEndToEnd:
+    async def test_ontology_only_reflect_uses_no_synthetic_evaluation_authority(self) -> None:
+        response = json.dumps(
+            {
+                "refined_goal": "Build a thing with explicit ownership",
+                "refined_constraints": ["c1"],
+                "ac_patches": [
+                    {"op": "revise", "index": 0, "content": "AC zero clarified"},
+                    {"op": "keep", "index": 1},
+                    {"op": "keep", "index": 2},
+                ],
+                "ontology_mutations": [
+                    {
+                        "action": "add",
+                        "field_name": "owner",
+                        "field_type": "entity",
+                        "reason": "answer the Wonder question",
+                    }
+                ],
+                "reasoning": "ontology-only exploration",
+            }
+        )
+        adapter = _FakeAdapter(response)
+
+        result = await ReflectEngine(llm_adapter=adapter, model="test").reflect(
+            current_seed=_seed(),
+            execution_output="",
+            evaluation_summary=None,
+            wonder_output=_wonder(),
+            lineage=OntologyLineage(lineage_id="l", goal="Build a thing"),
+        )
+
+        assert result.is_ok
+        assert result.value.refined_acs[0] == "AC zero clarified"
+        assert result.value.settled_ac_indices == ()
+        assert "Not evaluated (ontology-only exploration)" in adapter.messages[1].content
+        assert "No AC has PASS, protection, or settling authority" in adapter.messages[1].content
+
     async def test_whitespace_only_refined_constraints_rejected_before_seed_materialization(
         self,
     ) -> None:
@@ -1017,11 +1137,13 @@ class _FakeAdapter:
     def __init__(self, content: str) -> None:
         self.content = content
         self._max_turns = 1
+        self.messages = ()
 
     async def complete(self, messages, config):  # type: ignore[no-untyped-def]
         from ouroboros.core.types import Result
         from ouroboros.providers.base import CompletionResponse, UsageInfo
 
+        self.messages = messages
         return Result.ok(
             CompletionResponse(
                 content=self.content,

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -123,6 +123,39 @@ def _compose(
     )
 
 
+def _parse_explicit(
+    parent: Seed,
+    patches: list[dict[str, object]],
+    *,
+    refined_acs: tuple[str, ...] | None = None,
+) -> ReflectOutput | None:
+    data: dict[str, object] = {
+        "refined_goal": parent.goal,
+        "refined_constraints": list(parent.constraints),
+        "ac_patches": patches,
+        "ontology_mutations": [],
+        "reasoning": "r",
+    }
+    if refined_acs is not None:
+        data["refined_acs"] = list(refined_acs)
+    evaluation = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=2,
+        score=0.5,
+        ac_results=tuple(
+            ACResult(ac_index=index, ac_content=criterion.description, passed=False)
+            for index, criterion in enumerate(parent.acceptance_criteria)
+        ),
+    )
+    return ReflectEngine(llm_adapter=_FakeAdapter(""), model="test")._parse_response(
+        json.dumps(data),
+        parent,
+        evaluation,
+        _wonder(),
+        _regression(),
+    )
+
+
 class TestPatchParse:
     def test_parses_keep_revise_add(self) -> None:
         patches = _parse_ac_patches(
@@ -714,7 +747,6 @@ class TestReflectEndToEnd:
                 ACPatch(op="keep", index=1),
                 ACPatch(op="keep", index=2),
             ),
-            ac_patch_identity_explicit=True,
         )
 
         result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
@@ -825,16 +857,14 @@ class TestReflectEndToEnd:
                 ),
             )
         )
-        reflected = ReflectOutput(
-            refined_goal=parent.goal,
-            refined_constraints=parent.constraints,
-            refined_acs=("Approve the invoice safely", "Delete the account permanently"),
-            ac_patches=(
-                ACPatch(op="revise", index=0, content="Approve the invoice safely"),
-                ACPatch(op="revise", index=1, content="Delete the account permanently"),
-            ),
-            ac_patch_identity_explicit=True,
+        reflected = _parse_explicit(
+            parent,
+            [
+                {"op": "revise", "index": 0, "content": "Approve the invoice safely"},
+                {"op": "revise", "index": 1, "content": "Delete the account permanently"},
+            ],
         )
+        assert reflected is not None
 
         result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
             parent,
@@ -881,21 +911,86 @@ class TestReflectEndToEnd:
 
     def test_seed_generation_rejects_inconsistent_explicit_patch_for_plain_ac(self) -> None:
         parent = _seed(("original",))
-        reflected = ReflectOutput(
-            refined_goal=parent.goal,
-            refined_constraints=parent.constraints,
+        reflected = _parse_explicit(
+            parent,
+            [{"op": "keep", "index": 0}],
             refined_acs=("changed despite keep",),
-            ac_patches=(ACPatch(op="keep", index=0),),
-            ac_patch_identity_explicit=True,
+        )
+        assert reflected is None
+
+    def test_serialized_or_copied_boolean_cannot_forge_explicit_patch_provenance(
+        self,
+    ) -> None:
+        direct = ReflectOutput(
+            refined_goal="Build a thing",
+            refined_acs=("changed",),
+            ac_patches=(ACPatch(op="revise", index=0, content="changed"),),
+        )
+        serialized = direct.model_dump(mode="json")
+        serialized["ac_patch_identity_explicit"] = True
+
+        assert ReflectOutput.model_validate(serialized).ac_patch_identity_explicit is False
+        assert (
+            direct.model_copy(
+                update={"ac_patch_identity_explicit": True}
+            ).ac_patch_identity_explicit
+            is False
         )
 
+    def test_explicit_patch_provenance_is_not_serialized(self) -> None:
+        parsed = _parse_explicit(
+            _seed(("original",)),
+            [{"op": "revise", "index": 0, "content": "changed"}],
+        )
+        assert parsed is not None
+        assert parsed.ac_patch_identity_explicit is True
+        assert (
+            ReflectOutput.model_validate(parsed.model_dump(mode="json")).ac_patch_identity_explicit
+            is False
+        )
+
+    def test_model_copy_content_update_invalidates_explicit_patch_provenance(self) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="first",
+                    verify_command="python verify_first.py",
+                ),
+                AcceptanceCriterionSpec(
+                    description="second",
+                    verify_command="python verify_second.py",
+                ),
+            )
+        )
+        parsed = _parse_explicit(
+            parent,
+            [
+                {"op": "revise", "index": 0, "content": "first revised"},
+                {"op": "revise", "index": 1, "content": "second revised"},
+            ],
+        )
+        assert parsed is not None
+        forged = parsed.model_copy(
+            update={
+                "refined_acs": ("second", "first"),
+                "ac_patches": (
+                    ACPatch(op="revise", index=0, content="second"),
+                    ACPatch(op="revise", index=1, content="first"),
+                ),
+            }
+        )
+
+        assert forged.ac_patch_identity_explicit is False
         result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
             parent,
-            reflected,
+            forged,
         )
-
         assert result.is_err
-        assert "keep patch changed an acceptance criterion" in str(result.error)
+        assert "explicit stable AC identity" in str(result.error)
+
+    def test_ac_result_rejects_boolean_index(self) -> None:
+        with pytest.raises(ValueError):
+            ACResult(ac_index=True, ac_content="criterion", passed=True)
 
     @pytest.mark.parametrize(
         ("refined_acs", "expected_reason"),

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -487,9 +487,36 @@ class TestReflectEndToEnd:
         assert result.is_ok
         out = result.value
         assert out.refined_acs == ("AC zero", "fixed AC one", "AC two")
+        assert out.ac_patch_identity_explicit is True
         assert 0 in out.settled_ac_indices
         assert 2 in out.settled_ac_indices
         assert 1 not in out.settled_ac_indices
+
+    async def test_reflect_marks_legacy_full_list_patch_identity_as_inferred(self) -> None:
+        response = json.dumps(
+            {
+                "refined_goal": "Build a thing better",
+                "refined_constraints": ["c1"],
+                "refined_acs": ["AC zero", "fixed AC one", "AC two"],
+                "ontology_mutations": [],
+                "reasoning": "r",
+            }
+        )
+
+        result = await ReflectEngine(
+            llm_adapter=_FakeAdapter(response),
+            model="test",
+        ).reflect(
+            current_seed=_seed(),
+            execution_output="out",
+            evaluation_summary=_summary({0: True, 1: True, 2: True}),
+            wonder_output=_wonder(challenge_indices=(1,)),
+            lineage=OntologyLineage(lineage_id="l", goal="Build a thing"),
+        )
+
+        assert result.is_ok
+        assert result.value.ac_patches
+        assert result.value.ac_patch_identity_explicit is False
 
     async def test_valid_mutations_materialize_downstream_seed(self) -> None:
         parent = _seed_with_ontology(
@@ -572,6 +599,7 @@ class TestReflectEndToEnd:
                 ACPatch(op="keep", index=1),
                 ACPatch(op="keep", index=2),
             ),
+            ac_patch_identity_explicit=True,
         )
 
         result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
@@ -634,6 +662,145 @@ class TestReflectEndToEnd:
         assert result.is_err
         assert expected_reason in str(result.error)
         assert "structured acceptance contracts" in str(result.error)
+
+    def test_seed_generation_rejects_edited_structured_contract_reordering(self) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="Approve the invoice",
+                    verify_command="python verify_invoice.py",
+                    expected_artifacts=("invoice.json",),
+                ),
+                AcceptanceCriterionSpec(
+                    description="Delete the account",
+                    verify_command="python verify_delete.py",
+                    expected_artifacts=("deleted.json",),
+                ),
+            )
+        )
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=(
+                "Delete the account permanently",
+                "Approve the invoice safely",
+            ),
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_err
+        assert "explicit stable AC identity" in str(result.error)
+
+    def test_seed_generation_uses_explicit_patch_identity_for_multiple_revisions(self) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="Approve the invoice",
+                    verify_command="python verify_invoice.py",
+                    expected_artifacts=("invoice.json",),
+                ),
+                AcceptanceCriterionSpec(
+                    description="Delete the account",
+                    verify_command="python verify_delete.py",
+                    expected_artifacts=("deleted.json",),
+                ),
+            )
+        )
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=("Approve the invoice safely", "Delete the account permanently"),
+            ac_patches=(
+                ACPatch(op="revise", index=0, content="Approve the invoice safely"),
+                ACPatch(op="revise", index=1, content="Delete the account permanently"),
+            ),
+            ac_patch_identity_explicit=True,
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_ok
+        criteria = result.value.acceptance_criteria
+        assert criteria[0].verify_command == "python verify_invoice.py"
+        assert criteria[1].verify_command == "python verify_delete.py"
+
+    def test_seed_generation_rejects_legacy_positional_patches_for_edited_reorder(
+        self,
+    ) -> None:
+        parent = _seed(
+            (
+                AcceptanceCriterionSpec(
+                    description="Approve the invoice",
+                    verify_command="python verify_invoice.py",
+                ),
+                AcceptanceCriterionSpec(
+                    description="Delete the account",
+                    verify_command="python verify_delete.py",
+                ),
+            )
+        )
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=("Delete the account permanently", "Approve the invoice safely"),
+            ac_patches=(
+                ACPatch(op="revise", index=0, content="Delete the account permanently"),
+                ACPatch(op="revise", index=1, content="Approve the invoice safely"),
+            ),
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_err
+        assert "explicit stable AC identity" in str(result.error)
+
+    def test_seed_generation_rejects_inconsistent_explicit_patch_for_plain_ac(self) -> None:
+        parent = _seed(("original",))
+        reflected = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=("changed despite keep",),
+            ac_patches=(ACPatch(op="keep", index=0),),
+            ac_patch_identity_explicit=True,
+        )
+
+        result = SeedGenerator(llm_adapter=_FakeAdapter("")).generate_from_reflect(
+            parent,
+            reflected,
+        )
+
+        assert result.is_err
+        assert "keep patch changed an acceptance criterion" in str(result.error)
+
+    @pytest.mark.parametrize(
+        ("refined_acs", "expected_reason"),
+        [
+            (("   ",), "non-empty string"),
+            (("criterion\x00suffix",), "control characters"),
+            ((42,), "contain strings"),
+        ],
+        ids=("whitespace", "control-character", "non-string"),
+    )
+    def test_reflect_output_rejects_invalid_acceptance_criteria(
+        self,
+        refined_acs: tuple[object, ...],
+        expected_reason: str,
+    ) -> None:
+        with pytest.raises((TypeError, ValueError), match=expected_reason):
+            ReflectOutput(
+                refined_goal="Build a thing",
+                refined_acs=refined_acs,  # type: ignore[arg-type]
+            )
 
 
 class _FakeAdapter:

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -357,7 +357,11 @@ class TestReflectEndToEnd:
             {
                 "refined_goal": "Build a thing better",
                 "refined_constraints": ["c1", "   "],
-                "ac_patches": [{"op": "keep", "index": 0}],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "keep", "index": 1},
+                    {"op": "keep", "index": 2},
+                ],
                 "ontology_mutations": [],
                 "reasoning": "r",
             }
@@ -381,7 +385,11 @@ class TestReflectEndToEnd:
             {
                 "refined_goal": "Build a thing better",
                 "refined_constraints": ["c1"],
-                "ac_patches": [{"op": "revise", "index": 1, "content": "   "}],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "revise", "index": 1, "content": "   "},
+                    {"op": "keep", "index": 2},
+                ],
                 "ontology_mutations": [],
                 "reasoning": "r",
             }
@@ -439,7 +447,11 @@ class TestReflectEndToEnd:
             {
                 "refined_goal": "Build a thing better",
                 "refined_constraints": ["c1"],
-                "ac_patches": [{"op": "keep", "index": 0}],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "keep", "index": 1},
+                    {"op": "keep", "index": 2},
+                ],
                 "ontology_mutations": [mutation],
                 "reasoning": "r",
             }
@@ -492,6 +504,105 @@ class TestReflectEndToEnd:
         assert 2 in out.settled_ac_indices
         assert 1 not in out.settled_ac_indices
 
+    @pytest.mark.parametrize(
+        "ac_patches",
+        [
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "revise", "index": 0, "content": "conflict"},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+                {"op": "keep", "index": 3},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 1},
+                {"op": "remove", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0, "content": "replacement"},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "revise", "index": 1},
+                {"op": "keep", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "revise", "index": 1, "content": 42},
+                {"op": "keep", "index": 2},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+                {"op": "add"},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+                {"op": "add", "content": 42},
+            ],
+            [
+                {"op": "keep", "index": 0},
+                {"op": "keep", "index": 1},
+                {"op": "keep", "index": 2},
+                {"op": "add", "index": 0, "content": "new criterion"},
+            ],
+        ],
+        ids=(
+            "missing",
+            "duplicate",
+            "out-of-range",
+            "unsupported-op",
+            "keep-content",
+            "revise-missing-content",
+            "revise-non-string-content",
+            "add-missing-content",
+            "add-non-string-content",
+            "add-parent-index",
+        ),
+    )
+    async def test_reflect_rejects_malformed_explicit_patch_identity(
+        self,
+        ac_patches: list[dict[str, object]],
+    ) -> None:
+        response = json.dumps(
+            {
+                "refined_goal": "Build a thing better",
+                "refined_constraints": ["c1"],
+                "ac_patches": ac_patches,
+                "ontology_mutations": [],
+                "reasoning": "r",
+            }
+        )
+
+        result = await ReflectEngine(
+            llm_adapter=_FakeAdapter(response),
+            model="test",
+        ).reflect(
+            current_seed=_seed(),
+            execution_output="out",
+            evaluation_summary=_summary({0: True, 1: True, 2: True}),
+            wonder_output=_wonder(),
+            lineage=OntologyLineage(lineage_id="l", goal="Build a thing"),
+        )
+
+        assert result.is_err
+        assert "failed to parse" in result.error.message.lower()
+
     async def test_reflect_marks_legacy_full_list_patch_identity_as_inferred(self) -> None:
         response = json.dumps(
             {
@@ -529,7 +640,11 @@ class TestReflectEndToEnd:
             {
                 "refined_goal": "Build a thing with materialized ontology",
                 "refined_constraints": ["c1"],
-                "ac_patches": [{"op": "keep", "index": 0}],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "keep", "index": 1},
+                    {"op": "keep", "index": 2},
+                ],
                 "ontology_mutations": [
                     {
                         "action": "add",

--- a/tests/unit/evolution/test_scoped_reexecution.py
+++ b/tests/unit/evolution/test_scoped_reexecution.py
@@ -162,6 +162,9 @@ class TestConfig:
     def test_scoped_reexecution_can_disable(self) -> None:
         assert EvolutionaryLoopConfig(scoped_reexecution=False).scoped_reexecution is False
 
+    def test_focused_evolution_defaults_true(self) -> None:
+        assert EvolutionaryLoopConfig().focused_evolution is True
+
 
 def _make_loop_for_gen2(
     store, executor: _CaptureExecutor, config: EvolutionaryLoopConfig, settled: tuple[int, ...]
@@ -247,7 +250,12 @@ class TestScopedForwardingIntegration:
             generations=(_gen(1, seed_v1, _eval({0: True, 1: True})),),
         )
         executor = _CaptureExecutor()
-        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=(0, 1))
+        loop = _make_loop_for_gen2(
+            store,
+            executor,
+            EvolutionaryLoopConfig(focused_evolution=False),
+            settled=(0, 1),
+        )
 
         result = await loop._run_generation(
             lineage=lineage, generation_number=2, current_seed=seed_v1
@@ -276,6 +284,30 @@ class TestScopedForwardingIntegration:
         assert result.is_ok
         assert executor.called is True
         assert executor.captured is None
+
+    async def test_focus_is_derived_from_gate_not_reflect_claim(self) -> None:
+        """Prior PASS nodes freeze even when Reflect reports no settled indices."""
+        store = await _store()
+        seed_v1 = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_focus",
+            goal=seed_v1.goal,
+            generations=(_gen(1, seed_v1, _eval({0: True, 1: False})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=())
+
+        result = await loop._run_generation(
+            lineage=lineage,
+            generation_number=2,
+            current_seed=seed_v1,
+        )
+
+        assert result.is_ok
+        assert result.value.active_ac_indices == (1,)
+        assert result.value.frozen_ac_indices == (0,)
+        assert executor.captured is not None
+        assert set(executor.captured) == {0}
 
     async def test_empty_settled_not_forwarded_integration(self) -> None:
         store = await _store()

--- a/tests/unit/evolution/test_validation_result.py
+++ b/tests/unit/evolution/test_validation_result.py
@@ -1,5 +1,7 @@
 """Validator result normalization preserves absent proof as absent."""
 
+import pytest
+
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.types import Result
 from ouroboros.evolution.validation_result import normalize_validation_result, validation_passed
@@ -22,7 +24,27 @@ def test_validation_errors_remain_explicit() -> None:
 
 
 def test_validation_success_requires_an_explicit_pass_receipt() -> None:
-    assert validation_passed("Validation passed: all checks green")
+    assert validation_passed("Validation passed: typed validator returned true")
+    assert validation_passed("Validation passed (attempt 1/3)")
+    assert validation_passed("Validation passed after 3 fix attempts")
     assert not validation_passed(None)
     assert not validation_passed("Validation fix failed (attempt 1): timeout")
     assert not validation_passed("Validation: no fixable errors detected (exit code 2)")
+
+
+@pytest.mark.parametrize(
+    "output",
+    (
+        "Validation passed: false",
+        "Validation passed but 3 errors remain",
+        "Validation passed\nValidation error: tests failed",
+        "Validation passed (attempt 4/3)",
+        "Validation passed (attempt 1/4)",
+        "Validation passed (attempt 1/3)\nValidation error: tests failed",
+        "Validation passed after 4 fix attempts",
+        "Validation passed after 3 fix attempts but tests failed",
+        " Validation passed (attempt 1/3)",
+    ),
+)
+def test_validation_success_receipt_rejects_ambiguous_or_error_bearing_text(output: str) -> None:
+    assert not validation_passed(output)

--- a/tests/unit/evolution/test_validation_result.py
+++ b/tests/unit/evolution/test_validation_result.py
@@ -1,0 +1,28 @@
+"""Validator result normalization preserves absent proof as absent."""
+
+from ouroboros.core.errors import ValidationError
+from ouroboros.core.types import Result
+from ouroboros.evolution.validation_result import normalize_validation_result, validation_passed
+
+
+def test_missing_validation_results_remain_missing() -> None:
+    assert normalize_validation_result(None) is None
+    assert normalize_validation_result("") == ""
+    assert normalize_validation_result(Result.ok(None)) is None
+    assert normalize_validation_result(False) == "Validation failed: typed validator returned false"
+    assert normalize_validation_result(Result.ok(True)) == (
+        "Validation passed: typed validator returned true"
+    )
+
+
+def test_validation_errors_remain_explicit() -> None:
+    result = Result.err(ValidationError("validator failed"))
+
+    assert normalize_validation_result(result) == "Validation error: validator failed"
+
+
+def test_validation_success_requires_an_explicit_pass_receipt() -> None:
+    assert validation_passed("Validation passed: all checks green")
+    assert not validation_passed(None)
+    assert not validation_passed("Validation fix failed (attempt 1): timeout")
+    assert not validation_passed("Validation: no fixable errors detected (exit code 2)")

--- a/tests/unit/evolution/test_wonder_scope.py
+++ b/tests/unit/evolution/test_wonder_scope.py
@@ -187,6 +187,35 @@ class TestWonderEvolutionFocus:
         assert "AC 2: refresh test failed" in prompt
         assert "very large full execution output" not in prompt
 
+    def test_prompt_keeps_non_authoritative_pass_unresolved(self) -> None:
+        from unittest.mock import AsyncMock
+
+        engine = WonderEngine(llm_adapter=AsyncMock(), model="test")
+        seed = _make_seed()
+        summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="User can log in via Google",
+                    passed=True,
+                    ac_verdict_state="not_evaluated",
+                ),
+            ),
+        )
+
+        prompt = engine._build_prompt(
+            seed.ontology_schema,
+            summary,
+            execution_output=None,
+            lineage=OntologyLineage(lineage_id="lineage-unresolved", goal=seed.goal),
+            seed=seed,
+        )
+
+        assert "Active unresolved ACs (1)" in prompt
+        assert "Visible AC pass rate: 0/1" in prompt
+
     def test_response_drops_gaps_and_frozen_challenges(self) -> None:
         import json
         from unittest.mock import AsyncMock

--- a/tests/unit/evolution/test_wonder_scope.py
+++ b/tests/unit/evolution/test_wonder_scope.py
@@ -1,6 +1,6 @@
 """Tests for Wonder scope guard and degraded-mode convergence."""
 
-from ouroboros.core.lineage import EvaluationSummary, FeedbackMetadata, OntologyLineage
+from ouroboros.core.lineage import ACResult, EvaluationSummary, FeedbackMetadata, OntologyLineage
 from ouroboros.core.seed import (
     EvaluationPrinciple,
     ExitCondition,
@@ -137,6 +137,80 @@ class TestWonderDegradedModeConvergence:
         assert "Feedback Signals" in prompt
         assert "decomposition_depth_warning" in prompt
         assert "max_depth=3" in prompt
+
+
+class TestWonderEvolutionFocus:
+    """Wonder receives only the verifier-selected open node set."""
+
+    def test_prompt_omits_frozen_acceptance_nodes(self) -> None:
+        from unittest.mock import AsyncMock
+
+        engine = WonderEngine(llm_adapter=AsyncMock(), model="test")
+        seed = _make_seed().model_copy(
+            update={
+                "acceptance_criteria": (
+                    "FROZEN user profile remains unchanged",
+                    "ACTIVE token refresh works",
+                )
+            }
+        )
+        summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            score=0.5,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="FROZEN user profile remains unchanged",
+                    passed=True,
+                ),
+                ACResult(
+                    ac_index=1,
+                    ac_content="ACTIVE token refresh works",
+                    passed=False,
+                    evidence="refresh test failed",
+                ),
+            ),
+        )
+
+        prompt = engine._build_prompt(
+            seed.ontology_schema,
+            summary,
+            execution_output="very large full execution output",
+            lineage=OntologyLineage(lineage_id="lineage-focus", goal=seed.goal),
+            seed=seed,
+            active_ac_indices=(1,),
+        )
+
+        assert "ACTIVE AC 2: ACTIVE token refresh works" in prompt
+        assert "FROZEN user profile remains unchanged" not in prompt
+        assert "AC 2: refresh test failed" in prompt
+        assert "very large full execution output" not in prompt
+
+    def test_response_drops_gaps_and_frozen_challenges(self) -> None:
+        import json
+        from unittest.mock import AsyncMock
+
+        engine = WonderEngine(llm_adapter=AsyncMock(), model="test")
+        seed = _make_seed().model_copy(update={"acceptance_criteria": ("frozen", "active")})
+        content = json.dumps(
+            {
+                "questions": [
+                    {"question": "reopen frozen", "ac_refs": [1]},
+                    {"question": "fix active", "ac_refs": [2]},
+                    {"question": "add more scope", "kind": "gap"},
+                ],
+                "ontology_tensions": ["global tension"],
+                "should_continue": True,
+                "reasoning": "focus",
+            }
+        )
+
+        output = engine._parse_response(content, seed, active_ac_indices=(1,))
+
+        assert output.questions == ("fix active",)
+        assert output.grounded_questions[0].ac_indices == (1,)
+        assert output.ontology_tensions == ()
 
 
 class TestWonderParseResponseFallback:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -347,6 +347,41 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
+    def test_spec_verification_binds_verdict_to_seed_semantic_identity(self) -> None:
+        semantic_key = "ac_0123456789abcdef"
+        seed = SimpleNamespace(acceptance_criteria=(SimpleNamespace(semantic_ac_key=semantic_key),))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Implement feature",
+                    status="failed",
+                    completed=False,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="failed",
+            approval_status="not_evaluated",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Implement feature",
+                    results=(),
+                    agent_reported_pass=False,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.ac_results[0].semantic_ac_key == semantic_key
+
     def test_partial_spec_verification_coverage_does_not_approve_run(self) -> None:
         """Verifier reports must cover every expected AC before run approval."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
+++ b/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
@@ -116,6 +116,34 @@ def test_evolve_checkpoint_does_not_retry_attempted_pass_without_diff(tmp_path) 
     assert _git(repo, "rev-list", "--count", "HEAD") == "1"
 
 
+def test_evolve_checkpoint_never_commits_non_authoritative_pass(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('unverified')\n", encoding="utf-8")
+    summary = EvaluationSummary(
+        final_approved=True,
+        highest_stage_passed=2,
+        ac_results=(
+            ACResult(
+                ac_index=0,
+                ac_content="Command prints stable output",
+                passed=True,
+                ac_verdict_state="not_evaluated",
+            ),
+        ),
+    )
+
+    commits, attempts = _checkpoint_passed_generation_acs(
+        {"commit_policy": "ac_checkpoint", "auto_session_id": "auto_test123"},
+        summary,
+        repo,
+    )
+
+    assert commits == []
+    assert attempts == []
+    assert _git(repo, "rev-list", "--count", "HEAD") == "1"
+
+
 def test_evolve_checkpoint_accepts_plugin_null_checkpoint_arrays(tmp_path) -> None:
     """Plugin MCP clients may send optional array parameters as explicit null."""
     repo = tmp_path / "repo"

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -20,6 +20,7 @@ import pytest
 from ouroboros.mcp.tools.subagent import (
     SubagentPayload,
     build_evaluate_subagent,
+    build_evolve_subagent,
     build_execute_subagent,
     build_generate_seed_subagent,
     build_interview_question_advisory_subagents,
@@ -232,6 +233,18 @@ class TestBuildSubagentResult:
         assert result.value.is_error is False
 
 
+class TestBuildEvolveSubagent:
+    def test_ontology_only_prompt_never_claims_verified_convergence(self) -> None:
+        payload = build_evolve_subagent(
+            lineage_id="lin-single-ontology",
+            execute=False,
+        )
+
+        assert "return ontology_stable, never converged" in payload.prompt
+        assert "rerun the same lineage with execute=true" in payload.prompt
+        assert "ontology-only stability is ontology_stable" in payload.prompt
+
+
 class TestBuildRalphSubagent:
     """Ralph plugin dispatch payload preserves the full-loop contract."""
 
@@ -253,11 +266,8 @@ class TestBuildRalphSubagent:
         assert "delegation_depth: 1" in payload.prompt
         assert "allow_nested_ouroboros_ralph: false" in payload.prompt
         assert "Do not call ouroboros_ralph" in payload.prompt
-        # Without per_iteration_timeout_seconds, the timeout block is omitted.
         assert "Per-Iteration Timeout" not in payload.prompt
-        # Likewise the progress-stop block is omitted when no windows supplied.
         assert "Progress Stop Conditions" not in payload.prompt
-        # Without max_total_seconds, the wall-clock budget block is omitted.
         assert "Total Wall-Clock Budget" not in payload.prompt
         assert payload.context == {
             "lineage_id": "lin-ralph",
@@ -272,6 +282,17 @@ class TestBuildRalphSubagent:
         }
         assert "per_iteration_timeout_seconds" not in payload.context
         assert "max_total_seconds" not in payload.context
+
+    def test_ontology_only_prompt_requires_verified_same_lineage_handoff(self) -> None:
+        payload = build_ralph_subagent(
+            lineage_id="lin-ontology-only",
+            execute=False,
+            max_generations=3,
+        )
+
+        assert "On ontology_stable" in payload.prompt
+        assert "rerun the same lineage with execute=true" in payload.prompt
+        assert "ontology_stable must first rerun" in payload.prompt
 
     def test_forwards_per_iteration_timeout_to_prompt_and_context(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -263,6 +263,7 @@ class TestOscillationLoopRouting:
                 max_generations=30,
                 convergence_threshold=0.95,
                 min_generations=2,
+                outcome_gate_enabled=False,
             ),
         )
         loop._run_generation = AsyncMock(return_value=Result.ok(gen_result))
@@ -502,6 +503,118 @@ class TestConvergenceGating:
         assert "unsatisfactory" in signal.reason
 
 
+class TestLoopEngineeringExitSignals:
+    """Outcome PASS and no-drift are bounded loop exit gates."""
+
+    @staticmethod
+    def _scored_lineage(*scores: float) -> OntologyLineage:
+        schemas = (SCHEMA_A, SCHEMA_B, SCHEMA_C, SCHEMA_D)
+        generations = tuple(
+            GenerationRecord(
+                generation_number=index + 1,
+                seed_id=f"seed_{index + 1}",
+                ontology_snapshot=schemas[index],
+                evaluation_summary=EvaluationSummary(
+                    final_approved=False,
+                    highest_stage_passed=2,
+                    score=score,
+                ),
+                phase=GenerationPhase.COMPLETED,
+            )
+            for index, score in enumerate(scores)
+        )
+        return _lineage_with_generations(*generations)
+
+    def test_outcome_pass_stops_after_first_generation(self) -> None:
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=0.9,
+        )
+        lineage = _lineage_with_generations(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="seed_1",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            )
+        )
+        criteria = ConvergenceCriteria(
+            min_generations=3,
+            eval_gate_enabled=True,
+            outcome_gate_enabled=True,
+        )
+
+        signal = criteria.evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            validation_output="Validation passed: all checks green",
+        )
+
+        assert signal.converged
+        assert "Outcome gate passed" in signal.reason
+        assert signal.generation == 1
+
+    def test_validation_failure_blocks_first_generation_outcome_gate(self) -> None:
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=0.9,
+        )
+        lineage = _lineage_with_generations(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="seed_1",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            )
+        )
+        criteria = ConvergenceCriteria(
+            min_generations=3,
+            eval_gate_enabled=True,
+            outcome_gate_enabled=True,
+        )
+
+        signal = criteria.evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            validation_output="Validation error: tests did not collect",
+        )
+
+        assert not signal.converged
+        assert "Below minimum generations" in signal.reason
+
+    def test_rejected_score_plateau_stops_after_window(self) -> None:
+        lineage = self._scored_lineage(0.50, 0.505, 0.504)
+        latest = lineage.generations[-1].evaluation_summary
+        criteria = ConvergenceCriteria(
+            min_generations=2,
+            stagnation_window=3,
+            evaluation_plateau_epsilon=0.01,
+        )
+
+        signal = criteria.evaluate(lineage, latest_evaluation=latest)
+
+        assert signal.converged
+        assert "evaluation score plateau" in signal.reason
+
+    def test_meaningful_score_improvement_keeps_running(self) -> None:
+        lineage = self._scored_lineage(0.4, 0.5, 0.6)
+        latest = lineage.generations[-1].evaluation_summary
+        criteria = ConvergenceCriteria(
+            min_generations=2,
+            stagnation_window=3,
+            evaluation_plateau_epsilon=0.01,
+        )
+
+        signal = criteria.evaluate(lineage, latest_evaluation=latest)
+
+        assert not signal.converged
+        assert "Continuing" in signal.reason
+
+
 class TestEvolutionGateDetection:
     """Tests for evolution gate detection (P1-5).
 
@@ -509,8 +622,8 @@ class TestEvolutionGateDetection:
     block convergence — whether due to conservative Reflect or errors.
     """
 
-    def test_blocks_when_ontology_never_evolved(self) -> None:
-        """Identical ontology across all generations -> convergence withheld."""
+    def test_stops_when_ontology_never_evolved_for_full_window(self) -> None:
+        """Identical ontology for the full window stops instead of running to 30."""
         lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A, SCHEMA_A)
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
@@ -518,8 +631,8 @@ class TestEvolutionGateDetection:
             eval_gate_enabled=False,
         )
         signal = criteria.evaluate(lineage)
-        assert not signal.converged
-        assert "Convergence withheld" in signal.reason
+        assert signal.converged
+        assert "Stagnation" in signal.reason
 
     def test_allows_when_ontology_evolved_at_least_once(self) -> None:
         """Ontology evolved once then stabilized -> genuine convergence."""

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -530,7 +530,7 @@ class TestConvergenceGating:
             lineage,
             latest_evaluation=_approved_evaluation(seed),
             latest_seed=seed,
-            validation_output="Validation passed: all checks green",
+            validation_output="Validation passed (attempt 1/3)",
         )
 
         assert signal.should_stop
@@ -648,7 +648,7 @@ class TestLoopEngineeringExitSignals:
         signal = criteria.evaluate(
             lineage,
             latest_evaluation=evaluation,
-            validation_output="Validation passed: all checks green",
+            validation_output="Validation passed (attempt 1/3)",
             latest_seed=seed,
         )
 
@@ -705,7 +705,7 @@ class TestLoopEngineeringExitSignals:
             lineage,
             latest_evaluation=evaluation,
             latest_seed=seed,
-            validation_output="Validation passed: all checks green",
+            validation_output="Validation passed (attempt 1/3)",
         )
 
         assert not signal.converged
@@ -1012,7 +1012,7 @@ class TestValidationGate:
         )
         signal = criteria.evaluate(
             lineage,
-            validation_output="Validation passed: all checks green",
+            validation_output="Validation passed (attempt 1/3)",
             latest_evaluation=_approved_evaluation(seed),
             latest_seed=seed,
         )
@@ -1066,6 +1066,9 @@ class TestValidationGate:
             "Validation fix failed (attempt 1): timeout",
             "Validation: no fixable errors detected (exit code 2)",
             "False",
+            "Validation passed: false",
+            "Validation passed but 3 errors remain",
+            "Validation passed\nValidation error: tests failed",
         ),
     )
     def test_blocks_configured_validator_without_explicit_pass(

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -6,11 +6,13 @@ import json
 
 import pytest
 
+from ouroboros.core.directive import Directive
 from ouroboros.core.lineage import (
     ACResult,
     EvaluationSummary,
     GenerationPhase,
     GenerationRecord,
+    LineageStatus,
     OntologyDelta,
     OntologyLineage,
 )
@@ -405,14 +407,15 @@ class TestConvergenceGating:
         """
         return _lineage_with_schemas(SCHEMA_B, SCHEMA_A, SCHEMA_A)
 
-    def test_gate_disabled_explicitly(self) -> None:
-        """Explicitly disabled gate: convergence proceeds despite bad eval."""
+    def test_optional_gate_disabled_cannot_authorize_rejected_evaluation(self) -> None:
+        """Disabling score policy cannot bypass approval or all-AC authority."""
         lineage = self._converging_lineage()
         seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
+            outcome_gate_enabled=False,
         )
         signal = criteria.evaluate(
             lineage,
@@ -424,8 +427,174 @@ class TestConvergenceGating:
             ),
             latest_seed=seed,
         )
-        # Gate disabled -> converges despite bad result
+        assert not signal.converged
+        assert signal.failed_acs == (0,)
+        assert "Per-AC authority" in signal.reason
+
+    def test_optional_gate_disabled_allows_low_score_with_authoritative_pass(self) -> None:
+        """The optional gate still controls only the configured score threshold."""
+        lineage = self._converging_lineage()
+        seed = _seed("AC zero")
+
+        signal = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            eval_gate_enabled=False,
+            eval_min_score=0.7,
+        ).evaluate(
+            lineage,
+            latest_evaluation=_approved_evaluation(seed, score=0.1),
+            latest_seed=seed,
+        )
+
         assert signal.converged
+
+    def test_outcome_gate_runs_when_optional_eval_policy_is_disabled(self) -> None:
+        """A verified Gen 1 outcome must not wait for ontology convergence."""
+        seed = _seed("AC zero")
+        evaluation = _approved_evaluation(seed, score=0.1)
+        lineage = _lineage_with_generations(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="seed_1",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            )
+        )
+
+        signal = ConvergenceCriteria(
+            min_generations=3,
+            eval_gate_enabled=False,
+            eval_min_score=0.7,
+            outcome_gate_enabled=True,
+        ).evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert signal.should_stop
+        assert signal.converged
+        assert "Outcome gate passed" in signal.reason
+
+    def test_all_ac_pass_authority_cannot_be_disabled(self) -> None:
+        """Neither the optional eval gate nor ac_gate_mode can admit a failed AC."""
+        lineage = self._converging_lineage()
+        seed = _seed("AC zero", "AC one")
+        evaluation = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=(
+                ACResult(ac_index=0, ac_content="AC zero", passed=True),
+                ACResult(ac_index=1, ac_content="AC one", passed=False),
+            ),
+        )
+
+        signal = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            eval_gate_enabled=False,
+            ac_gate_mode="off",
+        ).evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert not signal.converged
+        assert signal.failed_acs == (1,)
+        assert "Per-AC authority" in signal.reason
+
+    def test_not_evaluated_pass_cannot_authorize_convergence(self) -> None:
+        """Exact indices and PASS labels are insufficient without verdict authority."""
+        lineage = self._converging_lineage()
+        seed = _seed("AC zero", "AC one")
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=tuple(
+                ACResult(
+                    ac_index=index,
+                    ac_content=criterion.description,
+                    passed=True,
+                    ac_verdict_state="not_evaluated",
+                    verification_method="unknown",
+                )
+                for index, criterion in enumerate(seed.acceptance_criteria)
+            ),
+        )
+
+        coverage = validate_seed_ac_coverage(seed, evaluation)
+        signal = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            eval_gate_enabled=False,
+            ac_gate_mode="off",
+        ).evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert not coverage.complete
+        assert "non-authoritative" in coverage.reason
+        assert not evaluation.final_approved
+        assert not signal.converged
+
+    def test_opaque_override_pass_cannot_authorize_convergence(self) -> None:
+        seed = _seed("AC zero")
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="AC zero",
+                    passed=True,
+                    ac_verdict_state="overridden",
+                    verification_method="unknown",
+                    evidence="",
+                ),
+            ),
+        )
+
+        signal = ConvergenceCriteria(eval_gate_enabled=False).evaluate(
+            self._converging_lineage(),
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert not evaluation.final_approved
+        assert not signal.converged
+
+    def test_explicit_final_rejection_cannot_be_upgraded_to_convergence(self) -> None:
+        seed = _seed("AC zero")
+        evaluation = EvaluationSummary(
+            final_approved=False,
+            approval_status="rejected",
+            highest_stage_passed=3,
+            failure_reason="Stage 3 consensus rejected the artifact",
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="AC zero",
+                    passed=True,
+                    verification_method="semantic",
+                ),
+            ),
+        )
+
+        signal = ConvergenceCriteria(eval_gate_enabled=False).evaluate(
+            self._converging_lineage(),
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert not evaluation.final_approved
+        assert not signal.converged
 
     def test_gate_blocks_when_not_approved(self) -> None:
         """Gate enabled + approved=False -> converged=False."""
@@ -734,10 +903,19 @@ class TestLoopEngineeringExitSignals:
         result = await loop.evolve_step("lin_ontology_only", execute=False)
 
         assert result.is_ok
-        assert result.value.action == StepAction.CONVERGED
+        assert result.value.action == StepAction.ONTOLOGY_STABLE
+        assert result.value.convergence_signal.converged is False
+        assert result.value.convergence_signal.ontology_stable is True
         assert result.value.convergence_signal.ontology_similarity == pytest.approx(1.0)
+        assert result.value.lineage.status == LineageStatus.ACTIVE
         assert run_generation.await_args.kwargs["execute"] is False
         validator.assert_not_awaited()
+
+        events = await store.replay_lineage("lin_ontology_only")
+        assert not any(event.type == "lineage.converged" for event in events)
+        directive = [event for event in events if event.type == "control.directive.emitted"][-1]
+        assert directive.data["directive"] == Directive.EVALUATE.value
+        assert directive.data["is_terminal"] is False
 
     @pytest.mark.parametrize(
         "results",
@@ -987,6 +1165,7 @@ class TestEvolutionGateDetection:
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
+            outcome_gate_enabled=False,
         )
         signal = criteria.evaluate(lineage)
         assert signal.should_stop
@@ -1001,6 +1180,7 @@ class TestEvolutionGateDetection:
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
+            outcome_gate_enabled=False,
         )
         signal = criteria.evaluate(
             lineage,
@@ -1018,6 +1198,7 @@ class TestEvolutionGateDetection:
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
+            outcome_gate_enabled=False,
         )
         signal = criteria.evaluate(
             lineage,
@@ -1026,6 +1207,23 @@ class TestEvolutionGateDetection:
         )
         assert not signal.converged
         assert "Convergence withheld" in signal.reason
+
+    def test_ontology_only_identical_generations_handoff_for_verification(self) -> None:
+        """Stability needs verification, not a fake mutation, in ontology-only mode."""
+        lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A)
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            eval_gate_enabled=False,
+            outcome_gate_enabled=False,
+        )
+
+        signal = criteria.evaluate(lineage, evaluation_expected=False)
+
+        assert signal.should_stop
+        assert signal.ontology_stable
+        assert not signal.converged
+        assert "evaluation are required" in signal.reason
 
     def test_max_generations_overrides_withheld_convergence(self) -> None:
         """Hard cap still terminates even with withheld convergence."""

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from ouroboros.core.lineage import (
+    ACResult,
     EvaluationSummary,
     GenerationPhase,
     GenerationRecord,
     OntologyDelta,
     OntologyLineage,
 )
-from ouroboros.core.seed import OntologyField, OntologySchema
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
 from ouroboros.evolution.convergence import ConvergenceCriteria
+from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
 from ouroboros.evolution.wonder import WonderOutput
 
 # -- Helpers --
@@ -33,6 +43,32 @@ SCHEMA_A = _schema(("alpha", "beta"))
 SCHEMA_B = _schema(("gamma", "delta"))
 SCHEMA_C = _schema(("epsilon", "zeta"))
 SCHEMA_D = _schema(("eta", "theta"))
+
+
+def _seed(*acs: str | AcceptanceCriterionSpec) -> Seed:
+    return Seed(
+        metadata=SeedMetadata(ambiguity_score=0.1),
+        goal="test goal",
+        constraints=("stay deterministic",),
+        acceptance_criteria=acs,
+        ontology_schema=SCHEMA_A,
+    )
+
+
+def _approved_evaluation(seed: Seed, *, score: float | None = 0.9) -> EvaluationSummary:
+    return EvaluationSummary(
+        final_approved=True,
+        highest_stage_passed=2,
+        score=score,
+        ac_results=tuple(
+            ACResult(
+                ac_index=index,
+                ac_content=criterion.description,
+                passed=True,
+            )
+            for index, criterion in enumerate(seed.acceptance_criteria)
+        ),
+    )
 
 
 def _lineage_with_schemas(*schemas: OntologySchema) -> OntologyLineage:
@@ -89,7 +125,8 @@ class TestOscillationDetection:
             max_generations=30,
         )
         signal = criteria.evaluate(lineage)
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Oscillation" in signal.reason
 
     def test_oscillation_period2_partial_3gens(self) -> None:
@@ -101,7 +138,8 @@ class TestOscillationDetection:
             max_generations=30,
         )
         signal = criteria.evaluate(lineage)
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Oscillation" in signal.reason
 
     def test_oscillation_not_detected_different(self) -> None:
@@ -153,7 +191,8 @@ class TestOscillationDetection:
             max_generations=30,
         )
         signal = criteria.evaluate(lineage)
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Oscillation" in signal.reason
 
     def test_oscillation_no_indexerror_3gens(self) -> None:
@@ -369,6 +408,7 @@ class TestConvergenceGating:
     def test_gate_disabled_explicitly(self) -> None:
         """Explicitly disabled gate: convergence proceeds despite bad eval."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -377,8 +417,12 @@ class TestConvergenceGating:
         signal = criteria.evaluate(
             lineage,
             latest_evaluation=EvaluationSummary(
-                final_approved=False, highest_stage_passed=1, score=0.3
+                final_approved=False,
+                highest_stage_passed=1,
+                score=0.3,
+                ac_results=(ACResult(ac_index=0, ac_content="AC zero", passed=False),),
             ),
+            latest_seed=seed,
         )
         # Gate disabled -> converges despite bad result
         assert signal.converged
@@ -422,6 +466,7 @@ class TestConvergenceGating:
     def test_gate_passes_when_satisfactory(self) -> None:
         """Gate enabled + approved=True + score >= min -> converged=True."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -431,13 +476,17 @@ class TestConvergenceGating:
         signal = criteria.evaluate(
             lineage,
             latest_evaluation=EvaluationSummary(
-                final_approved=True, highest_stage_passed=2, score=0.9
+                final_approved=True,
+                highest_stage_passed=2,
+                score=0.9,
+                ac_results=(ACResult(ac_index=0, ac_content="AC zero", passed=True),),
             ),
+            latest_seed=seed,
         )
         assert signal.converged
 
-    def test_gate_ignores_when_no_result(self) -> None:
-        """Gate enabled but no result provided -> converges normally."""
+    def test_gate_blocks_when_no_result(self) -> None:
+        """Gate enabled but no result provided -> fail closed."""
         lineage = self._converging_lineage()
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
@@ -445,7 +494,8 @@ class TestConvergenceGating:
             eval_gate_enabled=True,
         )
         signal = criteria.evaluate(lineage, latest_evaluation=None)
-        assert signal.converged
+        assert not signal.converged
+        assert "evaluation unavailable" in signal.reason
 
     def test_gate_does_not_affect_max_generations(self) -> None:
         """Hard cap (max_generations) still works even with gate."""
@@ -464,12 +514,33 @@ class TestConvergenceGating:
                 final_approved=False, highest_stage_passed=1, score=0.1
             ),
         )
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Max generations" in signal.reason
+
+    def test_verified_outcome_wins_on_final_generation(self) -> None:
+        lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_B, SCHEMA_C)
+        seed = _seed("AC zero")
+
+        signal = ConvergenceCriteria(
+            min_generations=2,
+            max_generations=3,
+            eval_gate_enabled=True,
+        ).evaluate(
+            lineage,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+            validation_output="Validation passed: all checks green",
+        )
+
+        assert signal.should_stop
+        assert signal.converged
+        assert "Outcome gate passed" in signal.reason
 
     def test_gate_approved_true_score_none(self) -> None:
         """approved=True + score=None -> convergence allowed (no score to block)."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -479,10 +550,32 @@ class TestConvergenceGating:
         signal = criteria.evaluate(
             lineage,
             latest_evaluation=EvaluationSummary(
-                final_approved=True, highest_stage_passed=2, score=None
+                final_approved=True,
+                highest_stage_passed=2,
+                score=None,
+                ac_results=(ACResult(ac_index=0, ac_content="AC zero", passed=True),),
             ),
+            latest_seed=seed,
         )
         assert signal.converged
+
+    def test_gate_blocks_when_current_seed_is_unavailable(self) -> None:
+        lineage = self._converging_lineage()
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=0.9,
+            ac_results=(ACResult(ac_index=0, ac_content="AC zero", passed=True),),
+        )
+
+        signal = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            eval_gate_enabled=True,
+        ).evaluate(lineage, latest_evaluation=evaluation)
+
+        assert not signal.converged
+        assert signal.reason == "Per-AC gate: current Seed unavailable for coverage validation"
 
     def test_gate_approved_false_score_none(self) -> None:
         """approved=False + score=None -> convergence blocked."""
@@ -526,10 +619,15 @@ class TestLoopEngineeringExitSignals:
         return _lineage_with_generations(*generations)
 
     def test_outcome_pass_stops_after_first_generation(self) -> None:
+        seed = _seed("AC zero", "AC one")
         evaluation = EvaluationSummary(
             final_approved=True,
             highest_stage_passed=2,
             score=0.9,
+            ac_results=(
+                ACResult(ac_index=0, ac_content="AC zero", passed=True),
+                ACResult(ac_index=1, ac_content="AC one", passed=True),
+            ),
         )
         lineage = _lineage_with_generations(
             GenerationRecord(
@@ -538,6 +636,7 @@ class TestLoopEngineeringExitSignals:
                 ontology_snapshot=SCHEMA_A,
                 evaluation_summary=evaluation,
                 phase=GenerationPhase.COMPLETED,
+                seed_json=json.dumps(seed.to_dict()),
             )
         )
         criteria = ConvergenceCriteria(
@@ -550,11 +649,148 @@ class TestLoopEngineeringExitSignals:
             lineage,
             latest_evaluation=evaluation,
             validation_output="Validation passed: all checks green",
+            latest_seed=seed,
         )
 
         assert signal.converged
         assert "Outcome gate passed" in signal.reason
         assert signal.generation == 1
+
+    @pytest.mark.parametrize(
+        "results",
+        [
+            (ACResult(ac_index=0, ac_content="AC zero", passed=True),),
+            (
+                ACResult(ac_index=0, ac_content="AC zero", passed=True),
+                ACResult(ac_index=0, ac_content="AC zero", passed=True),
+            ),
+            (
+                ACResult(ac_index=0, ac_content="AC zero", passed=True),
+                ACResult(ac_index=2, ac_content="outside", passed=True),
+            ),
+            (
+                ACResult(ac_index=0, ac_content="not AC zero", passed=True),
+                ACResult(ac_index=1, ac_content="AC one", passed=True),
+            ),
+        ],
+        ids=("missing", "duplicate", "out-of-range", "content-mismatch"),
+    )
+    def test_outcome_gate_requires_exact_seed_wide_verdict_coverage(
+        self,
+        results: tuple[ACResult, ...],
+    ) -> None:
+        seed = _seed("AC zero", "AC one")
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=0.9,
+            ac_results=results,
+        )
+        lineage = _lineage_with_generations(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="seed_1",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                seed_json=json.dumps(seed.to_dict()),
+                phase=GenerationPhase.COMPLETED,
+            )
+        )
+
+        signal = ConvergenceCriteria(
+            min_generations=3,
+            eval_gate_enabled=True,
+            outcome_gate_enabled=True,
+        ).evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+            validation_output="Validation passed: all checks green",
+        )
+
+        assert not signal.converged
+        assert "Below minimum generations" in signal.reason
+
+    def test_structured_coverage_rejects_stale_semantic_identity(self) -> None:
+        prior_seed = _seed(
+            AcceptanceCriterionSpec(
+                description="Artifact exists",
+                verify_command="test -f artifact.txt",
+            )
+        )
+        current_seed = _seed(
+            AcceptanceCriterionSpec(
+                description="Artifact exists",
+                verify_command="python scripts/verify_artifact.py",
+            )
+        )
+        stale_evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Artifact exists",
+                    semantic_ac_key=prior_seed.acceptance_criteria[0].semantic_ac_key,
+                    passed=True,
+                ),
+            ),
+        )
+
+        coverage = validate_seed_ac_coverage(current_seed, stale_evaluation)
+
+        assert not coverage.complete
+        assert "semantic identity differs" in coverage.reason
+
+    @pytest.mark.parametrize("ac_gate_mode", ("all", "off"))
+    def test_stability_gate_rejects_empty_verdict_coverage_for_current_seed(
+        self,
+        ac_gate_mode: str,
+    ) -> None:
+        seed = _seed("AC zero", "AC one")
+        evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=0.9,
+        )
+        lineage = _lineage_with_generations(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="seed_1",
+                ontology_snapshot=SCHEMA_B,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            ),
+            GenerationRecord(
+                generation_number=2,
+                seed_id="seed_2",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            ),
+            GenerationRecord(
+                generation_number=3,
+                seed_id="seed_3",
+                ontology_snapshot=SCHEMA_A,
+                evaluation_summary=evaluation,
+                phase=GenerationPhase.COMPLETED,
+            ),
+        )
+
+        signal = ConvergenceCriteria(
+            min_generations=2,
+            eval_gate_enabled=True,
+            outcome_gate_enabled=False,
+            ac_gate_mode=ac_gate_mode,
+        ).evaluate(
+            lineage,
+            latest_evaluation=evaluation,
+            latest_seed=seed,
+        )
+
+        assert not signal.converged
+        assert signal.reason == "Per-AC gate: missing per-AC verdict indices: [0, 1]"
 
     def test_validation_failure_blocks_first_generation_outcome_gate(self) -> None:
         evaluation = EvaluationSummary(
@@ -597,7 +833,8 @@ class TestLoopEngineeringExitSignals:
 
         signal = criteria.evaluate(lineage, latest_evaluation=latest)
 
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "evaluation score plateau" in signal.reason
 
     def test_meaningful_score_improvement_keeps_running(self) -> None:
@@ -613,6 +850,43 @@ class TestLoopEngineeringExitSignals:
 
         assert not signal.converged
         assert "Continuing" in signal.reason
+
+    def test_repetitive_feedback_is_an_explicit_non_success_stop(self) -> None:
+        seed = _seed("AC zero", "AC one")
+        partial_evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=(ACResult(ac_index=0, ac_content="AC zero", passed=True),),
+        )
+        lineage = _lineage_with_generations(
+            *(
+                GenerationRecord(
+                    generation_number=index,
+                    seed_id=f"seed_{index}",
+                    ontology_snapshot=schema,
+                    wonder_questions=("same unresolved question",),
+                    phase=GenerationPhase.COMPLETED,
+                )
+                for index, schema in enumerate((SCHEMA_A, SCHEMA_B, SCHEMA_C), start=1)
+            )
+        )
+
+        signal = ConvergenceCriteria(min_generations=2, eval_gate_enabled=True).evaluate(
+            lineage,
+            latest_wonder=WonderOutput(
+                questions=("same unresolved question",),
+                ontology_tensions=(),
+                should_continue=True,
+                reasoning="still unresolved",
+            ),
+            latest_evaluation=partial_evaluation,
+            latest_seed=seed,
+        )
+
+        assert signal.should_stop
+        assert not signal.converged
+        assert signal.reason.startswith("Stagnation detected:")
 
 
 class TestEvolutionGateDetection:
@@ -631,30 +905,41 @@ class TestEvolutionGateDetection:
             eval_gate_enabled=False,
         )
         signal = criteria.evaluate(lineage)
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Stagnation" in signal.reason
 
     def test_allows_when_ontology_evolved_at_least_once(self) -> None:
         """Ontology evolved once then stabilized -> genuine convergence."""
         lineage = _lineage_with_schemas(SCHEMA_B, SCHEMA_A, SCHEMA_A)
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
         )
-        signal = criteria.evaluate(lineage)
+        signal = criteria.evaluate(
+            lineage,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+        )
         assert signal.converged
         assert "converged" in signal.reason.lower()
 
     def test_blocks_two_gen_identical(self) -> None:
         """Two identical generations with no evolution -> blocked."""
         lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A)
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
             eval_gate_enabled=False,
         )
-        signal = criteria.evaluate(lineage)
+        signal = criteria.evaluate(
+            lineage,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+        )
         assert not signal.converged
         assert "Convergence withheld" in signal.reason
 
@@ -668,7 +953,8 @@ class TestEvolutionGateDetection:
             eval_gate_enabled=False,
         )
         signal = criteria.evaluate(lineage)
-        assert signal.converged
+        assert signal.should_stop
+        assert not signal.converged
         assert "Max generations" in signal.reason
 
 
@@ -682,6 +968,7 @@ class TestValidationGate:
     def test_blocks_when_validation_skipped(self) -> None:
         """Validation gate blocks convergence when validation was skipped."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -690,6 +977,8 @@ class TestValidationGate:
         signal = criteria.evaluate(
             lineage,
             validation_output="Validation skipped: no project directory found",
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
         )
         assert not signal.converged
         assert "Validation gate blocked" in signal.reason
@@ -697,6 +986,7 @@ class TestValidationGate:
     def test_blocks_when_validation_error(self) -> None:
         """Validation gate blocks convergence when validation had an error."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -705,6 +995,8 @@ class TestValidationGate:
         signal = criteria.evaluate(
             lineage,
             validation_output="Validation error: subprocess failed",
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
         )
         assert not signal.converged
         assert "Validation gate blocked" in signal.reason
@@ -712,6 +1004,7 @@ class TestValidationGate:
     def test_passes_when_validation_succeeded(self) -> None:
         """Validation gate allows convergence when validation passed."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -720,23 +1013,88 @@ class TestValidationGate:
         signal = criteria.evaluate(
             lineage,
             validation_output="Validation passed: all checks green",
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
         )
         assert signal.converged
 
     def test_passes_when_validation_output_none(self) -> None:
         """Validation gate allows convergence when no validation output."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
             validation_gate_enabled=True,
         )
-        signal = criteria.evaluate(lineage, validation_output=None)
+        signal = criteria.evaluate(
+            lineage,
+            validation_output=None,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+        )
         assert signal.converged
+
+    @pytest.mark.parametrize("validation_output", (None, "", "   "))
+    def test_blocks_when_configured_validator_returns_no_result(
+        self,
+        validation_output: str | None,
+    ) -> None:
+        lineage = self._converging_lineage()
+        seed = _seed("AC zero")
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            validation_gate_enabled=True,
+        )
+
+        signal = criteria.evaluate(
+            lineage,
+            validation_output=validation_output,
+            validation_expected=True,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+        )
+
+        assert not signal.converged
+        assert not signal.should_stop
+        assert signal.reason == "Validation gate blocked: configured validator returned no result"
+
+    @pytest.mark.parametrize(
+        "validation_output",
+        (
+            "Validation fix failed (attempt 1): timeout",
+            "Validation: no fixable errors detected (exit code 2)",
+            "False",
+        ),
+    )
+    def test_blocks_configured_validator_without_explicit_pass(
+        self,
+        validation_output: str,
+    ) -> None:
+        lineage = self._converging_lineage()
+        seed = _seed("AC zero")
+
+        signal = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            validation_gate_enabled=True,
+        ).evaluate(
+            lineage,
+            validation_output=validation_output,
+            validation_expected=True,
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
+        )
+
+        assert not signal.converged
+        assert not signal.should_stop
+        assert signal.reason == f"Validation gate blocked: {validation_output}"
 
     def test_disabled_allows_skipped_validation(self) -> None:
         """Disabled validation gate allows convergence even with skipped validation."""
         lineage = self._converging_lineage()
+        seed = _seed("AC zero")
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
@@ -745,5 +1103,7 @@ class TestValidationGate:
         signal = criteria.evaluate(
             lineage,
             validation_output="Validation skipped: no project directory",
+            latest_evaluation=_approved_evaluation(seed),
+            latest_seed=seed,
         )
         assert signal.converged

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -493,7 +493,11 @@ class TestConvergenceGating:
             min_generations=2,
             eval_gate_enabled=True,
         )
-        signal = criteria.evaluate(lineage, latest_evaluation=None)
+        signal = criteria.evaluate(
+            lineage,
+            latest_evaluation=None,
+            evaluation_expected=True,
+        )
         assert not signal.converged
         assert "evaluation unavailable" in signal.reason
 
@@ -656,6 +660,85 @@ class TestLoopEngineeringExitSignals:
         assert "Outcome gate passed" in signal.reason
         assert signal.generation == 1
 
+    @pytest.mark.asyncio
+    async def test_ontology_only_evolve_step_converges_after_real_change(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from ouroboros.core.types import Result
+        from ouroboros.events.lineage import lineage_created, lineage_generation_completed
+        from ouroboros.evolution.loop import (
+            EvolutionaryLoop,
+            EvolutionaryLoopConfig,
+            GenerationResult,
+            StepAction,
+        )
+        from ouroboros.persistence.event_store import EventStore
+
+        def ontology_seed(
+            seed_id: str,
+            parent_seed_id: str | None,
+            schema: OntologySchema,
+        ) -> Seed:
+            return Seed(
+                metadata=SeedMetadata(
+                    seed_id=seed_id,
+                    parent_seed_id=parent_seed_id,
+                    ambiguity_score=0.1,
+                ),
+                goal="test goal",
+                constraints=("stay deterministic",),
+                acceptance_criteria=("AC zero",),
+                ontology_schema=schema,
+            )
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+        seed_1 = ontology_seed("seed_1", None, SCHEMA_B)
+        seed_2 = ontology_seed("seed_2", "seed_1", SCHEMA_A)
+        seed_3 = ontology_seed("seed_3", "seed_2", SCHEMA_A)
+
+        await store.append(lineage_created("lin_ontology_only", "test goal"))
+        for generation_number, seed in enumerate((seed_1, seed_2), start=1):
+            await store.append(
+                lineage_generation_completed(
+                    "lin_ontology_only",
+                    generation_number,
+                    seed.metadata.seed_id,
+                    seed.ontology_schema.model_dump(mode="json"),
+                    None,
+                    [f"question {generation_number}"],
+                    seed_json=json.dumps(seed.to_dict()),
+                )
+            )
+
+        generation = GenerationResult(
+            generation_number=3,
+            seed=seed_3,
+            ontology_delta=OntologyDelta.compute(SCHEMA_A, SCHEMA_A),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        validator = AsyncMock()
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(
+                min_generations=2,
+                convergence_threshold=0.95,
+                eval_gate_enabled=True,
+            ),
+            validator=validator,
+        )
+        run_generation = AsyncMock(return_value=Result.ok(generation))
+        loop._run_generation = run_generation
+
+        result = await loop.evolve_step("lin_ontology_only", execute=False)
+
+        assert result.is_ok
+        assert result.value.action == StepAction.CONVERGED
+        assert result.value.convergence_signal.ontology_similarity == pytest.approx(1.0)
+        assert run_generation.await_args.kwargs["execute"] is False
+        validator.assert_not_awaited()
+
     @pytest.mark.parametrize(
         "results",
         [
@@ -787,6 +870,7 @@ class TestLoopEngineeringExitSignals:
             lineage,
             latest_evaluation=evaluation,
             latest_seed=seed,
+            evaluation_expected=True,
         )
 
         assert not signal.converged

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -172,6 +172,16 @@ class TestFormatSummary:
         assert "Create tasks" in output
         assert "Delete tasks" in output
 
+    def test_non_authoritative_pass_displays_as_unresolved(self) -> None:
+        unknown = _ac_result(0, True, "Unverified task creation").model_copy(
+            update={"ac_verdict_state": "not_evaluated"}
+        )
+
+        output = format_summary(_lineage_with_gens((unknown,)))
+
+        assert "UNRESOLVED" in output
+        assert "F (0/1)" in output
+
     def test_no_generations(self) -> None:
         lineage = OntologyLineage(lineage_id="empty", goal="test")
         output = format_summary(lineage)

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -151,6 +151,7 @@ def make_loop(
     event_store: EventStore,
     gen_result: GenerationResult | None = None,
     gen_error: OuroborosError | None = None,
+    config: EvolutionaryLoopConfig | None = None,
 ) -> EvolutionaryLoop:
     """Create an EvolutionaryLoop with mocked engines.
 
@@ -161,7 +162,8 @@ def make_loop(
     """
     loop = EvolutionaryLoop(
         event_store=event_store,
-        config=EvolutionaryLoopConfig(
+        config=config
+        or EvolutionaryLoopConfig(
             max_generations=30,
             convergence_threshold=0.95,
             stagnation_window=3,
@@ -338,7 +340,7 @@ class TestEvolveStepGen1:
 
         assert result.is_ok
         step = result.value
-        assert step.action == StepAction.CONTINUE
+        assert step.action == StepAction.CONVERGED
         assert step.generation_result.generation_number == 1
         assert step.lineage.lineage_id == "lin_test_001"
         assert step.lineage.current_generation == 1
@@ -736,7 +738,17 @@ class TestEvolveStepConvergence:
             phase=GenerationPhase.COMPLETED,
             success=True,
         )
-        loop = make_loop(store, gen_result=gen_result)
+        loop = make_loop(
+            store,
+            gen_result=gen_result,
+            config=EvolutionaryLoopConfig(
+                max_generations=30,
+                convergence_threshold=0.95,
+                stagnation_window=3,
+                min_generations=2,
+                outcome_gate_enabled=False,
+            ),
+        )
 
         result = await loop.evolve_step("lin_stag")
 
@@ -1395,7 +1407,7 @@ class TestEvolveStepHandler:
 
         assert result.is_ok
         assert "Generation 1" in result.value.text_content
-        assert result.value.meta["action"] == "continue"
+        assert result.value.meta["action"] == "converged"
         assert result.value.meta["qa_attempted"] is False
 
     @pytest.mark.asyncio

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -404,6 +404,35 @@ class TestEvolutionaryLoopConfig:
 
         assert first == second
 
+    def test_configured_project_shadows_cwd_in_handler_identity(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Configured workspace identity matches the handler's fallback target."""
+        from ouroboros.mcp.tools.evolution_handlers import _evolve_handler_request_key
+
+        configured = (tmp_path / "configured").resolve()
+        arguments = {"lineage_id": "lin_configured_workspace_identity"}
+
+        first = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=str(configured),
+            fallback_cwd=(tmp_path / "cwd-a").resolve(),
+        )
+        second = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=str(configured),
+            fallback_cwd=(tmp_path / "cwd-b").resolve(),
+        )
+        different = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=str((tmp_path / "configured-other").resolve()),
+            fallback_cwd=(tmp_path / "cwd-a").resolve(),
+        )
+
+        assert first == second
+        assert first != different
+
     def test_non_introspectable_executor_preserves_legacy_call_shape(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -2575,6 +2604,68 @@ class TestEvolveStepResume:
             == 1
         )
 
+    @pytest.mark.asyncio
+    async def test_hard_crash_after_empty_evaluation_does_not_redispatch_evaluator(self) -> None:
+        """A completed evaluation boundary is authoritative even without a summary."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_empty_eval_parent")
+        candidate = make_seed(
+            seed_id="seed_empty_eval_candidate",
+            parent_seed_id=parent.metadata.seed_id,
+        )
+        lineage_id = "lin_empty_eval_checkpoint"
+        await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+        await store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id=lineage_id,
+                generation_number=2,
+                phase=GenerationPhase.EVALUATING,
+                last_completed_phase=GenerationPhase.EVALUATING.value,
+                seed=candidate,
+                active_ac_indices=(0,),
+                frozen_ac_indices=(),
+                execution_output="durable execution",
+                execution_boundary_completed=True,
+                validation_boundary_completed=True,
+                evaluation_summary=None,
+            )
+        )
+        executor = AsyncMock(return_value="must not run")
+        evaluator = AsyncMock(return_value=make_eval_summary(True))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=3),
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        result = await loop.evolve_step(lineage_id, execute=True)
+
+        assert result.is_ok
+        assert result.value.generation_result.seed == candidate
+        assert result.value.generation_result.execution_output == "durable execution"
+        assert result.value.generation_result.evaluation_summary is None
+        executor.assert_not_awaited()
+        evaluator.assert_not_awaited()
+        replayed = await store.replay_lineage(lineage_id)
+        assert (
+            sum(
+                event.type == "lineage.generation.completed"
+                and event.data.get("generation_number") == 2
+                for event in replayed
+            )
+            == 1
+        )
+
 
 class TestRunGenerationFailures:
     """Test failure event emission inside _run_generation()."""
@@ -2803,6 +2894,65 @@ class TestEvolveStepHandler:
         assert result.value.meta["action"] == "converged"
         assert result.value.meta["converged"] is True
         assert result.value.meta["qa_attempted"] is False
+
+    @pytest.mark.asyncio
+    async def test_handler_uses_configured_project_when_explicit_project_is_absent(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The workspace hashed into the request key is the workspace used by evolve."""
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_configured_handler_workspace")
+        generation = GenerationResult(
+            generation_number=1,
+            seed=seed,
+            evaluation_summary=make_eval_summary(),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        step = StepResult(
+            generation_result=generation,
+            convergence_signal=ConvergenceSignal(
+                converged=True,
+                reason="verified",
+                ontology_similarity=1.0,
+                generation=1,
+                should_stop=True,
+            ),
+            lineage=OntologyLineage(
+                lineage_id="lin_configured_handler_workspace",
+                goal=seed.goal,
+            ),
+            action=StepAction.CONVERGED,
+            next_generation=2,
+        )
+        loop = make_loop(store)
+        configured = str((tmp_path / "configured-project").resolve())
+        configured_token = loop.set_project_dir(configured)
+        observed_project_dirs: list[str | None] = []
+
+        async def observe_workspace(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            observed_project_dirs.append(loop.get_project_dir())
+            return Result.ok(step)
+
+        loop.evolve_step = AsyncMock(side_effect=observe_workspace)
+        handler = EvolveStepHandler(evolutionary_loop=loop)
+        try:
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_configured_handler_workspace",
+                    "execute": False,
+                    "skip_qa": True,
+                }
+            )
+        finally:
+            loop.reset_project_dir(configured_token)
+            await store.close()
+
+        assert result.is_ok
+        assert observed_project_dirs == [configured]
 
     @pytest.mark.asyncio
     async def test_concurrent_public_handler_reuses_workspace_evidence_and_qa(

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -2138,7 +2138,6 @@ class TestEvolveStepResume:
             GenerationPhase.WONDERING,
             GenerationPhase.REFLECTING,
             GenerationPhase.SEEDING,
-            GenerationPhase.EXECUTING,
             GenerationPhase.EVALUATING,
         ],
     )
@@ -2149,17 +2148,48 @@ class TestEvolveStepResume:
         """A recovered nonterminal generation never advances under a new identity."""
         store = await create_event_store()
         parent = make_seed(seed_id="seed_hard_crash_parent")
+        candidate = make_seed(
+            seed_id=f"seed_checkpointed_{hard_crash_phase.value}",
+            parent_seed_id=parent.metadata.seed_id,
+        )
         lineage_id = f"lin_hard_crash_{hard_crash_phase.value}"
         await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
         await store.append(
             lineage_generation_started(
                 lineage_id,
                 2,
-                hard_crash_phase.value,
+                GenerationPhase.WONDERING.value,
                 parent.metadata.seed_id,
                 json.dumps(parent.to_dict()),
             )
         )
+        last_completed = {
+            GenerationPhase.REFLECTING: GenerationPhase.WONDERING.value,
+            GenerationPhase.SEEDING: GenerationPhase.REFLECTING.value,
+            GenerationPhase.EVALUATING: GenerationPhase.EXECUTING.value,
+        }.get(hard_crash_phase)
+        if last_completed is not None:
+            checkpoint_seed = (
+                candidate if hard_crash_phase == GenerationPhase.EVALUATING else parent
+            )
+            await store.append(
+                loop_support.generation_phase_checkpoint(
+                    lineage_id=lineage_id,
+                    generation_number=2,
+                    phase=hard_crash_phase,
+                    last_completed_phase=last_completed,
+                    seed=checkpoint_seed,
+                    active_ac_indices=(0,),
+                    frozen_ac_indices=(),
+                    execution_output=(
+                        "durable execution"
+                        if hard_crash_phase == GenerationPhase.EVALUATING
+                        else None
+                    ),
+                    execution_boundary_completed=(hard_crash_phase == GenerationPhase.EVALUATING),
+                    validation_boundary_completed=(hard_crash_phase == GenerationPhase.EVALUATING),
+                )
+            )
 
         successor = make_seed(
             seed_id=f"seed_recovered_{hard_crash_phase.value}",
@@ -2184,7 +2214,139 @@ class TestEvolveStepResume:
         assert result.value.generation_result.generation_number == 2
         call = loop._run_generation.call_args
         assert call.kwargs["generation_number"] == 2
-        assert call.kwargs["current_seed"] == parent
+        expected_seed = candidate if hard_crash_phase == GenerationPhase.EVALUATING else parent
+        assert call.kwargs["current_seed"] == expected_seed
+        assert call.kwargs["resume_after_phase"] == last_completed
+        replayed = await store.replay_lineage(lineage_id)
+        assert (
+            sum(
+                event.type == "lineage.generation.started"
+                and event.data.get("generation_number") == 2
+                for event in replayed
+            )
+            == 1
+        )
+        assert (
+            sum(
+                event.type == "lineage.generation.completed"
+                and event.data.get("generation_number") == 2
+                for event in replayed
+            )
+            == 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_hard_crash_during_execute_fails_closed_without_redispatch(self) -> None:
+        """Unknown executor outcome requires reconciliation, never a duplicate call."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_execute_crash_parent")
+        candidate = make_seed(
+            seed_id="seed_execute_crash_candidate",
+            parent_seed_id=parent.metadata.seed_id,
+        )
+        lineage_id = "lin_execute_crash"
+        await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+        await store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id=lineage_id,
+                generation_number=2,
+                phase=GenerationPhase.EXECUTING,
+                last_completed_phase=GenerationPhase.SEEDING.value,
+                seed=candidate,
+                active_ac_indices=(0,),
+                frozen_ac_indices=(),
+            )
+        )
+        loop = make_loop(
+            store,
+            gen_result=GenerationResult(
+                generation_number=2,
+                seed=candidate,
+                evaluation_summary=make_eval_summary(),
+            ),
+        )
+
+        result = await loop.evolve_step(lineage_id, execute=True)
+
+        assert result.is_err
+        assert "Cannot safely redispatch" in str(result.error)
+        loop._run_generation.assert_not_awaited()
+        replayed = await store.replay_lineage(lineage_id)
+        assert not any(
+            event.type == "lineage.generation.completed"
+            and event.data.get("generation_number") == 2
+            for event in replayed
+        )
+
+    @pytest.mark.asyncio
+    async def test_hard_crash_during_evaluation_resumes_without_executor(self) -> None:
+        """Durable candidate/output authority lets evaluation continue exactly once."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_eval_crash_parent")
+        candidate = make_seed(
+            seed_id="seed_eval_crash_candidate",
+            parent_seed_id=parent.metadata.seed_id,
+        )
+        lineage_id = "lin_eval_crash"
+        await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+        await store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id=lineage_id,
+                generation_number=2,
+                phase=GenerationPhase.EVALUATING,
+                last_completed_phase=GenerationPhase.EXECUTING.value,
+                seed=candidate,
+                active_ac_indices=(0,),
+                frozen_ac_indices=(),
+                execution_output="durable execution",
+                execution_boundary_completed=True,
+                validation_boundary_completed=True,
+            )
+        )
+        projected = LineageProjector().project(await store.replay_lineage(lineage_id))
+        assert projected is not None
+        checkpoint = projected.generations[-1]
+        assert checkpoint.phase == GenerationPhase.EVALUATING
+        assert checkpoint.last_completed_phase == GenerationPhase.EXECUTING.value
+        assert Seed.from_dict(json.loads(checkpoint.seed_json or "{}")) == candidate
+        assert checkpoint.active_ac_indices == (0,)
+        assert checkpoint.frozen_ac_indices == ()
+        assert checkpoint.partial_state is not None
+        assert checkpoint.partial_state["execution_output"] == "durable execution"
+        executor = AsyncMock(return_value="must not run")
+        evaluator = AsyncMock(return_value=make_eval_summary(True))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=3),
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        result = await loop.evolve_step(lineage_id, execute=True)
+
+        assert result.is_ok
+        assert result.value.generation_result.seed == candidate
+        assert result.value.generation_result.execution_output == "durable execution"
+        executor.assert_not_awaited()
+        evaluator.assert_awaited_once_with(candidate, "durable execution")
         replayed = await store.replay_lineage(lineage_id)
         assert (
             sum(
@@ -2900,6 +3062,20 @@ class TestEvolveStepHandler:
                 json.dumps(seed.to_dict()),
             )
         )
+        await store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id="lin_explicit_recovery",
+                generation_number=1,
+                phase=GenerationPhase.EVALUATING,
+                last_completed_phase=GenerationPhase.EXECUTING.value,
+                seed=seed,
+                active_ac_indices=(0,),
+                frozen_ac_indices=(),
+                execution_output="durable execution",
+                execution_boundary_completed=True,
+                validation_boundary_completed=True,
+            )
+        )
         generation = GenerationResult(
             generation_number=1,
             seed=seed,
@@ -2946,6 +3122,11 @@ class TestEvolveStepHandler:
         assert result.value.meta["generation"] == 1
         loop._run_generation.assert_awaited_once()
         assert loop._run_generation.call_args.kwargs["generation_number"] == 1
+        assert loop._run_generation.call_args.kwargs["current_seed"] == seed
+        assert (
+            loop._run_generation.call_args.kwargs["resume_after_phase"]
+            == GenerationPhase.EXECUTING.value
+        )
         replayed = await store.replay_lineage("lin_explicit_recovery")
         assert not any(
             event.data.get("generation_number") == 2

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import fields, replace
 import inspect
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -376,6 +377,32 @@ class TestEvolutionaryLoopConfig:
         config = EvolutionaryLoopConfig(runtime_controls=controls)
 
         assert config.runtime_controls == controls
+
+    def test_explicit_absolute_project_shadows_config_and_cwd_in_handler_identity(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Only the effective workspace participates in the durable request key."""
+        from ouroboros.mcp.tools.evolution_handlers import _evolve_handler_request_key
+
+        explicit = (tmp_path / "explicit").resolve()
+        arguments = {
+            "lineage_id": "lin_explicit_workspace_identity",
+            "project_dir": str(explicit),
+        }
+
+        first = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=str(tmp_path / "configured-a"),
+            fallback_cwd=(tmp_path / "cwd-a").resolve(),
+        )
+        second = _evolve_handler_request_key(
+            arguments,
+            configured_project_dir=str(tmp_path / "configured-b"),
+            fallback_cwd=(tmp_path / "cwd-b").resolve(),
+        )
+
+        assert first == second
 
     def test_non_introspectable_executor_preserves_legacy_call_shape(
         self,
@@ -2828,6 +2855,10 @@ class TestEvolveStepHandler:
         owner_loop.evolve_step = AsyncMock(side_effect=blocked_evolve)
         duplicate_loop = make_loop(duplicate_store)
         duplicate_loop.evolve_step = AsyncMock(side_effect=AssertionError("duplicate core step"))
+        owner_project_token = owner_loop.set_project_dir(str(tmp_path / "configured-owner"))
+        duplicate_project_token = duplicate_loop.set_project_dir(
+            str(tmp_path / "configured-duplicate")
+        )
         owner_handler = EvolveStepHandler(evolutionary_loop=owner_loop)
         duplicate_handler = EvolveStepHandler(evolutionary_loop=duplicate_loop)
         workspace_calls = 0
@@ -2868,6 +2899,7 @@ class TestEvolveStepHandler:
         arguments = {
             "lineage_id": "lin_public_single_flight",
             "seed_content": yaml.safe_dump(seed.to_dict()),
+            "project_dir": str((tmp_path / "explicit-project").resolve()),
         }
         equivalent_arguments = {
             "lineage_id": "lin_public_single_flight",
@@ -2875,7 +2907,7 @@ class TestEvolveStepHandler:
             "execute": True,
             "parallel": True,
             "skip_qa": False,
-            "project_dir": None,
+            "project_dir": str((tmp_path / "explicit-project").resolve()),
             "recover_expired_claim": False,
         }
         assert arguments["seed_content"] != equivalent_arguments["seed_content"]
@@ -2885,6 +2917,10 @@ class TestEvolveStepHandler:
                 patch(
                     "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
                     side_effect=restore_workspace,
+                ),
+                patch(
+                    "ouroboros.mcp.tools.evolution_handlers.is_git_repo",
+                    return_value=True,
                 ),
                 patch("ouroboros.mcp.tools.qa.QAHandler", _CountingQAHandler),
                 patch(
@@ -2910,6 +2946,8 @@ class TestEvolveStepHandler:
             assert workspace_calls == 1
             assert qa_calls == 1
         finally:
+            owner_loop.reset_project_dir(owner_project_token)
+            duplicate_loop.reset_project_dir(duplicate_project_token)
             await owner_store.close()
             await duplicate_store.close()
 

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -52,7 +52,7 @@ from ouroboros.evolution.loop import (
     StepResult,
 )
 from ouroboros.evolution.projector import LineageProjector
-from ouroboros.evolution.reflect import ReflectOutput
+from ouroboros.evolution.reflect import ACPatch, ReflectOutput
 from ouroboros.evolution.watchdog import GenerationWatchdogTimeout
 from ouroboros.evolution.wonder import WonderOutput
 from ouroboros.mcp.server.adapter import _extract_feedback_metadata_from_artifact
@@ -866,6 +866,64 @@ class TestEvolveStepGen2:
         executor.assert_awaited_once()
         assert executor.await_args.args[0] == seed_v2
         evaluator.assert_awaited_once_with(seed_v2, "verified output")
+
+    @pytest.mark.asyncio
+    async def test_hard_crash_after_reflect_without_provenance_fails_closed(self) -> None:
+        """A truncated pre-Seed checkpoint cannot trigger provider replay."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_truncated_reflect_parent")
+        lineage_id = "lin_truncated_reflect_checkpoint"
+        await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+        await store.append(
+            lineage_generation_phase_changed(
+                lineage_id,
+                2,
+                GenerationPhase.SEEDING.value,
+                last_completed_phase=GenerationPhase.REFLECTING.value,
+                seed_id=parent.metadata.seed_id,
+                seed_json=json.dumps(parent.to_dict()),
+                active_ac_indices=[0],
+                frozen_ac_indices=[],
+                partial_state={
+                    "focus_checkpointed": True,
+                    "wonder_output_complete": True,
+                    "reflect_output_complete": True,
+                    "reflect_output": {
+                        "refined_goal": parent.goal,
+                        "refined_constraints": list(parent.constraints),
+                        "refined_acs": ["Tasks can be created"],
+                        "ac_patches": [{"op": "keep", "index": 0}],
+                    },
+                    # reflect_patch_identity_explicit was truncated.
+                },
+            )
+        )
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock()
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        loop = EvolutionaryLoop(
+            event_store=store,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=SeedGenerator(llm_adapter=AsyncMock()),
+        )
+
+        result = await loop.evolve_step(lineage_id, execute=False)
+
+        assert result.is_err
+        assert "patch provenance" in str(result.error)
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_ontology_stable_handoff_survives_directive_append_failure(self) -> None:
@@ -2181,6 +2239,18 @@ class TestEvolveStepResume:
                     seed=checkpoint_seed,
                     active_ac_indices=(0,),
                     frozen_ac_indices=(),
+                    reflect_output=(
+                        ReflectOutput(
+                            refined_goal=parent.goal,
+                            refined_constraints=parent.constraints,
+                            refined_acs=tuple(
+                                criterion.description for criterion in parent.acceptance_criteria
+                            ),
+                            reasoning="durable reflect",
+                        )
+                        if hard_crash_phase == GenerationPhase.SEEDING
+                        else None
+                    ),
                     execution_output=(
                         "durable execution"
                         if hard_crash_phase == GenerationPhase.EVALUATING
@@ -2234,6 +2304,113 @@ class TestEvolveStepResume:
             )
             == 1
         )
+
+    @pytest.mark.asyncio
+    async def test_hard_crash_after_reflect_restores_exact_outputs_without_model_replay(
+        self,
+    ) -> None:
+        """A complete Reflect checkpoint resumes at Seed with identical authority."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_reflect_checkpoint_parent").model_copy(
+            update={
+                "acceptance_criteria": (
+                    "Tasks can be created",
+                    "Tasks can be deleted",
+                )
+            }
+        )
+        parent = Seed.from_dict(parent.to_dict())
+        prior_evaluation = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            score=0.5,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Tasks can be created",
+                    passed=True,
+                ),
+                ACResult(
+                    ac_index=1,
+                    ac_content="Tasks can be deleted",
+                    passed=False,
+                ),
+            ),
+        )
+        lineage_id = "lin_reflect_checkpoint"
+        await seed_events_for_gen1(store, lineage_id, parent, prior_evaluation)
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                GenerationPhase.WONDERING.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+        wonder_output = WonderOutput(
+            questions=(),
+            grounded_questions=(),
+            ontology_tensions=("Deletion semantics remain underspecified",),
+            should_continue=True,
+            reasoning="Continue despite the empty question list",
+        )
+        reflect_output = ReflectOutput(
+            refined_goal=parent.goal,
+            refined_constraints=parent.constraints,
+            refined_acs=("Tasks can be created", "Tasks can be archived"),
+            ac_patches=(
+                ACPatch(op="keep", index=0, reason="authoritative pass"),
+                ACPatch(
+                    op="revise",
+                    index=1,
+                    content="Tasks can be archived",
+                    reason="repair failed node",
+                ),
+            ),
+            settled_ac_indices=(0,),
+            ontology_mutations=(),
+            reasoning="Patch only the failed node",
+        )
+        reflect_output.restore_durable_patch_identity(parent)
+        await store.append(
+            loop_support.generation_phase_checkpoint(
+                lineage_id=lineage_id,
+                generation_number=2,
+                phase=GenerationPhase.SEEDING,
+                last_completed_phase=GenerationPhase.REFLECTING.value,
+                seed=parent,
+                active_ac_indices=(1,),
+                frozen_ac_indices=(0,),
+                wonder_output=wonder_output,
+                reflect_output=reflect_output,
+            )
+        )
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock()
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(focused_evolution=True),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=SeedGenerator(llm_adapter=AsyncMock()),
+        )
+
+        result = await loop.evolve_step(lineage_id, execute=False)
+
+        assert result.is_ok
+        generation = result.value.generation_result
+        assert generation.wonder_output == wonder_output
+        assert generation.reflect_output is not None
+        assert generation.reflect_output.ac_patch_identity_explicit is True
+        assert tuple(
+            criterion.description for criterion in generation.seed.acceptance_criteria
+        ) == ("Tasks can be created", "Tasks can be archived")
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_hard_crash_during_execute_fails_closed_without_redispatch(self) -> None:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -1,6 +1,7 @@
 """Unit tests for evolve_step() — single-generation stepping API."""
 
 import asyncio
+from dataclasses import fields, replace
 import inspect
 import json
 from types import SimpleNamespace
@@ -261,6 +262,109 @@ class TestEvolutionaryLoopConfig:
         )
 
         assert config.runtime_controls.generation_no_progress_timeout_seconds == 123
+
+    def test_every_execution_policy_field_changes_core_and_handler_request_identity(self) -> None:
+        """Rolling workers with any execution-significant config drift cannot coalesce."""
+        from pathlib import Path
+
+        from ouroboros.mcp.tools.evolution_handlers import _evolve_handler_request_key
+
+        base = EvolutionaryLoopConfig(runtime_controls=RuntimeControlsConfig())
+        alternatives = {
+            "max_generations": 31,
+            "convergence_threshold": 0.9,
+            "stagnation_window": 4,
+            "min_generations": 2,
+            "generation_timeout_seconds": 1,
+            "runtime_controls": RuntimeControlsConfig(mcp_tool_timeout_seconds=1),
+            "enable_oscillation_detection": False,
+            "eval_gate_enabled": False,
+            "eval_min_score": 0.8,
+            "outcome_gate_enabled": False,
+            "evaluation_plateau_epsilon": 0.02,
+            "scoped_reexecution": False,
+            "focused_evolution": False,
+        }
+        declared_fields = {item.name for item in fields(EvolutionaryLoopConfig)}
+        assert set(alternatives) == declared_fields
+
+        base_policy = loop_support.evolution_execution_policy(base)
+        assert base_policy is not None
+        assert set(base_policy) == declared_fields
+        core_key = loop_support.evolve_request_key(
+            None,
+            execute=True,
+            parallel=True,
+            conductor_directive=None,
+            generation_number=2,
+            execution_policy=base_policy,
+        )
+        handler_key = _evolve_handler_request_key(
+            {"lineage_id": "lin_policy"},
+            configured_project_dir=None,
+            fallback_cwd=Path.cwd().resolve(),
+            execution_policy=base_policy,
+        )
+
+        for field_name, alternative in alternatives.items():
+            changed_policy = loop_support.evolution_execution_policy(
+                replace(base, **{field_name: alternative})
+            )
+            assert changed_policy is not None
+            assert changed_policy != base_policy, field_name
+            assert (
+                loop_support.evolve_request_key(
+                    None,
+                    execute=True,
+                    parallel=True,
+                    conductor_directive=None,
+                    generation_number=2,
+                    execution_policy=changed_policy,
+                )
+                != core_key
+            ), field_name
+            assert (
+                _evolve_handler_request_key(
+                    {"lineage_id": "lin_policy"},
+                    configured_project_dir=None,
+                    fallback_cwd=Path.cwd().resolve(),
+                    execution_policy=changed_policy,
+                )
+                != handler_key
+            ), field_name
+
+        declared_runtime_fields = set(RuntimeControlsConfig.model_fields)
+        assert set(base_policy["runtime_controls"]) == declared_runtime_fields
+        for field_name in declared_runtime_fields:
+            runtime_values = base.runtime_controls.model_dump()
+            runtime_values[field_name] = float(runtime_values[field_name]) + 1.0
+            changed_policy = loop_support.evolution_execution_policy(
+                replace(
+                    base,
+                    runtime_controls=RuntimeControlsConfig.model_validate(runtime_values),
+                )
+            )
+            assert changed_policy is not None
+            assert (
+                loop_support.evolve_request_key(
+                    None,
+                    execute=True,
+                    parallel=True,
+                    conductor_directive=None,
+                    generation_number=2,
+                    execution_policy=changed_policy,
+                )
+                != core_key
+            ), f"runtime_controls.{field_name}"
+            assert (
+                _evolve_handler_request_key(
+                    {"lineage_id": "lin_policy"},
+                    configured_project_dir=None,
+                    fallback_cwd=Path.cwd().resolve(),
+                    execution_policy=changed_policy,
+                )
+                != handler_key
+            ), f"runtime_controls.{field_name}"
 
     def test_explicit_runtime_controls_are_preserved(self) -> None:
         controls = RuntimeControlsConfig(
@@ -2027,6 +2131,78 @@ class TestEvolveStepResume:
         step = result.value
         assert step.generation_result.generation_number == 2
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "hard_crash_phase",
+        [
+            GenerationPhase.WONDERING,
+            GenerationPhase.REFLECTING,
+            GenerationPhase.SEEDING,
+            GenerationPhase.EXECUTING,
+            GenerationPhase.EVALUATING,
+        ],
+    )
+    async def test_hard_crash_replays_the_unfinished_generation(
+        self,
+        hard_crash_phase: GenerationPhase,
+    ) -> None:
+        """A recovered nonterminal generation never advances under a new identity."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_hard_crash_parent")
+        lineage_id = f"lin_hard_crash_{hard_crash_phase.value}"
+        await seed_events_for_gen1(store, lineage_id, parent, make_eval_summary(False))
+        await store.append(
+            lineage_generation_started(
+                lineage_id,
+                2,
+                hard_crash_phase.value,
+                parent.metadata.seed_id,
+                json.dumps(parent.to_dict()),
+            )
+        )
+
+        successor = make_seed(
+            seed_id=f"seed_recovered_{hard_crash_phase.value}",
+            parent_seed_id=parent.metadata.seed_id,
+        )
+        loop = make_loop(
+            store,
+            gen_result=GenerationResult(
+                generation_number=2,
+                seed=successor,
+                evaluation_summary=make_eval_summary(),
+                phase=GenerationPhase.COMPLETED,
+                success=True,
+            ),
+        )
+
+        planned = await loop_support.planned_evolve_generation(store, lineage_id, execute=True)
+        result = await loop.evolve_step(lineage_id)
+
+        assert planned == 2
+        assert result.is_ok
+        assert result.value.generation_result.generation_number == 2
+        call = loop._run_generation.call_args
+        assert call.kwargs["generation_number"] == 2
+        assert call.kwargs["current_seed"] == parent
+        replayed = await store.replay_lineage(lineage_id)
+        assert (
+            sum(
+                event.type == "lineage.generation.started"
+                and event.data.get("generation_number") == 2
+                for event in replayed
+            )
+            == 1
+        )
+        assert (
+            sum(
+                event.type == "lineage.generation.completed"
+                and event.data.get("generation_number") == 2
+                for event in replayed
+            )
+            == 1
+        )
+
 
 class TestRunGenerationFailures:
     """Test failure event emission inside _run_generation()."""
@@ -2714,6 +2890,16 @@ class TestEvolveStepHandler:
 
         store = await create_event_store()
         seed = make_seed(seed_id="seed_explicit_recovery")
+        await store.append(lineage_created("lin_explicit_recovery", seed.goal))
+        await store.append(
+            lineage_generation_started(
+                "lin_explicit_recovery",
+                1,
+                GenerationPhase.EXECUTING.value,
+                seed.metadata.seed_id,
+                json.dumps(seed.to_dict()),
+            )
+        )
         generation = GenerationResult(
             generation_number=1,
             seed=seed,
@@ -2757,6 +2943,31 @@ class TestEvolveStepHandler:
             )
 
         assert result.is_ok
+        assert result.value.meta["generation"] == 1
+        loop._run_generation.assert_awaited_once()
+        assert loop._run_generation.call_args.kwargs["generation_number"] == 1
+        replayed = await store.replay_lineage("lin_explicit_recovery")
+        assert not any(
+            event.data.get("generation_number") == 2
+            for event in replayed
+            if event.type.startswith("lineage.generation.")
+        )
+        assert (
+            sum(
+                event.type == "lineage.generation.started"
+                and event.data.get("generation_number") == 1
+                for event in replayed
+            )
+            == 1
+        )
+        assert (
+            sum(
+                event.type == "lineage.generation.completed"
+                and event.data.get("generation_number") == 1
+                for event in replayed
+            )
+            == 1
+        )
         current = await lineage_claims.observe(
             store,
             scope="evolve-core",
@@ -2814,6 +3025,7 @@ class TestEvolveStepHandler:
             original_arguments,
             configured_project_dir=None,
             fallback_cwd=Path.cwd().resolve(),
+            execution_policy=loop_support.evolution_execution_policy(loop.config),
         )
         default_lease_seconds = lineage_claims.DEFAULT_LEASE_SECONDS
         monkeypatch.setattr(lineage_claims, "DEFAULT_LEASE_SECONDS", 0.01)

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -11,6 +11,7 @@ from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.directive import Directive
 from ouroboros.core.errors import OuroborosError
 from ouroboros.core.lineage import (
+    ACResult,
     EvaluationSummary,
     FeedbackMetadata,
     GenerationPhase,
@@ -124,6 +125,13 @@ def make_eval_summary(approved: bool = True, score: float = 0.85) -> EvaluationS
         final_approved=approved,
         highest_stage_passed=2,
         score=score,
+        ac_results=(
+            ACResult(
+                ac_index=0,
+                ac_content="Tasks can be created",
+                passed=approved,
+            ),
+        ),
     )
 
 
@@ -1408,7 +1416,56 @@ class TestEvolveStepHandler:
         assert result.is_ok
         assert "Generation 1" in result.value.text_content
         assert result.value.meta["action"] == "converged"
+        assert result.value.meta["converged"] is True
         assert result.value.meta["qa_attempted"] is False
+
+    @pytest.mark.asyncio
+    async def test_handler_does_not_publish_stagnation_as_verified_convergence(self) -> None:
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        store = await create_event_store()
+        seed = make_seed()
+        generation = GenerationResult(
+            generation_number=3,
+            seed=seed,
+            evaluation_summary=make_eval_summary(approved=False),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        loop = make_loop(store, gen_result=generation)
+        loop.evolve_step = AsyncMock(
+            return_value=Result.ok(
+                StepResult(
+                    generation_result=generation,
+                    convergence_signal=ConvergenceSignal(
+                        converged=False,
+                        reason="Stagnation detected: repetitive feedback questions",
+                        ontology_similarity=0.0,
+                        generation=3,
+                        should_stop=True,
+                    ),
+                    lineage=OntologyLineage(lineage_id="lin_stagnated_meta", goal=seed.goal),
+                    action=StepAction.STAGNATED,
+                    next_generation=4,
+                )
+            )
+        )
+        handler = EvolveStepHandler(evolutionary_loop=loop)
+
+        with patch(
+            "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+            return_value=None,
+        ):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_stagnated_meta",
+                    "skip_qa": True,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["action"] == "stagnated"
+        assert result.value.meta["converged"] is False
 
     @pytest.mark.asyncio
     async def test_handler_publishes_qa_attempt_when_qa_returns_no_result(self) -> None:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -1,5 +1,6 @@
 """Unit tests for evolve_step() — single-generation stepping API."""
 
+import asyncio
 import inspect
 import json
 from types import SimpleNamespace
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.directive import Directive
 from ouroboros.core.errors import OuroborosError
@@ -21,6 +23,7 @@ from ouroboros.core.lineage import (
     OntologyLineage,
 )
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
@@ -38,6 +41,7 @@ from ouroboros.events.lineage import (
     lineage_generation_phase_changed,
     lineage_generation_started,
 )
+from ouroboros.evolution import loop_support
 from ouroboros.evolution.convergence import ConvergenceSignal
 from ouroboros.evolution.loop import (
     EvolutionaryLoop,
@@ -292,11 +296,12 @@ class TestStepTypes:
         """StepAction has all expected values."""
         assert StepAction.CONTINUE == "continue"
         assert StepAction.CONVERGED == "converged"
+        assert StepAction.ONTOLOGY_STABLE == "ontology_stable"
         assert StepAction.STAGNATED == "stagnated"
         assert StepAction.EXHAUSTED == "exhausted"
         assert StepAction.FAILED == "failed"
         assert StepAction.INTERRUPTED == "interrupted"
-        assert len(StepAction) == 6
+        assert len(StepAction) == 7
 
     def test_step_result_is_frozen(self) -> None:
         """StepResult is frozen dataclass."""
@@ -611,6 +616,839 @@ class TestEvolveStepGen2:
         call_args = loop._run_generation.call_args
         passed_seed = call_args.kwargs.get("current_seed") or call_args[0][2]
         assert passed_seed.metadata.seed_id == "seed_v1"
+
+    @pytest.mark.asyncio
+    async def test_ontology_only_generations_keep_reflecting_without_evaluation(self) -> None:
+        """No-execute exploration must keep mutating after evaluation disappears."""
+        store = await create_event_store()
+        seed_v1 = make_seed(
+            seed_id="seed_ontology_1",
+            fields=(OntologyField(name="task", field_type="entity", description="task"),),
+        )
+        seed_v2 = make_seed(
+            seed_id="seed_ontology_2",
+            parent_seed_id="seed_ontology_1",
+            fields=(OntologyField(name="owner", field_type="entity", description="owner"),),
+        )
+        seed_v3 = make_seed(
+            seed_id="seed_ontology_3",
+            parent_seed_id="seed_ontology_2",
+            fields=(OntologyField(name="policy", field_type="entity", description="policy"),),
+        )
+        await seed_events_for_gen1(store, "lin_ontology_reflect", seed_v1)
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(
+            side_effect=(
+                Result.ok(make_wonder_output(("Who owns each task?",))),
+                Result.ok(make_wonder_output(("Which policy governs the owner?",))),
+            )
+        )
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock(
+            side_effect=(
+                Result.ok(
+                    ReflectOutput(
+                        refined_goal=seed_v1.goal,
+                        refined_constraints=seed_v1.constraints,
+                        refined_acs=("Tasks can be created",),
+                        reasoning="add owner",
+                    )
+                ),
+                Result.ok(
+                    ReflectOutput(
+                        refined_goal=seed_v2.goal,
+                        refined_constraints=seed_v2.constraints,
+                        refined_acs=("Tasks can be created",),
+                        reasoning="add policy",
+                    )
+                ),
+            )
+        )
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock(
+            side_effect=(Result.ok(seed_v2), Result.ok(seed_v3))
+        )
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=2, convergence_threshold=0.99),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+        )
+
+        generation_2 = await loop.evolve_step("lin_ontology_reflect", execute=False)
+        generation_3 = await loop.evolve_step("lin_ontology_reflect", execute=False)
+
+        assert generation_2.is_ok and generation_3.is_ok
+        assert generation_2.value.action is StepAction.CONTINUE
+        assert generation_3.value.action is StepAction.CONTINUE
+        assert generation_2.value.generation_result.seed.metadata.seed_id == "seed_ontology_2"
+        assert generation_3.value.generation_result.seed.metadata.seed_id == "seed_ontology_3"
+        assert reflect_engine.reflect.await_count == 2
+        assert all(
+            call.kwargs["evaluation_summary"] is None
+            for call in reflect_engine.reflect.await_args_list
+        )
+        assert seed_generator.generate_from_reflect.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ontology_stable_handoff_verifies_current_seed_without_wonder(self) -> None:
+        """The durable EVALUATE handoff must force Execute -> Evaluate on the stable Seed."""
+        store = await create_event_store()
+        seed_v1 = make_seed(
+            seed_id="seed_handoff_1",
+            fields=(OntologyField(name="task", field_type="entity", description="task"),),
+        )
+        seed_v2 = make_seed(
+            seed_id="seed_handoff_2",
+            parent_seed_id="seed_handoff_1",
+            fields=(OntologyField(name="owner", field_type="entity", description="owner"),),
+        )
+        await seed_events_for_gen1(store, "lin_verification_handoff", seed_v1)
+        await store.append(
+            lineage_generation_completed(
+                "lin_verification_handoff",
+                generation_number=2,
+                seed_id=seed_v2.metadata.seed_id,
+                ontology_snapshot=seed_v2.ontology_schema.model_dump(mode="json"),
+                evaluation_summary=None,
+                wonder_questions=["ownership clarified"],
+                seed_json=json.dumps(seed_v2.to_dict()),
+                parent_seed_id=seed_v2.metadata.parent_seed_id,
+            )
+        )
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(
+            return_value=Result.ok(make_wonder_output(questions=(), should_continue=False))
+        )
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock()
+        executor = AsyncMock(return_value="verified output")
+        evaluator = AsyncMock(return_value=make_eval_summary(approved=True, score=1.0))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=2, convergence_threshold=0.95),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        stable = await loop.evolve_step("lin_verification_handoff", execute=False)
+
+        assert stable.is_ok
+        assert stable.value.action is StepAction.ONTOLOGY_STABLE
+        assert stable.value.convergence_signal.converged is False
+        assert stable.value.lineage.status is LineageStatus.ACTIVE
+        wonder_engine.wonder.reset_mock()
+        reflect_engine.reflect.reset_mock()
+        seed_generator.generate_from_reflect.reset_mock()
+
+        verified = await loop.evolve_step("lin_verification_handoff", execute=True)
+
+        assert verified.is_ok
+        assert verified.value.action is StepAction.CONVERGED
+        assert verified.value.generation_result.seed == seed_v2
+        assert verified.value.generation_result.active_ac_indices == (0,)
+        assert verified.value.generation_result.frozen_ac_indices == ()
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
+        seed_generator.generate_from_reflect.assert_not_called()
+        executor.assert_awaited_once()
+        assert executor.await_args.args[0] == seed_v2
+        evaluator.assert_awaited_once_with(seed_v2, "verified output")
+
+    @pytest.mark.asyncio
+    async def test_ontology_stable_handoff_survives_directive_append_failure(self) -> None:
+        """Completed generation atomically retains the verification handoff authority."""
+        store = await create_event_store()
+        seed_v1 = make_seed(
+            seed_id="seed_atomic_handoff_1",
+            fields=(OntologyField(name="task", field_type="entity", description="task"),),
+        )
+        seed_v2 = make_seed(
+            seed_id="seed_atomic_handoff_2",
+            parent_seed_id=seed_v1.metadata.seed_id,
+            fields=(OntologyField(name="owner", field_type="entity", description="owner"),),
+        )
+        await seed_events_for_gen1(store, "lin_atomic_handoff", seed_v1)
+        await store.append(
+            lineage_generation_completed(
+                "lin_atomic_handoff",
+                generation_number=2,
+                seed_id=seed_v2.metadata.seed_id,
+                ontology_snapshot=seed_v2.ontology_schema.model_dump(mode="json"),
+                evaluation_summary=None,
+                wonder_questions=["ownership clarified"],
+                seed_json=json.dumps(seed_v2.to_dict()),
+                parent_seed_id=seed_v2.metadata.parent_seed_id,
+            )
+        )
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(
+            return_value=Result.ok(make_wonder_output(questions=(), should_continue=False))
+        )
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        executor = AsyncMock(return_value="verified output")
+        evaluator = AsyncMock(return_value=make_eval_summary(approved=True, score=1.0))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=2, convergence_threshold=0.95),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            executor=executor,
+            evaluator=evaluator,
+        )
+        original_append = store.append
+
+        async def fail_ontology_stable_directive(event):  # type: ignore[no-untyped-def]
+            if (
+                event.type == "control.directive.emitted"
+                and event.data.get("extra", {}).get("step_action") == "ontology_stable"
+            ):
+                raise OSError("injected directive append failure")
+            return await original_append(event)
+
+        with patch.object(store, "append", side_effect=fail_ontology_stable_directive):
+            first = await loop.evolve_step("lin_atomic_handoff", execute=False)
+
+        assert first.is_ok
+        assert first.value.action is StepAction.ONTOLOGY_STABLE
+        events = await store.replay_lineage("lin_atomic_handoff")
+        completed = [event for event in events if event.type == "lineage.generation.completed"][-1]
+        assert completed.data["verification_handoff_pending"] is True
+        replayed = LineageProjector().project(events)
+        assert replayed is not None
+        assert replayed.verification_handoff_pending is True
+
+        wonder_engine.wonder.reset_mock()
+        reflect_engine.reflect.reset_mock()
+        repeated = await loop.evolve_step("lin_atomic_handoff", execute=False)
+
+        assert repeated.is_ok
+        assert repeated.value.action is StepAction.ONTOLOGY_STABLE
+        assert repeated.value.generation_result.seed == seed_v2
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
+
+        override = make_seed(seed_id="seed_must_not_replace_pending_handoff")
+        repeated_with_override = await loop.evolve_step(
+            "lin_atomic_handoff",
+            initial_seed=override,
+            execute=False,
+        )
+
+        assert repeated_with_override.is_ok
+        assert repeated_with_override.value.generation_result.seed == seed_v2
+        verified = await loop.evolve_step(
+            "lin_atomic_handoff",
+            initial_seed=override,
+            execute=True,
+        )
+
+        assert verified.is_ok
+        assert verified.value.generation_result.seed == seed_v2
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
+        executor.assert_awaited_once()
+        evaluator.assert_awaited_once_with(seed_v2, "verified output")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_lineage_replays_one_ontology_stable_winner(self) -> None:
+        """Overlapping retries must share one provider path and durable generation."""
+        store = await create_event_store()
+        lineage_id = "lin_concurrent_evolve"
+        seed_v1 = make_seed(
+            seed_id="seed_concurrent_1",
+            fields=(OntologyField(name="task", field_type="entity", description="task"),),
+        )
+        seed_v2 = make_seed(
+            seed_id="seed_concurrent_2",
+            parent_seed_id=seed_v1.metadata.seed_id,
+            fields=(OntologyField(name="owner", field_type="entity", description="owner"),),
+        )
+        seed_v3 = make_seed(
+            seed_id="seed_concurrent_3",
+            parent_seed_id=seed_v2.metadata.seed_id,
+            fields=seed_v2.ontology_schema.fields,
+        )
+        await seed_events_for_gen1(store, lineage_id, seed_v1)
+        await store.append(
+            lineage_generation_completed(
+                lineage_id,
+                generation_number=2,
+                seed_id=seed_v2.metadata.seed_id,
+                ontology_snapshot=seed_v2.ontology_schema.model_dump(mode="json"),
+                evaluation_summary=None,
+                wonder_questions=["ownership clarified"],
+                seed_json=json.dumps(seed_v2.to_dict()),
+                parent_seed_id=seed_v2.metadata.parent_seed_id,
+            )
+        )
+
+        wonder_entered = asyncio.Event()
+        release_wonder = asyncio.Event()
+
+        async def stable_wonder(*args, **kwargs):  # type: ignore[no-untyped-def]
+            wonder_entered.set()
+            await release_wonder.wait()
+            return Result.ok(make_wonder_output(("What remains unresolved?",)))
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(side_effect=stable_wonder)
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock(
+            return_value=Result.ok(
+                ReflectOutput(
+                    refined_goal=seed_v2.goal,
+                    refined_constraints=seed_v2.constraints,
+                    refined_acs=("Tasks can be created",),
+                    reasoning="stable ontology",
+                )
+            )
+        )
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock(return_value=Result.ok(seed_v3))
+        config = EvolutionaryLoopConfig(min_generations=2, convergence_threshold=0.95)
+        first_loop = EvolutionaryLoop(
+            event_store=store,
+            config=config,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+        )
+        retry_loop = EvolutionaryLoop(
+            event_store=store,
+            config=config,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+        )
+
+        first_task = asyncio.create_task(first_loop.evolve_step(lineage_id, execute=False))
+        await wonder_entered.wait()
+        retry_task = asyncio.create_task(retry_loop.evolve_step(lineage_id, execute=False))
+        await asyncio.sleep(0)
+        assert not retry_task.done()
+        release_wonder.set()
+        first, retry = await asyncio.gather(first_task, retry_task)
+
+        assert first.is_ok and retry.is_ok
+        assert first is retry
+        assert first.value.action is StepAction.ONTOLOGY_STABLE
+        assert retry.value.action is StepAction.ONTOLOGY_STABLE
+        assert first.value.generation_result.generation_number == 3
+        assert retry.value.generation_result.generation_number == 3
+        assert first.value.generation_result.seed == retry.value.generation_result.seed
+        assert first.value.next_generation == retry.value.next_generation == 4
+        wonder_engine.wonder.assert_awaited_once()
+        reflect_engine.reflect.assert_awaited_once()
+        seed_generator.generate_from_reflect.assert_called_once()
+
+        events = await store.replay_lineage(lineage_id)
+        generation_started = [
+            event
+            for event in events
+            if event.type == "lineage.generation.started"
+            and event.data.get("generation_number") == 3
+        ]
+        generation_completed = [
+            event
+            for event in events
+            if event.type == "lineage.generation.completed"
+            and event.data.get("generation_number") == 3
+        ]
+        stable_directives = [
+            event
+            for event in events
+            if event.type == "control.directive.emitted"
+            and event.data.get("generation_number") == 3
+            and event.data.get("extra", {}).get("step_action") == "ontology_stable"
+        ]
+        assert len(generation_started) == 1
+        assert len(generation_completed) == 1
+        assert len(stable_directives) == 1
+
+    @pytest.mark.asyncio
+    async def test_different_single_flight_request_waits_before_retrying(self) -> None:
+        """A changed evolve request starts only after the winner is durable."""
+        store = await create_event_store()
+        winner_entered = asyncio.Event()
+        release_winner = asyncio.Event()
+        order: list[str] = []
+
+        async def winner() -> str:
+            order.append("winner_started")
+            winner_entered.set()
+            await release_winner.wait()
+            order.append("winner_completed")
+            return "winner"
+
+        async def retry() -> str:
+            order.append("retry_started")
+            return "retry"
+
+        first = asyncio.create_task(
+            loop_support.run_lineage_single_flight(store, "lineage", "request-a", winner)
+        )
+        await winner_entered.wait()
+        second = asyncio.create_task(
+            loop_support.run_lineage_single_flight(store, "lineage", "request-b", retry)
+        )
+        await asyncio.sleep(0)
+
+        assert order == ["winner_started"]
+        release_winner.set()
+        assert await asyncio.gather(first, second) == ["winner", "retry"]
+        assert order == ["winner_started", "winner_completed", "retry_started"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_duplicate_does_not_cancel_single_flight_winner(self) -> None:
+        """One retry caller cannot abort provider work shared by another caller."""
+        store = await create_event_store()
+        winner_entered = asyncio.Event()
+        release_winner = asyncio.Event()
+
+        async def winner() -> str:
+            winner_entered.set()
+            await release_winner.wait()
+            return "durable"
+
+        first = asyncio.create_task(
+            loop_support.run_lineage_single_flight(store, "lineage", "same-request", winner)
+        )
+        await winner_entered.wait()
+        duplicate = asyncio.create_task(
+            loop_support.run_lineage_single_flight(store, "lineage", "same-request", winner)
+        )
+        await asyncio.sleep(0)
+        duplicate.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await duplicate
+        release_winner.set()
+        assert await first == "durable"
+
+    @pytest.mark.asyncio
+    async def test_failed_generation_same_request_retries_without_second_started_event(
+        self,
+    ) -> None:
+        """A transient failure deduplicates overlap but does not pin the lineage forever."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_retryable_failure")
+        executor = AsyncMock(side_effect=[RuntimeError("transient"), "recovered output"])
+        evaluator = AsyncMock(return_value=make_eval_summary(approved=True, score=1.0))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=1),
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        failed = await loop.evolve_step("lin_retryable_failure", initial_seed=seed)
+        recovered = await loop.evolve_step("lin_retryable_failure", initial_seed=seed)
+
+        assert failed.is_ok and failed.value.action is StepAction.FAILED
+        assert recovered.is_ok and recovered.value.action is StepAction.CONVERGED
+        assert executor.await_count == 2
+        events = await store.replay_lineage("lin_retryable_failure")
+        started = [
+            event
+            for event in events
+            if event.type == "lineage.generation.started"
+            and event.data.get("generation_number") == 1
+        ]
+        completed = [
+            event
+            for event in events
+            if event.type == "lineage.generation.completed"
+            and event.data.get("generation_number") == 1
+        ]
+        assert len(started) == 1
+        assert len(completed) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_question_wonder_reverifies_non_authoritative_pass(self) -> None:
+        """Wonder may skip Reflect, but execute=True must still verify every unknown AC."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_unknown_pass")
+        unknown_pass = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Tasks can be created",
+                    passed=True,
+                    ac_verdict_state="not_evaluated",
+                ),
+            ),
+        )
+        await seed_events_for_gen1(store, "lin_unknown_pass", seed, unknown_pass)
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(
+            return_value=Result.ok(make_wonder_output(questions=(), should_continue=False))
+        )
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        executor = AsyncMock(return_value="fresh execution")
+        evaluator = AsyncMock(return_value=make_eval_summary(approved=True, score=1.0))
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(min_generations=2),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        result = await loop.evolve_step("lin_unknown_pass", execute=True)
+
+        assert result.is_ok
+        assert result.value.generation_result.active_ac_indices == (0,)
+        assert result.value.generation_result.frozen_ac_indices == ()
+        reflect_engine.reflect.assert_not_awaited()
+        executor.assert_awaited_once()
+        evaluator.assert_awaited_once_with(seed, "fresh execution")
+
+    @pytest.mark.asyncio
+    async def test_resume_preserves_ambiguous_legacy_unstructured_ac_list(self) -> None:
+        """Old interrupted Reflect output cannot delete/reorder parent prose ACs on resume."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_legacy_resume").model_copy(
+            update={
+                "acceptance_criteria": (
+                    "Tasks can be created",
+                    "Tasks can be deleted",
+                    "Tasks can be listed",
+                )
+            }
+        )
+        await seed_events_for_gen1(store, "lin_legacy_resume", seed, make_eval_summary(False))
+        await store.append(lineage_generation_started("lin_legacy_resume", 2, "wondering"))
+        await store.append(lineage_generation_phase_changed("lin_legacy_resume", 2, "reflecting"))
+        await store.append(
+            lineage_generation_interrupted(
+                "lin_legacy_resume",
+                2,
+                last_completed_phase="reflecting",
+                partial_state={
+                    "wonder_questions": ["What remains unresolved?"],
+                    "reflect_output": {
+                        "refined_goal": seed.goal,
+                        "refined_constraints": list(seed.constraints),
+                        "refined_acs": ["Tasks can be created"],
+                        "ontology_mutations": [],
+                        "reasoning": "legacy persisted output",
+                    },
+                },
+                seed_json=json.dumps(seed.to_dict()),
+            )
+        )
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock()
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        loop = EvolutionaryLoop(
+            event_store=store,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=SeedGenerator(llm_adapter=AsyncMock()),
+        )
+
+        result = await loop.evolve_step("lin_legacy_resume", execute=False)
+
+        assert result.is_ok
+        assert tuple(
+            criterion.description
+            for criterion in result.value.generation_result.seed.acceptance_criteria
+        ) == (
+            "Tasks can be created",
+            "Tasks can be deleted",
+            "Tasks can be listed",
+        )
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resume_discards_unsafe_legacy_structured_ac_rewrite(self) -> None:
+        """Resume keeps structured parent authority instead of failing or rebinding it."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_structured_resume").model_copy(
+            update={
+                "acceptance_criteria": (
+                    AcceptanceCriterionSpec(
+                        description="Tasks can be created",
+                        verify_command="pytest -q tests/test_create.py",
+                    ),
+                    AcceptanceCriterionSpec(
+                        description="Tasks can be deleted",
+                        verify_command="pytest -q tests/test_delete.py",
+                    ),
+                )
+            }
+        )
+        seed = Seed.from_dict(seed.to_dict())
+        await seed_events_for_gen1(store, "lin_structured_resume", seed, make_eval_summary(False))
+        await store.append(lineage_generation_started("lin_structured_resume", 2, "wondering"))
+        await store.append(
+            lineage_generation_phase_changed("lin_structured_resume", 2, "reflecting")
+        )
+        await store.append(
+            lineage_generation_interrupted(
+                "lin_structured_resume",
+                2,
+                last_completed_phase="reflecting",
+                partial_state={
+                    "wonder_questions": ["What remains unresolved?"],
+                    "reflect_output": {
+                        "refined_goal": seed.goal,
+                        "refined_constraints": list(seed.constraints),
+                        "refined_acs": ["Rewrite structured task creation"],
+                        "ontology_mutations": [],
+                        "reasoning": "legacy persisted output",
+                    },
+                },
+                seed_json=json.dumps(seed.to_dict()),
+            )
+        )
+        loop = EvolutionaryLoop(
+            event_store=store,
+            seed_generator=SeedGenerator(llm_adapter=AsyncMock()),
+        )
+
+        result = await loop.evolve_step("lin_structured_resume", execute=False)
+
+        assert result.is_ok
+        assert result.value.generation_result.seed.acceptance_criteria == seed.acceptance_criteria
+
+    @pytest.mark.asyncio
+    async def test_resume_reruns_patch_bearing_structured_ac_rewrite(self) -> None:
+        """Serialized patches cannot restore process-local parser provenance."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_patch_resume").model_copy(
+            update={
+                "acceptance_criteria": (
+                    AcceptanceCriterionSpec(
+                        description="Tasks can be created",
+                        verify_command="pytest -q tests/test_create.py",
+                    ),
+                    AcceptanceCriterionSpec(
+                        description="Tasks can be deleted",
+                        verify_command="pytest -q tests/test_delete.py",
+                    ),
+                )
+            }
+        )
+        seed = Seed.from_dict(seed.to_dict())
+        await seed_events_for_gen1(store, "lin_patch_resume", seed, make_eval_summary(False))
+        await store.append(lineage_generation_started("lin_patch_resume", 2, "wondering"))
+        await store.append(lineage_generation_phase_changed("lin_patch_resume", 2, "reflecting"))
+        await store.append(
+            lineage_generation_interrupted(
+                "lin_patch_resume",
+                2,
+                last_completed_phase="reflecting",
+                partial_state={
+                    "wonder_questions": ["What remains unresolved?"],
+                    "reflect_output": {
+                        "refined_goal": seed.goal,
+                        "refined_constraints": list(seed.constraints),
+                        "refined_acs": [
+                            "Rewrite structured task creation",
+                            "Tasks can be deleted",
+                        ],
+                        "ac_patches": [
+                            {
+                                "op": "revise",
+                                "index": 0,
+                                "content": "Rewrite structured task creation",
+                            },
+                            {"op": "keep", "index": 1},
+                        ],
+                        "ontology_mutations": [],
+                        "reasoning": "pre-upgrade persisted output",
+                    },
+                },
+                seed_json=json.dumps(seed.to_dict()),
+            )
+        )
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock()
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock(
+            return_value=Result.ok(
+                ReflectOutput(
+                    refined_goal=seed.goal,
+                    refined_constraints=seed.constraints,
+                    refined_acs=tuple(
+                        criterion.description for criterion in seed.acceptance_criteria
+                    ),
+                    ontology_mutations=(),
+                    reasoning="safe replay",
+                )
+            )
+        )
+        loop = EvolutionaryLoop(
+            event_store=store,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=SeedGenerator(llm_adapter=AsyncMock()),
+        )
+
+        result = await loop.evolve_step("lin_patch_resume", execute=False)
+
+        assert result.is_ok
+        assert result.value.generation_result.seed.acceptance_criteria == seed.acceptance_criteria
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resume_after_seeding_preserves_focused_parent_authority(self) -> None:
+        """A resumed candidate must not reactivate an unrelated authoritative PASS."""
+        store = await create_event_store()
+        parent = make_seed(seed_id="seed_resume_focus_parent").model_copy(
+            update={
+                "acceptance_criteria": (
+                    "Stable AC must remain frozen",
+                    "Failed AC original contract",
+                )
+            }
+        )
+        parent = Seed.from_dict(parent.to_dict())
+        prior_evaluation = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            score=0.5,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Stable AC must remain frozen",
+                    passed=True,
+                ),
+                ACResult(
+                    ac_index=1,
+                    ac_content="Failed AC original contract",
+                    passed=False,
+                ),
+            ),
+        )
+        await seed_events_for_gen1(store, "lin_seeding_resume_focus", parent, prior_evaluation)
+
+        candidate = parent.model_copy(
+            update={
+                "acceptance_criteria": (
+                    "Stable AC must remain frozen",
+                    "Failed AC revised contract",
+                ),
+                "metadata": parent.metadata.model_copy(
+                    update={
+                        "seed_id": "seed_resume_focus_candidate",
+                        "parent_seed_id": parent.metadata.seed_id,
+                    }
+                ),
+            }
+        )
+        candidate = Seed.from_dict(candidate.to_dict())
+        await store.append(lineage_generation_started("lin_seeding_resume_focus", 2, "wondering"))
+        await store.append(
+            lineage_generation_phase_changed("lin_seeding_resume_focus", 2, "reflecting")
+        )
+        await store.append(
+            lineage_generation_phase_changed("lin_seeding_resume_focus", 2, "seeding")
+        )
+        await store.append(
+            lineage_generation_interrupted(
+                "lin_seeding_resume_focus",
+                2,
+                last_completed_phase="seeding",
+                partial_state={
+                    "wonder_questions": ["What remains unresolved?"],
+                    "reflect_output": {
+                        "refined_goal": candidate.goal,
+                        "refined_constraints": list(candidate.constraints),
+                        "refined_acs": [
+                            criterion.description for criterion in candidate.acceptance_criteria
+                        ],
+                        "ontology_mutations": [],
+                        "reasoning": "persisted focused revision",
+                    },
+                },
+                seed_json=json.dumps(candidate.to_dict()),
+            )
+        )
+
+        captured: dict[str, object] = {}
+
+        async def _capture_executor(
+            seed: Seed,
+            *,
+            parallel: bool = True,
+            execution_id: str | None = None,
+            externally_satisfied_acs: dict[int, dict[str, object]] | None = None,
+        ) -> str:
+            captured["seed"] = seed
+            captured["parallel"] = parallel
+            captured["execution_id"] = execution_id
+            captured["externally_satisfied_acs"] = externally_satisfied_acs
+            return "fresh execution"
+
+        candidate_evaluation = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=tuple(
+                ACResult(
+                    ac_index=index,
+                    ac_content=criterion.description,
+                    passed=True,
+                )
+                for index, criterion in enumerate(candidate.acceptance_criteria)
+            ),
+        )
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock()
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock()
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock()
+        evaluator = AsyncMock(return_value=candidate_evaluation)
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(focused_evolution=True, scoped_reexecution=True),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+            executor=_capture_executor,
+            evaluator=evaluator,
+        )
+
+        result = await loop.evolve_step("lin_seeding_resume_focus", execute=True)
+
+        assert result.is_ok
+        generation = result.value.generation_result
+        assert generation.seed == candidate
+        assert generation.active_ac_indices == (1,)
+        assert generation.frozen_ac_indices == (0,)
+        assert captured["externally_satisfied_acs"] == {
+            0: {
+                "reason": (
+                    "frozen by prior PASS evidence; excluded from evolve and "
+                    "reverified at the final boundary"
+                )
+            }
+        }
+        wonder_engine.wonder.assert_not_awaited()
+        reflect_engine.reflect.assert_not_awaited()
+        seed_generator.generate_from_reflect.assert_not_called()
+        evaluator.assert_awaited_once_with(candidate, "fresh execution")
 
 
 class TestEvolveStepConvergence:
@@ -1285,9 +2123,8 @@ class TestRunGenerationFailures:
                 "Generation cancelled by timeout",
             )
         )
-        loop = make_loop(store)
-
-        phase = await loop._phase_for_failed_step_directive(
+        phase = await loop_support.phase_for_failed_step_directive(
+            store,
             lineage_id="lin_timeout_phase",
             generation_number=2,
         )
@@ -1420,6 +2257,142 @@ class TestEvolveStepHandler:
         assert result.value.meta["qa_attempted"] is False
 
     @pytest.mark.asyncio
+    async def test_concurrent_public_handler_reuses_workspace_evidence_and_qa(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Distinct processes share the full handler result, not only the core step."""
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+        from ouroboros.persistence import lineage_claims
+
+        database_url = f"sqlite+aiosqlite:///{tmp_path / 'public-handler.db'}"
+        owner_store = EventStore(database_url)
+        duplicate_store = EventStore(database_url)
+        await owner_store.initialize()
+        await duplicate_store.initialize()
+        seed = make_seed(seed_id="seed_public_single_flight")
+        generation = GenerationResult(
+            generation_number=1,
+            seed=seed,
+            execution_output="verified output",
+            validation_output="validated\n" + ("x" * 60_000),
+            evaluation_summary=make_eval_summary(),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        step = StepResult(
+            generation_result=generation,
+            convergence_signal=ConvergenceSignal(
+                converged=True,
+                reason="verified",
+                ontology_similarity=1.0,
+                generation=1,
+                should_stop=True,
+            ),
+            lineage=OntologyLineage(lineage_id="lin_public_single_flight", goal=seed.goal),
+            action=StepAction.CONVERGED,
+            next_generation=2,
+        )
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocked_evolve(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            entered.set()
+            await release.wait()
+            return Result.ok(step)
+
+        owner_loop = make_loop(owner_store)
+        owner_loop.evolve_step = AsyncMock(side_effect=blocked_evolve)
+        duplicate_loop = make_loop(duplicate_store)
+        duplicate_loop.evolve_step = AsyncMock(side_effect=AssertionError("duplicate core step"))
+        owner_handler = EvolveStepHandler(evolutionary_loop=owner_loop)
+        duplicate_handler = EvolveStepHandler(evolutionary_loop=duplicate_loop)
+        workspace_calls = 0
+        qa_calls = 0
+        waiter_registered = asyncio.Event()
+        original_try_acquire = lineage_claims.try_acquire
+
+        async def observe_waiter(*args, **kwargs):  # type: ignore[no-untyped-def]
+            claim = await original_try_acquire(*args, **kwargs)
+            if (
+                kwargs.get("scope") == "evolve-handler"
+                and claim is not None
+                and claim.waiter_registered
+            ):
+                waiter_registered.set()
+            return claim
+
+        monkeypatch.setattr(lineage_claims, "try_acquire", observe_waiter)
+        monkeypatch.setattr(
+            loop_support,
+            "_event_store_authority",
+            lambda event_store: f"object:{id(event_store)}",
+        )
+
+        def restore_workspace(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+            nonlocal workspace_calls
+            workspace_calls += 1
+            return None
+
+        class _CountingQAHandler:
+            async def handle(self, _arguments):  # noqa: ANN001
+                nonlocal qa_calls
+                qa_calls += 1
+                return Result.err(ProviderError(message="counted QA"))
+
+        import yaml
+
+        arguments = {
+            "lineage_id": "lin_public_single_flight",
+            "seed_content": yaml.safe_dump(seed.to_dict()),
+        }
+        equivalent_arguments = {
+            "lineage_id": "lin_public_single_flight",
+            "seed_content": yaml.safe_dump(seed.to_dict(), default_flow_style=True),
+            "execute": True,
+            "parallel": True,
+            "skip_qa": False,
+            "project_dir": None,
+            "recover_expired_claim": False,
+        }
+        assert arguments["seed_content"] != equivalent_arguments["seed_content"]
+        verification = SimpleNamespace(artifact="artifact", reference="reference")
+        try:
+            with (
+                patch(
+                    "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+                    side_effect=restore_workspace,
+                ),
+                patch("ouroboros.mcp.tools.qa.QAHandler", _CountingQAHandler),
+                patch(
+                    "ouroboros.mcp.tools.evolution_handlers.build_verification_artifacts",
+                    new=AsyncMock(return_value=verification),
+                ) as verification_mock,
+            ):
+                owner = asyncio.create_task(owner_handler.handle(dict(arguments)))
+                await entered.wait()
+                duplicate = asyncio.create_task(duplicate_handler.handle(equivalent_arguments))
+                await waiter_registered.wait()
+                assert not duplicate.done()
+                release.set()
+                owner_result, duplicate_result = await asyncio.gather(owner, duplicate)
+
+            assert owner_result.is_ok
+            assert duplicate_result.is_ok
+            assert duplicate_result is not owner_result
+            assert duplicate_result.value == owner_result.value
+            owner_loop.evolve_step.assert_awaited_once()
+            duplicate_loop.evolve_step.assert_not_awaited()
+            verification_mock.assert_awaited_once()
+            assert workspace_calls == 1
+            assert qa_calls == 1
+        finally:
+            await owner_store.close()
+            await duplicate_store.close()
+
+    @pytest.mark.asyncio
     async def test_handler_does_not_publish_stagnation_as_verified_convergence(self) -> None:
         from ouroboros.mcp.tools.definitions import EvolveStepHandler
 
@@ -1511,6 +2484,122 @@ class TestEvolveStepHandler:
         assert result.is_ok
         assert result.value.meta["qa_attempted"] is True
         assert "qa" not in result.value.meta
+
+    @pytest.mark.asyncio
+    async def test_handler_qa_uses_canonical_generation_seed_not_caller_override(
+        self,
+        tmp_path,
+    ) -> None:
+        """Post-execution QA must follow the Seed actually executed by the core loop."""
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        store = await create_event_store()
+        stable_seed = make_seed(seed_id="seed_qa_stable")
+        override_seed = make_seed(seed_id="seed_qa_override").model_copy(
+            update={"acceptance_criteria": ("ATTACKER-ONLY ACCEPTANCE CRITERION",)}
+        )
+        generation = GenerationResult(
+            generation_number=3,
+            seed=stable_seed,
+            execution_output="verified output",
+            evaluation_summary=make_eval_summary(),
+        )
+        loop = make_loop(store, gen_result=generation)
+        loop.evolve_step = AsyncMock(
+            return_value=Result.ok(
+                StepResult(
+                    generation_result=generation,
+                    convergence_signal=ConvergenceSignal(
+                        converged=True,
+                        reason="verified",
+                        ontology_similarity=1.0,
+                        generation=3,
+                        should_stop=True,
+                    ),
+                    lineage=OntologyLineage(lineage_id="lin_qa_authority", goal=stable_seed.goal),
+                    action=StepAction.CONVERGED,
+                    next_generation=4,
+                )
+            )
+        )
+        captured: dict[str, object] = {}
+        parent_dir = tmp_path / "parent"
+        worktree_dir = tmp_path / "worktree"
+        parent_dir.mkdir()
+        worktree_dir.mkdir()
+        epoch_file = worktree_dir / "generation.txt"
+        epoch_file.write_text("generation-3", encoding="utf-8")
+        workspace = SimpleNamespace(
+            effective_cwd=str(worktree_dir),
+            lock_path=tmp_path / "task.lock",
+            worktree_path=str(worktree_dir),
+            branch="codex/test-worktree",
+        )
+        order: list[str] = []
+
+        class _CapturingQAHandler:
+            async def handle(self, arguments):  # type: ignore[no-untyped-def]
+                order.append("qa")
+                captured.update(arguments)
+                return Result.err(ProviderError(message="stop after capture"))
+
+        def _capture_checkpoint(*arguments):  # type: ignore[no-untyped-def]
+            order.append("checkpoint")
+            captured["checkpoint_dir"] = arguments[2]
+            return [], []
+
+        async def _capture_verification_dir(*arguments):  # type: ignore[no-untyped-def]
+            order.append("build_verification")
+            captured["verification_dir"] = arguments[2]
+            captured["filesystem_epoch"] = epoch_file.read_text(encoding="utf-8")
+            raise RuntimeError("stop after working-dir capture")
+
+        def _release_and_advance_epoch(*_arguments):  # type: ignore[no-untyped-def]
+            order.append("release_lock")
+            epoch_file.write_text("generation-4", encoding="utf-8")
+
+        handler = EvolveStepHandler(evolutionary_loop=loop)
+
+        import yaml
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+                return_value=workspace,
+            ),
+            patch("ouroboros.mcp.tools.evolution_handlers.is_git_repo", return_value=True),
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.release_lock",
+                side_effect=_release_and_advance_epoch,
+            ),
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers._checkpoint_passed_generation_acs",
+                side_effect=_capture_checkpoint,
+            ),
+            patch("ouroboros.mcp.tools.qa.QAHandler", _CapturingQAHandler),
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.build_verification_artifacts",
+                new=AsyncMock(side_effect=_capture_verification_dir),
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_qa_authority",
+                    "seed_content": yaml.safe_dump(override_seed.to_dict()),
+                    "project_dir": str(parent_dir),
+                }
+            )
+
+        assert result.is_ok
+        assert "Tasks can be created" in str(captured["quality_bar"])
+        assert "ATTACKER-ONLY" not in str(captured["quality_bar"])
+        qa_seed = yaml.safe_load(str(captured["seed_content"]))
+        assert qa_seed["metadata"]["seed_id"] == stable_seed.metadata.seed_id
+        assert captured["checkpoint_dir"] == worktree_dir
+        assert captured["verification_dir"] == worktree_dir
+        assert captured["filesystem_epoch"] == "generation-3"
+        assert order == ["checkpoint", "build_verification", "release_lock", "qa"]
 
     @pytest.mark.asyncio
     async def test_handler_resets_project_dir_after_call(self) -> None:
@@ -1613,6 +2702,174 @@ class TestEvolveStepHandler:
 
         assert result.is_err
         assert "Task workspace error" in str(result.error)
+
+    @pytest.mark.asyncio
+    async def test_handler_explicitly_recovers_expired_writer_claim(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Recovery is operator-authorized and limited to an actually expired owner."""
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+        from ouroboros.persistence import lineage_claims
+
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_explicit_recovery")
+        generation = GenerationResult(
+            generation_number=1,
+            seed=seed,
+            evaluation_summary=make_eval_summary(),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        loop = make_loop(store, gen_result=generation)
+        handler = EvolveStepHandler(evolutionary_loop=loop)
+        default_lease_seconds = lineage_claims.DEFAULT_LEASE_SECONDS
+        monkeypatch.setattr(lineage_claims, "DEFAULT_LEASE_SECONDS", 0.01)
+        claim = await lineage_claims.try_acquire(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_explicit_recovery",
+            generation_number=1,
+            owner_id="dead-owner",
+            request_key="dead-request",
+        )
+        assert claim is not None and claim.acquired
+        await asyncio.sleep(0.02)
+        monkeypatch.setattr(
+            lineage_claims,
+            "DEFAULT_LEASE_SECONDS",
+            default_lease_seconds,
+        )
+
+        import yaml
+
+        with patch(
+            "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+            return_value=None,
+        ):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_explicit_recovery",
+                    "seed_content": yaml.safe_dump(seed.to_dict()),
+                    "recover_expired_claim": True,
+                    "skip_qa": True,
+                }
+            )
+
+        assert result.is_ok
+        current = await lineage_claims.observe(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_explicit_recovery",
+        )
+        assert current is not None and current.completed
+        assert current.owner_id != "dead-owner"
+
+    @pytest.mark.asyncio
+    async def test_handler_recovery_replays_completed_core_before_advancing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A crash after core commit resumes handler evidence for that generation."""
+        from pathlib import Path
+
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+        from ouroboros.mcp.tools.evolution_handlers import _evolve_handler_request_key
+        from ouroboros.persistence import lineage_claims
+
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_handler_recovery")
+        generation = GenerationResult(
+            generation_number=1,
+            seed=seed,
+            evaluation_summary=make_eval_summary(),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        step = StepResult(
+            generation_result=generation,
+            convergence_signal=ConvergenceSignal(
+                converged=True,
+                reason="verified",
+                ontology_similarity=1.0,
+                generation=1,
+                should_stop=True,
+            ),
+            lineage=OntologyLineage(lineage_id="lin_handler_recovery", goal=seed.goal),
+            action=StepAction.CONVERGED,
+            next_generation=2,
+        )
+        loop = make_loop(store)
+        loop.evolve_step = AsyncMock(side_effect=AssertionError("must replay core receipt"))
+        handler = EvolveStepHandler(evolutionary_loop=loop)
+
+        import yaml
+
+        original_arguments = {
+            "lineage_id": "lin_handler_recovery",
+            "seed_content": yaml.safe_dump(seed.to_dict()),
+            "skip_qa": True,
+        }
+        request_key = _evolve_handler_request_key(
+            original_arguments,
+            configured_project_dir=None,
+            fallback_cwd=Path.cwd().resolve(),
+        )
+        default_lease_seconds = lineage_claims.DEFAULT_LEASE_SECONDS
+        monkeypatch.setattr(lineage_claims, "DEFAULT_LEASE_SECONDS", 0.01)
+        handler_claim = await lineage_claims.try_acquire(
+            store,
+            scope="evolve-handler",
+            lineage_id="lin_handler_recovery",
+            generation_number=1,
+            owner_id="dead-handler",
+            request_key=request_key,
+        )
+        core_claim = await lineage_claims.try_acquire(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_handler_recovery",
+            generation_number=1,
+            owner_id="completed-core",
+            request_key="core-request",
+        )
+        assert handler_claim is not None and handler_claim.acquired
+        assert core_claim is not None and core_claim.acquired
+        assert await lineage_claims.complete(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_handler_recovery",
+            owner_id="completed-core",
+            result_payload={"durable": "core-result"},
+        )
+        await asyncio.sleep(0.02)
+        monkeypatch.setattr(
+            lineage_claims,
+            "DEFAULT_LEASE_SECONDS",
+            default_lease_seconds,
+        )
+
+        with (
+            patch(
+                "ouroboros.evolution.step_receipt.decode_step_result",
+                new=AsyncMock(return_value=Result.ok(step)),
+            ) as decode_mock,
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+                return_value=None,
+            ),
+        ):
+            result = await handler.handle(
+                {
+                    **original_arguments,
+                    "recover_expired_claim": True,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["generation"] == 1
+        decode_mock.assert_awaited_once()
+        loop.evolve_step.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handler_no_loop_returns_error(self) -> None:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -896,6 +896,7 @@ class TestEvolveStepGen2:
                 partial_state={
                     "focus_checkpointed": True,
                     "wonder_output_complete": True,
+                    "wonder_output": make_wonder_output().model_dump(mode="json"),
                     "reflect_output_complete": True,
                     "reflect_output": {
                         "refined_goal": parent.goal,
@@ -2239,6 +2240,11 @@ class TestEvolveStepResume:
                     seed=checkpoint_seed,
                     active_ac_indices=(0,),
                     frozen_ac_indices=(),
+                    wonder_output=(
+                        make_wonder_output()
+                        if hard_crash_phase == GenerationPhase.SEEDING
+                        else None
+                    ),
                     reflect_output=(
                         ReflectOutput(
                             refined_goal=parent.goal,

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -3580,6 +3580,22 @@ class TestEvolveStepHandler:
             execution_policy=loop_support.evolution_execution_policy(loop.config),
         )
         default_lease_seconds = lineage_claims.DEFAULT_LEASE_SECONDS
+        core_claim = await lineage_claims.try_acquire(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_handler_recovery",
+            generation_number=1,
+            owner_id="completed-core",
+            request_key="core-request",
+        )
+        assert core_claim is not None and core_claim.acquired
+        assert await lineage_claims.complete(
+            store,
+            scope="evolve-core",
+            lineage_id="lin_handler_recovery",
+            owner_id="completed-core",
+            result_payload={"durable": "core-result"},
+        )
         monkeypatch.setattr(lineage_claims, "DEFAULT_LEASE_SECONDS", 0.01)
         handler_claim = await lineage_claims.try_acquire(
             store,
@@ -3589,23 +3605,7 @@ class TestEvolveStepHandler:
             owner_id="dead-handler",
             request_key=request_key,
         )
-        core_claim = await lineage_claims.try_acquire(
-            store,
-            scope="evolve-core",
-            lineage_id="lin_handler_recovery",
-            generation_number=1,
-            owner_id="completed-core",
-            request_key="core-request",
-        )
         assert handler_claim is not None and handler_claim.acquired
-        assert core_claim is not None and core_claim.acquired
-        assert await lineage_claims.complete(
-            store,
-            scope="evolve-core",
-            lineage_id="lin_handler_recovery",
-            owner_id="completed-core",
-            result_payload={"durable": "core-result"},
-        )
         await asyncio.sleep(0.02)
         monkeypatch.setattr(
             lineage_claims,

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -331,6 +331,9 @@ class TestCheckShutdownSerialization:
         assert ps["reflect_output"]["refined_goal"] == "g"
         assert ps["execution_output"] == "exec output"
         assert ps["evaluation_summary"]["score"] == 0.6
+        assert ps["wonder_output_complete"] is True
+        assert ps["reflect_output_complete"] is True
+        assert ps["evaluation_summary_complete"] is True
 
 
 # -- Resume restore tests --

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -354,13 +354,16 @@ class TestResumeRestore:
         from ouroboros.core.lineage import OntologyLineage
 
         gen = MagicMock()
+        gen.generation_number = 2
         gen.phase = GenerationPhase.INTERRUPTED
+        gen.last_completed_phase = last_completed_phase
         gen.partial_state = partial_state
         gen.evaluation_summary = None
         gen.execution_output = None
         gen.seed_json = None
 
         prev_gen = MagicMock()
+        prev_gen.generation_number = 1
         prev_gen.phase = GenerationPhase.COMPLETED
         prev_gen.evaluation_summary = EvaluationSummary(
             final_approved=False, highest_stage_passed=1, score=0.5

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -37,3 +37,67 @@ def test_rewind_to_retains_directives_for_discarded_generation_audit() -> None:
     rewound = lineage.rewind_to(1)
 
     assert [e.directive for e in rewound.directive_emissions] == ["evolve", "retry"]
+
+
+def test_latest_ontology_stable_action_requests_verification_handoff() -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from ouroboros.core.lineage import ControlDirectiveEmission, GenerationRecord, OntologyLineage
+    from ouroboros.core.seed import OntologySchema
+
+    completed_at = datetime.now(UTC)
+    lineage = OntologyLineage(
+        goal="test",
+        generations=(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="s1",
+                ontology_snapshot=OntologySchema(name="o", description="o"),
+                created_at=completed_at,
+            ),
+        ),
+        directive_emissions=(
+            ControlDirectiveEmission(
+                directive="evaluate",
+                reason="ontology stable",
+                emitted_by="evolver",
+                timestamp=completed_at + timedelta(microseconds=1),
+                generation_number=1,
+                step_action="ontology_stable",
+            ),
+        ),
+    )
+
+    assert lineage.verification_handoff_pending is True
+
+
+def test_replaced_completion_does_not_inherit_stale_verification_handoff() -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from ouroboros.core.lineage import ControlDirectiveEmission, GenerationRecord, OntologyLineage
+    from ouroboros.core.seed import OntologySchema
+
+    completed_at = datetime.now(UTC)
+    lineage = OntologyLineage(
+        goal="test",
+        generations=(
+            GenerationRecord(
+                generation_number=1,
+                seed_id="replacement",
+                ontology_snapshot=OntologySchema(name="o", description="o"),
+                created_at=completed_at,
+            ),
+        ),
+        directive_emissions=(
+            ControlDirectiveEmission(
+                directive="evaluate",
+                reason="old attempt",
+                emitted_by="evolver",
+                timestamp=completed_at - timedelta(microseconds=1),
+                generation_number=1,
+                step_action="ontology_stable",
+            ),
+        ),
+    )
+
+    assert lineage.verification_handoff_pending is False

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -54,6 +54,7 @@ class TestDirectiveProjection:
                     "generation_number": 1,
                     "phase": "reflecting",
                     "is_terminal": False,
+                    "extra": {"step_action": "ontology_stable"},
                 },
             ),
         ]
@@ -69,6 +70,7 @@ class TestDirectiveProjection:
         assert emission.generation_number == 1
         assert emission.phase == "reflecting"
         assert emission.is_terminal is False
+        assert emission.step_action == "ontology_stable"
 
     def test_directives_preserve_event_order(self) -> None:
         """Multiple directives arrive on the projection in event-replay order."""
@@ -134,6 +136,7 @@ class TestDirectiveProjection:
         assert emission.target_id is None
         assert emission.generation_number is None
         assert emission.phase is None
+        assert emission.step_action is None
         assert emission.parent_directive_id is None
         assert emission.idempotency_key is None
 

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -666,6 +666,28 @@ async def test_converged_without_any_qa_attempt_keeps_completing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ontology_stable_promotes_same_lineage_to_execute_and_evaluate() -> None:
+    evolve = _ScriptedEvolveHandler(metas=[{"action": "ontology_stable"}, {"action": "converged"}])
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_ontology_handoff",
+            seed_content="goal: stable ontology",
+            execute=False,
+            max_generations=2,
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.stop_reason == "converged"
+    assert [item.action for item in result.iterations] == ["ontology_stable", "converged"]
+    assert [call["execute"] for call in evolve.seen_arguments] == [False, True]
+    assert evolve.seen_arguments[0]["seed_content"] == "goal: stable ontology"
+    assert "seed_content" not in evolve.seen_arguments[1]
+
+
+@pytest.mark.asyncio
 async def test_exhaustion_fails_when_qa_ran_but_returned_no_verdict() -> None:
     """Absent QA evidence must fail closed when QA was actually attempted.
 

--- a/tests/unit/test_ralph_shell.py
+++ b/tests/unit/test_ralph_shell.py
@@ -119,3 +119,51 @@ def test_project_dir_git_snapshot_commits_target_repo_changes(tmp_path: Path) ->
         == "ooo/lin_commit/gen_1"
     )
     assert (project_dir / "generated.txt").read_text(encoding="utf-8") == "changed\n"
+
+
+def test_no_execute_ontology_stable_promotes_next_cycle_to_execution(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts"
+    calls_file = tmp_path / "calls.json"
+    _copy_wrapper(script_dir)
+    (script_dir / "ralph.py").write_text(
+        "\n".join(
+            (
+                "import json, sys",
+                "from pathlib import Path",
+                f"calls_path = Path({str(calls_file)!r})",
+                "calls = json.loads(calls_path.read_text()) if calls_path.exists() else []",
+                "calls.append(sys.argv[1:])",
+                "calls_path.write_text(json.dumps(calls))",
+                "ontology_only = '--no-execute' in sys.argv[1:]",
+                "action = 'ontology_stable' if ontology_only else 'converged'",
+                "generation = 1 if ontology_only else 2",
+                "print(json.dumps({'action': action, 'generation': generation, 'similarity': 1.0}))",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_dir / "ralph.sh"),
+            "--lineage-id",
+            "lin_ontology_handoff",
+            "--no-execute",
+            "--max-cycles",
+            "2",
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    calls = json.loads(calls_file.read_text(encoding="utf-8"))
+    assert "--no-execute" in calls[0]
+    assert "--no-execute" not in calls[1]
+    assert calls[0][calls[0].index("--lineage-id") + 1] == "lin_ontology_handoff"
+    assert calls[1][calls[1].index("--lineage-id") + 1] == "lin_ontology_handoff"
+    assert "ONTOLOGY STABLE" in result.stderr
+    assert '"action": "converged"' in result.stdout

--- a/tests/unit/test_regression.py
+++ b/tests/unit/test_regression.py
@@ -75,6 +75,17 @@ class TestRegressionDetector:
         assert reg.failed_in_generation == 2
         assert reg.consecutive_failures == 1
 
+    def test_non_authoritative_pass_is_a_regression_from_verified_pass(self) -> None:
+        unknown = _ac(0, True).model_copy(update={"ac_verdict_state": "not_evaluated"})
+        lineage = _lineage(
+            _gen(1, (_ac(0, True),)),
+            _gen(2, (unknown,)),
+        )
+
+        report = RegressionDetector().detect(lineage)
+
+        assert report.regressed_ac_indices == (0,)
+
     def test_persistent_failure_not_regression(self) -> None:
         """AC that always failed is not a regression."""
         lineage = _lineage(


### PR DESCRIPTION
## Summary

- freeze verified acceptance criteria and evolve only failed or regressed nodes
- boundary-reverify frozen nodes without feeding the full graph back through Wonder/Reflect
- stop immediately on verified convergence and detect sustained negligible movement
- persist and compact active/frozen working-set metadata in lineage and MCP responses

## Why

This applies loop-engineering convergence discipline: feedback narrows to the unresolved frontier instead of repeatedly regenerating the whole Seed. Without per-AC verdict evidence the selector fails closed and keeps the full graph active.

## Verification

- `385 passed` focused evolve/MCP regression suite
- Ruff check passed
- full unit suite previously completed with `16148 passed, 13 skipped`; two unrelated Copilot executable-identity failures passed on isolated rerun

Relates to #1465.


Refs #1888.