### PR TITLE
feat(evolve): emit paired frugality proof receipts

### DIFF
--- a/docs/rfc/frugality-control-loop.md
+++ b/docs/rfc/frugality-control-loop.md
@@ -119,6 +119,111 @@ ones; 1 generation vs. 3 — surfaced as a single explained dial the **user** se
 never an automatic cut. This RFC records the lever and wires attribution to it;
 codified guardrails may *propose* a default position but never override the user.
 
+### 4. Focused-evolution proof receipts
+
+Focused evolution removes already-verified AC nodes from Wonder, Reflect, and
+execution. Its exact `active_ac_indices` / `frozen_ac_indices` trace proves a
+smaller logical working set, but node counts alone do not prove resource savings.
+AC identity is stable across that shrinking frontier: legacy shorter/reordered
+lists and patch/description disagreement are rejected. A criterion carrying a
+verify command, artifact/output assertion, or investment authority cannot change
+description until Reflect has a schema for proposing the complete replacement
+contract; otherwise old mechanical evidence could be rebound to new semantics.
+Gen 2+ therefore emits a lineage observation containing runtime-attributed tokens
+for the complete generation call universe (Wonder, every Reflect attempt,
+validation repair, assertion extraction, semantic/consensus evaluation, AC
+execution, dependency analysis, decomposition policy/attestation/repair,
+coordinator review, and any experiment-only shadow replay), wall time,
+calls/retries, the final evaluation, per-AC verdicts, regressions, and TraceGuard
+grounding results. A Wonder-only early stop still emits a durable
+`insufficient_data` receipt rather than disappearing from the evidence history.
+
+The deterministic comparison is deliberately paired and fail-closed:
+
+- **control**: `focused_evolution=false` and `scoped_reexecution=false`;
+- **treatment**: `focused_evolution=true` with at least one frozen node;
+- both arms must start from the same clean Git commit in distinct worktrees and
+  have the same canonical full-Seed/previous-evaluation input fingerprint. The
+  fingerprint excludes only Seed identity/provenance fields (`seed_id`,
+  `created_at`, `interview_id`, and `parent_seed_id`); task type, brownfield
+  context, structured AC contracts, evaluation principles, exit conditions,
+  semantic metadata, and plugin extras remain authoritative;
+- every primary runtime attempt must have one unique runtime-token receipt and
+  one unique TraceGuard deliver verdict bound to the same `ac_id`, retry,
+  `session_attempt_id`, primary `ac_dispatch_id`, and root AC index. The set of
+  dispatched root indices must exactly equal the arm's active working set;
+  zero or non-finite runtime usage is incomplete evidence;
+- a session-signal follow-up makes the arm incomplete until follow-up turns have
+  a stable cross-arm semantic chain identity; their aggregate spend is never
+  silently treated as configuration-equivalent primary work;
+- every non-executor generation provider call must likewise carry positive,
+  runtime-reported usage. Missing, zero, duplicate, malformed, opaque, or
+  unrelated call evidence makes that arm incomplete; completion prompt/output/
+  total counters must reconcile exactly and no partial subtotal is used;
+- executor-internal auxiliary provider calls use the same generation-scoped
+  accounting boundary. An arbitrary executor is opaque unless it explicitly
+  attests that all of its provider effects use the tracked boundary;
+- normalized primary-runtime and auxiliary-provider configurations (backend,
+  model/tier/mode, effort level/mode, permission mode, and applicable request
+  settings) must be present, non-unknown, and match across
+  control and treatment. Equality preserves assignment, not merely the unordered
+  set of values: each treatment root AC must match the same control root, and each
+  realized auxiliary phase role must match the same control role. Per-root retry
+  and per-role call sequences preserve order and multiplicity. A root or role
+  present in both arms must have an exactly equal sequence; only an entire
+  control-only root/role may be removed. Partial removal inside a shared unit is
+  `insufficient_data` until a stable cross-arm semantic call identity exists,
+  because value-only subsequences cannot distinguish deletion from configuration
+  reallocation. Missing, blank, or unknown phase identity is incomplete evidence. The
+  focused/scoped actuator flags are the only intended experimental difference;
+  configuration mismatch or reassignment is `insufficient_data`;
+- a `full_graph` control must execute every Seed root with no frozen partition;
+  an arm label alone is not coverage evidence. Every treatment active/frozen
+  set must be a disjoint, complete partition of the same Seed;
+- auxiliary request fingerprints bind tools, system-prompt identity, model,
+  effort/service/permission dials, extra request kwargs, and fresh/scoped session
+  mode. Completion adapters must resolve the task profile once, seal that exact
+  config for dispatch, and satisfy a centrally registered, exact-key schema for
+  the effective model/profile/sampling/effort request and instance envelope.
+  Endpoint/provider routing, timeout, retry policy, and all other provider-facing
+  state are bound; credential authority is represented only by a deterministic
+  HMAC, never the credential. Proof-eligible adapters must carry the prepared
+  endpoint and credential authority in memory through the actual provider-call
+  boundary; dependency-global routing or re-resolving mutable environment state
+  after attestation is ineligible. The registered retry field must mechanically prove
+  one measured attempt—an adapter's self-asserted completeness flag has no
+  authority. Empty, partial, extra, secret-bearing, cyclic, over-deep, oversized,
+  non-finite, or otherwise malformed attestations are `insufficient_data` and
+  must not fail evolution itself. Resumed transcript state has no stable
+  cross-arm semantic identity and is likewise `insufficient_data`. The final provider-resolved model is
+  revalidated after completion responses and agent streams; padded or
+  case-varied `unknown`, conflicting effective models, cyclic/deep opaque
+  configuration, or unreconciled counters are incomplete;
+- each arm's final evaluation must cover every current Seed AC exactly once,
+  in range and bound to the structured AC semantic identity, and the complete
+  final semantic Seed fingerprint must be identical across the pair;
+- PASS requires at least 10% fewer runtime-attributed **total generation** tokens
+  and zero final-approval, evaluation-score, evaluation-stage, drift,
+  reward-hacking-risk, per-AC verdict/score, lineage-regression, or grounding
+  degradation. A quality metric present in only one arm is incomparable and
+  returns `insufficient_data`;
+- missing control, isolation, token telemetry, final-gate evidence, or TraceGuard
+  evidence returns `insufficient_data`; partial evidence is never summed into a
+  savings claim. Savings below 10% return
+  `fail_no_savings`; any quality loss returns `fail_quality_regression`.
+
+Proof-relevant event reads and generation-local provider calls use fixed
+materialization caps. Reaching either cap records only bounded evidence plus an
+overflow marker and cannot PASS. Individual, per-axis aggregate, and combined
+primary-plus-auxiliary token totals must all remain finite, so long lineages and oversized telemetry cannot turn receipt
+collection into an unbounded memory sink or erase a durable non-PASS result.
+
+Production evolve records the treatment receipt but never auto-runs the control.
+The paired arm is an experiment/benchmark operation; doubling every production
+generation would spend the savings the controller is intended to preserve.
+The stricter completeness contract is receipt schema v2; legacy v1 observations
+and proof events are readable history but are not eligible for a current PASS.
+
 ## Out of scope (deliberately)
 
 - **The spend decision itself** (how much capability per unit) — that is the

--- a/docs/rfc/frugality-proof-producers.md
+++ b/docs/rfc/frugality-proof-producers.md
@@ -22,10 +22,11 @@ But a row only `counts_in_proof` when it carries **all** axes. This branch imple
 the three previously-missing producers plus authoritative outcome finalization.
 Missing, unsafe, or malformed measurements still return `INSUFFICIENT_DATA`; in
 particular, shadow replay is unavailable on bundled production runtimes until one
-can attest complete local and external side-effect isolation. Runtime decomposition
-currently validates only response shape/count, not semantic MECE coverage and
-exclusivity, so live children also carry no decomposition-trust attestation and
-cannot enter a proof row yet.
+can attest complete local and external side-effect isolation. The live
+`bounce_only` decomposition path now has a Verified-MECE decision: an independent
+runtime attests coverage, sibling non-overlap, and simpler units after at most one
+repair. Only that finalized decision carries `trustworthy=true`; forced-atomic,
+parse-degraded, repair-exhausted, and other unverified children remain quarantined.
 
 ## The fixed event contract (consumed by the #1478 gate)
 
@@ -41,8 +42,8 @@ run/root has one unambiguous session; otherwise it remains uncounted.
 | Event type | Producer | Required fields | Seed AC |
 |---|---|---|---|
 | `execution.ac.model_routed` | **done** | `model_tier`, `model`, `model_mode`, `is_decomposed_child`, `root_ac_index`, `retry_attempt`, `ac_id`, run anchor, `session_id` | routing contract |
-| `execution.ac.token_attribution.reported` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `token_spend` | AC2 |
-| `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
+| `execution.ac.token_attribution.reported` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `session_attempt_id`, primary `ac_dispatch_id`, `root_ac_index`, `retry_attempt`, `token_spend` | AC2 |
+| `execution.ac.deliver_verdict` | **implemented on this branch** | `ac_id`, run anchor, `session_id`, `session_attempt_id`, primary `ac_dispatch_id`, `root_ac_index`, `retry_attempt`, `traceguard_verdict`, `unsupported_claim_rate`, `grounding_regression` | AC4 |
 | `execution.ac.shadow_replay` | **implemented, fail-closed without an isolation-attested runtime** | `ac_id`, run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `baseline_token_spend`, `baseline_mode`, `baseline_tier`, `baseline_model`, `decomposition_trustworthy` | AC5 |
 | `execution.ac.attempt_judged` | **implemented in the outer verify/retry layer** | run anchor, `session_id`, `root_ac_index`, `retry_attempt`, `attempt_number`, `success`, `outcome`, `is_decomposed` | provisional attempt telemetry |
 | `execution.ac.acceptance_finalized` | **implemented by the terminal Final Gate** | run anchor, `session_id`, `acceptance_generation_id`, `root_ac_index`, `final_retry_attempt`, `accepted`, `disposition`, `outcome`, `terminal_status` | final admission |
@@ -140,10 +141,11 @@ with deterministic decomposition-trust attestation and an isolation-attested
 replay runtime is eligible for one re-execution at its **parent** model tier/effort.
 That run emits `execution.ac.shadow_replay` with `baseline_token_spend`,
 `baseline_mode: "shadow_replay"`, `baseline_tier`, `baseline_model`, and
-`decomposition_trustworthy`. The field is currently false for every live
-decomposition; only an explicitly attested test or future experiment producer may
-set it true. Untrusted units are quarantined out of the proof. This is the paired
-baseline the frugality bar measures reduction against.
+`decomposition_trustworthy`. A live `bounce_only` decision may now set the trust
+field true after Verified-MECE attestation; every other decomposition remains
+untrusted and quarantined. Trust alone does not authorize replay: the runtime must
+separately attest side-effect isolation. This is the paired baseline the frugality
+bar measures reduction against.
 
 The child and baseline must also resolve to different concrete model IDs. A sparse
 tier configuration may label a child `frugal` while falling upward to the same
@@ -195,6 +197,85 @@ triad pairs each child's lower-tier run with its parent-tier baseline.
 
 - The proof thresholds and verdict order remain fixed.
 - Reasoning-effort routing remains an auxiliary, independently observable contract.
+
+## Focused-evolution paired receipt completeness
+
+The evolve-level paired receipt is narrower than the population triad above, but
+uses the same fail-closed evidence posture. `execution.ac.attempt.dispatched`
+with `dispatch_kind=primary` defines the independently known executor attempt set
+for an arm. Its full identity is `(ac_id, retry_attempt, session_attempt_id,
+ac_dispatch_id, root_ac_index)`. Each identity must occur exactly once and have
+exactly one `execution.ac.token_attribution.reported` event sourced from
+`runtime_usage` and exactly one internally consistent
+`execution.ac.deliver_verdict`, both bound back to that primary dispatch.
+The producer emits one aggregate attribution for a primary attempt and any
+session-signal follow-up turns. Until those follow-ups expose a stable cross-arm
+semantic chain identity, the presence of any follow-up makes the paired receipt
+`INSUFFICIENT_DATA`; silently folding arm-specific follow-up work into a comparable
+primary subtotal could fabricate savings. The dispatched root set must exactly
+cover `active_ac_indices`.
+
+Executor telemetry is only one component of the generation total. A task-local
+collector also records the runtime usage of Wonder, every Reflect parse retry,
+validation repair, assertion extraction, semantic/consensus evaluation,
+dependency analysis, decomposition classification/proposal/attestation/repair,
+coordinator review, and shadow replay. Primary leaf execution remains joined
+through its exact durable attempt receipt. An opaque call site or any provider
+result without positive runtime usage invalidates the whole arm. Missing usage or
+claim surfaces remain honest `INSUFFICIENT_DATA`; duplicate or malformed evidence
+is never dropped and the remaining subset is never summed.
+
+The paired generation key hashes the complete canonical Seed and previous
+`EvaluationSummary`, plus the shared Git commit. Only volatile Seed identity and
+provenance (`seed_id`, `created_at`, `interview_id`, `parent_seed_id`) are removed.
+Final quality evidence is independently checked against each arm's current Seed:
+every AC index must appear once, in range, with matching content and structured
+semantic identity. Final approval, overall score, highest evaluation stage,
+drift, reward-hacking risk, per-AC scores, lineage regressions, and TraceGuard
+grounding are compared with lower-is-better direction where applicable. A
+metric present in only one arm is incomparable. The two arms must additionally
+have the same complete semantic fingerprint of the Seed actually evaluated;
+equal cardinality is not enough.
+These completeness facts and bounded digests of the executor and provider call
+identities are persisted in the observation before a PASS can be emitted.
+Separate normalized configuration fingerprints require and bind backend,
+model/tier/mode, effort level/mode, permission mode, and applicable request
+settings. Completion surfaces resolve the task profile once and dispatch the
+resulting sealed config. They require a versioned adapter-instance attestation
+validated against a centrally registered exact-key schema. The receipt binds the
+effective model, profile, sampling/output/effort fields, endpoint/routing,
+timeout, and retry field, while credential authority is persisted only as a
+deterministic HMAC. The prepared endpoint and credential remain secret-safe,
+in-memory dispatch authority and must be consumed unchanged at the actual
+provider-call boundary; dependency-global or post-attestation mutable routing is
+ineligible. The schema must mechanically establish one measured attempt;
+a self-declared retry-completeness boolean is insufficient. Unregistered,
+unattested, empty, partial, extra, secret-bearing, cyclic, over-deep, oversized,
+non-finite, retry-opaque, blank, or unknown configuration invalidates only the
+proof arm and never the evolution call.
+Assignment digests additionally preserve
+the root-AC-to-configuration and auxiliary-role-to-configuration call sequences
+across the pair, including order and multiplicity. A root or role realized in both
+arms must have an exactly equal sequence. The proof may remove an entire
+control-only root/role, but fails closed on partial removal within a shared unit
+until producers expose stable cross-arm semantic call identities. Missing, blank,
+or unknown phase roles are incomplete evidence. Equality of an unordered value
+set—or an identity-free subsequence—is insufficient because swapping or
+concentrating a cheap model could otherwise masquerade as a focused-evolution
+saving.
+Agent-runtime request envelopes also bind the tool set, system-prompt digest,
+known request kwargs, and whether the call is fresh or uses a scoped fresh
+handle. A true resumed transcript/session is ineligible until it exposes a
+stable semantic cross-arm context identity. Provider response model identity is
+normalized and revalidated for both completion and agent-stream surfaces, so a
+requested known model cannot be replaced by an opaque `unknown` or a different
+effective model without changing the assignment digest. Completion usage
+subtotals must reconcile exactly with the reported total.
+Proof-event reads use bounded keyset pages and provider-call capture has its own
+fixed cap. Either overflow fails incomplete while retaining only bounded metadata.
+Individual receipts, primary/provider subtotals, and their combined generation
+total must remain finite. A Wonder-only
+early exit persists a non-PASS receipt.
 
 ## Done = safe, fully measured runs stop returning INSUFFICIENT_DATA
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -35,6 +35,12 @@ ooo evolve "build a task management CLI" --no-execute
 ooo evolve --status <lineage_id>
 ```
 
+### Record an isolated full-graph benchmark control
+Call `ouroboros_evolve_step` for an existing Gen 2+ lineage with
+`benchmark_control: true`, `execute: true`, and an explicit clean Git
+`project_dir`. Use a distinct clean worktree at the treatment commit. Normal
+evolve calls keep `benchmark_control` false and never launch a control arm.
+
 ### Rewind to a previous generation
 ```
 ooo evolve --rewind <lineage_id> <generation_number>
@@ -82,6 +88,8 @@ documented fallback / Path B instead of retrying the failing call.
    - `seed_content`: the generated seed YAML
    - `execute`: `true` (default) for full Execute→Evaluate pipeline,
      `false` for fast ontology-only evolution (no seed execution)
+   - `benchmark_control`: `false` (default). Set `true` only for a deliberate
+     Gen 2+ full-graph control in an explicit clean Git project/worktree.
 6. Check the `action` in the response:
    - `continue` → Inspect `active_ac_indices`, then call `ouroboros_evolve_step`
      again with just `lineage_id`. Only active failed/reopened nodes evolve;
@@ -143,6 +151,43 @@ Then add to your runtime's MCP configuration (e.g., `~/.claude/mcp.json` for Cla
   active node set from failed/regressed verifier results. Only those nodes are
   open to Wonder, Reflect, and execution; PASS nodes are frozen. The active
   output should shrink toward zero rather than feeding the full graph back.
+- **Frugality proof**: A smaller active-node count is a working-set observation,
+  not a savings claim. Gen 2+ records measured total-generation runtime tokens
+  (Wonder, all Reflect attempts, validator/evaluator providers, executor AC
+  attempts, dependency analysis, decomposition policy/attestation/repair,
+  coordinator review, and shadow replay when enabled), wall time, calls, retries,
+  and quality evidence. A PASS requires a paired full-graph control and
+  focused treatment from distinct clean worktrees at the same Git commit, at
+  least 10% fewer total-generation runtime tokens, and no final-gate,
+  evaluation score/stage, drift, reward-hacking, per-AC verdict/score, lineage
+  regression, or TraceGuard degradation. The comparison key covers the complete semantic Seed
+  and previous evaluation. Every expected primary attempt needs exactly one
+  runtime-token receipt and TraceGuard verdict bound to the exact session,
+  primary dispatch, and root identity; every active root must be dispatched;
+  every other generation provider call needs runtime usage; normalized
+  backend/model/tier/mode/effort/permission and provider request configurations
+  must be complete and match
+  the same root AC or auxiliary phase role and preserve per-unit call multiplicity
+  across the paired arms. Shared-unit sequences must be exactly equal; only whole
+  control-only units may be removed. Blank/unknown phase roles are incomplete
+  evidence. Full-graph controls must execute every Seed root; treatment
+  active/frozen sets must exactly partition the Seed. Auxiliary tools,
+  system-prompt identity, request kwargs, and fresh/scoped session mode are
+  configuration-bound. Completion profiles are resolved once into a sealed
+  dispatch config; only registered exact-key, single-attempt, secret-safe adapter
+  attestations whose in-memory endpoint/credential authority reaches the actual
+  call boundary unchanged are proof-eligible. Global or post-attestation mutable
+  routing is ineligible. Malformed attestations invalidate the proof,
+  not evolution. True resumed contexts without semantic identity and
+  unknown/conflicting effective models or unreconciled usage counters are
+  incomplete. Every current
+  Seed AC needs exactly one final verdict against the same final semantic Seed
+  contract. Missing, duplicate, malformed, partial, or opaque evidence is
+  `insufficient_data`. Evidence reads and provider-call capture are capped;
+  oversized or non-finite individual/subtotal/combined usage, cap overflow, and
+  Wonder-only early stops also produce non-PASS durable receipts.
+  Evolve never launches the control automatically because doing so would consume
+  the production savings being measured.
 - **Judge/Gate split**: Evaluation records score and evidence; deterministic
   convergence logic decides accept/continue/stagnate. A passing Gen 1 may end
   immediately—minimum-generation churn is not required after the gate passes.

--- a/src/ouroboros/cli/commands/pm.py
+++ b/src/ouroboros/cli/commands/pm.py
@@ -46,6 +46,7 @@ app = typer.Typer(
 )
 
 log = structlog.get_logger()
+_LITELLM_OPTIONAL_IMPORT_ROOTS = frozenset({"httpx", "litellm", "openai"})
 
 
 def _create_pm_litellm_adapter() -> Any:
@@ -58,19 +59,15 @@ def _create_pm_litellm_adapter() -> Any:
     try:
         from ouroboros.providers.litellm_adapter import LiteLLMAdapter
     except ModuleNotFoundError as exc:
-        if exc.name == "litellm":
-            msg = litellm_missing_dependency_message(
-                "PM interviews require the optional LiteLLM dependency."
-            )
-            raise RuntimeError(msg) from exc
-        raise
+        _raise_missing_litellm_dependency(exc)
 
     return LiteLLMAdapter()
 
 
 def _raise_missing_litellm_dependency(exc: ModuleNotFoundError) -> None:
     """Convert a missing optional LiteLLM import into install guidance."""
-    if exc.name == "litellm" or "litellm" in str(exc):
+    missing_root = (exc.name or "").split(".", 1)[0]
+    if missing_root in _LITELLM_OPTIONAL_IMPORT_ROOTS or "litellm" in str(exc):
         msg = litellm_missing_dependency_message(
             "PM interviews require the optional LiteLLM dependency."
         )

--- a/src/ouroboros/evaluation/consensus.py
+++ b/src/ouroboros/evaluation/consensus.py
@@ -47,6 +47,7 @@ from ouroboros.events.evaluation import (
     create_stage3_completed_event,
     create_stage3_started_event,
 )
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.providers.base import CompletionConfig, LLMAdapter, Message, MessageRole
 from ouroboros.strategies.devil_advocate import ConsensusContext, DevilAdvocateStrategy
 
@@ -472,7 +473,7 @@ class ConsensusEvaluator:
             response_format={"type": "json_schema", "json_schema": VOTE_SCHEMA},
         )
 
-        llm_result = await self._llm.complete(messages, config)
+        llm_result = await tracked_complete(self._llm, messages, config)
         if llm_result.is_err:
             return Result.err(llm_result.error)
 
@@ -559,7 +560,7 @@ class ConsensusEvaluator:
             response_format={"type": "json_schema", "json_schema": VOTE_SCHEMA},
         )
 
-        llm_result = await self._llm.complete(messages, config)
+        llm_result = await tracked_complete(self._llm, messages, config)
         if llm_result.is_err:
             return Result.err(llm_result.error)
 
@@ -882,7 +883,7 @@ class DeliberativeConsensus:
                 response_format={"type": "json_schema", "json_schema": VOTE_SCHEMA},
             )
 
-            llm_result = await self._llm.complete(messages, config)
+            llm_result = await tracked_complete(self._llm, messages, config)
             if llm_result.is_err:
                 return Result.err(llm_result.error)
 
@@ -1026,7 +1027,7 @@ Based on both positions above, make your final judgment."""
             response_format={"type": "json_schema", "json_schema": JUDGMENT_SCHEMA},
         )
 
-        llm_result = await self._llm.complete(messages, config)
+        llm_result = await tracked_complete(self._llm, messages, config)
         if llm_result.is_err:
             return Result.err(llm_result.error)
 

--- a/src/ouroboros/evaluation/detector.py
+++ b/src/ouroboros/evaluation/detector.py
@@ -1,8 +1,7 @@
 """AI-driven mechanical command detector.
 
-Replaces per-language hardcoded presets with a single LLM call that inspects
-the project and proposes lint/build/test/static/coverage commands, which are
-persisted to ``.ouroboros/mechanical.toml`` and consumed by
+Replaces per-language hardcoded presets with one LLM call that proposes
+lint/build/test/static/coverage commands, persisted to ``.ouroboros/mechanical.toml`` and consumed by
 ``build_mechanical_config``.
 
 The contract is deliberately minimal: every AI proposal is validated against
@@ -30,6 +29,7 @@ import structlog
 
 from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.evaluation.languages import _ALLOWED_EXECUTABLES
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.providers.base import (
     CompletionConfig,
     LLMAdapter,
@@ -393,7 +393,7 @@ async def _ask_llm(
         max_tokens=512,
         response_format={"type": "json_object"},
     )
-    result = await adapter.complete(messages, config)
+    result = await tracked_complete(adapter, messages, config)
     if result.is_err:
         log.warning("detector.llm_failed", error=str(result.error))
         return None

--- a/src/ouroboros/evaluation/semantic.py
+++ b/src/ouroboros/evaluation/semantic.py
@@ -21,6 +21,7 @@ from ouroboros.events.evaluation import (
     create_stage2_completed_event,
     create_stage2_started_event,
 )
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.providers.base import CompletionConfig, LLMAdapter, Message, MessageRole
 
 # Default model for semantic evaluation (Standard tier)
@@ -366,7 +367,7 @@ class SemanticEvaluator:
             },
         )
 
-        llm_result = await self._llm.complete(messages, completion_config)
+        llm_result = await tracked_complete(self._llm, messages, completion_config)
         if llm_result.is_err:
             return Result.err(llm_result.error)
 

--- a/src/ouroboros/evolution/drift_recording.py
+++ b/src/ouroboros/evolution/drift_recording.py
@@ -1,0 +1,46 @@
+"""Best-effort drift observation at the generation boundary."""
+
+from __future__ import annotations
+
+import logging
+
+from ouroboros.core.seed import Seed
+from ouroboros.observability.drift import DriftMeasuredEvent, DriftMeasurement
+from ouroboros.persistence.event_store import EventStore
+
+logger = logging.getLogger(__name__)
+
+
+async def record_generation_drift(
+    event_store: EventStore,
+    lineage_id: str,
+    generation_number: int,
+    seed: Seed,
+    execution_output: str | None,
+) -> None:
+    """Persist drift telemetry without making observation a generation gate."""
+    if not execution_output:
+        return
+    try:
+        metrics = DriftMeasurement().measure(
+            current_output=execution_output,
+            constraint_violations=[],
+            current_concepts=[],
+            seed=seed,
+        )
+        await event_store.append(
+            DriftMeasuredEvent(
+                execution_id=lineage_id,
+                seed_id=seed.metadata.seed_id,
+                iteration=generation_number,
+                metrics=metrics,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - telemetry cannot fail evolution
+        logger.warning(
+            "evolution.drift.measurement_failed",
+            extra={"error": str(exc), "generation": generation_number},
+        )
+
+
+__all__ = ["record_generation_drift"]

--- a/src/ouroboros/evolution/focus.py
+++ b/src/ouroboros/evolution/focus.py
@@ -20,6 +20,8 @@ from typing import Any
 from ouroboros.core.lineage import EvaluationSummary
 from ouroboros.core.seed import Seed
 from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
+from ouroboros.evolution.provider_usage import call as call
+from ouroboros.evolution.provider_usage import observe_callable
 from ouroboros.evolution.regression import RegressionReport
 from ouroboros.evolution.wonder import WonderOutput
 
@@ -103,7 +105,7 @@ async def call_executor(
         kwargs["execution_id"] = execution_id
     if externally_satisfied_acs and callable_accepts_keyword(executor, "externally_satisfied_acs"):
         kwargs["externally_satisfied_acs"] = externally_satisfied_acs
-    return await executor(seed, **kwargs)
+    return await call(executor, seed, **kwargs)
 
 
 def add_active_focus(
@@ -112,6 +114,7 @@ def add_active_focus(
     focus: EvolutionFocus,
 ) -> None:
     """Pass the active set only to focus-aware Wonder/Reflect implementations."""
+    observe_callable(callable_obj)
     if focus.is_scoped and callable_accepts_keyword(callable_obj, "active_ac_indices"):
         kwargs["active_ac_indices"] = focus.active_ac_indices
 

--- a/src/ouroboros/evolution/frugality.py
+++ b/src/ouroboros/evolution/frugality.py
@@ -1,0 +1,1443 @@
+"""Fail-closed frugality receipts for focused evolution.
+
+Focused node counts prove that the loop did less *logical work*; they do not
+prove that it spent fewer resources.  This module records measured generation
+observations and compares them only when a full-graph control and a focused
+treatment started from the same clean Git commit in distinct worktrees.
+
+The control is never launched automatically.  Shadowing every production
+generation would consume the savings being measured.  A normal evolve run
+therefore emits an ``insufficient_data`` receipt until a deliberately isolated
+comparison arm exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import json
+import logging
+import math
+from pathlib import Path
+import subprocess
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from ouroboros.core.lineage import EvaluationSummary, OntologyLineage
+from ouroboros.core.seed import Seed
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.evaluation_coverage import validate_seed_ac_coverage
+from ouroboros.evolution.focus import EvolutionFocus
+from ouroboros.evolution.provider_usage import ProviderUsageSummary, current_summary
+
+OBSERVATION_EVENT = "lineage.generation.frugality_observed"
+PROOF_EVENT = "lineage.generation.frugality_evaluated"
+ATTEMPT_DISPATCHED_EVENT = "execution.ac.attempt.dispatched"
+TOKEN_ATTRIBUTION_EVENT = "execution.ac.token_attribution.reported"
+DELIVER_VERDICT_EVENT = "execution.ac.deliver_verdict"
+MIN_TOKEN_REDUCTION_PCT = 10.0
+_MAX_COMPARISON_OBSERVATIONS = 500
+_EVIDENCE_EVENT_PAGE_SIZE = 200
+_MAX_EVIDENCE_EVENTS_PER_TYPE = 2_000
+_MAX_EVIDENCE_ISSUES = 8
+_MAX_EVIDENCE_ISSUE_CHARS = 512
+_VOLATILE_SEED_METADATA_FIELDS = frozenset(
+    {"seed_id", "created_at", "interview_id", "parent_seed_id"}
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _LoopForFrugality(Protocol):
+    event_store: Any
+    config: Any
+
+    def get_project_dir(self) -> str | None: ...
+
+
+class EvolutionFrugalityArm(StrEnum):
+    """Whether a receipt came from a comparable control or treatment."""
+
+    FULL_GRAPH = "full_graph"
+    FOCUSED = "focused"
+    UNCONTROLLED = "uncontrolled"
+
+
+class EvolutionFrugalityStatus(StrEnum):
+    """Deterministic outcome of one paired generation comparison."""
+
+    PASS = "pass"
+    FAIL_NO_SAVINGS = "fail_no_savings"
+    FAIL_QUALITY_REGRESSION = "fail_quality_regression"
+    INSUFFICIENT_DATA = "insufficient_data"
+
+
+class ProjectBaseline(BaseModel, frozen=True):
+    """Starting workspace identity required for a trustworthy comparison."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_path: str | None = None
+    git_commit: str | None = None
+    clean: bool = False
+
+
+class EvolutionFrugalityObservation(BaseModel, frozen=True):
+    """Measured resource and quality axes for one evolution generation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[2] = 2
+    receipt_id: str
+    comparison_key: str
+    lineage_id: str
+    generation_number: int = Field(ge=2)
+    execution_id: str
+    arm: EvolutionFrugalityArm
+    workspace_path: str | None = None
+    baseline_commit: str | None = None
+    baseline_clean: bool = False
+    active_ac_indices: tuple[int, ...] = ()
+    frozen_ac_indices: tuple[int, ...] = ()
+    executed_ac_indices: tuple[int, ...] = ()
+    total_node_count: int = Field(ge=0)
+    evaluated_seed_fingerprint: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[a-f0-9]{64}$",
+    )
+    token_spend: float | None = Field(default=None, ge=0)
+    execution_token_spend: float | None = Field(default=None, ge=0)
+    token_event_count: int = Field(default=0, ge=0)
+    expected_attempt_count: int = Field(default=0, ge=0)
+    attempt_identity_digest: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[a-f0-9]{64}$",
+    )
+    execution_configuration_fingerprint: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[a-f0-9]{64}$",
+    )
+    execution_configuration_assignments: tuple[tuple[int, tuple[str, ...]], ...] = ()
+    token_evidence_complete: bool = False
+    provider_token_spend: float | None = Field(default=None, ge=0)
+    provider_call_count: int = Field(default=0, ge=0)
+    provider_identity_digest: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[a-f0-9]{64}$",
+    )
+    provider_configuration_fingerprint: str | None = Field(
+        default=None,
+        pattern=r"^sha256:[a-f0-9]{64}$",
+    )
+    provider_configuration_assignments: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    provider_evidence_complete: bool = False
+    generation_token_evidence_complete: bool = False
+    wall_time_seconds: float | None = Field(default=None, ge=0)
+    runtime_calls: int | None = Field(default=None, ge=0)
+    runtime_messages: int | None = Field(default=None, ge=0)
+    retry_calls: int = Field(default=0, ge=0)
+    final_approved: bool | None = None
+    evaluation_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    evaluation_drift_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    evaluation_reward_hacking_risk: float | None = Field(default=None, ge=0.0, le=1.0)
+    highest_stage_passed: int | None = Field(default=None, ge=1, le=3)
+    passed_ac_indices: tuple[int, ...] = ()
+    failed_ac_indices: tuple[int, ...] = ()
+    ac_score_assignments: tuple[tuple[int, float | None], ...] = ()
+    regressed_ac_indices: tuple[int, ...] = ()
+    grounding_observations: int = Field(default=0, ge=0)
+    grounding_regressions: int | None = Field(default=None, ge=0)
+    grounding_evidence_complete: bool = False
+    ac_evidence_complete: bool = False
+    evidence_issues: tuple[str, ...] = Field(default=(), max_length=_MAX_EVIDENCE_ISSUES)
+
+    @field_validator(
+        "evaluation_score",
+        "evaluation_drift_score",
+        "evaluation_reward_hacking_risk",
+    )
+    @classmethod
+    def _finite_score(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("evaluation_score must be finite")
+        return value
+
+    @field_validator("evidence_issues")
+    @classmethod
+    def _bounded_evidence_issues(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not issue or len(issue) > _MAX_EVIDENCE_ISSUE_CHARS for issue in value):
+            raise ValueError("evidence issues must be non-empty and bounded")
+        return value
+
+    @model_validator(mode="after")
+    def _complete_evidence_is_internally_consistent(self) -> EvolutionFrugalityObservation:
+        ac_scores = dict(self.ac_score_assignments)
+        if any(index < 0 for index, _ in self.ac_score_assignments) or any(
+            score is not None and _quality_score(score) is None
+            for _, score in self.ac_score_assignments
+        ):
+            raise ValueError("AC score evidence must be in range and finite")
+        if self.ac_evidence_complete:
+            reported = self.passed_ac_indices + self.failed_ac_indices
+            if (
+                len(reported) != self.total_node_count
+                or len(set(reported)) != len(reported)
+                or set(reported) != set(range(self.total_node_count))
+                or len(ac_scores) != len(self.ac_score_assignments)
+                or set(ac_scores) != set(range(self.total_node_count))
+            ):
+                raise ValueError("complete AC evidence must cover every node exactly once")
+            if self.evaluated_seed_fingerprint is None:
+                raise ValueError("complete AC evidence must bind the evaluated Seed")
+        if self.token_evidence_complete:
+            execution_assignments = dict(self.execution_configuration_assignments)
+            if (
+                self.expected_attempt_count <= 0
+                or self.token_event_count != self.expected_attempt_count
+                or _positive_finite(self.execution_token_spend) is None
+                or self.attempt_identity_digest is None
+                or self.execution_configuration_fingerprint is None
+                or len(execution_assignments) != len(self.execution_configuration_assignments)
+                or set(execution_assignments) != set(self.executed_ac_indices)
+                or sum(len(values) for values in execution_assignments.values())
+                != self.expected_attempt_count
+                or not all(
+                    values and all(_is_digest(value) for value in values)
+                    for values in execution_assignments.values()
+                )
+            ):
+                raise ValueError("complete token evidence must cover every expected attempt")
+        if self.provider_evidence_complete:
+            provider_assignments = dict(self.provider_configuration_assignments)
+            if (
+                not _provider_spend_is_complete(
+                    self.provider_call_count,
+                    self.provider_token_spend,
+                )
+                or self.provider_identity_digest is None
+                or self.provider_configuration_fingerprint is None
+                or len(provider_assignments) != len(self.provider_configuration_assignments)
+                or sum(len(values) for values in provider_assignments.values())
+                != self.provider_call_count
+                or not all(
+                    role.strip()
+                    and role.strip().lower() != "unknown"
+                    and values
+                    and all(_is_digest(value) for value in values)
+                    for role, values in provider_assignments.items()
+                )
+            ):
+                raise ValueError("complete provider evidence must bind every provider call")
+        if self.generation_token_evidence_complete:
+            expected_total = (self.execution_token_spend or 0.0) + (
+                self.provider_token_spend or 0.0
+            )
+            if (
+                not self.token_evidence_complete
+                or not self.provider_evidence_complete
+                or self.token_spend is None
+                or _positive_finite(self.token_spend) is None
+                or not math.isclose(self.token_spend, expected_total, rel_tol=0.0, abs_tol=1e-9)
+                or self.runtime_calls != self.expected_attempt_count + self.provider_call_count
+            ):
+                raise ValueError("complete generation token evidence must reconcile every call")
+        if self.grounding_evidence_complete:
+            if (
+                self.expected_attempt_count <= 0
+                or self.grounding_observations != self.expected_attempt_count
+                or self.grounding_regressions is None
+                or self.attempt_identity_digest is None
+            ):
+                raise ValueError("complete grounding evidence must cover every expected attempt")
+        return self
+
+
+class EvolutionFrugalityProof(BaseModel, frozen=True):
+    """Paired verdict; PASS is impossible without resource and quality evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[2] = 2
+    status: EvolutionFrugalityStatus
+    comparison_key: str
+    control_receipt_id: str | None = None
+    treatment_receipt_id: str | None = None
+    token_reduction_pct: float | None = None
+    wall_time_reduction_pct: float | None = None
+    call_reduction_pct: float | None = None
+    quality_vetoes: tuple[str, ...] = ()
+    reason: str
+    thresholds: dict[str, float] = Field(
+        default_factory=lambda: {"minimum_token_reduction_pct": MIN_TOKEN_REDUCTION_PCT}
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class EvolutionFrugalityEvidence:
+    """Observation plus the best proof available after recording it."""
+
+    observation: EvolutionFrugalityObservation
+    proof: EvolutionFrugalityProof
+
+
+@dataclass(frozen=True, slots=True)
+class _ExecutionAxes:
+    token_spend: float | None
+    token_event_count: int
+    expected_attempt_count: int
+    attempt_identity_digest: str | None
+    configuration_fingerprint: str | None
+    configuration_assignments: tuple[tuple[int, tuple[str, ...]], ...]
+    token_evidence_complete: bool
+    retry_calls: int
+    runtime_calls: int | None
+    grounding_observations: int
+    grounding_regressions: int | None
+    grounding_evidence_complete: bool
+    executed_ac_indices: tuple[int, ...]
+    evidence_issues: tuple[str, ...]
+
+
+def capture_project_baseline(project_dir: str | None) -> ProjectBaseline:
+    """Capture a clean Git starting point without mutating the workspace."""
+    if not project_dir:
+        return ProjectBaseline()
+    path = Path(project_dir).expanduser().resolve()
+    if not path.is_dir():
+        return ProjectBaseline(workspace_path=str(path))
+    try:
+        root = _git(path, "rev-parse", "--show-toplevel")
+        commit = _git(path, "rev-parse", "HEAD")
+        status = _git(path, "status", "--porcelain=v1", "--untracked-files=normal")
+    except (OSError, subprocess.SubprocessError):
+        return ProjectBaseline(workspace_path=str(path))
+    return ProjectBaseline(workspace_path=root, git_commit=commit, clean=not status)
+
+
+def _git(path: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(path), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return completed.stdout.strip()
+
+
+def comparison_key(
+    seed: Seed,
+    previous_evaluation: EvaluationSummary,
+    baseline: ProjectBaseline,
+) -> str:
+    """Hash the complete semantic generation input, excluding identity only."""
+    payload = {
+        "protocol": "focused-evolution-frugality/v2",
+        "seed": _semantic_seed_payload(seed),
+        "previous_evaluation": previous_evaluation.model_dump(mode="json"),
+        "baseline_commit": baseline.git_commit,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _semantic_seed_payload(seed: Seed) -> dict[str, Any]:
+    """Return every Seed field except explicitly volatile lineage identity."""
+    payload = seed.to_dict()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        payload["metadata"] = {
+            key: value
+            for key, value in metadata.items()
+            if key not in _VOLATILE_SEED_METADATA_FIELDS
+        }
+    return payload
+
+
+def semantic_seed_fingerprint(seed: Seed) -> str:
+    """Hash the complete final semantic Seed contract for paired quality equality."""
+    encoded = json.dumps(
+        _semantic_seed_payload(seed),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _arm(*, focused_evolution: bool, scoped_reexecution: bool) -> EvolutionFrugalityArm:
+    if focused_evolution:
+        return EvolutionFrugalityArm.FOCUSED
+    if not scoped_reexecution:
+        return EvolutionFrugalityArm.FULL_GRAPH
+    return EvolutionFrugalityArm.UNCONTROLLED
+
+
+def _finite_non_negative(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _provider_spend_is_complete(call_count: int, token_spend: object) -> bool:
+    """Require positive usage per measured call while allowing an empty provider surface."""
+    if call_count == 0:
+        return _finite_non_negative(token_spend) == 0.0
+    return _positive_finite(token_spend) is not None
+
+
+def _positive_finite(value: object) -> float | None:
+    number = _finite_non_negative(value)
+    return number if number is not None and number > 0 else None
+
+
+def _quality_score(value: object) -> float | None:
+    number = _finite_non_negative(value)
+    return number if number is not None and number <= 1.0 else None
+
+
+def _nonempty_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _execution_configuration(data: dict[str, Any]) -> str | None:
+    settings = {
+        name: _nonempty_text(data.get(name))
+        for name in (
+            "model",
+            "effective_model",
+            "model_tier",
+            "model_mode",
+            "effort_level",
+            "effort_mode",
+            "runtime_backend",
+            "llm_backend",
+            "permission_mode",
+            "request_authority_digest",
+        )
+    }
+    if any(
+        value is None or value.lower() == "unknown" for value in settings.values()
+    ) or not _is_digest(settings["request_authority_digest"]):
+        return None
+    return json.dumps(
+        {
+            "surface": "primary_runtime",
+            **settings,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _configuration_fingerprint(configurations: list[str]) -> str | None:
+    if not configurations:
+        return None
+    encoded = json.dumps(
+        sorted(set(configurations)),
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _is_digest(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 71
+        and value.startswith("sha256:")
+        and all(char in "0123456789abcdef" for char in value[7:])
+    )
+
+
+def _root_configuration_assignments(
+    token_configurations: dict[_AttemptKey, list[str]],
+    attempt_order: tuple[_AttemptKey, ...],
+) -> tuple[tuple[int, tuple[str, ...]], ...]:
+    by_root: dict[int, list[str]] = {}
+    for key in attempt_order:
+        configurations = token_configurations.get(key, ())
+        for configuration in configurations:
+            fingerprint = _configuration_fingerprint([configuration])
+            if fingerprint is not None:
+                by_root.setdefault(key[4], []).append(fingerprint)
+    return tuple(
+        (root_ac_index, tuple(configurations))
+        for root_ac_index, configurations in sorted(by_root.items())
+    )
+
+
+type _AttemptKey = tuple[str, int, str, str, int]
+
+
+def _attempt_key(data: dict[str, Any]) -> _AttemptKey | None:
+    ac_id = data.get("ac_id")
+    retry_attempt = data.get("retry_attempt")
+    session_attempt_id = data.get("session_attempt_id")
+    ac_dispatch_id = data.get("ac_dispatch_id")
+    root_ac_index = data.get("root_ac_index")
+    if (
+        not isinstance(ac_id, str)
+        or not ac_id.strip()
+        or isinstance(retry_attempt, bool)
+        or not isinstance(retry_attempt, int)
+        or retry_attempt < 0
+        or not isinstance(session_attempt_id, str)
+        or not session_attempt_id.strip()
+        or not isinstance(ac_dispatch_id, str)
+        or len(ac_dispatch_id) != 32
+        or any(char not in "0123456789abcdef" for char in ac_dispatch_id)
+        or isinstance(root_ac_index, bool)
+        or not isinstance(root_ac_index, int)
+        or root_ac_index < 0
+    ):
+        return None
+    return (
+        ac_id.strip(),
+        retry_attempt,
+        session_attempt_id.strip(),
+        ac_dispatch_id,
+        root_ac_index,
+    )
+
+
+def _execution_axes(events: list[BaseEvent], *, execution_id: str) -> _ExecutionAxes:
+    expected_counts: dict[_AttemptKey, int] = {}
+    dispatch_authorities: dict[_AttemptKey, str] = {}
+    token_values: dict[_AttemptKey, list[float]] = {}
+    token_configurations: dict[_AttemptKey, list[str]] = {}
+    token_authorities: dict[_AttemptKey, str] = {}
+    grounding_values: dict[_AttemptKey, list[bool]] = {}
+    invalid_dispatch = False
+    invalid_token = False
+    invalid_grounding = False
+
+    for event in events:
+        if event.type not in {
+            ATTEMPT_DISPATCHED_EVENT,
+            TOKEN_ATTRIBUTION_EVENT,
+            DELIVER_VERDICT_EVENT,
+        }:
+            continue
+        data = event.data
+        if data.get("execution_id") != execution_id:
+            if event.type != ATTEMPT_DISPATCHED_EVENT or data.get("dispatch_kind") == "primary":
+                if event.type == TOKEN_ATTRIBUTION_EVENT:
+                    invalid_token = True
+                elif event.type == DELIVER_VERDICT_EVENT:
+                    invalid_grounding = True
+                else:
+                    invalid_dispatch = True
+            continue
+        key = _attempt_key(data)
+
+        if event.type == ATTEMPT_DISPATCHED_EVENT:
+            dispatch_kind = data.get("dispatch_kind")
+            if dispatch_kind == "session_signal_followup":
+                invalid_dispatch = True
+                continue
+            if dispatch_kind != "primary" or key is None:
+                invalid_dispatch = True
+                continue
+            request_authority_digest = data.get("request_authority_digest")
+            if not _is_digest(request_authority_digest):
+                invalid_dispatch = True
+                continue
+            expected_counts[key] = expected_counts.get(key, 0) + 1
+            dispatch_authorities[key] = request_authority_digest
+            continue
+
+        if key is None:
+            if event.type == TOKEN_ATTRIBUTION_EVENT:
+                invalid_token = True
+            else:
+                invalid_grounding = True
+            continue
+
+        if event.type == TOKEN_ATTRIBUTION_EVENT:
+            spend = _positive_finite(data.get("token_spend"))
+            configuration = _execution_configuration(data)
+            if (
+                spend is None
+                or data.get("token_source") != "runtime_usage"
+                or configuration is None
+            ):
+                invalid_token = True
+                continue
+            token_values.setdefault(key, []).append(spend)
+            token_configurations.setdefault(key, []).append(configuration)
+            token_authorities[key] = data["request_authority_digest"]
+            continue
+
+        verdict = data.get("traceguard_verdict")
+        claim_rate = _finite_non_negative(data.get("unsupported_claim_rate"))
+        regression = data.get("grounding_regression")
+        consistent = (verdict == "accepted" and regression is False and claim_rate == 0.0) or (
+            verdict == "rejected"
+            and regression is True
+            and claim_rate is not None
+            and 0.0 <= claim_rate <= 1.0
+        )
+        if not consistent:
+            invalid_grounding = True
+            continue
+        grounding_values.setdefault(key, []).append(regression)
+
+    duplicate_dispatch = any(count != 1 for count in expected_counts.values())
+    attempt_order = tuple(expected_counts)
+    expected = set(expected_counts)
+    token_keys = set(token_values)
+    grounding_keys = set(grounding_values)
+    duplicate_tokens = any(len(values) != 1 for values in token_values.values())
+    duplicate_configurations = any(len(values) != 1 for values in token_configurations.values())
+    duplicate_grounding = any(len(values) != 1 for values in grounding_values.values())
+    token_complete = bool(expected) and not any(
+        (
+            invalid_dispatch,
+            invalid_token,
+            duplicate_dispatch,
+            duplicate_tokens,
+            duplicate_configurations,
+            token_keys != expected,
+            set(token_configurations) != expected,
+            token_authorities != dispatch_authorities,
+        )
+    )
+    grounding_complete = bool(expected) and not any(
+        (
+            invalid_dispatch,
+            invalid_grounding,
+            duplicate_dispatch,
+            duplicate_grounding,
+            grounding_keys != expected,
+        )
+    )
+    token_spend: float | None = None
+    aggregate_token_invalid = False
+    if token_complete:
+        token_spend = _positive_finite(sum(values[0] for values in token_values.values()))
+        aggregate_token_invalid = token_spend is None
+        if aggregate_token_invalid:
+            token_complete = False
+
+    issues: list[str] = []
+    if not expected:
+        issues.append("no authoritative primary attempt dispatches")
+    if invalid_dispatch or duplicate_dispatch:
+        issues.append("attempt dispatch identity is malformed or duplicated")
+    if not token_complete:
+        issues.append(
+            "runtime token/configuration attribution does not exactly cover expected attempts"
+        )
+    if aggregate_token_invalid:
+        issues.append("aggregate primary runtime-token usage is non-finite")
+    if not grounding_complete:
+        issues.append("TraceGuard evidence does not exactly cover expected attempts")
+
+    identities = [
+        {
+            "ac_id": ac_id,
+            "retry_attempt": attempt,
+            "session_attempt_id": session_attempt_id,
+            "ac_dispatch_id": ac_dispatch_id,
+            "root_ac_index": root_ac_index,
+        }
+        for ac_id, attempt, session_attempt_id, ac_dispatch_id, root_ac_index in sorted(expected)
+    ]
+    identity_digest = None
+    if identities and not invalid_dispatch and not duplicate_dispatch:
+        encoded = json.dumps(identities, separators=(",", ":"), ensure_ascii=True)
+        identity_digest = "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+    grounding_regressions = (
+        sum(int(values[0]) for values in grounding_values.values()) if grounding_complete else None
+    )
+    return _ExecutionAxes(
+        token_spend=token_spend,
+        token_event_count=sum(len(values) for values in token_values.values()),
+        expected_attempt_count=len(expected),
+        attempt_identity_digest=identity_digest,
+        configuration_fingerprint=(
+            _configuration_fingerprint([values[0] for values in token_configurations.values()])
+            if token_complete
+            else None
+        ),
+        configuration_assignments=(
+            _root_configuration_assignments(token_configurations, attempt_order)
+            if token_complete
+            else ()
+        ),
+        token_evidence_complete=token_complete,
+        retry_calls=sum(int(key[1] > 0) for key in expected),
+        runtime_calls=len(expected) if expected else None,
+        grounding_observations=sum(len(values) for values in grounding_values.values()),
+        grounding_regressions=grounding_regressions,
+        grounding_evidence_complete=grounding_complete,
+        executed_ac_indices=tuple(sorted({key[4] for key in expected})),
+        evidence_issues=tuple(issues),
+    )
+
+
+def build_observation(
+    *,
+    lineage_id: str,
+    generation_number: int,
+    execution_id: str,
+    parent_seed: Seed,
+    current_seed: Seed,
+    previous_evaluation: EvaluationSummary,
+    current_evaluation: EvaluationSummary | None,
+    focus: EvolutionFocus,
+    baseline: ProjectBaseline,
+    focused_evolution: bool,
+    scoped_reexecution: bool,
+    execution_events: list[BaseEvent],
+    executor_result: Any | None,
+    provider_usage: ProviderUsageSummary | None = None,
+    evidence_collection_complete: bool = True,
+) -> EvolutionFrugalityObservation:
+    """Build one deterministic observation from runtime telemetry."""
+    axes = _execution_axes(execution_events, execution_id=execution_id)
+    wall_time = _finite_non_negative(getattr(executor_result, "duration_seconds", None))
+    runtime_messages = getattr(executor_result, "messages_processed", None)
+    if (
+        isinstance(runtime_messages, bool)
+        or not isinstance(runtime_messages, int)
+        or runtime_messages < 0
+    ):
+        runtime_messages = None
+    ac_results = current_evaluation.ac_results if current_evaluation is not None else ()
+    evaluation_score = _quality_score(current_evaluation.score) if current_evaluation else None
+    evaluation_drift_score = (
+        _quality_score(current_evaluation.drift_score) if current_evaluation else None
+    )
+    evaluation_reward_hacking_risk = (
+        _quality_score(current_evaluation.reward_hacking_risk) if current_evaluation else None
+    )
+    previous_passes = {
+        result.ac_index for result in previous_evaluation.ac_results if result.passed
+    }
+    current_passes = {result.ac_index for result in ac_results if result.passed}
+    coverage = (
+        validate_seed_ac_coverage(current_seed, current_evaluation)
+        if current_evaluation is not None
+        else None
+    )
+    evidence_issues = list(axes.evidence_issues)
+    if not evidence_collection_complete:
+        evidence_issues.append("execution evidence exceeded the bounded collection limit")
+    if axes.executed_ac_indices != focus.active_ac_indices:
+        evidence_issues.append(
+            "primary dispatch roots do not exactly cover the active AC working set"
+        )
+    if provider_usage is None:
+        evidence_issues.append("generation provider-call evidence is missing")
+        provider_usage = ProviderUsageSummary(
+            call_count=0,
+            token_spend=None,
+            identity_digest=None,
+            configuration_fingerprint=None,
+            configuration_assignments=(),
+            complete=False,
+        )
+    evidence_issues.extend(provider_usage.issues)
+    if coverage is None:
+        evidence_issues.append("final Seed-wide AC evaluation is missing")
+    elif not coverage.complete:
+        evidence_issues.append(coverage.reason[:_MAX_EVIDENCE_ISSUE_CHARS])
+    if current_evaluation is not None:
+        raw_quality_values = (
+            current_evaluation.score,
+            current_evaluation.drift_score,
+            current_evaluation.reward_hacking_risk,
+            *(result.score for result in ac_results),
+        )
+        if any(value is not None and _quality_score(value) is None for value in raw_quality_values):
+            evidence_issues.append("evaluation quality metrics are malformed or out of range")
+    generation_token_spend: float | None = None
+    generation_token_evidence_complete = False
+    if (
+        axes.token_evidence_complete
+        and provider_usage.complete
+        and axes.token_spend is not None
+        and provider_usage.token_spend is not None
+    ):
+        generation_token_spend = _positive_finite(axes.token_spend + provider_usage.token_spend)
+        generation_token_evidence_complete = generation_token_spend is not None
+        if not generation_token_evidence_complete:
+            evidence_issues.append("aggregate total-generation runtime-token usage is non-finite")
+    key = comparison_key(parent_seed, previous_evaluation, baseline)
+    return EvolutionFrugalityObservation(
+        receipt_id=f"{lineage_id}:generation:{generation_number}",
+        comparison_key=key,
+        lineage_id=lineage_id,
+        generation_number=generation_number,
+        execution_id=execution_id,
+        arm=_arm(
+            focused_evolution=focused_evolution,
+            scoped_reexecution=scoped_reexecution,
+        ),
+        workspace_path=baseline.workspace_path,
+        baseline_commit=baseline.git_commit,
+        baseline_clean=baseline.clean,
+        active_ac_indices=focus.active_ac_indices,
+        frozen_ac_indices=focus.frozen_ac_indices,
+        executed_ac_indices=axes.executed_ac_indices,
+        total_node_count=len(current_seed.acceptance_criteria),
+        evaluated_seed_fingerprint=semantic_seed_fingerprint(current_seed),
+        token_spend=generation_token_spend,
+        execution_token_spend=axes.token_spend,
+        token_event_count=axes.token_event_count,
+        expected_attempt_count=axes.expected_attempt_count,
+        attempt_identity_digest=axes.attempt_identity_digest,
+        execution_configuration_fingerprint=axes.configuration_fingerprint,
+        execution_configuration_assignments=axes.configuration_assignments,
+        token_evidence_complete=axes.token_evidence_complete,
+        provider_token_spend=provider_usage.token_spend,
+        provider_call_count=provider_usage.call_count,
+        provider_identity_digest=provider_usage.identity_digest,
+        provider_configuration_fingerprint=provider_usage.configuration_fingerprint,
+        provider_configuration_assignments=provider_usage.configuration_assignments,
+        provider_evidence_complete=provider_usage.complete,
+        generation_token_evidence_complete=generation_token_evidence_complete,
+        wall_time_seconds=wall_time,
+        runtime_calls=(
+            axes.expected_attempt_count + provider_usage.call_count
+            if axes.expected_attempt_count and provider_usage.complete
+            else None
+        ),
+        runtime_messages=runtime_messages,
+        retry_calls=axes.retry_calls,
+        final_approved=(current_evaluation.final_approved if current_evaluation else None),
+        evaluation_score=evaluation_score,
+        evaluation_drift_score=evaluation_drift_score,
+        evaluation_reward_hacking_risk=evaluation_reward_hacking_risk,
+        highest_stage_passed=(
+            current_evaluation.highest_stage_passed if current_evaluation else None
+        ),
+        passed_ac_indices=tuple(sorted(result.ac_index for result in ac_results if result.passed)),
+        failed_ac_indices=tuple(
+            sorted(result.ac_index for result in ac_results if not result.passed)
+        ),
+        ac_score_assignments=tuple(
+            sorted((result.ac_index, _quality_score(result.score)) for result in ac_results)
+        ),
+        regressed_ac_indices=tuple(sorted(previous_passes - current_passes)),
+        grounding_observations=axes.grounding_observations,
+        grounding_regressions=axes.grounding_regressions,
+        grounding_evidence_complete=axes.grounding_evidence_complete,
+        ac_evidence_complete=bool(coverage and coverage.complete),
+        evidence_issues=tuple(evidence_issues[:_MAX_EVIDENCE_ISSUES]),
+    )
+
+
+def _reduction(control: float | int | None, treatment: float | int | None) -> float | None:
+    if control is None or treatment is None or control <= 0:
+        return None
+    # Threshold authority uses the unrounded measurement. Rounding before the
+    # comparison could promote 9.99996% to a false 10% PASS.
+    return (float(control) - float(treatment)) / float(control) * 100.0
+
+
+def _ac_evidence_issue(observation: EvolutionFrugalityObservation) -> str | None:
+    reported = observation.passed_ac_indices + observation.failed_ac_indices
+    ac_scores = dict(observation.ac_score_assignments)
+    if not observation.ac_evidence_complete:
+        return "Seed-wide final AC verdict coverage is incomplete"
+    if (
+        len(reported) != observation.total_node_count
+        or len(set(reported)) != len(reported)
+        or set(reported) != set(range(observation.total_node_count))
+        or len(ac_scores) != len(observation.ac_score_assignments)
+        or set(ac_scores) != set(range(observation.total_node_count))
+    ):
+        return "Seed-wide final AC verdict coverage is inconsistent"
+    return None
+
+
+def _focus_evidence_issue(observation: EvolutionFrugalityObservation) -> str | None:
+    active = observation.active_ac_indices
+    frozen = observation.frozen_ac_indices
+    expected = set(range(observation.total_node_count))
+    if observation.arm is EvolutionFrugalityArm.FULL_GRAPH and (
+        frozen or active != tuple(range(observation.total_node_count))
+    ):
+        return "full_graph control did not execute the complete Seed graph"
+    if (
+        len(active) != len(set(active))
+        or len(frozen) != len(set(frozen))
+        or set(active) & set(frozen)
+        or set(active) | set(frozen) != expected
+    ):
+        return "active/frozen working set is not an exact Seed partition"
+    return None
+
+
+def _runtime_evidence_issue(observation: EvolutionFrugalityObservation) -> str | None:
+    execution_assignments = dict(observation.execution_configuration_assignments)
+    provider_assignments = dict(observation.provider_configuration_assignments)
+    if observation.evidence_issues:
+        return "; ".join(observation.evidence_issues)
+    if (
+        observation.expected_attempt_count <= 0
+        or observation.attempt_identity_digest is None
+        or observation.execution_configuration_fingerprint is None
+        or set(execution_assignments) != set(observation.executed_ac_indices)
+        or sum(len(values) for values in execution_assignments.values())
+        != observation.expected_attempt_count
+        or observation.executed_ac_indices != observation.active_ac_indices
+    ):
+        return "authoritative runtime attempt identity is incomplete"
+    if (
+        not observation.token_evidence_complete
+        or observation.token_event_count != observation.expected_attempt_count
+        or _positive_finite(observation.execution_token_spend) is None
+    ):
+        return "runtime token attribution is incomplete"
+    if (
+        not observation.provider_evidence_complete
+        or observation.provider_identity_digest is None
+        or observation.provider_configuration_fingerprint is None
+        or sum(len(values) for values in provider_assignments.values())
+        != observation.provider_call_count
+        or any(
+            not role.strip() or role.strip().lower() == "unknown" for role in provider_assignments
+        )
+        or not _provider_spend_is_complete(
+            observation.provider_call_count,
+            observation.provider_token_spend,
+        )
+    ):
+        return "generation provider-call token attribution is incomplete"
+    if (
+        not observation.generation_token_evidence_complete
+        or _positive_finite(observation.token_spend) is None
+        or observation.runtime_calls
+        != observation.expected_attempt_count + observation.provider_call_count
+    ):
+        return "total generation token attribution does not reconcile"
+    if (
+        not observation.grounding_evidence_complete
+        or observation.grounding_observations != observation.expected_attempt_count
+        or observation.grounding_regressions is None
+    ):
+        return "TraceGuard grounding evidence is incomplete"
+    return None
+
+
+def evaluate_pair(
+    control: EvolutionFrugalityObservation,
+    treatment: EvolutionFrugalityObservation,
+) -> EvolutionFrugalityProof:
+    """Evaluate an isolated full-graph/focused pair with quality veto first."""
+    key = treatment.comparison_key
+    if control.comparison_key != key:
+        return _insufficient(key, treatment=treatment, reason="comparison inputs differ")
+    if control.arm is not EvolutionFrugalityArm.FULL_GRAPH:
+        return _insufficient(key, treatment=treatment, reason="control arm is not full_graph")
+    if treatment.arm is not EvolutionFrugalityArm.FOCUSED:
+        return _insufficient(key, control=control, reason="treatment arm is not focused")
+    if (
+        not control.baseline_clean
+        or not treatment.baseline_clean
+        or not control.baseline_commit
+        or control.baseline_commit != treatment.baseline_commit
+        or not control.workspace_path
+        or not treatment.workspace_path
+        or control.workspace_path == treatment.workspace_path
+    ):
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired proof requires distinct clean worktrees at the same Git commit",
+        )
+    if not treatment.frozen_ac_indices:
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="focused arm excluded no nodes",
+        )
+
+    for label, observation in (("control", control), ("treatment", treatment)):
+        issue = _focus_evidence_issue(observation)
+        if issue is not None:
+            return _insufficient(
+                key,
+                control=control,
+                treatment=treatment,
+                reason=f"{label} {issue}",
+            )
+        issue = _ac_evidence_issue(observation)
+        if issue is not None:
+            return _insufficient(
+                key,
+                control=control,
+                treatment=treatment,
+                reason=f"{label} {issue}",
+            )
+        issue = _runtime_evidence_issue(observation)
+        if issue is not None:
+            return _insufficient(
+                key,
+                control=control,
+                treatment=treatment,
+                reason=f"{label} {issue}",
+            )
+    control_root_configurations = dict(control.execution_configuration_assignments)
+    treatment_root_configurations = dict(treatment.execution_configuration_assignments)
+    if any(
+        control_root_configurations.get(root_ac_index) != configurations
+        for root_ac_index, configurations in treatment_root_configurations.items()
+    ):
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired primary runtime configurations differ for an active root AC",
+        )
+    control_role_configurations = dict(control.provider_configuration_assignments)
+    treatment_role_configurations = dict(treatment.provider_configuration_assignments)
+    if any(
+        control_role_configurations.get(role) != configurations
+        for role, configurations in treatment_role_configurations.items()
+    ):
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired auxiliary provider/runtime configurations differ by role",
+        )
+    if (
+        not control.evaluated_seed_fingerprint
+        or control.evaluated_seed_fingerprint != treatment.evaluated_seed_fingerprint
+    ):
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired final semantic Seed contracts differ",
+        )
+    if control.total_node_count != treatment.total_node_count:
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired final AC contracts differ in cardinality",
+        )
+
+    vetoes: list[str] = []
+    if control.final_approved is None or treatment.final_approved is None:
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired final-gate evaluations are required",
+        )
+    if control.final_approved and not treatment.final_approved:
+        vetoes.append("final approval regressed")
+    quality_metrics = (
+        ("evaluation score", control.evaluation_score, treatment.evaluation_score, False),
+        (
+            "evaluation drift",
+            control.evaluation_drift_score,
+            treatment.evaluation_drift_score,
+            True,
+        ),
+        (
+            "reward-hacking risk",
+            control.evaluation_reward_hacking_risk,
+            treatment.evaluation_reward_hacking_risk,
+            True,
+        ),
+    )
+    for label, control_value, treatment_value, higher_is_worse in quality_metrics:
+        if (control_value is None) != (treatment_value is None):
+            return _insufficient(
+                key,
+                control=control,
+                treatment=treatment,
+                reason=f"paired {label} evidence is not comparable",
+            )
+        if control_value is None or treatment_value is None:
+            continue
+        regressed = (
+            treatment_value > control_value if higher_is_worse else treatment_value < control_value
+        )
+        if regressed:
+            vetoes.append(f"{label} regressed from {control_value:.6f} to {treatment_value:.6f}")
+    if control.highest_stage_passed is None or treatment.highest_stage_passed is None:
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired evaluation-stage evidence is required",
+        )
+    if treatment.highest_stage_passed < control.highest_stage_passed:
+        vetoes.append(
+            "highest evaluation stage regressed from "
+            f"{control.highest_stage_passed} to {treatment.highest_stage_passed}"
+        )
+    control_ac_scores = dict(control.ac_score_assignments)
+    treatment_ac_scores = dict(treatment.ac_score_assignments)
+    for ac_index in range(control.total_node_count):
+        control_score = control_ac_scores[ac_index]
+        treatment_score = treatment_ac_scores[ac_index]
+        if (control_score is None) != (treatment_score is None):
+            return _insufficient(
+                key,
+                control=control,
+                treatment=treatment,
+                reason=f"paired AC {ac_index} score evidence is not comparable",
+            )
+        if (
+            control_score is not None
+            and treatment_score is not None
+            and treatment_score < control_score
+        ):
+            vetoes.append(
+                f"AC {ac_index} score regressed from {control_score:.6f} to {treatment_score:.6f}"
+            )
+    missing_passes = set(control.passed_ac_indices) - set(treatment.passed_ac_indices)
+    if missing_passes:
+        vetoes.append(f"previously passing ACs regressed: {sorted(missing_passes)}")
+    if treatment.regressed_ac_indices:
+        vetoes.append(
+            f"treatment lineage reports regressions: {list(treatment.regressed_ac_indices)}"
+        )
+    if treatment.grounding_regressions:
+        vetoes.append(f"grounding regressed on {treatment.grounding_regressions} runtime call(s)")
+    if vetoes:
+        return EvolutionFrugalityProof(
+            status=EvolutionFrugalityStatus.FAIL_QUALITY_REGRESSION,
+            comparison_key=key,
+            control_receipt_id=control.receipt_id,
+            treatment_receipt_id=treatment.receipt_id,
+            quality_vetoes=tuple(vetoes),
+            reason="Focused evolution reduced quality; resource savings are vetoed.",
+        )
+    token_reduction = _reduction(control.token_spend, treatment.token_spend)
+    if token_reduction is None:
+        return _insufficient(
+            key,
+            control=control,
+            treatment=treatment,
+            reason="paired runtime token attribution is required",
+        )
+    wall_reduction = _reduction(control.wall_time_seconds, treatment.wall_time_seconds)
+    call_reduction = _reduction(control.runtime_calls, treatment.runtime_calls)
+    status = (
+        EvolutionFrugalityStatus.PASS
+        if token_reduction >= MIN_TOKEN_REDUCTION_PCT
+        else EvolutionFrugalityStatus.FAIL_NO_SAVINGS
+    )
+    return EvolutionFrugalityProof(
+        status=status,
+        comparison_key=key,
+        control_receipt_id=control.receipt_id,
+        treatment_receipt_id=treatment.receipt_id,
+        token_reduction_pct=token_reduction,
+        wall_time_reduction_pct=wall_reduction,
+        call_reduction_pct=call_reduction,
+        reason=(
+            f"Paired focused evolution saved {token_reduction:.6f}% runtime tokens "
+            "with no measured quality regression."
+            if status is EvolutionFrugalityStatus.PASS
+            else (
+                f"Paired focused evolution saved only {token_reduction:.6f}% runtime tokens; "
+                f"the proof threshold is {MIN_TOKEN_REDUCTION_PCT:.2f}%."
+            )
+        ),
+    )
+
+
+def _insufficient(
+    key: str,
+    *,
+    control: EvolutionFrugalityObservation | None = None,
+    treatment: EvolutionFrugalityObservation | None = None,
+    reason: str,
+) -> EvolutionFrugalityProof:
+    return EvolutionFrugalityProof(
+        status=EvolutionFrugalityStatus.INSUFFICIENT_DATA,
+        comparison_key=key,
+        control_receipt_id=control.receipt_id if control else None,
+        treatment_receipt_id=treatment.receipt_id if treatment else None,
+        reason=reason,
+    )
+
+
+def evaluate_observations(
+    current: EvolutionFrugalityObservation,
+    observations: list[EvolutionFrugalityObservation],
+) -> EvolutionFrugalityProof:
+    """Pair the current receipt with the newest matching opposite arm."""
+    if current.arm is EvolutionFrugalityArm.UNCONTROLLED:
+        return _insufficient(
+            current.comparison_key,
+            reason="legacy scoped reexecution is not a full-graph control",
+        )
+    opposite = (
+        EvolutionFrugalityArm.FULL_GRAPH
+        if current.arm is EvolutionFrugalityArm.FOCUSED
+        else EvolutionFrugalityArm.FOCUSED
+    )
+    candidates = [
+        item
+        for item in observations
+        if item.comparison_key == current.comparison_key
+        and item.arm is opposite
+        and item.receipt_id != current.receipt_id
+    ]
+    if not candidates:
+        return _insufficient(
+            current.comparison_key,
+            control=(current if current.arm is EvolutionFrugalityArm.FULL_GRAPH else None),
+            treatment=(current if current.arm is EvolutionFrugalityArm.FOCUSED else None),
+            reason="matching isolated full-graph/focused receipt not found",
+        )
+    match = candidates[0]
+    control = current if current.arm is EvolutionFrugalityArm.FULL_GRAPH else match
+    treatment = current if current.arm is EvolutionFrugalityArm.FOCUSED else match
+    return evaluate_pair(control, treatment)
+
+
+async def _record_generation(
+    *,
+    event_store: Any,
+    lineage_id: str,
+    generation_number: int,
+    execution_id: str,
+    parent_seed: Seed,
+    current_seed: Seed,
+    previous_evaluation: EvaluationSummary,
+    current_evaluation: EvaluationSummary | None,
+    focus: EvolutionFocus,
+    baseline: ProjectBaseline,
+    focused_evolution: bool,
+    scoped_reexecution: bool,
+    executor_result: Any | None,
+    provider_usage: ProviderUsageSummary | None,
+) -> EvolutionFrugalityEvidence:
+    """Persist an observation and its fail-closed paired verdict."""
+    provider_usage = provider_usage or current_summary()
+    execution_events, evidence_collection_complete = await query_execution_evidence_events(
+        event_store,
+        execution_id,
+    )
+    observation = build_observation(
+        lineage_id=lineage_id,
+        generation_number=generation_number,
+        execution_id=execution_id,
+        parent_seed=parent_seed,
+        current_seed=current_seed,
+        previous_evaluation=previous_evaluation,
+        current_evaluation=current_evaluation,
+        focus=focus,
+        baseline=baseline,
+        focused_evolution=focused_evolution,
+        scoped_reexecution=scoped_reexecution,
+        execution_events=execution_events,
+        executor_result=executor_result,
+        provider_usage=provider_usage,
+        evidence_collection_complete=evidence_collection_complete,
+    )
+    await event_store.append(
+        BaseEvent(
+            type=OBSERVATION_EVENT,
+            aggregate_type="lineage",
+            aggregate_id=lineage_id,
+            data=observation.model_dump(mode="json"),
+        )
+    )
+    raw_observations = await event_store.query_events(
+        event_type=OBSERVATION_EVENT,
+        aggregate_type="lineage",
+        limit=_MAX_COMPARISON_OBSERVATIONS,
+    )
+    observations: list[EvolutionFrugalityObservation] = []
+    for event in raw_observations:
+        try:
+            observations.append(EvolutionFrugalityObservation.model_validate(event.data))
+        except (TypeError, ValueError):
+            continue
+    proof = evaluate_observations(observation, observations)
+    await event_store.append(
+        BaseEvent(
+            type=PROOF_EVENT,
+            aggregate_type="lineage",
+            aggregate_id=lineage_id,
+            data={
+                "generation_number": generation_number,
+                "receipt_id": observation.receipt_id,
+                "proof": proof.model_dump(mode="json"),
+            },
+        )
+    )
+    return EvolutionFrugalityEvidence(observation=observation, proof=proof)
+
+
+async def query_execution_evidence_events(
+    event_store: Any,
+    execution_id: str,
+) -> tuple[list[BaseEvent], bool]:
+    """Read only proof-relevant events through bounded, stable keyset pages."""
+    events: list[BaseEvent] = []
+    complete = True
+    for event_type in (
+        ATTEMPT_DISPATCHED_EVENT,
+        TOKEN_ATTRIBUTION_EVENT,
+        DELIVER_VERDICT_EVENT,
+    ):
+        latest = await event_store.query_execution_related_events(
+            execution_id,
+            event_type=event_type,
+            limit=1,
+        )
+        if not latest:
+            continue
+        through = (latest[0].timestamp, latest[0].id)
+        cursor = None
+        event_type_count = 0
+        while True:
+            remaining = _MAX_EVIDENCE_EVENTS_PER_TYPE - event_type_count
+            if remaining <= 0:
+                overflow = await event_store.query_execution_related_events(
+                    execution_id,
+                    event_type=event_type,
+                    limit=1,
+                    chronological=True,
+                    cursor_after=cursor,
+                    cursor_through=through,
+                )
+                complete = complete and not overflow
+                break
+            page_limit = min(_EVIDENCE_EVENT_PAGE_SIZE, remaining)
+            page = await event_store.query_execution_related_events(
+                execution_id,
+                event_type=event_type,
+                limit=page_limit,
+                chronological=True,
+                cursor_after=cursor,
+                cursor_through=through,
+            )
+            events.extend(page)
+            event_type_count += len(page)
+            if len(page) < page_limit:
+                break
+            cursor = (page[-1].timestamp, page[-1].id)
+    return events, complete
+
+
+async def record_generation(
+    *,
+    event_store: Any,
+    lineage_id: str,
+    generation_number: int,
+    execution_id: str,
+    parent_seed: Seed,
+    current_seed: Seed,
+    previous_evaluation: EvaluationSummary | None,
+    current_evaluation: EvaluationSummary | None,
+    focus: EvolutionFocus,
+    baseline: ProjectBaseline,
+    focused_evolution: bool,
+    scoped_reexecution: bool,
+    executor_result: Any | None,
+    provider_usage: ProviderUsageSummary | None = None,
+) -> EvolutionFrugalityEvidence | None:
+    """Record evidence without letting optional telemetry fail evolution."""
+    if generation_number < 2 or previous_evaluation is None:
+        return None
+    try:
+        return await _record_generation(
+            event_store=event_store,
+            lineage_id=lineage_id,
+            generation_number=generation_number,
+            execution_id=execution_id,
+            parent_seed=parent_seed,
+            current_seed=current_seed,
+            previous_evaluation=previous_evaluation,
+            current_evaluation=current_evaluation,
+            focus=focus,
+            baseline=baseline,
+            focused_evolution=focused_evolution,
+            scoped_reexecution=scoped_reexecution,
+            executor_result=executor_result,
+            provider_usage=provider_usage,
+        )
+    except Exception:  # noqa: BLE001 - proof is observe-only and fails closed
+        logger.warning(
+            "evolution.frugality.receipt_failed",
+            extra={"lineage_id": lineage_id, "generation": generation_number},
+            exc_info=True,
+        )
+        return None
+
+
+async def record_wonder_stop(
+    loop: _LoopForFrugality,
+    lineage: OntologyLineage,
+    context: tuple[int, Seed, EvolutionFocus, Any],
+) -> EvolutionFrugalityEvidence | None:
+    """Persist a non-PASS receipt when Wonder ends before execution."""
+    (
+        generation_number,
+        current_seed,
+        generation_focus,
+        execution_policy,
+    ) = context
+    previous = next(
+        (
+            generation
+            for generation in reversed(lineage.generations)
+            if getattr(generation, "evaluation_summary", None) is not None
+        ),
+        None,
+    )
+    logger.info("evolution.wonder.nothing_to_learn")
+    return await record_generation(
+        event_store=loop.event_store,
+        lineage_id=lineage.lineage_id,
+        generation_number=generation_number,
+        execution_id=f"evolve:{lineage.lineage_id}:generation:{generation_number}",
+        parent_seed=current_seed,
+        current_seed=current_seed,
+        previous_evaluation=(previous.evaluation_summary if previous is not None else None),
+        current_evaluation=None,
+        focus=generation_focus,
+        baseline=capture_project_baseline(loop.get_project_dir()),
+        focused_evolution=execution_policy.focused_evolution,
+        scoped_reexecution=execution_policy.scoped_reexecution,
+        executor_result=None,
+    )
+
+
+__all__ = [
+    "MIN_TOKEN_REDUCTION_PCT",
+    "OBSERVATION_EVENT",
+    "PROOF_EVENT",
+    "EvolutionFrugalityArm",
+    "EvolutionFrugalityEvidence",
+    "EvolutionFrugalityObservation",
+    "EvolutionFrugalityProof",
+    "EvolutionFrugalityStatus",
+    "ProjectBaseline",
+    "build_observation",
+    "capture_project_baseline",
+    "comparison_key",
+    "evaluate_observations",
+    "evaluate_pair",
+    "record_generation",
+    "record_wonder_stop",
+    "query_execution_evidence_events",
+    "semantic_seed_fingerprint",
+]

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -1,14 +1,6 @@
-"""EvolutionaryLoop orchestrator - manages generation-level execution.
+"""EvolutionaryLoop orchestrator for generation-level execution.
 
-Transforms the linear pipeline into a closed evolutionary loop:
-
-    Gen 1: Seed(O₁) → Execute → Validate → Evaluate
-    Gen 2: Wonder(O₁, E₁) → Reflect → Seed(O₂) → Execute → Validate → Evaluate
-    Gen 3: Wonder(O₂, E₂) → Reflect → Seed(O₃) → Execute → Validate → Evaluate
-    ...until convergence or max_generations
-
-The loop accepts a pre-built Seed for Gen 1 (interview is handled externally)
-and autonomously evolves through Wonder → Reflect cycles for Gen 2+.
+Runs Seed → Execute → Evaluate, then Wonder → Reflect feedback until convergence.
 """
 
 from __future__ import annotations
@@ -49,12 +41,13 @@ from ouroboros.events.lineage import (
     lineage_stagnated,
     lineage_wonder_degraded,
 )
-from ouroboros.evolution import focus, loop_support
+from ouroboros.evolution import focus, frugality, loop_support, provider_usage
 from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
 from ouroboros.evolution.directive_mapping import (
     is_terminal_directive,
     watchdog_timeout_to_directive,
 )
+from ouroboros.evolution.drift_recording import record_generation_drift
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
 from ouroboros.evolution.regression import RegressionDetector, RegressionReport
@@ -69,7 +62,6 @@ from ouroboros.evolution.watchdog import (
     GenerationWatchdogTimeout,
 )
 from ouroboros.evolution.wonder import WonderEngine, WonderOutput
-from ouroboros.observability.drift import DriftMeasuredEvent, DriftMeasurement
 from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessHandle
 from ouroboros.persistence.event_store import EventStore
 
@@ -121,6 +113,7 @@ class GenerationResult:
     validation_output: str | None = None
     active_ac_indices: tuple[int, ...] = ()
     frozen_ac_indices: tuple[int, ...] = ()
+    frugality_evidence: frugality.EvolutionFrugalityEvidence | None = None
     phase: GenerationPhase = GenerationPhase.COMPLETED
     success: bool = True
 
@@ -582,56 +575,52 @@ class EvolutionaryLoop:
         execute: bool = True,
         parallel: bool = True,
         conductor_directive: ConductorDirective | None = None,
+        benchmark_control: bool = False,
     ) -> Result[StepResult, OuroborosError]:
-        """Advance one lineage exactly once while concurrent retries coalesce.
-
-        The replay that chooses a generation number and the provider-backed work
-        that completes it form one lineage-owned critical section.  A concurrent
-        caller with the same request observes the winner's result; a different
-        request waits and then replays the durable winner. Completed tasks remove
-        their single-flight entry so the registry remains bounded.
-        """
+        """Advance one lineage once while task-local policy and durable claims coalesce retries."""
         from ouroboros.evolution.step_receipt import decode_step_result, encode_step_result
 
-        while True:
-            generation_number = await loop_support.planned_evolve_generation(
-                self.event_store,
-                lineage_id,
-                execute=execute,
-            )
-            request_key = loop_support.evolve_request_key(
-                initial_seed,
-                execute=execute,
-                parallel=parallel,
-                conductor_directive=conductor_directive,
-                project_dir=self.get_project_dir(),
-                generation_number=generation_number,
-                execution_policy=loop_support.evolution_execution_policy(self.config),
-            )
-            try:
-                return await loop_support.run_lineage_single_flight(
+        durable_policy = loop_support.evolution_execution_policy(self.config, benchmark_control)
+        with loop_support.evolution_execution_policy_context(self.config, benchmark_control):
+            while True:
+                generation_number = await loop_support.planned_evolve_generation(
                     self.event_store,
                     lineage_id,
-                    request_key,
-                    lambda: loop_support.run_durable_lineage_single_flight(
+                    execute=execute,
+                )
+                request_key = loop_support.evolve_request_key(
+                    initial_seed,
+                    execute=execute,
+                    parallel=parallel,
+                    conductor_directive=conductor_directive,
+                    project_dir=self.get_project_dir(),
+                    generation_number=generation_number,
+                    execution_policy=durable_policy,
+                )
+                try:
+                    return await loop_support.run_lineage_single_flight(
                         self.event_store,
                         lineage_id,
                         request_key,
-                        lambda: self._evolve_step_once(
+                        lambda: loop_support.run_durable_lineage_single_flight(
+                            self.event_store,
                             lineage_id,
-                            initial_seed=initial_seed,
-                            execute=execute,
-                            parallel=parallel,
-                            conductor_directive=conductor_directive,
+                            request_key,
+                            lambda: self._evolve_step_once(
+                                lineage_id,
+                                initial_seed=initial_seed,
+                                execute=execute,
+                                parallel=parallel,
+                                conductor_directive=conductor_directive,
+                            ),
+                            generation_number=generation_number,
+                            encode=encode_step_result,
+                            decode=lambda payload: decode_step_result(self.event_store, payload),
                         ),
-                        generation_number=generation_number,
-                        encode=encode_step_result,
-                        decode=lambda payload: decode_step_result(self.event_store, payload),
-                    ),
-                    replan_on_different=True,
-                )
-            except loop_support.LineageWinnerAdvanced:
-                continue
+                        replan_on_different=True,
+                    )
+                except loop_support.LineageWinnerAdvanced:
+                    continue
 
     async def _evolve_step_once(
         self,
@@ -1413,6 +1402,7 @@ class EvolutionaryLoop:
             success=False,
         )
 
+    @provider_usage.capture_provider_usage
     async def _run_generation_phases(
         self,
         lineage: OntologyLineage,
@@ -1434,9 +1424,12 @@ class EvolutionaryLoop:
         def _should_skip(phase: str) -> bool:
             return loop_support.phase_should_skip(phase, resume_after_phase)
 
+        execution_policy = loop_support.current_evolution_execution_policy(self.config)
         ontology_delta: OntologyDelta | None = None
         generation_parent_seed = current_seed
         generation_focus = focus.initial_evolution_focus(current_seed)
+        project_baseline = frugality.capture_project_baseline(self.get_project_dir())
+        executor_result: Any | None = None
         prev_gen = (
             next(
                 (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
@@ -1478,7 +1471,7 @@ class EvolutionaryLoop:
                 current_seed,
                 prev_gen.evaluation_summary,
                 regression_report=regression_report,
-                enabled=self.config.focused_evolution,
+                enabled=execution_policy.focused_evolution,
             )
 
             await loop_support.emit_generation_started_once(
@@ -1510,11 +1503,17 @@ class EvolutionaryLoop:
                         and not wonder_output.should_continue
                         and not wonder_output.questions
                     ):
-                        # Only early-return if Wonder has NO questions at all.
-                        # If questions exist, we must continue to Reflect even if
-                        # should_continue=false, because the questions represent
-                        # ontological gaps that need to be addressed.
-                        logger.info("evolution.wonder.nothing_to_learn")
+                        # Question-bearing output still requires Reflect; only an empty stop returns.
+                        await frugality.record_wonder_stop(
+                            self,
+                            lineage,
+                            (
+                                generation_number,
+                                current_seed,
+                                generation_focus,
+                                execution_policy,
+                            ),
+                        )
                         return Result.ok(
                             GenerationResult(
                                 generation_number=generation_number,
@@ -1754,7 +1753,7 @@ class EvolutionaryLoop:
                 prev_gen.evaluation_summary,
                 wonder=wonder_output,
                 regression_report=regression_report,
-                enabled=self.config.focused_evolution,
+                enabled=execution_policy.focused_evolution,
             )
             if checkpoint_focus is not None:
                 generation_focus = checkpoint_focus
@@ -1807,8 +1806,8 @@ class EvolutionaryLoop:
             )
         elif execute and self.executor:
             externally_satisfied_acs = focus.select_externally_satisfied_acs(
-                scoped_reexecution=self.config.scoped_reexecution,
-                focused_evolution=self.config.focused_evolution,
+                scoped_reexecution=execution_policy.scoped_reexecution,
+                focused_evolution=execution_policy.focused_evolution,
                 focus=generation_focus,
                 settled_ac_indices=(
                     reflect_output.settled_ac_indices if reflect_output is not None else ()
@@ -1824,6 +1823,7 @@ class EvolutionaryLoop:
                 )
                 if hasattr(exec_result, "is_ok") and exec_result.is_ok:
                     orch_result = exec_result.value
+                    executor_result = orch_result
                     summary = getattr(orch_result, "summary", {})
                     verification_report = (
                         summary.get("verification_report") if isinstance(summary, dict) else None
@@ -1876,7 +1876,7 @@ class EvolutionaryLoop:
             )
         elif execute and execution_output and self.validator:
             try:
-                validation_result = await self.validator(current_seed, execution_output)
+                validation_result = await focus.call(self.validator, current_seed, execution_output)
                 validation_output = normalize_validation_result(validation_result)
                 if validation_output and "skipped" in validation_output.lower():
                     logger.warning(
@@ -1939,7 +1939,7 @@ class EvolutionaryLoop:
             )
         elif execute and self.evaluator:
             try:
-                eval_result = await self.evaluator(current_seed, execution_output)
+                eval_result = await focus.call(self.evaluator, current_seed, execution_output)
                 if hasattr(eval_result, "is_ok") and eval_result.is_ok:
                     evaluation_summary = eval_result.value
                 elif isinstance(eval_result, EvaluationSummary):
@@ -1969,28 +1969,9 @@ class EvolutionaryLoop:
             )
         )
 
-        # Measure drift after evaluation
-        if execution_output:
-            try:
-                drift_measurement = DriftMeasurement()
-                drift_metrics = drift_measurement.measure(
-                    current_output=execution_output,
-                    constraint_violations=[],
-                    current_concepts=[],
-                    seed=current_seed,
-                )
-                drift_event = DriftMeasuredEvent(
-                    execution_id=lineage.lineage_id,
-                    seed_id=current_seed.metadata.seed_id,
-                    iteration=generation_number,
-                    metrics=drift_metrics,
-                )
-                await self.event_store.append(drift_event)
-            except Exception as e:
-                logger.warning(
-                    "evolution.drift.measurement_failed",
-                    extra={"error": str(e), "generation": generation_number},
-                )
+        await record_generation_drift(
+            self.event_store, lineage.lineage_id, generation_number, current_seed, execution_output
+        )
 
         # Check for graceful shutdown after evaluating
         interrupted = await self._check_shutdown(
@@ -2008,6 +1989,22 @@ class EvolutionaryLoop:
         if interrupted:
             return Result.ok(interrupted)
 
+        frugality_evidence = await frugality.record_generation(
+            event_store=self.event_store,
+            lineage_id=lineage.lineage_id,
+            generation_number=generation_number,
+            execution_id=execution_id or lineage.lineage_id,
+            parent_seed=generation_parent_seed,
+            current_seed=current_seed,
+            previous_evaluation=(prev_gen.evaluation_summary if prev_gen is not None else None),
+            current_evaluation=evaluation_summary,
+            focus=generation_focus,
+            baseline=project_baseline,
+            focused_evolution=execution_policy.focused_evolution,
+            scoped_reexecution=execution_policy.scoped_reexecution,
+            executor_result=executor_result,
+        )
+
         return Result.ok(
             GenerationResult(
                 generation_number=generation_number,
@@ -2020,6 +2017,7 @@ class EvolutionaryLoop:
                 validation_output=validation_output,
                 active_ac_indices=generation_focus.active_ac_indices,
                 frozen_ac_indices=generation_focus.frozen_ac_indices,
+                frugality_evidence=frugality_evidence,
                 phase=GenerationPhase.COMPLETED,
                 success=True,
             )

--- a/src/ouroboros/evolution/loop_support.py
+++ b/src/ouroboros/evolution/loop_support.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, fields, is_dataclass
 import inspect
 import json
@@ -36,6 +38,20 @@ _PHASE_ORDER = ("wondering", "reflecting", "seeding", "executing", "evaluating")
 
 class LineageWinnerAdvanced(RuntimeError):
     """The caller must recompute its request from the durable winner state."""
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveEvolutionExecutionPolicy:
+    """Task-local focus policy after applying an explicit benchmark override."""
+
+    focused_evolution: bool
+    scoped_reexecution: bool
+    benchmark_control: bool
+
+
+_ACTIVE_EVOLUTION_EXECUTION_POLICY: ContextVar[EffectiveEvolutionExecutionPolicy | None] = (
+    ContextVar("ouroboros_effective_evolution_execution_policy", default=None)
+)
 
 
 def phase_should_skip(phase: str, resume_after_phase: str | None) -> bool:
@@ -95,13 +111,59 @@ def _execution_policy_value(value: Any) -> Any:
     raise TypeError(f"Unsupported evolution execution-policy value: {type(value).__qualname__}")
 
 
-def evolution_execution_policy(config: Any | None) -> dict[str, Any] | None:
+def effective_evolution_execution_policy(
+    config: Any,
+    benchmark_control: bool = False,
+) -> EffectiveEvolutionExecutionPolicy:
+    """Resolve one immutable policy without mutating the shared loop config."""
+    if not isinstance(benchmark_control, bool):
+        raise TypeError("benchmark_control must be a boolean")
+    return EffectiveEvolutionExecutionPolicy(
+        focused_evolution=(False if benchmark_control else bool(config.focused_evolution)),
+        scoped_reexecution=(False if benchmark_control else bool(config.scoped_reexecution)),
+        benchmark_control=benchmark_control,
+    )
+
+
+@contextmanager
+def evolution_execution_policy_context(
+    config: Any,
+    benchmark_control: bool = False,
+) -> Iterator[EffectiveEvolutionExecutionPolicy]:
+    """Bind one policy to the current async task and every child task it creates."""
+    policy = effective_evolution_execution_policy(
+        config,
+        benchmark_control=benchmark_control,
+    )
+    token = _ACTIVE_EVOLUTION_EXECUTION_POLICY.set(policy)
+    try:
+        yield policy
+    finally:
+        _ACTIVE_EVOLUTION_EXECUTION_POLICY.reset(token)
+
+
+def current_evolution_execution_policy(config: Any) -> EffectiveEvolutionExecutionPolicy:
+    """Return the active task-local policy or the normal configured policy."""
+    return _ACTIVE_EVOLUTION_EXECUTION_POLICY.get() or effective_evolution_execution_policy(config)
+
+
+def evolution_execution_policy(
+    config: Any | None,
+    benchmark_control: bool = False,
+) -> dict[str, Any] | None:
     """Return every declared evolution config field for durable request identity."""
     if config is None:
         return None
     projected = _execution_policy_value(config)
     if not isinstance(projected, dict):
         raise TypeError("Evolution execution policy must project to an object")
+    effective = effective_evolution_execution_policy(
+        config,
+        benchmark_control=benchmark_control,
+    )
+    projected["benchmark_control"] = effective.benchmark_control
+    projected["effective_focused_evolution"] = effective.focused_evolution
+    projected["effective_scoped_reexecution"] = effective.scoped_reexecution
     return projected
 
 

--- a/src/ouroboros/evolution/provider_usage.py
+++ b/src/ouroboros/evolution/provider_usage.py
@@ -1,0 +1,1458 @@
+"""Fail-closed token accounting for non-executor evolution provider calls.
+
+The AC executor already persists one token receipt per primary runtime attempt.
+Wonder, Reflect, validation repair, assertion extraction, and semantic/consensus
+evaluation use different provider interfaces, so their calls are collected in a
+generation-local context and folded into the same paired frugality receipt.
+
+Only runtime-reported usage is accepted.  A provider error, exception, malformed
+counter, or zero/absent usage makes the whole generation incomplete rather than
+letting a partial numerator manufacture savings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from functools import wraps
+import hashlib
+import json
+import math
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from ouroboros.core.types import Result
+from ouroboros.providers.base import CompletionConfig
+from ouroboros.providers.frugality_attestation import PreparedFrugalityCompletion
+
+_MAX_PROVIDER_CALLS = 2_000
+_MAX_CONFIGURATION_DEPTH = 16
+_MAX_CONFIGURATION_NODES = 4_096
+_MAX_CONFIGURATION_TEXT_LENGTH = 16_384
+_INVALID_CONFIGURATION = object()
+_SENSITIVE_CONFIGURATION_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "client_secret",
+        "credential",
+        "credentials",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+    }
+)
+_COMPLETION_CONTRACT_KEYS = frozenset(
+    {
+        "schema_version",
+        "schema_id",
+        "internal_attempt_limit",
+        "credential_authority",
+        "effective_request",
+        "settings",
+    }
+)
+_AGENT_RUNTIME_CONTRACT_KEYS = frozenset(
+    {
+        "schema_version",
+        "schema_id",
+        "implementation",
+        "runtime_backend",
+        "runtime_handle_backend",
+        "settings",
+    }
+)
+_EFFECTIVE_REQUEST_KEYS = frozenset(
+    {
+        "model",
+        "profile_model",
+        "temperature",
+        "max_tokens",
+        "stop",
+        "top_p",
+        "response_format",
+        "role",
+        "profile",
+        "profile_name",
+        "backend_profile",
+        "max_turns",
+        "reasoning_effort",
+        "model_is_explicit",
+    }
+)
+_SCOPED_HANDLE_METADATA_FIELDS = frozenset(
+    {
+        "execution_id",
+        "level_number",
+        "scope",
+        "server_session_id",
+        "session_role",
+        "session_scope_id",
+        "session_state_path",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _CompletionAdapterSchema:
+    schema_id: str
+    settings: frozenset[str]
+    retry_setting: str
+    proof_retry_value: int
+    schema_version: int = 1
+    requires_sealed_dispatch: bool = False
+
+
+_COMPLETION_ADAPTER_SCHEMAS: dict[str, _CompletionAdapterSchema] = {
+    "ouroboros.providers.litellm_adapter.LiteLLMAdapter": _CompletionAdapterSchema(
+        schema_id="ouroboros.litellm.v7",
+        settings=frozenset(
+            {
+                "api_base",
+                "timeout",
+                "max_retries",
+                "io_recorder_configured",
+                "dependency_version",
+                "dependency_provider",
+                "dependency_defaults_verified",
+                "dependency_max_retries",
+                "dependency_client_sealed",
+                "dependency_client_type",
+                "dependency_transport_contract",
+                "dependency_cleanup_required",
+                "dependency_isolation_kind",
+                "dependency_worker_protocol",
+                "dependency_worker_environment_contract",
+                "dependency_worker_cwd_contract",
+                "dependency_mutation_audit",
+                "worker_launcher_path",
+                "worker_executable_resolved_path",
+                "worker_executable_content_sha256",
+                "worker_python_version",
+                "worker_module",
+                "worker_implementation_sha256",
+                "adapter_module",
+                "adapter_implementation_sha256",
+                "ouroboros_implementation_contract",
+                "ouroboros_implementation_sha256",
+                "httpx_dependency_version",
+                "openai_dependency_version",
+            }
+        ),
+        retry_setting="max_retries",
+        proof_retry_value=1,
+        schema_version=7,
+        requires_sealed_dispatch=True,
+    ),
+    "ouroboros.providers.anthropic_adapter.AnthropicAdapter": _CompletionAdapterSchema(
+        schema_id="ouroboros.anthropic.v2",
+        settings=frozenset(
+            {
+                "api_base",
+                "timeout",
+                "max_retries",
+                "default_model",
+                "io_recorder_configured",
+            }
+        ),
+        retry_setting="max_retries",
+        proof_retry_value=0,
+        schema_version=2,
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentRuntimeSchema:
+    schema_id: str
+    runtime_backend: str
+    runtime_handle_backend: str
+    setting_kinds: Mapping[str, str]
+    schema_version: int = 1
+    literal_settings: Mapping[str, frozenset[str]] = field(default_factory=dict)
+
+
+_AGENT_RUNTIME_SCHEMAS: dict[str, _AgentRuntimeSchema] = {
+    "ouroboros.orchestrator.codex_cli_runtime.CodexCliRuntime": _AgentRuntimeSchema(
+        schema_id="ouroboros.codex_cli_runtime.v4",
+        runtime_backend="codex",
+        runtime_handle_backend="codex_cli",
+        schema_version=4,
+        setting_kinds={
+            "provider_name": "text",
+            "llm_backend": "text",
+            "permission_mode": "text",
+            "constructor_model": "optional_text",
+            "runtime_profile": "optional_text",
+            "codex_profile": "optional_text",
+            "resolved_model": "optional_text",
+            "resolved_profile": "optional_text",
+            "resolved_agent": "optional_text",
+            "resolved_reasoning_effort": "optional_text",
+            "semantic_cwd": "relative_posix_path",
+            "cli_path": "absolute_path",
+            "cli_executable_path": "absolute_path",
+            "cli_executable_content_sha256": "sha256",
+            "cli_executable_version_identity": "sha256",
+            "skills_source": "text",
+            "skills_location": "skill_location",
+            "skill_dispatcher_kind": "text",
+            "skill_dispatcher_identity": "dispatcher_identity",
+            "skill_dispatch_registry_fingerprint": "sha256",
+            "builtin_mcp_handler_registry_fingerprint": "sha256",
+            "startup_output_timeout_seconds": "optional_positive_number",
+            "stdout_idle_timeout_seconds": "optional_positive_number",
+            "process_shutdown_timeout_seconds": "positive_number",
+            "completed_process_group_shutdown_timeout_seconds": "positive_number",
+            "max_resume_retries": "positive_int",
+            "max_ouroboros_depth": "positive_int",
+            "max_stderr_lines": "positive_int",
+            "use_process_group": "bool",
+            "child_session_env_keys": "string_sequence",
+            "child_environment_authority_fingerprint": "sha256",
+            "child_environment_authority_scheme": "text",
+            "child_environment_entry_count": "positive_int",
+            "child_environment_sensitive_entry_count": "non_negative_int",
+            "profile_resolution_fingerprint": "sha256",
+            "codex_config_authority_fingerprint": "sha256",
+            "codex_config_authority_scheme": "text",
+            "codex_profile_v2_names": "string_sequence",
+            "codex_project_trust_paths": "string_sequence",
+        },
+        literal_settings={
+            "skills_source": frozenset({"directory", "package"}),
+            "skill_dispatcher_kind": frozenset({"custom", "packaged"}),
+            "child_environment_authority_scheme": frozenset({"hmac-sha256-installation-key-v2"}),
+            "codex_config_authority_scheme": frozenset({"hmac-sha256-installation-key-v2"}),
+        },
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderUsageSummary:
+    """Generation-level provider-call token evidence."""
+
+    call_count: int
+    token_spend: float | None
+    identity_digest: str | None
+    configuration_fingerprint: str | None
+    configuration_assignments: tuple[tuple[str, tuple[str, ...]], ...]
+    complete: bool
+    issues: tuple[str, ...] = ()
+
+
+@dataclass(slots=True)
+class _ProviderCall:
+    call_id: str
+    role: str
+    model: str
+    configuration: str
+    token_spend: float | None = None
+    finished: bool = False
+
+
+@dataclass(slots=True)
+class GenerationProviderUsageCapture:
+    """Mutable collector scoped to one evolution generation task."""
+
+    _calls: list[_ProviderCall] = field(default_factory=list)
+    _overflowed_call_count: int = 0
+    instrumentation_complete: bool = True
+
+    def begin(
+        self,
+        *,
+        role: str | None,
+        model: str | None,
+        configuration: Mapping[str, object],
+    ) -> _ProviderCall:
+        normalized_role = role.strip() if isinstance(role, str) and role.strip() else "unknown"
+        normalized_model = model.strip() if isinstance(model, str) and model.strip() else "unknown"
+        try:
+            normalized_configuration = _canonical_configuration(configuration)
+        except (TypeError, ValueError, RecursionError):
+            normalized_configuration = "invalid"
+            self.instrumentation_complete = False
+        call_index = len(self._calls) + self._overflowed_call_count
+        call = _ProviderCall(
+            call_id=f"provider:{call_index}",
+            role=normalized_role,
+            model=normalized_model,
+            configuration=normalized_configuration,
+        )
+        if normalized_role.lower() == "unknown":
+            self.instrumentation_complete = False
+        if normalized_model.lower() == "unknown":
+            self.instrumentation_complete = False
+        if len(self._calls) >= _MAX_PROVIDER_CALLS:
+            self._overflowed_call_count += 1
+            self.instrumentation_complete = False
+        else:
+            self._calls.append(call)
+        return call
+
+    @staticmethod
+    def finish(call: _ProviderCall, token_spend: float | None) -> None:
+        call.token_spend = token_spend
+        call.finished = True
+
+    def resolve_model(self, call: _ProviderCall, model: object) -> None:
+        resolved = model.strip() if isinstance(model, str) and model.strip() else None
+        if resolved is None:
+            self.instrumentation_complete = False
+            return
+        call.model = resolved
+        if resolved.lower() == "unknown":
+            self.instrumentation_complete = False
+            return
+        try:
+            configuration = json.loads(call.configuration)
+        except (TypeError, json.JSONDecodeError):
+            return
+        if isinstance(configuration, dict):
+            configuration["resolved_model"] = resolved
+            call.configuration = _canonical_configuration(configuration)
+
+    def observe_callable(self, callable_obj: Any) -> None:
+        owner = getattr(callable_obj, "__self__", None)
+        if not any(
+            getattr(candidate, "frugality_provider_tracking", False) is True
+            for candidate in (callable_obj, owner)
+            if candidate is not None
+        ):
+            self.instrumentation_complete = False
+
+    def mark_incomplete(self) -> None:
+        self.instrumentation_complete = False
+
+    def summary(self, *, instrumentation_complete: bool | None = None) -> ProviderUsageSummary:
+        complete_instrumentation = (
+            self.instrumentation_complete
+            if instrumentation_complete is None
+            else instrumentation_complete and self.instrumentation_complete
+        )
+        issues: list[str] = []
+        if not complete_instrumentation:
+            issues.append("generation provider-call instrumentation is incomplete")
+        if self._overflowed_call_count:
+            issues.append("provider call evidence exceeded the bounded collection limit")
+        incomplete = [call.call_id for call in self._calls if not call.finished]
+        missing_usage = [
+            call.call_id
+            for call in self._calls
+            if call.finished and _positive_finite(call.token_spend) is None
+        ]
+        if incomplete:
+            issues.append("provider calls did not reach a measured terminal result")
+        if missing_usage:
+            issues.append("provider runtime-token usage is missing or invalid")
+
+        identities = [
+            {
+                "call_id": call.call_id,
+                "role": call.role,
+                "model": call.model,
+                "configuration": call.configuration,
+            }
+            for call in self._calls
+        ]
+        encoded = json.dumps(identities, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        digest = "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+        configuration_fingerprint = _fingerprint_configurations(
+            call.configuration for call in self._calls
+        )
+        configuration_assignments = _configuration_assignments(self._calls)
+        complete = (
+            complete_instrumentation
+            and not self._overflowed_call_count
+            and not incomplete
+            and not missing_usage
+        )
+        token_spend: float | None = None
+        if complete:
+            candidate_spend = sum(float(call.token_spend) for call in self._calls)
+            token_spend = _finite_non_negative(candidate_spend)
+            if token_spend is None:
+                complete = False
+                issues.append("provider runtime-token total is non-finite")
+        return ProviderUsageSummary(
+            call_count=len(self._calls) + self._overflowed_call_count,
+            token_spend=token_spend,
+            identity_digest=digest,
+            configuration_fingerprint=configuration_fingerprint,
+            configuration_assignments=configuration_assignments,
+            complete=complete,
+            issues=tuple(issues),
+        )
+
+
+_ACTIVE_CAPTURE: ContextVar[GenerationProviderUsageCapture | None] = ContextVar(
+    "ouroboros_evolution_provider_usage_capture",
+    default=None,
+)
+
+
+@contextmanager
+def capture_generation_provider_usage() -> Iterator[GenerationProviderUsageCapture]:
+    """Install one task-local provider usage collector."""
+    capture = GenerationProviderUsageCapture()
+    token = _ACTIVE_CAPTURE.set(capture)
+    try:
+        yield capture
+    finally:
+        _ACTIVE_CAPTURE.reset(token)
+
+
+def capture_provider_usage(callable_obj: Any) -> Any:
+    """Decorate one generation coroutine with a task-local usage capture."""
+
+    @wraps(callable_obj)
+    async def _wrapped(*args: Any, **kwargs: Any) -> Any:
+        with capture_generation_provider_usage() as capture:
+            if kwargs.get("resume_after_phase") is not None:
+                capture.mark_incomplete()
+            return await callable_obj(*args, **kwargs)
+
+    return _wrapped
+
+
+def observe_callable(callable_obj: Any) -> None:
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is not None:
+        capture.observe_callable(callable_obj)
+
+
+async def call(callable_obj: Any, *args: Any, **kwargs: Any) -> Any:
+    """Mark an opaque phase incomplete unless its callable owns all call tracking."""
+    observe_callable(callable_obj)
+    return await callable_obj(*args, **kwargs)
+
+
+def current_summary() -> ProviderUsageSummary | None:
+    capture = _ACTIVE_CAPTURE.get()
+    return capture.summary() if capture is not None else None
+
+
+async def tracked_complete(
+    adapter: Any,
+    messages: Any,
+    config: Any,
+) -> Any:
+    """Call an LLM adapter and account for its runtime-reported token usage."""
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is None:
+        return await adapter.complete(messages, config)
+
+    (
+        effective_config,
+        adapter_contract,
+        preparation_error,
+        preparation_complete,
+        prepared,
+    ) = _prepare_completion_configuration(adapter, config)
+    if not preparation_complete:
+        capture.mark_incomplete()
+
+    call = capture.begin(
+        role=getattr(config, "role", None),
+        model=getattr(effective_config, "model", None),
+        configuration=_completion_configuration(
+            adapter,
+            config,
+            effective_config,
+            adapter_contract,
+        ),
+    )
+    if preparation_error is not None:
+        capture.finish(call, None)
+        return preparation_error
+    if prepared is not None and not _prepared_completion_authority_is_current(adapter, prepared):
+        capture.mark_incomplete()
+    try:
+        prepared_dispatch = getattr(adapter, "frugality_complete_prepared", None)
+        if prepared is not None and callable(prepared_dispatch):
+            result = await prepared_dispatch(messages, prepared)
+        else:
+            result = await adapter.complete(messages, effective_config)
+    except BaseException:
+        if prepared is not None and not _prepared_completion_authority_is_current(
+            adapter, prepared
+        ):
+            capture.mark_incomplete()
+        capture.finish(call, None)
+        raise
+
+    if prepared is not None and not _prepared_completion_authority_is_current(adapter, prepared):
+        capture.mark_incomplete()
+
+    token_spend: float | None = None
+    if getattr(result, "is_ok", False):
+        response = getattr(result, "value", None)
+        capture.resolve_model(call, getattr(response, "model", None))
+        usage = getattr(response, "usage", None)
+        counters = [
+            getattr(usage, field, None)
+            for field in ("prompt_tokens", "completion_tokens", "total_tokens")
+        ]
+        normalized_counters = tuple(_non_negative_counter(counter) for counter in counters)
+        if all(counter is not None for counter in normalized_counters):
+            prompt_tokens, completion_tokens, total_tokens = normalized_counters
+            if (
+                prompt_tokens is not None
+                and completion_tokens is not None
+                and total_tokens is not None
+                and total_tokens == prompt_tokens + completion_tokens
+            ):
+                token_spend = _positive_finite(total_tokens)
+    capture.finish(call, token_spend)
+    return result
+
+
+def _prepared_completion_authority_is_current(
+    adapter: Any,
+    prepared: PreparedFrugalityCompletion,
+) -> bool:
+    """Treat mutable provider-authority drift as incomplete telemetry only."""
+    validator = getattr(adapter, "frugality_validate_prepared_completion", None)
+    if not callable(validator):
+        return True
+    try:
+        return validator(prepared) is True
+    except Exception:  # noqa: BLE001 — opaque dependency authority fails closed
+        return False
+
+
+async def tracked_agent_task_to_result(
+    runtime: Any,
+    *,
+    role: str,
+    prompt: str,
+    tools: list[str] | None = None,
+    system_prompt: str | None = None,
+) -> Any:
+    """Call an agent runtime and strictly sum usage across its message stream."""
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is None:
+        return await runtime.execute_task_to_result(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+        )
+
+    call = capture.begin(
+        role=role,
+        model=_runtime_setting(runtime, "model", "_model"),
+        configuration=_agent_runtime_configuration(
+            runtime,
+            {},
+            tools=tools,
+            system_prompt=system_prompt,
+        ),
+    )
+    try:
+        result = await runtime.execute_task_to_result(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+        )
+    except BaseException:
+        capture.finish(call, None)
+        _complete_agent_runtime_attestation(runtime, capture)
+        raise
+
+    token_spend: float | None = None
+    if getattr(result, "is_ok", False):
+        task_result = getattr(result, "value", None)
+        try:
+            messages = tuple(getattr(task_result, "messages", ()))
+        except TypeError:
+            messages = ()
+            capture.mark_incomplete()
+        _bind_stream_effective_model(capture, call, messages)
+        token_spend = _message_token_spend(messages)
+    capture.finish(call, token_spend)
+    _complete_agent_runtime_attestation(runtime, capture)
+    return result
+
+
+async def tracked_agent_task(
+    runtime: Any,
+    *,
+    role: str,
+    prompt: str,
+    tools: list[str] | None = None,
+    system_prompt: str | None = None,
+    **kwargs: Any,
+) -> AsyncIterator[Any]:
+    """Stream one auxiliary runtime call while accounting all reported usage."""
+    capture = _ACTIVE_CAPTURE.get()
+    if capture is None:
+        async for message in runtime.execute_task(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+            **kwargs,
+        ):
+            yield message
+        return
+
+    call = capture.begin(
+        role=role,
+        model=_runtime_setting(runtime, "model", "_model"),
+        configuration=_agent_runtime_configuration(
+            runtime,
+            kwargs,
+            tools=tools,
+            system_prompt=system_prompt,
+        ),
+    )
+    messages: list[Any] = []
+    try:
+        async for message in runtime.execute_task(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+            **kwargs,
+        ):
+            messages.append(message)
+            yield message
+    except BaseException:
+        capture.finish(call, None)
+        _complete_agent_runtime_attestation(runtime, capture)
+        raise
+    _bind_stream_effective_model(capture, call, messages)
+    capture.finish(call, _message_token_spend(messages))
+    _complete_agent_runtime_attestation(runtime, capture)
+
+
+def _complete_agent_runtime_attestation(
+    runtime: Any,
+    capture: GenerationProviderUsageCapture,
+) -> None:
+    """Release task-local runtime authority without failing evolution."""
+    complete = getattr(runtime, "frugality_runtime_attestation_complete", None)
+    if not callable(complete):
+        return
+    try:
+        complete()
+    except Exception:  # noqa: BLE001 - cleanup failure invalidates only proof
+        capture.mark_incomplete()
+
+
+def _runtime_setting(runtime: Any, *names: str) -> str | None:
+    for name in names:
+        value = getattr(runtime, name, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _runtime_configuration_setting(runtime: Any, *names: str) -> object:
+    """Return the first declared value without erasing explicit blanks."""
+    for name in names:
+        value = getattr(runtime, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _prepare_completion_configuration(
+    adapter: Any,
+    config: Any,
+) -> tuple[
+    Any,
+    object,
+    Result[Any, Any] | None,
+    bool,
+    PreparedFrugalityCompletion | None,
+]:
+    """Seal profile resolution before fingerprinting and provider dispatch.
+
+    Eligible adapters resolve their role/profile exactly once and return a
+    config with those selectors cleared.  Passing that sealed config through
+    ``complete`` prevents the adapter from resolving a different global
+    profile after evidence has already been captured.
+    """
+    provider = getattr(adapter, "frugality_prepare_completion", None)
+    if not callable(provider):
+        return config, _INVALID_CONFIGURATION, None, False, None
+    try:
+        prepared_result = provider(config)
+    except Exception:  # noqa: BLE001 — opaque preparation must fail closed
+        return config, _INVALID_CONFIGURATION, None, False, None
+    if not isinstance(prepared_result, Result):
+        return config, _INVALID_CONFIGURATION, None, False, None
+    if prepared_result.is_err:
+        return config, _INVALID_CONFIGURATION, prepared_result, False, None
+    prepared = prepared_result.value
+    if (
+        not isinstance(prepared, PreparedFrugalityCompletion)
+        or not isinstance(prepared.config, CompletionConfig)
+        or prepared.config.role is not None
+        or prepared.config.profile is not None
+    ):
+        return config, _INVALID_CONFIGURATION, None, False, None
+    adapter_class = f"{type(adapter).__module__}.{type(adapter).__qualname__}"
+    schema = _COMPLETION_ADAPTER_SCHEMAS.get(adapter_class)
+    if schema is not None and schema.requires_sealed_dispatch:
+        dispatch = getattr(adapter, "frugality_complete_prepared", None)
+        if prepared.dispatch is None or not callable(dispatch):
+            return prepared.config, prepared.contract, None, False, prepared
+    return prepared.config, prepared.contract, None, True, prepared
+
+
+def _completion_configuration(
+    adapter: Any,
+    requested_config: Any,
+    effective_config: Any,
+    adapter_contract: object,
+) -> dict[str, object]:
+    return {
+        "surface": "completion",
+        "backend": _completion_backend_configuration(adapter),
+        "adapter_contract": _completion_adapter_configuration(adapter, adapter_contract),
+        "requested_model": _configuration_text(getattr(requested_config, "model", None)),
+        "requested_profile": _configuration_text(
+            getattr(requested_config, "profile", None),
+            optional=True,
+        ),
+        "model": _configuration_text(getattr(effective_config, "model", None)),
+        "reasoning_effort": _configuration_text(
+            getattr(effective_config, "reasoning_effort", None),
+            optional=True,
+        ),
+        "temperature": getattr(effective_config, "temperature", None),
+        "top_p": getattr(effective_config, "top_p", None),
+        "max_tokens": getattr(effective_config, "max_tokens", None),
+        "max_turns": getattr(effective_config, "max_turns", None),
+        "model_is_explicit": getattr(effective_config, "model_is_explicit", None),
+        "response_format": getattr(effective_config, "response_format", None),
+        "stop": getattr(effective_config, "stop", None),
+    }
+
+
+def _completion_backend_configuration(adapter: Any) -> object:
+    """Preserve an explicit blank/unknown backend as invalid, not absent."""
+    for name in ("llm_backend", "runtime_backend", "provider"):
+        value = getattr(adapter, name, None)
+        if value is not None:
+            return _configuration_text(value)
+    return _configuration_text(f"{type(adapter).__module__}.{type(adapter).__qualname__}")
+
+
+def _completion_adapter_configuration(adapter: Any, contract: object) -> object:
+    """Validate one registered, resolved, single-attempt execution envelope."""
+    adapter_class = f"{type(adapter).__module__}.{type(adapter).__qualname__}"
+    schema = _COMPLETION_ADAPTER_SCHEMAS.get(adapter_class)
+    if schema is None:
+        return _INVALID_CONFIGURATION
+    try:
+        if not _valid_completion_adapter_contract(contract, schema):
+            return _INVALID_CONFIGURATION
+        assert isinstance(contract, Mapping)
+        settings = contract["settings"]
+        effective_request = contract["effective_request"]
+        assert isinstance(settings, Mapping)
+        assert isinstance(effective_request, Mapping)
+        return {
+            "adapter_class": adapter_class,
+            "schema_version": schema.schema_version,
+            "schema_id": schema.schema_id,
+            "internal_attempt_limit": 1,
+            "credential_authority": contract["credential_authority"],
+            "effective_request": dict(effective_request),
+            "settings": dict(settings),
+        }
+    except Exception:  # noqa: BLE001 — opaque attestation must fail closed
+        return _INVALID_CONFIGURATION
+
+
+def _valid_completion_adapter_contract(
+    contract: object,
+    schema: _CompletionAdapterSchema,
+) -> bool:
+    if not isinstance(contract, Mapping):
+        return False
+    if not _json_primitive_tree(contract, reject_sensitive_keys=True):
+        return False
+    if set(contract) != _COMPLETION_CONTRACT_KEYS:
+        return False
+    schema_version = contract.get("schema_version")
+    if (
+        type(schema_version) is not int
+        or schema_version != schema.schema_version
+        or contract.get("schema_id") != schema.schema_id
+    ):
+        return False
+    attempt_limit = contract.get("internal_attempt_limit")
+    if type(attempt_limit) is not int or attempt_limit != 1:
+        return False
+    if not _valid_credential_authority(contract.get("credential_authority")):
+        return False
+
+    settings = contract.get("settings")
+    if not isinstance(settings, Mapping) or not settings or set(settings) != schema.settings:
+        return False
+    retry_value = settings.get(schema.retry_setting)
+    if type(retry_value) is not int or retry_value != schema.proof_retry_value:
+        return False
+    if not _valid_registered_settings(settings):
+        return False
+
+    return _valid_effective_request(contract.get("effective_request"))
+
+
+def _valid_credential_authority(value: object) -> bool:
+    prefix = "hmac-sha256-installation-key-v2:"
+    if not isinstance(value, str) or not value.startswith(prefix):
+        return False
+    digest = value.removeprefix(prefix)
+    return len(digest) == 64 and all(character in "0123456789abcdef" for character in digest)
+
+
+def _valid_registered_settings(settings: Mapping[str, object]) -> bool:
+    if _positive_finite(settings.get("timeout")) is None:
+        return False
+    if not isinstance(settings.get("io_recorder_configured"), bool):
+        return False
+    api_base = settings.get("api_base")
+    if not _valid_api_base(api_base):
+        return False
+    if "dependency_defaults_verified" in settings and (
+        settings.get("dependency_defaults_verified") is not True
+        or type(settings.get("dependency_max_retries")) is not int
+        or settings.get("dependency_max_retries") != 0
+        or _configuration_text(settings.get("dependency_version")) is _INVALID_CONFIGURATION
+        or settings.get("dependency_provider")
+        not in {"anthropic", "google", "openai", "openrouter"}
+        or settings.get("dependency_client_sealed") is not True
+        or settings.get("dependency_cleanup_required") is not True
+        or settings.get("dependency_transport_contract") != "ouroboros.httpx.async.v1"
+        or settings.get("dependency_isolation_kind") != "subprocess"
+        or settings.get("dependency_worker_protocol") != "ouroboros.litellm.worker.v1"
+        or settings.get("dependency_worker_environment_contract") != "ouroboros.empty-env.v1"
+        or settings.get("dependency_worker_cwd_contract") != "ouroboros.private-empty-tempdir.v1"
+        or settings.get("dependency_mutation_audit") != "litellm.module-setattr.v1"
+        or _configuration_text(settings.get("worker_launcher_path")) is _INVALID_CONFIGURATION
+        or not isinstance(settings.get("worker_launcher_path"), str)
+        or not Path(settings["worker_launcher_path"]).is_absolute()
+        or _configuration_text(settings.get("worker_executable_resolved_path"))
+        is _INVALID_CONFIGURATION
+        or not isinstance(settings.get("worker_executable_resolved_path"), str)
+        or not Path(settings["worker_executable_resolved_path"]).is_absolute()
+        or not _valid_sha256(settings.get("worker_executable_content_sha256"))
+        or _configuration_text(settings.get("worker_python_version")) is _INVALID_CONFIGURATION
+        or settings.get("worker_module") != "ouroboros.providers.litellm_proof_worker"
+        or not _valid_sha256(settings.get("worker_implementation_sha256"))
+        or settings.get("adapter_module") != "ouroboros.providers.litellm_adapter"
+        or not _valid_sha256(settings.get("adapter_implementation_sha256"))
+        or settings.get("ouroboros_implementation_contract") != "ouroboros.python-sources.v1"
+        or not _valid_sha256(settings.get("ouroboros_implementation_sha256"))
+        or _configuration_text(settings.get("httpx_dependency_version")) is _INVALID_CONFIGURATION
+        or _configuration_text(settings.get("openai_dependency_version")) is _INVALID_CONFIGURATION
+        or settings.get("dependency_client_type")
+        != (
+            "openai.AsyncOpenAI"
+            if settings.get("dependency_provider") == "openai"
+            else "litellm.AsyncHTTPHandler"
+        )
+    ):
+        return False
+    default_model = settings.get("default_model")
+    return not (
+        default_model is not None and _configuration_text(default_model) is _INVALID_CONFIGURATION
+    )
+
+
+def _valid_api_base(value: object) -> bool:
+    """Accept only explicit, credential-free HTTP(S) route authority."""
+    if _configuration_text(value) is _INVALID_CONFIGURATION or not isinstance(value, str):
+        return False
+    try:
+        parsed = urlsplit(value)
+        _ = parsed.port
+    except ValueError:
+        return False
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _valid_effective_request(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != _EFFECTIVE_REQUEST_KEYS:
+        return False
+    for key in ("model", "profile_model", "role"):
+        if _configuration_text(value.get(key)) is _INVALID_CONFIGURATION:
+            return False
+    for key in ("profile", "profile_name", "backend_profile", "reasoning_effort"):
+        candidate = value.get(key)
+        if candidate is not None and _configuration_text(candidate) is _INVALID_CONFIGURATION:
+            return False
+    max_tokens = value.get("max_tokens")
+    if type(max_tokens) is not int or _positive_finite(max_tokens) is None:
+        return False
+    if _finite_non_negative(value.get("temperature")) is None:
+        return False
+    if _finite_non_negative(value.get("top_p")) is None:
+        return False
+    max_turns = value.get("max_turns")
+    if max_turns is not None and (
+        type(max_turns) is not int or _positive_finite(max_turns) is None
+    ):
+        return False
+    if not isinstance(value.get("model_is_explicit"), bool):
+        return False
+    stop = value.get("stop")
+    if stop is not None and (
+        not isinstance(stop, list) or any(not isinstance(item, str) for item in stop)
+    ):
+        return False
+    response_format = value.get("response_format")
+    return response_format is None or isinstance(response_format, Mapping)
+
+
+def _agent_runtime_attestation_configuration(runtime: Any) -> object:
+    """Validate one exact, registered runtime-owned execution envelope."""
+    runtime_class = f"{type(runtime).__module__}.{type(runtime).__qualname__}"
+    schema = _AGENT_RUNTIME_SCHEMAS.get(runtime_class)
+    provider = getattr(runtime, "frugality_runtime_attestation", None)
+    if schema is None or not callable(provider):
+        return _INVALID_CONFIGURATION
+    try:
+        contract = provider()
+        if not _valid_agent_runtime_contract(contract, runtime_class, schema):
+            return _INVALID_CONFIGURATION
+        assert isinstance(contract, Mapping)
+        settings = contract["settings"]
+        assert isinstance(settings, Mapping)
+        return {
+            "schema_version": schema.schema_version,
+            "schema_id": schema.schema_id,
+            "implementation": runtime_class,
+            "runtime_backend": schema.runtime_backend,
+            "runtime_handle_backend": schema.runtime_handle_backend,
+            "settings": dict(settings),
+        }
+    except Exception:  # noqa: BLE001 - opaque runtime authority fails closed
+        return _INVALID_CONFIGURATION
+
+
+def _valid_agent_runtime_contract(
+    contract: object,
+    runtime_class: str,
+    schema: _AgentRuntimeSchema,
+) -> bool:
+    if not isinstance(contract, Mapping):
+        return False
+    if not _json_primitive_tree(contract, reject_sensitive_keys=True):
+        return False
+    if set(contract) != _AGENT_RUNTIME_CONTRACT_KEYS:
+        return False
+    if (
+        type(contract.get("schema_version")) is not int
+        or contract.get("schema_version") != schema.schema_version
+        or contract.get("schema_id") != schema.schema_id
+        or contract.get("implementation") != runtime_class
+        or contract.get("runtime_backend") != schema.runtime_backend
+        or contract.get("runtime_handle_backend") != schema.runtime_handle_backend
+    ):
+        return False
+    settings = contract.get("settings")
+    if not isinstance(settings, Mapping) or set(settings) != set(schema.setting_kinds):
+        return False
+    for name, kind in schema.setting_kinds.items():
+        if not _valid_agent_runtime_setting(settings.get(name), kind):
+            return False
+    for name, allowed in schema.literal_settings.items():
+        if settings.get(name) not in allowed:
+            return False
+    if schema.schema_id == "ouroboros.codex_cli_runtime.v4":
+        entry_count = settings.get("child_environment_entry_count")
+        sensitive_entry_count = settings.get("child_environment_sensitive_entry_count")
+        if (
+            type(entry_count) is not int
+            or type(sensitive_entry_count) is not int
+            or sensitive_entry_count > entry_count
+        ):
+            return False
+        if settings.get("cli_path") != settings.get("cli_executable_path"):
+            return False
+        if settings.get("skills_source") == "package" and not str(
+            settings.get("skills_location", "")
+        ).startswith("packaged://"):
+            return False
+        if (
+            settings.get("skill_dispatcher_kind") == "packaged"
+            and settings.get("skill_dispatcher_identity") != "packaged"
+        ):
+            return False
+    return True
+
+
+def _valid_agent_runtime_setting(value: object, kind: str) -> bool:
+    if kind == "optional_text":
+        return value is None or _configuration_text(value) is not _INVALID_CONFIGURATION
+    if kind == "text":
+        return _configuration_text(value) is not _INVALID_CONFIGURATION
+    if kind == "sha256":
+        return _valid_sha256(value)
+    if kind == "absolute_path":
+        return (
+            _configuration_text(value) is not _INVALID_CONFIGURATION
+            and isinstance(value, str)
+            and Path(value).is_absolute()
+        )
+    if kind == "skill_location":
+        return (
+            _configuration_text(value) is not _INVALID_CONFIGURATION
+            and isinstance(value, str)
+            and (value.startswith("packaged://") or Path(value).is_absolute())
+        )
+    if kind == "dispatcher_identity":
+        return value == "packaged" or _valid_sha256(value)
+    if kind == "positive_number":
+        return _positive_finite(value) is not None
+    if kind == "optional_positive_number":
+        return value is None or _positive_finite(value) is not None
+    if kind == "positive_int":
+        return type(value) is int and value > 0
+    if kind == "non_negative_int":
+        return type(value) is int and value >= 0
+    if kind == "bool":
+        return isinstance(value, bool)
+    if kind == "string_sequence":
+        return (
+            isinstance(value, list | tuple)
+            and all(_configuration_text(item) is not _INVALID_CONFIGURATION for item in value)
+            and len(set(value)) == len(value)
+            and list(value) == sorted(value)
+        )
+    if kind == "relative_posix_path":
+        if (
+            _configuration_text(value) is _INVALID_CONFIGURATION
+            or not isinstance(value, str)
+            or "\\" in value
+        ):
+            return False
+        parsed = PurePosixPath(value)
+        return not parsed.is_absolute() and ".." not in parsed.parts and str(parsed) == value
+    return False
+
+
+def _valid_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _agent_runtime_configuration(
+    runtime: Any,
+    kwargs: Mapping[str, object],
+    *,
+    tools: list[str] | None,
+    system_prompt: str | None,
+) -> dict[str, object]:
+    runtime_backend = _configuration_text(
+        _runtime_configuration_setting(runtime, "runtime_backend", "_runtime_backend"),
+        fallback=f"{type(runtime).__module__}.{type(runtime).__qualname__}",
+    )
+    known_kwargs = {
+        "model",
+        "permission_mode",
+        "reasoning_effort",
+        "resume_handle",
+        "resume_session_id",
+        "service_tier",
+    }
+    extra_request_settings = {
+        key: value for key, value in kwargs.items() if key not in known_kwargs
+    }
+    return {
+        "surface": "agent_runtime",
+        "runtime_attestation": _agent_runtime_attestation_configuration(runtime),
+        "runtime_backend": runtime_backend,
+        "llm_backend": _configuration_text(
+            _runtime_configuration_setting(runtime, "llm_backend", "_llm_backend"),
+            fallback=runtime_backend,
+        ),
+        "model": _configuration_text(
+            kwargs.get("model"),
+            fallback=_runtime_configuration_setting(runtime, "model", "_model"),
+        ),
+        "reasoning_effort": _configuration_text(
+            kwargs.get("reasoning_effort"),
+            fallback=_runtime_configuration_setting(
+                runtime,
+                "reasoning_effort",
+                "_reasoning_effort",
+            ),
+            optional=True,
+        ),
+        "service_tier": _configuration_text(
+            kwargs.get("service_tier"),
+            fallback=_runtime_configuration_setting(runtime, "service_tier", "_service_tier"),
+            optional=True,
+        ),
+        "permission_mode": _configuration_text(
+            kwargs.get("permission_mode"),
+            fallback=_runtime_configuration_setting(
+                runtime,
+                "permission_mode",
+                "_permission_mode",
+            ),
+            optional=True,
+        ),
+        "resume_handle": _resume_handle_configuration(kwargs.get("resume_handle")),
+        "resume_session": _resume_session_configuration(kwargs.get("resume_session_id")),
+        "tools": _tools_configuration(tools),
+        "system_prompt_digest": _optional_text_digest(system_prompt),
+        "extra_request_settings": extra_request_settings,
+    }
+
+
+def _configuration_text(
+    value: object,
+    *,
+    fallback: object = None,
+    optional: bool = False,
+) -> object:
+    candidate = value if value is not None else fallback
+    if candidate is None:
+        return None if optional else _INVALID_CONFIGURATION
+    if not isinstance(candidate, str) or not candidate.strip():
+        return _INVALID_CONFIGURATION
+    normalized = candidate.strip()
+    return _INVALID_CONFIGURATION if normalized.lower() == "unknown" else normalized
+
+
+def _resume_handle_configuration(handle: object) -> object:
+    if handle is None:
+        return {"mode": "fresh"}
+    backend = _configuration_text(_runtime_setting(handle, "backend"))
+    kind = _configuration_text(_runtime_setting(handle, "kind"))
+    metadata = getattr(handle, "metadata", None)
+    if (
+        backend is _INVALID_CONFIGURATION
+        or kind is _INVALID_CONFIGURATION
+        or not isinstance(metadata, Mapping)
+    ):
+        return _INVALID_CONFIGURATION
+    resume_identifiers = (
+        getattr(handle, "native_session_id", None),
+        getattr(handle, "conversation_id", None),
+        getattr(handle, "previous_response_id", None),
+        getattr(handle, "transcript_path", None),
+        metadata.get("server_session_id"),
+    )
+    if any(value is not None for value in resume_identifiers):
+        # The runtime would inherit arm-specific transcript state. Without a
+        # stable semantic context fingerprint it is not a comparable provider call.
+        return _INVALID_CONFIGURATION
+    if set(metadata) - _SCOPED_HANDLE_METADATA_FIELDS:
+        return _INVALID_CONFIGURATION
+    semantic_metadata = {
+        key: metadata[key] for key in ("level_number", "scope", "session_role") if key in metadata
+    }
+    if not _json_primitive_tree(semantic_metadata):
+        return _INVALID_CONFIGURATION
+    return {
+        "mode": "scoped_fresh",
+        "backend": backend,
+        "kind": kind,
+        "approval_mode": _configuration_text(
+            _runtime_configuration_setting(handle, "approval_mode"),
+            fallback="none",
+        ),
+        "cwd_bound": bool(_runtime_setting(handle, "cwd")),
+        "semantic_metadata": semantic_metadata,
+    }
+
+
+def _resume_session_configuration(session_id: object) -> object:
+    if session_id is None:
+        return "fresh"
+    if isinstance(session_id, str) and session_id.strip():
+        return _INVALID_CONFIGURATION
+    return _INVALID_CONFIGURATION
+
+
+def _tools_configuration(tools: list[str] | None) -> object:
+    if tools is None:
+        return None
+    if not isinstance(tools, list) or any(not isinstance(tool, str) or not tool for tool in tools):
+        return _INVALID_CONFIGURATION
+    return tuple(tools)
+
+
+def _optional_text_digest(value: str | None) -> object:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return _INVALID_CONFIGURATION
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _json_primitive_tree(
+    value: object,
+    *,
+    reject_sensitive_keys: bool = False,
+) -> bool:
+    """Validate a bounded JSON tree without recursive traversal."""
+    stack: list[tuple[object, int, bool]] = [(value, 0, False)]
+    active_containers: set[int] = set()
+    node_count = 0
+    while stack:
+        current, depth, exiting = stack.pop()
+        if exiting:
+            active_containers.discard(id(current))
+            continue
+        node_count += 1
+        if node_count > _MAX_CONFIGURATION_NODES:
+            return False
+        if current is None or isinstance(current, int | bool):
+            continue
+        if isinstance(current, float):
+            if not math.isfinite(current):
+                return False
+            continue
+        if isinstance(current, str):
+            if len(current) > _MAX_CONFIGURATION_TEXT_LENGTH:
+                return False
+            continue
+        if depth >= _MAX_CONFIGURATION_DEPTH:
+            return False
+        if isinstance(current, Mapping):
+            identity = id(current)
+            if identity in active_containers:
+                return False
+            active_containers.add(identity)
+            try:
+                if len(current) > _MAX_CONFIGURATION_NODES:
+                    return False
+                items = tuple(current.items())
+            except Exception:  # noqa: BLE001 — opaque mappings fail closed
+                return False
+            for key, _item in items:
+                if not isinstance(key, str) or len(key) > _MAX_CONFIGURATION_TEXT_LENGTH:
+                    return False
+                if reject_sensitive_keys and _sensitive_configuration_key(key):
+                    return False
+            stack.append((current, depth, True))
+            stack.extend((item, depth + 1, False) for _, item in reversed(items))
+            continue
+        if isinstance(current, list | tuple):
+            identity = id(current)
+            if identity in active_containers:
+                return False
+            active_containers.add(identity)
+            if len(current) > _MAX_CONFIGURATION_NODES:
+                return False
+            stack.append((current, depth, True))
+            stack.extend((item, depth + 1, False) for item in reversed(current))
+            continue
+        return False
+    return True
+
+
+def _sensitive_configuration_key(key: str) -> bool:
+    normalized = "_".join(
+        part
+        for part in "".join(
+            character.lower() if character.isalnum() else " " for character in key
+        ).split()
+    )
+    return normalized in _SENSITIVE_CONFIGURATION_KEYS
+
+
+def _canonical_configuration(configuration: Mapping[str, object]) -> str:
+    if not _json_primitive_tree(configuration):
+        raise ValueError("provider configuration is not a finite JSON primitive tree")
+    return json.dumps(
+        dict(configuration),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _fingerprint_configurations(configurations: Iterator[str]) -> str:
+    encoded = json.dumps(
+        sorted(set(configurations)),
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _configuration_assignments(
+    calls: list[_ProviderCall],
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Bind each stable provider role to its ordered configuration calls."""
+    by_role: dict[str, list[str]] = {}
+    for call in calls:
+        by_role.setdefault(call.role, []).append(
+            _fingerprint_configurations(iter((call.configuration,)))
+        )
+    return tuple((role, tuple(configurations)) for role, configurations in sorted(by_role.items()))
+
+
+def _positive_finite(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) and number > 0 else None
+
+
+def _finite_non_negative(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _non_negative_counter(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+_FALLBACK_USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+_USAGE_KEYS = (*_FALLBACK_USAGE_KEYS, "cached_input_tokens", "total_tokens")
+
+
+def _message_token_spend(messages: Any) -> float | None:
+    """Use the same all-or-nothing semantics as executor token attribution."""
+    spend = 0.0
+    observed = False
+    try:
+        iterator: AsyncIterator[Any] | Iterator[Any] = iter(messages)
+    except TypeError:
+        return None
+    for message in iterator:
+        data = getattr(message, "data", None)
+        if not isinstance(data, Mapping):
+            continue
+        if data.get("usage_invalid") is True:
+            return None
+        if "usage" not in data:
+            continue
+        usage = data["usage"]
+        if not isinstance(usage, Mapping):
+            return None
+        unknown_token_keys = {
+            key
+            for key in usage
+            if isinstance(key, str) and key.endswith("_tokens") and key not in _USAGE_KEYS
+        }
+        if unknown_token_keys:
+            return None
+        normalized: dict[str, int] = {}
+        for key in _USAGE_KEYS:
+            if key not in usage:
+                continue
+            raw = usage[key]
+            counter = _non_negative_counter(raw)
+            if counter is None or _finite_non_negative(counter) is None:
+                return None
+            normalized[key] = counter
+        if "total_tokens" in normalized:
+            fallback_keys_present = {key for key in _FALLBACK_USAGE_KEYS if key in normalized}
+            if fallback_keys_present and not {"input_tokens", "output_tokens"}.issubset(
+                fallback_keys_present
+            ):
+                return None
+            components = [normalized[key] for key in _FALLBACK_USAGE_KEYS if key in normalized]
+            if components and normalized["total_tokens"] != sum(components):
+                return None
+            spend += float(normalized["total_tokens"])
+            observed = True
+            continue
+        components = [normalized[key] for key in _FALLBACK_USAGE_KEYS if key in normalized]
+        if {"input_tokens", "output_tokens"}.issubset(normalized):
+            component_total = sum(components)
+            if _finite_non_negative(component_total) is None:
+                return None
+            spend += float(component_total)
+            observed = True
+        elif components:
+            return None
+    return spend if observed and spend > 0 and math.isfinite(spend) else None
+
+
+def _bind_stream_effective_model(
+    capture: GenerationProviderUsageCapture,
+    call: _ProviderCall,
+    messages: Any,
+) -> None:
+    observations_present = False
+    malformed = False
+    effective_models: list[str] = []
+    try:
+        iterator: Iterator[Any] = iter(messages)
+    except TypeError:
+        capture.mark_incomplete()
+        return
+    for message in iterator:
+        data = getattr(message, "data", None)
+        if not isinstance(data, Mapping) or "model_observation" not in data:
+            continue
+        observations_present = True
+        observation = data["model_observation"]
+        if not isinstance(observation, Mapping) or "effective_model" not in observation:
+            malformed = True
+            continue
+        raw_model = observation["effective_model"]
+        if raw_model is None:
+            continue
+        if not isinstance(raw_model, str) or not raw_model.strip():
+            malformed = True
+            continue
+        effective_models.append(raw_model.strip())
+    if not observations_present or malformed or not effective_models:
+        capture.mark_incomplete()
+        return
+    if len(set(effective_models)) > 1:
+        capture.mark_incomplete()
+        return
+    if effective_models:
+        capture.resolve_model(call, effective_models[0])
+
+
+__all__ = [
+    "GenerationProviderUsageCapture",
+    "ProviderUsageSummary",
+    "call",
+    "capture_generation_provider_usage",
+    "capture_provider_usage",
+    "current_summary",
+    "observe_callable",
+    "tracked_agent_task",
+    "tracked_agent_task_to_result",
+    "tracked_complete",
+]

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import logging
-from typing import Literal
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, ValidationError, field_validator
 
@@ -28,6 +28,7 @@ from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDe
 from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.evolution.regression import RegressionDetector, RegressionReport
 from ouroboros.evolution.wonder import WonderOutput
 from ouroboros.providers.base import (
@@ -451,6 +452,8 @@ class ReflectEngine:
         consumers).
     """
 
+    frugality_provider_tracking: ClassVar[bool] = True
+
     llm_adapter: LLMAdapter
     model: str | None = None
     adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
@@ -600,7 +603,7 @@ class ReflectEngine:
             max_tokens=3000,
         )
 
-        result = await adapter.complete(messages, config)
+        result = await tracked_complete(adapter, messages, config)
 
         if result.is_err:
             logger.error("ReflectEngine LLM call failed: %s", result.error)

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -16,7 +16,7 @@ import json
 import logging
 import math
 import re
-from typing import Literal
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -27,6 +27,7 @@ from ouroboros.core.lineage import EvaluationSummary, OntologyLineage
 from ouroboros.core.seed import OntologySchema, Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.evolution.regression import RegressionDetector
 from ouroboros.providers.base import (
     CompletionConfig,
@@ -137,6 +138,8 @@ class WonderEngine:
     Includes degraded mode: if the LLM call fails, falls back to generic
     questions derived from evaluation gaps rather than halting the loop.
     """
+
+    frugality_provider_tracking: ClassVar[bool] = True
 
     llm_adapter: LLMAdapter
     model: str | None = None
@@ -274,7 +277,7 @@ class WonderEngine:
             max_tokens=2048,
         )
 
-        result = await adapter.complete(messages, config)
+        result = await tracked_complete(adapter, messages, config)
 
         if result.is_err:
             logger.warning(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1767,11 +1767,16 @@ def create_ouroboros_server(
 
     llm_adapters: dict[str, Any] = {}
 
-    def create_stage_llm_adapter(backend: str) -> Any:
+    def create_stage_llm_adapter(
+        backend: str,
+        *,
+        frugality_proof: bool = False,
+    ) -> Any:
         return create_llm_adapter(
             backend=backend,
             max_turns=stage_max_turns,
             cwd=effective_cwd,
+            frugality_proof=frugality_proof,
             allowed_tools=(
                 [] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
             ),
@@ -1784,7 +1789,14 @@ def create_ouroboros_server(
 
     llm_adapter = shared_stage_llm_adapter(interview_llm_backend)
     evaluation_llm_adapter = shared_stage_llm_adapter(evaluate_llm_backend)
-    reflect_llm_adapter = shared_stage_llm_adapter(reflect_llm_backend)
+    reflect_llm_adapter = create_stage_llm_adapter(
+        reflect_llm_backend,
+        frugality_proof=True,
+    )
+    evolution_evaluation_llm_adapter = create_stage_llm_adapter(
+        evaluate_llm_backend,
+        frugality_proof=True,
+    )
 
     # The shared interview adapter above is catalog-sealed for
     # envelope-capable backends (``allowed_tools=[]`` → ``--tools ""``), so
@@ -1833,13 +1845,9 @@ def create_ouroboros_server(
 
     def fresh_llm_adapter(role: str = "reflect"):
         backend = role_llm_backend(role)
-        return create_llm_adapter(
-            backend=backend,
-            max_turns=stage_max_turns,
-            cwd=effective_cwd,
-            allowed_tools=(
-                [] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
-            ),
+        return create_stage_llm_adapter(
+            backend,
+            frugality_proof=True,
         )
 
     def fresh_reflect_stage_llm_adapter():
@@ -1870,7 +1878,7 @@ def create_ouroboros_server(
     # Disabled by default to reduce latency per generation step.
     evolve_stage1 = os.environ.get("OUROBOROS_EVOLVE_STAGE1", "false").lower() == "true"
     evolution_eval_pipeline = EvaluationPipeline(
-        llm_adapter=evaluation_llm_adapter,
+        llm_adapter=evolution_evaluation_llm_adapter,
         config=PipelineConfig(
             stage1_enabled=evolve_stage1,
             stage2_enabled=True,
@@ -1945,7 +1953,7 @@ def create_ouroboros_server(
         return _parse_legacy_execution_task_summary(artifact, seed)
 
     spec_extractor = AssertionExtractor(
-        llm_adapter=evaluation_llm_adapter,
+        llm_adapter=evolution_evaluation_llm_adapter,
         model=get_llm_model_for_role(
             "assertion_extraction",
             backend=role_llm_backend("assertion_extraction"),
@@ -2180,7 +2188,11 @@ def create_ouroboros_server(
                 project_dir=project_dir,
             )
 
-            fix_result = await validation_adapter.execute_task_to_result(
+            from ouroboros.evolution.provider_usage import tracked_agent_task_to_result
+
+            fix_result = await tracked_agent_task_to_result(
+                validation_adapter,
+                role="evolution_validation_repair",
                 prompt=fix_prompt,
                 tools=["Read", "Edit", "Write", "Bash", "Glob", "Grep"],
             )
@@ -2197,6 +2209,13 @@ def create_ouroboros_server(
             f"Validation: {len(remaining)} errors remain after {max_attempts} attempts. "
             f"Remaining: {', '.join(remaining[:5])}"
         )
+
+    # These callables either use generation-scoped tracked provider helpers for
+    # every possible model call or stay deterministic.  The loop refuses a
+    # frugality PASS for arbitrary opaque evaluator/validator callables.
+    _evolution_evaluator.frugality_provider_tracking = True  # type: ignore[attr-defined]
+    _evolution_validator.frugality_provider_tracking = True  # type: ignore[attr-defined]
+    _evolution_executor.frugality_provider_tracking = True  # type: ignore[attr-defined]
 
     _scoped_reexecution_env = os.environ.get("OUROBOROS_SCOPED_REEXECUTION", "").strip().lower()
     _scoped_reexecution = _scoped_reexecution_env not in ("0", "false")

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -38,6 +38,11 @@ from ouroboros.core.worktree import (
 from ouroboros.evaluation.verification_artifacts import build_verification_artifacts
 from ouroboros.events.conductor import create_conductor_directive_attached_event
 from ouroboros.evolution import loop_support
+from ouroboros.evolution.frugality import (
+    PROOF_EVENT,
+    EvolutionFrugalityProof,
+    capture_project_baseline,
+)
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools.background import start_background_tool_job
@@ -65,6 +70,7 @@ log = structlog.get_logger(__name__)
 _EVOLVE_HANDLER_DEFAULTS: dict[str, object] = {
     "seed_content": None,
     "execute": True,
+    "benchmark_control": False,
     "parallel": True,
     "skip_qa": False,
     "project_dir": None,
@@ -78,6 +84,42 @@ _EVOLVE_HANDLER_DEFAULTS: dict[str, object] = {
     "conductor_directive": None,
     "recover_expired_claim": False,
 }
+
+
+async def _benchmark_control_error(
+    arguments: dict[str, Any],
+    *,
+    event_store: EventStore,
+    lineage_id: str,
+) -> str | None:
+    """Fail closed unless an explicit Gen 2+ control has a clean Git baseline."""
+    requested = arguments.get("benchmark_control", False)
+    if type(requested) is not bool:
+        return "benchmark_control must be a boolean"
+    if not requested:
+        return None
+    if arguments.get("execute", True) is not True:
+        return "benchmark_control requires execute=true"
+    if arguments.get("seed_content") not in (None, ""):
+        return "benchmark_control is Gen 2+ only; omit seed_content"
+    project_dir = arguments.get("project_dir")
+    if not isinstance(project_dir, str) or not project_dir.strip():
+        return "benchmark_control requires an explicit project_dir"
+    await event_store.initialize()
+    events = await event_store.replay_lineage(lineage_id)
+    if not any(
+        event.type == "lineage.generation.completed"
+        and isinstance(event.data.get("generation_number"), int)
+        and event.data["generation_number"] >= 1
+        for event in events
+    ):
+        return "benchmark_control requires an existing completed generation (Gen 2+)"
+    baseline = capture_project_baseline(project_dir)
+    if baseline.git_commit is None or baseline.workspace_path is None:
+        return "benchmark_control requires project_dir to be an explicit Git project/worktree"
+    if not baseline.clean:
+        return "benchmark_control requires a clean Git baseline"
+    return None
 
 
 def _evolve_handler_request_key(
@@ -358,6 +400,17 @@ class EvolveStepHandler(BridgeAwareMixin):
                     default=True,
                 ),
                 MCPToolParameter(
+                    name="benchmark_control",
+                    type=ToolInputType.BOOLEAN,
+                    description=(
+                        "Run a deliberate full-graph frugality control. Default: false. "
+                        "Requires execute=true, Gen 2+, an explicit Git project_dir, "
+                        "and a clean baseline; unavailable through plugin delegation."
+                    ),
+                    required=False,
+                    default=False,
+                ),
+                MCPToolParameter(
                     name="parallel",
                     type=ToolInputType.BOOLEAN,
                     description=(
@@ -459,8 +512,33 @@ class EvolveStepHandler(BridgeAwareMixin):
                 )
             )
         event_store = self.event_store or getattr(self.evolutionary_loop, "event_store", None)
+        benchmark_control = arguments.get("benchmark_control", False)
         if not isinstance(event_store, EventStore):
+            if benchmark_control is not False:
+                return Result.err(
+                    MCPToolError(
+                        "benchmark_control requires a durable EventStore",
+                        tool_name="ouroboros_evolve_step",
+                    )
+                )
             return await self._handle_once(dict(arguments))
+        benchmark_error = await _benchmark_control_error(
+            arguments,
+            event_store=event_store,
+            lineage_id=str(lineage_id),
+        )
+        if benchmark_error is not None:
+            return Result.err(MCPToolError(benchmark_error, tool_name="ouroboros_evolve_step"))
+        if benchmark_control is True and should_dispatch_via_plugin(
+            self.agent_runtime_backend,
+            self.opencode_mode,
+        ):
+            return Result.err(
+                MCPToolError(
+                    "benchmark_control requires the in-process evolve runtime",
+                    tool_name="ouroboros_evolve_step",
+                )
+            )
         configured_project_dir = (
             self.evolutionary_loop.get_project_dir()
             if self.evolutionary_loop is not None
@@ -472,7 +550,8 @@ class EvolveStepHandler(BridgeAwareMixin):
             configured_project_dir=configured_project_dir,
             fallback_cwd=Path.cwd().resolve(),
             execution_policy=loop_support.evolution_execution_policy(
-                getattr(self.evolutionary_loop, "config", None)
+                getattr(self.evolutionary_loop, "config", None),
+                benchmark_control=benchmark_control is True,
             ),
         )
         recovered_generation: int | None = None
@@ -672,6 +751,7 @@ class EvolveStepHandler(BridgeAwareMixin):
 
         execute = arguments.get("execute", True)
         parallel = arguments.get("parallel", True)
+        benchmark_control = arguments.get("benchmark_control", False) is True
         project_dir = arguments.get("project_dir")
         normalized_project_dir = (
             project_dir if isinstance(project_dir, str) and project_dir else None
@@ -701,6 +781,24 @@ class EvolveStepHandler(BridgeAwareMixin):
                     )
                 )
 
+        if benchmark_control:
+            effective_baseline = capture_project_baseline(
+                workspace.effective_cwd if workspace else effective_source_project_dir
+            )
+            if (
+                effective_baseline.git_commit is None
+                or effective_baseline.workspace_path is None
+                or not effective_baseline.clean
+            ):
+                if workspace is not None:
+                    release_lock(workspace.lock_path)
+                return Result.err(
+                    MCPToolError(
+                        "benchmark_control effective worktree must have a clean Git baseline",
+                        tool_name="ouroboros_evolve_step",
+                    )
+                )
+
         project_dir_token = self.evolutionary_loop.set_project_dir(
             workspace.effective_cwd if workspace else effective_source_project_dir
         )
@@ -712,6 +810,8 @@ class EvolveStepHandler(BridgeAwareMixin):
             # (evolve_step calls replay_lineage/append before executor/evaluator)
             await self.evolutionary_loop.event_store.initialize()
             evolve_kwargs: dict[str, Any] = {"execute": execute, "parallel": parallel}
+            if benchmark_control:
+                evolve_kwargs["benchmark_control"] = True
             if conductor_directive is not None:
                 evolve_kwargs["conductor_directive"] = conductor_directive
             result = recovered_evolve_result
@@ -799,6 +899,14 @@ class EvolveStepHandler(BridgeAwareMixin):
                         f"{len(gen.active_ac_indices)} active / "
                         f"{len(gen.frozen_ac_indices)} frozen"
                     ),
+                ]
+            )
+        if gen.frugality_evidence is not None:
+            proof = gen.frugality_evidence.proof
+            text_lines.extend(
+                [
+                    f"**Frugality proof**: {proof.status.value}",
+                    f"**Frugality evidence**: {proof.reason}",
                 ]
             )
         if workspace is not None:
@@ -918,6 +1026,7 @@ class EvolveStepHandler(BridgeAwareMixin):
             "similarity": sig.ontology_similarity,
             "next_generation": step.next_generation,
             "executed": execute,
+            "benchmark_control": benchmark_control,
             "qa_attempted": qa_attempted,
             "has_execution_output": gen.execution_output is not None,
             "active_ac_indices": list(gen.active_ac_indices),
@@ -932,6 +1041,11 @@ class EvolveStepHandler(BridgeAwareMixin):
             meta["worktree_branch"] = workspace.branch
         if qa_meta:
             meta["qa"] = qa_meta
+        if gen.frugality_evidence is not None:
+            meta["frugality"] = {
+                "observation": gen.frugality_evidence.observation.model_dump(mode="json"),
+                "proof": gen.frugality_evidence.proof.model_dump(mode="json"),
+            }
 
         from ouroboros.evolution.loop import StepAction
 
@@ -1320,6 +1434,25 @@ class LineageStatusHandler:
             f"**Generations**: {lineage.current_generation}",
             f"**Created**: {lineage.created_at.isoformat()}",
         ]
+        latest_frugality = next(
+            (event for event in reversed(events) if event.type == PROOF_EVENT),
+            None,
+        )
+        frugality_proof = None
+        if latest_frugality is not None:
+            try:
+                frugality_proof = EvolutionFrugalityProof.model_validate(
+                    latest_frugality.data.get("proof")
+                )
+            except (TypeError, ValueError):
+                frugality_proof = None
+        if frugality_proof is not None:
+            text_lines.extend(
+                [
+                    f"**Frugality proof**: {frugality_proof.status.value}",
+                    f"**Frugality evidence**: {frugality_proof.reason}",
+                ]
+            )
 
         # Ontology summary
         if lineage.current_ontology:
@@ -1379,6 +1512,11 @@ class LineageStatusHandler:
                     "status": lineage.status.value,
                     "generations": lineage.current_generation,
                     "goal": lineage.goal,
+                    "frugality": (
+                        frugality_proof.model_dump(mode="json")
+                        if frugality_proof is not None
+                        else None
+                    ),
                 },
             )
         )
@@ -1422,6 +1560,24 @@ class StartEvolveStepHandler:
             return Result.err(
                 MCPToolError(
                     "lineage_id is required",
+                    tool_name="ouroboros_start_evolve_step",
+                )
+            )
+        benchmark_control = arguments.get("benchmark_control", False)
+        if type(benchmark_control) is not bool:
+            return Result.err(
+                MCPToolError(
+                    "benchmark_control must be a boolean",
+                    tool_name="ouroboros_start_evolve_step",
+                )
+            )
+        if benchmark_control and should_dispatch_via_plugin(
+            self.agent_runtime_backend,
+            self.opencode_mode,
+        ):
+            return Result.err(
+                MCPToolError(
+                    "benchmark_control requires the in-process evolve runtime",
                     tool_name="ouroboros_start_evolve_step",
                 )
             )

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -94,6 +94,26 @@ def build_ac_dispatch_authority_scope(
     return _sha256_text(_canonical_json(payload))
 
 
+def build_ac_dispatch_request_digest(
+    *,
+    dispatch_contract: Mapping[str, object],
+    execution_policy: Mapping[str, object],
+) -> str:
+    """Hash the cross-worktree semantic request authority for one AC dispatch.
+
+    The durable capsule authority also binds execution/workspace identity through
+    ``base_scope``.  Those arm-specific values must not be compared across an
+    isolated frugality pair, while the provider-facing contract and execution
+    policy must match exactly for every shared root attempt.
+    """
+    payload = {
+        "version": 1,
+        "dispatch_contract": dict(dispatch_contract),
+        "execution_policy": dict(execution_policy),
+    }
+    return _sha256_text(_canonical_json(payload))
+
+
 class ACContextReferenceKind(StrEnum):
     """External context source named by an execution capsule."""
 
@@ -865,5 +885,6 @@ __all__ = [
     "bind_capsule_to_runtime_handle",
     "build_ac_dependency_references",
     "build_ac_dispatch_authority_scope",
+    "build_ac_dispatch_request_digest",
     "compile_ac_execution_capsule",
 ]

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -25,7 +25,6 @@ from typing import Any
 from ouroboros.codex.cli_policy import (
     DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS,
     DEFAULT_MAX_OUROBOROS_DEPTH,
-    build_codex_child_env,
     resolve_codex_cli_path,
 )
 from ouroboros.codex.runtime_profile import resolve_codex_profile
@@ -51,6 +50,12 @@ from ouroboros.orchestrator.adapter import (
     TaskResult,
     resolve_worker_cwd,
     worker_cwd_failure_message,
+)
+from ouroboros.orchestrator.frugality_runtime_attestation import (
+    attested_codex_child_environment,
+    build_codex_runtime_child_environment,
+    clear_attested_codex_child_environment,
+    codex_cli_runtime_attestation,
 )
 from ouroboros.orchestrator.skill_tool_mapping import discover_skill_tool_mappings
 from ouroboros.providers.base import CompletionConfig
@@ -251,11 +256,9 @@ class _CodexItemCorrelationScope:
 class CodexCliRuntime:
     """Agent runtime that shells out to the locally installed Codex CLI."""
 
-    _runtime_handle_backend = "codex_cli"
-    _runtime_backend = "codex"
+    _runtime_handle_backend, _runtime_backend = "codex_cli", "codex"
     _requires_memory_gate = True
-    _provider_name = "codex_cli"
-    _runtime_error_type = "CodexCliError"
+    _provider_name, _runtime_error_type = "codex_cli", "CodexCliError"
     _log_namespace = "codex_cli_runtime"
     _display_name = "Codex CLI"
     _default_cli_name = "codex"
@@ -271,6 +274,8 @@ class CodexCliRuntime:
     _child_session_env_keys = DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS
     _use_process_group = os.name == "posix"
     _completed_process_group_shutdown_timeout_seconds = 0.2
+    frugality_runtime_attestation = codex_cli_runtime_attestation
+    frugality_runtime_attestation_complete = clear_attested_codex_child_environment
 
     def __init__(
         self,
@@ -2168,21 +2173,9 @@ class CodexCliRuntime:
         return current_handle.native_session_id
 
     def _build_child_env(self) -> dict[str, str]:
-        """Build an isolated environment for child runtime processes.
-
-        Strips ``OUROBOROS_AGENT_RUNTIME`` and ``OUROBOROS_LLM_BACKEND`` so
-        that a child Codex process does not re-load the Ouroboros MCP server,
-        preventing the recursive startup loop described in #185. Also strips
-        parent Codex thread/session env so nested ``codex exec`` starts a fresh
-        subprocess instead of inheriting the current agent thread.
-        """
-        return build_codex_child_env(
-            max_depth=self._max_ouroboros_depth,
-            child_session_env_keys=self._child_session_env_keys,
-            depth_error_factory=lambda _depth, max_depth: RuntimeError(
-                f"Maximum Ouroboros nesting depth ({max_depth}) exceeded"
-            ),
-        )
+        """Return the proof-sealed child environment, or build a fresh one."""
+        attested = attested_codex_child_environment(self)
+        return attested or build_codex_runtime_child_environment(self)
 
     def _requires_process_stdin(self) -> bool:
         """Return True when the runtime needs a writable stdin pipe."""

--- a/src/ouroboros/orchestrator/coordinator.py
+++ b/src/ouroboros/orchestrator/coordinator.py
@@ -33,6 +33,7 @@ import math
 import re
 from typing import TYPE_CHECKING, Any
 
+from ouroboros.evolution.provider_usage import tracked_agent_task
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import DEFAULT_TOOLS, RuntimeHandle
 from ouroboros.orchestrator.capabilities import build_capability_graph
@@ -922,7 +923,9 @@ class LevelCoordinator:
                 base_effort=self._reasoning_effort,
                 is_decomposed_child=False,
             )
-            async for message in self._adapter.execute_task(
+            async for message in tracked_agent_task(
+                self._adapter,
+                role="executor_coordinator_review",
                 prompt=prompt,
                 tools=tools,
                 system_prompt=COORDINATOR_SYSTEM_PROMPT,

--- a/src/ouroboros/orchestrator/dependency_analyzer.py
+++ b/src/ouroboros/orchestrator/dependency_analyzer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.seed import AcceptanceCriterionInput, ac_text
 from ouroboros.core.types import Result
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -547,7 +548,8 @@ class DependencyAnalyzer:
         ac_list = "\n".join(f"AC {index}: {content}" for index, content in enumerate(criteria))
         prompt = DEPENDENCY_ANALYSIS_PROMPT.format(ac_list=ac_list)
 
-        response = await self._llm.complete(
+        response = await tracked_complete(
+            self._llm,
             messages=[Message(role=MessageRole.USER, content=prompt)],
             config=CompletionConfig(
                 model=self._model,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -56,6 +56,7 @@ class ExecutionEventEmitter:
         self._safe_emit_event = safe_emit_event
         self._last_ac_phase: dict[str, str] = {}
         self._last_discovery_signature: dict[str, tuple[tuple[str, ...], str]] = {}
+        self._primary_dispatch_by_attempt: dict[str, str] = {}
 
     @staticmethod
     def runtime_event_metadata(message: AgentMessage) -> dict[str, Any]:
@@ -154,6 +155,7 @@ class ExecutionEventEmitter:
         execution_id: str,
         session_id: str,
         capsule_fingerprint: str,
+        request_authority_digest: str,
         session_origin: str,
         runtime_handle: Any,
         dispatch_kind: str = "primary",
@@ -186,6 +188,10 @@ class ExecutionEventEmitter:
             r"sha256:[0-9a-f]{64}", capsule_fingerprint
         ):
             raise ValueError("AC dispatch capsule fingerprint is invalid")
+        if not isinstance(request_authority_digest, str) or not re.fullmatch(
+            r"sha256:[0-9a-f]{64}", request_authority_digest
+        ):
+            raise ValueError("AC dispatch request authority digest is invalid")
         if runtime_handle is not None:
             metadata = runtime_handle.metadata
             if metadata.get("ac_dispatch_id") != dispatch_id:
@@ -208,6 +214,7 @@ class ExecutionEventEmitter:
                     "signal_mode": signal_mode,
                     "follow_up_input_digest": follow_up_input_digest,
                     "capsule_fingerprint": capsule_fingerprint,
+                    "request_authority_digest": request_authority_digest,
                     "session_origin": session_origin,
                     "runtime_backend": (
                         runtime_handle.backend if runtime_handle is not None else None
@@ -216,6 +223,10 @@ class ExecutionEventEmitter:
                 },
             )
         )
+        if dispatch_kind == "primary":
+            if len(self._primary_dispatch_by_attempt) >= 4096:
+                self._primary_dispatch_by_attempt.pop(next(iter(self._primary_dispatch_by_attempt)))
+            self._primary_dispatch_by_attempt[runtime_identity.session_attempt_id] = dispatch_id
 
     async def emit_ac_dispatch_sealed(
         self,
@@ -652,10 +663,15 @@ class ExecutionEventEmitter:
         token_spend: float,
         usage_breakdown: dict[str, float],
         model: str | None,
+        effective_model: str | None,
         model_tier: str | None,
         model_mode: str | None,
         effort_level: str | None,
         runtime_backend: str | None,
+        llm_backend: str | None = None,
+        effort_mode: str | None = None,
+        permission_mode: str | None = None,
+        request_authority_digest: str | None = None,
     ) -> None:
         """Persist per-AC runtime-measured token spend (frugality-proof token axis).
 
@@ -684,10 +700,18 @@ class ExecutionEventEmitter:
                     "usage_breakdown": usage_breakdown,
                     "token_source": "runtime_usage",
                     "model": model,
-                    "model_tier": model_tier,
-                    "model_mode": model_mode,
-                    "effort_level": effort_level,
+                    "effective_model": effective_model,
+                    "model_tier": model_tier or "none",
+                    "model_mode": model_mode or "none",
+                    "effort_level": effort_level or "none",
+                    "effort_mode": effort_mode or "none",
                     "runtime_backend": runtime_backend,
+                    "llm_backend": llm_backend,
+                    "permission_mode": permission_mode,
+                    "request_authority_digest": request_authority_digest,
+                    "ac_dispatch_id": self._primary_dispatch_by_attempt.pop(
+                        runtime_identity.session_attempt_id, None
+                    ),
                 },
             )
         )
@@ -733,6 +757,9 @@ class ExecutionEventEmitter:
             "rejected_reasons": rejected_reasons,
             "accepted_fact_count": accepted_fact_count,
             "semantic_ac_key": semantic_ac_key,
+            "ac_dispatch_id": self._primary_dispatch_by_attempt.get(
+                runtime_identity.session_attempt_id
+            ),
         }
         # Strict bool only: a non-bool would be dropped by the proof's
         # ``_strict_bool`` guard anyway, so never smuggle a truthy string here.

--- a/src/ouroboros/orchestrator/frugality_evidence.py
+++ b/src/ouroboros/orchestrator/frugality_evidence.py
@@ -1,0 +1,132 @@
+"""Fail-closed primary-runtime evidence normalization for frugality receipts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import math
+
+from ouroboros.orchestrator.adapter import AgentMessage
+
+_TOKEN_SPEND_FALLBACK_KEYS: tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+_TOKEN_USAGE_KEYS: tuple[str, ...] = (
+    *_TOKEN_SPEND_FALLBACK_KEYS,
+    "cached_input_tokens",
+    "total_tokens",
+)
+
+
+def _nonnegative_token_counter(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def harvest_token_spend(
+    messages: list[AgentMessage],
+) -> tuple[float, dict[str, float]] | None:
+    """Sum a stream only when every runtime counter is known and reconciled."""
+    breakdown: dict[str, float] = {}
+    token_spend = 0.0
+    observed_spend = False
+    for message in messages:
+        data = getattr(message, "data", None)
+        if not isinstance(data, dict):
+            continue
+        if data.get("usage_invalid") is True:
+            return None
+        if "usage" not in data:
+            continue
+        usage = data["usage"]
+        if not isinstance(usage, Mapping):
+            return None
+        unknown_token_keys = {
+            key
+            for key in usage
+            if isinstance(key, str) and key.endswith("_tokens") and key not in _TOKEN_USAGE_KEYS
+        }
+        if unknown_token_keys:
+            return None
+        usable_usage: dict[str, float] = {}
+        for key in _TOKEN_USAGE_KEYS:
+            if key not in usage:
+                continue
+            counter = _nonnegative_token_counter(usage[key])
+            if counter is None:
+                return None
+            number = float(counter)
+            usable_usage[key] = number
+            breakdown[key] = breakdown.get(key, 0.0) + number
+
+        total_tokens = usable_usage.get("total_tokens")
+        if total_tokens is not None:
+            fallback_keys_present = {
+                key for key in _TOKEN_SPEND_FALLBACK_KEYS if key in usable_usage
+            }
+            if fallback_keys_present and not {"input_tokens", "output_tokens"}.issubset(
+                fallback_keys_present
+            ):
+                return None
+            spend_components = [
+                usable_usage[key] for key in _TOKEN_SPEND_FALLBACK_KEYS if key in usable_usage
+            ]
+            if spend_components and total_tokens != sum(spend_components):
+                return None
+            token_spend += total_tokens
+            observed_spend = True
+            continue
+
+        spend_components = [
+            usable_usage[key] for key in _TOKEN_SPEND_FALLBACK_KEYS if key in usable_usage
+        ]
+        if {
+            "input_tokens",
+            "output_tokens",
+        }.issubset(usable_usage):
+            token_spend += sum(spend_components)
+            observed_spend = True
+        elif spend_components:
+            return None
+
+    if (
+        not observed_spend
+        or token_spend <= 0
+        or not math.isfinite(token_spend)
+        or any(not math.isfinite(value) for value in breakdown.values())
+    ):
+        return None
+    return token_spend, breakdown
+
+
+def observed_effective_model(messages: list[AgentMessage]) -> str | None:
+    """Return one runtime-observed model or fail closed on an opaque stream."""
+    observations_present = False
+    models: list[str] = []
+    for message in messages:
+        data = getattr(message, "data", None)
+        if not isinstance(data, Mapping) or "model_observation" not in data:
+            continue
+        observations_present = True
+        observation = data["model_observation"]
+        if not isinstance(observation, Mapping) or "effective_model" not in observation:
+            return None
+        raw_model = observation["effective_model"]
+        if raw_model is None:
+            continue
+        if (
+            not isinstance(raw_model, str)
+            or not raw_model.strip()
+            or raw_model.strip().lower() == "unknown"
+        ):
+            return None
+        models.append(raw_model.strip())
+    if not observations_present or not models or len(set(models)) != 1:
+        return None
+    return models[0]
+
+
+__all__ = ["harvest_token_spend", "observed_effective_model"]

--- a/src/ouroboros/orchestrator/frugality_runtime_attestation.py
+++ b/src/ouroboros/orchestrator/frugality_runtime_attestation.py
@@ -1,0 +1,374 @@
+"""Stable auxiliary-runtime attestations for paired frugality evidence.
+
+The execution/resume authority contracts intentionally include process-local
+state.  Frugality compares independent arms, so its runtime contract must bind
+the same effect-bearing settings without nonces, object ids, or secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextvars import ContextVar
+import hashlib
+import hmac
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from ouroboros.codex.cli_policy import build_codex_child_env
+from ouroboros.core.project_identity import ProjectIdentityError, resolve_project_identity
+from ouroboros.providers.credential_authority import (
+    INSTALLATION_AUTHORITY_KEY_BYTES,
+    installation_authority_key,
+)
+
+_MAX_CHILD_ENVIRONMENT_ENTRIES = 4_096
+_MAX_CHILD_ENVIRONMENT_KEY_BYTES = 1_024
+_MAX_CHILD_ENVIRONMENT_VALUE_BYTES = 128 * 1_024
+_MAX_CHILD_ENVIRONMENT_TOTAL_BYTES = 2 * 1_024 * 1_024
+_CHILD_ENVIRONMENT_ENTRY_CONTEXT = b"ouroboros-codex-child-environment-authority-v2"
+_CHILD_ENVIRONMENT_AUTHORITY_SCHEME = "hmac-sha256-installation-key-v2"
+_CODEX_CONFIG_AUTHORITY_CONTEXT = b"ouroboros-codex-config-authority-v1"
+_SENSITIVE_ENVIRONMENT_KEY_RE = re.compile(
+    r"(?:^|_)(?:"
+    r"access_?token|api_?key|apikey|auth(?:entication|orization)?|bearer|"
+    r"client_?secret|cookie|credential(?:s)?|password|passwd|private_?key|"
+    r"refresh_?token|secret|session_?token|token"
+    r")(?:$|_)",
+    re.IGNORECASE,
+)
+_ATTESTED_CHILD_ENVIRONMENT_ATTR = "_frugality_attested_child_environment"
+
+
+def _text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _digest(value: object) -> str | None:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, RecursionError):
+        return None
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stable_dispatcher_identity(dispatcher: object) -> str | None:
+    if dispatcher is None:
+        return "packaged"
+    owner = getattr(dispatcher, "__self__", None) or dispatcher
+    stable_identity = getattr(owner, "stable_identity_contract", None)
+    if not callable(stable_identity):
+        return None
+    try:
+        identity = stable_identity()
+    except Exception:  # noqa: BLE001 - opaque custom authority fails closed
+        return None
+    if not isinstance(identity, Mapping):
+        return None
+    return _digest(
+        {
+            "module": getattr(dispatcher, "__module__", type(owner).__module__),
+            "qualname": getattr(dispatcher, "__qualname__", type(owner).__qualname__),
+            "stable_identity": dict(identity),
+        }
+    )
+
+
+def _resolved_path(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        return str(Path(value).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _environment_entry_authority(
+    key: str,
+    value: str,
+    *,
+    installation_key: bytes,
+) -> str:
+    """Return an installation-keyed entry identity without retaining its value."""
+    message = b"\x00".join(
+        (_CHILD_ENVIRONMENT_ENTRY_CONTEXT, key.encode("utf-8"), value.encode("utf-8"))
+    )
+    digest = hmac.new(
+        installation_key,
+        message,
+        hashlib.sha256,
+    ).hexdigest()
+    return digest
+
+
+def _codex_config_authority(
+    fingerprint: object,
+    *,
+    installation_key: bytes,
+) -> str | None:
+    """Protect a config-content fingerprint from offline candidate checks."""
+    if (
+        not isinstance(fingerprint, str)
+        or len(fingerprint) != 64
+        or any(character not in "0123456789abcdef" for character in fingerprint)
+    ):
+        return None
+    message = b"\x00".join((_CODEX_CONFIG_AUTHORITY_CONTEXT, fingerprint.encode("ascii")))
+    return hmac.new(installation_key, message, hashlib.sha256).hexdigest()
+
+
+def codex_child_environment_attestation(
+    environment: Mapping[str, str],
+    *,
+    secret_authority_key: bytes | None = None,
+) -> dict[str, object] | None:
+    """Fingerprint the complete inherited Codex child environment safely.
+
+    Every key/value that reaches the subprocess is reduced through installation-
+    keyed authority before persistence. Name classification is retained only as
+    diagnostic cardinality; it is not the confidentiality boundary. Explicit
+    size ceilings keep malformed or hostile mappings proof-ineligible.
+    """
+    if not isinstance(environment, Mapping) or not environment:
+        return None
+    try:
+        items = list(environment.items())
+    except Exception:  # noqa: BLE001 - opaque environment authority fails closed
+        return None
+    if len(items) > _MAX_CHILD_ENVIRONMENT_ENTRIES:
+        return None
+    if (
+        not isinstance(secret_authority_key, bytes)
+        or len(secret_authority_key) != INSTALLATION_AUTHORITY_KEY_BYTES
+    ):
+        return None
+
+    entry_authorities: list[str] = []
+    sensitive_entry_count = 0
+    total_bytes = 0
+    for key, value in items:
+        if not isinstance(key, str) or not isinstance(value, str):
+            return None
+        try:
+            key_bytes = key.encode("utf-8")
+            value_bytes = value.encode("utf-8")
+        except UnicodeError:
+            return None
+        if (
+            not key
+            or "=" in key
+            or "\x00" in key
+            or "\x00" in value
+            or len(key_bytes) > _MAX_CHILD_ENVIRONMENT_KEY_BYTES
+            or len(value_bytes) > _MAX_CHILD_ENVIRONMENT_VALUE_BYTES
+        ):
+            return None
+        total_bytes += len(key_bytes) + len(value_bytes)
+        if total_bytes > _MAX_CHILD_ENVIRONMENT_TOTAL_BYTES:
+            return None
+        if _SENSITIVE_ENVIRONMENT_KEY_RE.search(key):
+            sensitive_entry_count += 1
+        entry_authorities.append(
+            _environment_entry_authority(
+                key,
+                value,
+                installation_key=secret_authority_key,
+            )
+        )
+
+    entry_authorities.sort()
+    authority_fingerprint = _digest(entry_authorities)
+    if authority_fingerprint is None:
+        return None
+    return {
+        "authority_fingerprint": authority_fingerprint,
+        "entry_count": len(items),
+        "sensitive_entry_count": sensitive_entry_count,
+    }
+
+
+def _semantic_cwd(runtime: Any) -> str | None:
+    """Return the canonical repository-relative path used by Codex ``-C``."""
+    cwd = _text(getattr(runtime, "_cwd", None))
+    if cwd is None:
+        return None
+    try:
+        return resolve_project_identity(cwd).workspace_path
+    except ProjectIdentityError:
+        return None
+
+
+def build_codex_runtime_child_environment(runtime: Any) -> dict[str, str]:
+    """Build the child environment from the exact runtime-owned policy."""
+    return build_codex_child_env(
+        max_depth=runtime._max_ouroboros_depth,
+        child_session_env_keys=runtime._child_session_env_keys,
+        depth_error_factory=lambda _depth, max_depth: RuntimeError(
+            f"Maximum Ouroboros nesting depth ({max_depth}) exceeded"
+        ),
+    )
+
+
+def _attested_child_environment_context(
+    runtime: Any,
+) -> ContextVar[Mapping[str, str] | None]:
+    context = getattr(runtime, _ATTESTED_CHILD_ENVIRONMENT_ATTR, None)
+    if isinstance(context, ContextVar):
+        return context
+    context = ContextVar(
+        "ouroboros_codex_frugality_attested_child_environment",
+        default=None,
+    )
+    setattr(runtime, _ATTESTED_CHILD_ENVIRONMENT_ATTR, context)
+    return context
+
+
+def attested_codex_child_environment(runtime: Any) -> dict[str, str] | None:
+    """Return the task-local environment sealed for every spawn in one call."""
+    context = getattr(runtime, _ATTESTED_CHILD_ENVIRONMENT_ATTR, None)
+    if not isinstance(context, ContextVar):
+        return None
+    environment = context.get()
+    return dict(environment) if environment is not None else None
+
+
+def clear_attested_codex_child_environment(runtime: Any) -> None:
+    """Release the task-local environment after the tracked call terminates."""
+    context = getattr(runtime, _ATTESTED_CHILD_ENVIRONMENT_ATTR, None)
+    if isinstance(context, ContextVar):
+        context.set(None)
+
+
+def codex_cli_runtime_attestation(runtime: Any) -> dict[str, object]:
+    """Return Codex CLI settings that can alter auxiliary provider work.
+
+    Every executable identity is the constructor-time snapshot.  The runtime
+    separately rejects drift before dispatch; using the snapshot here keeps two
+    isolated arms comparable without re-reading mutable global state.
+    """
+    implementation = f"{type(runtime).__module__}.{type(runtime).__qualname__}"
+    skills_dir = getattr(runtime, "_skills_dir", None)
+    skills_source = "directory" if skills_dir is not None else "package"
+    skills_location = (
+        _resolved_path(skills_dir)
+        if skills_dir is not None
+        else _text(getattr(runtime, "_skills_package_uri", None))
+    )
+    trust_baseline = getattr(runtime, "_codex_project_trust_baseline", None)
+    trust_paths = (
+        tuple(sorted(str(path) for path in trust_baseline))
+        if isinstance(trust_baseline, (set, frozenset, dict))
+        else None
+    )
+    authority_key = installation_authority_key()
+    child_environment_candidate = build_codex_runtime_child_environment(runtime)
+    child_environment = codex_child_environment_attestation(
+        child_environment_candidate,
+        secret_authority_key=authority_key,
+    )
+    codex_config_authority = (
+        _codex_config_authority(
+            getattr(runtime, "_codex_config_fingerprint", None),
+            installation_key=authority_key,
+        )
+        if isinstance(authority_key, bytes)
+        else None
+    )
+    if child_environment is not None:
+        _attested_child_environment_context(runtime).set(child_environment_candidate)
+    if not isinstance(child_environment, Mapping):
+        child_environment = {}
+    return {
+        "schema_version": 4,
+        "schema_id": "ouroboros.codex_cli_runtime.v4",
+        "implementation": implementation,
+        "runtime_backend": getattr(runtime, "_runtime_backend", None),
+        "runtime_handle_backend": getattr(runtime, "_runtime_handle_backend", None),
+        "settings": {
+            "provider_name": getattr(runtime, "_provider_name", None),
+            "llm_backend": getattr(runtime, "_llm_backend", None),
+            "permission_mode": getattr(runtime, "_permission_mode", None),
+            "constructor_model": _text(getattr(runtime, "_model", None)),
+            "runtime_profile": _text(getattr(runtime, "_runtime_profile", None)),
+            "codex_profile": _text(getattr(runtime, "_codex_profile", None)),
+            "resolved_model": _text(getattr(runtime, "_resolved_fallback_model", None)),
+            "resolved_profile": _text(getattr(runtime, "_resolved_fallback_profile", None)),
+            "resolved_agent": _text(getattr(runtime, "_copilot_agent", None)),
+            "resolved_reasoning_effort": _text(
+                getattr(runtime, "_resolved_fallback_reasoning_effort", None)
+            ),
+            "semantic_cwd": _semantic_cwd(runtime),
+            "cli_path": _text(getattr(runtime, "_cli_path", None)),
+            "cli_executable_path": getattr(runtime, "_cli_executable_path_identity", None),
+            "cli_executable_content_sha256": getattr(
+                runtime, "_cli_executable_content_identity_snapshot", None
+            ),
+            "cli_executable_version_identity": getattr(
+                runtime, "_cli_executable_version_identity_snapshot", None
+            ),
+            "skills_source": skills_source,
+            "skills_location": skills_location,
+            "skill_dispatcher_kind": (
+                "custom" if getattr(runtime, "_skill_dispatcher", None) is not None else "packaged"
+            ),
+            "skill_dispatcher_identity": _stable_dispatcher_identity(
+                getattr(runtime, "_skill_dispatcher", None)
+            ),
+            "skill_dispatch_registry_fingerprint": getattr(
+                runtime, "_skill_dispatch_registry_fingerprint", None
+            ),
+            "builtin_mcp_handler_registry_fingerprint": getattr(
+                runtime, "_builtin_mcp_handler_registry_fingerprint", None
+            ),
+            "startup_output_timeout_seconds": getattr(
+                runtime, "_startup_output_timeout_seconds", None
+            ),
+            "stdout_idle_timeout_seconds": getattr(runtime, "_stdout_idle_timeout_seconds", None),
+            "process_shutdown_timeout_seconds": getattr(
+                runtime, "_process_shutdown_timeout_seconds", None
+            ),
+            "completed_process_group_shutdown_timeout_seconds": getattr(
+                runtime, "_completed_process_group_shutdown_timeout_seconds", None
+            ),
+            "max_resume_retries": getattr(runtime, "_max_resume_retries", None),
+            "max_ouroboros_depth": getattr(runtime, "_max_ouroboros_depth", None),
+            "max_stderr_lines": getattr(runtime, "_max_stderr_lines", None),
+            "use_process_group": getattr(runtime, "_use_process_group", None),
+            "child_session_env_keys": tuple(
+                sorted(str(key) for key in getattr(runtime, "_child_session_env_keys", ()))
+            ),
+            "child_environment_authority_fingerprint": child_environment.get(
+                "authority_fingerprint"
+            ),
+            "child_environment_authority_scheme": _CHILD_ENVIRONMENT_AUTHORITY_SCHEME,
+            "child_environment_entry_count": child_environment.get("entry_count"),
+            "child_environment_sensitive_entry_count": child_environment.get(
+                "sensitive_entry_count"
+            ),
+            "profile_resolution_fingerprint": getattr(
+                runtime, "_profile_resolution_fingerprint", None
+            ),
+            "codex_config_authority_fingerprint": codex_config_authority,
+            "codex_config_authority_scheme": _CHILD_ENVIRONMENT_AUTHORITY_SCHEME,
+            "codex_profile_v2_names": tuple(
+                sorted(str(name) for name in getattr(runtime, "_codex_profile_v2_names", ()))
+            ),
+            "codex_project_trust_paths": trust_paths,
+        },
+    }
+
+
+__all__ = [
+    "attested_codex_child_environment",
+    "build_codex_runtime_child_environment",
+    "clear_attested_codex_child_environment",
+    "codex_child_environment_attestation",
+    "codex_cli_runtime_attestation",
+]

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -67,6 +67,7 @@ from ouroboros.events.session_signal import (
     create_session_signal_delivery_uncertain_event,
     create_session_signal_rejected_event,
 )
+from ouroboros.evolution.provider_usage import tracked_agent_task
 
 # Import the harness submodules directly, NOT the ``ouroboros.harness`` package
 # aggregate: ``harness.__init__`` pulls in ``deliver_routing`` which imports from
@@ -87,6 +88,7 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     UnmaterializableSuccessContractError,
     bind_capsule_to_runtime_handle,
     build_ac_dispatch_authority_scope,
+    build_ac_dispatch_request_digest,
     compile_ac_execution_capsule,
 )
 from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
@@ -308,6 +310,12 @@ from ouroboros.orchestrator.execution_runtime_scope import (
     ExecutionNodeIdentity,
     build_ac_runtime_identity,
     build_level_coordinator_runtime_scope,
+)
+from ouroboros.orchestrator.frugality_evidence import (
+    harvest_token_spend as _harvest_token_spend,
+)
+from ouroboros.orchestrator.frugality_evidence import (
+    observed_effective_model as _observed_effective_model,
 )
 from ouroboros.orchestrator.leaf_dispatcher import (
     LeafDispatcher,
@@ -1343,113 +1351,6 @@ _STANDARD_DELIVER_EVIDENCE_FIELDS: tuple[str, ...] = (
     "tests_passed",
 )
 _FILE_MUTATION_TOOLS = frozenset({"Edit", "Write", "NotebookEdit", "MultiEdit"})
-_TOKEN_SPEND_FALLBACK_KEYS: tuple[str, ...] = (
-    "input_tokens",
-    "output_tokens",
-    "cache_creation_input_tokens",
-    "cache_read_input_tokens",
-)
-_TOKEN_USAGE_KEYS: tuple[str, ...] = (
-    *_TOKEN_SPEND_FALLBACK_KEYS,
-    "cached_input_tokens",
-    "total_tokens",
-)
-
-
-def _finite_nonneg_number(value: object) -> float | None:
-    """Return ``value`` as a finite, non-negative float, else ``None``.
-
-    Mirrors ``frugality_proof._finite_number`` (rejects ``None``, booleans,
-    non-numerics, NaN/inf) and additionally rejects negatives: a token count is a
-    spend, and a negative spend is malformed telemetry that must be dropped rather
-    than counted (a negative would understate the run's real spend and skew the
-    proof's aggregate reduction).
-    """
-    if value is None or isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    try:
-        number = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return None
-    if not math.isfinite(number) or number < 0:
-        return None
-    return number
-
-
-def _harvest_token_spend(
-    messages: list[AgentMessage],
-) -> tuple[float, dict[str, float]] | None:
-    """Sum runtime-reported token usage across a leaf's message stream.
-
-    Usage semantics are resolved PER MESSAGE before messages are added together:
-
-    * a usable ``total_tokens`` is authoritative for that message;
-    * otherwise spend is ``input_tokens + output_tokens`` plus Anthropic's
-      additive ``cache_creation_input_tokens + cache_read_input_tokens``;
-    * OpenAI's ``cached_input_tokens`` remains in the diagnostic breakdown but is
-      never added separately because it is already a subset of ``input_tokens``.
-
-    Token telemetry is all-or-nothing across the leaf. If a ``usage`` payload is
-    malformed, or any present recognized counter is invalid, the whole attempt
-    returns ``None``. Dropping only the bad component (or falling back when an
-    invalid ``total_tokens`` is present) would undercount spend and can create a
-    false frugality PASS. An absent payload or a valid payload with no spend
-    counter contributes nothing; when no spend is observed the function returns
-    ``None`` rather than fabricating a char-proxy or zero-token spend.
-
-    Multiple usage-bearing messages in one stream (e.g. a Claude result message
-    plus Codex ``turn.completed`` messages) are summed, so a decomposed child's
-    full spend is attributed even when the runtime reports it in pieces.
-
-    Returns:
-        ``(token_spend, usage_breakdown)`` where ``usage_breakdown`` is the summed
-        per-key total for every usable key, or ``None`` when no spend was seen.
-    """
-    breakdown: dict[str, float] = {}
-    token_spend = 0.0
-    observed_spend = False
-    for message in messages:
-        data = getattr(message, "data", None)
-        if not isinstance(data, dict):
-            continue
-        if data.get("usage_invalid") is True:
-            return None
-        if "usage" not in data:
-            continue
-        usage = data["usage"]
-        if not isinstance(usage, Mapping):
-            return None
-        usable_usage: dict[str, float] = {}
-        for key in _TOKEN_USAGE_KEYS:
-            if key not in usage:
-                continue
-            raw_value = usage[key]
-            number = _finite_nonneg_number(raw_value)
-            if number is None:
-                return None
-            usable_usage[key] = number
-            breakdown[key] = breakdown.get(key, 0.0) + number
-
-        total_tokens = usable_usage.get("total_tokens")
-        if total_tokens is not None:
-            token_spend += total_tokens
-            observed_spend = True
-            continue
-
-        spend_components = [
-            usable_usage[key] for key in _TOKEN_SPEND_FALLBACK_KEYS if key in usable_usage
-        ]
-        if spend_components:
-            token_spend += sum(spend_components)
-            observed_spend = True
-
-    if (
-        not observed_spend
-        or not math.isfinite(token_spend)
-        or any(not math.isfinite(value) for value in breakdown.values())
-    ):
-        return None
-    return token_spend, breakdown
 
 
 def _first_nonblank_str(entry: Mapping[str, Any], keys: tuple[str, ...]) -> str | None:
@@ -6312,12 +6213,7 @@ class ParallelACExecutor:
         system_prompt: str,
         independent_session: bool = False,
     ) -> str:
-        """Run one bounded tool-free decomposition-policy request.
-
-        Semantic attestation must not resume the proposer conversation. Passing
-        ``independent_session=True`` starts a fresh runtime session even when the
-        parent executor inherited a resumable handle.
-        """
+        """Run one bounded, tracked, tool-free decomposition-policy request."""
         self._announce_param_degradations(system_prompt=system_prompt, tools=[])
         _invoke_execution_authority_guard(self)
         await _invoke_execution_authority_entry(
@@ -6326,13 +6222,13 @@ class ParallelACExecutor:
             prompt=prompt,
             system_prompt=system_prompt,
         )
-        # Acquiring rate budget can suspend, so validate once more at the
-        # immediate effect boundary rather than assuming the pre-wait snapshot
-        # still applies.
+        # Revalidate authority after the rate-budget await.
         _invoke_execution_authority_guard(self)
         response_text = ""
         async with asyncio.timeout(DECOMPOSITION_TIMEOUT_SECONDS):
-            async for message in self._adapter.execute_task(
+            async for message in tracked_agent_task(
+                self._adapter,
+                role="executor_decomposition_policy",
                 prompt=prompt,
                 tools=[],
                 system_prompt=system_prompt,
@@ -8070,6 +7966,55 @@ Respond with either ATOMIC or the structured JSON object only.
             effort=None,
         )
         try:
+            dispatch_contract: dict[str, object] = {
+                "backend": getattr(self._adapter, "runtime_backend", None),
+                "tools": list(tools),
+                # The allow-list is only a projection of the provider
+                # contract. Fingerprint the complete canonical catalog too,
+                # so schema/source changes cannot reuse a dispatch authority
+                # that merely has the same tool names.
+                "tool_catalog": {
+                    "present": tool_catalog is not None,
+                    "entries": serialize_tool_catalog(tool_catalog or ()),
+                },
+                "system_prompt": system_prompt,
+                "ac_content": ac_content,
+                "seed_goal": seed_goal,
+                "retry_prompt_extra": retry_prompt_extra,
+                "sibling_acs": [
+                    {"ac_index": sibling_index, "content": sibling_content}
+                    for sibling_index, sibling_content in (sibling_acs or [])
+                ],
+                "level_context_prompt": build_context_prompt(level_contexts or []),
+            }
+            execution_policy: dict[str, object] = {
+                "retry_attempt": retry_attempt,
+                "is_sub_ac": is_sub_ac,
+                "decomposition_trustworthy": decomposition_trustworthy,
+                "base_reasoning_effort": self._reasoning_effort,
+                "model_routing": serialize_model_router(model_router_snapshot),
+                "route_compat": serialize_route_compat_contract(durable_route_projection),
+                "route_id_override": route_id_override,
+                "expected_route_candidate": (
+                    expected_route_candidate.to_contract_data()
+                    if expected_route_candidate is not None
+                    else None
+                ),
+                "execution_profile": (
+                    self._execution_profile.model_dump(mode="json")
+                    if self._execution_profile is not None
+                    else None
+                ),
+                "run_verify_commands": self._run_verify_commands,
+                "fat_harness_mode": self._fat_harness_mode,
+                "investment_spec": (
+                    investment_spec.model_dump(mode="json") if investment_spec is not None else None
+                ),
+            }
+            request_authority_digest = build_ac_dispatch_request_digest(
+                dispatch_contract=dispatch_contract,
+                execution_policy=execution_policy,
+            )
             capsule = compile_ac_execution_capsule(
                 runtime_identity=runtime_identity,
                 execution_id=execution_context_id,
@@ -8082,66 +8027,8 @@ Respond with either ATOMIC or the structured JSON object only.
                 authority_scope=(
                     build_ac_dispatch_authority_scope(
                         base_scope=self.execution_authority.fingerprint,
-                        dispatch_contract={
-                            "backend": getattr(self._adapter, "runtime_backend", None),
-                            "tools": list(tools),
-                            # The allow-list is only a projection of the provider
-                            # contract.  Fingerprint the complete canonical catalog
-                            # too, so schema/source changes cannot reuse a dispatch
-                            # authority that merely has the same tool names.
-                            # Preserve presence separately from entries: ``None``
-                            # means the provider received no catalog authority,
-                            # while an explicit empty tuple means an intentionally
-                            # empty capability/control-plane contract.
-                            "tool_catalog": {
-                                "present": tool_catalog is not None,
-                                "entries": serialize_tool_catalog(tool_catalog or ()),
-                            },
-                            "system_prompt": system_prompt,
-                            "ac_content": ac_content,
-                            "seed_goal": seed_goal,
-                            "retry_prompt_extra": retry_prompt_extra,
-                            # These values are projected into the provider prompt
-                            # and therefore are part of the dispatch authority even
-                            # though they are not provider/session continuity.
-                            "sibling_acs": [
-                                {"ac_index": sibling_index, "content": sibling_content}
-                                for sibling_index, sibling_content in (sibling_acs or [])
-                            ],
-                            "level_context_prompt": build_context_prompt(level_contexts or []),
-                        },
-                        execution_policy={
-                            "retry_attempt": retry_attempt,
-                            "is_sub_ac": is_sub_ac,
-                            "decomposition_trustworthy": decomposition_trustworthy,
-                            "base_reasoning_effort": self._reasoning_effort,
-                            "model_routing": serialize_model_router(model_router_snapshot),
-                            "route_compat": serialize_route_compat_contract(
-                                durable_route_projection
-                            ),
-                            "route_id_override": route_id_override,
-                            "expected_route_candidate": (
-                                expected_route_candidate.to_contract_data()
-                                if expected_route_candidate is not None
-                                else None
-                            ),
-                            "execution_profile": (
-                                self._execution_profile.model_dump(mode="json")
-                                if self._execution_profile is not None
-                                else None
-                            ),
-                            "fat_harness_mode": self._fat_harness_mode,
-                            # Investment metadata is authority-bearing: the effort
-                            # router can lower or raise the dispatched tier from it.
-                            # Keep the canonical Seed representation in the capsule
-                            # scope so materially different investment decisions can
-                            # never reuse one durable dispatch identity.
-                            "investment_spec": (
-                                investment_spec.model_dump(mode="json")
-                                if investment_spec is not None
-                                else None
-                            ),
-                        },
+                        dispatch_contract=dispatch_contract,
+                        execution_policy=execution_policy,
                     )
                 ),
                 seed_goal=seed_goal,
@@ -8683,6 +8570,7 @@ Respond with either ATOMIC or the structured JSON object only.
             execution_id=execution_context_id,
             session_id=session_id,
             capsule_fingerprint=capsule.fingerprint,
+            request_authority_digest=request_authority_digest,
             session_origin=session_origin,
             runtime_handle=runtime_handle,
         )
@@ -8953,6 +8841,7 @@ Respond with either ATOMIC or the structured JSON object only.
                         execution_id=execution_context_id,
                         session_id=session_id,
                         capsule_fingerprint=capsule.fingerprint,
+                        request_authority_digest=request_authority_digest,
                         session_origin="restored_same_attempt",
                         runtime_handle=candidate_follow_up_runtime_handle,
                         dispatch_kind="session_signal_followup",
@@ -9516,6 +9405,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     retry_attempt=retry_attempt,
                     model_decision=model_decision,
                     effort_decision=effort_decision,
+                    request_authority_digest=request_authority_digest,
                 )
                 if clear_cached_runtime_handle:
                     await self._terminate_runtime_handle(
@@ -9553,17 +9443,20 @@ Respond with either ATOMIC or the structured JSON object only.
         retry_attempt: int,
         model_decision: Any,
         effort_decision: Any,
+        request_authority_digest: str,
     ) -> None:
         """Harvest and emit this leaf's runtime token spend (frugality-proof AC2).
 
         Emits nothing when the stream carried no runtime usage telemetry — the
         proof treats missing as missing rather than fabricating a spend. Observe-only:
-        any failure degrades to a warning so token attribution never disrupts the
-        leaf's teardown or result.
+        failures degrade to warnings without disrupting leaf teardown or results.
         """
         try:
             harvested = _harvest_token_spend(messages)
             if harvested is None:
+                return
+            effective_model = _observed_effective_model(messages)
+            if effective_model is None:
                 return
             token_spend, usage_breakdown = harvested
             await self._event_emitter.emit_token_attribution(
@@ -9576,10 +9469,17 @@ Respond with either ATOMIC or the structured JSON object only.
                 token_spend=token_spend,
                 usage_breakdown=usage_breakdown,
                 model=getattr(model_decision, "model", None),
+                effective_model=effective_model,
                 model_tier=getattr(model_decision, "tier", None),
                 model_mode=getattr(model_decision, "mode", None),
                 effort_level=getattr(effort_decision, "level", None),
+                effort_mode=getattr(effort_decision, "mode", None),
                 runtime_backend=getattr(self._adapter, "runtime_backend", None),
+                llm_backend=(
+                    getattr(self._adapter, "llm_backend", None) or self._adapter.runtime_backend
+                ),
+                permission_mode=getattr(self._adapter, "permission_mode", None),
+                request_authority_digest=request_authority_digest,
             )
         except Exception as exc:
             log.warning(

--- a/src/ouroboros/orchestrator/shadow_replay.py
+++ b/src/ouroboros/orchestrator/shadow_replay.py
@@ -87,6 +87,7 @@ import shutil
 import tempfile
 from typing import TYPE_CHECKING
 
+from ouroboros.evolution.provider_usage import tracked_agent_task
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.effort_routing import resolve_execute_effort
 from ouroboros.orchestrator.model_routing import resolve_execute_model
@@ -436,7 +437,7 @@ async def _measure_baseline_spend(
     """
     # Lazy imports break the import cycle (parallel_executor imports this module)
     # and mirror the executor's own lazy ``create_agent_runtime`` use.
-    from ouroboros.orchestrator.parallel_executor import _harvest_token_spend
+    from ouroboros.orchestrator.frugality_evidence import harvest_token_spend
     from ouroboros.orchestrator.runtime_factory import create_agent_runtime
 
     try:
@@ -485,7 +486,9 @@ async def _measure_baseline_spend(
         # and closing it early can cancel sibling tasks (see the decomposition loop's
         # note). Let it complete; the timeout bounds a stuck baseline instead.
         async with asyncio.timeout(_BASELINE_TIMEOUT_SECONDS):
-            async for message in baseline_runtime.execute_task(
+            async for message in tracked_agent_task(
+                baseline_runtime,
+                role="executor_shadow_replay",
                 prompt=baseline_prompt,
                 tools=tools,
                 system_prompt=system_prompt,
@@ -516,7 +519,7 @@ async def _measure_baseline_spend(
             )
             return None
 
-        harvested = _harvest_token_spend(messages)
+        harvested = harvest_token_spend(messages)
         if harvested is None:
             return None
         baseline_token_spend, _breakdown = harvested

--- a/src/ouroboros/providers/anthropic_adapter.py
+++ b/src/ouroboros/providers/anthropic_adapter.py
@@ -5,6 +5,7 @@ protocol using the official Anthropic Python SDK. This is the recommended defaul
 for Ouroboros MCP server — no OpenRouter or LiteLLM dependency required.
 """
 
+from dataclasses import replace
 import json
 import os
 from typing import Any
@@ -21,6 +22,11 @@ from ouroboros.providers.base import (
     Message,
     MessageRole,
     UsageInfo,
+)
+from ouroboros.providers.frugality_attestation import (
+    PreparedFrugalityCompletion,
+    credential_authority_digest,
+    effective_completion_request,
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
 
@@ -151,6 +157,46 @@ class AnthropicAdapter:
         self._default_model = default_model
         self._client: Any = None
         self._io_recorder = io_recorder
+
+    def frugality_prepare_completion(
+        self,
+        config: CompletionConfig,
+    ) -> Result[PreparedFrugalityCompletion, ProviderError]:
+        """Resolve once, seal dispatch, and attest the non-secret execution envelope."""
+        profile_result = resolve_completion_profile_result(config, backend="anthropic")
+        if profile_result.is_err:
+            return Result.err(profile_result.error)
+        resolved = profile_result.value
+        effective_config = resolved.config
+        # The cached SDK client owns dispatch. Its resolved authority may come
+        # from SDK profile configuration rather than this process environment,
+        # so attest the exact client that ``complete`` will reuse.
+        client = self._get_client()
+        client_base_url = getattr(client, "base_url", None)
+        client_api_key = getattr(client, "api_key", None)
+        contract: dict[str, object] = {
+            "schema_version": 2,
+            "schema_id": "ouroboros.anthropic.v2",
+            "internal_attempt_limit": self._max_retries + 1,
+            "credential_authority": credential_authority_digest(client_api_key),
+            "effective_request": effective_completion_request(
+                resolved,
+                provider_model=self._resolve_model(effective_config.model),
+            ),
+            "settings": {
+                "api_base": str(client_base_url) if client_base_url is not None else None,
+                "timeout": self._timeout,
+                "max_retries": self._max_retries,
+                "default_model": self._default_model,
+                "io_recorder_configured": self._io_recorder is not None,
+            },
+        }
+        return Result.ok(
+            PreparedFrugalityCompletion(
+                config=replace(effective_config, role=None, profile=None),
+                contract=contract,
+            )
+        )
 
     def _get_client(self) -> Any:
         """Lazy-initialize the Anthropic async client.

--- a/src/ouroboros/providers/credential_authority.py
+++ b/src/ouroboros/providers/credential_authority.py
@@ -1,0 +1,183 @@
+"""Installation-held authority for secret-safe frugality identities."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from pathlib import Path
+import secrets
+import stat
+
+from ouroboros.config.models import get_config_dir
+
+INSTALLATION_AUTHORITY_KEY_BYTES = 32
+_INSTALLATION_AUTHORITY_KEY_FILE = "frugality-authority.key"
+_CREDENTIAL_AUTHORITY_CONTEXT = b"ouroboros-frugality-credential-authority-v2"
+_MAX_CREDENTIAL_BYTES = 128 * 1_024
+
+
+def _read_installation_authority_key(path: Path) -> bytes | None:
+    """Read one owner-only regular key file without following symlinks."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o077:
+            return None
+        getuid = getattr(os, "getuid", None)
+        if callable(getuid) and metadata.st_uid != getuid():
+            return None
+        value = os.read(descriptor, INSTALLATION_AUTHORITY_KEY_BYTES + 1)
+    except OSError:
+        return None
+    finally:
+        os.close(descriptor)
+    return value if len(value) == INSTALLATION_AUTHORITY_KEY_BYTES else None
+
+
+def _remove_recoverable_partial_key(path: Path) -> bool:
+    """Remove only an owner-only regular partial artifact at the exact path."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    try:
+        opened = os.fstat(descriptor)
+        getuid = getattr(os, "getuid", None)
+        owner_matches = not callable(getuid) or opened.st_uid == getuid()
+        recoverable = (
+            stat.S_ISREG(opened.st_mode)
+            and owner_matches
+            and not stat.S_IMODE(opened.st_mode) & 0o077
+            and opened.st_size != INSTALLATION_AUTHORITY_KEY_BYTES
+        )
+        current = path.lstat()
+        if not recoverable or (current.st_dev, current.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            return False
+        path.unlink()
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(directory: Path) -> bool:
+    """Durably publish one directory entry when the platform permits it."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(directory, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError:
+        return False
+    return True
+
+
+def installation_authority_key() -> bytes | None:
+    """Load or transactionally provision the installation-held proof HMAC key."""
+    directory = get_config_dir()
+    path = directory / _INSTALLATION_AUTHORITY_KEY_FILE
+    try:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if directory.is_symlink():
+            return None
+        existing = _read_installation_authority_key(path)
+        if existing is not None:
+            return existing
+        if os.path.lexists(path) and not _remove_recoverable_partial_key(path):
+            return None
+        candidate = secrets.token_bytes(INSTALLATION_AUTHORITY_KEY_BYTES)
+        temporary_path = directory / (
+            f".{_INSTALLATION_AUTHORITY_KEY_FILE}.{secrets.token_hex(16)}.tmp"
+        )
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(temporary_path, flags, 0o600)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    write_complete = False
+    try:
+        remaining = memoryview(candidate)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("installation authority key write made no progress")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        write_complete = True
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+    if not write_complete:
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    try:
+        os.link(temporary_path, path, follow_symlinks=False)
+    except FileExistsError:
+        return _read_installation_authority_key(path)
+    except OSError:
+        return None
+    finally:
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    if not _fsync_directory(directory):
+        return None
+    return _read_installation_authority_key(path)
+
+
+def credential_authority_digest(
+    secret: str | None,
+    *,
+    installation_key: bytes | None = None,
+) -> str | None:
+    """Identify a credential without creating an offline guess verifier."""
+    if not isinstance(secret, str) or not secret.strip():
+        return None
+    authority_key = (
+        installation_key if installation_key is not None else installation_authority_key()
+    )
+    if (
+        not isinstance(authority_key, bytes)
+        or len(authority_key) != INSTALLATION_AUTHORITY_KEY_BYTES
+    ):
+        return None
+    try:
+        encoded_secret = secret.encode("utf-8")
+    except UnicodeError:
+        return None
+    if len(encoded_secret) > _MAX_CREDENTIAL_BYTES:
+        return None
+    message = b"\x00".join((_CREDENTIAL_AUTHORITY_CONTEXT, encoded_secret))
+    digest = hmac.new(authority_key, message, hashlib.sha256).hexdigest()
+    return f"hmac-sha256-installation-key-v2:{digest}"
+
+
+__all__ = [
+    "INSTALLATION_AUTHORITY_KEY_BYTES",
+    "credential_authority_digest",
+    "installation_authority_key",
+]

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -92,6 +92,7 @@ class _LLMAdapterRequest:
     max_retries: int
     io_recorder: IOJournalRecorder | None
     strict_mcp_config: bool
+    frugality_proof: bool
 
 
 def resolve_llm_backend(backend: str | None = None) -> str:
@@ -323,6 +324,7 @@ def _create_litellm_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
         timeout=request.timeout,
         max_retries=request.max_retries,
         io_recorder=request.io_recorder,
+        frugality_proof=request.frugality_proof,
     )
 
 
@@ -373,8 +375,14 @@ def create_llm_adapter(
     max_retries: int = 3,
     io_recorder: IOJournalRecorder | None = None,
     strict_mcp_config: bool = False,
+    frugality_proof: bool = False,
 ) -> LLMAdapter:
-    """Create an LLM adapter from config or explicit options."""
+    """Create an LLM adapter from config or explicit options.
+
+    ``frugality_proof`` asks registered completion producers to seal a
+    measurable execution envelope. It is opt-in so ordinary user-facing
+    flows retain their existing retry and timeout policies.
+    """
     resolved_backend = resolve_llm_backend(backend)
     # Backends in ``_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT`` accept the
     # envelope but enforce it via prompt injection + post-hoc detection
@@ -425,6 +433,7 @@ def create_llm_adapter(
             max_retries=max_retries,
             io_recorder=io_recorder,
             strict_mcp_config=strict_mcp_config,
+            frugality_proof=frugality_proof,
         )
     )
 

--- a/src/ouroboros/providers/frugality_attestation.py
+++ b/src/ouroboros/providers/frugality_attestation.py
@@ -1,0 +1,51 @@
+"""Secret-safe completion configuration receipts for frugality proofs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from ouroboros.providers.base import CompletionConfig
+from ouroboros.providers.credential_authority import credential_authority_digest
+from ouroboros.providers.profiles import ResolvedCompletionProfile
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedFrugalityCompletion:
+    """One profile-sealed request and its pre-dispatch evidence contract."""
+
+    config: CompletionConfig
+    contract: Mapping[str, object]
+    dispatch: object | None = None
+
+
+def effective_completion_request(
+    resolved: ResolvedCompletionProfile,
+    *,
+    provider_model: str,
+) -> dict[str, object]:
+    """Return every effect-bearing field after task-profile resolution."""
+    config = resolved.config
+    return {
+        "model": provider_model,
+        "profile_model": config.model,
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
+        "stop": config.stop,
+        "top_p": config.top_p,
+        "response_format": config.response_format,
+        "role": config.role,
+        "profile": config.profile,
+        "profile_name": resolved.profile_name,
+        "backend_profile": resolved.backend_profile,
+        "max_turns": config.max_turns,
+        "reasoning_effort": config.reasoning_effort,
+        "model_is_explicit": config.model_is_explicit,
+    }
+
+
+__all__ = [
+    "PreparedFrugalityCompletion",
+    "credential_authority_digest",
+    "effective_completion_request",
+]

--- a/src/ouroboros/providers/litellm_adapter.py
+++ b/src/ouroboros/providers/litellm_adapter.py
@@ -4,11 +4,25 @@ This module provides the LiteLLMAdapter class that implements the LLMAdapter
 protocol using LiteLLM for multi-provider support including OpenRouter.
 """
 
+import asyncio
+from dataclasses import dataclass, field, replace
+import hashlib
+import importlib.metadata
+import importlib.util
 import json
+import math
 import os
+from pathlib import Path
+import sys
+import tempfile
+import threading
+import types
 from typing import TYPE_CHECKING, Any
 
+import httpx
 import litellm
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+import openai
 import structlog
 
 from ouroboros.core.errors import ProviderError
@@ -22,6 +36,11 @@ from ouroboros.providers.base import (
     Message,
     UsageInfo,
 )
+from ouroboros.providers.frugality_attestation import (
+    PreparedFrugalityCompletion,
+    credential_authority_digest,
+    effective_completion_request,
+)
 from ouroboros.providers.profiles import resolve_completion_profile_result
 
 if TYPE_CHECKING:
@@ -31,6 +50,129 @@ log = structlog.get_logger()
 _CREDENTIALS_UNSET = object()
 _PLACEHOLDER_API_KEY_PREFIX = "YOUR_"
 _PLACEHOLDER_API_KEY_SUFFIX = "_API_KEY"
+_PROOF_DEFAULT_API_BASES = {
+    "anthropic": "https://api.anthropic.com",
+    "google": "https://generativelanguage.googleapis.com",
+    "openai": "https://api.openai.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
+}
+_PROOF_API_BASE_ENVIRONMENT = {
+    "anthropic": ("ANTHROPIC_API_BASE", "ANTHROPIC_BASE_URL"),
+    "google": ("GEMINI_API_BASE",),
+    "openai": ("OPENAI_API_BASE", "OPENAI_BASE_URL"),
+    "openrouter": ("OPENROUTER_API_BASE",),
+}
+_PROOF_NONE_GLOBALS = (
+    "aclient_session",
+    "add_user_information_to_llm_headers",
+    "api_version",
+    "client_session",
+    "headers",
+    "organization",
+    "project",
+    "proxy_auth",
+    "ssl_certificate",
+    "ssl_ecdh_curve",
+    "ssl_security_level",
+)
+_PROOF_FALSE_GLOBALS = (
+    "add_function_to_prompt",
+    "aiohttp_trust_env",
+    "check_provider_endpoint",
+    "disable_add_transform_inline_image_block",
+    "disable_aiohttp_transport",
+    "disable_aiohttp_trust_env",
+    "drop_params",
+    "enable_json_schema_validation",
+    "enable_preview_features",
+    "filter_invalid_headers",
+    "force_ipv4",
+    "modify_params",
+    "network_mock",
+    "route_all_chat_openai_to_responses",
+    "strip_anthropic_total_tokens",
+    "use_chat_completions_url_for_anthropic_messages",
+)
+_PROOF_TRUE_GLOBALS = (
+    "ssl_verify",
+    "use_aiohttp_transport",
+)
+_PROOF_EMPTY_SEQUENCE_GLOBALS = (
+    "callbacks",
+    "failure_callback",
+    "input_callback",
+    "post_call_rules",
+    "pre_call_rules",
+    "service_callback",
+    "success_callback",
+)
+_PROOF_EMPTY_MAPPING_GLOBALS = (
+    "custom_prompt_dict",
+    "guardrail_name_config_map",
+    "model_alias_map",
+)
+_PROOF_UNSEALED_PROVIDER_ENVIRONMENT = {
+    "anthropic": ("ANTHROPIC_API_VERSION", "LITELLM_ANTHROPIC_DISABLE_URL_SUFFIX"),
+    "google": (
+        "GEMINI_API_VERSION",
+        "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_GENAI_USE_VERTEXAI",
+    ),
+    "openai": ("OPENAI_API_VERSION", "OPENAI_ORGANIZATION", "OPENAI_PROJECT"),
+    "openrouter": ("OR_APP_NAME", "OR_SITE_URL"),
+}
+_PROOF_UNSEALED_TRANSPORT_ENVIRONMENT = (
+    "AIOHTTP_TRUST_ENV",
+    "ALL_PROXY",
+    "CURL_CA_BUNDLE",
+    "DISABLE_AIOHTTP_TRANSPORT",
+    "DISABLE_AIOHTTP_TRUST_ENV",
+    "EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "LITELLM_USER_AGENT",
+    "NO_PROXY",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERTIFICATE",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "SSL_ECDH_CURVE",
+    "SSL_SECURITY_LEVEL",
+    "SSL_VERIFY",
+    "all_proxy",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+)
+_PROOF_PROVIDER_CONFIG_DEFAULTS = {
+    "anthropic": ("AnthropicConfig", {"max_tokens": 4096}),
+    "google": ("GoogleAIStudioGeminiConfig", {}),
+    "openai": ("OpenAIConfig", {}),
+    "openrouter": ("OpenrouterConfig", {}),
+}
+_PROOF_LITELLM_MAX_RETRIES = 0
+_PROOF_TRANSPORT_CONTRACT = "ouroboros.httpx.async.v1"
+_PROOF_ISOLATION_KIND = "subprocess"
+_PROOF_WORKER_PROTOCOL = "ouroboros.litellm.worker.v1"
+_PROOF_WORKER_ENVIRONMENT_CONTRACT = "ouroboros.empty-env.v1"
+_PROOF_WORKER_CWD_CONTRACT = "ouroboros.private-empty-tempdir.v1"
+_PROOF_MUTATION_AUDIT = "litellm.module-setattr.v1"
+_PROOF_WORKER_MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+_PROOF_OPENAI_CLIENT_TYPE = "openai.AsyncOpenAI"
+_PROOF_HTTP_HANDLER_CLIENT_TYPE = "litellm.AsyncHTTPHandler"
+try:
+    _LITELLM_DEPENDENCY_VERSION = importlib.metadata.version("litellm")
+except importlib.metadata.PackageNotFoundError:
+    _LITELLM_DEPENDENCY_VERSION = None
+try:
+    _HTTPX_DEPENDENCY_VERSION = importlib.metadata.version("httpx")
+except importlib.metadata.PackageNotFoundError:
+    _HTTPX_DEPENDENCY_VERSION = None
+try:
+    _OPENAI_DEPENDENCY_VERSION = importlib.metadata.version("openai")
+except importlib.metadata.PackageNotFoundError:
+    _OPENAI_DEPENDENCY_VERSION = None
 
 # LiteLLM exceptions that should trigger retries
 RETRIABLE_EXCEPTIONS = (
@@ -39,6 +181,220 @@ RETRIABLE_EXCEPTIONS = (
     litellm.Timeout,
     litellm.APIConnectionError,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _LiteLLMDependencyAuthority:
+    """Non-secret proof eligibility for LiteLLM's process-global state."""
+
+    version: str | None
+    provider: str
+    defaults_verified: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _LiteLLMWorkerAuthority:
+    """Exact interpreter and worker implementation used for provider effects."""
+
+    launcher_path: str | None
+    resolved_executable_path: str | None
+    executable_content_sha256: str | None
+    python_version: str | None
+    worker_module: str
+    worker_implementation_sha256: str | None
+    adapter_module: str
+    adapter_implementation_sha256: str | None
+    ouroboros_implementation_contract: str
+    ouroboros_implementation_sha256: str | None
+
+
+@dataclass(slots=True)
+class _LiteLLMDispatchState:
+    """Ephemeral proof status that must never enter durable receipts."""
+
+    dispatch_started: bool = False
+    cleanup_complete: bool = False
+    cleanup_failed: bool = False
+    authority_drifted: bool = False
+
+
+@dataclass(slots=True)
+class _SealedLiteLLMClient:
+    """A dedicated client whose transport is independent of process globals."""
+
+    value: openai.AsyncOpenAI | AsyncHTTPHandler = field(repr=False)
+    client_type: str
+
+    async def close(self) -> None:
+        await self.value.close()
+
+
+class _SealedAsyncHTTPHandler(AsyncHTTPHandler):
+    """LiteLLM-compatible handler backed by an explicitly constructed client."""
+
+    def __init__(self, client: httpx.AsyncClient, *, timeout: float | None) -> None:
+        # Do not call AsyncHTTPHandler.__init__: it resolves mutable LiteLLM and
+        # environment transport authority while constructing its client.
+        self.timeout = timeout
+        self.event_hooks = None
+        self.client = client
+        self.client_alias = "ouroboros-frugality-proof"
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedLiteLLMDispatch:
+    """In-memory route authority; secrets never enter the proof contract."""
+
+    config: CompletionConfig
+    api_key: str | None = field(repr=False)
+    api_base: str | None = field(repr=False)
+    timeout: float | None
+    max_retries: int
+    dependency_authority: _LiteLLMDependencyAuthority
+    worker_authority: _LiteLLMWorkerAuthority
+    client_type: str | None
+    state: _LiteLLMDispatchState = field(
+        default_factory=_LiteLLMDispatchState,
+        repr=False,
+        compare=False,
+    )
+
+
+_PROOF_AUDITED_GLOBALS = frozenset(
+    {
+        *_PROOF_NONE_GLOBALS,
+        *_PROOF_FALSE_GLOBALS,
+        *_PROOF_TRUE_GLOBALS,
+        *_PROOF_EMPTY_SEQUENCE_GLOBALS,
+        *_PROOF_EMPTY_MAPPING_GLOBALS,
+        "api_base",
+        "api_key",
+        "anthropic_key",
+        "gemini_key",
+        "openai_key",
+        "openrouter_key",
+    }
+)
+_PROOF_AUDIT_LOCK = threading.Lock()
+_ACTIVE_PROOF_AUDITS: dict[int, _LiteLLMDispatchState] = {}
+
+
+class _AuditedLiteLLMModule(types.ModuleType):
+    """Record every protected LiteLLM assignment while proof work is active."""
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name in _PROOF_AUDITED_GLOBALS:
+            with _PROOF_AUDIT_LOCK:
+                states = tuple(_ACTIVE_PROOF_AUDITS.values())
+            for state in states:
+                state.authority_drifted = True
+        super().__setattr__(name, value)
+
+
+def _register_proof_authority_audit(state: _LiteLLMDispatchState) -> None:
+    """Install an event-driven parent mutation audit for one isolated dispatch."""
+    try:
+        if not isinstance(litellm, _AuditedLiteLLMModule):
+            litellm.__class__ = _AuditedLiteLLMModule
+    except (AttributeError, TypeError):
+        state.authority_drifted = True
+    with _PROOF_AUDIT_LOCK:
+        _ACTIVE_PROOF_AUDITS[id(state)] = state
+
+
+def _unregister_proof_authority_audit(state: _LiteLLMDispatchState) -> None:
+    with _PROOF_AUDIT_LOCK:
+        _ACTIVE_PROOF_AUDITS.pop(id(state), None)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _module_implementation_sha256(module_name: str) -> str:
+    module_spec = importlib.util.find_spec(module_name)
+    module_origin = getattr(module_spec, "origin", None)
+    if not isinstance(module_origin, str):
+        raise ValueError(f"{module_name} implementation is unavailable")
+    module_path = Path(module_origin).resolve(strict=True)
+    if not module_path.is_file():
+        raise ValueError(f"{module_name} implementation must be a regular file")
+    return _sha256_file(module_path)
+
+
+def _ouroboros_implementation_sha256() -> str:
+    """Bind every Python source that can enter the isolated worker import graph."""
+    package_spec = importlib.util.find_spec("ouroboros")
+    locations = getattr(package_spec, "submodule_search_locations", None)
+    if locations is None:
+        raise ValueError("ouroboros package implementation is unavailable")
+    package_roots = tuple(locations)
+    if len(package_roots) != 1:
+        raise ValueError("ouroboros package implementation must have one source root")
+    package_root = Path(package_roots[0]).resolve(strict=True)
+    if not package_root.is_dir():
+        raise ValueError("ouroboros package source root must be a directory")
+
+    source_files = sorted(package_root.rglob("*.py"))
+    if not source_files:
+        raise ValueError("ouroboros package contains no Python sources")
+    digest = hashlib.sha256()
+    for source_file in source_files:
+        if source_file.is_symlink():
+            raise ValueError("ouroboros package sources must not be symlinks")
+        resolved_source = source_file.resolve(strict=True)
+        resolved_source.relative_to(package_root)
+        if not resolved_source.is_file():
+            raise ValueError("ouroboros package source must be a regular file")
+        relative_path = resolved_source.relative_to(package_root).as_posix().encode("utf-8")
+        content = resolved_source.read_bytes()
+        digest.update(len(relative_path).to_bytes(8, "big"))
+        digest.update(relative_path)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _worker_runtime_authority(launcher: object) -> _LiteLLMWorkerAuthority:
+    worker_module = "ouroboros.providers.litellm_proof_worker"
+    adapter_module = "ouroboros.providers.litellm_adapter"
+    implementation_contract = "ouroboros.python-sources.v1"
+    try:
+        if not isinstance(launcher, str) or not launcher or not Path(launcher).is_absolute():
+            raise ValueError("worker launcher must be absolute")
+        launcher_path = Path(launcher)
+        resolved_executable = launcher_path.resolve(strict=True)
+        if not resolved_executable.is_file() or not os.access(launcher_path, os.X_OK):
+            raise ValueError("worker launcher must resolve to an executable file")
+        return _LiteLLMWorkerAuthority(
+            launcher_path=str(launcher_path),
+            resolved_executable_path=str(resolved_executable),
+            executable_content_sha256=_sha256_file(resolved_executable),
+            python_version=sys.version.split()[0],
+            worker_module=worker_module,
+            worker_implementation_sha256=_module_implementation_sha256(worker_module),
+            adapter_module=adapter_module,
+            adapter_implementation_sha256=_module_implementation_sha256(adapter_module),
+            ouroboros_implementation_contract=implementation_contract,
+            ouroboros_implementation_sha256=_ouroboros_implementation_sha256(),
+        )
+    except (OSError, TypeError, ValueError):
+        return _LiteLLMWorkerAuthority(
+            launcher_path=None,
+            resolved_executable_path=None,
+            executable_content_sha256=None,
+            python_version=None,
+            worker_module=worker_module,
+            worker_implementation_sha256=None,
+            adapter_module=adapter_module,
+            adapter_implementation_sha256=None,
+            ouroboros_implementation_contract=implementation_contract,
+            ouroboros_implementation_sha256=None,
+        )
 
 
 def _serialise_messages_for_hash(
@@ -119,9 +475,10 @@ class LiteLLMAdapter:
         *,
         api_key: str | None = None,
         api_base: str | None = None,
-        timeout: float = 60.0,
+        timeout: float | None = 60.0,
         max_retries: int = 3,
         io_recorder: "IOJournalRecorder | None" = None,
+        frugality_proof: bool = False,
     ) -> None:
         """Initialize the LiteLLM adapter.
 
@@ -138,13 +495,158 @@ class LiteLLMAdapter:
                 pair, so failures across retries appear in the journal
                 as distinct attempts. Default ``None`` is byte-for-byte
                 the previous behaviour.
+            frugality_proof: Seal one measurable attempt, a bounded timeout,
+                and the provider route used by focused-evolution proof.
         """
         self._api_key = api_key
         self._api_base = api_base
-        self._timeout = timeout
-        self._max_retries = max_retries
+        self._timeout = 60.0 if frugality_proof and timeout is None else timeout
+        self._max_retries = 1 if frugality_proof else max_retries
         self._credentials_cache: object = _CREDENTIALS_UNSET
         self._io_recorder = io_recorder
+        self._frugality_proof = frugality_proof
+
+    def frugality_prepare_completion(
+        self,
+        config: CompletionConfig,
+    ) -> Result[PreparedFrugalityCompletion, ProviderError]:
+        """Resolve once, seal dispatch, and attest the non-secret execution envelope."""
+        profile_result = resolve_completion_profile_result(config, backend="litellm")
+        if profile_result.is_err:
+            return Result.err(profile_result.error)
+        resolved = profile_result.value
+        effective_config = resolved.config
+        api_key = self._get_api_key(effective_config.model)
+        api_base = self._get_api_base(effective_config.model)
+        dependency_authority = self._dependency_authority(
+            effective_config.model,
+            api_key=api_key,
+        )
+        worker_authority = _worker_runtime_authority(sys.executable)
+        client_type = self._proof_client_type(dependency_authority.provider)
+        contract: dict[str, object] = {
+            "schema_version": 7,
+            "schema_id": "ouroboros.litellm.v7",
+            "internal_attempt_limit": self._max_retries,
+            "credential_authority": credential_authority_digest(api_key),
+            "effective_request": effective_completion_request(
+                resolved,
+                provider_model=effective_config.model,
+            ),
+            "settings": {
+                "api_base": api_base,
+                "timeout": self._timeout,
+                "max_retries": self._max_retries,
+                "io_recorder_configured": self._io_recorder is not None,
+                "dependency_version": dependency_authority.version,
+                "dependency_provider": dependency_authority.provider,
+                "dependency_defaults_verified": dependency_authority.defaults_verified,
+                "dependency_max_retries": _PROOF_LITELLM_MAX_RETRIES,
+                "dependency_client_sealed": client_type is not None,
+                "dependency_client_type": client_type,
+                "dependency_transport_contract": _PROOF_TRANSPORT_CONTRACT,
+                "dependency_cleanup_required": True,
+                "dependency_isolation_kind": _PROOF_ISOLATION_KIND,
+                "dependency_worker_protocol": _PROOF_WORKER_PROTOCOL,
+                "dependency_worker_environment_contract": (_PROOF_WORKER_ENVIRONMENT_CONTRACT),
+                "dependency_worker_cwd_contract": _PROOF_WORKER_CWD_CONTRACT,
+                "dependency_mutation_audit": _PROOF_MUTATION_AUDIT,
+                "worker_launcher_path": worker_authority.launcher_path,
+                "worker_executable_resolved_path": (worker_authority.resolved_executable_path),
+                "worker_executable_content_sha256": (worker_authority.executable_content_sha256),
+                "worker_python_version": worker_authority.python_version,
+                "worker_module": worker_authority.worker_module,
+                "worker_implementation_sha256": (worker_authority.worker_implementation_sha256),
+                "adapter_module": worker_authority.adapter_module,
+                "adapter_implementation_sha256": (worker_authority.adapter_implementation_sha256),
+                "ouroboros_implementation_contract": (
+                    worker_authority.ouroboros_implementation_contract
+                ),
+                "ouroboros_implementation_sha256": (
+                    worker_authority.ouroboros_implementation_sha256
+                ),
+                "httpx_dependency_version": _HTTPX_DEPENDENCY_VERSION,
+                "openai_dependency_version": _OPENAI_DEPENDENCY_VERSION,
+            },
+        }
+        return Result.ok(
+            PreparedFrugalityCompletion(
+                config=replace(effective_config, role=None, profile=None),
+                contract=contract,
+                dispatch=_PreparedLiteLLMDispatch(
+                    config=replace(effective_config, role=None, profile=None),
+                    api_key=api_key,
+                    api_base=api_base,
+                    timeout=self._timeout,
+                    max_retries=self._max_retries,
+                    dependency_authority=dependency_authority,
+                    worker_authority=worker_authority,
+                    client_type=client_type,
+                ),
+            )
+        )
+
+    def frugality_validate_prepared_completion(
+        self,
+        prepared: PreparedFrugalityCompletion,
+    ) -> bool:
+        """Revalidate mutable dependency authority before and after dispatch."""
+        dispatch = prepared.dispatch
+        if not isinstance(dispatch, _PreparedLiteLLMDispatch) or dispatch.config != prepared.config:
+            return False
+        current_authority = self._dependency_authority(
+            prepared.config.model, api_key=dispatch.api_key
+        )
+        current_worker_authority = _worker_runtime_authority(
+            dispatch.worker_authority.launcher_path
+        )
+        return bool(
+            dispatch.client_type is not None
+            and not dispatch.state.authority_drifted
+            and not dispatch.state.cleanup_failed
+            and (not dispatch.state.dispatch_started or dispatch.state.cleanup_complete)
+            and dispatch.dependency_authority == current_authority
+            and dispatch.worker_authority == current_worker_authority
+        )
+
+    async def frugality_complete_prepared(
+        self,
+        messages: list[Message],
+        prepared: PreparedFrugalityCompletion,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Dispatch with the exact route authority attested during preparation."""
+        dispatch = prepared.dispatch
+        if not isinstance(dispatch, _PreparedLiteLLMDispatch) or dispatch.config != prepared.config:
+            return Result.err(
+                ProviderError(
+                    "Invalid prepared LiteLLM completion authority",
+                    provider=self._extract_provider(prepared.config.model),
+                )
+            )
+        if dispatch.state.dispatch_started:
+            return Result.err(
+                ProviderError(
+                    "Prepared LiteLLM completion authority is single-use",
+                    provider=self._extract_provider(prepared.config.model),
+                )
+            )
+
+        dispatch.state.dispatch_started = True
+        _register_proof_authority_audit(dispatch.state)
+        try:
+            return await self._complete_in_isolated_worker(
+                messages,
+                prepared.config,
+                dispatch,
+            )
+        finally:
+            _unregister_proof_authority_audit(dispatch.state)
+            if dispatch.dependency_authority != self._dependency_authority(
+                prepared.config.model,
+                api_key=dispatch.api_key,
+            ):
+                dispatch.state.authority_drifted = True
+            dispatch.state.cleanup_complete = True
 
     def _load_credentials_config(self):
         """Load credentials.yaml once, caching missing-config cases."""
@@ -248,14 +750,388 @@ class LiteLLMAdapter:
 
         configured = self._get_configured_provider_credentials(model)
         if configured is not None:
-            return configured.base_url
+            configured_base = self._normalize_api_base(configured.base_url)
+            if configured_base:
+                return configured_base
+
+        if self._frugality_proof:
+            global_base = self._normalize_api_base(getattr(litellm, "api_base", None))
+            if global_base:
+                return global_base
+            provider = self._extract_provider(model)
+            for name in _PROOF_API_BASE_ENVIRONMENT.get(provider, ()):
+                environment_base = self._normalize_api_base(os.environ.get(name))
+                if environment_base:
+                    return environment_base
+            return _PROOF_DEFAULT_API_BASES.get(provider)
 
         return None
+
+    def _dependency_authority(
+        self,
+        model: str,
+        *,
+        api_key: str | None,
+    ) -> _LiteLLMDependencyAuthority:
+        """Accept only a bounded provider running with verified default globals."""
+        provider = self._extract_provider(model)
+        provider_config = _PROOF_PROVIDER_CONFIG_DEFAULTS.get(provider)
+        config_is_default = False
+        if provider_config is not None:
+            config_name, expected = provider_config
+            config_type = getattr(litellm, config_name, None)
+            get_config = getattr(config_type, "get_config", None)
+            try:
+                config_is_default = callable(get_config) and get_config() == expected
+            except Exception:  # noqa: BLE001 — opaque dependency state fails closed
+                config_is_default = False
+        provider_sdk_is_default = True
+        if provider in {"openai", "openrouter"}:
+            openai_module = getattr(litellm, "openai", None)
+            provider_sdk_is_default = openai_module is not None and all(
+                getattr(openai_module, name, None) is None
+                for name in (
+                    "api_key",
+                    "api_version",
+                    "base_url",
+                    "default_headers",
+                    "organization",
+                    "project",
+                )
+            )
+        defaults_verified = bool(
+            _LITELLM_DEPENDENCY_VERSION
+            and api_key
+            and provider in _PROOF_UNSEALED_PROVIDER_ENVIRONMENT
+            and all(getattr(litellm, name, None) is None for name in _PROOF_NONE_GLOBALS)
+            and all(getattr(litellm, name, None) is False for name in _PROOF_FALSE_GLOBALS)
+            and all(getattr(litellm, name, None) is True for name in _PROOF_TRUE_GLOBALS)
+            and all(getattr(litellm, name, None) == [] for name in _PROOF_EMPTY_SEQUENCE_GLOBALS)
+            and all(getattr(litellm, name, None) == {} for name in _PROOF_EMPTY_MAPPING_GLOBALS)
+            and all(
+                os.environ.get(name) in (None, "")
+                for name in _PROOF_UNSEALED_PROVIDER_ENVIRONMENT.get(provider, ())
+            )
+            and all(
+                os.environ.get(name) in (None, "") for name in _PROOF_UNSEALED_TRANSPORT_ENVIRONMENT
+            )
+            and config_is_default
+            and provider_sdk_is_default
+        )
+        return _LiteLLMDependencyAuthority(
+            version=_LITELLM_DEPENDENCY_VERSION,
+            provider=provider,
+            defaults_verified=defaults_verified,
+        )
+
+    @staticmethod
+    def _sealed_httpx_client(timeout: float | None) -> httpx.AsyncClient:
+        """Build the exact transport consumed by one proof-mode dispatch."""
+        transport = httpx.AsyncHTTPTransport(
+            verify=True,
+            cert=None,
+            trust_env=False,
+            http1=True,
+            http2=False,
+            proxy=None,
+            uds=None,
+            local_address=None,
+            retries=0,
+        )
+        return httpx.AsyncClient(
+            verify=True,
+            cert=None,
+            trust_env=False,
+            http1=True,
+            http2=False,
+            proxy=None,
+            timeout=timeout,
+            follow_redirects=True,
+            transport=transport,
+            headers={"User-Agent": f"litellm/{_LITELLM_DEPENDENCY_VERSION}"},
+        )
+
+    def _create_sealed_client(
+        self,
+        *,
+        provider: str,
+        api_key: str | None,
+        api_base: str | None,
+        timeout: float | None,
+    ) -> _SealedLiteLLMClient | None:
+        """Create a provider-compatible client without consulting mutable authority."""
+        if provider not in _PROOF_DEFAULT_API_BASES or not api_key or not api_base:
+            return None
+        try:
+            http_client = self._sealed_httpx_client(timeout)
+            if provider == "openai":
+                return _SealedLiteLLMClient(
+                    value=openai.AsyncOpenAI(
+                        api_key=api_key,
+                        base_url=api_base,
+                        timeout=timeout,
+                        max_retries=_PROOF_LITELLM_MAX_RETRIES,
+                        http_client=http_client,
+                    ),
+                    client_type=_PROOF_OPENAI_CLIENT_TYPE,
+                )
+            return _SealedLiteLLMClient(
+                value=_SealedAsyncHTTPHandler(http_client, timeout=timeout),
+                client_type=_PROOF_HTTP_HANDLER_CLIENT_TYPE,
+            )
+        except Exception:  # noqa: BLE001 — unavailable sealing fails proof closed
+            return None
+
+    @staticmethod
+    def _proof_client_type(provider: str) -> str | None:
+        if provider == "openai":
+            return _PROOF_OPENAI_CLIENT_TYPE
+        if provider in {"anthropic", "google", "openrouter"}:
+            return _PROOF_HTTP_HANDLER_CLIENT_TYPE
+        return None
+
+    async def _complete_in_isolated_worker(
+        self,
+        messages: list[Message],
+        config: CompletionConfig,
+        dispatch: _PreparedLiteLLMDispatch,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Run LiteLLM beyond the mutable parent-process effect boundary."""
+        recorder = get_current_io_journal_recorder() or self._io_recorder
+        if recorder is None or not recorder.is_active:
+            return await self._run_isolated_completion(messages, config, dispatch)
+
+        request_options = _request_options_for_hash(config)
+        prompt_text = _serialise_messages_for_hash(messages, request_options)
+        async with recorder.record_llm_call(
+            model_id=config.model,
+            prompt_text=prompt_text,
+            caller="litellm_adapter",
+            max_tokens=config.max_tokens,
+            temperature=config.temperature,
+            extra=request_options,
+        ) as call:
+            result = await self._run_isolated_completion(messages, config, dispatch)
+            if result.is_ok:
+                _record_litellm_completion(call, result.value)
+        return result
+
+    async def _run_isolated_completion(
+        self,
+        messages: list[Message],
+        config: CompletionConfig,
+        dispatch: _PreparedLiteLLMDispatch,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Exchange one bounded request with a clean, single-purpose worker."""
+        kwargs = self._build_completion_kwargs(
+            messages,
+            config,
+            _sealed_dispatch=dispatch,
+        )
+        payload = json.dumps(
+            {
+                "protocol": _PROOF_WORKER_PROTOCOL,
+                "client_type": dispatch.client_type,
+                "completion_kwargs": kwargs,
+                "config": {
+                    "model": config.model,
+                    "temperature": config.temperature,
+                    "max_tokens": config.max_tokens,
+                    "stop": config.stop,
+                    "top_p": config.top_p,
+                    "response_format": config.response_format,
+                    "role": None,
+                    "profile": None,
+                    "max_turns": config.max_turns,
+                    "reasoning_effort": config.reasoning_effort,
+                    "model_is_explicit": config.model_is_explicit,
+                },
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        worker_environment = {
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        }
+        process: asyncio.subprocess.Process | None = None
+        if dispatch.worker_authority != _worker_runtime_authority(
+            dispatch.worker_authority.launcher_path
+        ):
+            dispatch.state.authority_drifted = True
+        worker_directory = tempfile.TemporaryDirectory(prefix="ouroboros-litellm-proof-")
+        try:
+            process = await asyncio.create_subprocess_exec(
+                dispatch.worker_authority.launcher_path or "",
+                "-I",
+                "-m",
+                "ouroboros.providers.litellm_proof_worker",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+                env=worker_environment,
+                cwd=worker_directory.name,
+            )
+            timeout = (
+                dispatch.timeout
+                if isinstance(dispatch.timeout, int | float)
+                and math.isfinite(dispatch.timeout)
+                and dispatch.timeout > 0
+                else 60.0
+            )
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(payload),
+                timeout=timeout + 10.0,
+            )
+        except asyncio.CancelledError:
+            if process is not None and process.returncode is None:
+                process.kill()
+                await process.wait()
+            raise
+        except Exception as exc:  # noqa: BLE001 — provider failures become Result errors
+            if process is not None and process.returncode is None:
+                process.kill()
+                await process.wait()
+            dispatch.state.cleanup_failed = True
+            return Result.err(
+                ProviderError.from_exception(
+                    exc,
+                    provider=self._extract_provider(config.model),
+                )
+            )
+        finally:
+            try:
+                worker_directory.cleanup()
+            except Exception:  # noqa: BLE001 — cleanup invalidates proof only
+                dispatch.state.cleanup_failed = True
+
+        if process.returncode != 0 or len(stdout) > _PROOF_WORKER_MAX_OUTPUT_BYTES:
+            dispatch.state.cleanup_failed = True
+            return Result.err(
+                ProviderError(
+                    "Isolated LiteLLM worker failed",
+                    provider=self._extract_provider(config.model),
+                )
+            )
+        try:
+            report = json.loads(stdout)
+            if not isinstance(report, dict) or set(report) != {"ok", "proof", "response"}:
+                raise ValueError("invalid worker report")
+            proof = report["proof"]
+            proof_keys = {
+                "authority_verified",
+                "client_cleanup_succeeded",
+                "client_type",
+                "httpx_dependency_version",
+                "litellm_dependency_version",
+                "openai_dependency_version",
+                "transport_contract",
+                "worker_executable_resolved_path",
+                "worker_executable_content_sha256",
+                "worker_python_version",
+                "worker_module",
+                "worker_implementation_sha256",
+                "adapter_module",
+                "adapter_implementation_sha256",
+                "ouroboros_implementation_contract",
+                "ouroboros_implementation_sha256",
+            }
+            proof_is_valid = isinstance(proof, dict) and set(proof) == proof_keys
+            if not proof_is_valid:
+                dispatch.state.authority_drifted = True
+                dispatch.state.cleanup_failed = True
+            else:
+                assert isinstance(proof, dict)
+                if (
+                    proof["authority_verified"] is not True
+                    or proof["client_type"] != dispatch.client_type
+                    or proof["transport_contract"] != _PROOF_TRANSPORT_CONTRACT
+                    or proof["httpx_dependency_version"] != _HTTPX_DEPENDENCY_VERSION
+                    or proof["litellm_dependency_version"] != _LITELLM_DEPENDENCY_VERSION
+                    or proof["openai_dependency_version"] != _OPENAI_DEPENDENCY_VERSION
+                    or proof["worker_executable_resolved_path"]
+                    != dispatch.worker_authority.resolved_executable_path
+                    or proof["worker_executable_content_sha256"]
+                    != dispatch.worker_authority.executable_content_sha256
+                    or proof["worker_python_version"] != dispatch.worker_authority.python_version
+                    or proof["worker_module"] != dispatch.worker_authority.worker_module
+                    or proof["worker_implementation_sha256"]
+                    != dispatch.worker_authority.worker_implementation_sha256
+                    or proof["adapter_module"] != dispatch.worker_authority.adapter_module
+                    or proof["adapter_implementation_sha256"]
+                    != dispatch.worker_authority.adapter_implementation_sha256
+                    or proof["ouroboros_implementation_contract"]
+                    != dispatch.worker_authority.ouroboros_implementation_contract
+                    or proof["ouroboros_implementation_sha256"]
+                    != dispatch.worker_authority.ouroboros_implementation_sha256
+                ):
+                    dispatch.state.authority_drifted = True
+                if proof["client_cleanup_succeeded"] is not True:
+                    dispatch.state.cleanup_failed = True
+            if report["ok"] is not True:
+                return Result.err(
+                    ProviderError(
+                        "Isolated LiteLLM completion failed",
+                        provider=self._extract_provider(config.model),
+                    )
+                )
+            response = report["response"]
+            if not isinstance(response, dict) or set(response) != {
+                "content",
+                "finish_reason",
+                "model",
+                "usage",
+            }:
+                raise ValueError("invalid worker response")
+            usage = response["usage"]
+            if not isinstance(usage, dict) or set(usage) != {
+                "completion_tokens",
+                "prompt_tokens",
+                "total_tokens",
+            }:
+                raise ValueError("invalid worker usage")
+            counters = tuple(
+                usage[name] for name in ("prompt_tokens", "completion_tokens", "total_tokens")
+            )
+            if not all(type(value) is int and value >= 0 for value in counters):
+                raise ValueError("invalid worker counters")
+            prompt_tokens, completion_tokens, total_tokens = counters
+            if total_tokens != prompt_tokens + completion_tokens:
+                raise ValueError("inconsistent worker counters")
+            if not all(
+                isinstance(response[name], str) for name in ("content", "finish_reason", "model")
+            ):
+                raise ValueError("invalid worker text")
+            return Result.ok(
+                CompletionResponse(
+                    content=response["content"],
+                    model=response["model"],
+                    usage=UsageInfo(
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        total_tokens=total_tokens,
+                    ),
+                    finish_reason=response["finish_reason"],
+                )
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            dispatch.state.authority_drifted = True
+            return Result.err(
+                ProviderError.from_exception(
+                    exc,
+                    provider=self._extract_provider(config.model),
+                )
+            )
+
+    @staticmethod
+    def _normalize_api_base(value: object) -> str | None:
+        return value.strip() if isinstance(value, str) and value.strip() else None
 
     def _build_completion_kwargs(
         self,
         messages: list[Message],
         config: CompletionConfig,
+        *,
+        _sealed_dispatch: _PreparedLiteLLMDispatch | None = None,
     ) -> dict[str, Any]:
         """Build the kwargs for litellm.acompletion.
 
@@ -271,8 +1147,12 @@ class LiteLLMAdapter:
             "messages": [m.to_dict() for m in messages],
             "temperature": config.temperature,
             "max_tokens": config.max_tokens,
-            "timeout": self._timeout,
+            "timeout": (
+                _sealed_dispatch.timeout if _sealed_dispatch is not None else self._timeout
+            ),
         }
+        if _sealed_dispatch is not None:
+            kwargs["max_retries"] = _PROOF_LITELLM_MAX_RETRIES
 
         # Anthropic models don't accept both temperature and top_p together
         # Other providers (OpenAI, OpenRouter) support both
@@ -293,11 +1173,19 @@ class LiteLLMAdapter:
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
-        api_key = self._get_api_key(config.model)
+        api_key = (
+            _sealed_dispatch.api_key
+            if _sealed_dispatch is not None
+            else self._get_api_key(config.model)
+        )
         if api_key:
             kwargs["api_key"] = api_key
 
-        api_base = self._get_api_base(config.model)
+        api_base = (
+            _sealed_dispatch.api_base
+            if _sealed_dispatch is not None
+            else self._get_api_base(config.model)
+        )
         if api_base:
             kwargs["api_base"] = api_base
 
@@ -307,6 +1195,8 @@ class LiteLLMAdapter:
         self,
         messages: list[Message],
         config: CompletionConfig,
+        *,
+        _sealed_dispatch: _PreparedLiteLLMDispatch | None = None,
     ) -> litellm.ModelResponse:
         """Make the raw completion call.
 
@@ -320,7 +1210,11 @@ class LiteLLMAdapter:
         Raises:
             litellm exceptions for API errors.
         """
-        kwargs = self._build_completion_kwargs(messages, config)
+        kwargs = self._build_completion_kwargs(
+            messages,
+            config,
+            _sealed_dispatch=_sealed_dispatch,
+        )
 
         log.debug(
             "llm.request.started",
@@ -386,6 +1280,8 @@ class LiteLLMAdapter:
         self,
         messages: list[Message],
         config: CompletionConfig,
+        *,
+        _sealed_dispatch: _PreparedLiteLLMDispatch | None = None,
     ) -> Result[CompletionResponse, ProviderError]:
         """Make a completion request to the LLM provider.
 
@@ -399,15 +1295,26 @@ class LiteLLMAdapter:
         Returns:
             Result containing either the completion response or a ProviderError.
         """
-        profile_result = resolve_completion_profile_result(config, backend="litellm")
-        if profile_result.is_err:
-            return Result.err(profile_result.error)
-        config = profile_result.value.config
+        if _sealed_dispatch is None:
+            profile_result = resolve_completion_profile_result(config, backend="litellm")
+            if profile_result.is_err:
+                return Result.err(profile_result.error)
+            config = profile_result.value.config
+        elif _sealed_dispatch.config != config:
+            return Result.err(
+                ProviderError(
+                    "Prepared LiteLLM config does not match sealed dispatch authority",
+                    provider=self._extract_provider(config.model),
+                )
+            )
 
-        # Create the retry-decorated function with instance's max_retries
+        max_retries = (
+            _sealed_dispatch.max_retries if _sealed_dispatch is not None else self._max_retries
+        )
+
         @retry_async(
             on=RETRIABLE_EXCEPTIONS,
-            attempts=self._max_retries,
+            attempts=max_retries,
             wait_initial=1.0,
             wait_max=10.0,
             wait_jitter=1.0,
@@ -415,7 +1322,11 @@ class LiteLLMAdapter:
         async def _with_retry() -> CompletionResponse:
             recorder = get_current_io_journal_recorder() or self._io_recorder
             if recorder is None or not recorder.is_active:
-                response = await self._raw_complete(messages, config)
+                response = await self._raw_complete(
+                    messages,
+                    config,
+                    _sealed_dispatch=_sealed_dispatch,
+                )
                 return self._parse_response(response, config)
             request_options = _request_options_for_hash(config)
             prompt_text = _serialise_messages_for_hash(messages, request_options)
@@ -427,7 +1338,11 @@ class LiteLLMAdapter:
                 temperature=config.temperature,
                 extra=request_options,
             ) as call:
-                response = await self._raw_complete(messages, config)
+                response = await self._raw_complete(
+                    messages,
+                    config,
+                    _sealed_dispatch=_sealed_dispatch,
+                )
                 parsed = self._parse_response(response, config)
                 _record_litellm_completion(call, parsed)
             return parsed
@@ -441,7 +1356,7 @@ class LiteLLMAdapter:
                 "llm.request.failed.retries_exhausted",
                 model=config.model,
                 error=str(e),
-                max_retries=self._max_retries,
+                max_retries=max_retries,
             )
             return Result.err(
                 ProviderError.from_exception(e, provider=self._extract_provider(config.model))

--- a/src/ouroboros/providers/litellm_proof_worker.py
+++ b/src/ouroboros/providers/litellm_proof_worker.py
@@ -1,0 +1,221 @@
+"""Single-request LiteLLM worker for frugality-proof effect isolation."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import redirect_stdout
+import json
+import sys
+from typing import Any
+
+import litellm
+
+from ouroboros.providers.base import CompletionConfig
+from ouroboros.providers.litellm_adapter import (
+    _HTTPX_DEPENDENCY_VERSION,
+    _LITELLM_DEPENDENCY_VERSION,
+    _OPENAI_DEPENDENCY_VERSION,
+    _PROOF_LITELLM_MAX_RETRIES,
+    _PROOF_TRANSPORT_CONTRACT,
+    _PROOF_WORKER_PROTOCOL,
+    LiteLLMAdapter,
+    _worker_runtime_authority,
+)
+
+_MAX_INPUT_BYTES = 4 * 1024 * 1024
+_COMPLETION_KWARGS = frozenset(
+    {
+        "api_base",
+        "api_key",
+        "max_retries",
+        "max_tokens",
+        "messages",
+        "model",
+        "reasoning_effort",
+        "response_format",
+        "stop",
+        "temperature",
+        "timeout",
+        "top_p",
+    }
+)
+_REQUIRED_COMPLETION_KWARGS = frozenset(
+    {
+        "api_base",
+        "api_key",
+        "max_retries",
+        "max_tokens",
+        "messages",
+        "model",
+        "temperature",
+        "timeout",
+    }
+)
+_PAYLOAD_KEYS = frozenset({"client_type", "completion_kwargs", "config", "protocol"})
+
+
+def _proof_report(
+    *,
+    authority_verified: bool,
+    client_cleanup_succeeded: bool,
+    client_type: object,
+) -> dict[str, object]:
+    worker_authority = _worker_runtime_authority(sys.executable)
+    return {
+        "authority_verified": authority_verified,
+        "client_cleanup_succeeded": client_cleanup_succeeded,
+        "client_type": client_type,
+        "httpx_dependency_version": _HTTPX_DEPENDENCY_VERSION,
+        "litellm_dependency_version": _LITELLM_DEPENDENCY_VERSION,
+        "openai_dependency_version": _OPENAI_DEPENDENCY_VERSION,
+        "worker_executable_resolved_path": (worker_authority.resolved_executable_path),
+        "worker_executable_content_sha256": (worker_authority.executable_content_sha256),
+        "worker_python_version": worker_authority.python_version,
+        "worker_module": worker_authority.worker_module,
+        "worker_implementation_sha256": (worker_authority.worker_implementation_sha256),
+        "adapter_module": worker_authority.adapter_module,
+        "adapter_implementation_sha256": (worker_authority.adapter_implementation_sha256),
+        "ouroboros_implementation_contract": (worker_authority.ouroboros_implementation_contract),
+        "ouroboros_implementation_sha256": (worker_authority.ouroboros_implementation_sha256),
+        "transport_contract": _PROOF_TRANSPORT_CONTRACT,
+    }
+
+
+def _failure_report(
+    *,
+    authority_verified: bool = False,
+    client_cleanup_succeeded: bool = False,
+    client_type: object = None,
+) -> dict[str, object]:
+    return {
+        "ok": False,
+        "proof": _proof_report(
+            authority_verified=authority_verified,
+            client_cleanup_succeeded=client_cleanup_succeeded,
+            client_type=client_type,
+        ),
+        "response": None,
+    }
+
+
+def _validated_payload(raw: object) -> tuple[dict[str, Any], CompletionConfig, str] | None:
+    if not isinstance(raw, dict) or set(raw) != _PAYLOAD_KEYS:
+        return None
+    if raw.get("protocol") != _PROOF_WORKER_PROTOCOL:
+        return None
+    kwargs = raw.get("completion_kwargs")
+    config_raw = raw.get("config")
+    client_type = raw.get("client_type")
+    if (
+        not isinstance(kwargs, dict)
+        or not _REQUIRED_COMPLETION_KWARGS.issubset(kwargs)
+        or not set(kwargs).issubset(_COMPLETION_KWARGS)
+        or not isinstance(config_raw, dict)
+        or not isinstance(client_type, str)
+        or kwargs.get("max_retries") != _PROOF_LITELLM_MAX_RETRIES
+        or not isinstance(kwargs.get("api_key"), str)
+        or not kwargs["api_key"]
+        or not isinstance(kwargs.get("api_base"), str)
+        or not kwargs["api_base"]
+    ):
+        return None
+    try:
+        config = CompletionConfig(**config_raw)
+    except (TypeError, ValueError):
+        return None
+    if kwargs.get("model") != config.model:
+        return None
+    return kwargs, config, client_type
+
+
+async def _run(raw: object) -> dict[str, object]:
+    validated = _validated_payload(raw)
+    if validated is None:
+        return _failure_report()
+    kwargs, config, expected_client_type = validated
+    adapter = LiteLLMAdapter(
+        api_key=kwargs["api_key"],
+        api_base=kwargs["api_base"],
+        timeout=kwargs["timeout"],
+        max_retries=1,
+        frugality_proof=True,
+    )
+    provider = adapter._extract_provider(config.model)
+    initial_authority = adapter._dependency_authority(
+        config.model,
+        api_key=kwargs["api_key"],
+    )
+    sealed_client = adapter._create_sealed_client(
+        provider=provider,
+        api_key=kwargs["api_key"],
+        api_base=kwargs["api_base"],
+        timeout=kwargs["timeout"],
+    )
+    if sealed_client is None or sealed_client.client_type != expected_client_type:
+        return _failure_report(client_type=expected_client_type)
+
+    response: dict[str, object] | None = None
+    call_succeeded = False
+    cleanup_succeeded = False
+    try:
+        with redirect_stdout(sys.stderr):
+            raw_response = await litellm.acompletion(
+                **kwargs,
+                client=sealed_client.value,
+            )
+        parsed = adapter._parse_response(raw_response, config)
+        response = {
+            "content": parsed.content,
+            "finish_reason": parsed.finish_reason,
+            "model": parsed.model,
+            "usage": {
+                "completion_tokens": parsed.usage.completion_tokens,
+                "prompt_tokens": parsed.usage.prompt_tokens,
+                "total_tokens": parsed.usage.total_tokens,
+            },
+        }
+        call_succeeded = True
+    except BaseException:  # noqa: BLE001 — never expose provider or credential details
+        call_succeeded = False
+    finally:
+        try:
+            await sealed_client.close()
+            cleanup_succeeded = True
+        except BaseException:  # noqa: BLE001 — cleanup status is proof evidence
+            cleanup_succeeded = False
+
+    final_authority = adapter._dependency_authority(
+        config.model,
+        api_key=kwargs["api_key"],
+    )
+    authority_verified = bool(
+        initial_authority.defaults_verified and initial_authority == final_authority
+    )
+    return {
+        "ok": call_succeeded,
+        "proof": _proof_report(
+            authority_verified=authority_verified,
+            client_cleanup_succeeded=cleanup_succeeded,
+            client_type=sealed_client.client_type,
+        ),
+        "response": response,
+    }
+
+
+def main() -> int:
+    raw_bytes = sys.stdin.buffer.read(_MAX_INPUT_BYTES + 1)
+    if len(raw_bytes) > _MAX_INPUT_BYTES:
+        report = _failure_report()
+    else:
+        try:
+            payload = json.loads(raw_bytes)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            report = _failure_report()
+        else:
+            report = asyncio.run(_run(payload))
+    sys.stdout.write(json.dumps(report, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -21,6 +21,7 @@ from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.seed import AcceptanceCriterionInput, ac_texts
 from ouroboros.core.types import Result
+from ouroboros.evolution.provider_usage import tracked_complete
 from ouroboros.providers.base import (
     CompletionConfig,
     LLMAdapter,
@@ -129,7 +130,7 @@ class AssertionExtractor:
             max_tokens=4096,
         )
 
-        result = await self.llm_adapter.complete(messages, config)
+        result = await tracked_complete(self.llm_adapter, messages, config)
         if result.is_err:
             logger.warning("AssertionExtractor LLM failed: %s", result.error)
             return Result.err(f"Extraction failed: {result.error}")

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -873,9 +873,16 @@ class TestCreateOuroborosServer:
 
             create_ouroboros_server(runtime_backend="codex", llm_backend="codex")
 
-        mock_create_llm_adapter.assert_called_once()
-        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "codex"
-        assert mock_create_llm_adapter.call_args.kwargs["max_turns"] == 15
+        assert len(mock_create_llm_adapter.call_args_list) == 3
+        assert [call.kwargs["backend"] for call in mock_create_llm_adapter.call_args_list] == [
+            "codex",
+            "codex",
+            "codex",
+        ]
+        assert [
+            call.kwargs["frugality_proof"] for call in mock_create_llm_adapter.call_args_list
+        ] == [False, True, True]
+        assert {call.kwargs["max_turns"] for call in mock_create_llm_adapter.call_args_list} == {15}
 
     def test_evolution_adapter_factory_resolves_live_backend_with_cwd(self) -> None:
         """Per-call evolution adapter factory must not freeze startup llm_backend."""
@@ -1055,8 +1062,15 @@ class TestCreateOuroborosServer:
 
             create_ouroboros_server(runtime_backend="opencode", llm_backend="opencode")
 
-        mock_create_llm_adapter.assert_called_once()
-        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "opencode"
+        assert len(mock_create_llm_adapter.call_args_list) == 3
+        assert [call.kwargs["backend"] for call in mock_create_llm_adapter.call_args_list] == [
+            "opencode",
+            "opencode",
+            "opencode",
+        ]
+        assert [
+            call.kwargs["frugality_proof"] for call in mock_create_llm_adapter.call_args_list
+        ] == [False, True, True]
         mock_create_runtime.assert_called_once()
         assert mock_create_runtime.call_args.kwargs["backend"] == "opencode"
 

--- a/tests/unit/evolution/test_drift_recording.py
+++ b/tests/unit/evolution/test_drift_recording.py
@@ -1,0 +1,58 @@
+"""Generation drift recording remains best-effort and durable."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.evolution.drift_recording import record_generation_drift
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Preserve the verified outcome",
+        acceptance_criteria=("Outcome holds",),
+        ontology_schema=OntologySchema(name="outcome", description="Verified outcome"),
+        metadata=SeedMetadata(seed_id="seed_drift", ambiguity_score=0.1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_execution_output_does_not_emit_drift() -> None:
+    event_store = AsyncMock()
+
+    await record_generation_drift(event_store, "lin_1", 2, _seed(), None)
+
+    event_store.append.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execution_output_emits_lineage_bound_drift_event() -> None:
+    event_store = AsyncMock()
+    seed = _seed()
+
+    await record_generation_drift(event_store, "lin_1", 2, seed, "verified output")
+
+    event_store.append.assert_awaited_once()
+    event = event_store.append.await_args.args[0]
+    assert event.type == "observability.drift.measured"
+    assert event.aggregate_id == "lin_1"
+    assert event.data["seed_id"] == seed.metadata.seed_id
+    assert event.data["iteration"] == 2
+
+
+@pytest.mark.asyncio
+async def test_drift_failure_does_not_fail_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    event_store = AsyncMock()
+
+    def fail_measurement(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("telemetry unavailable")
+
+    monkeypatch.setattr(
+        "ouroboros.evolution.drift_recording.DriftMeasurement.measure",
+        fail_measurement,
+    )
+
+    await record_generation_drift(event_store, "lin_1", 2, _seed(), "verified output")
+
+    event_store.append.assert_not_awaited()

--- a/tests/unit/evolution/test_frugality.py
+++ b/tests/unit/evolution/test_frugality.py
@@ -1,0 +1,1546 @@
+"""Focused-evolution frugality is paired, measured, and quality-vetoed."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.focus import EvolutionFocus
+from ouroboros.evolution.frugality import (
+    OBSERVATION_EVENT,
+    PROOF_EVENT,
+    EvolutionFrugalityArm,
+    EvolutionFrugalityObservation,
+    EvolutionFrugalityStatus,
+    ProjectBaseline,
+    build_observation,
+    comparison_key,
+    evaluate_observations,
+    evaluate_pair,
+    query_execution_evidence_events,
+    record_generation,
+)
+from ouroboros.evolution.provider_usage import ProviderUsageSummary
+from ouroboros.persistence.event_store import EventStore
+
+
+def _observation(
+    arm: EvolutionFrugalityArm,
+    *,
+    receipt: str,
+    workspace: str,
+    tokens: float | None,
+    frozen: tuple[int, ...] = (),
+    approved: bool = True,
+    passed: tuple[int, ...] = (0, 1),
+    regressed: tuple[int, ...] = (),
+    grounding: int | None = 0,
+    evaluation_score: float | None = 0.9,
+    evaluation_drift_score: float | None = 0.1,
+    evaluation_reward_hacking_risk: float | None = 0.1,
+    highest_stage_passed: int | None = 2,
+    ac_scores: tuple[float | None, ...] = (0.9, 0.9),
+) -> EvolutionFrugalityObservation:
+    expected_attempts = 10 if arm is EvolutionFrugalityArm.FULL_GRAPH else 6
+    active = (1,) if frozen else (0, 1)
+    attempt_counts = (expected_attempts,) if len(active) == 1 else (4, 6)
+    execution_assignments = tuple(
+        (
+            index,
+            ("sha256:" + "d" * 64,) * attempt_counts[offset],
+        )
+        for offset, index in enumerate(active)
+    )
+    return EvolutionFrugalityObservation(
+        receipt_id=receipt,
+        comparison_key="sha256:paired",
+        lineage_id=receipt,
+        generation_number=2,
+        execution_id=f"{receipt}:2",
+        arm=arm,
+        workspace_path=workspace,
+        baseline_commit="abc123",
+        baseline_clean=True,
+        active_ac_indices=active,
+        frozen_ac_indices=frozen,
+        executed_ac_indices=active,
+        total_node_count=2,
+        evaluated_seed_fingerprint="sha256:" + "b" * 64,
+        token_spend=tokens,
+        execution_token_spend=tokens,
+        token_event_count=expected_attempts if tokens is not None else 0,
+        expected_attempt_count=expected_attempts,
+        attempt_identity_digest="sha256:" + "a" * 64,
+        execution_configuration_fingerprint="sha256:" + "d" * 64,
+        execution_configuration_assignments=execution_assignments,
+        token_evidence_complete=tokens is not None,
+        provider_token_spend=0,
+        provider_call_count=0,
+        provider_identity_digest="sha256:" + "c" * 64,
+        provider_configuration_fingerprint="sha256:" + "e" * 64,
+        provider_configuration_assignments=(),
+        provider_evidence_complete=True,
+        generation_token_evidence_complete=tokens is not None,
+        wall_time_seconds=10 if arm is EvolutionFrugalityArm.FULL_GRAPH else 6,
+        runtime_calls=expected_attempts,
+        final_approved=approved,
+        evaluation_score=evaluation_score,
+        evaluation_drift_score=evaluation_drift_score,
+        evaluation_reward_hacking_risk=evaluation_reward_hacking_risk,
+        highest_stage_passed=highest_stage_passed,
+        passed_ac_indices=passed,
+        failed_ac_indices=tuple(index for index in (0, 1) if index not in passed),
+        ac_score_assignments=tuple(enumerate(ac_scores)),
+        regressed_ac_indices=regressed,
+        grounding_observations=expected_attempts if grounding is not None else 0,
+        grounding_regressions=grounding,
+        grounding_evidence_complete=grounding is not None,
+        ac_evidence_complete=True,
+    )
+
+
+def _provider_usage() -> ProviderUsageSummary:
+    return ProviderUsageSummary(
+        call_count=0,
+        token_spend=0,
+        identity_digest="sha256:" + "c" * 64,
+        configuration_fingerprint="sha256:" + "e" * 64,
+        configuration_assignments=(),
+        complete=True,
+    )
+
+
+def _pair(*, control_tokens: float = 100, treatment_tokens: float = 70):
+    control = _observation(
+        EvolutionFrugalityArm.FULL_GRAPH,
+        receipt="control",
+        workspace="/tmp/control",
+        tokens=control_tokens,
+    )
+    treatment = _observation(
+        EvolutionFrugalityArm.FOCUSED,
+        receipt="treatment",
+        workspace="/tmp/treatment",
+        tokens=treatment_tokens,
+        frozen=(0,),
+    )
+    return control, treatment
+
+
+def _seed(seed_id: str = "seed_one") -> Seed:
+    return Seed(
+        metadata=SeedMetadata(seed_id=seed_id, ambiguity_score=0.1),
+        goal="Build the product",
+        constraints=("preserve quality",),
+        acceptance_criteria=("first", "second"),
+        ontology_schema=OntologySchema(
+            name="product",
+            description="product",
+            fields=(OntologyField(name="item", field_type="entity", description="item"),),
+        ),
+    )
+
+
+def _evaluation(*passed: bool, seed: Seed | None = None) -> EvaluationSummary:
+    evaluated_seed = seed or _seed()
+    return EvaluationSummary(
+        final_approved=all(passed),
+        highest_stage_passed=2,
+        score=sum(passed) / len(passed),
+        ac_results=tuple(
+            ACResult(
+                ac_index=index,
+                ac_content=evaluated_seed.acceptance_criteria[index].description,
+                semantic_ac_key=evaluated_seed.acceptance_criteria[index].semantic_ac_key,
+                passed=value,
+            )
+            for index, value in enumerate(passed)
+        ),
+    )
+
+
+def test_pair_passes_only_with_measured_savings_and_preserved_quality() -> None:
+    control, treatment = _pair()
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.PASS
+    assert proof.token_reduction_pct == 30.0
+    assert proof.wall_time_reduction_pct == 40.0
+    assert proof.call_reduction_pct == 40.0
+    assert proof.quality_vetoes == ()
+
+
+def test_legacy_v1_receipts_cannot_be_reused_as_current_passes() -> None:
+    control, treatment = _pair()
+    proof = evaluate_pair(control, treatment)
+
+    with pytest.raises(ValueError):
+        EvolutionFrugalityObservation.model_validate(
+            {**control.model_dump(mode="json"), "schema_version": 1}
+        )
+    with pytest.raises(ValueError):
+        type(proof).model_validate({**proof.model_dump(mode="json"), "schema_version": 1})
+
+
+def test_complete_receipt_rejects_assignment_count_mismatch() -> None:
+    control, _ = _pair()
+    data = control.model_dump(mode="json")
+    data["execution_configuration_assignments"][0][1].pop()
+
+    with pytest.raises(ValueError, match="every expected attempt"):
+        EvolutionFrugalityObservation.model_validate(data)
+
+
+@pytest.mark.parametrize("role", ["", "   ", "unknown", " unknown ", "UNKNOWN", " Unknown "])
+def test_complete_receipt_rejects_invalid_persisted_provider_role(role: str) -> None:
+    control, _ = _pair()
+    data = control.model_dump(mode="json")
+    data.update(
+        {
+            "execution_token_spend": 98,
+            "provider_token_spend": 2,
+            "provider_call_count": 1,
+            "provider_configuration_assignments": [[role, ["sha256:" + "e" * 64]]],
+            "runtime_calls": control.expected_attempt_count + 1,
+        }
+    )
+
+    with pytest.raises(ValueError, match="every provider call"):
+        EvolutionFrugalityObservation.model_validate(data)
+
+
+def test_complete_receipt_rejects_zero_spend_for_nonempty_provider_surface() -> None:
+    control, _ = _pair()
+    data = control.model_dump(mode="json")
+    data.update(
+        {
+            "provider_call_count": 1,
+            "provider_configuration_assignments": [["reflect", ["sha256:" + "e" * 64]]],
+            "runtime_calls": control.expected_attempt_count + 1,
+        }
+    )
+
+    with pytest.raises(ValueError, match="every provider call"):
+        EvolutionFrugalityObservation.model_validate(data)
+
+
+def test_pair_defensively_rejects_zero_spend_for_nonempty_provider_surface() -> None:
+    control, treatment = _pair()
+    invalid = {
+        "provider_call_count": 1,
+        "provider_configuration_assignments": (("reflect", ("sha256:" + "e" * 64,)),),
+    }
+    control = control.model_copy(
+        update={**invalid, "runtime_calls": control.expected_attempt_count + 1}
+    )
+    treatment = treatment.model_copy(
+        update={**invalid, "runtime_calls": treatment.expected_attempt_count + 1}
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "provider-call token attribution" in proof.reason
+
+
+def test_pair_fails_when_savings_are_below_threshold() -> None:
+    control, treatment = _pair(treatment_tokens=95)
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.FAIL_NO_SAVINGS
+    assert proof.token_reduction_pct == 5.0
+
+
+def test_pair_rejects_different_final_semantic_seed_contracts() -> None:
+    control, treatment = _pair()
+    treatment = treatment.model_copy(update={"evaluated_seed_fingerprint": "sha256:" + "d" * 64})
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "final semantic Seed contracts differ" in proof.reason
+
+
+def test_pair_rejects_primary_configuration_swapped_between_root_acs() -> None:
+    control, treatment = _pair()
+    control = control.model_copy(
+        update={
+            "active_ac_indices": (0, 1, 2),
+            "executed_ac_indices": (0, 1, 2),
+            "total_node_count": 3,
+            "passed_ac_indices": (0, 1, 2),
+            "ac_score_assignments": ((0, 0.9), (1, 0.9), (2, 0.9)),
+            "execution_configuration_assignments": (
+                (0, ("sha256:" + "a" * 64,) * 4),
+                (1, ("sha256:" + "a" * 64,) * 3),
+                (2, ("sha256:" + "b" * 64,) * 3),
+            ),
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "active_ac_indices": (1, 2),
+            "frozen_ac_indices": (0,),
+            "executed_ac_indices": (1, 2),
+            "total_node_count": 3,
+            "passed_ac_indices": (0, 1, 2),
+            "ac_score_assignments": ((0, 0.9), (1, 0.9), (2, 0.9)),
+            "execution_configuration_assignments": (
+                (1, ("sha256:" + "b" * 64,) * 3),
+                (2, ("sha256:" + "a" * 64,) * 3),
+            ),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "active root AC" in proof.reason
+
+
+def test_full_graph_control_must_execute_every_seed_root() -> None:
+    control, treatment = _pair()
+    control_data = control.model_dump(mode="json")
+    control_data.update(
+        {
+            "active_ac_indices": (1,),
+            "executed_ac_indices": (1,),
+            "token_event_count": 6,
+            "expected_attempt_count": 6,
+            "execution_configuration_assignments": ((1, ("sha256:" + "d" * 64,) * 6),),
+            "runtime_calls": 6,
+            "grounding_observations": 6,
+        }
+    )
+    incomplete_control = EvolutionFrugalityObservation.model_validate(control_data)
+
+    proof = evaluate_pair(incomplete_control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "complete Seed graph" in proof.reason
+
+
+def test_pair_rejects_configuration_multiplicity_swap_within_one_root() -> None:
+    control, treatment = _pair()
+    expensive = "sha256:" + "a" * 64
+    cheap = "sha256:" + "b" * 64
+    control = control.model_copy(
+        update={
+            "execution_configuration_assignments": (
+                (0, (expensive,)),
+                (1, (expensive,) * 8 + (cheap,)),
+            )
+        }
+    )
+    treatment = treatment.model_copy(
+        update={"execution_configuration_assignments": ((1, (expensive,) + (cheap,) * 5),)}
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "active root AC" in proof.reason
+
+
+def test_pair_rejects_auxiliary_configuration_swapped_between_roles() -> None:
+    control, treatment = _pair()
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 99,
+            "provider_token_spend": 1,
+            "provider_call_count": 2,
+            "runtime_calls": control.expected_attempt_count + 2,
+            "provider_configuration_assignments": (
+                ("semantic_evaluation", ("sha256:" + "a" * 64,)),
+                ("wonder", ("sha256:" + "b" * 64,)),
+            ),
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "execution_token_spend": 68,
+            "provider_token_spend": 2,
+            "provider_call_count": 2,
+            "runtime_calls": treatment.expected_attempt_count + 2,
+            "provider_configuration_assignments": (
+                ("semantic_evaluation", ("sha256:" + "b" * 64,)),
+                ("wonder", ("sha256:" + "a" * 64,)),
+            ),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "differ by role" in proof.reason
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "semantic_cwd",
+        "child_environment",
+        "worker_executable",
+        "adapter_implementation",
+    ],
+)
+def test_pair_returns_insufficient_data_for_runtime_authority_drift(authority: str) -> None:
+    control, treatment = _pair()
+    control_digest, treatment_digest = ("a", "b") if authority == "semantic_cwd" else ("c", "d")
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 99,
+            "provider_token_spend": 1,
+            "provider_call_count": 1,
+            "runtime_calls": control.expected_attempt_count + 1,
+            "provider_configuration_fingerprint": "sha256:" + "1" * 64,
+            "provider_configuration_assignments": (
+                ("executor_auxiliary", ("sha256:" + control_digest * 64,)),
+            ),
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "execution_token_spend": 69,
+            "provider_token_spend": 1,
+            "provider_call_count": 1,
+            "runtime_calls": treatment.expected_attempt_count + 1,
+            "provider_configuration_fingerprint": "sha256:" + "2" * 64,
+            "provider_configuration_assignments": (
+                ("executor_auxiliary", ("sha256:" + treatment_digest * 64,)),
+            ),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "differ by role" in proof.reason
+
+
+def test_pair_rejects_configuration_multiplicity_swap_within_one_role() -> None:
+    control, treatment = _pair()
+    expensive = "sha256:" + "a" * 64
+    cheap = "sha256:" + "b" * 64
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 90,
+            "provider_token_spend": 10,
+            "provider_call_count": 10,
+            "runtime_calls": control.expected_attempt_count + 10,
+            "provider_configuration_assignments": (("reflect", (expensive,) * 9 + (cheap,)),),
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "execution_token_spend": 60,
+            "provider_token_spend": 10,
+            "provider_call_count": 10,
+            "runtime_calls": treatment.expected_attempt_count + 10,
+            "provider_configuration_assignments": (("reflect", (expensive,) + (cheap,) * 9),),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "differ by role" in proof.reason
+
+
+def test_pair_rejects_ambiguous_call_removal_within_shared_role() -> None:
+    control, treatment = _pair()
+    first = "sha256:" + "a" * 64
+    middle = "sha256:" + "b" * 64
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 97,
+            "provider_token_spend": 3,
+            "provider_call_count": 3,
+            "runtime_calls": control.expected_attempt_count + 3,
+            "provider_configuration_assignments": (("reflect", (first, middle, first)),),
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "execution_token_spend": 68,
+            "provider_token_spend": 2,
+            "provider_call_count": 2,
+            "runtime_calls": treatment.expected_attempt_count + 2,
+            "provider_configuration_assignments": (("reflect", (middle, first)),),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "differ by role" in proof.reason
+
+
+def test_pair_allows_eliminating_an_entire_control_only_role() -> None:
+    control, treatment = _pair()
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 90,
+            "provider_token_spend": 10,
+            "provider_call_count": 2,
+            "runtime_calls": control.expected_attempt_count + 2,
+            "provider_configuration_assignments": (
+                ("executor_shadow_replay", (("sha256:" + "a" * 64),) * 2),
+            ),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.PASS
+
+
+def test_pair_prices_all_generation_provider_calls() -> None:
+    control, treatment = _pair()
+    control = control.model_copy(
+        update={
+            "execution_token_spend": 80,
+            "provider_token_spend": 20,
+            "provider_call_count": 1,
+            "provider_configuration_assignments": (("reflect", ("sha256:" + "e" * 64,)),),
+            "runtime_calls": control.expected_attempt_count + 1,
+        }
+    )
+    treatment = treatment.model_copy(
+        update={
+            "token_spend": 105,
+            "execution_token_spend": 40,
+            "provider_token_spend": 65,
+            "provider_call_count": 1,
+            "provider_configuration_assignments": (("reflect", ("sha256:" + "e" * 64,)),),
+            "runtime_calls": treatment.expected_attempt_count + 1,
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.FAIL_NO_SAVINGS
+    assert proof.token_reduction_pct == -5.0
+
+
+def test_unrounded_reduction_must_reach_threshold() -> None:
+    control, treatment = _pair(treatment_tokens=90.00004)
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.FAIL_NO_SAVINGS
+    assert proof.token_reduction_pct is not None
+    assert proof.token_reduction_pct < 10.0
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected"),
+    [
+        ({"approved": False}, "final approval regressed"),
+        ({"passed": (1,), "regressed": (0,)}, "previously passing ACs regressed"),
+        ({"grounding": 1}, "grounding regressed"),
+        ({"evaluation_score": 0.8}, "evaluation score regressed"),
+        ({"evaluation_drift_score": 0.2}, "evaluation drift regressed"),
+        (
+            {"evaluation_reward_hacking_risk": 0.2},
+            "reward-hacking risk regressed",
+        ),
+        ({"highest_stage_passed": 1}, "highest evaluation stage regressed"),
+        ({"ac_scores": (0.9, 0.8)}, "AC 1 score regressed"),
+    ],
+)
+def test_quality_regression_vetoes_resource_savings(
+    changes: dict[str, object], expected: str
+) -> None:
+    control, _ = _pair()
+    treatment = _observation(
+        EvolutionFrugalityArm.FOCUSED,
+        receipt="treatment",
+        workspace="/tmp/treatment",
+        tokens=10,
+        frozen=(0,),
+        **changes,
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.FAIL_QUALITY_REGRESSION
+    assert any(expected in veto for veto in proof.quality_vetoes)
+    assert proof.token_reduction_pct is None
+
+
+def test_asymmetric_quality_metric_evidence_is_insufficient() -> None:
+    control, _ = _pair()
+    treatment = _observation(
+        EvolutionFrugalityArm.FOCUSED,
+        receipt="treatment",
+        workspace="/tmp/treatment",
+        tokens=10,
+        frozen=(0,),
+        evaluation_drift_score=None,
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "evaluation drift evidence is not comparable" in proof.reason
+
+
+@pytest.mark.parametrize(
+    "treatment",
+    [
+        _observation(
+            EvolutionFrugalityArm.FOCUSED,
+            receipt="dirty",
+            workspace="/tmp/treatment",
+            tokens=70,
+            frozen=(0,),
+        ).model_copy(update={"baseline_clean": False}),
+        _observation(
+            EvolutionFrugalityArm.FOCUSED,
+            receipt="same-worktree",
+            workspace="/tmp/control",
+            tokens=70,
+            frozen=(0,),
+        ),
+        _observation(
+            EvolutionFrugalityArm.FOCUSED,
+            receipt="no-grounding",
+            workspace="/tmp/treatment",
+            tokens=70,
+            frozen=(0,),
+            grounding=None,
+        ),
+        _observation(
+            EvolutionFrugalityArm.FOCUSED,
+            receipt="no-tokens",
+            workspace="/tmp/treatment",
+            tokens=None,
+            frozen=(0,),
+        ),
+    ],
+)
+def test_missing_isolation_or_measurement_is_insufficient(
+    treatment: EvolutionFrugalityObservation,
+) -> None:
+    control, _ = _pair()
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+
+
+def test_node_count_reduction_alone_does_not_prove_frugality() -> None:
+    control, treatment = _pair()
+    treatment = treatment.model_copy(update={"token_spend": None, "token_event_count": 0})
+
+    proof = evaluate_pair(control, treatment)
+
+    assert treatment.frozen_ac_indices == (0,)
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert "token attribution" in proof.reason
+
+
+def test_current_observation_pairs_with_opposite_arm() -> None:
+    control, treatment = _pair()
+
+    proof = evaluate_observations(treatment, [treatment, control])
+
+    assert proof.status is EvolutionFrugalityStatus.PASS
+    assert proof.control_receipt_id == "control"
+
+
+def test_comparison_key_ignores_run_identity_but_tracks_starting_semantics() -> None:
+    evaluation = _evaluation(True, False)
+    baseline = ProjectBaseline(
+        workspace_path="/tmp/worktree",
+        git_commit="abc123",
+        clean=True,
+    )
+
+    first = comparison_key(_seed("seed_one"), evaluation, baseline)
+    second = comparison_key(_seed("seed_two"), evaluation, baseline)
+    changed = comparison_key(_seed("seed_two"), _evaluation(False, False), baseline)
+
+    assert first == second
+    assert first != changed
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("goal", "Build a different product"),
+        ("task_type", "research"),
+        (
+            "brownfield_context",
+            {
+                "project_type": "brownfield",
+                "existing_patterns": ["repository pattern"],
+            },
+        ),
+        ("constraints", ["different constraint"]),
+        (
+            "acceptance_criteria",
+            [
+                {
+                    "description": "first",
+                    "verify_command": "python -m pytest",
+                    "expected_artifacts": ["report.json"],
+                },
+                "second",
+            ],
+        ),
+        (
+            "ontology_schema",
+            {
+                "name": "product",
+                "description": "different ontology",
+                "fields": [{"name": "item", "type": "entity", "description": "item"}],
+            },
+        ),
+        (
+            "evaluation_principles",
+            [{"name": "quality", "description": "Preserve quality", "weight": 0.8}],
+        ),
+        (
+            "exit_conditions",
+            [
+                {
+                    "name": "done",
+                    "description": "All work is done",
+                    "criteria": "Every AC passes",
+                }
+            ],
+        ),
+        ("plugin_contract", {"mode": "strict", "limits": [1, 2]}),
+    ],
+)
+def test_comparison_key_tracks_complete_seed_semantics(field: str, value: object) -> None:
+    seed = _seed()
+    seed_data = seed.to_dict()
+    seed_data[field] = value
+    changed = Seed.from_dict(seed_data)
+    evaluation = _evaluation(True, False, seed=seed)
+    baseline = ProjectBaseline(git_commit="abc123", clean=True)
+
+    assert comparison_key(seed, evaluation, baseline) != comparison_key(
+        changed,
+        evaluation,
+        baseline,
+    )
+
+
+def test_comparison_key_tracks_semantic_seed_metadata() -> None:
+    seed = _seed()
+    seed_data = seed.to_dict()
+    seed_data["metadata"] = {**seed_data["metadata"], "ambiguity_score": 0.2}
+    changed = Seed.from_dict(seed_data)
+    evaluation = _evaluation(True, False, seed=seed)
+    baseline = ProjectBaseline(git_commit="abc123", clean=True)
+
+    assert comparison_key(seed, evaluation, baseline) != comparison_key(
+        changed,
+        evaluation,
+        baseline,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("seed_id", "seed_other"),
+        ("created_at", "2030-01-01T00:00:00Z"),
+        ("interview_id", "interview-other"),
+        ("parent_seed_id", "seed-parent-other"),
+    ],
+)
+def test_comparison_key_excludes_only_volatile_seed_identity(field: str, value: object) -> None:
+    seed = _seed()
+    seed_data = seed.to_dict()
+    seed_data["metadata"] = {**seed_data["metadata"], field: value}
+    changed = Seed.from_dict(seed_data)
+    evaluation = _evaluation(True, False, seed=seed)
+    baseline = ProjectBaseline(git_commit="abc123", clean=True)
+
+    assert comparison_key(seed, evaluation, baseline) == comparison_key(
+        changed,
+        evaluation,
+        baseline,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("highest_stage_passed", 3),
+        ("drift_score", 0.2),
+        ("reward_hacking_risk", 0.3),
+        ("failure_reason", "new failure context"),
+        (
+            "task_results",
+            [
+                {
+                    "task_index": 0,
+                    "task_content": "implementation",
+                    "status": "completed",
+                    "completed": True,
+                }
+            ],
+        ),
+        (
+            "feedback_metadata",
+            [
+                {
+                    "code": "changed",
+                    "message": "changed feedback",
+                }
+            ],
+        ),
+        ("execution_completion_status", "failed"),
+    ],
+)
+def test_comparison_key_tracks_complete_previous_evaluation(field: str, value: object) -> None:
+    seed = _seed()
+    evaluation = _evaluation(True, False, seed=seed)
+    evaluation_data = evaluation.model_dump(mode="json")
+    evaluation_data[field] = value
+    changed = EvaluationSummary.model_validate(evaluation_data)
+    baseline = ProjectBaseline(git_commit="abc123", clean=True)
+
+    assert comparison_key(seed, evaluation, baseline) != comparison_key(
+        seed,
+        changed,
+        baseline,
+    )
+
+
+def test_observation_uses_runtime_tokens_and_fail_closed_grounding() -> None:
+    dispatched = BaseEvent(
+        type="execution.ac.attempt.dispatched",
+        aggregate_type="execution",
+        aggregate_id="exec",
+        data={
+            "execution_id": "exec",
+            "ac_id": "leaf-1",
+            "retry_attempt": 1,
+            "session_attempt_id": "leaf-1-attempt-2",
+            "ac_dispatch_id": "a" * 32,
+            "root_ac_index": 1,
+            "dispatch_kind": "primary",
+            "request_authority_digest": "sha256:" + "f" * 64,
+        },
+    )
+    token = BaseEvent(
+        type="execution.ac.token_attribution.reported",
+        aggregate_type="execution",
+        aggregate_id="exec",
+        data={
+            "execution_id": "exec",
+            "ac_id": "leaf-1",
+            "token_spend": 40,
+            "token_source": "runtime_usage",
+            "retry_attempt": 1,
+            "session_attempt_id": "leaf-1-attempt-2",
+            "ac_dispatch_id": "a" * 32,
+            "root_ac_index": 1,
+            "model": "test-model",
+            "effective_model": "test-model",
+            "request_authority_digest": "sha256:" + "f" * 64,
+            "model_tier": "standard",
+            "model_mode": "enforced",
+            "effort_level": "high",
+            "effort_mode": "enforced",
+            "runtime_backend": "test",
+            "llm_backend": "test-provider",
+            "permission_mode": "acceptEdits",
+        },
+    )
+    grounded = BaseEvent(
+        type="execution.ac.deliver_verdict",
+        aggregate_type="execution",
+        aggregate_id="exec",
+        data={
+            "execution_id": "exec",
+            "ac_id": "leaf-1",
+            "retry_attempt": 1,
+            "session_attempt_id": "leaf-1-attempt-2",
+            "ac_dispatch_id": "a" * 32,
+            "root_ac_index": 1,
+            "traceguard_verdict": "accepted",
+            "unsupported_claim_rate": 0.0,
+            "grounding_regression": False,
+        },
+    )
+    seed = _seed()
+
+    observation = build_observation(
+        lineage_id="lineage",
+        generation_number=2,
+        execution_id="exec",
+        parent_seed=seed,
+        current_seed=seed,
+        previous_evaluation=_evaluation(True, False, seed=seed),
+        current_evaluation=_evaluation(True, True, seed=seed),
+        focus=EvolutionFocus(active_ac_indices=(1,), frozen_ac_indices=(0,), reason="test"),
+        baseline=ProjectBaseline(
+            workspace_path="/tmp/treatment",
+            git_commit="abc123",
+            clean=True,
+        ),
+        focused_evolution=True,
+        scoped_reexecution=True,
+        execution_events=[dispatched, token, grounded],
+        executor_result=SimpleNamespace(duration_seconds=3.5, messages_processed=4),
+        provider_usage=_provider_usage(),
+    )
+
+    assert observation.token_spend == 40
+    assert observation.token_event_count == 1
+    assert observation.expected_attempt_count == 1
+    assert observation.token_evidence_complete is True
+    assert observation.retry_calls == 1
+    assert observation.grounding_observations == 1
+    assert observation.grounding_regressions == 0
+    assert observation.grounding_evidence_complete is True
+    assert observation.ac_evidence_complete is True
+    assert observation.regressed_ac_indices == ()
+
+
+def _complete_execution_events(execution_id: str = "exec") -> list[BaseEvent]:
+    common = {
+        "execution_id": execution_id,
+        "ac_id": "leaf-1",
+        "retry_attempt": 0,
+        "session_attempt_id": "leaf-1-attempt-1",
+        "ac_dispatch_id": "a" * 32,
+        "root_ac_index": 1,
+        "model": "test-model",
+        "effective_model": "test-model",
+        "request_authority_digest": "sha256:" + "f" * 64,
+        "model_tier": "standard",
+        "model_mode": "enforced",
+        "effort_level": "high",
+        "effort_mode": "enforced",
+        "runtime_backend": "test",
+        "llm_backend": "test-provider",
+        "permission_mode": "acceptEdits",
+    }
+    return [
+        BaseEvent(
+            type="execution.ac.attempt.dispatched",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={**common, "dispatch_kind": "primary"},
+        ),
+        BaseEvent(
+            type="execution.ac.token_attribution.reported",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={**common, "token_spend": 40, "token_source": "runtime_usage"},
+        ),
+        BaseEvent(
+            type="execution.ac.deliver_verdict",
+            aggregate_type="execution",
+            aggregate_id=execution_id,
+            data={
+                **common,
+                "traceguard_verdict": "accepted",
+                "unsupported_claim_rate": 0.0,
+                "grounding_regression": False,
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("event_index", "field", "value"),
+    [
+        (1, "session_attempt_id", "unrelated-token-attempt"),
+        (2, "session_attempt_id", "unrelated-verdict-attempt"),
+        (1, "ac_dispatch_id", "b" * 32),
+        (2, "ac_dispatch_id", "b" * 32),
+    ],
+)
+def test_receipts_must_bind_the_exact_primary_dispatch(
+    event_index: int,
+    field: str,
+    value: str,
+) -> None:
+    events = _complete_execution_events()
+    original = events[event_index]
+    events[event_index] = original.model_copy(update={"data": {**original.data, field: value}})
+
+    observation = _built_observation(events)
+
+    assert observation.token_evidence_complete is (event_index != 1)
+    assert observation.grounding_evidence_complete is (event_index != 2)
+    if event_index == 1:
+        assert observation.token_spend is None
+    else:
+        assert observation.token_spend == 40.0
+    assert observation.evidence_issues
+
+
+def test_primary_dispatch_roots_must_exactly_cover_active_working_set() -> None:
+    events = _complete_execution_events()
+    events = [
+        event.model_copy(update={"data": {**event.data, "root_ac_index": 0}}) for event in events
+    ]
+
+    observation = _built_observation(events)
+
+    assert observation.executed_ac_indices == (0,)
+    assert observation.active_ac_indices == (1,)
+    assert "primary dispatch roots" in "; ".join(observation.evidence_issues)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("model", "other-model"),
+        ("effective_model", "other-effective-model"),
+        ("model_tier", "frugal"),
+        ("model_mode", "advised"),
+        ("runtime_backend", "other-runtime"),
+        ("llm_backend", "other-provider"),
+        ("effort_level", "low"),
+        ("effort_mode", "advised"),
+        ("permission_mode", "bypassPermissions"),
+    ),
+)
+def test_execution_configuration_fingerprint_tracks_runtime_dials(
+    field: str,
+    value: str,
+) -> None:
+    baseline = _built_observation(_complete_execution_events())
+    events = _complete_execution_events()
+    token = events[1]
+    events[1] = token.model_copy(update={"data": {**token.data, field: value}})
+
+    changed = _built_observation(events)
+
+    assert changed.token_evidence_complete is True
+    assert (
+        changed.execution_configuration_fingerprint != baseline.execution_configuration_fingerprint
+    )
+
+
+def test_execution_configuration_binds_dispatch_request_authority() -> None:
+    baseline = _built_observation(_complete_execution_events())
+    events = _complete_execution_events()
+    changed_digest = "sha256:" + "e" * 64
+    for index in (0, 1):
+        event = events[index]
+        events[index] = event.model_copy(
+            update={"data": {**event.data, "request_authority_digest": changed_digest}}
+        )
+
+    changed = _built_observation(events)
+
+    assert baseline.token_evidence_complete is True
+    assert changed.token_evidence_complete is True
+    assert (
+        changed.execution_configuration_assignments != baseline.execution_configuration_assignments
+    )
+
+
+def test_primary_configuration_assignments_follow_dispatch_not_token_completion_order() -> None:
+    attempts: list[list[BaseEvent]] = []
+    for suffix, model in (("a", "model-a"), ("b", "model-b")):
+        attempt = []
+        for event in _complete_execution_events():
+            attempt.append(
+                event.model_copy(
+                    update={
+                        "data": {
+                            **event.data,
+                            "ac_id": f"leaf-{suffix}",
+                            "session_attempt_id": f"leaf-{suffix}-attempt-1",
+                            "ac_dispatch_id": suffix * 32,
+                            "model": model,
+                        }
+                    }
+                )
+            )
+        attempts.append(attempt)
+
+    dispatches = [attempts[0][0], attempts[1][0]]
+    verdicts = [attempts[0][2], attempts[1][2]]
+    dispatch_then_completion = _built_observation(
+        dispatches + [attempts[0][1], attempts[1][1]] + verdicts
+    )
+    dispatch_then_reverse_completion = _built_observation(
+        dispatches + [attempts[1][1], attempts[0][1]] + verdicts
+    )
+    reverse_dispatch = _built_observation(
+        list(reversed(dispatches)) + [attempts[0][1], attempts[1][1]] + verdicts
+    )
+
+    assert dispatch_then_completion.token_evidence_complete is True
+    assert dispatch_then_reverse_completion.token_evidence_complete is True
+    assert (
+        dispatch_then_completion.execution_configuration_assignments
+        == dispatch_then_reverse_completion.execution_configuration_assignments
+    )
+    assert (
+        dispatch_then_completion.execution_configuration_assignments
+        != reverse_dispatch.execution_configuration_assignments
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "model",
+        "effective_model",
+        "model_tier",
+        "model_mode",
+        "effort_level",
+        "effort_mode",
+        "runtime_backend",
+        "llm_backend",
+        "permission_mode",
+        "request_authority_digest",
+    ),
+)
+@pytest.mark.parametrize("invalid_value", [None, "", " unknown "])
+def test_primary_configuration_requires_every_runtime_dial(
+    field: str,
+    invalid_value: object,
+) -> None:
+    events = _complete_execution_events()
+    token = events[1]
+    events[1] = token.model_copy(update={"data": {**token.data, field: invalid_value}})
+
+    observation = _built_observation(events)
+
+    assert observation.token_evidence_complete is False
+    assert observation.token_spend is None
+    assert "token/configuration attribution" in "; ".join(observation.evidence_issues)
+
+
+def test_primary_runtime_token_aggregate_overflow_fails_closed() -> None:
+    events: list[BaseEvent] = []
+    for suffix in ("1", "2"):
+        for event in _complete_execution_events():
+            data = {
+                **event.data,
+                "ac_id": f"leaf-{suffix}",
+                "session_attempt_id": f"leaf-{suffix}-attempt-1",
+                "ac_dispatch_id": suffix * 32,
+            }
+            if event.type == "execution.ac.token_attribution.reported":
+                data["token_spend"] = 1e308
+            events.append(event.model_copy(update={"data": data}))
+
+    observation = _built_observation(events)
+
+    assert observation.token_evidence_complete is False
+    assert observation.token_spend is None
+    assert "aggregate primary runtime-token usage is non-finite" in observation.evidence_issues
+
+
+def test_total_generation_token_aggregate_overflow_fails_closed() -> None:
+    events = _complete_execution_events()
+    token = events[1]
+    events[1] = token.model_copy(update={"data": {**token.data, "token_spend": 1e308}})
+    provider_usage = ProviderUsageSummary(
+        call_count=1,
+        token_spend=1e308,
+        identity_digest="sha256:" + "c" * 64,
+        configuration_fingerprint="sha256:" + "e" * 64,
+        configuration_assignments=(("reflect", ("sha256:" + "e" * 64,)),),
+        complete=True,
+    )
+
+    observation = _built_observation(events, provider_usage=provider_usage)
+
+    assert observation.token_evidence_complete is True
+    assert observation.provider_evidence_complete is True
+    assert observation.generation_token_evidence_complete is False
+    assert observation.token_spend is None
+    assert (
+        "aggregate total-generation runtime-token usage is non-finite"
+        in observation.evidence_issues
+    )
+
+
+def _built_observation(
+    events: list[BaseEvent],
+    *,
+    current_evaluation: EvaluationSummary | None = None,
+    provider_usage: ProviderUsageSummary | None = None,
+) -> EvolutionFrugalityObservation:
+    seed = _seed()
+    return build_observation(
+        lineage_id="lineage",
+        generation_number=2,
+        execution_id="exec",
+        parent_seed=seed,
+        current_seed=seed,
+        previous_evaluation=_evaluation(True, False, seed=seed),
+        current_evaluation=(
+            current_evaluation
+            if current_evaluation is not None
+            else _evaluation(True, True, seed=seed)
+        ),
+        focus=EvolutionFocus(active_ac_indices=(1,), frozen_ac_indices=(0,), reason="test"),
+        baseline=ProjectBaseline(
+            workspace_path="/tmp/treatment",
+            git_commit="abc123",
+            clean=True,
+        ),
+        focused_evolution=True,
+        scoped_reexecution=True,
+        execution_events=events,
+        executor_result=SimpleNamespace(duration_seconds=3.5, messages_processed=4),
+        provider_usage=provider_usage or _provider_usage(),
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing_dispatch",
+        "duplicate_dispatch",
+        "missing_token",
+        "duplicate_token",
+        "malformed_token",
+        "zero_token",
+        "unmatched_token",
+        "missing_grounding",
+        "duplicate_grounding",
+        "malformed_grounding",
+        "followup_dispatch",
+        "missing_dispatch_authority",
+        "mismatched_request_authority",
+    ],
+)
+def test_runtime_evidence_requires_exact_attempt_coverage(case: str) -> None:
+    events = _complete_execution_events()
+    if case == "missing_dispatch":
+        events.pop(0)
+    elif case == "duplicate_dispatch":
+        events.append(events[0].model_copy())
+    elif case == "missing_token":
+        events.pop(1)
+    elif case == "duplicate_token":
+        events.append(events[1].model_copy())
+    elif case == "malformed_token":
+        events[1] = events[1].model_copy(
+            update={"data": {**events[1].data, "token_source": "character_estimate"}}
+        )
+    elif case == "zero_token":
+        events[1] = events[1].model_copy(update={"data": {**events[1].data, "token_spend": 0}})
+    elif case == "unmatched_token":
+        events.append(events[1].model_copy(update={"data": {**events[1].data, "ac_id": "leaf-2"}}))
+    elif case == "missing_grounding":
+        events.pop(2)
+    elif case == "duplicate_grounding":
+        events.append(events[2].model_copy())
+    elif case == "malformed_grounding":
+        events[2] = events[2].model_copy(
+            update={"data": {**events[2].data, "unsupported_claim_rate": 2.0}}
+        )
+    elif case == "followup_dispatch":
+        events.append(
+            events[0].model_copy(
+                update={"data": {**events[0].data, "dispatch_kind": "session_signal_followup"}}
+            )
+        )
+    elif case == "missing_dispatch_authority":
+        dispatch_data = dict(events[0].data)
+        dispatch_data.pop("request_authority_digest")
+        events[0] = events[0].model_copy(update={"data": dispatch_data})
+    elif case == "mismatched_request_authority":
+        events[1] = events[1].model_copy(
+            update={
+                "data": {
+                    **events[1].data,
+                    "request_authority_digest": "sha256:" + "e" * 64,
+                }
+            }
+        )
+
+    observation = _built_observation(events)
+
+    assert not (observation.token_evidence_complete and observation.grounding_evidence_complete)
+    assert observation.evidence_issues
+
+
+@pytest.mark.parametrize(
+    "ac_results",
+    [
+        (ACResult(ac_index=0, ac_content="first", passed=True),),
+        (
+            ACResult(ac_index=0, ac_content="first", passed=True),
+            ACResult(ac_index=0, ac_content="first", passed=True),
+        ),
+        (
+            ACResult(ac_index=0, ac_content="first", passed=True),
+            ACResult(ac_index=2, ac_content="third", passed=True),
+        ),
+        (
+            ACResult(ac_index=0, ac_content="wrong", passed=True),
+            ACResult(ac_index=1, ac_content="second", passed=True),
+        ),
+        (
+            ACResult(
+                ac_index=0,
+                ac_content="first",
+                semantic_ac_key="ac_0000000000000000",
+                passed=True,
+            ),
+            ACResult(ac_index=1, ac_content="second", passed=True),
+        ),
+    ],
+)
+def test_observation_rejects_incomplete_or_stale_ac_evidence(
+    ac_results: tuple[ACResult, ...],
+) -> None:
+    evaluation = EvaluationSummary(
+        final_approved=True,
+        highest_stage_passed=3,
+        score=1.0,
+        ac_results=ac_results,
+    )
+
+    observation = _built_observation(
+        _complete_execution_events(),
+        current_evaluation=evaluation,
+    )
+
+    assert observation.ac_evidence_complete is False
+    assert observation.evidence_issues
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected"),
+    [
+        (
+            {"token_evidence_complete": False, "token_event_count": 1},
+            "token attribution",
+        ),
+        (
+            {"grounding_evidence_complete": False, "grounding_observations": 1},
+            "TraceGuard",
+        ),
+        (
+            {
+                "ac_evidence_complete": False,
+                "passed_ac_indices": (0,),
+                "failed_ac_indices": (),
+            },
+            "AC verdict coverage",
+        ),
+    ],
+)
+def test_pair_never_passes_partial_evidence(
+    updates: dict[str, object],
+    expected: str,
+) -> None:
+    control, treatment = _pair()
+    treatment = treatment.model_copy(update=updates)
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert expected in proof.reason
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "organization",
+        "headers",
+        "api_version",
+        "modify_params",
+        "drop_params",
+        "custom_client",
+        "mock_transport",
+        "proxy_trust",
+        "transport_selection",
+        "tls",
+    ],
+)
+def test_pair_rejects_incomplete_litellm_dependency_authority(authority: str) -> None:
+    control, treatment = _pair()
+    treatment = treatment.model_copy(
+        update={
+            "provider_evidence_complete": False,
+            "generation_token_evidence_complete": False,
+            "evidence_issues": (f"unsealed LiteLLM {authority} authority",),
+        }
+    )
+
+    proof = evaluate_pair(control, treatment)
+
+    assert proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+    assert authority in proof.reason
+
+
+async def _append_runtime_evidence(
+    store: EventStore,
+    execution_id: str,
+    tokens: float,
+    *,
+    ac_ids: tuple[str, ...],
+) -> None:
+    for offset, ac_id in enumerate(ac_ids):
+        root_ac_index = 1 if len(ac_ids) == 1 else offset
+        common = {
+            "execution_id": execution_id,
+            "ac_id": ac_id,
+            "retry_attempt": 0,
+            "session_attempt_id": f"{ac_id}-attempt-1",
+            "ac_dispatch_id": f"{offset + 1:032x}",
+            "root_ac_index": root_ac_index,
+            "request_authority_digest": "sha256:" + "f" * 64,
+        }
+        await store.append(
+            BaseEvent(
+                type="execution.ac.attempt.dispatched",
+                aggregate_type="execution",
+                aggregate_id=execution_id,
+                data={**common, "dispatch_kind": "primary"},
+            )
+        )
+        await store.append(
+            BaseEvent(
+                type="execution.ac.token_attribution.reported",
+                aggregate_type="execution",
+                aggregate_id=execution_id,
+                data={
+                    **common,
+                    "token_spend": tokens / len(ac_ids),
+                    "token_source": "runtime_usage",
+                    "model": "test-model",
+                    "effective_model": "test-model",
+                    "model_tier": "standard",
+                    "model_mode": "enforced",
+                    "effort_level": "high",
+                    "effort_mode": "enforced",
+                    "runtime_backend": "test",
+                    "llm_backend": "test-provider",
+                    "permission_mode": "acceptEdits",
+                },
+            )
+        )
+        await store.append(
+            BaseEvent(
+                type="execution.ac.deliver_verdict",
+                aggregate_type="execution",
+                aggregate_id=execution_id,
+                data={
+                    **common,
+                    "traceguard_verdict": "accepted",
+                    "unsupported_claim_rate": 0.0,
+                    "grounding_regression": False,
+                },
+            )
+        )
+
+
+async def test_recorded_control_completes_a_prior_focused_proof(tmp_path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'frugality.db'}")
+    await store.initialize()
+    seed = _seed()
+    await _append_runtime_evidence(
+        store,
+        "treatment-exec",
+        70,
+        ac_ids=("treatment-ac-1",),
+    )
+    treatment = await record_generation(
+        event_store=store,
+        lineage_id="treatment-lineage",
+        generation_number=2,
+        execution_id="treatment-exec",
+        parent_seed=seed,
+        current_seed=seed,
+        previous_evaluation=_evaluation(True, False, seed=seed),
+        current_evaluation=_evaluation(True, True, seed=seed),
+        focus=EvolutionFocus(active_ac_indices=(1,), frozen_ac_indices=(0,), reason="focused"),
+        baseline=ProjectBaseline(
+            workspace_path="/tmp/treatment-worktree",
+            git_commit="abc123",
+            clean=True,
+        ),
+        focused_evolution=True,
+        scoped_reexecution=True,
+        executor_result=SimpleNamespace(duration_seconds=7, messages_processed=7),
+        provider_usage=_provider_usage(),
+    )
+    assert treatment is not None
+    assert treatment.proof.status is EvolutionFrugalityStatus.INSUFFICIENT_DATA
+
+    await _append_runtime_evidence(
+        store,
+        "control-exec",
+        100,
+        ac_ids=("control-ac-0", "control-ac-1"),
+    )
+    control = await record_generation(
+        event_store=store,
+        lineage_id="control-lineage",
+        generation_number=2,
+        execution_id="control-exec",
+        parent_seed=seed,
+        current_seed=seed,
+        previous_evaluation=_evaluation(True, False, seed=seed),
+        current_evaluation=_evaluation(True, True, seed=seed),
+        focus=EvolutionFocus(active_ac_indices=(0, 1), frozen_ac_indices=(), reason="full"),
+        baseline=ProjectBaseline(
+            workspace_path="/tmp/control-worktree",
+            git_commit="abc123",
+            clean=True,
+        ),
+        focused_evolution=False,
+        scoped_reexecution=False,
+        executor_result=SimpleNamespace(duration_seconds=10, messages_processed=10),
+        provider_usage=_provider_usage(),
+    )
+
+    assert control is not None
+    assert control.proof.status is EvolutionFrugalityStatus.PASS
+    assert control.proof.token_reduction_pct == 30.0
+    observations = await store.query_events(event_type=OBSERVATION_EVENT, limit=10)
+    proofs = await store.query_events(event_type=PROOF_EVENT, limit=10)
+    assert len(observations) == 2
+    assert len(proofs) == 2
+    await store.close()
+
+
+async def test_execution_evidence_collection_is_bounded_and_fails_closed() -> None:
+    class _PagedEvidenceStore:
+        event_count = 2_001
+
+        async def query_execution_related_events(
+            self,
+            execution_id: str,
+            *,
+            event_type: str,
+            limit: int,
+            chronological: bool = False,
+            cursor_after=None,
+            cursor_through=None,
+        ):
+            del execution_id, event_type, cursor_through
+            if not chronological:
+                index = self.event_count - 1
+                return [SimpleNamespace(timestamp=index, id=str(index))]
+            start = 0 if cursor_after is None else int(cursor_after[1]) + 1
+            stop = min(start + limit, self.event_count)
+            return [SimpleNamespace(timestamp=index, id=str(index)) for index in range(start, stop)]
+
+    events, complete = await query_execution_evidence_events(
+        _PagedEvidenceStore(),
+        "execution",
+    )
+
+    assert len(events) == 6_000
+    assert complete is False

--- a/tests/unit/evolution/test_provider_usage.py
+++ b/tests/unit/evolution/test_provider_usage.py
@@ -1,0 +1,2244 @@
+"""Generation provider calls are measured completely or fail closed."""
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from dataclasses import field as dataclass_field
+import json
+import os
+from pathlib import Path
+import shutil
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.config.models import OuroborosConfig
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.types import Result
+from ouroboros.evolution import provider_usage as provider_usage_module
+from ouroboros.evolution.focus import call_executor
+from ouroboros.evolution.provider_usage import (
+    capture_generation_provider_usage,
+    observe_callable,
+    tracked_agent_task,
+    tracked_agent_task_to_result,
+    tracked_complete,
+)
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+import ouroboros.orchestrator.frugality_runtime_attestation as frugality_attestation_module
+from ouroboros.orchestrator.frugality_runtime_attestation import (
+    codex_child_environment_attestation,
+)
+from ouroboros.providers.anthropic_adapter import AnthropicAdapter
+from ouroboros.providers.base import CompletionConfig, CompletionResponse, UsageInfo
+import ouroboros.providers.credential_authority as credential_authority_module
+from ouroboros.providers.credential_authority import (
+    installation_authority_key as _real_installation_authority_key,
+)
+from ouroboros.providers.frugality_attestation import (
+    PreparedFrugalityCompletion,
+    credential_authority_digest,
+    effective_completion_request,
+)
+from ouroboros.providers.profiles import (
+    ResolvedCompletionProfile,
+    resolve_completion_profile_result,
+)
+
+
+@dataclass
+class _Adapter:
+    tokens: int | None
+    response_model: str = "test-model"
+    llm_backend: str | None = None
+    api_base: str = "https://provider.example/v1"
+    timeout: float = 30.0
+    max_retries: int = 1
+    permission_mode: str = "read-only"
+    allowed_tools: tuple[str, ...] = ("Read",)
+    runtime_profile: str = "worker"
+    resolve_profiles: bool = False
+    dispatched: list[CompletionConfig] = dataclass_field(default_factory=list)
+    contract_override: Mapping[str, object] | None = None
+
+    def _contract(self, resolved: ResolvedCompletionProfile) -> Mapping[str, object]:
+        if self.contract_override is not None:
+            return self.contract_override
+        return {
+            "schema_version": 1,
+            "schema_id": "test.adapter.v1",
+            "internal_attempt_limit": self.max_retries,
+            "credential_authority": credential_authority_digest("test-credential"),
+            "effective_request": effective_completion_request(
+                resolved,
+                provider_model=resolved.config.model,
+            ),
+            "settings": {
+                "api_base": self.api_base,
+                "timeout": self.timeout,
+                "max_retries": self.max_retries,
+                "io_recorder_configured": False,
+                "permission_mode": self.permission_mode,
+                "allowed_tools": self.allowed_tools,
+                "runtime_profile": self.runtime_profile,
+            },
+        }
+
+    def frugality_prepare_completion(
+        self,
+        config: CompletionConfig,
+    ) -> Result[PreparedFrugalityCompletion, ProviderError]:
+        if self.resolve_profiles:
+            profile_result = resolve_completion_profile_result(config, backend="litellm")
+            if profile_result.is_err:
+                return Result.err(profile_result.error)
+            resolved = profile_result.value
+        else:
+            resolved = ResolvedCompletionProfile(config=config)
+        return Result.ok(
+            PreparedFrugalityCompletion(
+                config=replace(resolved.config, role=None, profile=None),
+                contract=self._contract(resolved),
+            )
+        )
+
+    async def complete(self, messages: object, config: CompletionConfig):  # noqa: ANN201, ARG002
+        self.dispatched.append(config)
+        if self.tokens is None:
+            return Result.err(ProviderError(message="provider failed", provider="test"))
+        return Result.ok(
+            CompletionResponse(
+                content="{}",
+                model=self.response_model,
+                usage=UsageInfo(
+                    prompt_tokens=self.tokens,
+                    completion_tokens=0,
+                    total_tokens=self.tokens,
+                ),
+            )
+        )
+
+
+class _AttestedRuntime:
+    runtime_backend = "test-runtime-handle"
+    _runtime_backend = "test-runtime"
+    llm_backend = "test-provider"
+    _model = "test-model"
+    permission_mode = "acceptEdits"
+
+    def __init__(
+        self,
+        *,
+        usage: Mapping[str, object] | None = None,
+        effective_model: object = "test-model",
+    ) -> None:
+        self.usage = dict(usage or {"total_tokens": 150})
+        self.effective_model = effective_model
+
+    def frugality_runtime_attestation(self) -> Mapping[str, object]:
+        runtime_class = f"{type(self).__module__}.{type(self).__qualname__}"
+        return {
+            "schema_version": 1,
+            "schema_id": "test.agent_runtime.v1",
+            "implementation": runtime_class,
+            "runtime_backend": "test-runtime",
+            "runtime_handle_backend": "test-runtime-handle",
+            "settings": {"runtime_version": "v1"},
+        }
+
+    def _message(self) -> SimpleNamespace:
+        data: dict[str, object] = {"usage": self.usage}
+        if self.effective_model is not None:
+            data["model_observation"] = {"effective_model": self.effective_model}
+        return SimpleNamespace(data=data)
+
+    async def execute_task(self, **kwargs):  # noqa: ANN201, ARG002
+        yield self._message()
+
+    async def execute_task_to_result(self, **kwargs):  # noqa: ANN201, ARG002
+        return Result.ok(SimpleNamespace(messages=(self._message(),)))
+
+
+def _write_fake_codex_cli(path: Path, *, version: str) -> Path:
+    path.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then\n'
+        f"  echo 'codex {version}'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+async def _codex_runtime_summary(runtime: CodexCliRuntime):  # noqa: ANN202
+    async def _execute_task(**kwargs):  # noqa: ANN201, ARG001
+        yield SimpleNamespace(
+            data={
+                "model_observation": {"effective_model": "test-model"},
+                "usage": {"total_tokens": 100},
+            }
+        )
+
+    runtime.execute_task = _execute_task  # type: ignore[method-assign]
+    with capture_generation_provider_usage() as capture:
+        _ = [
+            message
+            async for message in tracked_agent_task(
+                runtime,
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+    return capture.summary()
+
+
+@pytest.fixture(autouse=True)
+def _register_test_completion_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        frugality_attestation_module,
+        "installation_authority_key",
+        lambda: b"i" * 32,
+    )
+    monkeypatch.setattr(
+        credential_authority_module,
+        "installation_authority_key",
+        lambda: b"i" * 32,
+    )
+    adapter_class = f"{_Adapter.__module__}.{_Adapter.__qualname__}"
+    monkeypatch.setitem(
+        provider_usage_module._COMPLETION_ADAPTER_SCHEMAS,
+        adapter_class,
+        provider_usage_module._CompletionAdapterSchema(
+            schema_id="test.adapter.v1",
+            settings=frozenset(
+                {
+                    "api_base",
+                    "timeout",
+                    "max_retries",
+                    "io_recorder_configured",
+                    "permission_mode",
+                    "allowed_tools",
+                    "runtime_profile",
+                }
+            ),
+            retry_setting="max_retries",
+            proof_retry_value=1,
+        ),
+    )
+    runtime_class = f"{_AttestedRuntime.__module__}.{_AttestedRuntime.__qualname__}"
+    monkeypatch.setitem(
+        provider_usage_module._AGENT_RUNTIME_SCHEMAS,
+        runtime_class,
+        provider_usage_module._AgentRuntimeSchema(
+            schema_id="test.agent_runtime.v1",
+            runtime_backend="test-runtime",
+            runtime_handle_backend="test-runtime-handle",
+            setting_kinds={"runtime_version": "text"},
+        ),
+    )
+
+
+async def test_generation_provider_usage_sums_every_tracked_call() -> None:
+    config = CompletionConfig(model="test-model", role="wonder")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(30), [], config)
+        await tracked_complete(_Adapter(20), [], config)
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is True
+    assert summary.call_count == 2
+    assert summary.token_spend == 50
+    assert summary.identity_digest is not None
+    assert summary.configuration_fingerprint is not None
+    assert summary.configuration_assignments
+    assert summary.issues == ()
+
+
+async def test_generation_provider_usage_rejects_any_missing_runtime_usage() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(20), [], config)
+        await tracked_complete(_Adapter(None), [], config)
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is False
+    assert summary.call_count == 2
+    assert summary.token_spend is None
+    assert "missing or invalid" in "; ".join(summary.issues)
+
+
+async def test_completion_usage_counters_must_reconcile_exactly() -> None:
+    class _InconsistentAdapter:
+        async def complete(self, messages: object, config: object):  # noqa: ANN201, ARG002
+            return Result.ok(
+                CompletionResponse(
+                    content="{}",
+                    model="test-model",
+                    usage=UsageInfo(
+                        prompt_tokens=100,
+                        completion_tokens=50,
+                        total_tokens=1,
+                    ),
+                )
+            )
+
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(
+            _InconsistentAdapter(),
+            [],
+            CompletionConfig(model="test-model", role="reflect"),
+        )
+
+    summary = capture.summary()
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "missing or invalid" in "; ".join(summary.issues)
+
+
+async def test_generation_provider_usage_rejects_overflowing_runtime_usage() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(10**400), [], config)
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "missing or invalid" in "; ".join(summary.issues)
+
+
+async def test_generation_provider_usage_rejects_non_finite_aggregate() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(10**308), [], config)
+        await tracked_complete(_Adapter(10**308), [], config)
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "total is non-finite" in "; ".join(summary.issues)
+
+
+async def test_generation_provider_usage_is_bounded(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(provider_usage_module, "_MAX_PROVIDER_CALLS", 1)
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(10), [], config)
+        await tracked_complete(_Adapter(10), [], config)
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is False
+    assert summary.call_count == 2
+    assert summary.token_spend is None
+    assert sum(len(values) for _, values in summary.configuration_assignments) == 1
+    assert "bounded collection limit" in "; ".join(summary.issues)
+
+
+def test_cyclic_provider_configuration_fails_closed_without_escaping() -> None:
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+    with capture_generation_provider_usage() as capture:
+        call = capture.begin(role="reflect", model="test-model", configuration=cyclic)
+        capture.finish(call, 10)
+
+    summary = capture.summary()
+
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_provider_configuration_fingerprint_tracks_model_and_effort() -> None:
+    with capture_generation_provider_usage() as first:
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-a", role="reflect", reasoning_effort="low"),
+        )
+    with capture_generation_provider_usage() as second:
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-b", role="reflect", reasoning_effort="high"),
+        )
+
+    assert first.summary().configuration_fingerprint != second.summary().configuration_fingerprint
+
+
+async def test_completion_adapter_contract_binds_instance_execution_settings() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    first_adapter = _Adapter(100)
+    second_adapter = _Adapter(
+        10,
+        api_base="https://other.example/v1",
+        timeout=90.0,
+        permission_mode="acceptEdits",
+        allowed_tools=("Read", "Write"),
+        runtime_profile="frontier",
+    )
+    with capture_generation_provider_usage() as first:
+        await tracked_complete(first_adapter, [], config)
+    with capture_generation_provider_usage() as second:
+        await tracked_complete(second_adapter, [], config)
+
+    assert first.summary().complete is True
+    assert second.summary().complete is True
+    assert first.summary().configuration_fingerprint != second.summary().configuration_fingerprint
+    assert first.summary().configuration_assignments != second.summary().configuration_assignments
+
+
+async def test_unattested_or_retry_opaque_completion_adapter_fails_closed() -> None:
+    class _UnattestedAdapter:
+        async def complete(self, messages: object, config: object):  # noqa: ANN201, ARG002
+            return await _Adapter(10).complete(messages, config)
+
+    config = CompletionConfig(model="test-model", role="reflect")
+    for adapter in (_UnattestedAdapter(), _Adapter(10, max_retries=2)):
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(adapter, [], config)
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_completion_adapter_contract_rejects_boolean_schema_or_empty_settings() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    base = dict(_Adapter(10)._contract(ResolvedCompletionProfile(config=config)))
+    settings = dict(base["settings"])  # type: ignore[arg-type]
+    contracts = (
+        {**base, "schema_version": True},
+        {**base, "settings": {}},
+        {**base, "settings": {"timeout": 1.0}},
+        {**base, "settings": {**settings, "api_key": "sk-super-secret"}},
+        {**base, "settings": {**settings, "max_retries": 99}},
+    )
+    for contract in contracts:
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(
+                _Adapter(10, contract_override=contract),
+                [],
+                config,
+            )
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_cyclic_adapter_attestation_fails_closed_without_escaping() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    base = dict(_Adapter(10)._contract(ResolvedCompletionProfile(config=config)))
+    cyclic_settings = dict(base["settings"])  # type: ignore[arg-type]
+    cyclic_settings["cycle"] = cyclic_settings
+    contract = {**base, "settings": cyclic_settings}
+
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(10, contract_override=contract), [], config)
+
+    summary = capture.summary()
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_shared_configuration_dag_is_not_misclassified_as_a_cycle() -> None:
+    shared_schema = {
+        "type": "json_schema",
+        "json_schema": {"name": "result", "schema": {"type": "object"}},
+    }
+    config = CompletionConfig(
+        model="test-model",
+        role="semantic_evaluation",
+        response_format=shared_schema,
+    )
+
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(_Adapter(10), [], config)
+
+    summary = capture.summary()
+    assert summary.complete is True
+    assert summary.token_spend == 10
+
+
+async def test_unbounded_or_non_finite_adapter_attestation_fails_closed() -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    base = dict(_Adapter(10)._contract(ResolvedCompletionProfile(config=config)))
+    settings = dict(base["settings"])  # type: ignore[arg-type]
+    nested: object = "leaf"
+    for _ in range(provider_usage_module._MAX_CONFIGURATION_DEPTH + 1):
+        nested = {"nested": nested}
+    contracts = (
+        {**base, "settings": {**settings, "runtime_profile": nested}},
+        {
+            **base,
+            "settings": {
+                **settings,
+                "runtime_profile": "x" * (provider_usage_module._MAX_CONFIGURATION_TEXT_LENGTH + 1),
+            },
+        },
+        {**base, "settings": {**settings, "timeout": float("inf")}},
+        {**base, "credential_authority": "sk-plaintext-secret"},
+    )
+
+    for contract in contracts:
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(_Adapter(10, contract_override=contract), [], config)
+        assert capture.summary().complete is False
+
+
+async def test_completion_tracking_binds_and_dispatches_profile_resolved_config() -> None:
+    dispatched: list[CompletionConfig] = []
+    adapter = _Adapter(10, resolve_profiles=True, dispatched=dispatched)
+    request = CompletionConfig(model="default", role="reflect", profile="proof")
+    profiles = (
+        OuroborosConfig(
+            llm_profiles={"proof": {"model": "model-a", "temperature": 0.1, "max_tokens": 100}}
+        ),
+        OuroborosConfig(
+            llm_profiles={"proof": {"model": "model-b", "temperature": 0.9, "max_tokens": 200}}
+        ),
+    )
+    summaries = []
+    for profile_config in profiles:
+        with patch("ouroboros.providers.profiles.load_config", return_value=profile_config):
+            with capture_generation_provider_usage() as capture:
+                await tracked_complete(adapter, [], request)
+        summaries.append(capture.summary())
+
+    assert all(summary.complete for summary in summaries)
+    assert summaries[0].configuration_assignments != summaries[1].configuration_assignments
+    assert summaries[0].configuration_fingerprint != summaries[1].configuration_fingerprint
+    assert [(config.model, config.temperature, config.max_tokens) for config in dispatched] == [
+        ("model-a", 0.1, 100),
+        ("model-b", 0.9, 200),
+    ]
+    assert all(config.role is None and config.profile is None for config in dispatched)
+
+
+async def test_litellm_attestation_binds_post_profile_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    LiteLLMAdapter = litellm_adapter.LiteLLMAdapter
+    dispatched: list[CompletionConfig] = []
+    adapter = LiteLLMAdapter(
+        api_key="test-credential",
+        api_base="https://provider.example/v1",
+        max_retries=1,
+    )
+
+    async def _complete_prepared(
+        messages: object,
+        prepared: PreparedFrugalityCompletion,
+    ) -> Result[CompletionResponse, ProviderError]:
+        config = prepared.config
+        dispatched.append(config)
+        return Result.ok(
+            CompletionResponse(
+                content="{}",
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=9, completion_tokens=1, total_tokens=10),
+            )
+        )
+
+    monkeypatch.setattr(adapter, "frugality_complete_prepared", _complete_prepared)
+    request = CompletionConfig(model="default", role="reflect", profile="proof")
+    profiles = (
+        OuroborosConfig(
+            llm_profiles={
+                "proof": {
+                    "model": "openai/model-a",
+                    "temperature": 0.1,
+                    "max_tokens": 100,
+                    "reasoning_effort": "low",
+                }
+            }
+        ),
+        OuroborosConfig(
+            llm_profiles={
+                "proof": {
+                    "model": "openai/model-b",
+                    "temperature": 0.9,
+                    "max_tokens": 200,
+                    "reasoning_effort": "high",
+                }
+            }
+        ),
+    )
+    summaries = []
+    for profile_config in profiles:
+        with patch("ouroboros.providers.profiles.load_config", return_value=profile_config):
+            with capture_generation_provider_usage() as capture:
+                await tracked_complete(adapter, [], request)
+        summaries.append(capture.summary())
+
+    assert all(summary.complete for summary in summaries)
+    assert summaries[0].configuration_assignments != summaries[1].configuration_assignments
+    assert [(config.model, config.temperature, config.max_tokens) for config in dispatched] == [
+        ("openai/model-a", 0.1, 100),
+        ("openai/model-b", 0.9, 200),
+    ]
+    assert all(config.role is None and config.profile is None for config in dispatched)
+
+
+def test_anthropic_attestation_requires_one_attempt_and_secret_safe_authority() -> None:
+    client = SimpleNamespace(
+        base_url="https://provider.example/v1",
+        api_key="credential-a",
+    )
+    config = CompletionConfig(model="claude-sonnet-4-20250514", role="reflect")
+    safe = AnthropicAdapter(api_key="credential-a", max_retries=0)
+    unsafe = AnthropicAdapter(api_key="credential-a", max_retries=1)
+    safe._client = client
+    unsafe._client = client
+
+    prepared_result = safe.frugality_prepare_completion(config)
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    normalized = provider_usage_module._completion_adapter_configuration(
+        safe,
+        prepared.contract,
+    )
+    assert normalized is not provider_usage_module._INVALID_CONFIGURATION
+    assert "credential-a" not in repr(normalized)
+
+    prepared_result = unsafe.frugality_prepare_completion(config)
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            unsafe,
+            prepared.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+def test_anthropic_attestation_uses_cached_client_dispatch_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CachedClient:
+        base_url = "https://cached-client.example/v1/"
+        api_key = "cached-client-credential"
+
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://environment.example/v1")
+    adapter = AnthropicAdapter(api_key="constructor-credential", max_retries=0)
+    adapter._client = _CachedClient()
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="claude-sonnet-4-20250514", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    contract = prepared_result.value.contract
+    assert contract["credential_authority"] == credential_authority_digest(
+        "cached-client-credential"
+    )
+    settings = contract["settings"]
+    assert isinstance(settings, Mapping)
+    assert settings["api_base"] == "https://cached-client.example/v1/"
+    assert "environment.example" not in repr(contract)
+    assert "cached-client-credential" not in repr(contract)
+
+
+def test_litellm_attestation_requires_one_attempt_and_secret_safe_authority() -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    LiteLLMAdapter = litellm_adapter.LiteLLMAdapter
+    config = CompletionConfig(model="claude-sonnet-4-20250514", role="reflect")
+    safe = LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        max_retries=1,
+    )
+    unsafe = LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        max_retries=2,
+    )
+
+    prepared_result = safe.frugality_prepare_completion(config)
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    normalized = provider_usage_module._completion_adapter_configuration(
+        safe,
+        prepared.contract,
+    )
+    assert normalized is not provider_usage_module._INVALID_CONFIGURATION
+    assert "credential-a" not in repr(normalized)
+
+    prepared_result = unsafe.frugality_prepare_completion(config)
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            unsafe,
+            prepared.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+@pytest.mark.parametrize(
+    ("setting", "value"),
+    [
+        ("dependency_client_sealed", False),
+        ("dependency_client_type", "custom.Client"),
+        ("dependency_transport_contract", "custom-transport"),
+        ("dependency_cleanup_required", False),
+        ("dependency_isolation_kind", "in-process"),
+        ("dependency_worker_protocol", "custom-worker"),
+        ("dependency_worker_environment_contract", "inherited-env"),
+        ("dependency_worker_cwd_contract", "inherited-cwd"),
+        ("dependency_mutation_audit", "polling"),
+        ("worker_launcher_path", None),
+        ("worker_executable_resolved_path", None),
+        ("worker_executable_content_sha256", None),
+        ("worker_python_version", None),
+        ("worker_module", "custom.worker"),
+        ("worker_implementation_sha256", None),
+        ("adapter_module", "custom.adapter"),
+        ("adapter_implementation_sha256", None),
+        ("ouroboros_implementation_contract", "partial-sources"),
+        ("ouroboros_implementation_sha256", None),
+        ("httpx_dependency_version", None),
+        ("openai_dependency_version", None),
+    ],
+)
+def test_litellm_sealed_client_contract_fails_closed(
+    setting: str,
+    value: object,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        max_retries=1,
+    )
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    contract = dict(prepared_result.value.contract)
+    settings = dict(contract["settings"])
+    settings[setting] = value
+    contract["settings"] = settings
+    assert (
+        provider_usage_module._completion_adapter_configuration(adapter, contract)
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+def test_litellm_worker_executable_authority_changes_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        max_retries=1,
+    )
+    config = CompletionConfig(model="openai/gpt-test", role="reflect")
+    original = adapter.frugality_prepare_completion(config)
+    alternate_executable = tmp_path / "python-worker"
+    shutil.copy2(Path(litellm_adapter.sys.executable).resolve(strict=True), alternate_executable)
+    alternate_executable.chmod(0o700)
+    monkeypatch.setattr(litellm_adapter.sys, "executable", str(alternate_executable))
+    changed = adapter.frugality_prepare_completion(config)
+
+    assert original.is_ok
+    assert changed.is_ok
+    original_configuration = provider_usage_module._completion_adapter_configuration(
+        adapter,
+        original.value.contract,
+    )
+    changed_configuration = provider_usage_module._completion_adapter_configuration(
+        adapter,
+        changed.value.contract,
+    )
+    assert original_configuration is not provider_usage_module._INVALID_CONFIGURATION
+    assert changed_configuration is not provider_usage_module._INVALID_CONFIGURATION
+    assert original_configuration != changed_configuration
+    original_settings = original.value.contract["settings"]
+    changed_settings = changed.value.contract["settings"]
+    assert isinstance(original_settings, Mapping)
+    assert isinstance(changed_settings, Mapping)
+    assert original_settings["worker_launcher_path"] != changed_settings["worker_launcher_path"]
+    assert (
+        original_settings["worker_executable_content_sha256"]
+        == changed_settings["worker_executable_content_sha256"]
+    )
+
+
+def test_litellm_adapter_implementation_drift_invalidates_prepared_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        max_retries=1,
+    )
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+    assert prepared_result.is_ok
+    original_module_digest = litellm_adapter._module_implementation_sha256
+
+    def drifted_module_digest(module_name: str) -> str:
+        if module_name == "ouroboros.providers.litellm_adapter":
+            return "f" * 64
+        return original_module_digest(module_name)
+
+    monkeypatch.setattr(
+        litellm_adapter,
+        "_module_implementation_sha256",
+        drifted_module_digest,
+    )
+
+    assert adapter.frugality_validate_prepared_completion(prepared_result.value) is False
+
+
+@pytest.mark.asyncio
+async def test_litellm_adapter_implementation_drift_makes_usage_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    original_prepare = adapter.frugality_prepare_completion
+    original_module_digest = litellm_adapter._module_implementation_sha256
+
+    def prepare_then_drift(config: CompletionConfig):  # noqa: ANN202
+        prepared_result = original_prepare(config)
+
+        def drifted_module_digest(module_name: str) -> str:
+            if module_name == "ouroboros.providers.litellm_adapter":
+                return "f" * 64
+            return original_module_digest(module_name)
+
+        monkeypatch.setattr(
+            litellm_adapter,
+            "_module_implementation_sha256",
+            drifted_module_digest,
+        )
+        return prepared_result
+
+    async def complete_prepared(
+        messages: object,
+        prepared: PreparedFrugalityCompletion,
+    ) -> Result[CompletionResponse, ProviderError]:
+        del messages
+        return Result.ok(
+            CompletionResponse(
+                content="done",
+                model=prepared.config.model,
+                usage=UsageInfo(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            )
+        )
+
+    monkeypatch.setattr(adapter, "frugality_prepare_completion", prepare_then_drift)
+    monkeypatch.setattr(adapter, "frugality_complete_prepared", complete_prepared)
+
+    with capture_generation_provider_usage() as capture:
+        result = await tracked_complete(
+            adapter,
+            [],
+            CompletionConfig(model="openai/gpt-test", role="reflect"),
+        )
+
+    assert result.is_ok
+    summary = capture.summary()
+    assert summary.call_count == 1
+    assert summary.token_spend is None
+    assert summary.complete is False
+
+
+def test_litellm_global_or_implicit_endpoint_authority_is_ineligible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    LiteLLMAdapter = litellm_adapter.LiteLLMAdapter
+    monkeypatch.setattr(litellm_adapter.litellm, "api_base", "https://global.example/v1")
+    adapter = LiteLLMAdapter(api_key="credential-a", api_base=None, max_retries=1)
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-4", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared_result.value.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_api_base", "expected_client_type"),
+    [
+        (
+            "anthropic/claude-test",
+            "https://api.anthropic.com",
+            "litellm.AsyncHTTPHandler",
+        ),
+        (
+            "google/gemini-test",
+            "https://generativelanguage.googleapis.com",
+            "litellm.AsyncHTTPHandler",
+        ),
+        ("openai/gpt-test", "https://api.openai.com/v1", "openai.AsyncOpenAI"),
+        (
+            "openrouter/openai/gpt-test",
+            "https://openrouter.ai/api/v1",
+            "litellm.AsyncHTTPHandler",
+        ),
+    ],
+)
+def test_litellm_proof_adapter_seals_provider_default_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    expected_api_base: str,
+    expected_client_type: str,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        frugality_proof=True,
+    )
+    monkeypatch.setattr(litellm_adapter.litellm, "api_base", None)
+    monkeypatch.setattr(adapter, "_load_credentials_config", lambda: None)
+    for names in litellm_adapter._PROOF_API_BASE_ENVIRONMENT.values():
+        for name in names:
+            monkeypatch.delenv(name, raising=False)
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model=model, role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    settings = prepared.contract["settings"]
+    assert isinstance(settings, Mapping)
+    assert settings["api_base"] == expected_api_base
+    assert settings["dependency_client_sealed"] is True
+    assert settings["dependency_client_type"] == expected_client_type
+    assert settings["dependency_transport_contract"] == "ouroboros.httpx.async.v1"
+    assert settings["dependency_cleanup_required"] is True
+    assert settings["dependency_isolation_kind"] == "subprocess"
+    assert settings["dependency_worker_protocol"] == "ouroboros.litellm.worker.v1"
+    assert settings["dependency_worker_environment_contract"] == "ouroboros.empty-env.v1"
+    assert settings["dependency_worker_cwd_contract"] == "ouroboros.private-empty-tempdir.v1"
+    assert settings["dependency_mutation_audit"] == "litellm.module-setattr.v1"
+    assert Path(settings["worker_launcher_path"]).is_absolute()
+    assert Path(settings["worker_executable_resolved_path"]).is_absolute()
+    assert len(settings["worker_executable_content_sha256"]) == 64
+    assert settings["worker_python_version"]
+    assert settings["worker_module"] == "ouroboros.providers.litellm_proof_worker"
+    assert len(settings["worker_implementation_sha256"]) == 64
+    assert settings["adapter_module"] == "ouroboros.providers.litellm_adapter"
+    assert len(settings["adapter_implementation_sha256"]) == 64
+    assert settings["ouroboros_implementation_contract"] == "ouroboros.python-sources.v1"
+    assert len(settings["ouroboros_implementation_sha256"]) == 64
+    assert prepared.dispatch is not None
+    assert prepared.dispatch.api_base == expected_api_base
+    assert prepared.dispatch.client_type == expected_client_type
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared.contract,
+        )
+        is not provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+def test_litellm_proof_adapter_seals_environment_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        frugality_proof=True,
+    )
+    monkeypatch.setattr(litellm_adapter.litellm, "api_base", None)
+    monkeypatch.setattr(adapter, "_load_credentials_config", lambda: None)
+    monkeypatch.setenv("OPENAI_BASE_URL", " https://gateway.example/v1 ")
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    settings = prepared.contract["settings"]
+    assert isinstance(settings, Mapping)
+    assert settings["api_base"] == "https://gateway.example/v1"
+    assert prepared.dispatch is not None
+    assert prepared.dispatch.api_base == "https://gateway.example/v1"
+
+
+def test_litellm_credentialed_endpoint_is_proof_ineligible() -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://user:guessable-password@provider.example/v1",
+        frugality_proof=True,
+    )
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared_result.value.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("aclient_session", object()),
+        ("organization", "org-drift"),
+        ("headers", {"Authorization": "secret-header"}),
+        ("api_version", "2026-08-04"),
+        ("client_session", object()),
+        ("modify_params", True),
+        ("drop_params", True),
+        ("network_mock", True),
+        ("disable_aiohttp_transport", True),
+        ("aiohttp_trust_env", True),
+        ("disable_aiohttp_trust_env", True),
+        ("force_ipv4", True),
+        ("ssl_verify", False),
+        ("ssl_security_level", "DEFAULT:@SECLEVEL=1"),
+        ("ssl_certificate", "/tmp/client.pem"),
+        ("ssl_ecdh_curve", "X25519"),
+        ("use_aiohttp_transport", False),
+    ],
+)
+def test_litellm_dependency_globals_are_proof_ineligible(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: object,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    monkeypatch.setattr(litellm_adapter.litellm, name, value)
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    prepared = prepared_result.value
+    if isinstance(value, str):
+        assert value not in repr(prepared.contract)
+    if isinstance(value, Mapping):
+        assert "secret-header" not in repr(prepared.contract)
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "OPENAI_ORGANIZATION",
+        "OPENAI_PROJECT",
+        "AIOHTTP_TRUST_ENV",
+        "DISABLE_AIOHTTP_TRANSPORT",
+        "DISABLE_AIOHTTP_TRUST_ENV",
+        "EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER",
+        "LITELLM_USER_AGENT",
+        "SSL_CERTIFICATE",
+        "SSL_ECDH_CURVE",
+        "SSL_SECURITY_LEVEL",
+        "SSL_VERIFY",
+    ],
+)
+def test_litellm_unsealed_provider_environment_is_proof_ineligible(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    monkeypatch.setenv(name, "environment-drift")
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared_result.value.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+def test_litellm_provider_config_override_is_proof_ineligible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    monkeypatch.setattr(
+        litellm_adapter.litellm.OpenAIConfig,
+        "get_config",
+        lambda: {"frequency_penalty": 0.5},
+    )
+
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+
+    assert prepared_result.is_ok
+    assert (
+        provider_usage_module._completion_adapter_configuration(
+            adapter,
+            prepared_result.value.contract,
+        )
+        is provider_usage_module._INVALID_CONFIGURATION
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("aclient_session", object()),
+        ("network_mock", True),
+        ("disable_aiohttp_transport", True),
+        ("aiohttp_trust_env", True),
+        ("ssl_verify", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_litellm_dependency_drift_after_preparation_only_invalidates_proof(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: object,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    original_prepare = adapter.frugality_prepare_completion
+
+    def prepare_then_drift(config: CompletionConfig):  # noqa: ANN202
+        prepared_result = original_prepare(config)
+        monkeypatch.setattr(litellm_adapter.litellm, name, value)
+        return prepared_result
+
+    async def complete_prepared(
+        messages: object,
+        prepared: PreparedFrugalityCompletion,
+    ) -> Result[CompletionResponse, ProviderError]:
+        del messages
+        return Result.ok(
+            CompletionResponse(
+                content="done",
+                model=prepared.config.model,
+                usage=UsageInfo(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            )
+        )
+
+    monkeypatch.setattr(adapter, "frugality_prepare_completion", prepare_then_drift)
+    monkeypatch.setattr(adapter, "frugality_complete_prepared", complete_prepared)
+
+    with capture_generation_provider_usage() as capture:
+        result = await tracked_complete(
+            adapter,
+            [],
+            CompletionConfig(model="openai/gpt-test", role="reflect"),
+        )
+
+    assert result.is_ok
+    summary = capture.summary()
+    assert summary.call_count == 1
+    assert summary.token_spend is None
+    assert summary.complete is False
+
+
+@pytest.mark.asyncio
+async def test_litellm_inflight_mutate_and_restore_invalidates_proof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    entered_dispatch = asyncio.Event()
+    release_dispatch = asyncio.Event()
+
+    async def isolated_completion(
+        messages: object,
+        config: CompletionConfig,
+        dispatch: object,
+    ) -> Result[CompletionResponse, ProviderError]:
+        del messages, dispatch
+        entered_dispatch.set()
+        await release_dispatch.wait()
+        return Result.ok(
+            CompletionResponse(
+                content="done",
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            )
+        )
+
+    async def mutate_and_restore() -> None:
+        await entered_dispatch.wait()
+        litellm_adapter.litellm.modify_params = True
+        litellm_adapter.litellm.modify_params = False
+        release_dispatch.set()
+
+    mutation = asyncio.create_task(mutate_and_restore())
+    monkeypatch.setattr(adapter, "_run_isolated_completion", isolated_completion)
+
+    with capture_generation_provider_usage() as capture:
+        result = await tracked_complete(
+            adapter,
+            [],
+            CompletionConfig(model="openai/gpt-test", role="reflect"),
+        )
+    await mutation
+
+    assert result.is_ok
+    summary = capture.summary()
+    assert summary.call_count == 1
+    assert summary.token_spend is None
+    assert summary.complete is False
+
+
+@pytest.mark.asyncio
+async def test_litellm_sealed_client_cleanup_failure_only_invalidates_proof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+
+    async def cleanup_failure(
+        messages: object,
+        config: CompletionConfig,
+        dispatch: object,
+    ) -> Result[CompletionResponse, ProviderError]:
+        del messages
+        dispatch.state.cleanup_failed = True
+        return Result.ok(
+            CompletionResponse(
+                content="done",
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            )
+        )
+
+    monkeypatch.setattr(adapter, "_run_isolated_completion", cleanup_failure)
+
+    with capture_generation_provider_usage() as capture:
+        result = await tracked_complete(
+            adapter,
+            [],
+            CompletionConfig(model="openai/gpt-test", role="reflect"),
+        )
+
+    assert result.is_ok
+    summary = capture.summary()
+    assert summary.call_count == 1
+    assert summary.token_spend is None
+    assert summary.complete is False
+
+
+@pytest.mark.asyncio
+async def test_litellm_tracked_dispatch_uses_attested_route_without_reresolving() -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(max_retries=1)
+    adapter._get_api_key = MagicMock(side_effect=["credential-before", "credential-after"])
+    adapter._get_api_base = MagicMock(
+        side_effect=["https://before.example/v1", "https://after.example/v1"]
+    )
+    original_prepare = adapter.frugality_prepare_completion
+
+    def _prepare_then_mutate(config: CompletionConfig):  # noqa: ANN202
+        prepared = original_prepare(config)
+        adapter._timeout = 999
+        adapter._max_retries = 2
+        return prepared
+
+    adapter.frugality_prepare_completion = _prepare_then_mutate
+    observed: dict[str, object] = {}
+
+    async def isolated_completion(
+        messages: object,
+        config: CompletionConfig,
+        dispatch: object,
+    ) -> Result[CompletionResponse, ProviderError]:
+        del messages
+        observed.update(
+            api_key=dispatch.api_key,
+            api_base=dispatch.api_base,
+            timeout=dispatch.timeout,
+            max_retries=dispatch.max_retries,
+            client_type=dispatch.client_type,
+        )
+        return Result.ok(
+            CompletionResponse(
+                content="done",
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+            )
+        )
+
+    adapter._run_isolated_completion = isolated_completion
+    with capture_generation_provider_usage() as capture:
+        result = await tracked_complete(
+            adapter,
+            [],
+            CompletionConfig(model="openai/gpt-4", role="reflect"),
+        )
+
+    assert result.is_ok
+    assert capture.summary().complete
+    adapter._get_api_key.assert_called_once_with("openai/gpt-4")
+    adapter._get_api_base.assert_called_once_with("openai/gpt-4")
+    assert observed == {
+        "api_key": "credential-before",
+        "api_base": "https://before.example/v1",
+        "timeout": 60.0,
+        "max_retries": 1,
+        "client_type": "openai.AsyncOpenAI",
+    }
+
+
+@pytest.mark.asyncio
+async def test_litellm_isolated_worker_uses_empty_environment_and_stdin_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    litellm_adapter = pytest.importorskip("ouroboros.providers.litellm_adapter")
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base="https://provider.example/v1",
+        frugality_proof=True,
+    )
+    prepared_result = adapter.frugality_prepare_completion(
+        CompletionConfig(model="openai/gpt-test", role="reflect")
+    )
+    assert prepared_result.is_ok
+    dispatch = prepared_result.value.dispatch
+    assert dispatch is not None
+    observed: dict[str, object] = {}
+    worker_report = {
+        "ok": True,
+        "proof": {
+            "authority_verified": True,
+            "client_cleanup_succeeded": True,
+            "client_type": "openai.AsyncOpenAI",
+            "httpx_dependency_version": litellm_adapter._HTTPX_DEPENDENCY_VERSION,
+            "litellm_dependency_version": litellm_adapter._LITELLM_DEPENDENCY_VERSION,
+            "openai_dependency_version": litellm_adapter._OPENAI_DEPENDENCY_VERSION,
+            "transport_contract": litellm_adapter._PROOF_TRANSPORT_CONTRACT,
+            "worker_executable_resolved_path": (dispatch.worker_authority.resolved_executable_path),
+            "worker_executable_content_sha256": (
+                dispatch.worker_authority.executable_content_sha256
+            ),
+            "worker_python_version": dispatch.worker_authority.python_version,
+            "worker_module": dispatch.worker_authority.worker_module,
+            "worker_implementation_sha256": (
+                dispatch.worker_authority.worker_implementation_sha256
+            ),
+            "adapter_module": dispatch.worker_authority.adapter_module,
+            "adapter_implementation_sha256": (
+                dispatch.worker_authority.adapter_implementation_sha256
+            ),
+            "ouroboros_implementation_contract": (
+                dispatch.worker_authority.ouroboros_implementation_contract
+            ),
+            "ouroboros_implementation_sha256": (
+                dispatch.worker_authority.ouroboros_implementation_sha256
+            ),
+        },
+        "response": {
+            "content": "done",
+            "finish_reason": "stop",
+            "model": "openai/gpt-test",
+            "usage": {
+                "completion_tokens": 2,
+                "prompt_tokens": 3,
+                "total_tokens": 5,
+            },
+        },
+    }
+
+    class _Process:
+        returncode = 0
+
+        async def communicate(self, payload: bytes) -> tuple[bytes, bytes]:
+            observed["payload"] = payload
+            return json.dumps(worker_report).encode(), b""
+
+    async def create_process(*command: str, **kwargs: object) -> _Process:
+        observed["command"] = command
+        observed["environment"] = kwargs["env"]
+        return _Process()
+
+    monkeypatch.setattr(litellm_adapter.asyncio, "create_subprocess_exec", create_process)
+
+    result = await adapter._run_isolated_completion(
+        [],
+        prepared_result.value.config,
+        dispatch,
+    )
+
+    assert result.is_ok
+    command = observed["command"]
+    assert isinstance(command, tuple)
+    assert command[1:] == (
+        "-I",
+        "-m",
+        "ouroboros.providers.litellm_proof_worker",
+    )
+    assert observed["environment"] == {
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUTF8": "1",
+    }
+    assert "credential-a" not in repr(command)
+    assert "credential-a" not in repr(observed["environment"])
+    payload = json.loads(observed["payload"])
+    assert payload["completion_kwargs"]["api_key"] == "credential-a"
+
+
+async def test_provider_configuration_assignments_reject_role_swaps() -> None:
+    with capture_generation_provider_usage() as first:
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-a", role="wonder"),
+        )
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-b", role="semantic_evaluation"),
+        )
+    with capture_generation_provider_usage() as second:
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-b", role="wonder"),
+        )
+        await tracked_complete(
+            _Adapter(20),
+            [],
+            CompletionConfig(model="model-a", role="semantic_evaluation"),
+        )
+
+    first_summary = first.summary()
+    second_summary = second.summary()
+    assert first_summary.configuration_fingerprint != second_summary.configuration_fingerprint
+    assert first_summary.configuration_assignments != second_summary.configuration_assignments
+
+
+async def test_provider_configuration_assignments_preserve_call_multiplicity() -> None:
+    with capture_generation_provider_usage() as first:
+        for _ in range(9):
+            await tracked_complete(
+                _Adapter(100),
+                [],
+                CompletionConfig(model="expensive", role="reflect"),
+            )
+        await tracked_complete(
+            _Adapter(1),
+            [],
+            CompletionConfig(model="cheap", role="reflect"),
+        )
+    with capture_generation_provider_usage() as second:
+        await tracked_complete(
+            _Adapter(100),
+            [],
+            CompletionConfig(model="expensive", role="reflect"),
+        )
+        for _ in range(9):
+            await tracked_complete(
+                _Adapter(1),
+                [],
+                CompletionConfig(model="cheap", role="reflect"),
+            )
+
+    first_summary = first.summary()
+    second_summary = second.summary()
+    assert first_summary.configuration_fingerprint == second_summary.configuration_fingerprint
+    assert first_summary.configuration_assignments != second_summary.configuration_assignments
+
+
+async def test_missing_or_unknown_provider_role_fails_closed() -> None:
+    for role in (None, "", "unknown", "UNKNOWN", " Unknown "):
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(
+                _Adapter(20),
+                [],
+                CompletionConfig(model="test-model", role=role),
+            )
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_unknown_completion_backend_fails_closed() -> None:
+    for backend in ("", "   ", "unknown", "UNKNOWN", " Unknown "):
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(
+                _Adapter(20, llm_backend=backend),
+                [],
+                CompletionConfig(model="test-model", role="reflect"),
+            )
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_unknown_completion_profile_or_effort_fails_closed() -> None:
+    configs = (
+        CompletionConfig(model="test-model", role="reflect", profile=" Unknown "),
+        CompletionConfig(
+            model="test-model",
+            role="reflect",
+            reasoning_effort=" Unknown ",  # type: ignore[arg-type]
+        ),
+    )
+    for config in configs:
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(_Adapter(20), [], config)
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_unknown_provider_model_fails_closed_case_insensitively() -> None:
+    for model in ("unknown", "UNKNOWN", " Unknown "):
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(
+                _Adapter(20),
+                [],
+                CompletionConfig(model=model, role="reflect"),
+            )
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_missing_or_invalid_resolved_provider_model_fails_closed() -> None:
+    for response_model in (None, "", "   ", " Unknown "):
+        with capture_generation_provider_usage() as capture:
+            await tracked_complete(
+                _Adapter(20, response_model=response_model),  # type: ignore[arg-type]
+                [],
+                CompletionConfig(model="requested-model", role="reflect"),
+            )
+
+        summary = capture.summary()
+        assert summary.complete is False
+        assert summary.token_spend is None
+        assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+async def test_generation_provider_usage_rejects_opaque_call_sites() -> None:
+    with capture_generation_provider_usage() as capture:
+        pass
+
+    summary = capture.summary(instrumentation_complete=False)
+
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "instrumentation is incomplete" in "; ".join(summary.issues)
+
+
+def test_bound_method_inherits_its_engine_tracking_contract() -> None:
+    class _TrackedEngine:
+        frugality_provider_tracking = True
+
+        def phase(self) -> None:
+            return None
+
+    with capture_generation_provider_usage() as capture:
+        observe_callable(_TrackedEngine().phase)
+
+    assert capture.summary().complete is True
+
+
+async def test_unknown_or_malformed_agent_runtime_attestation_fails_closed() -> None:
+    class _UnknownRuntime(_AttestedRuntime):
+        pass
+
+    unknown = _UnknownRuntime()
+    malformed = _AttestedRuntime()
+    malformed.frugality_runtime_attestation = lambda: {  # type: ignore[method-assign]
+        "schema_version": 1,
+        "schema_id": "test.agent_runtime.v1",
+        "implementation": f"{type(malformed).__module__}.{type(malformed).__qualname__}",
+        "runtime_backend": "test-runtime",
+        "runtime_handle_backend": "test-runtime-handle",
+        "settings": {"api_key": "secret"},
+    }
+
+    for runtime in (unknown, malformed):
+        with capture_generation_provider_usage() as capture:
+            _ = [
+                message
+                async for message in tracked_agent_task(
+                    runtime,
+                    role="executor_auxiliary",
+                    prompt="analyze",
+                )
+            ]
+        assert capture.summary().complete is False
+        assert capture.summary().token_spend is None
+
+
+async def test_runtime_attestation_cleanup_failure_invalidates_only_proof() -> None:
+    runtime = _AttestedRuntime()
+
+    def fail_cleanup() -> None:
+        raise RuntimeError("cleanup failed")
+
+    runtime.frugality_runtime_attestation_complete = fail_cleanup  # type: ignore[attr-defined]
+    with capture_generation_provider_usage() as capture:
+        messages = [
+            message
+            async for message in tracked_agent_task(
+                runtime,
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+
+    assert len(messages) == 1
+    assert capture.summary().complete is False
+    assert capture.summary().token_spend is None
+
+
+async def test_codex_runtime_attestation_fingerprint_tracks_effect_bearing_drift(
+    tmp_path: Path,
+) -> None:
+    cli = _write_fake_codex_cli(tmp_path / "codex-a", version="1.0")
+    other_cli = _write_fake_codex_cli(tmp_path / "codex-b", version="2.0")
+    skills_a = tmp_path / "skills-a"
+    skills_b = tmp_path / "skills-b"
+    skills_a.mkdir()
+    skills_b.mkdir()
+
+    class _StableDispatcher:
+        def __init__(self, identity: str) -> None:
+            self.identity = identity
+
+        def stable_identity_contract(self) -> Mapping[str, object]:
+            return {"schema_version": 1, "identity": self.identity}
+
+        async def __call__(self, *args, **kwargs):  # noqa: ANN201, ARG002
+            return ()
+
+    baseline = CodexCliRuntime(cli_path=cli, model="test-model")
+    variants = [
+        CodexCliRuntime(cli_path=cli, model="test-model", runtime_profile="worker"),
+        CodexCliRuntime(cli_path=other_cli, model="test-model"),
+        CodexCliRuntime(
+            cli_path=cli,
+            model="test-model",
+            startup_output_timeout_seconds=15,
+        ),
+        CodexCliRuntime(cli_path=cli, model="test-model", skills_dir=skills_a),
+        CodexCliRuntime(cli_path=cli, model="test-model", skills_dir=skills_b),
+        CodexCliRuntime(
+            cli_path=cli,
+            model="test-model",
+            skill_dispatcher=_StableDispatcher("dispatcher-a"),
+        ),
+        CodexCliRuntime(
+            cli_path=cli,
+            model="test-model",
+            skill_dispatcher=_StableDispatcher("dispatcher-b"),
+        ),
+    ]
+    backend_specific = CodexCliRuntime(cli_path=cli, model="test-model")
+    backend_specific._codex_config_fingerprint = "f" * 64
+    variants.append(backend_specific)
+
+    baseline_summary = await _codex_runtime_summary(baseline)
+    variant_summaries = [await _codex_runtime_summary(runtime) for runtime in variants]
+
+    assert baseline_summary.complete is True
+    assert all(summary.complete for summary in variant_summaries)
+    assert all(
+        summary.configuration_fingerprint != baseline_summary.configuration_fingerprint
+        for summary in variant_summaries
+    )
+
+
+async def test_codex_runtime_attestation_tracks_repository_relative_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _write_fake_codex_cli(tmp_path / "codex", version="1.0")
+    repository_root = tmp_path / "repository"
+    (repository_root / "src").mkdir(parents=True)
+
+    def project_identity(cwd: str) -> SimpleNamespace:
+        relative = Path(cwd).relative_to(repository_root).as_posix() or "."
+        return SimpleNamespace(workspace_path=relative)
+
+    monkeypatch.setattr(
+        frugality_attestation_module,
+        "resolve_project_identity",
+        project_identity,
+    )
+    root_runtime = CodexCliRuntime(
+        cli_path=cli,
+        model="test-model",
+        cwd=repository_root,
+    )
+    nested_runtime = CodexCliRuntime(
+        cli_path=cli,
+        model="test-model",
+        cwd=repository_root / "src",
+    )
+
+    root_contract = root_runtime.frugality_runtime_attestation()
+    nested_contract = nested_runtime.frugality_runtime_attestation()
+    root_summary = await _codex_runtime_summary(root_runtime)
+    nested_summary = await _codex_runtime_summary(nested_runtime)
+
+    assert root_contract["settings"]["semantic_cwd"] == "."  # type: ignore[index]
+    assert nested_contract["settings"]["semantic_cwd"] == "src"  # type: ignore[index]
+    assert root_summary.complete is True
+    assert nested_summary.complete is True
+    assert root_summary.configuration_fingerprint != nested_summary.configuration_fingerprint
+
+
+@pytest.mark.parametrize(
+    ("key", "baseline_value", "changed_value"),
+    [
+        ("OPENAI_BASE_URL", "https://provider-a.example/v1", "https://provider-b.example/v1"),
+        ("OPENAI_API_KEY", "test-credential-a", "test-credential-b"),
+        ("PATH", "/opt/toolchain-a/bin", "/opt/toolchain-b/bin"),
+        ("CODEX_SANDBOX_NETWORK_DISABLED", "1", "0"),
+    ],
+)
+async def test_codex_runtime_attestation_tracks_complete_child_environment_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    baseline_value: str,
+    changed_value: str,
+) -> None:
+    cli = _write_fake_codex_cli(tmp_path / "codex", version="1.0")
+    if key == "PATH":
+        inherited_path = os.environ.get("PATH", "")
+        baseline_value = os.pathsep.join((baseline_value, inherited_path))
+        changed_value = os.pathsep.join((changed_value, inherited_path))
+
+    with monkeypatch.context() as environment:
+        environment.setenv(key, baseline_value)
+        baseline_summary = await _codex_runtime_summary(
+            CodexCliRuntime(cli_path=cli, model="test-model")
+        )
+    with monkeypatch.context() as environment:
+        environment.setenv(key, changed_value)
+        changed_summary = await _codex_runtime_summary(
+            CodexCliRuntime(cli_path=cli, model="test-model")
+        )
+
+    assert baseline_summary.complete is True
+    assert changed_summary.complete is True
+    assert baseline_summary.configuration_fingerprint != changed_summary.configuration_fingerprint
+    assert baseline_summary.configuration_assignments != changed_summary.configuration_assignments
+
+
+def test_codex_runtime_attestation_never_persists_child_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "test-secret-that-must-not-escape"
+    cli = _write_fake_codex_cli(tmp_path / "codex", version="1.0")
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    runtime = CodexCliRuntime(cli_path=cli, model="test-model")
+
+    contract = runtime.frugality_runtime_attestation()
+    encoded = json.dumps(contract, sort_keys=True)
+
+    assert contract["schema_version"] == 4
+    assert contract["schema_id"] == "ouroboros.codex_cli_runtime.v4"
+    assert secret not in encoded
+    assert "hmac-sha256:" not in encoded
+
+
+def test_installation_authority_key_is_owner_only_and_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(credential_authority_module, "get_config_dir", lambda: tmp_path)
+
+    first = _real_installation_authority_key()
+    second = _real_installation_authority_key()
+    key_path = tmp_path / "frugality-authority.key"
+
+    assert first is not None and len(first) == 32
+    assert second == first
+    assert key_path.stat().st_mode & 0o777 == 0o600
+    key_path.chmod(0o644)
+    assert _real_installation_authority_key() is None
+
+
+def test_installation_authority_key_recovers_owner_only_partial_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(credential_authority_module, "get_config_dir", lambda: tmp_path)
+    key_path = tmp_path / "frugality-authority.key"
+    key_path.write_bytes(b"partial")
+    key_path.chmod(0o600)
+
+    recovered = _real_installation_authority_key()
+
+    assert recovered is not None and len(recovered) == 32
+    assert key_path.read_bytes() == recovered
+
+
+def test_installation_authority_key_interrupted_write_is_replay_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_write = os.write
+    writes = 0
+
+    def interrupted_write(descriptor: int, value: object) -> int:
+        nonlocal writes
+        writes += 1
+        if writes == 1:
+            return real_write(descriptor, bytes(value)[:1])  # type: ignore[arg-type]
+        raise OSError("simulated interrupted write")
+
+    with monkeypatch.context() as interrupted:
+        interrupted.setattr(credential_authority_module, "get_config_dir", lambda: tmp_path)
+        interrupted.setattr(credential_authority_module.os, "write", interrupted_write)
+        assert _real_installation_authority_key() is None
+
+    key_path = tmp_path / "frugality-authority.key"
+    assert not key_path.exists()
+    assert not tuple(tmp_path.glob(".frugality-authority.key.*.tmp"))
+    with monkeypatch.context() as recovered_context:
+        recovered_context.setattr(
+            credential_authority_module,
+            "get_config_dir",
+            lambda: tmp_path,
+        )
+        recovered = _real_installation_authority_key()
+    assert recovered is not None and len(recovered) == 32
+
+
+def test_codex_runtime_spawns_with_exact_environment_bound_by_attestation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _write_fake_codex_cli(tmp_path / "codex", version="1.0")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://provider-a.example/v1")
+    runtime = CodexCliRuntime(cli_path=cli, model="test-model")
+    _ = runtime.frugality_runtime_attestation()
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://provider-b.example/v1")
+    first_attested_environment = runtime._build_child_env()
+    retry_attested_environment = runtime._build_child_env()
+    runtime.frugality_runtime_attestation_complete()
+    next_environment = runtime._build_child_env()
+
+    assert first_attested_environment["OPENAI_BASE_URL"] == "https://provider-a.example/v1"
+    assert retry_attested_environment["OPENAI_BASE_URL"] == "https://provider-a.example/v1"
+    assert next_environment["OPENAI_BASE_URL"] == "https://provider-b.example/v1"
+
+
+def test_codex_child_environment_attestation_is_bounded() -> None:
+    oversized = {"PATH": "x" * (128 * 1_024 + 1)}
+
+    assert codex_child_environment_attestation(oversized) is None
+
+
+def test_persisted_environment_evidence_cannot_verify_low_entropy_secret_guesses() -> None:
+    environment = {"PATH": "/usr/bin", "DATABASE_PASSWORD": "guessable-password"}
+
+    unavailable = codex_child_environment_attestation(environment)
+    first_installation = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"a" * 32,
+    )
+    second_installation = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"b" * 32,
+    )
+
+    assert unavailable is None
+    assert first_installation is not None
+    assert second_installation is not None
+    assert (
+        first_installation["authority_fingerprint"] != second_installation["authority_fingerprint"]
+    )
+    persisted = json.dumps(first_installation, sort_keys=True)
+    assert "guessable-password" not in persisted
+    assert "hmac-sha256:" not in persisted
+
+
+@pytest.mark.parametrize("key", ["GH_TOKEN", "GITHUB_TOKEN", "NPM_TOKEN", "HF_TOKEN"])
+def test_common_token_aliases_use_installation_keyed_authority(key: str) -> None:
+    environment = {"PATH": "/usr/bin", key: "low-entropy-token"}
+
+    first = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"a" * 32,
+    )
+    second = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"b" * 32,
+    )
+
+    assert first is not None and first["sensitive_entry_count"] == 1
+    assert second is not None and second["sensitive_entry_count"] == 1
+    assert first["authority_fingerprint"] != second["authority_fingerprint"]
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("DATABASE_URL", "postgres://user:guessable-password@db.example/app"),
+        ("HTTPS_PROXY", "https://proxy-user:guessable-password@proxy.example:8443"),
+    ],
+)
+def test_embedded_environment_credentials_are_installation_keyed(
+    key: str,
+    value: str,
+) -> None:
+    environment = {"PATH": "/usr/bin", key: value}
+
+    first = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"a" * 32,
+    )
+    second = codex_child_environment_attestation(
+        environment,
+        secret_authority_key=b"b" * 32,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first["authority_fingerprint"] != second["authority_fingerprint"]
+    persisted = json.dumps(first, sort_keys=True)
+    assert value not in persisted
+    assert "guessable-password" not in persisted
+
+
+def test_provider_credential_authority_is_installation_keyed() -> None:
+    credential = "low-entropy-api-key"
+
+    first = credential_authority_digest(credential, installation_key=b"a" * 32)
+    second = credential_authority_digest(credential, installation_key=b"b" * 32)
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+    assert credential not in first
+    assert first.startswith("hmac-sha256-installation-key-v2:")
+    assert credential_authority_digest(credential, installation_key=b"short") is None
+    assert credential_authority_digest(f" {credential}", installation_key=b"a" * 32) != first
+
+
+async def test_opaque_executor_invalidates_generation_provider_completeness() -> None:
+    async def executor(seed: object, *, parallel: bool) -> object:
+        return seed, parallel
+
+    with capture_generation_provider_usage() as capture:
+        await call_executor(
+            executor,
+            SimpleNamespace(),  # type: ignore[arg-type]
+            parallel=True,
+            execution_id=None,
+        )
+
+    assert capture.summary().complete is False
+
+
+async def test_auxiliary_agent_stream_usage_is_included_in_generation_total() -> None:
+    with capture_generation_provider_usage() as capture:
+        messages = [
+            message
+            async for message in tracked_agent_task(
+                _AttestedRuntime(),
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+
+    summary = capture.summary()
+    assert len(messages) == 1
+    assert summary.complete is True
+    assert summary.call_count == 1
+    assert summary.token_spend == 150
+    assert summary.configuration_fingerprint is not None
+
+
+async def test_agent_runtime_explicit_blank_configuration_fails_closed() -> None:
+    for field in (
+        "runtime_backend",
+        "llm_backend",
+        "permission_mode",
+        "reasoning_effort",
+        "service_tier",
+    ):
+        runtime = _AttestedRuntime(usage={"total_tokens": 10})
+        setattr(runtime, field, "   ")
+        with capture_generation_provider_usage() as capture:
+            _ = [
+                message
+                async for message in tracked_agent_task(
+                    runtime,
+                    role="executor_auxiliary",
+                    prompt="analyze",
+                )
+            ]
+
+        summary = capture.summary()
+        assert summary.complete is False, field
+        assert summary.token_spend is None
+
+
+async def test_auxiliary_agent_stream_usage_must_reconcile() -> None:
+    with capture_generation_provider_usage() as capture:
+        _ = [
+            message
+            async for message in tracked_agent_task(
+                _AttestedRuntime(
+                    usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 1}
+                ),
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+
+    summary = capture.summary()
+    assert summary.complete is False
+    assert summary.token_spend is None
+
+
+async def test_auxiliary_agent_stream_rejects_partial_fallback_subtotals() -> None:
+    for usage in (
+        {"input_tokens": 10},
+        {"output_tokens": 5},
+        {"cache_read_input_tokens": 8},
+    ):
+        with capture_generation_provider_usage() as capture:
+            _ = [
+                message
+                async for message in tracked_agent_task(
+                    _AttestedRuntime(usage=usage),
+                    role="executor_auxiliary",
+                    prompt="analyze",
+                )
+            ]
+
+        assert capture.summary().complete is False
+
+
+async def test_agent_resume_state_is_configuration_bound_or_fails_closed() -> None:
+    async def _capture(handle: object):  # noqa: ANN202
+        with capture_generation_provider_usage() as capture:
+            _ = [
+                message
+                async for message in tracked_agent_task(
+                    _AttestedRuntime(),
+                    role="executor_auxiliary",
+                    prompt="analyze",
+                    resume_handle=handle,
+                )
+            ]
+        return capture.summary()
+
+    fresh = await _capture(None)
+    scoped_fresh = await _capture(
+        SimpleNamespace(
+            backend="test-runtime",
+            kind="agent_runtime",
+            metadata={},
+            native_session_id=None,
+            conversation_id=None,
+            previous_response_id=None,
+            transcript_path=None,
+            approval_mode="acceptEdits",
+            cwd="/tmp/isolated",
+        )
+    )
+    opaque = await _capture(object())
+    resumed = await _capture(
+        SimpleNamespace(
+            backend="test-runtime",
+            kind="agent_runtime",
+            metadata={},
+            native_session_id="session-1",
+            conversation_id=None,
+            previous_response_id=None,
+            transcript_path=None,
+            approval_mode="acceptEdits",
+            cwd="/tmp/isolated",
+        )
+    )
+
+    assert fresh.complete is True
+    assert scoped_fresh.complete is True
+    assert fresh.configuration_assignments != scoped_fresh.configuration_assignments
+    assert opaque.complete is False
+    assert resumed.complete is False
+
+    metadata_opaque = await _capture(
+        SimpleNamespace(
+            backend="test-runtime",
+            kind="agent_runtime",
+            metadata={"control_plane": [{"action": "resume"}]},
+            native_session_id=None,
+            conversation_id=None,
+            previous_response_id=None,
+            transcript_path=None,
+            approval_mode="acceptEdits",
+            cwd="/tmp/isolated",
+        )
+    )
+    assert metadata_opaque.complete is False
+
+    with capture_generation_provider_usage() as unknown_setting_capture:
+        _ = [
+            message
+            async for message in tracked_agent_task(
+                _AttestedRuntime(),
+                role="executor_auxiliary",
+                prompt="analyze",
+                model=" Unknown ",
+            )
+        ]
+    assert unknown_setting_capture.summary().complete is False
+
+
+async def test_agent_stream_binds_observed_effective_model() -> None:
+    async def _capture(effective_model: object):  # noqa: ANN202
+        with capture_generation_provider_usage() as capture:
+            _ = [
+                message
+                async for message in tracked_agent_task(
+                    _AttestedRuntime(
+                        usage={"total_tokens": 100},
+                        effective_model=effective_model,
+                    ),
+                    role="executor_auxiliary",
+                    prompt="analyze",
+                )
+            ]
+        return capture.summary()
+
+    expensive = await _capture("expensive-model")
+    cheap = await _capture("cheap-model")
+    unknown = await _capture(" Unknown ")
+    missing = await _capture(None)
+
+    assert expensive.complete is True
+    assert cheap.complete is True
+    assert expensive.configuration_assignments != cheap.configuration_assignments
+    assert unknown.complete is False
+    assert missing.complete is False
+
+
+async def test_agent_stream_without_effective_model_observation_fails_closed() -> None:
+    with capture_generation_provider_usage() as capture:
+        _ = [
+            message
+            async for message in tracked_agent_task(
+                _AttestedRuntime(usage={"total_tokens": 100}, effective_model=None),
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+
+    assert capture.summary().complete is False
+
+
+async def test_agent_result_without_effective_model_observation_fails_closed() -> None:
+    with capture_generation_provider_usage() as capture:
+        await tracked_agent_task_to_result(
+            _AttestedRuntime(usage={"total_tokens": 100}, effective_model=None),
+            role="validation_repair",
+            prompt="repair",
+        )
+
+    assert capture.summary().complete is False
+
+
+async def test_auxiliary_agent_stream_overflow_fails_closed() -> None:
+    with capture_generation_provider_usage() as capture:
+        messages = [
+            message
+            async for message in tracked_agent_task(
+                _AttestedRuntime(usage={"total_tokens": 10**400}),
+                role="executor_auxiliary",
+                prompt="analyze",
+            )
+        ]
+
+    summary = capture.summary()
+    assert len(messages) == 1
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "missing or invalid" in "; ".join(summary.issues)

--- a/tests/unit/evolution/test_scoped_reexecution.py
+++ b/tests/unit/evolution/test_scoped_reexecution.py
@@ -29,6 +29,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.core.types import Result
+from ouroboros.evolution.frugality import OBSERVATION_EVENT, PROOF_EVENT, EvolutionFrugalityStatus
 from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
 from ouroboros.evolution.wonder import WonderOutput
@@ -207,6 +208,36 @@ def _make_loop_for_gen2(
 
 
 class TestScopedForwardingIntegration:
+    async def test_ontology_only_wonder_stop_persists_insufficient_frugality_receipt(self) -> None:
+        store = await _store()
+        seed = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_wonder_stop",
+            goal=seed.goal,
+            generations=(_gen(1, seed, _eval({0: True, 1: True})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=())
+        loop.wonder_engine.wonder = AsyncMock(
+            return_value=Result.ok(
+                WonderOutput(questions=(), grounded_questions=(), should_continue=False)
+            )
+        )
+
+        result = await loop._run_generation(
+            lineage=lineage,
+            generation_number=2,
+            current_seed=seed,
+            execute=False,
+        )
+
+        assert result.is_ok
+        assert executor.called is False
+        observations = await store.query_events(event_type=OBSERVATION_EVENT, limit=10)
+        proofs = await store.query_events(event_type=PROOF_EVENT, limit=10)
+        assert len(observations) == 1
+        assert proofs[0].data["proof"]["status"] == EvolutionFrugalityStatus.INSUFFICIENT_DATA
+
     async def test_conductor_preservation_blocks_executor_before_side_effects(self) -> None:
         store = await _store()
         seed_v1 = _seed()

--- a/tests/unit/mcp/server/test_evolve_frugality_provider_wiring.py
+++ b/tests/unit/mcp/server/test_evolve_frugality_provider_wiring.py
@@ -1,0 +1,100 @@
+"""Production wiring for proof-eligible evolve completion providers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.evolution.provider_usage import (
+    capture_generation_provider_usage,
+    tracked_complete,
+)
+from ouroboros.mcp.server.adapter import create_ouroboros_server
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.providers.base import CompletionConfig, CompletionResponse, UsageInfo
+import ouroboros.providers.credential_authority as credential_authority_module
+from ouroboros.providers.factory import create_llm_adapter as real_create_llm_adapter
+from ouroboros.providers.frugality_attestation import PreparedFrugalityCompletion
+
+litellm_adapter_module = pytest.importorskip("ouroboros.providers.litellm_adapter")
+LiteLLMAdapter = litellm_adapter_module.LiteLLMAdapter
+
+
+@pytest.mark.asyncio
+async def test_public_evolve_factory_emits_complete_litellm_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public handler must receive the real factory's proof-safe producer."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "low-entropy-production-key")
+    monkeypatch.setattr(
+        credential_authority_module,
+        "installation_authority_key",
+        lambda: b"i" * 32,
+    )
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+
+    with (
+        patch(
+            "ouroboros.orchestrator.create_agent_runtime",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "ouroboros.providers.create_llm_adapter",
+            wraps=real_create_llm_adapter,
+        ) as factory,
+    ):
+        server = create_ouroboros_server(
+            event_store=store,
+            state_dir=tmp_path / "state",
+            runtime_backend="codex",
+            llm_backend="litellm",
+        )
+
+    try:
+        handler = server._tool_handlers["ouroboros_evolve_step"]
+        adapter = handler.evolutionary_loop.reflect_engine.llm_adapter
+        assert isinstance(adapter, LiteLLMAdapter)
+        assert adapter._max_retries == 1
+        assert handler.evolutionary_loop.wonder_engine.llm_adapter is adapter
+        proof_factory_calls = [
+            call for call in factory.call_args_list if call.kwargs.get("frugality_proof") is True
+        ]
+        assert len(proof_factory_calls) == 2
+        assert all(call.kwargs["backend"] == "litellm" for call in proof_factory_calls)
+
+        async def complete_prepared(
+            messages: object,
+            prepared: PreparedFrugalityCompletion,
+        ) -> Result[CompletionResponse, object]:
+            del messages
+            return Result.ok(
+                CompletionResponse(
+                    content="{}",
+                    model=prepared.config.model,
+                    usage=UsageInfo(
+                        prompt_tokens=8,
+                        completion_tokens=2,
+                        total_tokens=10,
+                    ),
+                )
+            )
+
+        monkeypatch.setattr(adapter, "frugality_complete_prepared", complete_prepared)
+        with capture_generation_provider_usage() as capture:
+            result = await tracked_complete(
+                adapter,
+                [],
+                CompletionConfig(model="anthropic/claude-test", role="reflect"),
+            )
+
+        assert result.is_ok
+        summary = capture.summary()
+        assert summary.complete is True
+        assert summary.call_count == 1
+        assert summary.token_spend == 10
+    finally:
+        await server.shutdown()

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2392,6 +2392,22 @@ class TestAsyncJobHandlers:
         assert "not JSON-shaped text or an object literal" in start_seed.description
         assert "before Ouroboros receives it" in start_seed.description
 
+    def test_evolve_step_exposes_isolation_gated_benchmark_control(self) -> None:
+        evolve_params = {
+            parameter.name: parameter for parameter in EvolveStepHandler().definition.parameters
+        }
+        start_params = {
+            parameter.name: parameter
+            for parameter in StartEvolveStepHandler().definition.parameters
+        }
+
+        benchmark = evolve_params["benchmark_control"]
+        assert benchmark.type == ToolInputType.BOOLEAN
+        assert benchmark.default is False
+        assert "Gen 2+" in benchmark.description
+        assert "clean baseline" in benchmark.description
+        assert start_params["benchmark_control"] == benchmark
+
     def test_evolve_step_has_no_fixed_mcp_timeout_by_default(self) -> None:
         """evolve_step uses progress-aware controls rather than a hard 2h wall clock."""
         handler = EvolveStepHandler()

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     UnmaterializableSuccessContractError,
     bind_capsule_to_runtime_handle,
     build_ac_dispatch_authority_scope,
+    build_ac_dispatch_request_digest,
     compile_ac_execution_capsule,
 )
 from ouroboros.orchestrator.ac_runtime_handle_manager import (
@@ -574,6 +575,40 @@ def test_dispatch_authority_scope_distinguishes_absent_and_empty_tool_catalog() 
     assert absent != empty
 
 
+def test_dispatch_request_digest_binds_cross_worktree_provider_authority() -> None:
+    dispatch = {
+        "tools": ["Read"],
+        "tool_catalog": {"present": True, "entries": [{"name": "Read"}]},
+        "system_prompt": "system",
+    }
+    policy = {"reasoning_effort": "high"}
+    original = build_ac_dispatch_request_digest(
+        dispatch_contract=dispatch,
+        execution_policy=policy,
+    )
+    changed_tool = build_ac_dispatch_request_digest(
+        dispatch_contract={**dispatch, "tools": ["Read", "Edit"]},
+        execution_policy=policy,
+    )
+    changed_system = build_ac_dispatch_request_digest(
+        dispatch_contract={**dispatch, "system_prompt": "different"},
+        execution_policy=policy,
+    )
+    changed_policy = build_ac_dispatch_request_digest(
+        dispatch_contract=dispatch,
+        execution_policy={"reasoning_effort": "low"},
+    )
+    repeated = build_ac_dispatch_request_digest(
+        dispatch_contract=dict(reversed(tuple(dispatch.items()))),
+        execution_policy=dict(policy),
+    )
+
+    assert original != changed_tool
+    assert original != changed_system
+    assert original != changed_policy
+    assert original == repeated
+
+
 def test_context_reference_rejects_prompt_control_characters() -> None:
     with pytest.raises(ValueError, match="control characters"):
         ACContextReference(
@@ -729,6 +764,7 @@ async def test_capsule_dispatch_lifecycle_is_durable_and_ordered(tmp_path) -> No
         execution_id="execution-1",
         session_id="session-1",
         capsule_fingerprint=capsule.fingerprint,
+        request_authority_digest="sha256:" + "f" * 64,
         session_origin="fresh",
         runtime_handle=handle,
     )
@@ -1284,6 +1320,7 @@ async def test_session_signal_follow_up_dispatch_links_predecessor(tmp_path) -> 
         execution_id="execution-1",
         session_id="session-1",
         capsule_fingerprint=capsule.fingerprint,
+        request_authority_digest="sha256:" + "f" * 64,
         session_origin="fresh",
         runtime_handle=handle,
     )
@@ -1294,6 +1331,7 @@ async def test_session_signal_follow_up_dispatch_links_predecessor(tmp_path) -> 
         execution_id="execution-1",
         session_id="session-1",
         capsule_fingerprint=capsule.fingerprint,
+        request_authority_digest="sha256:" + "f" * 64,
         session_origin="restored_same_attempt",
         runtime_handle=replace(handle, metadata={**handle.metadata, "ac_dispatch_id": "2" * 32}),
         dispatch_kind="session_signal_followup",

--- a/tests/unit/orchestrator/test_coordinator.py
+++ b/tests/unit/orchestrator/test_coordinator.py
@@ -554,6 +554,17 @@ class _StubCoordinatorRuntime:
     def permission_mode(self) -> str | None:
         return self._permission_mode
 
+    def frugality_runtime_attestation(self) -> Mapping[str, object]:
+        implementation = f"{type(self).__module__}.{type(self).__qualname__}"
+        return {
+            "schema_version": 1,
+            "schema_id": "test.coordinator_runtime.v1",
+            "implementation": implementation,
+            "runtime_backend": "opencode",
+            "runtime_handle_backend": "opencode",
+            "settings": {"fixture": "coordinator"},
+        }
+
     async def execute_task(
         self,
         prompt: str,
@@ -890,6 +901,58 @@ class TestParseReviewResponse:
 
 class TestRunReview:
     """Tests for LevelCoordinator.run_review()."""
+
+    @pytest.mark.asyncio
+    async def test_review_usage_is_included_in_generation_total(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from ouroboros.evolution import provider_usage as provider_usage_module
+        from ouroboros.evolution.provider_usage import capture_generation_provider_usage
+
+        runtime_class = (
+            f"{_StubCoordinatorRuntime.__module__}.{_StubCoordinatorRuntime.__qualname__}"
+        )
+        monkeypatch.setitem(
+            provider_usage_module._AGENT_RUNTIME_SCHEMAS,
+            runtime_class,
+            provider_usage_module._AgentRuntimeSchema(
+                schema_id="test.coordinator_runtime.v1",
+                runtime_backend="opencode",
+                runtime_handle_backend="opencode",
+                setting_kinds={"fixture": "text"},
+            ),
+        )
+
+        runtime = _StubCoordinatorRuntime(
+            (
+                AgentMessage(
+                    type="result",
+                    content='{"review_summary":"Reviewed","fixes_applied":[],"warnings_for_next_level":[],"conflicts_resolved":[]}',
+                    data={
+                        "subtype": "success",
+                        "model_observation": {"effective_model": "test-model"},
+                        "usage": {"total_tokens": 80},
+                    },
+                ),
+            )
+        )
+        runtime.llm_backend = "test-provider"
+        runtime._model = "test-model"
+        coordinator = LevelCoordinator(runtime)
+
+        with capture_generation_provider_usage() as capture:
+            await coordinator.run_review(
+                execution_id="exec_measured",
+                conflicts=[FileConflict(file_path="src/app.py", ac_indices=(0, 1))],
+                level_context=LevelContext(level_number=1, completed_acs=()),
+                level_number=1,
+            )
+
+        summary = capture.summary()
+        assert summary.complete is True
+        assert summary.call_count == 1
+        assert summary.token_spend == 80
 
     @pytest.mark.asyncio
     async def test_run_review_announces_param_degradation(self):

--- a/tests/unit/orchestrator/test_dependency_analyzer.py
+++ b/tests/unit/orchestrator/test_dependency_analyzer.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
 
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
+from ouroboros.evolution import provider_usage as provider_usage_module
+from ouroboros.evolution.provider_usage import capture_generation_provider_usage
 from ouroboros.orchestrator.dependency_analyzer import (
     ACDependencySpec,
     ACNode,
@@ -18,7 +21,13 @@ from ouroboros.orchestrator.dependency_analyzer import (
     ExecutionStage,
     HybridExecutionPlanner,
 )
-from ouroboros.providers.base import CompletionResponse, UsageInfo
+from ouroboros.providers.base import CompletionConfig, CompletionResponse, UsageInfo
+from ouroboros.providers.frugality_attestation import (
+    PreparedFrugalityCompletion,
+    credential_authority_digest,
+    effective_completion_request,
+)
+from ouroboros.providers.profiles import ResolvedCompletionProfile
 
 
 class StubLLMAdapter:
@@ -27,6 +36,33 @@ class StubLLMAdapter:
     def __init__(self, content: str | None = None, error: ProviderError | None = None) -> None:
         self._content = content
         self._error = error
+
+    def frugality_prepare_completion(
+        self,
+        config: CompletionConfig,
+    ) -> Result[PreparedFrugalityCompletion, ProviderError]:
+        resolved = ResolvedCompletionProfile(config=config)
+        return Result.ok(
+            PreparedFrugalityCompletion(
+                config=replace(config, role=None, profile=None),
+                contract={
+                    "schema_version": 1,
+                    "schema_id": "test.dependency-adapter.v1",
+                    "internal_attempt_limit": 1,
+                    "credential_authority": credential_authority_digest("test-credential"),
+                    "effective_request": effective_completion_request(
+                        resolved,
+                        provider_model=config.model,
+                    ),
+                    "settings": {
+                        "api_base": "https://provider.example/v1",
+                        "timeout": 30.0,
+                        "max_retries": 1,
+                        "io_recorder_configured": False,
+                    },
+                },
+            )
+        )
 
     async def complete(
         self, messages: list[Any], config: Any
@@ -41,6 +77,21 @@ class StubLLMAdapter:
                 usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
             )
         )
+
+
+@pytest.fixture(autouse=True)
+def _register_stub_completion_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter_class = f"{StubLLMAdapter.__module__}.{StubLLMAdapter.__qualname__}"
+    monkeypatch.setitem(
+        provider_usage_module._COMPLETION_ADAPTER_SCHEMAS,
+        adapter_class,
+        provider_usage_module._CompletionAdapterSchema(
+            schema_id="test.dependency-adapter.v1",
+            settings=frozenset({"api_base", "timeout", "max_retries", "io_recorder_configured"}),
+            retry_setting="max_retries",
+            proof_retry_value=1,
+        ),
+    )
 
 
 def _empty_dependency_response(ac_count: int) -> str:
@@ -139,6 +190,22 @@ class TestDependencyAnalyzer:
         assert graph.serialized_indices == expected_serialized
         for ac_index, expected in expected_dependencies.items():
             assert graph.get_dependencies(ac_index) == expected
+
+    @pytest.mark.asyncio
+    async def test_llm_analysis_is_included_in_generation_provider_usage(self) -> None:
+        analyzer = DependencyAnalyzer(
+            llm_adapter=StubLLMAdapter(_empty_dependency_response(2)),
+            model="test-model",
+        )
+
+        with capture_generation_provider_usage() as capture:
+            result = await analyzer.analyze(("first", "second"))
+
+        assert result.is_ok
+        summary = capture.summary()
+        assert summary.complete is True
+        assert summary.call_count == 1
+        assert summary.token_spend == 2
 
     @pytest.mark.asyncio
     async def test_analyze_uses_prerequisites_and_metadata_dependencies(self) -> None:

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -107,8 +107,16 @@ def _claude_router() -> ModelRouter:
     return router
 
 
-def _claude_result(usage: dict | None = None, content: str = "[TASK_COMPLETE]") -> AgentMessage:
-    data: dict = {"subtype": "success"}
+def _claude_result(
+    usage: dict | None = None,
+    content: str = "[TASK_COMPLETE]",
+    *,
+    effective_model: str = "test-model",
+) -> AgentMessage:
+    data: dict = {
+        "subtype": "success",
+        "model_observation": {"effective_model": effective_model},
+    }
     if usage is not None:
         data["usage"] = usage
     return AgentMessage(type="result", content=content, data=data)
@@ -117,7 +125,13 @@ def _claude_result(usage: dict | None = None, content: str = "[TASK_COMPLETE]") 
 def _codex_turn_completed(usage: dict) -> AgentMessage:
     # Mirrors codex_cli_runtime: a ``turn.completed`` system message carrying usage.
     return AgentMessage(
-        type="system", content="", data={"subtype": "turn.completed", "usage": usage}
+        type="system",
+        content="",
+        data={
+            "subtype": "turn.completed",
+            "model_observation": {"effective_model": "test-model"},
+            "usage": usage,
+        },
     )
 
 
@@ -200,7 +214,7 @@ class _EnforcedModelUsageRuntime:
         model: str | None = None,
     ):
         self.received_model = model
-        yield _claude_result(self._usage)
+        yield _claude_result(self._usage, effective_model=model or "test-model")
 
 
 def _token_events(events: list) -> list:
@@ -239,6 +253,29 @@ async def _run_one_ac(
 # -- Producer 1: token attribution (seed AC2) --------------------------------
 class TestTokenAttribution:
     @pytest.mark.asyncio
+    async def test_dispatch_authority_binds_verify_command_policy(self) -> None:
+        """Different provider instructions cannot share frugality authority."""
+        digests: list[str] = []
+        for run_verify_commands in (True, False):
+            store, events = _capturing_event_store()
+            executor = ParallelACExecutor(
+                adapter=_ScriptedRuntime([_claude_result({"total_tokens": 10})]),
+                event_store=store,
+                console=MagicMock(),
+                enable_decomposition=False,
+                run_verify_commands=run_verify_commands,
+            )
+
+            await _run_one_ac(executor)
+
+            dispatch = next(
+                event for event in events if event.type == "execution.ac.attempt.dispatched"
+            )
+            digests.append(dispatch.data["request_authority_digest"])
+
+        assert digests[0] != digests[1]
+
+    @pytest.mark.asyncio
     async def test_summed_spend_from_multi_usage_stream(self) -> None:
         # A Claude result usage plus a Codex turn.completed usage in one stream are
         # summed — a child's full spend is attributed even when reported in pieces.
@@ -258,7 +295,7 @@ class TestTokenAttribution:
                         "output_tokens": 20,
                         "cache_creation_input_tokens": 50,
                         "cache_read_input_tokens": 25,
-                        "total_tokens": 140,
+                        "total_tokens": 195,
                     }
                 ),
             ]
@@ -277,14 +314,14 @@ class TestTokenAttribution:
         data = token[0].data
         # Per-message semantics: Codex cached_input_tokens is already included in
         # input_tokens, while Claude's explicit total wins over its components.
-        assert data["token_spend"] == pytest.approx(30 + 7 + 140)
+        assert data["token_spend"] == pytest.approx(30 + 7 + 195)
         # usage_breakdown carries the summed per-key totals.
         assert data["usage_breakdown"]["input_tokens"] == pytest.approx(130)
         assert data["usage_breakdown"]["output_tokens"] == pytest.approx(27)
         assert data["usage_breakdown"]["cached_input_tokens"] == pytest.approx(12)
         assert data["usage_breakdown"]["cache_creation_input_tokens"] == pytest.approx(50)
         assert data["usage_breakdown"]["cache_read_input_tokens"] == pytest.approx(25)
-        assert data["usage_breakdown"]["total_tokens"] == pytest.approx(140)
+        assert data["usage_breakdown"]["total_tokens"] == pytest.approx(195)
         assert data["token_source"] == "runtime_usage"
 
     @pytest.mark.asyncio
@@ -376,8 +413,25 @@ class TestTokenAttribution:
             {"total_tokens": float("nan"), "input_tokens": 10, "output_tokens": 2},
             {"input_tokens": 10, "output_tokens": -1},
             {"input_tokens": 10, "output_tokens": 10**10_000},
+            {"input_tokens": 100, "output_tokens": 50, "total_tokens": 1},
+            {"input_tokens": 10, "output_tokens": 5, "reasoning_tokens": 200},
+            {"input_tokens": 10.5, "output_tokens": 5},
+            {"input_tokens": 10},
+            {"output_tokens": 5},
+            {"cache_read_input_tokens": 8},
         ],
-        ids=["non-mapping", "invalid-total-no-fallback", "negative", "overflow"],
+        ids=[
+            "non-mapping",
+            "invalid-total-no-fallback",
+            "negative",
+            "overflow",
+            "inconsistent-total",
+            "unknown-token-counter",
+            "fractional-counter",
+            "missing-output-counter",
+            "missing-input-counter",
+            "cache-only-counter",
+        ],
     )
     async def test_any_malformed_usage_shape_emits_no_attribution(self, usage: object) -> None:
         store, events = _capturing_event_store()
@@ -463,11 +517,61 @@ class TestTokenAttribution:
         assert data["is_decomposed_child"] is True
         assert data["model_tier"] == "frugal"
         assert data["model"] == "haiku-x"
+        assert data["effective_model"] == "haiku-x"
         assert data["model_mode"] == "enforced"
         assert data["effort_level"] == "high"  # child inherits parent effort unchanged
         assert data["runtime_backend"] == "claude"
         # ac_id is present so the proof can join token × effort × grounding.
         assert data["ac_id"]
+        dispatch = next(
+            event for event in events if event.type == "execution.ac.attempt.dispatched"
+        )
+        assert data["request_authority_digest"] == dispatch.data["request_authority_digest"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("observation_case", ["missing", "unknown", "conflicting"])
+    async def test_effective_model_observation_is_required_for_primary_attribution(
+        self,
+        observation_case: str,
+    ) -> None:
+        store, events = _capturing_event_store()
+        observations: list[AgentMessage] = []
+        if observation_case == "unknown":
+            observations.append(
+                AgentMessage(
+                    type="system",
+                    content="",
+                    data={"model_observation": {"effective_model": " Unknown "}},
+                )
+            )
+        elif observation_case == "conflicting":
+            observations.extend(
+                [
+                    AgentMessage(
+                        type="system",
+                        content="",
+                        data={"model_observation": {"effective_model": model}},
+                    )
+                    for model in ("model-a", "model-b")
+                ]
+            )
+        observations.append(
+            AgentMessage(
+                type="result",
+                content="done",
+                data={"subtype": "success", "usage": {"total_tokens": 10}},
+            )
+        )
+        executor = ParallelACExecutor(
+            adapter=_ScriptedRuntime(observations),
+            event_store=store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        await _run_one_ac(executor)
+
+        assert _token_events(events) == []
 
     @pytest.mark.asyncio
     async def test_failure_path_still_emits_when_usage_present(self) -> None:
@@ -479,7 +583,10 @@ class TestTokenAttribution:
                 AgentMessage(
                     type="assistant",
                     content="",
-                    data={"usage": {"input_tokens": 12, "output_tokens": 3}},
+                    data={
+                        "model_observation": {"effective_model": "test-model"},
+                        "usage": {"input_tokens": 12, "output_tokens": 3},
+                    },
                 )
             ],
             raise_after=True,
@@ -1423,6 +1530,59 @@ class TestFrugalityProofConsumer:
 
 # -- End-to-end honesty check: produced events → contract match --------------
 class TestProducedEventsMatchProofContract:
+    @pytest.mark.asyncio
+    async def test_token_and_deliver_receipts_bind_primary_dispatch_id(self) -> None:
+        executor, events = _deliver_executor()
+        identity = _runtime_identity()
+        dispatch_id = "d" * 32
+        await executor._event_emitter.emit_ac_attempt_dispatched(
+            runtime_identity=identity,
+            dispatch_id=dispatch_id,
+            previous_dispatch_id=None,
+            execution_id="exec_frugal",
+            session_id="sess_frugal",
+            capsule_fingerprint="sha256:" + "a" * 64,
+            request_authority_digest="sha256:" + "f" * 64,
+            session_origin="fresh",
+            runtime_handle=None,
+        )
+        await executor._event_emitter.emit_deliver_verdict(
+            runtime_identity=identity,
+            execution_id="exec_frugal",
+            session_id="sess_frugal",
+            is_sub_ac=True,
+            traceguard_verdict="accepted",
+            unsupported_claim_rate=0.0,
+            rejected_reasons=[],
+            accepted_fact_count=1,
+            grounding_regression=False,
+        )
+        await executor._event_emitter.emit_token_attribution(
+            runtime_identity=identity,
+            execution_id="exec_frugal",
+            session_id="sess_frugal",
+            ac_index=1,
+            is_sub_ac=True,
+            retry_attempt=0,
+            token_spend=10,
+            usage_breakdown={"total_tokens": 10},
+            model="test-model",
+            effective_model="test-model",
+            model_tier="frugal",
+            model_mode="enforced",
+            effort_level=None,
+            runtime_backend="test",
+            request_authority_digest="sha256:" + "f" * 64,
+        )
+
+        proof_receipts = [
+            event
+            for event in events
+            if event.type in {EVENT_DELIVER_VERDICT, EVENT_TOKEN_ATTRIBUTION}
+        ]
+        assert len(proof_receipts) == 2
+        assert {event.data["ac_dispatch_id"] for event in proof_receipts} == {dispatch_id}
+
     @pytest.mark.asyncio
     async def test_live_default_reasoning_none_events_and_final_marker_count(self) -> None:
         """The shipped ``reasoning_effort=None`` path can prove model-tier lowering.

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -16333,6 +16333,71 @@ async def test_try_decompose_ac_replaces_goose_chunks_with_final_result() -> Non
 
 
 @pytest.mark.asyncio
+async def test_decomposition_policy_usage_is_included_in_generation_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ouroboros.evolution import provider_usage as provider_usage_module
+    from ouroboros.evolution.provider_usage import capture_generation_provider_usage
+
+    class _MeasuredRuntime:
+        runtime_backend = "goose"
+        llm_backend = "test-provider"
+        _model = "test-model"
+
+        def frugality_runtime_attestation(self) -> dict[str, object]:
+            implementation = f"{type(self).__module__}.{type(self).__qualname__}"
+            return {
+                "schema_version": 1,
+                "schema_id": "test.decomposition_runtime.v1",
+                "implementation": implementation,
+                "runtime_backend": "goose",
+                "runtime_handle_backend": "goose",
+                "settings": {"fixture": "decomposition"},
+            }
+
+        async def execute_task(self, **kwargs):  # noqa: ANN201, ARG002
+            yield AgentMessage(
+                type="result",
+                content='["Sub-AC 1: inspect", "Sub-AC 2: test"]',
+                data={
+                    "model_observation": {"effective_model": "test-model"},
+                    "usage": {"total_tokens": 150},
+                },
+            )
+
+    runtime_class = f"{_MeasuredRuntime.__module__}.{_MeasuredRuntime.__qualname__}"
+    monkeypatch.setitem(
+        provider_usage_module._AGENT_RUNTIME_SCHEMAS,
+        runtime_class,
+        provider_usage_module._AgentRuntimeSchema(
+            schema_id="test.decomposition_runtime.v1",
+            runtime_backend="goose",
+            runtime_handle_backend="goose",
+            setting_kinds={"fixture": "text"},
+        ),
+    )
+
+    executor = ParallelACExecutor(
+        adapter=_MeasuredRuntime(),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=True,
+    )
+
+    with capture_generation_provider_usage() as capture:
+        response = await executor._dispatch_decomposition_prompt(
+            prompt="Investigate and test sub-AC behavior.",
+            system_prompt="system",
+        )
+
+    assert response == '["Sub-AC 1: inspect", "Sub-AC 2: test"]'
+    summary = capture.summary()
+    assert summary.complete is True
+    assert summary.call_count == 1
+    assert summary.token_spend == 150
+
+
+@pytest.mark.asyncio
 async def test_try_decompose_ac_accumulates_goose_stream_chunks() -> None:
     """Goose stream-json emits token chunks; decomposition must parse accumulated output."""
 

--- a/tests/unit/orchestrator/test_shadow_replay.py
+++ b/tests/unit/orchestrator/test_shadow_replay.py
@@ -321,10 +321,12 @@ class _EmitterHarness:
             token_spend=spend,
             usage_breakdown={"input_tokens": spend},
             model="haiku-x",
+            effective_model="haiku-x",
             model_tier="frugal",
             model_mode="enforced",
             effort_level="high",
             runtime_backend="claude",
+            request_authority_digest="sha256:" + "f" * 64,
         )
         await self.emitter.emit_deliver_verdict(
             runtime_identity=identity,

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -194,6 +194,21 @@ class TestCreateLLMAdapter:
         adapter = create_llm_adapter(backend="litellm")
         assert isinstance(adapter, LiteLLMAdapter)
 
+    def test_litellm_frugality_proof_is_task_local(self) -> None:
+        """Proof construction must not change ordinary LiteLLM policies."""
+        if LiteLLMAdapter is None:
+            pytest.skip("litellm not installed")
+
+        ordinary = create_llm_adapter(backend="litellm")
+        proof = create_llm_adapter(backend="litellm", frugality_proof=True)
+
+        assert isinstance(ordinary, LiteLLMAdapter)
+        assert ordinary._max_retries == 3
+        assert ordinary._timeout is None
+        assert isinstance(proof, LiteLLMAdapter)
+        assert proof._max_retries == 1
+        assert proof._timeout == 60.0
+
     def test_forwards_io_recorder_to_litellm_adapter(self) -> None:
         """LiteLLM factory path preserves explicit recorder wiring."""
         if LiteLLMAdapter is None:

--- a/tests/unit/providers/test_litellm_proof_worker.py
+++ b/tests/unit/providers/test_litellm_proof_worker.py
@@ -6,6 +6,10 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip("httpx")
+pytest.importorskip("litellm")
+pytest.importorskip("openai")
+
 from ouroboros.evolution.provider_usage import (
     capture_generation_provider_usage,
     tracked_complete,

--- a/tests/unit/providers/test_litellm_proof_worker.py
+++ b/tests/unit/providers/test_litellm_proof_worker.py
@@ -1,0 +1,202 @@
+"""The LiteLLM proof worker owns one sealed effect boundary."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from ouroboros.evolution.provider_usage import (
+    capture_generation_provider_usage,
+    tracked_complete,
+)
+from ouroboros.providers import litellm_adapter
+from ouroboros.providers import litellm_proof_worker as worker
+from ouroboros.providers.base import CompletionConfig
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "protocol": worker._PROOF_WORKER_PROTOCOL,
+        "client_type": "openai.AsyncOpenAI",
+        "completion_kwargs": {
+            "api_base": "https://provider.example/v1",
+            "api_key": "credential-a",
+            "max_retries": 0,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "openai/gpt-test",
+            "temperature": 0.0,
+            "timeout": 30.0,
+            "top_p": 1.0,
+        },
+        "config": {
+            "model": "openai/gpt-test",
+            "temperature": 0.0,
+            "max_tokens": 64,
+            "stop": None,
+            "top_p": 1.0,
+            "response_format": None,
+            "role": None,
+            "profile": None,
+            "max_turns": None,
+            "reasoning_effort": None,
+            "model_is_explicit": True,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_worker_passes_the_sealed_client_to_litellm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    async def completion(**kwargs: object) -> object:
+        observed.update(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(content="done"),
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            model="openai/gpt-test",
+            model_dump=lambda: {},
+        )
+
+    monkeypatch.setattr(worker.litellm, "acompletion", completion)
+
+    report = await worker._run(_payload())
+
+    assert report["ok"] is True
+    assert observed["client"] is not None
+    assert observed["api_key"] == "credential-a"
+    assert observed["api_base"] == "https://provider.example/v1"
+    assert observed["max_retries"] == 0
+    proof = report["proof"]
+    assert isinstance(proof, dict)
+    assert proof["authority_verified"] is True
+    assert proof["client_cleanup_succeeded"] is True
+    assert proof["client_type"] == "openai.AsyncOpenAI"
+    assert proof["worker_executable_resolved_path"]
+    assert len(proof["worker_executable_content_sha256"]) == 64
+    assert proof["worker_python_version"]
+    assert proof["worker_module"] == "ouroboros.providers.litellm_proof_worker"
+    assert len(proof["worker_implementation_sha256"]) == 64
+    assert proof["adapter_module"] == "ouroboros.providers.litellm_adapter"
+    assert len(proof["adapter_implementation_sha256"]) == 64
+    assert proof["ouroboros_implementation_contract"] == "ouroboros.python-sources.v1"
+    assert len(proof["ouroboros_implementation_sha256"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_unregistered_payload_fields() -> None:
+    payload = _payload()
+    payload["ambient_authority"] = "parent"
+
+    report = await worker._run(payload)
+
+    assert report["ok"] is False
+    assert report["response"] is None
+
+
+@pytest.mark.asyncio
+async def test_real_worker_isolates_sub_poll_parent_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_received: dict[str, object] = {}
+
+    async def serve_completion(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        header = await reader.readuntil(b"\r\n\r\n")
+        content_length = 0
+        for line in header.decode("latin-1").split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":", 1)[1].strip())
+        request_received["payload"] = json.loads(await reader.readexactly(content_length))
+        body = json.dumps(
+            {
+                "id": "completion-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "gpt-test",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "done"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                },
+            }
+        ).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            + f"Content-Length: {len(body)}\r\n".encode()
+            + b"Connection: close\r\n\r\n"
+            + body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(serve_completion, "127.0.0.1", 0)
+    address = server.sockets[0].getsockname()
+    adapter = litellm_adapter.LiteLLMAdapter(
+        api_key="credential-a",
+        api_base=f"http://127.0.0.1:{address[1]}/v1",
+        frugality_proof=True,
+    )
+    worker_started = asyncio.Event()
+    create_process = litellm_adapter.asyncio.create_subprocess_exec
+
+    async def observed_create_process(*args: object, **kwargs: object) -> object:
+        process = await create_process(*args, **kwargs)
+        worker_started.set()
+        return process
+
+    async def mutate_and_restore() -> None:
+        await worker_started.wait()
+        litellm_adapter.litellm.modify_params = True
+        litellm_adapter.litellm.modify_params = False
+
+    monkeypatch.setattr(
+        litellm_adapter.asyncio,
+        "create_subprocess_exec",
+        observed_create_process,
+    )
+    mutation = asyncio.create_task(mutate_and_restore())
+    try:
+        with capture_generation_provider_usage() as capture:
+            result = await tracked_complete(
+                adapter,
+                [],
+                CompletionConfig(model="openai/gpt-test", role="reflect"),
+            )
+        await mutation
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert result.is_ok
+    assert result.value.content == "done"
+    assert request_received["payload"] == {
+        "messages": [],
+        "model": "gpt-test",
+        "temperature": 0.7,
+        "max_tokens": 4096,
+        "top_p": 1.0,
+    }
+    summary = capture.summary()
+    assert summary.call_count == 1
+    assert summary.token_spend is None
+    assert summary.complete is False

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -490,6 +490,7 @@ class TestConvergenceGating:
                 ACResult(ac_index=0, ac_content="AC zero", passed=True),
                 ACResult(ac_index=1, ac_content="AC one", passed=False),
             ),
+            latest_seed=seed,
         )
 
         signal = ConvergenceCriteria(

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -5,6 +5,7 @@ from dataclasses import fields, replace
 import inspect
 import json
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,7 +35,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.core.types import Result
-from ouroboros.core.worktree import WorktreeError
+from ouroboros.core.worktree import TaskWorkspace, WorktreeError
 from ouroboros.events.lineage import (
     lineage_created,
     lineage_generation_completed,
@@ -237,6 +238,34 @@ async def seed_events_for_gen1(
     )
 
 
+def create_clean_git_project(path: Path) -> Path:
+    """Create one committed project for public benchmark-control tests."""
+    path.mkdir()
+    commands = (
+        ("init",),
+        ("config", "user.email", "tests@example.com"),
+        ("config", "user.name", "Ouroboros Tests"),
+    )
+    for command in commands:
+        subprocess.run(
+            ["git", *command],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    (path / "README.md").write_text("benchmark fixture\n", encoding="utf-8")
+    for command in (("add", "README.md"), ("commit", "-m", "test baseline")):
+        subprocess.run(
+            ["git", *command],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return path
+
+
 # -- Test Classes --
 
 
@@ -291,7 +320,12 @@ class TestEvolutionaryLoopConfig:
 
         base_policy = loop_support.evolution_execution_policy(base)
         assert base_policy is not None
-        assert set(base_policy) == declared_fields
+        effective_fields = {
+            "benchmark_control",
+            "effective_focused_evolution",
+            "effective_scoped_reexecution",
+        }
+        assert set(base_policy) == declared_fields | effective_fields
         core_key = loop_support.evolve_request_key(
             None,
             execute=True,
@@ -305,6 +339,41 @@ class TestEvolutionaryLoopConfig:
             configured_project_dir=None,
             fallback_cwd=Path.cwd().resolve(),
             execution_policy=base_policy,
+        )
+        control_policy = loop_support.evolution_execution_policy(base, True)
+        assert control_policy is not None
+        assert control_policy["benchmark_control"] is True
+        assert control_policy["effective_focused_evolution"] is False
+        assert control_policy["effective_scoped_reexecution"] is False
+        assert control_policy != base_policy
+        assert (
+            loop_support.evolve_request_key(
+                None,
+                execute=True,
+                parallel=True,
+                conductor_directive=None,
+                generation_number=2,
+                execution_policy=control_policy,
+            )
+            != core_key
+        )
+        assert (
+            _evolve_handler_request_key(
+                {"lineage_id": "lin_policy", "benchmark_control": True},
+                configured_project_dir=None,
+                fallback_cwd=Path.cwd().resolve(),
+                execution_policy=control_policy,
+            )
+            != handler_key
+        )
+        assert (
+            _evolve_handler_request_key(
+                {"lineage_id": "lin_policy", "benchmark_control": False},
+                configured_project_dir=None,
+                fallback_cwd=Path.cwd().resolve(),
+                execution_policy=base_policy,
+            )
+            == handler_key
         )
 
         for field_name, alternative in alternatives.items():
@@ -377,6 +446,28 @@ class TestEvolutionaryLoopConfig:
         config = EvolutionaryLoopConfig(runtime_controls=controls)
 
         assert config.runtime_controls == controls
+
+    @pytest.mark.asyncio
+    async def test_benchmark_execution_policy_is_task_local(self) -> None:
+        config = EvolutionaryLoopConfig(focused_evolution=True, scoped_reexecution=True)
+        barrier = asyncio.Barrier(2)
+
+        async def observe(benchmark_control: bool) -> tuple[bool, bool, bool]:
+            with loop_support.evolution_execution_policy_context(config, benchmark_control):
+                await barrier.wait()
+                policy = loop_support.current_evolution_execution_policy(config)
+                return (
+                    policy.benchmark_control,
+                    policy.focused_evolution,
+                    policy.scoped_reexecution,
+                )
+
+        normal, control = await asyncio.gather(observe(False), observe(True))
+
+        assert normal == (False, True, True)
+        assert control == (True, False, False)
+        assert config.focused_evolution is True
+        assert config.scoped_reexecution is True
 
     def test_explicit_absolute_project_shadows_config_and_cwd_in_handler_identity(
         self,
@@ -2852,6 +2943,44 @@ class TestLineageStatusHandler:
 
         assert result.is_err
 
+    @pytest.mark.asyncio
+    async def test_returns_latest_frugality_proof(self) -> None:
+        """Status exposes proof state without treating node shrinkage as PASS."""
+        from ouroboros.events.base import BaseEvent
+        from ouroboros.evolution.frugality import (
+            PROOF_EVENT,
+            EvolutionFrugalityProof,
+            EvolutionFrugalityStatus,
+        )
+        from ouroboros.mcp.tools.definitions import LineageStatusHandler
+
+        store = await create_event_store()
+        seed = make_seed()
+        await seed_events_for_gen1(store, "lin_status_frugal", seed, make_eval_summary())
+        proof = EvolutionFrugalityProof(
+            status=EvolutionFrugalityStatus.INSUFFICIENT_DATA,
+            comparison_key="sha256:test",
+            treatment_receipt_id="lin_status_frugal:generation:2",
+            reason="matching isolated full-graph/focused receipt not found",
+        )
+        await store.append(
+            BaseEvent(
+                type=PROOF_EVENT,
+                aggregate_type="lineage",
+                aggregate_id="lin_status_frugal",
+                data={"generation_number": 2, "proof": proof.model_dump(mode="json")},
+            )
+        )
+        handler = LineageStatusHandler(event_store=store)
+        handler._event_store = store
+        handler._initialized = True
+
+        result = await handler.handle({"lineage_id": "lin_status_frugal"})
+
+        assert result.is_ok
+        assert "Frugality proof**: insufficient_data" in result.value.text_content
+        assert result.value.meta["frugality"]["status"] == "insufficient_data"
+
 
 class TestEvolveStepHandler:
     """Test EvolveStepHandler MCP tool."""
@@ -2894,6 +3023,171 @@ class TestEvolveStepHandler:
         assert result.value.meta["action"] == "converged"
         assert result.value.meta["converged"] is True
         assert result.value.meta["qa_attempted"] is False
+
+    @pytest.mark.asyncio
+    async def test_public_benchmark_control_isolation_gates_fail_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_benchmark_gates")
+        for lineage_id in ("lin_missing_project", "lin_no_execute", "lin_dirty_project"):
+            await seed_events_for_gen1(store, lineage_id, seed, make_eval_summary(False))
+        clean_project = create_clean_git_project(tmp_path / "clean-project")
+        dirty_project = create_clean_git_project(tmp_path / "dirty-project")
+        (dirty_project / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+        handler = EvolveStepHandler(evolutionary_loop=make_loop(store), event_store=store)
+
+        missing_project = await handler.handle(
+            {"lineage_id": "lin_missing_project", "benchmark_control": True}
+        )
+        no_execute = await handler.handle(
+            {
+                "lineage_id": "lin_no_execute",
+                "benchmark_control": True,
+                "execute": False,
+                "project_dir": str(clean_project),
+            }
+        )
+        gen_one = await handler.handle(
+            {
+                "lineage_id": "lin_gen_one_control",
+                "benchmark_control": True,
+                "project_dir": str(clean_project),
+            }
+        )
+        dirty = await handler.handle(
+            {
+                "lineage_id": "lin_dirty_project",
+                "benchmark_control": True,
+                "project_dir": str(dirty_project),
+            }
+        )
+
+        assert missing_project.is_err
+        assert "explicit project_dir" in str(missing_project.error)
+        assert no_execute.is_err
+        assert "execute=true" in str(no_execute.error)
+        assert gen_one.is_err
+        assert "Gen 2+" in str(gen_one.error)
+        assert dirty.is_err
+        assert "clean Git baseline" in str(dirty.error)
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_public_handler_emits_full_graph_benchmark_control_observation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from ouroboros.mcp.tools.definitions import EvolveStepHandler
+
+        source = create_clean_git_project(tmp_path / "source")
+        control_worktree = tmp_path / "control-worktree"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "benchmark-control", str(control_worktree)],
+            cwd=source,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        workspace = TaskWorkspace(
+            durable_id="lin_public_control",
+            repo_root=str(source),
+            repo_name=source.name,
+            original_cwd=str(source),
+            effective_cwd=str(control_worktree),
+            worktree_path=str(control_worktree),
+            branch="benchmark-control",
+            lock_path=str(tmp_path / "control.lock"),
+        )
+        seed = make_seed(seed_id="seed_public_control").model_copy(
+            update={"acceptance_criteria": ("First criterion", "Second criterion")}
+        )
+        previous = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            score=0.5,
+            ac_results=(
+                ACResult(ac_index=0, ac_content="First criterion", passed=True),
+                ACResult(ac_index=1, ac_content="Second criterion", passed=False),
+            ),
+        )
+        current = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            score=1.0,
+            ac_results=(
+                ACResult(ac_index=0, ac_content="First criterion", passed=True),
+                ACResult(ac_index=1, ac_content="Second criterion", passed=True),
+            ),
+        )
+        store = await create_event_store()
+        await seed_events_for_gen1(store, "lin_public_control", seed, previous)
+        externally_satisfied: list[object] = []
+
+        async def executor(
+            _seed: Seed,
+            *,
+            parallel: bool,
+            execution_id: str | None = None,
+            externally_satisfied_acs: object = None,
+        ) -> Result[SimpleNamespace, OuroborosError]:
+            del parallel, execution_id
+            externally_satisfied.append(externally_satisfied_acs)
+            return Result.ok(
+                SimpleNamespace(
+                    summary={},
+                    final_message="executed full graph",
+                    duration_seconds=1.0,
+                    messages_processed=1,
+                )
+            )
+
+        async def evaluator(_seed: Seed, _output: str):
+            return Result.ok(current)
+
+        executor.frugality_provider_tracking = True  # type: ignore[attr-defined]
+        evaluator.frugality_provider_tracking = True  # type: ignore[attr-defined]
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(
+                min_generations=2,
+                focused_evolution=True,
+                scoped_reexecution=True,
+            ),
+            executor=executor,
+            evaluator=evaluator,
+        )
+        handler = EvolveStepHandler(evolutionary_loop=loop, event_store=store)
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.evolution_handlers.maybe_restore_task_workspace",
+                return_value=workspace,
+            ),
+            patch("ouroboros.mcp.tools.evolution_handlers.release_lock"),
+        ):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_public_control",
+                    "benchmark_control": True,
+                    "execute": True,
+                    "project_dir": str(source),
+                    "skip_qa": True,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["benchmark_control"] is True
+        assert result.value.meta["active_ac_indices"] == [0, 1]
+        assert result.value.meta["frozen_ac_indices"] == []
+        assert result.value.meta["frugality"]["observation"]["arm"] == "full_graph"
+        assert externally_satisfied == [None]
+        assert loop.config.focused_evolution is True
+        assert loop.config.scoped_reexecution is True
+        await store.close()
 
     @pytest.mark.asyncio
     async def test_handler_uses_configured_project_when_explicit_project_is_absent(


### PR DESCRIPTION
## Summary

- record Gen 2+ focused/full-graph observations with complete runtime-token attribution, active/frozen nodes, final Seed-wide AC verdicts, regressions, and TraceGuard grounding
- expose an isolation-gated public `benchmark_control` mode that produces a real full-graph control through `EvolveStepHandler`
- bind task-local effective focus/scoped policy into durable request identity, focus selection, execution, and receipt creation
- attest Codex CLI auxiliary runtime configuration with an exact versioned schema covering executable, profiles, skills, timeouts, retry/process behavior, permission, model, backend, and complete inherited child-environment authority
- pair only distinct clean worktrees at the same Git commit and the same complete semantic Seed/prior-evaluation fingerprint
- require at least 10% measured token reduction with zero quality degradation for PASS
- fail closed to `insufficient_data` for missing, malformed, duplicate, opaque, oversized, non-finite, cardinality-incomplete, or unregistered runtime evidence
- preserve the focused/replay/single-writer semantics approved in #1846

## Production behavior

A normal focused evolve run records a treatment receipt but never auto-runs a full-graph control. A deliberate control calls `ouroboros_evolve_step` with `benchmark_control=true`, `execute=true`, an existing Gen 2+ lineage, and an explicit clean Git `project_dir`. The mode is rejected for plugin delegation and uses a task-local policy override, so concurrent normal calls cannot race through shared config.

## Exact-head blocker resolution

1. Public control producer: the MCP schema, handler defaults, public/core durable identities, effective policy, and response metadata carry `benchmark_control`. A real `EvolveStepHandler` integration test executes Gen 2 and asserts the emitted observation arm is `full_graph`.
2. Auxiliary runtime authority: `CodexCliRuntime.frugality_runtime_attestation()` emits a nonce-free versioned contract, while `provider_usage.py` validates an exact registered schema. Unknown/custom or malformed runtimes fail proof completeness. Negative tests prove fingerprint drift for runtime profile, CLI executable, timeout, skills/dispatcher, and Codex-specific configuration.
3. Inherited child environment authority: schema v3 fingerprints every bounded key/value passed to child Codex and task-locally seals that exact environment across all subprocess/retry spawns in one tracked call. Endpoint, credential, `PATH`, and sandbox drift produce different provider configurations; paired proof returns `insufficient_data`. Cleanup failure invalidates only proof evidence and does not fail evolution.
4. Cwd and secret-safe authority: schema v3 binds Git-proven repository-relative `semantic_cwd`, so different `-C` scopes cannot pair. Credential-like values use a 32-byte installation-held HMAC key stored as an owner-only `0600` file; the key and raw/HMAC credential identities never enter receipts. Missing, malformed, symlinked, or over-permissive key authority makes proof incomplete while evolution continues.
5. Token aliases and replay-safe key provisioning: generic token-bearing names, including `GH_TOKEN`, `GITHUB_TOKEN`, `NPM_TOKEN`, and `HF_TOKEN`, use installation-keyed authority. New keys are written to a private temporary file, fsynced, and published without clobbering a concurrent winner; failed candidates are removed and owner-only partial legacy artifacts recover automatically. The semantic-cwd test now supplies explicit project identity and passes from source archives.
6. Secret-safe durable authority: Anthropic completion receipts use schema v2 and LiteLLM completion receipts use schema v7 with the installation key as HMAC authority, and Codex runtime schema v4 installation-keys every child-environment entry rather than trusting name classification. Database URLs, credentialed proxy URLs, direct API keys, and config-content fingerprints cannot be checked offline from persisted evidence; unavailable authority fails proof closed.
7. Production producer attainability: the public MCP composition root creates dedicated proof-mode adapters for Wonder/Reflect, assertion extraction, and evolution evaluation without changing ordinary interview/evaluate policies. LiteLLM owns the single measurable attempt, bounded proof timeout, and sealed configured/global/environment/default endpoint authority; malformed or credential-bearing endpoint URLs fail proof closed. An integration test follows the real server → public evolve handler → real factory adapter boundary and verifies complete provider evidence.
8. LiteLLM dependency-global authority: schema v7 permits proof only for the bounded Anthropic/Google/OpenAI/OpenRouter routes when request-affecting LiteLLM globals, callbacks, provider config, unsealed provider environment, and OpenAI-compatible SDK globals remain verified defaults. The sealed worker call pins both LiteLLM and provider SDK retries to zero.
9. LiteLLM isolated effect boundary: each proof completion runs in a single-purpose `python -I` subprocess with a minimal environment and private empty cwd. Credential and request authority travel only over stdin; the worker creates the dedicated AsyncOpenAI or AsyncHTTPHandler client backed by an explicit HTTPX transport with trust_env disabled, no proxy/client certificate, TLS verification enabled, HTTP/2 disabled, and retries zero. Schema v7 exact-validates isolation, worker protocol/environment/cwd, client/transport, cleanup, mutation-audit, Python, dependency, executable, and worker-implementation identities. An event-driven parent assignment audit catches even immediate mutate-and-restore drift; drift or worker/client cleanup failure makes evidence incomplete without discarding a successful evolution result.
10. Worker executable and transitive implementation authority: proof preparation binds the absolute launcher path, resolved executable path and SHA-256, worker Python version, worker module/file SHA-256, adapter module/file SHA-256, and a deterministic path-framed digest over every installed Ouroboros Python source. Dispatch revalidates that complete implementation authority before spawn, and the isolated child independently reports it. Adapter or transitive-source drift and malformed metadata make provider evidence incomplete without discarding a valid completion result.


## Verification

Exact HEAD: `ff782b4e58be426629234a9e3566f79bc261c2e4`

- `1321 passed` across the expanded reviewer scope, including real isolated-worker/local-provider, immediate mutate-and-restore, executable/worker/adapter/transitive implementation identity, malformed-proof, and incomplete-usage regressions
- Ruff passed for `src` and `tests`
- Ruff format check passed for 1,199 files
- MyPy passed for 510 source files on Python 3.13 + LiteLLM
- module-size ratchet passed: 509 modules checked, 26 grandfathered
- `git diff --check` passed
- post-retarget feature restack tree matches the previously approved head
- MCP composition integration: `47 passed`; the two formerly failing assertions pass on Python 3.13 and 3.14
- optional-dependency boundary: Python 3.14 base `2 passed, 1 skipped`; Python 3.13 LiteLLM profile `5 passed`
## Dependency and governance

Clean-restacked onto `main` at `f69899d560a09a1438b17ee7fa2d77fa564f9f8d` after #1846 rebase-merged. The new exact HEAD tree `8dfb445c38c157ef1858577199c57748428dd8cd` is byte-identical to the previously approved #1847 tree at `cc5ad5323ab2c591072041aad74f6119dbc307bf`. RFC #1888 is accepted for ordered rollout and remains open until this post-retarget gate completes.

Refs #1465

Refs #1888.