### PR TITLE
fix(providers): stop reporting a degraded ourocode turn as a clean one

### DIFF
--- a/src/ouroboros/providers/ourocode_llm_adapter.py
+++ b/src/ouroboros/providers/ourocode_llm_adapter.py
@@ -199,9 +199,20 @@ class OurocodeLLMAdapter:
         response_model: str,
     ) -> Result[CompletionResponse, ProviderError]:
         if not config.response_format:
-            return Result.ok(
-                await self._run(client, prompt_text, config, response_model=response_model)
-            )
+            parsed = await self._run(client, prompt_text, config, response_model=response_model)
+            if not parsed.content.strip():
+                # A turn that produced no text is a failed turn, whatever it
+                # stopped for. Returning it as `ok` hands the caller an empty
+                # string where an answer belongs, and every sibling adapter
+                # fails closed here instead.
+                return Result.err(
+                    ProviderError(
+                        message="Empty response from ourocode",
+                        provider="ourocode",
+                        details={"stop_reason": parsed.finish_reason},
+                    )
+                )
+            return Result.ok(parsed)
 
         last_response_preview = ""
         for _attempt in range(_STRUCTURED_RESPONSE_ATTEMPTS):
@@ -320,7 +331,19 @@ class OurocodeLLMAdapter:
 
     @staticmethod
     def _finish_reason(stop_reason: str) -> str:
-        return {"end_turn": "stop", "cancelled": "cancelled"}.get(stop_reason, stop_reason)
+        """Translate an ACP ``stopReason`` into this codebase's ``finish_reason``.
+
+        ``max_tokens`` has to become ``"length"``: that is the marker callers
+        test for, and an untranslated one reads as an unremarkable stop rather
+        than a truncation. Unknown reasons pass through unchanged so a new ACP
+        value is visible rather than silently recoded as a clean stop.
+        """
+        return {
+            "end_turn": "stop",
+            "cancelled": "cancelled",
+            "max_tokens": "length",
+            "max_turn_requests": "length",
+        }.get(stop_reason, stop_reason)
 
     @staticmethod
     def _compose_prompt(messages: list[Message]) -> str:

--- a/src/ouroboros/providers/ourocode_llm_adapter.py
+++ b/src/ouroboros/providers/ourocode_llm_adapter.py
@@ -209,7 +209,7 @@ class OurocodeLLMAdapter:
                     ProviderError(
                         message="Empty response from ourocode",
                         provider="ourocode",
-                        details={"stop_reason": parsed.finish_reason},
+                        details={"stop_reason": parsed.raw_response["stop_reason"]},
                     )
                 )
             return Result.ok(parsed)
@@ -259,7 +259,10 @@ class OurocodeLLMAdapter:
             model=response_model,
             usage=_ZERO_USAGE,
             finish_reason=self._finish_reason(result.stop_reason),
-            raw_response={"ourocode_model": response_model},
+            raw_response={
+                "ourocode_model": response_model,
+                "stop_reason": result.stop_reason,
+            },
         )
 
     def _resolve_ourocode_model(

--- a/tests/unit/providers/test_ourocode_llm_adapter.py
+++ b/tests/unit/providers/test_ourocode_llm_adapter.py
@@ -33,6 +33,7 @@ async def test_complete_returns_completion_response() -> None:
     assert response.content == "hi there"
     assert response.model == "claude"
     assert response.raw_response["ourocode_model"] == "claude"
+    assert response.raw_response["stop_reason"] == "end_turn"
     # ACP carries no token usage — honestly zero, not fabricated.
     assert response.usage.total_tokens == 0
     assert response.finish_reason == "stop"
@@ -44,9 +45,10 @@ async def test_complete_returns_completion_response() -> None:
         ("", "end_turn"),
         ("", "refusal"),
         ("", "max_tokens"),
+        ("", "max_turn_requests"),
         ("   \n\t", "end_turn"),
     ],
