### PR TITLE
refactor: put the pre-anchor legacy identity path behind one observable seam

### DIFF
--- a/docs/rfc/project-map-v1.md
+++ b/docs/rfc/project-map-v1.md
@@ -236,12 +236,26 @@ This dual representation is a transitional surface, not a second contract:
   `resume_workspace_comparison` and a `prepared_live_execution` context flag.
   An activation is counted only when a durable start-identity snapshot is
   present and still lacks the anchor; current prepared executions restore an
-  intentionally anchorless contract-only snapshot and never count. The metric
-  therefore stays trustworthy for the removal decision.
-- **Removal criterion.** Delete `legacy_identity.py` and the legacy branch
-  once no `project_map.legacy_identity_path` activation has been observed for
-  90 consecutive days of production logs, and in no case while any session
-  started before the anchor is still within the operator's retention window.
+  intentionally anchorless contract-only snapshot and never count. The event
+  is an advisory liveness signal only — the default file sink rotates away
+  after `LoggingConfig.max_log_days` (seven) days, file logging may be
+  disabled, and a sink that cannot be created is skipped — so absence from
+  available logs can never prove inactivity and carries no removal
+  authority.
+- **Removal criterion.** Delete `legacy_identity.py` and the runner's legacy
+  branch only after a fail-closed pre-anchor inventory preflight over the
+  durable EventStore — the same store resume itself reads — finds no
+  remaining pre-anchor session. The preflight enumerates every persisted
+  session with `EventStore.get_all_sessions()`, reads each session's
+  immutable start-identity snapshot (the `_session_start_identity` value
+  persisted at session start), and applies the runner's own
+  `_project_start_identity` predicate: any snapshot without the complete
+  anchor is pre-anchor. A session that cannot be enumerated or whose
+  snapshot cannot be read also counts as pre-anchor, so missing or
+  unreadable evidence blocks removal instead of authorizing it. An empty
+  inventory is a structural guarantee — every session the store could still
+  be asked to resume carries the anchor — not an inference from log
+  absence.
 
 ## Authority boundary
 

--- a/docs/rfc/project-map-v1.md
+++ b/docs/rfc/project-map-v1.md
@@ -219,24 +219,26 @@ only when it is present.
 
 Sessions started before the anchor landed carry no `project_id` on their
 durable `orchestrator.session.started` event. Resume detects this from the
-persisted start event itself (`has_project_anchor` is false) — never from a
-version heuristic — and takes a preserved legacy path instead of the resolver:
-the exact pre-anchor direct-cwd (or managed-task-workspace) representation is
-reproduced for the workspace comparison, and recoverable identity fields are
-validated against the start-event snapshot before any legacy migration writes
-a checkpoint. Rewriting these sessions under the current resolver would make
-resume disagree with their own immutable start events.
+persisted start-identity snapshot itself (`has_project_anchor` is false) —
+never from a version heuristic — and takes a preserved legacy path instead of
+the resolver: the exact pre-anchor direct-cwd (or managed-task-workspace)
+representation is reproduced for the workspace comparison. Rewriting these
+sessions under the current resolver would make resume disagree with their own
+immutable start events.
 
 This dual representation is a transitional surface, not a second contract:
 
 - **Implementation.** The legacy representation and its activation event live
-  in `orchestrator/legacy_identity.py`; the consuming branches in the runner
-  carry a comment pointing back here.
+  in `orchestrator/legacy_identity.py`; the consuming branch in the runner
+  carries a comment pointing back here.
 - **Observability.** Every activation emits the structured log event
-  `project_map.legacy_identity_path` with an `entry_point` field
-  (`resume_workspace_comparison` or `resume_identity_validation`), so the
-  removal decision is argued from evidence.
-- **Removal criterion.** Delete `legacy_identity.py` and the legacy branches
+  `project_map.legacy_identity_path` with `entry_point`
+  `resume_workspace_comparison` and a `prepared_live_execution` context flag.
+  An activation is counted only when a durable start-identity snapshot is
+  present and still lacks the anchor; current prepared executions restore an
+  intentionally anchorless contract-only snapshot and never count. The metric
+  therefore stays trustworthy for the removal decision.
+- **Removal criterion.** Delete `legacy_identity.py` and the legacy branch
   once no `project_map.legacy_identity_path` activation has been observed for
   90 consecutive days of production logs, and in no case while any session
   started before the anchor is still within the operator's retention window.

--- a/docs/rfc/project-map-v1.md
+++ b/docs/rfc/project-map-v1.md
@@ -215,6 +215,32 @@ map. Complete top-level anchors from the public low-level event producer also
 remain readable when no execution contract exists; nested identity is compared
 only when it is present.
 
+### Legacy pre-anchor sessions (transitional)
+
+Sessions started before the anchor landed carry no `project_id` on their
+durable `orchestrator.session.started` event. Resume detects this from the
+persisted start event itself (`has_project_anchor` is false) — never from a
+version heuristic — and takes a preserved legacy path instead of the resolver:
+the exact pre-anchor direct-cwd (or managed-task-workspace) representation is
+reproduced for the workspace comparison, and recoverable identity fields are
+validated against the start-event snapshot before any legacy migration writes
+a checkpoint. Rewriting these sessions under the current resolver would make
+resume disagree with their own immutable start events.
+
+This dual representation is a transitional surface, not a second contract:
+
+- **Implementation.** The legacy representation and its activation event live
+  in `orchestrator/legacy_identity.py`; the consuming branches in the runner
+  carry a comment pointing back here.
+- **Observability.** Every activation emits the structured log event
+  `project_map.legacy_identity_path` with an `entry_point` field
+  (`resume_workspace_comparison` or `resume_identity_validation`), so the
+  removal decision is argued from evidence.
+- **Removal criterion.** Delete `legacy_identity.py` and the legacy branches
+  once no `project_map.legacy_identity_path` activation has been observed for
+  90 consecutive days of production logs, and in no case while any session
+  started before the anchor is still within the operator's retention window.
+
 ## Authority boundary
 
 Project identity is an indexing and attribution contract only:

--- a/docs/rfc/project-map-v1.md
+++ b/docs/rfc/project-map-v1.md
@@ -242,20 +242,28 @@ This dual representation is a transitional surface, not a second contract:
   disabled, and a sink that cannot be created is skipped — so absence from
   available logs can never prove inactivity and carries no removal
   authority.
