### PR TITLE
fix(persistence): make the EventStore's SQLite-only contract explicit

### DIFF
--- a/src/ouroboros/persistence/backend_contract.py
+++ b/src/ouroboros/persistence/backend_contract.py
@@ -1,0 +1,36 @@
+"""The EventStore's storage-backend contract (#1832).
+
+Every cursor API is built on SQLite's implicit ``rowid`` ordering — the
+semantics documented in #1274: ``append_with_rowid``, ``get_current_rowid``,
+``get_events_after`` and the replay paths all query ``rowid`` directly, and
+the declared ``events`` schema carries no portable substitute. A non-SQLite
+backend cannot run those statements (PostgreSQL has no ``rowid`` system
+column), so accepting such a URL only defers the failure to first cursor
+use while misreporting capabilities in the meantime. The boundary is
+therefore explicit: the EventStore is SQLite-only, checked at construction.
+Introducing a declared monotonic cursor column later can relax this in one
+place, as a deliberate change rather than a silent one.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.engine import make_url
+
+
+def require_sqlite_event_store_url(database_url: str) -> None:
+    """Reject database URLs the EventStore's cursor contract cannot serve.
+
+    A malformed URL is left for engine creation to report with its own,
+    more specific error; only a well-formed URL naming a non-SQLite
+    backend is refused here.
+    """
+    try:
+        backend = make_url(database_url).get_backend_name()
+    except Exception:
+        return
+    if backend != "sqlite":
+        raise ValueError(
+            "EventStore is SQLite-only: its cursor APIs are built on SQLite "
+            f"rowid semantics, which a {backend!r} backend cannot serve. "
+            "Use a sqlite+aiosqlite:// URL."
+        )

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -682,9 +682,8 @@ class EventStore:
             parsed = make_url(database_url)
         except Exception:
             return None
-        if parsed.get_backend_name() != "sqlite":
-            return None
-        if str(parsed.query.get("mode", "")).lower() == "memory":
+        is_memory_mode = str(parsed.query.get("mode", "")).lower() == "memory"
+        if parsed.get_backend_name() != "sqlite" or is_memory_mode:
             return None
         database = parsed.database or ""
         if database.startswith("file:"):

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -20,6 +20,7 @@ from urllib.parse import quote, unquote
 from uuid import uuid4
 
 from sqlalchemy import and_, case, event, func, or_, select, text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 if TYPE_CHECKING:
@@ -672,23 +673,23 @@ class EventStore:
     def _sqlite_path_from_url(database_url: str) -> str | None:
         """Filesystem path of the SQLite file this URL points at, else ``None``.
 