-    ids=["end-turn", "refusal", "max-tokens", "whitespace-only"],
+    ids=["end-turn", "refusal", "max-tokens", "max-turn-requests", "whitespace-only"],
 )
 @pytest.mark.asyncio
 async def test_complete_rejects_a_turn_that_produced_no_text(text: str, stop_reason: str) -> None:
@@ -71,6 +73,7 @@ async def test_complete_rejects_a_turn_that_produced_no_text(text: str, stop_rea
 
     assert result.is_err, f"empty turn stopping on {stop_reason!r} must not report success"
     assert result.error.provider == "ourocode"
+    assert result.error.details == {"stop_reason": stop_reason}
 
 
 @pytest.mark.parametrize(
@@ -84,7 +87,10 @@ async def test_complete_rejects_a_turn_that_produced_no_text(text: str, stop_rea
     ],
 )
 @pytest.mark.asyncio
-async def test_complete_reports_truncation_as_length(stop_reason: str, expected: str) -> None:
+async def test_complete_preserves_raw_stop_reason_while_normalizing_public_finish_reason(
+    stop_reason: str,
+    expected: str,
+) -> None:
     """Truncation has to surface as ``length`` — that is the marker callers test for.
 
     ``max_tokens`` reaching a caller untranslated reads as an unremarkable stop,
@@ -107,6 +113,7 @@ async def test_complete_reports_truncation_as_length(stop_reason: str, expected:
 
     assert result.is_ok
     assert result.value.finish_reason == expected
+    assert result.value.raw_response["stop_reason"] == stop_reason
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_ourocode_llm_adapter.py
+++ b/tests/unit/providers/test_ourocode_llm_adapter.py
@@ -38,6 +38,77 @@ async def test_complete_returns_completion_response() -> None:
     assert response.finish_reason == "stop"
 
 
+@pytest.mark.parametrize(
+    ("text", "stop_reason"),
+    [
+        ("", "end_turn"),
+        ("", "refusal"),
+        ("", "max_tokens"),
+        ("   \n\t", "end_turn"),
+    ],
+    ids=["end-turn", "refusal", "max-tokens", "whitespace-only"],
+)
+@pytest.mark.asyncio
+async def test_complete_rejects_a_turn_that_produced_no_text(text: str, stop_reason: str) -> None:
+    """A turn with no text is a failed turn, whatever it stopped for.
+
+    Returning it as ``ok`` handed the caller an empty string where an answer
+    belongs, and a refusal arrived indistinguishable from a clean stop.
+    """
+    adapter = OurocodeLLMAdapter()
+    turn = AcpTurnResult(text=text, stop_reason=stop_reason, session_id="s1")
+    with (
+        patch.object(OurocodeLLMAdapter, "_compose_prompt", return_value="composed"),
+        patch(
+            "ouroboros.providers.ourocode_llm_adapter.OurocodeAcpClient.run_turn",
+            new=AsyncMock(return_value=turn),
+        ),
+    ):
+        result = await adapter.complete(
+            messages=[Message(role=MessageRole.USER, content="hi")],
+            config=CompletionConfig(model="claude-sonnet-4-6"),
+        )
+
+    assert result.is_err, f"empty turn stopping on {stop_reason!r} must not report success"
+    assert result.error.provider == "ourocode"
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [
+        ("end_turn", "stop"),
+        ("max_tokens", "length"),
+        ("max_turn_requests", "length"),
+        ("cancelled", "cancelled"),
+        ("refusal", "refusal"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_complete_reports_truncation_as_length(stop_reason: str, expected: str) -> None:
+    """Truncation has to surface as ``length`` — that is the marker callers test for.
+
+    ``max_tokens`` reaching a caller untranslated reads as an unremarkable stop,
+    so a cut-off answer was consumed as a complete one. Reasons with no
+    established translation pass through rather than being recoded as ``stop``.
+    """
+    adapter = OurocodeLLMAdapter()
+    turn = AcpTurnResult(text="partial answer", stop_reason=stop_reason, session_id="s1")
+    with (
+        patch.object(OurocodeLLMAdapter, "_compose_prompt", return_value="composed"),
+        patch(
+            "ouroboros.providers.ourocode_llm_adapter.OurocodeAcpClient.run_turn",
+            new=AsyncMock(return_value=turn),
+        ),
+    ):
+        result = await adapter.complete(
+            messages=[Message(role=MessageRole.USER, content="hi")],
+            config=CompletionConfig(model="claude-sonnet-4-6"),
+        )
+
+    assert result.is_ok
+    assert result.value.finish_reason == expected
+
+
 @pytest.mark.asyncio
 async def test_complete_maps_not_signed_in_to_provider_error() -> None:
     adapter = OurocodeLLMAdapter()


### PR DESCRIPTION
Fixes #1894.

## The defect

Two independent ways `OurocodeLLMAdapter` made a degraded turn indistinguishable from a good one, both on the plain (non-`response_format`) path:

- **An empty turn returned `Result.ok`.** `_run_result` handed back whatever `_run` produced without inspecting it, so a turn with no text became a success carrying `content=''` — including on `stopReason: "refusal"`, which arrived looking like an ordinary answer that happened to be empty. Every sibling adapter fails closed here: `gjc_llm_adapter.py:447`, `codex_cli_adapter.py:1023`, `gemini_cli_adapter.py:469`, `claude_code_adapter.py:1252`.
- **Truncation never surfaced as `length`.** `_finish_reason` translated only `end_turn` and `cancelled`, so ACP's `max_tokens` reached callers verbatim. `finish_reason == "length"` is the marker this codebase tests for — `bigbang/ambiguity.py:527` and `:921` both key on it — so under ourocode that guard was never reached and a cut-off answer was consumed as a complete one.

## The change

Reject an empty turn in `_run_result` before it becomes `Result.ok`, carrying the stop reason in `details` so the failure is attributable. Translate `max_tokens` and `max_turn_requests` to `length`; `claude_code_adapter.py:1104` already treats the turn-budget case as `length`, so this follows the established reading rather than inventing one.

Unrecognized stop reasons still pass through unchanged. Recoding them to `stop` would hide a new ACP value behind a clean-completion verdict, which is the same failure shape being fixed here.

Emptiness is tested with `.strip()`, so a turn of pure whitespace counts as no answer.

Scope note: the structured `response_format` path is untouched — it already fails closed, because an empty response yields no extractable JSON and falls through to its existing non-conforming-output error.

## Verification

Through the public `complete()` with `OurocodeAcpClient.run_turn` patched:

| `text` | `stopReason` | Before | After |
|---|---|---|---|
| `""` | `end_turn` | `ok`, `content=''` | `err` |
| `""` | `refusal` | `ok`, `content=''` | `err` |
| `""` | `max_tokens` | `ok`, `content=''` | `err` |
| `"  \n\t"` | `end_turn` | `ok`, `content='  \n\t'` | `err` |
| `"hi"` | `max_tokens` | `ok`, `finish_reason='max_tokens'` | `ok`, `finish_reason='length'` |
| `"hi"` | `max_turn_requests` | `ok`, `finish_reason='max_turn_requests'` | `ok`, `finish_reason='length'` |
| *control* `"hi"` | `end_turn` | `ok`, `finish_reason='stop'` | unchanged |
| *control* `"hi"` | `cancelled` / `refusal` | `ok`, passthrough | unchanged |

Both are parametrized regression tests on the public path: `test_complete_rejects_a_turn_that_produced_no_text` and `test_complete_reports_truncation_as_length`. The second covers the passthrough reasons too, so a future translation cannot quietly become `stop`.

## Gates

- `tests/unit/providers` — 631 passed, 5 skipped
- `ruff check` / `ruff format --check` / `mypy` — clean
- `scripts/check-module-size.py --baseline-ref upstream/main` — OK (493 modules, cap 2000)
- `scripts/check-auto-boundary.py` — OK (39 files scanned, 0 findings); no `auto/` file is touched

Rebased on `000f9580`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
