### PR TITLE
fix(cli/mcp): stop test isolation leak of proxy/token vars into os.environ

### DIFF
--- a/tests/unit/cli/test_mcp_shell_env.py
+++ b/tests/unit/cli/test_mcp_shell_env.py
@@ -8,7 +8,18 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 from ouroboros.cli.commands import mcp
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    """Restore os.environ after every test; _ensure_shell_env writes it directly."""
+    saved = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(saved)
 
 
 def test_shell_env_loader_preserves_mcp_stdin(monkeypatch, tmp_path) -> None:
@@ -70,7 +81,6 @@ def test_shell_env_merge_is_whitelisted(monkeypatch, tmp_path) -> None:
     assert "/extra/bin" in os.environ["PATH"]
     assert "PYTHONPATH" not in os.environ
     assert "VIRTUAL_ENV" not in os.environ
-    monkeypatch.delenv("SOME_VENDOR_API_KEY", raising=False)
 
 
 def test_shell_env_cache_skips_login_shell(monkeypatch, tmp_path) -> None:
@@ -90,7 +100,6 @@ def test_shell_env_cache_skips_login_shell(monkeypatch, tmp_path) -> None:
     mcp._ensure_shell_env(timeout=1.25)
 
     assert os.environ["CACHED_TEST_API_KEY"] == "cached"
-    monkeypatch.delenv("CACHED_TEST_API_KEY", raising=False)
 
 
 def test_shell_env_cache_merges_other_provider_key_when_anthropic_is_present(
@@ -112,7 +121,6 @@ def test_shell_env_cache_merges_other_provider_key_when_anthropic_is_present(
     mcp._ensure_shell_env(timeout=1.25)
 
     assert os.environ["OPENAI_API_KEY"] == "openai-cached"
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
 def test_shell_env_cache_written_with_whitelisted_subset(monkeypatch, tmp_path) -> None:
@@ -134,7 +142,6 @@ def test_shell_env_cache_written_with_whitelisted_subset(monkeypatch, tmp_path) 
     cached = json.loads(cache_file.read_text(encoding="utf-8"))
     assert "FOO_API_KEY" in cached
     assert "RANDOM_VAR" not in cached
-    monkeypatch.delenv("FOO_API_KEY", raising=False)
 
 
 def test_shell_env_whitelist_admits_proxy_and_gateway_vars(monkeypatch, tmp_path) -> None:
@@ -165,5 +172,9 @@ def test_shell_env_whitelist_admits_proxy_and_gateway_vars(monkeypatch, tmp_path
     assert os.environ["NO_PROXY"] == "localhost"
     assert os.environ["ANTHROPIC_BASE_URL"] == "https://gw.example.com"
     assert os.environ["GH_TOKEN"] == "gho_x"
-    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN"):
-        monkeypatch.delenv(key, raising=False)
+
+
+def test_environ_mutations_do_not_survive_past_the_test() -> None:
+    """Regression test for #1793: no earlier test's env vars survive teardown."""
+    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN", "SOME_VENDOR_API_KEY"):
+        assert key not in os.environ

--- a/tests/unit/cli/test_mcp_shell_env.py
+++ b/tests/unit/cli/test_mcp_shell_env.py
@@ -174,7 +174,18 @@ def test_shell_env_whitelist_admits_proxy_and_gateway_vars(monkeypatch, tmp_path
     assert os.environ["GH_TOKEN"] == "gho_x"
 
 
+_LEAK_CHECK_BASELINE = {
+    key: os.environ.get(key)
+    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN", "SOME_VENDOR_API_KEY")
+}
+
+
 def test_environ_mutations_do_not_survive_past_the_test() -> None:
-    """Regression test for #1793: no earlier test's env vars survive teardown."""
-    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN", "SOME_VENDOR_API_KEY"):
-        assert key not in os.environ
+    """Regression test for #1793: no earlier test's env vars survive teardown.
+
+    Compares against the baseline captured at module import (before any test's
+    autouse fixture ran) rather than asserting absence, so a legitimately
+    ambient proxy/gateway/token value is not mistaken for a leak.
+    """
+    for key, baseline in _LEAK_CHECK_BASELINE.items():
+        assert os.environ.get(key) == baseline


### PR DESCRIPTION
`_ensure_shell_env()` merges allowed login-shell vars (proxy config, `GH_TOKEN`,
`*_API_KEY`/`*_BASE_URL`) straight into `os.environ`, bypassing monkeypatch's
tracking. `test_shell_env_whitelist_admits_proxy_and_gateway_vars` tried to clean
up after itself with `monkeypatch.delenv(key, raising=False)` once its assertions
ran, but `delenv` snapshots the *current* value as the state to restore on
teardown. Since the value it captured was the one the test itself had just leaked
into the real process environment, monkeypatch's teardown put it right back
afterwards. The apparent cleanup made the leak permanent instead of preventing it.

Same shape, three more places in this file: `test_shell_env_loader_preserves_mcp_stdin`
(`OUROBOROS_TEST_ENV`), `test_shell_env_merge_is_whitelisted` (`SOME_VENDOR_API_KEY`),
`test_shell_env_cache_written_with_whitelisted_subset` (`FOO_API_KEY`), and the two
cache tests (`CACHED_TEST_API_KEY`, `OPENAI_API_KEY`) — found while tracing the
reported one, since they all call the same `_ensure_shell_env` merge path.

Replaced the per-test `monkeypatch.delenv(...)` cleanup attempts with one autouse
fixture that snapshots `os.environ` before each test and restores it afterward,
independent of how a given test mutated it.

## Verification

- New test `test_environ_mutations_do_not_survive_past_the_test`: fails on
  unmodified `main` (`HTTPS_PROXY`/`NO_PROXY`/`ANTHROPIC_BASE_URL`/`GH_TOKEN`/
  `SOME_VENDOR_API_KEY` all present in `os.environ`), passes on this branch.
  Ran both ways in a clean `python:3.13-slim` container.
- Full `tests/unit/cli/` suite (1470 tests): same 22 pre-existing failures on
  both `main` and this branch (unrelated Codex-setup tests that need a real
  `uv`/executable on `PATH`, not present in this container); no new failures.
- `ruff check`, `ruff format --check`, and `mypy src/ouroboros` all clean.
- Not verified: behavior under `pytest-xdist` (`-n auto`); the fix is process-local
  environment restoration, which xdist workers already isolate by process, but I
  did not run the suite under `-n auto` here.

Closes #1793