-- **Removal criterion.** Delete `legacy_identity.py` and the runner's legacy
-  branch only after a fail-closed pre-anchor inventory preflight over the
-  durable EventStore — the same store resume itself reads — finds no
-  remaining pre-anchor session. The preflight enumerates every persisted
-  session with `EventStore.get_all_sessions()`, reads each session's
-  immutable start-identity snapshot (the `_session_start_identity` value
-  persisted at session start), and applies the runner's own
-  `_project_start_identity` predicate: any snapshot without the complete
-  anchor is pre-anchor. A session that cannot be enumerated or whose
-  snapshot cannot be read also counts as pre-anchor, so missing or
-  unreadable evidence blocks removal instead of authorizing it. An empty
-  inventory is a structural guarantee — every session the store could still
-  be asked to resume carries the anchor — not an inference from log
-  absence.
+- **Removal criterion.** The seam is a package-wide compatibility
+  contract. EventStores are local and independently configured per
+  installation, so no store inspection — maintainer-side or otherwise —
+  can establish that other installations hold no resumable pre-anchor
+  sessions, and no such inspection authorizes removal. Removal is instead
+  governed by a finite support window this RFC declares: sessions started
+  before the anchor (2026-07-29) remain resumable in every release
+  published before 2027-07-29, and the seam must be retained through that
+  entire window. After the window ends, a release may delete
+  `legacy_identity.py` and the runner's legacy branch only as a documented
+  breaking change that simultaneously replaces the branch with a
+  fail-closed rejection: when `_project_start_identity` finds a persisted
+  start-identity snapshot without the complete anchor, resume must raise a
+  typed error naming the last compatible release — never silently rewrite
+  the session under the current resolver, and never strand it without
+  explanation. Operators who want to know whether the cutover affects
+  their installation can run a per-installation inventory preflight before
+  upgrading — enumerate sessions with `EventStore.get_all_sessions()`,
+  read each persisted `_session_start_identity` snapshot, and treat any
+  session that cannot be enumerated or read as pre-anchor — but this
+  preflight is a verification tool for that one store only; it grants no
+  package-wide removal authority.
 
 ## Authority boundary
 

--- a/docs/rfc/project-map-v1.md
+++ b/docs/rfc/project-map-v1.md
@@ -242,22 +242,24 @@ This dual representation is a transitional surface, not a second contract:
   disabled, and a sink that cannot be created is skipped — so absence from
   available logs can never prove inactivity and carries no removal
   authority.
-- **Removal criterion.** The seam is a package-wide compatibility
-  contract. EventStores are local and independently configured per
-  installation, so no store inspection — maintainer-side or otherwise —
-  can establish that other installations hold no resumable pre-anchor
-  sessions, and no such inspection authorizes removal. Removal is instead
-  governed by a finite support window this RFC declares: sessions started
-  before the anchor (2026-07-29) remain resumable in every release
-  published before 2027-07-29, and the seam must be retained through that
-  entire window. After the window ends, a release may delete
+- **Removal criterion.** The seam is a package-wide project-identity
+  compatibility contract. EventStores are local and independently configured
+  per installation, so no store inspection — maintainer-side or otherwise —
+  can establish that other installations hold no pre-anchor sessions, and no
+  such inspection authorizes removal. Removal is instead governed by a finite
+  support window this RFC declares: every release published before 2027-07-29
+  must retain the pre-anchor project-identity representation for sessions
+  started before the anchor (2026-07-29). This window governs only the identity
+  seam; it does not bypass independently versioned execution-contract,
+  provider, permission, or workspace compatibility gates, all of which remain
+  fail-closed. After the window ends, a release may delete
   `legacy_identity.py` and the runner's legacy branch only as a documented
   breaking change that simultaneously replaces the branch with a
   fail-closed rejection: when `_project_start_identity` finds a persisted
   start-identity snapshot without the complete anchor, resume must raise a
-  typed error naming the last compatible release — never silently rewrite
-  the session under the current resolver, and never strand it without
-  explanation. Operators who want to know whether the cutover affects
+  typed error naming the last identity-compatible release — never silently
+  rewrite the session under the current resolver, and never strand it without
+  explanation. Operators who want to know whether the identity cutover affects
   their installation can run a per-installation inventory preflight before
   upgrading — enumerate sessions with `EventStore.get_all_sessions()`,
   read each persisted `_session_start_identity` snapshot, and treat any

--- a/src/ouroboros/orchestrator/legacy_identity.py
+++ b/src/ouroboros/orchestrator/legacy_identity.py
@@ -14,13 +14,16 @@ This surface is transitional, not permanent:
   ``project_map.legacy_identity_path`` only when a durable start-identity
   snapshot is present and still lacks the anchor; current prepared
   executions restore an intentionally anchorless contract-only snapshot and
-  never count. The removal decision can therefore be argued from evidence
-  instead of a guess.
+  never count. The event is an advisory liveness signal only — the default
+  log sink retains seven days and may be absent — so log absence carries no
+  removal authority.
 - **Removal criterion** (mirrored in ``docs/rfc/project-map-v1.md``):
-  delete this module and the ``has_project_anchor`` legacy branch once no
-  ``project_map.legacy_identity_path`` activation has been observed for 90
-  consecutive days of production logs — and in no case while any
-  pre-2026-07-29 session is still within the operator's retention window.
+  delete this module and the ``has_project_anchor`` legacy branch only
+  after a fail-closed inventory preflight over the durable EventStore
+  finds no persisted session whose start-identity snapshot still lacks the
+  anchor. A session that cannot be enumerated or whose snapshot cannot be
+  read counts as pre-anchor, so missing evidence blocks removal instead of
+  authorizing it.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/orchestrator/legacy_identity.py
+++ b/src/ouroboros/orchestrator/legacy_identity.py
@@ -18,12 +18,14 @@ This surface is transitional, not permanent:
   log sink retains seven days and may be absent — so log absence carries no
   removal authority.
 - **Removal criterion** (mirrored in ``docs/rfc/project-map-v1.md``):