-        Returns ``None`` for in-memory or non-SQLite backends (they have no local
-        file). Understands both the plain ``sqlite+aiosqlite:///<path>`` form and
-        the read-only ``…///file:<path>?mode=ro&uri=true`` URI form.
+        Returns ``None`` for in-memory or non-SQLite backends. Parsed
+        structurally, so a query string on any accepted form — plain,
+        ``:memory:``, or ``file:`` URIs (``mode=ro``/``mode=memory``) —
+        never masquerades as part of a filesystem path.
         """
-        prefix = "sqlite+aiosqlite:///"
-        if not database_url.startswith(prefix):
+        try:
+            parsed = make_url(database_url)
+        except Exception:
             return None
-        path_part = database_url[len(prefix) :]
-        if path_part.startswith("file:"):
-            # URI form. A ``mode=memory`` database is process-local no matter
-            # its name — no file another process can open; otherwise decode
-            # the path back to its filesystem form.
-            rest, _, query = path_part[len("file:") :].partition("?")
-            if "mode=memory" in unquote(query.split("#", 1)[0]):
-                return None
-            path_part = unquote(rest.split("#", 1)[0])
-        return None if path_part in (":memory:", "") else path_part
+        if parsed.get_backend_name() != "sqlite":
+            return None
+        if str(parsed.query.get("mode", "")).lower() == "memory":
+            return None
+        database = parsed.database or ""
+        if database.startswith("file:"):
+            database = unquote(database[len("file:") :])
+        return None if database in (":memory:", "") else database
 
     def sqlite_path(self) -> str | None:
         """Filesystem path of the backing SQLite file, or ``None``.

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -29,6 +29,7 @@ from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
+from ouroboros.persistence.backend_contract import require_sqlite_event_store_url
 from ouroboros.persistence.schema import (
     ac_acceptance_guards_table,
     events_table,
@@ -602,8 +603,8 @@ class EventStore:
         """Initialize EventStore with database URL.
 
         Args:
-            database_url: SQLAlchemy database URL.
-                         For async SQLite: "sqlite+aiosqlite:///path/to/db.sqlite"
+            database_url: SQLAlchemy database URL — SQLite-only, else ValueError
+                         (#1832). For async SQLite: "sqlite+aiosqlite:///path/to/db.sqlite"
                          If not provided, uses the configured EventStore path
                          with the legacy ~/.ouroboros/ouroboros.db fallback.
             read_only: When True, open the underlying SQLite database in true
@@ -615,7 +616,7 @@ class EventStore:
                 ``sqlite3.OperationalError: attempt to write a readonly database``.
                 Callers that opt in should also skip schema creation by calling
                 ``initialize(create_schema=False)`` — this is the default when
-                ``read_only=True``. ``read_only`` is a no-op for non-SQLite URLs.
+                ``read_only=True``.
         """
         self._configuration_error: ValueError | None = None
         if database_url is None:
@@ -636,6 +637,7 @@ class EventStore:
         self._lifecycle_lock = asyncio.Lock()
         if read_only:
             database_url = self._coerce_to_readonly_url(database_url)
+        require_sqlite_event_store_url(database_url)
         self._database_url = database_url
         self._engine: AsyncEngine | None = None
         # Anchor connection for process-shared in-memory databases (memdb VFS):
@@ -712,8 +714,6 @@ class EventStore:
     @property
     def supports_cross_process_workers(self) -> bool:
         """Whether another process can observe this store's event stream."""
-        if not self._database_url.startswith("sqlite+aiosqlite:///"):
-            return True
         return self.sqlite_path() is not None
 
     def _raise_invalid_append_input(

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -681,14 +681,14 @@ class EventStore:
             return None
         path_part = database_url[len(prefix) :]
         if path_part.startswith("file:"):
-            # URI form — drop the ``file:`` scheme and any ``?query``/``#fragment``,
-            # then percent-decode the path back to its filesystem form.
-            rest = path_part[len("file:") :]
-            rest = rest.split("?", 1)[0].split("#", 1)[0]
-            path_part = unquote(rest)
-        if path_part in (":memory:", ""):
-            return None
-        return path_part
+            # URI form. A ``mode=memory`` database is process-local no matter
+            # its name — no file another process can open; otherwise decode
+            # the path back to its filesystem form.
+            rest, _, query = path_part[len("file:") :].partition("?")
+            if "mode=memory" in unquote(query.split("#", 1)[0]):
+                return None
+            path_part = unquote(rest.split("#", 1)[0])
+        return None if path_part in (":memory:", "") else path_part
 
     def sqlite_path(self) -> str | None:
         """Filesystem path of the backing SQLite file, or ``None``.

--- a/tests/unit/mcp/tools/test_dashboard_db_path.py
+++ b/tests/unit/mcp/tools/test_dashboard_db_path.py
@@ -38,8 +38,10 @@ class TestDaemonDbTarget:
     def test_memory_store_is_suppressed(self) -> None:
         assert _dashboard._daemon_db_target(EventStore(_MEMORY_URL)) == (True, None)
 
-    def test_non_sqlite_store_is_suppressed(self) -> None:
-        assert _dashboard._daemon_db_target(EventStore("postgresql+asyncpg://h/db")) == (True, None)
+    def test_pathless_store_is_suppressed(self) -> None:
+        # Non-SQLite stores can no longer be constructed (#1832); a pathless
+        # in-memory store pins the same no-local-file suppression contract.
+        assert _dashboard._daemon_db_target(EventStore("sqlite+aiosqlite://")) == (True, None)
 
     def test_handlers_expose_injected_custom_store_to_resolution(self) -> None:
         # Each handler must surface the custom store via the exact attribute the

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -3014,3 +3014,27 @@ class TestCancellationSettlement:
         stored = await store.replay("test", "settle-batch")
         assert len(stored) == 2
         await store.close()
+
+
+class TestSqliteOnlyBackendContract:
+    """#1832: the cursor APIs are rowid-built; the backend boundary says so."""
+
+    def test_non_sqlite_url_is_rejected_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="SQLite-only"):
+            EventStore("postgresql+asyncpg://user:pass@localhost/ouroboros")
+
+    def test_every_sqlite_form_still_constructs(self, tmp_path) -> None:
+        EventStore("sqlite+aiosqlite://")
+        EventStore("sqlite+aiosqlite:///:memory:")
+        EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+        EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}", read_only=True)
+
+    def test_capability_report_matches_the_contract(self, tmp_path) -> None:
+        """Cross-process capability requires a real file another process can open."""
+        file_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+        assert file_store.supports_cross_process_workers is True
+
+        assert EventStore("sqlite+aiosqlite://").supports_cross_process_workers is False, (
+            "a pathless in-memory store is private to this process"
+        )
+        assert EventStore("sqlite+aiosqlite:///:memory:").supports_cross_process_workers is False

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -3045,3 +3045,13 @@ class TestSqliteOnlyBackendContract:
             "a named in-memory database is process-local regardless of its name"
         )
         assert named_memory.sqlite_path() is None
