### PR TITLE
cleanup(orchestrator): drop the tri-state project-identity sentinel

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -267,15 +267,6 @@ def _mapping_has_exact_keys(value: object, expected: frozenset[str]) -> bool:
     return False
 
 
-class _UnresolvedProjectIdentity:
-    """Sentinel type separating omitted resolution from resolved absence."""
-
-    __slots__ = ()
-
-
-_UNRESOLVED_PROJECT_IDENTITY = _UnresolvedProjectIdentity()
-
-
 @dataclass(frozen=True, slots=True)
 class _PersistedExecutionStrategy:
     """Effect-bearing prompt/tool strategy restored without live config reads."""
@@ -5679,9 +5670,7 @@ class OrchestratorRunner:
         seed_fingerprint: str | None = None,
         authority_generation: _ProcessLocalAuthorityGeneration | None = None,
         execution_inputs_contract: Mapping[str, Any] | None = None,
-        project_identity: ProjectIdentity | None | _UnresolvedProjectIdentity = (
-            _UNRESOLVED_PROJECT_IDENTITY
-        ),
+        project_identity: ProjectIdentity | None,
         runtime_handle: RuntimeHandle | None = None,
     ) -> dict[str, Any]:
         """Build the durable resolved inputs shared by resume and proof cohorting."""
@@ -5738,12 +5727,7 @@ class OrchestratorRunner:
             ),
             "execution_inputs_fingerprint": self._execution_inputs_fingerprint(execution_inputs),
         }
-        resolved_project_identity = (
-            self._project_identity()
-            if isinstance(project_identity, _UnresolvedProjectIdentity)
-            else project_identity
-        )
-        workspace_identity = self._resolved_proof_workspace_identity(resolved_project_identity)
+        workspace_identity = self._resolved_proof_workspace_identity(project_identity)
         if workspace_identity is not None:
             proof_contract.update(workspace_identity)
         resolved_seed_fingerprint = seed_fingerprint

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -1199,7 +1199,9 @@ class TestFrugalityProofConsumer:
             ontology_schema=OntologySchema(name="Proof", description="Proof cohort"),
             metadata=SeedMetadata(seed_id="seed-proof"),
         )
-        contract = runner._build_execution_contract(seed=cohort_seed)
+        contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(), seed=cohort_seed
+        )
         other_project_contract = {
             **contract,
             "frugality_proof": {
@@ -1215,6 +1217,7 @@ class TestFrugalityProofConsumer:
             },
         }
         edited_seed_contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(),
             seed=cohort_seed.model_copy(
                 update={
                     "acceptance_criteria": (
@@ -1223,7 +1226,7 @@ class TestFrugalityProofConsumer:
                         ),
                     )
                 }
-            )
+            ),
         )
         store.query_events.return_value = [
             BaseEvent(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -126,7 +126,9 @@ def _attach_live_process_local_contract(
     if not isinstance(getattr(runner._adapter, "_model", None), str):
         runner._adapter._model = "test-model"
     generation = runner._begin_process_local_authority_generation()
-    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=seed, authority_generation=generation
+    )
     runner._register_process_local_authority(
         session_id=tracker.session_id,
         execution_id=tracker.execution_id,

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -5720,7 +5720,9 @@ def test_clear_cancellation_request_retries_and_surfaces_final_failure(
 
 def test_process_local_contract_is_not_a_cross_run_proof_cohort_key() -> None:
     runner = _runner()
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     assert (
         runner._proof_cohort_identity(
@@ -6998,7 +7000,9 @@ def test_diagnostic_contract_builds_do_not_leak_registry_issuances() -> None:
     issued_before = len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued)
 
     for _ in range(25):
-        contract = runner._build_execution_contract(seed=_seed())
+        contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(), seed=_seed()
+        )
         assert contract["foundation_a_authority"]["scope"] == "process_local"
 
     assert len(_PROCESS_LOCAL_AUTHORITY_REGISTRY._issued) == issued_before

--- a/tests/unit/orchestrator/test_routing_contract_resume.py
+++ b/tests/unit/orchestrator/test_routing_contract_resume.py
@@ -228,6 +228,18 @@ def _clear_model_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("ouroboros.config.load_config", get_default_config)
 
 
+def test_execution_contract_requires_explicit_project_identity() -> None:
+    """#1798: the self-resolving sentinel default is gone.
+
+    Omitting project_identity used to silently trigger a Git-subprocess
+    resolution through a private sentinel that no call site could see. The
+    parameter is required now, so an implicit call fails at the call site
+    instead of hiding a resolution cost.
+    """
+    with pytest.raises(TypeError, match="project_identity"):
+        _runner()._build_execution_contract(seed=_seed())
+
+
 def test_router_contract_round_trips_custom_frontier_policy() -> None:
     router = _frontier_custom_router()
 
@@ -303,7 +315,9 @@ def test_router_contract_rejects_semantically_invalid_ladder(router_payload: dic
 def test_resume_restores_persisted_custom_frontier_router() -> None:
     original = _runner()
     _use_frontier_custom_routing(original)
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     resumed = _runner()
     resumed._route_economics = _frontier_custom_economics()
@@ -335,7 +349,11 @@ def test_v9_resume_rejects_every_inexact_top_level_shape_before_effects(
     schema_mutation: str,
 ) -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(), seed=_seed()
+        )
+    )
     assert frozenset(persisted) == EXECUTION_CONTRACT_V9_TOP_LEVEL_KEYS
     if schema_mutation == "unknown_top_level_key":
         persisted[schema_mutation] = "not part of v9"
@@ -376,7 +394,11 @@ def test_v9_resume_rejects_every_inexact_top_level_shape_before_effects(
 
 def test_resume_rejects_router_policy_that_validates_its_own_projection() -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     routing = persisted["model_routing"]
     router = routing["router"]
     projection = routing["route_compat"]["projection"]
@@ -391,7 +413,11 @@ def test_resume_rejects_router_policy_that_validates_its_own_projection() -> Non
 
 def test_pre_admission_v2_contract_fails_closed_without_complete_effect_inputs() -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(), seed=_seed()
+        )
+    )
     persisted["version"] = 2
     routing = persisted["model_routing"]
     del routing["reasoning_effort"]
@@ -414,7 +440,11 @@ def test_pre_admission_v2_contract_fails_closed_without_complete_effect_inputs()
 
 def test_pre_requested_tier_v3_contract_fails_closed_without_complete_effect_inputs() -> None:
     original = _runner(base_model_tier="frontier")
-    persisted = copy.deepcopy(original._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(), seed=_seed()
+        )
+    )
     persisted["version"] = 3
     routing = persisted["model_routing"]
     del routing["requested_model_tier"]
@@ -435,7 +465,11 @@ def test_pre_requested_tier_v3_contract_fails_closed_without_complete_effect_inp
 
 def test_pre_execution_semantics_v4_contract_fails_closed_without_complete_effect_inputs() -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(), seed=_seed()
+        )
+    )
     persisted["version"] = 4
     del persisted["execution_semantics"]
     del persisted["frugality_proof"]["execution_semantics_fingerprint"]