-  delete this module and the ``has_project_anchor`` legacy branch only
-  after a fail-closed inventory preflight over the durable EventStore
-  finds no persisted session whose start-identity snapshot still lacks the
-  anchor. A session that cannot be enumerated or whose snapshot cannot be
-  read counts as pre-anchor, so missing evidence blocks removal instead of
-  authorizing it.
+  the seam is a package-wide support contract — pre-anchor sessions stay
+  resumable in every release published before 2027-07-29, and no single
+  EventStore inspection can authorize removal because stores are local
+  and per-installation. After the window ends, a release may delete this
+  module only as a documented breaking change that replaces the
+  ``has_project_anchor`` branch with a typed fail-closed rejection
+  naming the last compatible release, never a silent rewrite of resume
+  identity.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/orchestrator/legacy_identity.py
+++ b/src/ouroboros/orchestrator/legacy_identity.py
@@ -18,14 +18,15 @@ This surface is transitional, not permanent:
   log sink retains seven days and may be absent — so log absence carries no
   removal authority.
 - **Removal criterion** (mirrored in ``docs/rfc/project-map-v1.md``):
-  the seam is a package-wide support contract — pre-anchor sessions stay
-  resumable in every release published before 2027-07-29, and no single
-  EventStore inspection can authorize removal because stores are local
-  and per-installation. After the window ends, a release may delete this
-  module only as a documented breaking change that replaces the
-  ``has_project_anchor`` branch with a typed fail-closed rejection
-  naming the last compatible release, never a silent rewrite of resume
-  identity.
+  the seam is a package-wide project-identity support contract — every
+  release published before 2027-07-29 retains this representation, and no
+  single EventStore inspection can authorize removal because stores are
+  local and per-installation. The window does not bypass independent
+  execution-contract, provider, permission, or workspace compatibility
+  gates. After it ends, a release may delete this module only as a
+  documented breaking change that replaces the ``has_project_anchor``
+  branch with a typed fail-closed rejection naming the last
+  identity-compatible release, never a silent rewrite of resume identity.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/orchestrator/legacy_identity.py
+++ b/src/ouroboros/orchestrator/legacy_identity.py
@@ -8,13 +8,16 @@ and only those — keep the exact pre-anchor representation reproduced here.
 
 This surface is transitional, not permanent:
 
-- **Trigger.** The legacy path is taken only when the persisted start event
-  predates the anchor (``has_project_anchor`` is false).
-- **Observability.** Every activation emits the structured event
-  ``project_map.legacy_identity_path`` with its entry point, so the removal
-  decision can be argued from evidence instead of a guess.
+- **Trigger.** The legacy path is taken only when the persisted start
+  snapshot predates the anchor (``has_project_anchor`` is false).
+- **Observability.** An activation emits the structured event
+  ``project_map.legacy_identity_path`` only when a durable start-identity
+  snapshot is present and still lacks the anchor; current prepared
+  executions restore an intentionally anchorless contract-only snapshot and
+  never count. The removal decision can therefore be argued from evidence
+  instead of a guess.
 - **Removal criterion** (mirrored in ``docs/rfc/project-map-v1.md``):
-  delete this module and the ``has_project_anchor`` legacy branches once no
+  delete this module and the ``has_project_anchor`` legacy branch once no
   ``project_map.legacy_identity_path`` activation has been observed for 90
   consecutive days of production logs — and in no case while any
   pre-2026-07-29 session is still within the operator's retention window.

--- a/src/ouroboros/orchestrator/legacy_identity.py
+++ b/src/ouroboros/orchestrator/legacy_identity.py
@@ -1,0 +1,64 @@
+"""Pre-anchor (v9) project-identity representations — transitional (#1799).
+
+Sessions started before the Project Map anchor landed (2026-07-29, #1769)
+carry no ``project_id`` on their durable ``orchestrator.session.started``
+events. Rewriting their resume authority under the current resolver would
+make resume disagree with the immutable start event, so those sessions —
+and only those — keep the exact pre-anchor representation reproduced here.
+
+This surface is transitional, not permanent:
+
+- **Trigger.** The legacy path is taken only when the persisted start event
+  predates the anchor (``has_project_anchor`` is false).
+- **Observability.** Every activation emits the structured event
+  ``project_map.legacy_identity_path`` with its entry point, so the removal
+  decision can be argued from evidence instead of a guess.
+- **Removal criterion** (mirrored in ``docs/rfc/project-map-v1.md``):
+  delete this module and the ``has_project_anchor`` legacy branches once no
+  ``project_map.legacy_identity_path`` activation has been observed for 90
+  consecutive days of production logs — and in no case while any
+  pre-2026-07-29 session is still within the operator's retention window.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from ouroboros.core.worktree import TaskWorkspace
+
+log = structlog.get_logger(__name__)
+
+
+def note_legacy_identity_path(entry_point: str, **context: Any) -> None:
+    """Counter-style structured event marking one legacy-path activation."""
+    log.info(
+        "project_map.legacy_identity_path",
+        entry_point=entry_point,
+        **context,
+    )
+
+
+def legacy_task_workspace_identity(
+    workspace: TaskWorkspace, canonical: Callable[[str], str]
+) -> dict[str, str]:
+    """Reproduce the pre-anchor managed-workspace representation exactly."""
+    project_root = Path(canonical(workspace.repo_root))
+    source_workspace = Path(canonical(workspace.original_cwd))
+    try:
+        workspace_path = source_workspace.relative_to(project_root).as_posix() or "."
+    except ValueError as exc:
+        # Deferred: OrchestratorError lives in runner, which imports this module.
+        from ouroboros.orchestrator.runner import OrchestratorError
+
+        raise OrchestratorError(
+            message="Cannot resume from an invalid historical task workspace",
+            details={"invalid": "legacy_task_workspace"},
+        ) from exc
+    return {
+        "project_root": str(project_root),
+        "workspace_path": workspace_path,
+    }

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -161,6 +161,10 @@ from ouroboros.orchestrator.execution_semantics import (
 )
 from ouroboros.orchestrator.execution_strategy import ExecutionStrategy, get_strategy
 from ouroboros.orchestrator.failure_taxonomy import FailureClass
+from ouroboros.orchestrator.legacy_identity import (
+    legacy_task_workspace_identity,
+    note_legacy_identity_path,
+)
 from ouroboros.orchestrator.mcp_tools import (
     MCPToolProvider,
     SessionToolCatalog,
@@ -3301,23 +3305,6 @@ class OrchestratorRunner:
                 },
             ) from exc
 
-    @classmethod
-    def _legacy_task_workspace_identity(cls, workspace: TaskWorkspace) -> dict[str, str]:
-        """Reproduce the pre-anchor managed-workspace representation exactly."""
-        project_root = Path(cls._canonical_path(workspace.repo_root))
-        source_workspace = Path(cls._canonical_path(workspace.original_cwd))
-        try:
-            workspace_path = source_workspace.relative_to(project_root).as_posix() or "."
-        except ValueError as exc:
-            raise OrchestratorError(
-                message="Cannot resume from an invalid historical task workspace",
-                details={"invalid": "legacy_task_workspace"},
-            ) from exc
-        return {
-            "project_root": str(project_root),
-            "workspace_path": workspace_path,
-        }
-
     @staticmethod
     def _project_identity_error(exc: ProjectIdentityError) -> OrchestratorError:
         """Normalize resolver failures at the orchestration lifecycle boundary."""
@@ -3367,7 +3354,7 @@ class OrchestratorRunner:
     def _legacy_proof_workspace_identity(self) -> dict[str, str] | None:
         """Reproduce the pre-Project-Map V1 nested workspace representation."""
         if self._task_workspace is not None:
-            return self._legacy_task_workspace_identity(self._task_workspace)
+            return legacy_task_workspace_identity(self._task_workspace, self._canonical_path)
         effective_cwd = self._effective_cwd()
         if not isinstance(effective_cwd, str) or not effective_cwd.strip():
             return None
@@ -6032,6 +6019,7 @@ class OrchestratorRunner:
         the migration checkpoint is written.
         """
 
