### PR TITLE
fix(providers): keep an empty OpenCode error frame terminal

### DIFF
--- a/src/ouroboros/providers/opencode_adapter.py
+++ b/src/ouroboros/providers/opencode_adapter.py
@@ -426,18 +426,29 @@ class OpenCodeLLMAdapter:
         Returns:
             Error message string, or ``None`` if no terminal error.
         """
+        saw_error_event = False
         for event in events:
             # Top-level error events are always terminal
-            if event.get("type") == "error":
-                error = event.get("error", {})
-                if isinstance(error, dict):
-                    name = error.get("name", "")
-                    data = error.get("data", {})
-                    msg = data.get("message", "") if isinstance(data, dict) else ""
-                    return msg or name or "Unknown error"
-                return str(error) if error else None
+            if event.get("type") != "error":
+                continue
+            saw_error_event = True
+            error = event.get("error", {})
+            if isinstance(error, dict):
+                name = error.get("name", "")
+                data = error.get("data", {})
+                msg = data.get("message", "") if isinstance(data, dict) else ""
+                if msg or name:
+                    return msg or name
+            elif error:
+                return str(error)
+            # This frame declares a failure but withholds the reason. Keep
+            # reading — a later frame may name it — but do not let the missing
+            # reason be read as a missing failure.
 
-        return None
+        # An error frame with nothing in it is still an error frame. Reporting
+        # `None` here handed the caller a run that failed as one that succeeded,
+        # carrying whatever partial text had been emitted before the failure.
+        return "Unknown error" if saw_error_event else None
 
     async def complete(
         self,

--- a/tests/unit/providers/test_opencode_adapter.py
+++ b/tests/unit/providers/test_opencode_adapter.py
@@ -279,6 +279,71 @@ class TestOpenCodeLLMAdapter:
         assert result.is_err, "Top-level error must override exit code"
         assert "Session crashed" in result.error.message
 
+    @pytest.mark.parametrize(
+        "payload",
+        [None, "", 0, [], {}],
+        ids=["null", "empty-string", "zero", "empty-list", "empty-dict"],
+    )
+    @pytest.mark.asyncio
+    async def test_complete_error_frame_with_empty_payload_still_fails(
+        self, payload: object
+    ) -> None:
+        """A terminal error frame stays terminal however thin its payload is.
+
+        The frame's own ``type`` declares the failure; the payload only carries
+        the reason. Reading emptiness as "no error" let a failed run return the
+        partial text it had produced as a success.
+        """
+        stdout = (
+            json.dumps({"type": "error", "sessionID": "sess-1", "error": payload})
+            + "\n"
+            + json.dumps({"type": "text", "part": {"type": "text", "text": "partial answer"}})
+            + "\n"
+        )
+        process = _FakeProcess(stdout=stdout, returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Calculate")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err, f"error frame with payload {payload!r} must not report success"
+        assert "partial answer" not in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_complete_empty_error_frame_does_not_mask_a_later_one(self) -> None:
+        """An early thin frame must not answer for the frames behind it.
+
+        ``_extract_error_from_events`` returned from inside its own loop, so the
+        first error frame decided the whole stream — and a null one decided it
+        was clean, discarding the populated frame that followed.
+        """
+        stdout = "".join(
+            json.dumps(event) + "\n"
+            for event in (
+                {"type": "error", "sessionID": "sess-1", "error": None},
+                {
+                    "type": "error",
+                    "sessionID": "sess-1",
+                    "error": {"name": "RuntimeError", "data": {"message": "Session crashed"}},
+                },
+                {"type": "text", "part": {"type": "text", "text": "partial answer"}},
+            )
+        )
+        process = _FakeProcess(stdout=stdout, returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Calculate")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "Session crashed" in result.error.message
+
     def test_extract_error_tool_use_not_terminal(self) -> None:
         """tool_use.state.error is not returned by _extract_error_from_events."""
         adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")


### PR DESCRIPTION
Fixes #1892.

## The defect

`_extract_error_from_events` answered "no terminal error" for a top-level `error` frame whose payload was null or empty, and it answered from inside its own loop. Two consequences:

- A run the CLI declared failed came back from the public `complete()` as `Result.ok`, carrying whatever partial text had been emitted before the failure.
- An early thin frame decided the whole stream, discarding a fully populated error frame behind it.

The verdict turned on payload *shape*, not on the failure: `error: {}` took the dict branch and correctly reported `"Unknown error"`, while `error: null` reported nothing — the same declared failure, opposite verdicts. That contradicts the invariant stated three lines above it, `# Top-level error events are always terminal`.

## The change

The frame's `type` is the failure signal; the payload only carries the reason. Scan every error frame for one that names a reason, and fall back to `"Unknown error"` when a frame was seen but none named one — fail closed without losing the detail a later frame carries.

Net effect on existing behavior: nothing that previously produced an error message produces a different one. The dict branch now defers its `"Unknown error"` to the end of the scan instead of returning immediately, which is what lets a later populated frame be found; when no later frame names a reason, the same `"Unknown error"` comes back.

Tool-level errors (`tool_use` with `state.error`) remain non-terminal — that behavior is deliberate and untouched.

## Verification

Probed through the public `complete()` with `asyncio.create_subprocess_exec` patched, exit code 0, each stream ending in a `text` frame carrying `"partial answer"`:

| Stream | Before | After |
|---|---|---|
| `error: null` | `ok`, `content='partial answer'` | `err`, `"Unknown error"` |
| `error: ""` | `ok`, `content='partial answer'` | `err`, `"Unknown error"` |
| `error: null` then populated `"Session crashed"` frame | `ok`, `content='partial answer'` | `err`, `"Session crashed"` |
| *control* — `{"type":"error"}`, key absent | `err`, `"Unknown error"` | unchanged |
| *control* — populated frame only | `err`, `"Session crashed"` | unchanged |
| *control* — no error frame | `ok` | unchanged |

Regression tests land on the public path: `test_complete_error_frame_with_empty_payload_still_fails` parametrized over `None`, `""`, `0`, `[]`, `{}`, and `test_complete_empty_error_frame_does_not_mask_a_later_one` for the masking case. The first asserts the partial text does not reach the caller as a success, not merely that `is_err` is set.

## Gates

- `tests/unit/providers/test_opencode_adapter.py` — 39 passed
- `ruff check` / `ruff format --check` / `mypy` — clean
- `scripts/check-module-size.py --baseline-ref upstream/main` — OK (493 modules, cap 2000)
- `scripts/check-auto-boundary.py` — OK (39 files scanned, 0 findings); no `auto/` file is touched

Rebased on `000f9580`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