@@ -453,7 +487,11 @@ def test_pre_execution_semantics_v4_contract_fails_closed_without_complete_effec
 def test_recent_contracts_without_complete_effect_inputs_fail_closed(
     legacy_version: int,
 ) -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(), seed=_seed()
+        )
+    )
     persisted["version"] = legacy_version
 
     with pytest.raises(OrchestratorError, match="without durable effect inputs") as exc_info:
@@ -468,7 +506,9 @@ def test_recent_contracts_without_complete_effect_inputs_fail_closed(
 
 def test_fat_harness_contract_freezes_resolved_profile_strategy_and_catalog() -> None:
     runner = _runner(fat_harness_mode=True)
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     strategy = runner._execution_strategy_snapshot(contract, require_bound=True)
     inputs = contract["execution_inputs"]
@@ -498,7 +538,9 @@ def test_v9_inputs_freeze_context_profile_parent_lineage_pause_and_runtime_capab
     )
     runner = _runner(cwd=str(tmp_path), inherited_runtime_handle=inherited)
     seed = _seed()
-    contract = runner._build_execution_contract(seed=seed)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=seed
+    )
 
     inputs = contract["execution_inputs"]
     semantics = contract["execution_semantics"]
@@ -551,7 +593,7 @@ def test_execution_inputs_reject_noncanonical_parent_handle_before_publication()
     )
 
     with pytest.raises(OrchestratorError, match="non-canonical execution effect inputs"):
-        runner._build_execution_contract(seed=_seed())
+        runner._build_execution_contract(project_identity=None, seed=_seed())
 
 
 @pytest.mark.parametrize(
@@ -563,7 +605,11 @@ def test_execution_inputs_reject_noncanonical_parent_handle_before_publication()
     ],
 )
 def test_current_execution_inputs_require_complete_effect_population(field: str) -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract(seed=_seed()))
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(), seed=_seed()
+        )
+    )
     del persisted["execution_inputs"][field]
     persisted["frugality_proof"]["execution_inputs_fingerprint"] = (
         OrchestratorRunner._execution_inputs_fingerprint(persisted["execution_inputs"])
@@ -579,7 +625,9 @@ def test_current_execution_inputs_require_complete_effect_population(field: str)
 def test_persisted_research_strategy_does_not_gain_edit_on_resume() -> None:
     runner = _runner()
     research_seed = _seed().model_copy(update={"task_type": "research"})
-    contract = runner._build_execution_contract(seed=research_seed)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=research_seed
+    )
 
     strategy = runner._execution_strategy_snapshot(contract, require_bound=True)
 
@@ -592,7 +640,9 @@ def test_complete_tool_catalog_drift_is_rejected_before_resume_dispatch() -> Non
 
     runner = _runner()
     research_seed = _seed().model_copy(update={"task_type": "research"})
-    contract = runner._build_execution_contract(seed=research_seed)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=research_seed
+    )
     drifted_catalog = assemble_session_tool_catalog(
         ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     )
@@ -607,7 +657,11 @@ def test_complete_tool_catalog_drift_is_rejected_before_resume_dispatch() -> Non
 
 def test_malformed_v3_contract_does_not_bypass_effect_input_version_gate() -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     persisted["version"] = 3
     routing = persisted["model_routing"]
     del routing["requested_model_tier"]
@@ -624,7 +678,9 @@ def test_malformed_v3_contract_does_not_bypass_effect_input_version_gate() -> No
 
 def test_execution_semantics_change_contract_without_changing_route_identity() -> None:
     runner = _runner()
-    baseline = runner._build_execution_contract()
+    baseline = runner._build_execution_contract(
+        project_identity=runner._project_identity(),
+    )
     baseline_routing_fingerprint = baseline["frugality_proof"]["routing_fingerprint"]
 
     runner._run_verify_commands = False
@@ -634,7 +690,9 @@ def test_execution_semantics_change_contract_without_changing_route_identity() -
     runner._decomposition_mode = "off"
     runner._max_decomposition_depth = 7
     runner._fat_harness_mode = True
-    changed = runner._build_execution_contract()
+    changed = runner._build_execution_contract(
+        project_identity=runner._project_identity(),
+    )
 
     assert changed["model_routing"] == baseline["model_routing"]
     assert changed["frugality_proof"]["routing_fingerprint"] == baseline_routing_fingerprint
@@ -650,7 +708,9 @@ def test_resume_rejects_weaker_current_execution_semantics_before_dispatch() -> 
     original._run_verify_commands = True
     original._verify_command_timeout_seconds = 600
     original._ac_retry_attempts = 2
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     resumed = _runner(enable_decomposition=False, fat_harness_mode=False)
     resumed._run_verify_commands = False