+        note_legacy_identity_path("resume_identity_validation")
         raw_start_identity = progress.get(SESSION_START_IDENTITY_PROGRESS_KEY)
         if raw_start_identity is not None and not isinstance(raw_start_identity, Mapping):
             raise OrchestratorError(
@@ -6505,6 +6493,13 @@ class OrchestratorRunner:
             # Historical v9 session starts predate the additive project anchor.
             # Preserve their exact direct-cwd representation rather than
             # rewriting durable resume authority under the new resolver.
+            # Transitional (#1799): remove this branch once the criterion in
+            # orchestrator/legacy_identity.py and docs/rfc/project-map-v1.md is
+            # met (90 activation-free days past the retention window).
+            note_legacy_identity_path(
+                "resume_workspace_comparison",
+                prepared_live_execution=prepared_live_execution,
+            )
             active_workspace = (
                 self._proof_workspace_identity()
                 if prepared_live_execution

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -6353,10 +6353,12 @@ class OrchestratorRunner:
             # Historical v9 session starts predate the additive project anchor.
             # Preserve their exact direct-cwd representation rather than
             # rewriting durable resume authority under the new resolver.
-            # Transitional (#1799): remove this branch once the fail-closed
-            # EventStore inventory preflight in orchestrator/legacy_identity.py
-            # and docs/rfc/project-map-v1.md finds no persisted pre-anchor
-            # start snapshot.
+            # Transitional (#1799): this branch is a package-wide support
+            # contract — see the removal criterion in
+            # orchestrator/legacy_identity.py and docs/rfc/project-map-v1.md.
+            # Removal is allowed only after the documented compatibility
+            # window ends and must replace this path with a typed
+            # fail-closed rejection.
             #
             # Current prepared executions intentionally restore an anchorless
             # contract-only mapping; only a durable historical start snapshot

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -6353,9 +6353,10 @@ class OrchestratorRunner:
             # Historical v9 session starts predate the additive project anchor.
             # Preserve their exact direct-cwd representation rather than
             # rewriting durable resume authority under the new resolver.
-            # Transitional (#1799): remove this branch once the criterion in
-            # orchestrator/legacy_identity.py and docs/rfc/project-map-v1.md is
-            # met (90 activation-free days past the retention window).
+            # Transitional (#1799): remove this branch once the fail-closed
+            # EventStore inventory preflight in orchestrator/legacy_identity.py
+            # and docs/rfc/project-map-v1.md finds no persisted pre-anchor
+            # start snapshot.
             #
             # Current prepared executions intentionally restore an anchorless
             # contract-only mapping; only a durable historical start snapshot

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -6353,12 +6353,12 @@ class OrchestratorRunner:
             # Historical v9 session starts predate the additive project anchor.
             # Preserve their exact direct-cwd representation rather than
             # rewriting durable resume authority under the new resolver.
-            # Transitional (#1799): this branch is a package-wide support
-            # contract — see the removal criterion in
+            # Transitional (#1799): this branch is a package-wide
+            # project-identity support contract — see the removal criterion in
             # orchestrator/legacy_identity.py and docs/rfc/project-map-v1.md.
-            # Removal is allowed only after the documented compatibility
-            # window ends and must replace this path with a typed
-            # fail-closed rejection.
+            # It does not bypass other resume gates. Removal is allowed only
+            # after the documented identity-compatibility window ends and must
+            # replace this path with a typed fail-closed rejection.
             #
             # Current prepared executions intentionally restore an anchorless
             # contract-only mapping; only a durable historical start snapshot

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -6003,146 +6003,6 @@ class OrchestratorRunner:
             restored[ac_index] = {"reason": reason, "commit": commit}
         return restored
 
-    def _validate_legacy_resume_identity(
-        self,
-        progress: Mapping[str, Any],
-        *,
-        seed: Seed | None,
-    ) -> None:
-        """Validate every recoverable identity field before legacy migration.
-
-        Legacy sessions predate the versioned execution contract, but their
-        authoritative start event already records the seed id/goal and runtime
-        backend. ``SessionRepository`` exposes that snapshot under
-        :data:`SESSION_START_IDENTITY_PROGRESS_KEY`; accepting a mismatched
-        current invocation would permanently bless the wrong seed/backend when
-        the migration checkpoint is written.
-        """
-
-        note_legacy_identity_path("resume_identity_validation")
-        raw_start_identity = progress.get(SESSION_START_IDENTITY_PROGRESS_KEY)
-        if raw_start_identity is not None and not isinstance(raw_start_identity, Mapping):
-            raise OrchestratorError(
-                message="Cannot migrate a legacy session with invalid start identity",
-                details={"invalid": SESSION_START_IDENTITY_PROGRESS_KEY},
-            )
-        start_identity = raw_start_identity if isinstance(raw_start_identity, Mapping) else {}
-
-        if "seed_id" in start_identity:
-            persisted_seed_id = start_identity.get("seed_id")
-            current_seed_id = seed.metadata.seed_id if seed is not None else None
-            if (
-                not isinstance(persisted_seed_id, str)
-                or not persisted_seed_id.strip()
-                or current_seed_id != persisted_seed_id
-            ):
-                raise OrchestratorError(
-                    message="Cannot resume a legacy session with a different Seed identity",
-                    details={
-                        "persisted_seed_id": persisted_seed_id,
-                        "current_seed_id": current_seed_id,
-                        "hint": "Resume with the original Seed, or start a new session.",
-                    },
-                )
-
-        if "seed_goal" in start_identity:
-            persisted_seed_goal = start_identity.get("seed_goal")
-            current_seed_goal = seed.goal if seed is not None else None
-            if (
-                not isinstance(persisted_seed_goal, str)
-                or not persisted_seed_goal.strip()
-                or current_seed_goal != persisted_seed_goal
-            ):
-                raise OrchestratorError(
-                    message="Cannot resume a legacy session with a modified Seed goal",
-                    details={
-                        "persisted_seed_goal": persisted_seed_goal,
-                        "current_seed_goal": current_seed_goal,
-                        "hint": "Resume with the original Seed, or start a new session.",
-                    },
-                )
-
-        persisted_runtime_backend: object | None = None
-        if "runtime_backend" in start_identity:
-            persisted_runtime_backend = start_identity.get("runtime_backend")
-        elif "runtime_backend" in progress:
-            # Older start events may lack the backend while runtime progress
-            # still carries the backend that owns the resumable handle.
-            persisted_runtime_backend = progress.get("runtime_backend")
-        if persisted_runtime_backend is not None:
-            current_runtime_backend = self._runtime_backend_contract()
-            if (
-                not isinstance(persisted_runtime_backend, str)
-                or not persisted_runtime_backend.strip()
-                or current_runtime_backend != persisted_runtime_backend
-            ):
-                raise OrchestratorError(
-                    message="Cannot resume a legacy session with a different runtime backend",
-                    details={
-                        "persisted_runtime_backend": persisted_runtime_backend,
-                        "current_runtime_backend": current_runtime_backend,
-                        "hint": "Resume with the original runtime, or start a new session.",
-                    },
-                )
-
-        if "llm_backend" in start_identity:
-            persisted_llm_backend = start_identity.get("llm_backend")
-            current_llm_backend = getattr(self._adapter, "llm_backend", None)
-            if (
-                not isinstance(persisted_llm_backend, str)
-                or not persisted_llm_backend.strip()
-                or current_llm_backend != persisted_llm_backend
-            ):
-                raise OrchestratorError(
-                    message="Cannot resume a legacy session with a different LLM backend",
-                    details={
-                        "persisted_llm_backend": persisted_llm_backend,
-                        "current_llm_backend": current_llm_backend,
-                        "hint": "Resume with the original backend, or start a new session.",
-                    },
-                )
-
-        if "workspace" in progress:
-            persisted_task_workspace = TaskWorkspace.from_progress_dict(progress.get("workspace"))
-            if persisted_task_workspace is None:
-                raise OrchestratorError(
-                    message="Cannot migrate a legacy session with invalid workspace identity",
-                    details={"invalid": "workspace"},
-                )
-            persisted_workspace = self._task_resume_workspace_identity(persisted_task_workspace)
-            active_workspace = self._resume_workspace_identity()
-            if active_workspace != persisted_workspace:
-                raise OrchestratorError(
-                    message="Cannot resume a legacy session from a different project workspace",
-                    details={
-                        "persisted_workspace": persisted_workspace,
-                        "current_workspace": active_workspace,
-                        "hint": "Resume from the original project/workspace.",
-                    },
-                )
-        else:
-            runtime_progress = progress.get("runtime")
-            if isinstance(runtime_progress, Mapping) and "cwd" in runtime_progress:
-                persisted_cwd = runtime_progress.get("cwd")
-                if persisted_cwd is not None:
-                    current_cwd = self._effective_cwd()
-                    if (
-                        not isinstance(persisted_cwd, str)
-                        or not persisted_cwd.strip()
-                        or not isinstance(current_cwd, str)
-                        or self._canonical_path(current_cwd) != self._canonical_path(persisted_cwd)
-                    ):
-                        raise OrchestratorError(
-                            message=(
-                                "Cannot resume a legacy session from a different project workspace"
-                            ),
-                            details={
-                                "persisted_workspace": persisted_cwd,
-                                "current_workspace": current_cwd,
-                                "hint": "Resume from the original project/workspace.",
-                            },
-                        )
-
     def _restore_execution_contract(
         self,
         progress: Mapping[str, Any],
@@ -6496,10 +6356,16 @@ class OrchestratorRunner:
             # Transitional (#1799): remove this branch once the criterion in
             # orchestrator/legacy_identity.py and docs/rfc/project-map-v1.md is
             # met (90 activation-free days past the retention window).
-            note_legacy_identity_path(
-                "resume_workspace_comparison",
-                prepared_live_execution=prepared_live_execution,
-            )
+            #
+            # Current prepared executions intentionally restore an anchorless
+            # contract-only mapping; only a durable historical start snapshot
+            # that still lacks the anchor counts as a legacy activation.
+            raw_start_snapshot = progress.get(SESSION_START_IDENTITY_PROGRESS_KEY)
+            if isinstance(raw_start_snapshot, Mapping):
+                note_legacy_identity_path(
+                    "resume_workspace_comparison",
+                    prepared_live_execution=prepared_live_execution,
+                )
             active_workspace = (
                 self._proof_workspace_identity()
                 if prepared_live_execution

--- a/tests/unit/orchestrator/test_legacy_identity_observability.py
+++ b/tests/unit/orchestrator/test_legacy_identity_observability.py
@@ -190,3 +190,18 @@ class TestActivationEvents:
 
         assert changed is False
         assert _activations(logs) == []
+
+    def test_identity_window_does_not_bypass_execution_contract_gate(self, tmp_path: Path) -> None:
+        """The support window preserves identity only, not every resume contract."""
+        persisted, resumed = _contract_and_resumed_runner(tmp_path)
+        persisted["version"] = 8
+        progress = {
+            EXECUTION_CONTRACT_PROGRESS_KEY: persisted,
+            SESSION_START_IDENTITY_PROGRESS_KEY: {"seed_id": "seed-legacy"},
+        }
+
+        with capture_logs() as logs, pytest.raises(OrchestratorError) as exc_info:
+            resumed._restore_execution_contract(progress)
+
+        assert exc_info.value.details["resume_blocked"] == "execution_inputs_unavailable"
+        assert _activations(logs) == []

--- a/tests/unit/orchestrator/test_legacy_identity_observability.py
+++ b/tests/unit/orchestrator/test_legacy_identity_observability.py
@@ -1,0 +1,172 @@
+"""Pre-anchor legacy identity path: observable activations, unchanged behavior.
+
+The transitional pre-anchor representation now lives in
+``orchestrator.legacy_identity`` and every activation emits the structured
+event ``project_map.legacy_identity_path`` (see docs/rfc/project-map-v1.md,
+"Legacy pre-anchor sessions"). These tests pin the event contract at each
+entry point and the byte-identical legacy representation behind it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from structlog.testing import capture_logs
+
+from ouroboros.core.worktree import TaskWorkspace
+from ouroboros.orchestrator.legacy_identity import (
+    legacy_task_workspace_identity,
+    note_legacy_identity_path,
+)
+from ouroboros.orchestrator.runner import (
+    EXECUTION_CONTRACT_PROGRESS_KEY,
+    OrchestratorError,
+    OrchestratorRunner,
+)
+from ouroboros.orchestrator.session import SESSION_START_IDENTITY_PROGRESS_KEY
+
+_EVENT = "project_map.legacy_identity_path"
+
+
+def _adapter(cwd: str) -> MagicMock:
+    adapter = MagicMock()
+    adapter.runtime_backend = "claude"
+    adapter.llm_backend = "anthropic"
+    adapter.working_directory = cwd
+    adapter.permission_mode = "acceptEdits"
+    adapter._model = "constructor-sonnet"
+    return adapter
+
+
+def _runner(cwd: str = "/tmp/project", **kwargs) -> OrchestratorRunner:
+    return OrchestratorRunner(_adapter(cwd), AsyncMock(), MagicMock(), **kwargs)
+
+
+def _workspace(*, repo_root: str, original_cwd: str) -> TaskWorkspace:
+    return TaskWorkspace(
+        durable_id="task-1",
+        repo_root=repo_root,
+        repo_name="repo",
+        original_cwd=original_cwd,
+        effective_cwd=original_cwd,
+        worktree_path=repo_root,
+        branch="main",
+        lock_path="/tmp/task-1.lock",
+    )
+
+
+def _activations(logs: list[dict]) -> list[dict]:
+    return [entry for entry in logs if entry["event"] == _EVENT]
+
+
+class TestLegacyTaskWorkspaceIdentity:
+    """The extracted pure representation reproduces pre-anchor output exactly."""
+
+    def test_nested_cwd_maps_to_relative_posix_path(self) -> None:
+        workspace = _workspace(repo_root="/repo/root", original_cwd="/repo/root/pkg/sub")
+
+        identity = legacy_task_workspace_identity(workspace, lambda path: path)
+
+        assert identity == {"project_root": "/repo/root", "workspace_path": "pkg/sub"}
+
+    def test_cwd_at_repo_root_maps_to_dot(self) -> None:
+        workspace = _workspace(repo_root="/repo/root", original_cwd="/repo/root")
+
+        identity = legacy_task_workspace_identity(workspace, lambda path: path)
+
+        assert identity == {"project_root": "/repo/root", "workspace_path": "."}
+
+    def test_paths_are_canonicalized_before_comparison(self) -> None:
+        # A symlinked original_cwd must land inside the canonical root, exactly
+        # as the pre-extraction classmethod resolved both sides first.
+        workspace = _workspace(repo_root="/repo/root", original_cwd="/link")
+        canonical = {"/link": "/repo/root/pkg"}
+
+        identity = legacy_task_workspace_identity(workspace, lambda path: canonical.get(path, path))
+
+        assert identity == {"project_root": "/repo/root", "workspace_path": "pkg"}
+
+    def test_cwd_outside_root_raises_the_historical_error(self) -> None:
+        workspace = _workspace(repo_root="/repo/root", original_cwd="/elsewhere")
+
+        with pytest.raises(OrchestratorError) as exc_info:
+            legacy_task_workspace_identity(workspace, lambda path: path)
+
+        assert "invalid historical task workspace" in str(exc_info.value)
+        assert exc_info.value.details == {"invalid": "legacy_task_workspace"}
+
+
+class TestRunnerDelegation:
+    """The runner's proof-identity path reuses the extracted representation."""
+
+    def test_task_workspace_proof_identity_matches_module_output(self) -> None:
+        workspace = _workspace(repo_root="/tmp/project", original_cwd="/tmp/project")
+        runner = _runner(task_workspace=workspace)
+
+        assert runner._legacy_proof_workspace_identity() == legacy_task_workspace_identity(
+            workspace, runner._canonical_path
+        )
+
+    def test_direct_cwd_proof_identity_is_unchanged(self) -> None:
+        runner = _runner(cwd="/tmp/project")
+
+        assert runner._legacy_proof_workspace_identity() == {
+            "project_root": runner._canonical_path("/tmp/project"),
+            "workspace_path": ".",
+        }
+
+
+class TestActivationEvents:
+    """Every legacy entry point emits one attributable activation event."""
+
+    def test_note_emits_the_structured_event(self) -> None:
+        with capture_logs() as logs:
+            note_legacy_identity_path("some_entry", session_id="sess-1")
+
+        activations = _activations(logs)
+        assert len(activations) == 1
+        assert activations[0]["entry_point"] == "some_entry"
+        assert activations[0]["session_id"] == "sess-1"
+        assert activations[0]["log_level"] == "info"
+
+    def test_legacy_resume_validation_emits_activation(self) -> None:
+        runner = _runner()
+
+        with capture_logs() as logs:
+            runner._validate_legacy_resume_identity({}, seed=None)
+
+        assert [entry["entry_point"] for entry in _activations(logs)] == [
+            "resume_identity_validation"
+        ]
+
+    def test_activation_is_counted_even_when_validation_rejects(self) -> None:
+        # The event marks that the legacy path was ENTERED; a rejected resume
+        # is still evidence the path is live and must delay removal.
+        runner = _runner()
+        progress = {SESSION_START_IDENTITY_PROGRESS_KEY: "corrupt"}
+
+        with capture_logs() as logs:
+            with pytest.raises(OrchestratorError):
+                runner._validate_legacy_resume_identity(progress, seed=None)
+
+        assert [entry["entry_point"] for entry in _activations(logs)] == [
+            "resume_identity_validation"
+        ]
+
+    def test_anchorless_contract_restore_emits_workspace_comparison(self) -> None:
+        # A persisted contract without the additive project anchor is exactly
+        # the historical v9 shape: restoring it must take — and record — the
+        # legacy workspace-comparison branch, then still restore cleanly.
+        persisted = _runner()._build_execution_contract()
+        resumed = _runner()
+
+        with capture_logs() as logs:
+            changed = resumed._restore_execution_contract(
+                {EXECUTION_CONTRACT_PROGRESS_KEY: persisted}
+            )
+
+        assert changed is False
+        activations = _activations(logs)
+        assert [entry["entry_point"] for entry in activations] == ["resume_workspace_comparison"]
+        assert activations[0]["prepared_live_execution"] is False

--- a/tests/unit/orchestrator/test_legacy_identity_observability.py
+++ b/tests/unit/orchestrator/test_legacy_identity_observability.py
@@ -118,7 +118,7 @@ class TestRunnerDelegation:
 
 
 class TestActivationEvents:
-    """Every legacy entry point emits one attributable activation event."""
+    """Only genuine durable pre-anchor resumes count as legacy activations."""
 
     def test_note_emits_the_structured_event(self) -> None:
         with capture_logs() as logs:
@@ -130,34 +130,46 @@ class TestActivationEvents:
         assert activations[0]["session_id"] == "sess-1"
         assert activations[0]["log_level"] == "info"
 
-    def test_legacy_resume_validation_emits_activation(self) -> None:
-        runner = _runner()
+    def test_durable_preanchor_resume_emits_workspace_comparison(self) -> None:
+        # A durable start-identity snapshot without the additive project anchor
+        # is exactly the historical v9 shape: restoring it must take — and
+        # record — the legacy workspace-comparison branch, then still restore
+        # cleanly.
+        persisted = _runner()._build_execution_contract()
+        resumed = _runner()
+        progress = {
+            EXECUTION_CONTRACT_PROGRESS_KEY: persisted,
+            SESSION_START_IDENTITY_PROGRESS_KEY: {"seed_id": "seed-legacy"},
+        }
 
         with capture_logs() as logs:
-            runner._validate_legacy_resume_identity({}, seed=None)
+            changed = resumed._restore_execution_contract(progress)
 
-        assert [entry["entry_point"] for entry in _activations(logs)] == [
-            "resume_identity_validation"
-        ]
+        assert changed is False
+        activations = _activations(logs)
+        assert [entry["entry_point"] for entry in activations] == ["resume_workspace_comparison"]
+        assert activations[0]["prepared_live_execution"] is False
 
-    def test_activation_is_counted_even_when_validation_rejects(self) -> None:
-        # The event marks that the legacy path was ENTERED; a rejected resume
-        # is still evidence the path is live and must delay removal.
-        runner = _runner()
-        progress = {SESSION_START_IDENTITY_PROGRESS_KEY: "corrupt"}
+    def test_prepared_live_restore_is_not_a_legacy_activation(self) -> None:
+        # The bot-probed false-positive shape: current prepared executions
+        # restore an intentionally anchorless contract-only mapping with
+        # prepared_live_execution=True. That is not a historical resume and
+        # must not pollute the removal metric.
+        persisted = _runner()._build_execution_contract()
+        resumed = _runner()
 
         with capture_logs() as logs:
-            with pytest.raises(OrchestratorError):
-                runner._validate_legacy_resume_identity(progress, seed=None)
+            resumed._restore_execution_contract(
+                {EXECUTION_CONTRACT_PROGRESS_KEY: persisted},
+                prepared_live_execution=True,
+            )
 
-        assert [entry["entry_point"] for entry in _activations(logs)] == [
-            "resume_identity_validation"
-        ]
+        assert _activations(logs) == []
 
-    def test_anchorless_contract_restore_emits_workspace_comparison(self) -> None:
-        # A persisted contract without the additive project anchor is exactly
-        # the historical v9 shape: restoring it must take — and record — the
-        # legacy workspace-comparison branch, then still restore cleanly.
+    def test_contract_only_restore_without_snapshot_does_not_count(self) -> None:
+        # Without a durable start-identity snapshot there is no evidence the
+        # session is historical, so no activation may be recorded even on the
+        # non-prepared path.
         persisted = _runner()._build_execution_contract()
         resumed = _runner()
 
@@ -167,6 +179,4 @@ class TestActivationEvents:
             )
 
         assert changed is False
-        activations = _activations(logs)
-        assert [entry["entry_point"] for entry in activations] == ["resume_workspace_comparison"]
-        assert activations[0]["prepared_live_execution"] is False
+        assert _activations(logs) == []

--- a/tests/unit/orchestrator/test_legacy_identity_observability.py
+++ b/tests/unit/orchestrator/test_legacy_identity_observability.py
@@ -9,6 +9,7 @@ entry point and the byte-identical legacy representation behind it.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -58,6 +59,18 @@ def _workspace(*, repo_root: str, original_cwd: str) -> TaskWorkspace:
 
 def _activations(logs: list[dict]) -> list[dict]:
     return [entry for entry in logs if entry["event"] == _EVENT]
+
+
+def _contract_and_resumed_runner(tmp_path: Path) -> tuple[dict, OrchestratorRunner]:
+    """Build a contract from an owned live project, as production does."""
+    project = tmp_path / "project"
+    project.mkdir()
+    original = _runner(cwd=str(project))
+    project_identity = original._project_identity()
+    return (
+        original._build_execution_contract(project_identity=project_identity),
+        _runner(cwd=str(project)),
+    )
 
 
 class TestLegacyTaskWorkspaceIdentity:
@@ -130,13 +143,12 @@ class TestActivationEvents:
         assert activations[0]["session_id"] == "sess-1"
         assert activations[0]["log_level"] == "info"
 
-    def test_durable_preanchor_resume_emits_workspace_comparison(self) -> None:
+    def test_durable_preanchor_resume_emits_workspace_comparison(self, tmp_path: Path) -> None:
         # A durable start-identity snapshot without the additive project anchor
         # is exactly the historical v9 shape: restoring it must take — and
         # record — the legacy workspace-comparison branch, then still restore
         # cleanly.
-        persisted = _runner()._build_execution_contract()
-        resumed = _runner()
+        persisted, resumed = _contract_and_resumed_runner(tmp_path)
         progress = {
             EXECUTION_CONTRACT_PROGRESS_KEY: persisted,
             SESSION_START_IDENTITY_PROGRESS_KEY: {"seed_id": "seed-legacy"},
@@ -150,13 +162,12 @@ class TestActivationEvents:
         assert [entry["entry_point"] for entry in activations] == ["resume_workspace_comparison"]
         assert activations[0]["prepared_live_execution"] is False
 
-    def test_prepared_live_restore_is_not_a_legacy_activation(self) -> None:
+    def test_prepared_live_restore_is_not_a_legacy_activation(self, tmp_path: Path) -> None:
         # The bot-probed false-positive shape: current prepared executions
         # restore an intentionally anchorless contract-only mapping with
         # prepared_live_execution=True. That is not a historical resume and
         # must not pollute the removal metric.
-        persisted = _runner()._build_execution_contract()
-        resumed = _runner()
+        persisted, resumed = _contract_and_resumed_runner(tmp_path)
 
         with capture_logs() as logs:
             resumed._restore_execution_contract(
@@ -166,12 +177,11 @@ class TestActivationEvents:
 
         assert _activations(logs) == []
 
-    def test_contract_only_restore_without_snapshot_does_not_count(self) -> None:
+    def test_contract_only_restore_without_snapshot_does_not_count(self, tmp_path: Path) -> None:
         # Without a durable start-identity snapshot there is no evidence the
         # session is historical, so no activation may be recorded even on the
         # non-prepared path.
-        persisted = _runner()._build_execution_contract()
-        resumed = _runner()
+        persisted, resumed = _contract_and_resumed_runner(tmp_path)
 
         with capture_logs() as logs:
             changed = resumed._restore_execution_contract(

--- a/tests/unit/orchestrator/test_process_local_authority.py
+++ b/tests/unit/orchestrator/test_process_local_authority.py
@@ -15,6 +15,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 import yaml
 
 from ouroboros.cli.commands.cancel import _cancel_session
@@ -475,10 +476,14 @@ async def test_precreated_session_rejects_stale_running_tracker_after_durable_pa
     contract = tracker.progress[EXECUTION_CONTRACT_PROGRESS_KEY]
 
     try:
-        first = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
+        with capture_logs() as legacy_logs:
+            first = await runner.execute_precreated_session(_seed(), tracker, parallel=False)
         assert first.is_ok
         assert first.value.success is False
         assert runtime.execute_calls == 1
+        assert [
+            entry for entry in legacy_logs if entry["event"] == "project_map.legacy_identity_path"
+        ] == []
         durable = await SessionRepository(event_store).reconstruct_session(tracker.session_id)
         assert durable.is_ok and durable.value.status is SessionStatus.PAUSED
 
@@ -2099,11 +2104,18 @@ async def test_pre_anchor_resume_invalid_workspace_cleans_claim_before_retry(
             "reconstruct_session",
             side_effect=reconstruct_historical_then_durable,
         ):
-            first = await runner.resume_session(tracker.session_id, _seed())
-            second = await runner.resume_session(tracker.session_id, _seed())
+            with capture_logs() as legacy_logs:
+                first = await runner.resume_session(tracker.session_id, _seed())
+                second = await runner.resume_session(tracker.session_id, _seed())
 
         assert first.is_err
         assert first.error.message == "Cannot resolve project identity"
+        legacy_activations = [
+            entry for entry in legacy_logs if entry["event"] == "project_map.legacy_identity_path"
+        ]
+        assert [entry["entry_point"] for entry in legacy_activations] == [
+            "resume_workspace_comparison"
+        ]
         assert second.is_err
         assert second.error.details.get("resume_blocked") != "process_local_execution_in_progress"
         assert runtime.execute_calls == 0


### PR DESCRIPTION
Closes #1799

## Why

Sessions started before the Project Map anchor landed have no `project_id` on their immutable `orchestrator.session.started` event. Re-resolving those sessions under the current project resolver would rewrite durable resume authority, so the pre-anchor project-identity representation must remain available behind an explicit compatibility boundary.

The old boundary was inline in the runner, had no trustworthy activation signal, and had no finite removal contract.

## What changed

### One transitional identity seam

- Moves the historical managed-workspace representation into `orchestrator/legacy_identity.py`.
- Preserves the exact pre-anchor direct-cwd and managed-workspace representations, canonicalization behavior, and historical error shape.
- Keeps anchored sessions on canonical `ProjectIdentity`; partial or invalid anchors still fail closed.
- Removes the unused legacy resume-identity validator instead of advertising a production path that did not exist.

### Truthful local observability

The single production decision point emits the structured local log event `project_map.legacy_identity_path` with `entry_point=resume_workspace_comparison` when a durable start-identity snapshot is present and still lacks the anchor.

- Genuine historical resumes emit before workspace comparison, so rejected resumes still show that the seam is live.
- Current prepared executions and snapshot-free contract restores do not emit false legacy activations.
- The event remains local `structlog`; it is not added to anonymous PostHog usage telemetry.
- Log absence is advisory only. Rotation, disabled logging, sink failure, offline installs, and telemetry opt-out mean absence can never authorize deletion.

### Finite project-identity support window

Every release published before 2027-07-29 must retain the pre-anchor project-identity representation for sessions started before the anchor on 2026-07-29. This is intentionally an identity-compatibility promise only: it does not bypass independently versioned execution-contract, provider, permission, or workspace gates, which remain fail closed.

After the window, removing the seam requires a documented breaking change that replaces the anchorless branch with a typed fail-closed rejection naming the last identity-compatible release. A per-installation EventStore inventory may help an operator assess that installation, but no local store can authorize package-wide removal.

## Review findings resolved

- The observability fixture owns its `tmp_path/project` directory and no longer depends on test order or `/tmp/project` existing.
- `_build_execution_contract(project_identity=...)` receives the already-resolved identity explicitly.
- Public lifecycle tests prove one activation for a rejected historical resume and zero for current precreated execution.
- A regression proves the identity support window does not bypass the execution-contract version gate.

## Verification

Exact rebased candidate: `f130f4a13097cfccb4f133b6bc480418a4d7e293`  
Exact base: `08822b148e99f96cf4165c282d2d3419cc47f51f`

- Independent exact-head verifier: PASS
- Rebase preservation: 7/7 commits patch-identical; #2027 zero file overlap
- Changed observability and process-local authority files: 161 passed
- Project identity / legacy resume selection: 11 passed, 189 deselected
- Anonymous telemetry and local logging integration: 205 passed
- Module-size and CLI/TUI docs contracts: 41 passed
- Ruff check and format: PASS across `src/` and `tests/`
- MyPy: PASS for both changed source modules
- `git diff --check`, clean tree, and latest-main ancestry: PASS
