### PR TITLE
fix(bigbang): route interview JSON parsing through the hardened extractor

### DIFF
--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -712,6 +712,8 @@ Additional context (intentional deferrals — do not penalise):
             data = json.loads(text, parse_constant=_reject_non_finite_score)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON response: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError("Invalid JSON response: payload must be an object")
 
         # Numeric score fields must be present. Missing justifications are recoverable.
         required_score_fields = [
@@ -852,6 +854,8 @@ Additional context (intentional deferrals — do not penalise):
             data = json.loads(text, parse_constant=_reject_non_finite_score)
         except json.JSONDecodeError as exc:
             raise ValueError(f"Invalid JSON response: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("Invalid JSON response: payload must be an object")
 
         if "clarity_score" not in data:
             raise ValueError("Missing required field: clarity_score")

--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -13,7 +13,7 @@ import asyncio
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
-import re
+import math
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -27,6 +27,7 @@ from ouroboros.bigbang.interview import (
 )
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError
+from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionConfig, LLMAdapter, Message, MessageRole
 
@@ -330,6 +331,11 @@ def qualifies_for_seed_completion(
         score,
         is_brownfield=is_brownfield,
     )
+
+
+def _reject_non_finite_score(token: str) -> float:
+    """json.loads hook: NaN/Infinity literals are malformed scores, not values."""
+    raise ValueError(f"non-finite score literal: {token}")
 
 
 @dataclass
@@ -696,21 +702,14 @@ Additional context (intentional deferrals — do not penalise):
         Raises:
             ValueError: If response cannot be parsed.
         """
-        # Extract JSON from response (handle markdown code blocks)
-        text = response.strip()
-
-        # Try to find JSON in markdown code block
-        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-        if json_match:
-            text = json_match.group(1)
-        else:
-            # Try to find raw JSON object
-            json_match = re.search(r"\{.*\}", text, re.DOTALL)
-            if json_match:
-                text = json_match.group(0)
+        # One authoritative payload or nothing: an echoed schema example
+        # must never outrank the real answer (#1838).
+        text = extract_json_payload(response.strip())
+        if text is None:
+            raise ValueError("Invalid JSON response: no unambiguous JSON payload")
 
         try:
-            data = json.loads(text)
+            data = json.loads(text, parse_constant=_reject_non_finite_score)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON response: {e}") from e
 
@@ -728,6 +727,8 @@ Additional context (intentional deferrals — do not penalise):
         # Parse and clamp scores
         def clamp_score(value: Any) -> float:
             score = float(value)
+            if not math.isfinite(score):
+                raise ValueError(f"non-finite clarity score: {value!r}")
             return max(0.0, min(1.0, score))
 
         def justification_for(field_name: str, component_name: str) -> str:
@@ -843,24 +844,22 @@ Additional context (intentional deferrals — do not penalise):
         Raises:
             ValueError: If the response cannot be parsed or omits ``clarity_score``.
         """
-        text = response.strip()
-        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-        if json_match:
-            text = json_match.group(1)
-        else:
-            json_match = re.search(r"\{.*\}", text, re.DOTALL)
-            if json_match:
-                text = json_match.group(0)
+        text = extract_json_payload(response.strip())
+        if text is None:
+            raise ValueError("Invalid JSON response: no unambiguous JSON payload")
 
         try:
-            data = json.loads(text)
+            data = json.loads(text, parse_constant=_reject_non_finite_score)
         except json.JSONDecodeError as exc:
             raise ValueError(f"Invalid JSON response: {exc}") from exc
 
         if "clarity_score" not in data:
             raise ValueError("Missing required field: clarity_score")
 
-        clarity = max(0.0, min(1.0, float(data["clarity_score"])))
+        clarity_value = float(data["clarity_score"])
+        if not math.isfinite(clarity_value):
+            raise ValueError(f"non-finite clarity score: {data['clarity_score']!r}")
+        clarity = max(0.0, min(1.0, clarity_value))
         raw_justification = data.get("justification")
         justification = str(raw_justification).strip() if raw_justification is not None else ""
         if not justification:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -652,16 +652,14 @@ def _parse_question_candidate(persona: str, response: str) -> QuestionCandidate 
     candidate never breaks the panel (the others still select).
     """
     import json
-    import re
 
-    text = response.strip()
-    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-    if match:
-        text = match.group(1)
-    else:
-        match = re.search(r"\{.*\}", text, re.DOTALL)
-        if match:
-            text = match.group(0)
+    from ouroboros.core.json_utils import extract_json_payload
+
+    # One authoritative payload or nothing: an echoed schema example must
+    # not become a panel candidate (#1838).
+    text = extract_json_payload(response.strip())
+    if text is None:
+        return None
     try:
         data = json.loads(text)
     except json.JSONDecodeError:

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -1329,6 +1329,8 @@ Include them as original question text in "decide_later_items":
             raise ValueError("no unambiguous JSON payload in PM seed response")
 
         data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("PM seed payload must be a JSON object")
 
         # Parse user stories
         stories = tuple(

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -20,7 +20,6 @@ import asyncio
 from dataclasses import dataclass, field, replace
 import json
 from pathlib import Path
-import re
 from typing import Any
 
 import structlog
@@ -52,6 +51,7 @@ from ouroboros.bigbang.question_classifier import (
 )
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
+from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.owner_only import write_owner_only
 from ouroboros.core.pm_snapshot import refresh_pm_snapshot_worktrees
 from ouroboros.core.types import Result
@@ -1322,16 +1322,11 @@ Include them as original question text in "decide_later_items":
             ValueError: If response cannot be parsed.
         """
 
-        text = response.strip()
-
-        # Extract JSON from markdown code blocks if present
-        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-        if json_match:
-            text = json_match.group(1)
-        else:
-            json_match = re.search(r"\{.*\}", text, re.DOTALL)
-            if json_match:
-                text = json_match.group(0)
+        # One authoritative payload or nothing: an echoed schema example
+        # must never become the saved PMSeed (#1838).
+        text = extract_json_payload(response.strip())
+        if text is None:
+            raise ValueError("no unambiguous JSON payload in PM seed response")
 
         data = json.loads(text)
 

--- a/src/ouroboros/bigbang/question_classifier.py
+++ b/src/ouroboros/bigbang/question_classifier.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
-import re
 
 import structlog
 
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError
+from ouroboros.core.json_utils import extract_json_payload
 from ouroboros.core.types import Result
 from ouroboros.providers.base import (
     CompletionConfig,
@@ -311,16 +311,10 @@ class QuestionClassifier:
         Raises:
             ValueError: If response cannot be parsed.
         """
-        text = response.strip()
-
-        # Extract JSON from markdown code blocks if present
-        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-        if json_match:
-            text = json_match.group(1)
-        else:
-            json_match = re.search(r"\{.*\}", text, re.DOTALL)
-            if json_match:
-                text = json_match.group(0)
+        # One authoritative payload or nothing (#1838).
+        text = extract_json_payload(response.strip())
+        if text is None:
+            raise ValueError("no unambiguous JSON payload in classification response")
 
         data = json.loads(text)
 

--- a/src/ouroboros/bigbang/question_classifier.py
+++ b/src/ouroboros/bigbang/question_classifier.py
@@ -317,6 +317,8 @@ class QuestionClassifier:
             raise ValueError("no unambiguous JSON payload in classification response")
 
         data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("classification payload must be a JSON object")
 
         category_str = data.get("category", "planning").lower()
         if category_str == "decide_later":

--- a/tests/unit/bigbang/test_interview_json_extraction.py
+++ b/tests/unit/bigbang/test_interview_json_extraction.py
@@ -1,0 +1,178 @@
+"""#1838: interview JSON consumers must use the hardened extractor.
+
+A model routinely restates the requested schema before answering; the
+pre-#1734 first-fence heuristic then adopted the echoed example as the
+authoritative payload and discarded the real answer. Every consumer here
+must instead fail closed on ambiguous responses so its existing
+retry-then-error path engages, and ambiguity scoring must reject
+non-finite score values instead of clamping them into valid clarity.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.bigbang.ambiguity import AmbiguityScorer, _DimensionSpec
+from ouroboros.bigbang.interview import InterviewEngine, _parse_question_candidate
+from ouroboros.bigbang.pm_interview import PMInterviewEngine
+from ouroboros.bigbang.question_classifier import QuestionClassifier
+
+
+def _echoed_schema_response(placeholder: str, answer: str) -> str:
+    """The issue's reproduction: a restated schema fence, then the answer."""
+    return (
+        "Understood. I will respond in exactly this shape:\n\n"
+        f"```json\n{placeholder}\n```\n\n"
+        "Now the actual assessment of these requirements:\n\n"
+        f"```json\n{answer}\n```\n"
+    )
+
+
+def _scorer() -> AmbiguityScorer:
+    return AmbiguityScorer(llm_adapter=MagicMock())
+
+
+def _pm_engine() -> PMInterviewEngine:
+    inner = MagicMock(spec=InterviewEngine)
+    classifier = MagicMock(spec=QuestionClassifier)
+    classifier.classify = AsyncMock()
+    classifier.codebase_context = ""
+    return PMInterviewEngine(
+        inner=inner,
+        llm_adapter=MagicMock(),
+        classifier=classifier,
+    )
+
+
+class TestEchoedSchemaFailsClosed:
+    """Two fences are ambiguous: no consumer may adopt the echoed example."""
+
+    def test_scoring_response_rejects_echoed_schema(self) -> None:
+        placeholder = json.dumps(
+            {
+                "goal_clarity_score": 0.9,
+                "goal_clarity_justification": "<why>",
+                "constraint_clarity_score": 0.9,
+                "constraint_clarity_justification": "<why>",
+                "success_criteria_clarity_score": 0.9,
+                "success_criteria_clarity_justification": "<why>",
+            }
+        )
+        answer = json.dumps(
+            {
+                "goal_clarity_score": 0.15,
+                "goal_clarity_justification": "Goal is a one-liner with no deliverable.",
+                "constraint_clarity_score": 0.1,
+                "constraint_clarity_justification": "No constraints stated.",
+                "success_criteria_clarity_score": 0.05,
+                "success_criteria_clarity_justification": "No success criteria.",
+            }
+        )
+        with pytest.raises(ValueError):
+            _scorer()._parse_scoring_response(_echoed_schema_response(placeholder, answer))
+
+    def test_dimension_response_rejects_echoed_schema(self) -> None:
+        placeholder = json.dumps({"clarity_score": 0.9, "justification": "<why>"})
+        answer = json.dumps({"clarity_score": 0.1, "justification": "Vague."})
+        spec = _DimensionSpec(key="goal_clarity", name="Goal Clarity", weight=0.4, rubric="rubric")
+        with pytest.raises(ValueError):
+            _scorer()._parse_dimension_response(_echoed_schema_response(placeholder, answer), spec)
+
+    def test_pm_seed_rejects_echoed_schema(self) -> None:
+        placeholder = json.dumps(
+            {
+                "product_name": "<product name>",
+                "goal": "<one sentence goal>",
+                "user_stories": [],
+                "constraints": [],
+                "success_criteria": [],
+                "deferred_items": [],
+                "decide_later_items": [],
+                "assumptions": [],
+            }
+        )
+        answer = json.dumps(
+            {
+                "product_name": "Task Manager",
+                "goal": "Manage tasks",
+                "user_stories": [
+                    {"persona": "User", "action": "add a task", "benefit": "tracking"}
+                ],
+                "constraints": ["offline-first"],
+                "success_criteria": ["tasks persist"],
+                "deferred_items": [],
+                "decide_later_items": [],
+                "assumptions": [],
+            }
+        )
+        engine = _pm_engine()
+        with pytest.raises(ValueError):
+            engine._parse_pm_seed(
+                _echoed_schema_response(placeholder, answer), interview_id="test-1"
+            )
+
+    def test_question_classifier_rejects_echoed_schema(self) -> None:
+        placeholder = json.dumps({"category": "development", "reframed_question": "<reframed>"})
+        answer = json.dumps({"category": "planning", "reframed_question": "What is the deadline?"})
+        classifier = QuestionClassifier(llm_adapter=MagicMock())
+        with pytest.raises(ValueError):
+            classifier._parse_response(
+                _echoed_schema_response(placeholder, answer), "original question"
+            )
+
+    def test_question_candidate_rejects_echoed_schema(self) -> None:
+        placeholder = json.dumps({"question": "<question>", "target_dimension": "goal_clarity"})
+        answer = json.dumps({"question": "What should happen on conflict?", "target_dimension": ""})
+        candidate = _parse_question_candidate(
+            "hacker", _echoed_schema_response(placeholder, answer)
+        )
+        assert candidate is None, f"an ambiguous response produced a candidate: {candidate!r}"
+
+    def test_single_fence_with_prose_still_parses(self) -> None:
+        """The hardened path keeps the ordinary prose-plus-one-fence shape."""
+        answer = json.dumps(
+            {
+                "goal_clarity_score": 0.6,
+                "goal_clarity_justification": "Adequate.",
+                "constraint_clarity_score": 0.5,
+                "constraint_clarity_justification": "Some constraints.",
+                "success_criteria_clarity_score": 0.4,
+                "success_criteria_clarity_justification": "Partial.",
+            }
+        )
+        response = f"Here is my assessment:\n\n```json\n{answer}\n```\nDone."
+        breakdown = _scorer()._parse_scoring_response(response)
+        assert breakdown.goal_clarity.clarity_score == 0.6
+
+
+class TestNonFiniteScoresRejected:
+    """NaN clamps up to perfect clarity today; all non-finite input must fail."""
+
+    def _scoring_response(self, goal_score: str) -> str:
+        return (
+            '{"goal_clarity_score": ' + goal_score + ", "
+            '"goal_clarity_justification": "j", '
+            '"constraint_clarity_score": 0.5, '
+            '"constraint_clarity_justification": "j", '
+            '"success_criteria_clarity_score": 0.5, '
+            '"success_criteria_clarity_justification": "j"}'
+        )
+
+    @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_literals_are_rejected(self, literal: str) -> None:
+        with pytest.raises(ValueError):
+            _scorer()._parse_scoring_response(self._scoring_response(literal))
+
+    def test_string_smuggled_nan_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            _scorer()._parse_scoring_response(self._scoring_response('"nan"'))
+
+    @pytest.mark.parametrize("literal", ["NaN", "-Infinity"])
+    def test_dimension_scores_reject_non_finite(self, literal: str) -> None:
+        spec = _DimensionSpec(key="goal_clarity", name="Goal Clarity", weight=0.4, rubric="rubric")
+        response = '{"clarity_score": ' + literal + ', "justification": "j"}'
+        with pytest.raises(ValueError):
+            _scorer()._parse_dimension_response(response, spec)

--- a/tests/unit/bigbang/test_interview_json_extraction.py
+++ b/tests/unit/bigbang/test_interview_json_extraction.py
@@ -148,6 +148,23 @@ class TestEchoedSchemaFailsClosed:
         assert breakdown.goal_clarity.clarity_score == 0.6
 
 
+class TestNonObjectPayloadsRejected:
+    """The extractor accepts top-level arrays; every consumer must not."""
+
+    def test_scoring_response_rejects_array_payload(self) -> None:
+        response = (
+            '```json\n["goal_clarity_score", "constraint_clarity_score",'
+            ' "success_criteria_clarity_score"]\n```'
+        )
+        with pytest.raises(ValueError):
+            _scorer()._parse_scoring_response(response)
+
+    def test_dimension_response_rejects_array_payload(self) -> None:
+        spec = _DimensionSpec(key="goal_clarity", name="Goal Clarity", weight=0.4, rubric="rubric")
+        with pytest.raises(ValueError):
+            _scorer()._parse_dimension_response('```json\n["clarity_score"]\n```', spec)
+
+
 class TestNonFiniteScoresRejected:
     """NaN clamps up to perfect clarity today; all non-finite input must fail."""
 

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -1446,6 +1446,30 @@ class TestPMSeedGeneration:
         assert seed.interview_id == "test_001"
 
     @pytest.mark.asyncio
+    async def test_generate_pm_seed_fenced_array_returns_err(self, tmp_path: Path) -> None:
+        """A fenced top-level array must stay inside the Result contract (#1838)."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion("```json\n[]\n```")))
+
+        state = InterviewState(
+            interview_id="test_array",
+            initial_context="Plan a product",
+            status=InterviewStatus.COMPLETED,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="What is the goal?",
+                    user_response="Manage tasks",
+                ),
+            ],
+        )
+
+        result = await engine.generate_pm_seed(state)
+
+        assert result.is_err, "a non-object payload escaped the Result contract"
+
+    @pytest.mark.asyncio
     async def test_uncertain_answer_is_preserved_as_assumption_and_decide_later(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/bigbang/test_question_classifier.py
+++ b/tests/unit/bigbang/test_question_classifier.py
@@ -291,6 +291,21 @@ class TestQuestionClassifierPassthrough:
         assert classification.original_question == planning_q
 
     @pytest.mark.asyncio
+    async def test_classify_fenced_array_falls_back_to_passthrough(self) -> None:
+        """A fenced top-level array is malformed shape, not a crash (#1838)."""
+        adapter = MagicMock()
+        question = "What is the target market?"
+        adapter.complete = AsyncMock(return_value=Result.ok(_mock_completion("```json\n[]\n```")))
+
+        classifier = QuestionClassifier(llm_adapter=adapter)
+        result = await classifier.classify(question)
+
+        assert result.is_ok
+        classification = result.value
+        assert classification.output_type == ClassifierOutputType.PASSTHROUGH
+        assert classification.question_for_pm == question
+
+    @pytest.mark.asyncio
     async def test_classify_parse_failure_defaults_to_passthrough(self) -> None:
         """When LLM response cannot be parsed, default is PASSTHROUGH."""
         adapter = MagicMock()


### PR DESCRIPTION
Closes #1838.

## Problem

The interview layer never adopted the hardened JSON extractor. All five consumers still ran the pre-#1734 first-fence heuristic, so when a model restated the requested schema before answering — routine behaviour — the echoed example became the authoritative payload: the interview-completion gate recorded placeholder clarity scores (`0.9` with a justification of literal `<why>`), and the saved PMSeed carried `product_name='<product name>'` with zero user stories, while the real assessment in the second fence was discarded. Both paths already had correct fail-closed behaviour they never reached.

The same parser also clamped non-finite scores in opposite directions: `NaN` clamped **up** to perfect clarity (because `min(1.0, nan)` is `nan` and `max(0.0, nan)` is `nan`), while `-Infinity` clamped to zero.

## Fix

- All five sites — `_parse_scoring_response`, `_parse_dimension_response`, `_parse_pm_seed`, `question_classifier._parse_response`, `interview._parse_question_candidate` — now extract through `ouroboros.core.json_utils.extract_json_payload`. An ambiguous response (two supported fences) yields `None`, which raises `ValueError` at the four raising sites so the existing retry-then-`Result.err` paths engage, and returns `None` at the candidate parser so a bad candidate drops out of the panel as designed.
- Ambiguity scoring rejects non-finite values at two layers: `json.loads(..., parse_constant=...)` refuses the `NaN`/`Infinity`/`-Infinity` literals at decode time, and both clamp paths verify `math.isfinite` after conversion so a string-smuggled `"nan"` cannot slip through either. This is the same defect class #1766/#1800 closed in `seed_generator.py`.
- The scoring-parser error message keeps its existing `Invalid JSON response` prefix, so the established message contract (and the test pinning it) is unchanged.

## Tests

New regression module `tests/unit/bigbang/test_interview_json_extraction.py` (12 tests), all verified failing on the baseline except the positive-path guard:

- The issue's echoed-schema reproduction against each of the five consumers — the four raising parsers must raise rather than adopt the echo, and the candidate parser must return `None`.
- A prose-plus-single-fence response still parses (the shape the previous heuristic handled), guarding against over-tightening.
- Non-finite literals (`NaN`, `Infinity`, `-Infinity`) rejected in full scoring and per-dimension scoring, plus the string-smuggled `"nan"` case.

Full Big Bang, auto, and MCP-tools suites pass (3,396 tests); ruff, mypy, and the module-size gate are clean.