### PR TITLE
fix(persistence): snapshot checkpoint state and validate integrity on save

### DIFF
--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -27,6 +27,20 @@ from ouroboros.core.file_lock import file_lock as _file_lock
 from ouroboros.core.types import Result
 
 
+def _checkpoint_hash(seed_id: str, phase: str, state: dict[str, Any], timestamp_iso: str) -> str:
+    """Integrity hash over one exact checkpoint payload."""
+    serialized = json.dumps(
+        {
+            "seed_id": seed_id,
+            "phase": phase,
+            "state": state,
+            "timestamp": timestamp_iso,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
 @dataclass(frozen=True, slots=True)
 class CheckpointData:
     """Immutable checkpoint data for workflow state.
@@ -64,15 +78,7 @@ class CheckpointData:
         # construction cannot desync the two (#1829). State is JSON-bound by
         # the hash below, so every valid state is deep-copyable.
         state = copy.deepcopy(state)
-        # Create temporary instance without hash to compute it
-        temp_data = {
-            "seed_id": seed_id,
-            "phase": phase,
-            "state": state,
-            "timestamp": timestamp.isoformat(),
-        }
-        serialized = json.dumps(temp_data, sort_keys=True)
-        hash_value = hashlib.sha256(serialized.encode()).hexdigest()
+        hash_value = _checkpoint_hash(seed_id, phase, state, timestamp.isoformat())
 
         return cls(
             seed_id=seed_id,
@@ -88,14 +94,9 @@ class CheckpointData:
         Returns:
             Result.ok(True) if hash matches, Result.err with details if corrupted.
         """
-        temp_data = {
-            "seed_id": self.seed_id,
-            "phase": self.phase,
-            "state": self.state,
-            "timestamp": self.timestamp.isoformat(),
-        }
-        serialized = json.dumps(temp_data, sort_keys=True)
-        computed_hash = hashlib.sha256(serialized.encode()).hexdigest()
+        computed_hash = _checkpoint_hash(
+            self.seed_id, self.phase, self.state, self.timestamp.isoformat()
+        )
 
         if computed_hash != self.hash:
             return Result.err(f"Hash mismatch: expected {self.hash}, got {computed_hash}")
@@ -279,14 +280,26 @@ class CheckpointStore:
             Result.ok(None) on success, Result.err(PersistenceError) on failure.
         """
         try:
-            integrity = checkpoint.validate_integrity()
-            if integrity.is_err:
+            # Serialize exactly once and validate that snapshot: the live
+            # object's state is caller-visible and mutable, so validating one
+            # read and writing a second would reopen the desync between
+            # payload and hash (#1829). The snapshot below is what gets
+            # written, byte for byte.
+            payload = checkpoint.to_dict()
+            snapshot_hash = _checkpoint_hash(
+                payload["seed_id"],
+                payload["phase"],
+                payload["state"],
+                payload["timestamp"],
+            )
+            if snapshot_hash != payload["hash"]:
                 # Never persist a checkpoint load() would immediately reject:
                 # refusing here keeps the committed chain untouched and
                 # surfaces the mismatch to the caller instead (#1829).
                 return Result.err(
                     PersistenceError(
-                        f"Refusing to save checkpoint with stale integrity hash: {integrity.error}",
+                        "Refusing to save checkpoint with stale integrity hash: "
+                        f"expected {payload['hash']}, got {snapshot_hash}",
                         operation="write",
                         details={
                             "seed_id": checkpoint.seed_id,
@@ -306,7 +319,7 @@ class CheckpointStore:
                 staged = checkpoint_path.with_name(f".tmp-{secrets.token_hex(8)}.json")
                 try:
                     with staged.open("w") as f:
-                        json.dump(checkpoint.to_dict(), f, indent=2)
+                        json.dump(payload, f, indent=2)
                         f.flush()
                         os.fsync(f.fileno())
                     self._publish_staged_checkpoint(checkpoint.seed_id, staged, checkpoint_path)

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+import copy
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 import hashlib
@@ -57,6 +58,12 @@ class CheckpointData:
             New CheckpointData instance with computed hash.
         """
         timestamp = datetime.now(UTC)
+        # Snapshot the caller's state before hashing: the integrity hash must
+        # bind exactly the payload this checkpoint will carry, so a caller
+        # mutating its dictionary (or anything nested in it) after
+        # construction cannot desync the two (#1829). State is JSON-bound by
+        # the hash below, so every valid state is deep-copyable.
+        state = copy.deepcopy(state)
         # Create temporary instance without hash to compute it
         temp_data = {
             "seed_id": seed_id,
@@ -272,6 +279,23 @@ class CheckpointStore:
             Result.ok(None) on success, Result.err(PersistenceError) on failure.
         """
         try:
+            integrity = checkpoint.validate_integrity()
+            if integrity.is_err:
+                # Never persist a checkpoint load() would immediately reject:
+                # refusing here keeps the committed chain untouched and
+                # surfaces the mismatch to the caller instead (#1829).
+                return Result.err(
+                    PersistenceError(
+                        f"Refusing to save checkpoint with stale integrity hash: {integrity.error}",
+                        operation="write",
+                        details={
+                            "seed_id": checkpoint.seed_id,
+                            "phase": checkpoint.phase,
+                            "integrity_mismatch": True,
+                        },
+                    )
+                )
+
             checkpoint_path = self._get_checkpoint_path(checkpoint.seed_id)
 
             # Use file locking to prevent race conditions

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -509,6 +509,41 @@ class TestCheckpointStateIsolation:
         rollback = checkpoint_store._get_checkpoint_path("tampered", 1)
         assert not rollback.exists(), "a refused save rotated history"
 
+    def test_mutation_between_validation_and_serialization_is_harmless(
+        self, checkpoint_store: CheckpointStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """save() writes the exact snapshot it validated.
+
+        The file lock only serializes store access — it cannot protect the
+        caller-owned object. A mutation landing during lock acquisition must
+        not desync the written payload from its hash: the persisted file is
+        the validated snapshot, and load() accepts it.
+        """
+        from ouroboros.persistence import checkpoint as checkpoint_module
+
+        saved = CheckpointData.create("race-mutation", "execution", {"step": 1})
+        real_lock = checkpoint_module._file_lock
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def mutating_lock(path, exclusive):
+            # The bot-shaped interleaving: the holder mutates the live
+            # object while save() waits for the lock.
+            saved.state["step"] = 999
+            with real_lock(path, exclusive=exclusive):
+                yield
+
+        monkeypatch.setattr(checkpoint_module, "_file_lock", mutating_lock)
+        result = checkpoint_store.save(saved)
+
+        assert result.is_ok, str(result.error) if result.is_err else ""
+        loaded = checkpoint_store.load("race-mutation")
+        assert loaded.is_ok, "the persisted payload no longer matches its hash"
+        assert loaded.value.state == {"step": 1}, (
+            "save() wrote a different payload than the one it validated"
+        )
+
 
 class TestCheckpointStoreAtomicSave:
     """#1830: a failed save must not disturb the committed checkpoint chain."""

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -456,6 +456,60 @@ class TestCheckpointStoreRollback:
         assert not rollback4_path.exists()  # Should be deleted
 
 
+class TestCheckpointStateIsolation:
+    """#1829: caller mutation after create() must not desync payload and hash."""
+
+    def test_top_level_mutation_after_create_is_invisible(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        state = {"steps": [1]}
+        checkpoint = CheckpointData.create("mutable-state", "execution", state)
+        state["added"] = "later"
+
+        assert checkpoint_store.save(checkpoint).is_ok
+        loaded = checkpoint_store.load("mutable-state")
+        assert loaded.is_ok, "a mutated caller dict invalidated the saved checkpoint"
+        assert loaded.value.state == {"steps": [1]}, "the snapshot leaked caller mutation"
+
+    def test_nested_mutation_after_create_is_invisible(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        state = {"steps": [1], "nested": {"flag": True}}
+        checkpoint = CheckpointData.create("nested-state", "execution", state)
+        state["steps"].append(2)
+        state["nested"]["flag"] = False
+
+        assert checkpoint_store.save(checkpoint).is_ok
+        loaded = checkpoint_store.load("nested-state")
+        assert loaded.is_ok, "nested caller mutation invalidated the saved checkpoint"
+        assert loaded.value.state == {"steps": [1], "nested": {"flag": True}}
+
+    def test_save_refuses_a_checkpoint_whose_hash_does_not_match(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Integrity is validated before any rotation or write."""
+        valid = CheckpointData.create("tampered", "execution", {"step": 1})
+        assert checkpoint_store.save(valid).is_ok
+        current = checkpoint_store._get_checkpoint_path("tampered")
+        original = current.read_bytes()
+
+        tampered = CheckpointData(
+            seed_id="tampered",
+            phase="execution",
+            state={"step": 999},
+            timestamp=valid.timestamp,
+            hash=valid.hash,
+        )
+        result = checkpoint_store.save(tampered)
+
+        assert result.is_err, "save persisted a checkpoint load() would reject"
+        assert current.read_bytes() == original, (
+            "a refused save still touched the committed checkpoint"
+        )
+        rollback = checkpoint_store._get_checkpoint_path("tampered", 1)
+        assert not rollback.exists(), "a refused save rotated history"
+
+
 class TestCheckpointStoreAtomicSave:
     """#1830: a failed save must not disturb the committed checkpoint chain."""
 


### PR DESCRIPTION
Closes #1829.

## Problem

`CheckpointData.create()` computed its integrity hash from the caller's state dictionary but stored that mutable dictionary by reference. Mutating the dictionary — or a nested list or dict inside it — after construction and before `save()` changed the payload while the hash stayed stale: `save()` reported success for a checkpoint that `load()` immediately rejected as corrupt, exactly as in the issue's reproduction (`save_is_ok=True`, `load_is_ok=False`, all four levels exhausted). The frozen dataclass protects the fields, not the objects nested inside `state`.

## Fix

- `create()` deep-copies the state before hashing, so the hash binds exactly the payload the checkpoint carries and later caller mutation is invisible. Every `create()` call site passes JSON-serializable state by construction — the hash serialization already `json.dumps`s it — so every valid state is deep-copyable; a survey of all nine production call sites confirmed plain literal dictionaries throughout.
- `save()` validates integrity before taking the file lock or rotating anything, and returns the documented `PersistenceError` (with an `integrity_mismatch` detail) for a checkpoint whose payload does not match its hash, leaving the committed checkpoint and the rollback chain untouched.

## Tests

Per the acceptance criteria, all verified failing on the baseline:

- Top-level mutation after `create()` no longer invalidates the saved checkpoint, and the loaded state is the pre-mutation snapshot.
- Nested mutation (a list append and a nested-dict write) is likewise invisible.
- A hand-constructed checkpoint whose payload does not match its stored hash is refused by `save()` with no file touched and no history rotated.

Persistence suite plus the agent-process and parallel-executor suites that build checkpoints pass (834); ruff, mypy, and the module-size gate are clean.