@@ -672,7 +732,9 @@ def test_resume_rejects_context_pack_and_effective_concurrency_drift(
     monkeypatch.setenv("OUROBOROS_CONTEXT_PACK", "1")
     monkeypatch.setenv("OUROBOROS_MAX_CONCURRENCY", "1")
     original = _runner(max_parallel_workers=3)
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     assert persisted["execution_semantics"]["context_pack_enabled"] is True
     assert persisted["execution_semantics"]["effective_parallel_workers"] == 1
 
@@ -694,7 +756,9 @@ def test_resume_rejects_backend_rate_and_pacing_owner_drift(
     monkeypatch.setenv("OUROBOROS_CLAUDE_RPM", "10")
     original = _runner(max_parallel_workers=3)
     original._adapter.self_governs_rate_limit = False
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     assert persisted["execution_semantics"]["backend_requests_per_minute"] == 10
     assert persisted["execution_semantics"]["backend_self_governs_rate_limit"] is False
 
@@ -715,7 +779,9 @@ def test_resume_rejects_usage_limit_pause_policy_drift(
     """Recovery timing is immutable execution authority, not live resume config."""
 
     monkeypatch.setenv("OUROBOROS_USAGE_LIMIT_PAUSE_HOURS", "1")
-    persisted = _runner()._build_execution_contract(seed=_seed())
+    persisted = _runner()._build_execution_contract(
+        project_identity=_runner()._project_identity(), seed=_seed()
+    )
     assert persisted["execution_semantics"]["usage_limit_pause_seconds"] == 3600
 
     monkeypatch.setenv("OUROBOROS_USAGE_LIMIT_PAUSE_HOURS", "9")
@@ -761,7 +827,9 @@ def test_resume_rejects_runtime_effort_capability_or_vocabulary_drift(
         enforceable_reasoning_efforts=frozenset({"low", "medium", "high", "xhigh"}),
         model_override_support=ParamSupport.NATIVE,
     )
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     assert (
         persisted["execution_semantics"]["runtime_effect_capabilities"]["reasoning_effort_support"]
         == "native"
@@ -806,7 +874,11 @@ def test_resume_rejects_runtime_effort_capability_or_vocabulary_drift(
 )
 def test_current_execution_semantics_requires_complete_exact_population(field: str) -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     del persisted["execution_semantics"][field]
     persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
         OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
@@ -817,7 +889,11 @@ def test_current_execution_semantics_requires_complete_exact_population(field: s
 
 
 def test_current_execution_semantics_migrates_retired_preflight_authority_once() -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(),
+        )
+    )
     persisted["execution_semantics"]["decomposition_mode"] = "preflight"
     persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
         OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
@@ -837,7 +913,11 @@ def test_current_execution_semantics_migrates_retired_preflight_authority_once()
 
 
 def test_legacy_preflight_migration_rejects_unsealed_semantics() -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(),
+        )
+    )
     persisted["execution_semantics"]["decomposition_mode"] = "preflight"
 
     with pytest.raises(OrchestratorError, match="invalid legacy preflight contract"):
@@ -857,7 +937,11 @@ def test_legacy_preflight_migration_rejects_unsealed_semantics() -> None:
 def test_current_runtime_effect_capabilities_require_complete_exact_population(
     field: str,
 ) -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(),
+        )
+    )
     del persisted["execution_semantics"]["runtime_effect_capabilities"][field]
     persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
         OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