+
+        for query_bearing in (
+            "sqlite+aiosqlite:///?cache=shared",
+            "sqlite+aiosqlite:///:memory:?cache=shared",
+        ):
+            store = EventStore(query_bearing)
+            assert store.sqlite_path() is None, (
+                f"a query string masqueraded as a path: {query_bearing}"
+            )
+            assert store.supports_cross_process_workers is False

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -3038,3 +3038,10 @@ class TestSqliteOnlyBackendContract:
             "a pathless in-memory store is private to this process"
         )
         assert EventStore("sqlite+aiosqlite:///:memory:").supports_cross_process_workers is False
+        named_memory = EventStore(
+            "sqlite+aiosqlite:///file:namedmem?mode=memory&cache=shared&uri=true"
+        )
+        assert named_memory.supports_cross_process_workers is False, (
+            "a named in-memory database is process-local regardless of its name"
+        )
+        assert named_memory.sqlite_path() is None

--- a/tests/unit/persistence/test_event_store_sqlite_path.py
+++ b/tests/unit/persistence/test_event_store_sqlite_path.py
@@ -28,8 +28,10 @@ class TestSqlitePath:
     def test_memory_backend_has_no_file(self) -> None:
         assert EventStore("sqlite+aiosqlite:///:memory:").sqlite_path() is None
 
-    def test_non_sqlite_backend_has_no_local_file(self) -> None:
-        assert EventStore("postgresql+asyncpg://host/db").sqlite_path() is None
+    def test_non_sqlite_url_yields_no_local_file(self) -> None:
+        # Construction refuses non-SQLite URLs outright (#1832); the path
+        # helper's contract for such URLs is still pinned directly.
+        assert EventStore._sqlite_path_from_url("postgresql+asyncpg://host/db") is None
 
     def test_read_only_uri_form_is_decoded_back_to_a_path(self) -> None:
         # read_only=True rewrites the URL into the ``file:...?mode=ro&uri=true``


### PR DESCRIPTION
Closes #1832.

## Problem

`EventStore` accepted non-SQLite SQLAlchemy URLs and reported them as cross-process capable, but every cursor API — `append_with_rowid`, `get_current_rowid`, `get_events_after` and the replay paths — emits SQLite-only `rowid` queries. On PostgreSQL those statements reference a column that does not exist in the declared `events` schema, so the accepted backend failed at first cursor use while `supports_cross_process_workers` claimed `True` the whole time.

## Fix

Of the two remedies the issue offers, this takes the coherent-boundary option: the store is explicitly SQLite-only.

- Construction refuses a well-formed non-SQLite URL with an error naming the rowid contract. The check lives in a small `persistence/backend_contract.py` module so the boundary is documented in one place — if a declared portable cursor column ever becomes worth its migration, this is the single spot that relaxes, as a deliberate change rather than a silent one. A malformed URL is still left for engine creation to report with its own, more specific error.
- Capability reporting agrees with the contract: `supports_cross_process_workers` is now simply whether a real SQLite file exists for another process to open. This also corrects the pathless `sqlite+aiosqlite://` form, which previously fell through the prefix check and misreported `True` for a database that is private to one process by construction.
- Two tests that constructed non-SQLite stores only to pin unrelated helpers (`sqlite_path`, the dashboard's daemon-target suppression) now pin those helpers directly, preserving their intent under the new boundary.

## Tests

- A `postgresql+asyncpg` URL is refused at construction with a message matching the contract (verified failing on the baseline, which accepted it).
- Every accepted SQLite form — pathless, `:memory:`, file path, and the read-only URI rewrite — still constructs.
- The capability report matches the contract: file-backed stores report `True`; pathless and `:memory:` stores report `False` (the pathless case verified failing on the baseline).

Persistence, evolution, and MCP-tools suites pass; ruff, mypy, and the module-size gate are clean — `event_store.py` stays exactly at its ratcheted budget, with the new boundary in its own module.