@@ -871,7 +955,11 @@ def test_current_runtime_effect_capabilities_require_complete_exact_population(
 def test_current_execution_semantics_rejects_unbounded_pause_policy(
     pause_seconds: object,
 ) -> None:
-    persisted = copy.deepcopy(_runner()._build_execution_contract())
+    persisted = copy.deepcopy(
+        _runner()._build_execution_contract(
+            project_identity=_runner()._project_identity(),
+        )
+    )
     persisted["execution_semantics"]["usage_limit_pause_seconds"] = pause_seconds
     persisted["frugality_proof"]["execution_semantics_fingerprint"] = (
         OrchestratorRunner._execution_semantics_fingerprint(persisted["execution_semantics"])
@@ -886,7 +974,11 @@ def test_current_contract_missing_admission_field_is_not_treated_as_legacy(
     missing: str,
 ) -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     routing = persisted["model_routing"]
     del routing[missing]
     persisted["frugality_proof"]["routing_fingerprint"] = OrchestratorRunner._routing_fingerprint(
@@ -916,7 +1008,9 @@ def test_unbounded_economics_contract_is_json_safe_and_round_trips() -> None:
     original._model_router = router
     original._requested_model_tier = "frontier"
 
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     encoded = json.dumps(persisted, sort_keys=True)
     assert isinstance(encoded, str)
     routing = persisted["model_routing"]
@@ -952,7 +1046,9 @@ def test_contract_serialization_ignores_constrained_python_digit_limit() -> None
         runner._model_router = router
         runner._requested_model_tier = "frontier"
 
-        contract = runner._build_execution_contract()
+        contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(),
+        )
 
         assert json.dumps(contract, sort_keys=True)
         assert contract["model_routing"]["router"]["escalation_retry_threshold"] == (
@@ -967,7 +1063,9 @@ def test_resume_without_argument_preserves_persisted_non_default_tier(
     requested_tier: str,
 ) -> None:
     original = _runner(base_model_tier=requested_tier)
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     assert persisted["model_routing"]["requested_model_tier"] == requested_tier
 
     resumed = _runner()
@@ -989,7 +1087,9 @@ def test_resume_rejects_base_reasoning_effort_transition(
 ) -> None:
     original = _runner()
     original._reasoning_effort = persisted_effort
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     route_compat = persisted["model_routing"]["route_compat"]
     assert route_compat["projection"]["effort"] == persisted_effort
 
@@ -1003,7 +1103,9 @@ def test_resume_rejects_base_reasoning_effort_transition(
 def test_resume_restores_persisted_kill_switch() -> None:
     original = _runner()
     original._model_router = None
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     resumed = _runner()
     assert resumed._model_router is not None
@@ -1017,7 +1119,9 @@ def test_dormant_model_routing_still_rejects_reasoning_effort_drift() -> None:
     original = _runner()
     original._model_router = None
     original._reasoning_effort = "low"
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     routing = persisted["model_routing"]
     assert routing["route_compat"] == {"version": 1, "enabled": False}
     assert routing["reasoning_effort"] == "low"
@@ -1035,7 +1139,9 @@ def test_resume_rejects_changed_base_reasoning_effort(
     """The effort used to form each dispatch is part of resume identity."""
     monkeypatch.setattr("ouroboros.config.get_agent_reasoning_effort", lambda: "low")
     original = _runner()
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     assert persisted["model_routing"]["base_reasoning_effort"] == "low"
 
@@ -1048,7 +1154,9 @@ def test_resume_rejects_changed_base_reasoning_effort(
 def test_legacy_contract_without_base_effort_migrates_dormant_effort() -> None:
     """A missing base effort can be recovered from the persisted routing effort."""
     original = _runner()
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     legacy_routing = dict(persisted["model_routing"])
     legacy_routing.pop("base_reasoning_effort")
     legacy_contract = {
@@ -1074,7 +1182,9 @@ def test_legacy_contract_without_base_effort_migrates_enabled_effort() -> None:
     """An old contract's routing effort is the historical base effort."""
     original = _runner()
     original._reasoning_effort = "high"
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     legacy_routing = dict(persisted["model_routing"])
     legacy_routing.pop("base_reasoning_effort")
     legacy_contract = {
@@ -1103,7 +1213,9 @@ def test_legacy_contract_missing_base_effort_rejects_historical_high_to_none(
     """The migrated historical effort still protects against current drift."""
     original = _runner()
     original._reasoning_effort = "high"
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
     legacy_routing = dict(persisted["model_routing"])
     legacy_routing.pop("base_reasoning_effort")
     legacy_contract = {
@@ -1125,7 +1237,9 @@ def test_legacy_contract_missing_base_effort_rejects_historical_high_to_none(
 def test_explicit_resume_tier_override_replaces_persisted_contract() -> None:
     original = _runner()
     _use_frontier_custom_routing(original)
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     resumed = _runner(base_model_tier="standard")
     resumed._route_economics = _frontier_custom_economics()
@@ -1147,7 +1261,9 @@ def test_explicit_override_preserves_legacy_workspace_across_two_resumes(
     _init_git_repo(repo_root)
     original = _runner(cwd=str(workspace))
     _use_frontier_custom_routing(original)
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     persisted["frugality_proof"]["project_root"] = str(workspace.resolve())
     persisted["frugality_proof"]["workspace_path"] = "."
     legacy_start = {
@@ -1192,7 +1308,9 @@ def test_explicit_override_preserves_legacy_workspace_across_two_resumes(
 def test_explicit_resume_tier_override_replaces_changed_catalog() -> None:
     original = _runner()
     _use_frontier_custom_routing(original)
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     resumed = _runner(base_model_tier="standard")
     changed_economics = _frontier_custom_economics()
@@ -1219,7 +1337,11 @@ def test_explicit_resume_tier_override_replaces_changed_catalog() -> None:
 
 def test_enabled_router_rejects_dormant_route_compat_on_resume() -> None:
     original = _runner()
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     routing = persisted["model_routing"]
     routing["route_compat"] = {"version": 1, "enabled": False}
     persisted["frugality_proof"]["routing_fingerprint"] = OrchestratorRunner._routing_fingerprint(
@@ -1233,7 +1355,11 @@ def test_enabled_router_rejects_dormant_route_compat_on_resume() -> None:
 def test_dormant_current_contract_requires_explicit_route_compat() -> None:
     original = _runner()
     original._model_router = None
-    persisted = copy.deepcopy(original._build_execution_contract())
+    persisted = copy.deepcopy(
+        original._build_execution_contract(
+            project_identity=original._project_identity(),
+        )
+    )
     routing = persisted["model_routing"]
     del routing["route_compat"]
     persisted["frugality_proof"]["routing_fingerprint"] = OrchestratorRunner._routing_fingerprint(
@@ -1261,7 +1387,9 @@ def test_present_malformed_resume_contract_fails_closed() -> None:
 
 def test_empty_observed_runtime_identity_is_rejected() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     malformed_routing = {
         **persisted["model_routing"],
         "runtime_execution": {
@@ -1289,7 +1417,9 @@ def test_empty_observed_runtime_identity_is_rejected() -> None:
 def test_cross_backend_resume_is_rejected_before_dispatch() -> None:
     original = _runner()
     original._model_router = _frontier_custom_router()
-    persisted = original._build_execution_contract()
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(),
+    )
 
     resumed = _runner()
     resumed._adapter.runtime_backend = "codex_cli"
@@ -1300,7 +1430,9 @@ def test_cross_backend_resume_is_rejected_before_dispatch() -> None:
 
 def test_explicit_tier_does_not_authorize_cross_backend_resume() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     resumed = _runner(base_model_tier="standard")
     resumed._adapter.runtime_backend = "codex_cli"
@@ -1314,7 +1446,9 @@ def test_explicit_tier_does_not_authorize_cross_backend_resume() -> None:
 
 def test_explicit_tier_does_not_bypass_malformed_persisted_router() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     persisted_routing = persisted["model_routing"]
     assert isinstance(persisted_routing.get("router"), dict)
     malformed_routing = {
@@ -1343,7 +1477,9 @@ def test_explicit_tier_does_not_bypass_malformed_persisted_router() -> None:
 
 def test_explicit_tier_does_not_bypass_nested_backend_mismatch() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     persisted_routing = persisted["model_routing"]
     assert isinstance(persisted_routing.get("router"), dict)
     inconsistent_routing = {
@@ -1372,7 +1508,9 @@ def test_explicit_tier_does_not_bypass_nested_backend_mismatch() -> None:
 
 def test_constructor_model_pin_is_persisted_and_mismatch_is_rejected() -> None:
     original = _runner(constructor_model="claude-sonnet-original")
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     assert persisted["model_routing"]["runtime_backend"] == "claude"
     assert persisted["model_routing"]["constructor_model"] == {
@@ -1399,7 +1537,9 @@ def test_codex_dynamic_profiles_do_not_create_a_portable_resume_identity() -> No
     original_runtime._resolved_fallback_model = "resolved-fallback-model"
     original_runtime._resolved_fallback_profile = None
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    original_contract = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     resumed_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
@@ -1414,7 +1554,14 @@ def test_codex_dynamic_profiles_do_not_create_a_portable_resume_identity() -> No
         resumed_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            resumed_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     _assert_runtime_identity_observed(original_contract)
     _assert_runtime_identity_observed(resumed_contract)
@@ -1494,7 +1641,14 @@ def test_codex_resolved_fallback_state_stays_out_of_durable_runtime_identity() -
         original_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            original_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     resumed_runtime = CodexCliRuntime(
         cli_path="/bin/echo",
@@ -1507,7 +1661,14 @@ def test_codex_resolved_fallback_state_stays_out_of_durable_runtime_identity() -
         resumed_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            resumed_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     _assert_runtime_identity_observed(original_contract)
     _assert_runtime_identity_observed(resumed_contract)
@@ -1526,7 +1687,9 @@ def test_codex_profile_name_alone_stays_process_local(
     runtime._resolved_fallback_model = None
     runtime._resolved_fallback_profile = "same-name-mutable-profile"
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    persisted = runner._build_execution_contract(seed=_seed())
+    persisted = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     _assert_runtime_identity_observed(persisted)
 
@@ -1546,7 +1709,9 @@ def test_automatic_codex_default_resume_requires_observed_model(
     original_runtime._resolved_fallback_model = None
     original_runtime._resolved_fallback_profile = None
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     assert original._model_router is None
     assert persisted["model_routing"]["constructor_model"] == {
@@ -1595,7 +1760,12 @@ def test_automatic_codex_default_resume_rejects_a_different_executable_path(
     original_runtime._resolved_fallback_profile = None
     persisted = OrchestratorRunner(
         original_runtime, AsyncMock(), MagicMock()
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            original_runtime, AsyncMock(), MagicMock()
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     persisted_identity = persisted["model_routing"]["runtime_execution"]["identity"]
     assert persisted_identity["cli_executable_path"] == str(first_cli.absolute())
@@ -1631,7 +1801,12 @@ def test_automatic_codex_default_resume_rejects_in_place_cli_upgrade(
     original_runtime._resolved_fallback_profile = None
     persisted = OrchestratorRunner(
         original_runtime, AsyncMock(), MagicMock()
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            original_runtime, AsyncMock(), MagicMock()
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     cli.write_text("#!/bin/sh\necho codex 2.0\n", encoding="utf-8")
     resumed_runtime = CodexCliRuntime(cli_path=cli, model=None, cwd="/tmp/project")
@@ -1664,7 +1839,12 @@ def test_automatic_codex_default_resume_rejects_same_version_changed_executable(
     original_runtime._resolved_fallback_profile = None
     persisted = OrchestratorRunner(
         original_runtime, AsyncMock(), MagicMock()
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            original_runtime, AsyncMock(), MagicMock()
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     cli.write_text("#!/bin/sh\n# two\necho codex 1.0\n", encoding="utf-8")
     resumed_runtime = CodexCliRuntime(cli_path=cli, model=None, cwd="/tmp/project")
@@ -1692,7 +1872,9 @@ def test_non_codex_subclass_does_not_inherit_codex_profile_as_model_identity(
     runtime._codex_profile = "irrelevant-codex-profile"
     runtime._resolved_fallback_model = "irrelevant-codex-model"
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    persisted = runner._build_execution_contract(seed=_seed())
+    persisted = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     identity = _assert_runtime_identity_observed(persisted)
     assert identity["kind"] == "goose_v1"
@@ -1764,7 +1946,9 @@ def test_runtime_model_sentinel_is_not_persisted_as_a_constructor_pin(
         cwd="/tmp/project",
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    persisted = runner._build_execution_contract(seed=_seed())
+    persisted = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     assert persisted["model_routing"]["constructor_model"] == {
         "observed": True,
@@ -1802,7 +1986,9 @@ def test_codex_profile_file_changes_do_not_create_a_portable_runtime_identity(
     )
     original_runtime._codex_profile = "stable-name"
     original = OrchestratorRunner(original_runtime, AsyncMock(), MagicMock())
-    original_contract = original._build_execution_contract(seed=_seed())
+    original_contract = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     profile_path.write_text('model_provider = "proxy-b"\n', encoding="utf-8")
     resumed_runtime = CodexCliRuntime(
@@ -1815,7 +2001,14 @@ def test_codex_profile_file_changes_do_not_create_a_portable_runtime_identity(
         resumed_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            resumed_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     _assert_runtime_identity_observed(original_contract)
     _assert_runtime_identity_observed(resumed_contract)
@@ -1839,7 +2032,14 @@ def test_codex_home_changes_do_not_create_a_portable_runtime_identity(
         original_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            original_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     monkeypatch.setenv("CODEX_HOME", str(second_home))
     resumed_runtime = CodexCliRuntime(
@@ -1851,7 +2051,14 @@ def test_codex_home_changes_do_not_create_a_portable_runtime_identity(
         resumed_runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            resumed_runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     _assert_runtime_identity_observed(original_contract)
     _assert_runtime_identity_observed(resumed_contract)
@@ -1868,7 +2075,14 @@ def test_contract_build_records_codex_runtime_execution_identity() -> None:
         runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     identity = _assert_runtime_identity_observed(contract)
     assert identity["kind"] == "codex_cli_v1"
@@ -1883,7 +2097,9 @@ def test_resume_rejects_unobserved_runtime_identity_for_pinned_codex_v9() -> Non
         cwd="/tmp/project",
     )
     original = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     legacy_routing = {
         **persisted["model_routing"],
         "runtime_execution": {"version": 1, "observed": False},
@@ -1985,7 +2201,14 @@ def test_factory_codex_runtime_records_portable_dispatcher_identity() -> None:
         runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed())
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+    )
 
     identity = _assert_runtime_identity_observed(contract)
     assert identity["kind"] == "codex_cli_v1"
@@ -2182,7 +2405,9 @@ def test_runtime_selector_validation_rejects_changed_resume_handle(
         cwd="/tmp/project",
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    runner._execution_contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     with pytest.raises(OrchestratorError, match="different runtime handle selector"):
         runner._validate_resume_handle_execution_identity(runtime_handle)
@@ -2195,7 +2420,9 @@ def test_runtime_selector_validation_accepts_default_handle() -> None:
         cwd="/tmp/project",
     )
     runner = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    runner._execution_contract = runner._build_execution_contract(seed=_seed())
+    runner._execution_contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     runner._validate_resume_handle_execution_identity(
         RuntimeHandle(
@@ -2222,7 +2449,15 @@ def test_contract_build_binds_inherited_runtime_handle_selector() -> None:
         runtime,
         AsyncMock(),
         MagicMock(),
-    )._build_execution_contract(seed=_seed(), runtime_handle=handle)
+    )._build_execution_contract(
+        project_identity=OrchestratorRunner(
+            runtime,
+            AsyncMock(),
+            MagicMock(),
+        )._project_identity(),
+        seed=_seed(),
+        runtime_handle=handle,
+    )
 
     identity = _assert_runtime_identity_observed(contract)
     assert identity["resume_handle_selector"] == {
@@ -2245,7 +2480,9 @@ def test_restore_accepts_same_bound_runtime_handle_selector() -> None:
         metadata={"llm_role": "agent_runtime_implementation"},
     )
     original = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    contract = original._build_execution_contract(seed=_seed(), runtime_handle=handle)
+    contract = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed(), runtime_handle=handle
+    )
 
     resumed = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
 
@@ -2273,7 +2510,9 @@ def test_restore_rejects_different_bound_runtime_handle_selector() -> None:
         metadata={"llm_role": "agent_runtime_review"},
     )
     original = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
-    contract = original._build_execution_contract(seed=_seed(), runtime_handle=original_handle)
+    contract = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed(), runtime_handle=original_handle
+    )
 
     resumed = OrchestratorRunner(runtime, AsyncMock(), MagicMock())
     with pytest.raises(OrchestratorError, match="different runtime execution profile"):
@@ -2377,7 +2616,9 @@ def test_kill_switched_resume_cannot_drift_to_a_new_constructor_model(
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
     original = _runner(constructor_model="claude-sonnet-original")
     assert original._model_router is None
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     monkeypatch.delenv("OUROBOROS_MODEL_TIER_ROUTING")
     resumed = _runner(constructor_model="claude-sonnet-changed")
@@ -2394,7 +2635,9 @@ def test_unpinned_kill_switched_runtime_is_limited_to_process_local_resume(
 ) -> None:
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
     original = _runner(constructor_model=None)
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     assert persisted["model_routing"]["constructor_model"] == {
         "observed": True,
@@ -2414,7 +2657,9 @@ def test_kill_switched_contract_still_rejects_cross_backend_resume(
     monkeypatch.setenv("OUROBOROS_MODEL_TIER_ROUTING", "off")
     original = _runner(constructor_model="shared-model-pin")
     assert original._model_router is None
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     monkeypatch.delenv("OUROBOROS_MODEL_TIER_ROUTING")
     resumed = _runner(constructor_model="shared-model-pin")
@@ -2431,7 +2676,9 @@ def test_explicit_constructor_model_change_requires_a_new_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     original = _runner(constructor_model="claude-sonnet-original")
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     monkeypatch.setenv("OUROBOROS_EXECUTION_MODEL", "claude-sonnet-intentional")
     resumed = _runner(constructor_model="claude-sonnet-intentional")
@@ -2449,7 +2696,9 @@ def test_cross_workspace_resume_is_rejected_before_dispatch(tmp_path: Path) -> N
     project_a.mkdir()
     project_b.mkdir()
     original = _runner(cwd=str(project_a))
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     resumed = _runner(cwd=str(project_b))
 
     with pytest.raises(OrchestratorError, match="different project workspace"):
@@ -2468,7 +2717,9 @@ def test_same_repo_different_managed_worktree_cannot_resume(tmp_path: Path) -> N
             repo_root=repo_root,
         )
     )
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     resumed = _runner(
         task_workspace=_workspace(
             durable_id="run-different",
@@ -2487,7 +2738,9 @@ def test_same_repo_different_managed_worktree_cannot_resume(tmp_path: Path) -> N
 
 def test_current_contract_rejects_llm_backend_drift() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     resumed = _runner()
     resumed._adapter.llm_backend = "openai"
 
@@ -2500,7 +2753,9 @@ def test_current_contract_rejects_llm_backend_drift() -> None:
 
 def test_current_contract_always_binds_bypass_permission_mode() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     resumed = _runner()
     resumed._adapter.permission_mode = "acceptEdits"
 
@@ -2519,7 +2774,9 @@ def test_current_contract_always_binds_bypass_permission_mode() -> None:
 
 def test_modified_seed_is_rejected_on_resume() -> None:
     original = _runner()
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     with pytest.raises(OrchestratorError, match="modified Seed"):
         _runner()._restore_execution_contract(
@@ -2731,10 +2988,18 @@ def test_managed_worktrees_share_canonical_source_workspace_identity(tmp_path: P
         )
     )
 
-    first_proof = first._build_execution_contract(seed=_seed())["frugality_proof"]
-    second_proof = second._build_execution_contract(seed=_seed())["frugality_proof"]
-    first_resume = first._build_execution_contract(seed=_seed())["resume"]
-    second_resume = second._build_execution_contract(seed=_seed())["resume"]
+    first_proof = first._build_execution_contract(
+        project_identity=first._project_identity(), seed=_seed()
+    )["frugality_proof"]
+    second_proof = second._build_execution_contract(
+        project_identity=second._project_identity(), seed=_seed()
+    )["frugality_proof"]
+    first_resume = first._build_execution_contract(
+        project_identity=first._project_identity(), seed=_seed()
+    )["resume"]
+    second_resume = second._build_execution_contract(
+        project_identity=second._project_identity(), seed=_seed()
+    )["resume"]
 
     assert first_proof == second_proof
     assert first_resume != second_resume
@@ -3150,7 +3415,9 @@ def test_pre_anchor_managed_linked_override_survives_two_resumes(tmp_path: Path)
     )
     original = _runner(task_workspace=task_workspace)
     _use_frontier_custom_routing(original)
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     persisted["frugality_proof"]["project_root"] = str(linked.resolve())
     persisted["frugality_proof"]["workspace_path"] = "packages/app"
     legacy_start = {
@@ -3218,7 +3485,9 @@ def test_pre_anchor_nested_contract_resumes_with_legacy_cwd_identity(tmp_path: P
     workspace.mkdir(parents=True)
     _init_git_repo(repo_root)
     original = _runner(cwd=str(workspace))
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     persisted["frugality_proof"]["project_root"] = str(workspace.resolve())
     persisted["frugality_proof"]["workspace_path"] = "."
     resumed = _runner(cwd=str(workspace))
@@ -3281,7 +3550,9 @@ def test_project_anchor_rejects_partial_or_invalid_identity(
     start_identity: dict[str, str],
 ) -> None:
     runner = _runner()
-    persisted = runner._build_execution_contract(seed=_seed())
+    persisted = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     with pytest.raises(OrchestratorError, match="project identity anchor"):
         runner._restore_execution_contract(
@@ -3365,7 +3636,9 @@ def test_project_anchor_rejects_deleted_current_workspace(tmp_path: Path) -> Non
 @pytest.mark.asyncio
 async def test_start_event_contract_is_resume_fallback_without_progress_row() -> None:
     runner = _runner()
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -3569,7 +3842,9 @@ async def test_malformed_start_contract_is_preserved_and_rejected(
 @pytest.mark.asyncio
 async def test_progress_omission_preserves_start_event_execution_contract() -> None:
     runner = _runner()
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",
@@ -3599,7 +3874,9 @@ async def test_progress_omission_preserves_start_event_execution_contract() -> N
 @pytest.mark.asyncio
 async def test_corrupt_progress_contract_does_not_downgrade_to_legacy_resume() -> None:
     runner = _runner()
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
     start = BaseEvent(
         type="orchestrator.session.started",
         aggregate_type="session",

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -216,7 +216,9 @@ def _attach_live_process_local_contract(
     if not isinstance(getattr(runner._adapter, "_model", None), str):
         runner._adapter._model = "test-model"
     generation = runner._begin_process_local_authority_generation()
-    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=seed, authority_generation=generation
+    )
     runner._register_process_local_authority(
         session_id=session_id,
         execution_id=tracker.execution_id,
@@ -5985,7 +5987,9 @@ class TestOrchestratorRunner:
             sample_seed.metadata.seed_id,
             session_id="sess_parallel_semantics_drift",
         )
-        execution_contract = runner._build_execution_contract(seed=sample_seed)
+        execution_contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(), seed=sample_seed
+        )
         runner._run_verify_commands = not runner._run_verify_commands
         analyzer = MagicMock()
         analyzer.analyze = AsyncMock(
@@ -6066,7 +6070,9 @@ class TestOrchestratorRunner:
             sample_seed.metadata.seed_id,
             session_id="sess_parallel_resolved_limits",
         )
-        execution_contract = runner._build_execution_contract(seed=sample_seed)
+        execution_contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(), seed=sample_seed
+        )
         semantics = execution_contract["execution_semantics"]
         executor_cls = MagicMock()
         cancellation_result: Result[OrchestratorResult, OrchestratorError] = Result.err(
@@ -6535,6 +6541,7 @@ class TestOrchestratorRunner:
         execution_id = "exec-legacy-managed-linked"
         generation = runner._begin_process_local_authority_generation()
         contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(),
             seed=sample_seed,
             authority_generation=generation,
         )
@@ -7206,7 +7213,11 @@ class TestOrchestratorRunner:
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
-        legacy_contract = copy.deepcopy(runner._build_execution_contract(seed=sample_seed))
+        legacy_contract = copy.deepcopy(
+            runner._build_execution_contract(
+                project_identity=runner._project_identity(), seed=sample_seed
+            )
+        )
         legacy_contract["execution_semantics"]["decomposition_mode"] = "preflight"
         legacy_contract["frugality_proof"]["execution_semantics_fingerprint"] = (
             runner._execution_semantics_fingerprint(legacy_contract["execution_semantics"])
@@ -8293,7 +8304,9 @@ class TestOrchestratorRunner:
             mock_console,
             inherited_runtime_handle=inherited_handle,
         )
-        execution_contract = runner._build_execution_contract(seed=sample_seed)
+        execution_contract = runner._build_execution_contract(
+            project_identity=runner._project_identity(), seed=sample_seed
+        )
         persisted_profile = runner._execution_profile_snapshot(
             execution_contract,
             require_bound=True,

--- a/tests/unit/orchestrator/test_runner_execution_guidance.py
+++ b/tests/unit/orchestrator/test_runner_execution_guidance.py
@@ -110,7 +110,9 @@ def test_execution_contract_persists_declared_guidance(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     runner, _store = _runner(tmp_path, ("team",))
 
-    contract = runner._build_execution_contract(seed=_seed())
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=_seed()
+    )
 
     guidance = contract["guidance"]
     assert guidance["mode"] == "declared"
@@ -124,7 +126,9 @@ def test_execution_contract_persists_declared_guidance(tmp_path: Path) -> None:
 def test_resume_uses_persisted_ids_not_current_config(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     original, _store = _runner(tmp_path, ("team",))
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
 
     resumed, _store = _runner(tmp_path, ())
     changed = resumed._restore_execution_contract(
@@ -140,7 +144,9 @@ def test_resume_uses_persisted_ids_not_current_config(tmp_path: Path) -> None:
 def test_resume_rejects_changed_guidance_content(tmp_path: Path) -> None:
     path = _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     original, _store = _runner(tmp_path, ("team",))
-    persisted = original._build_execution_contract(seed=_seed())
+    persisted = original._build_execution_contract(
+        project_identity=original._project_identity(), seed=_seed()
+    )
     path.write_text("Changed conventions.\n", encoding="utf-8")
 
     resumed, _store = _runner(tmp_path, ())
@@ -159,13 +165,17 @@ def test_process_local_contract_never_forms_a_guidance_proof_cohort(tmp_path: Pa
     guided_identity = guided._proof_cohort_identity(
         {
             "seed_id": _seed().metadata.seed_id,
-            EXECUTION_CONTRACT_PROGRESS_KEY: guided._build_execution_contract(seed=_seed()),
+            EXECUTION_CONTRACT_PROGRESS_KEY: guided._build_execution_contract(
+                project_identity=guided._project_identity(), seed=_seed()
+            ),
         }
     )
     unguided_identity = unguided._proof_cohort_identity(
         {
             "seed_id": _seed().metadata.seed_id,
-            EXECUTION_CONTRACT_PROGRESS_KEY: unguided._build_execution_contract(seed=_seed()),
+            EXECUTION_CONTRACT_PROGRESS_KEY: unguided._build_execution_contract(
+                project_identity=unguided._project_identity(), seed=_seed()
+            ),
         }
     )
 
@@ -235,7 +245,7 @@ def test_legacy_contract_cannot_reconstruct_guidance_or_effect_inputs(tmp_path: 
 async def test_records_bounded_guidance_injection_event(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     runner, event_store = _runner(tmp_path, ("team",))
-    runner._build_execution_contract(seed=_seed())
+    runner._build_execution_contract(project_identity=runner._project_identity(), seed=_seed())
 
     await runner._record_execution_guidance_injection(
         session_id="sess-guidance",
@@ -254,7 +264,7 @@ async def test_records_bounded_guidance_injection_event(tmp_path: Path) -> None:
 async def test_guidance_injection_replay_deduplicates_same_attempt(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     runner, event_store = _runner(tmp_path, ("team",))
-    runner._build_execution_contract(seed=_seed())
+    runner._build_execution_contract(project_identity=runner._project_identity(), seed=_seed())
 
     await runner._record_execution_guidance_injection(
         session_id="sess-guidance",
@@ -278,7 +288,7 @@ async def test_guidance_injection_replay_deduplicates_same_attempt(tmp_path: Pat
 async def test_guidance_provenance_persistence_is_fail_closed(tmp_path: Path) -> None:
     _write_guidance(tmp_path, "team", "Use the project conventions.\n")
     runner, event_store = _runner(tmp_path, ("team",))
-    runner._build_execution_contract(seed=_seed())
+    runner._build_execution_contract(project_identity=runner._project_identity(), seed=_seed())
     event_store.append.side_effect = RuntimeError("store unavailable")
 
     with pytest.raises(OrchestratorError, match="persist.*guidance provenance"):
@@ -391,7 +401,9 @@ async def test_parallel_execution_receives_declared_guidance(tmp_path: Path) -> 
         session_id="sess-guidance-parallel",
     )
     generation = runner._begin_process_local_authority_generation()
-    contract = runner._build_execution_contract(seed=seed, authority_generation=generation)
+    contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(), seed=seed, authority_generation=generation
+    )
     runner._register_process_local_authority(
         session_id=tracker.session_id,
         execution_id=tracker.execution_id,
@@ -498,6 +510,7 @@ async def test_same_process_resume_delivers_persisted_guidance_to_adapter_system
     seed = _seed()
     generation = original._begin_process_local_authority_generation()
     persisted_contract = original._build_execution_contract(
+        project_identity=original._project_identity(),
         seed=seed,
         authority_generation=generation,
     )
@@ -585,6 +598,7 @@ async def test_guided_resume_rejects_missing_guidance_before_provider_call(
     seed = _seed()
     generation = runner._begin_process_local_authority_generation()
     malformed_contract = runner._build_execution_contract(
+        project_identity=runner._project_identity(),
         seed=seed,
         authority_generation=generation,
     )


### PR DESCRIPTION
Closes #1798.

## Problem

`_build_execution_contract`'s `project_identity` parameter carried three meanings through a private module-level sentinel default: unresolved ("resolve it yourself" — spawning a Git subprocess), resolved-but-absent (`None`), and resolved. The sentinel state was invisible at every call site, so the next contributor omitting the argument would silently trigger a resolution — a latency and correctness trap rather than a style concern.

## Fix

Option (a) from the issue: `project_identity: ProjectIdentity | None` is required, and the sentinel class and singleton are deleted. Every production caller already passed the argument explicitly (`_build_new_session_contract` a resolved identity, both `_restore_execution_contract` branches the replacement identity), so production behavior is unchanged — the diff there is pure deletion, and `runner.py` shrinks by 16 lines against the budget #1797 is ratcheting down.

Test callers that relied on the self-resolving default now resolve visibly at the call site (`project_identity=<runner>._project_identity()`), preserving prior behavior exactly. One test passes an explicit `None` instead: it asserts a non-canonical-inputs rejection that must fire first, and argument-time resolution in its intentionally broken workspace would preempt the error it exists to pin. A new regression asserts the implicit form is now a `TypeError` at the call site.

## The skill_intercept half

Recorded as matches-convention per the issue's own guidance rather than forced: the typed non-optional constructor split would grow `adapter.py` past its exact module-size budget (2,125 lines, pinned) for a narrowing the codebase performs twenty times over in `runner.py` alone. If the convention is revisited wholesale, that is the moment to split the constructor; the decision is noted on the issue either way.

## Tests

The six orchestrator suites that exercise `_build_execution_contract` pass deterministically (699 tests); ruff, mypy, and the module-size gate are clean.