### PR TITLE
fix(config): deny the suffix-less OUROBOROS_CLI alias from an untrusted .env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "prompt-toolkit>=3.0.0,<4.0.0",
     # Ceiling is deliberately tighter than the major-version bounds around it:
     # this parses `.env`, a documented trust boundary (see
-    # `_UNTRUSTED_ENV_DENYLIST` in config/loader.py), so only patch releases
+    # `UNTRUSTED_ENV_DENYLIST` in config/untrusted_env.py), so only patch releases
     # flow without review. An exact pin would be tighter still, but
     # `test_runtime_and_optional_dependencies_have_upper_bounds` reserves
     # `==` for the optional extras; core runtime deps stay bounded ranges.

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -61,6 +61,7 @@ from ouroboros.config.models import (  # noqa: E402
     get_default_config,
     get_default_credentials,
 )
+from ouroboros.config.untrusted_env import is_untrusted_env_denied_key
 from ouroboros.core.errors import ConfigError  # noqa: E402
 from ouroboros.orchestrator_stage import (  # noqa: E402
     Stage,
@@ -170,182 +171,11 @@ def _is_placeholder_api_key(value: str) -> bool:
     )
 
 
-# Environment variables that determine HOW Ouroboros executes work. This
-# is the single authoritative trust boundary: a cloned repository's `.env`
-# must not be able to change which binary runs or whether the user's
-# approval gate applies. Four classes, all remote-code-execution sinks
-# when sourced from an untrusted location:
-#   1. Explicit CLI path overrides fed straight into a subprocess.
-#   2. Runtime/backend selectors that pick which adapter (and therefore
-#      which executable) is spawned — a selector can route to a backend
-#      whose CLI then resolves via a weak shutil.which / bare-name lookup.
-#   3. Permission-mode overrides — setting acceptEdits/bypassPermissions
-#      silently removes the human approval gate, letting a malicious repo
-#      auto-approve arbitrary tool calls (effectively RCE).
-#   4. Runtime-native preload hooks such as NODE_OPTIONS, which can execute
-#      attacker-controlled code before a spawned JavaScript CLI starts.
-# These keys are only honored from trusted sources (the real process
-# environment, ~/.ouroboros/.env, ~/.ouroboros/config.yaml), never from
-# the project-directory .env that travels with a cloned repo. Trusted .env
-# files still follow the loader's normal "do not override an already-set
-# real process environment value" precedence. Enforcing this here — at the
-# .env load — keeps the policy in one place rather than split across
-# downstream sinks.
-_UNTRUSTED_ENV_DENYLIST = frozenset(
-    {
-        # Search PATH used by shutil.which()/bare executable spawning.
-        "PATH",
-        # Node/Electron preload hook. A project .env could otherwise inject a
-        # --require/--import payload before a spawned JavaScript CLI starts.
-        "NODE_OPTIONS",
-        # Non-LD_/DYLD_ dynamic-loader controls used by supported or adjacent
-        # Unix platforms. Prefix families are rejected below.
-        "LDR_PRELOAD",
-        "LIBPATH",
-        "SHLIB_PATH",
-        # Explicit executable-path overrides.
-        "OUROBOROS_CLI_PATH",
-        "OUROBOROS_CODEX_CLI_PATH",
-        "OUROBOROS_COPILOT_CLI_PATH",
-        "OUROBOROS_KIRO_CLI_PATH",
-        "OUROBOROS_OPENCODE_CLI_PATH",
-        "OUROBOROS_HERMES_CLI_PATH",
-        "OUROBOROS_GOOSE_CLI_PATH",
-        "OUROBOROS_GEMINI_CLI_PATH",
-        "OUROBOROS_PI_CLI_PATH",
-        "OUROBOROS_GJC_CLI_PATH",
-        "OUROBOROS_ANTIGRAVITY_CLI_PATH",
-        "OUROBOROS_GROK_CLI_PATH",
-        "OUROBOROS_OUROCODE_CLI_PATH",
-        "OUROBOROS_ZCODE_CLI_PATH",
-        # Bare provider aliases (no OUROBOROS_ prefix) that adapters also
-        # honor and then execute. Any new such alias MUST be added here:
-        # `opencode_config._configured_opencode_cli_path` reads
-        # OPENCODE_CLI_PATH and runs it via subprocess.run.
-        "OPENCODE_CLI_PATH",
-        # The `ooo` frontdoor bridges read this *suffix-less* alias — it is not
-        # a _CLI_PATH variant, which is exactly why it was missed. Both the gjc
-        # extension (`gjc_bridge/index.ts`) and the Pi extension emitted by
-        # `ouroboros setup --runtime pi` do:
-        #     if (process.env.OUROBOROS_CLI) return { command: ..., args: [] }
-        # and then execFile/pi.exec that command. The bridges run inside the
-        # spawned vendor CLI, which inherits this process' environment, so an
-        # untrusted repo .env would choose the binary that every `ooo ...`
-        # input executes. Ouroboros never sets this key itself; it exists only
-        # as an operator escape hatch, so denying it from an untrusted source
-        # costs nothing. Any new bridge/adapter key that names an executable
-        # belongs here regardless of whether it ends in _CLI_PATH.
-        "OUROBOROS_CLI",
-        # Spawned-CLI discovery roots. The gjc CLI resolves its agent dir
-        # (rules/skills/extensions it loads into every session) from these
-        # vars; an untrusted repo .env must not be able to point a spawned
-        # gjc at attacker-controlled instruction/extension directories.
-        "GJC_CODING_AGENT_DIR",
-        "GJC_CONFIG_DIR",
-        "PI_CONFIG_DIR",
-        # Copilot custom-instruction roots — same instruction-injection class
-        # as GJC_CODING_AGENT_DIR. `copilot/cli_policy.py` derives the child
-        # env from os.environ and only *appends* the setup-owned dir, so an
-        # untrusted .env entry survives and a spawned Copilot loads attacker
-        # AGENTS.md from it.
-        "COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
-        # Ouroboros agent-definition root. `agents/loader.py` resolves every
-        # agent's role/persona markdown (socratic-interviewer, evaluator, …)
-        # from this dir first; an untrusted .env pointing it at a committed
-        # repo dir lets a cloned repo replace the system prompt of every
-        # spawned sub-agent — instruction injection, same class as above.
-        "OUROBOROS_AGENTS_DIR",
-        # Backend config-home roots. The spawned vendor CLI resolves its own
-        # config file — which can name MCP servers to launch, disable the
-        # approval gate, and widen the sandbox — from these vars, and the var
-        # passes through the child env untouched (it is not in any backend's
-        # strip_keys). An untrusted repo .env must not redirect a nested agent
-        # at attacker-controlled config. Codex honors $CODEX_HOME/config.toml
-        # (mcp_servers.<name>.command/args -> arbitrary command execution;
-        # approval_policy="never" + sandbox_mode="danger-full-access" ->
-        # silent removal of the human approval gate). OpenCode resolves its
-        # config from OPENCODE_CONFIG / OPENCODE_CONFIG_DIR and otherwise
-        # falls back to $XDG_CONFIG_HOME/opencode. Completes CVE-2026-47211.
-        "CODEX_HOME",
-        "OPENCODE_CONFIG",
-        "OPENCODE_CONFIG_DIR",
-        "XDG_CONFIG_HOME",
-        # Platform home selectors also choose Ouroboros' trusted config root.
-        # A project .env must not turn a repository directory into ~/.ouroboros.
-        "HOME",
-        "USERPROFILE",
-        "HOMEDRIVE",
-        "HOMEPATH",
-        # Ouroboros' own MCP-bridge / plugin execution roster roots. Each
-        # selects a file whose contents name an external command that the
-        # bridge or plugin dispatcher then spawns verbatim — direct RCE, the
-        # same threat model as the backend config-home roots above:
-        #   - OUROBOROS_MCP_CONFIG -> mcp/bridge/config.py:discover_config
-        #     returns the path; the YAML's server `command`/`args` are spawned
-        #     via stdio_client (loader -> discover_config -> MCPClientAdapter
-        #     -> stdio_client).
-        #   - OUROBOROS_PLUGIN_LOCKFILE / OUROBOROS_PLUGIN_TRUST_ROOT ->
-        #     plugin_dispatch resolves the installed-plugin roster and trust
-        #     root from these; redirecting them lets a cloned repo register an
-        #     attacker manifest / mark a malicious plugin as trusted, so
-        #     `ooo <name>` dispatches into attacker code.
-        "OUROBOROS_MCP_CONFIG",
-        "OUROBOROS_PLUGIN_LOCKFILE",
-        "OUROBOROS_PLUGIN_TRUST_ROOT",
-        # SSRF guard toggle. `mcp/types.py` blocks loopback/private/link-local
-        # MCP transport targets unless this is "1"; an untrusted .env must not
-        # be able to re-enable connections to internal addresses.
-        "OUROBOROS_ALLOW_LOCAL_TRANSPORT",
-        # Runtime/backend selectors — choose which adapter is spawned.
-        "OUROBOROS_AGENT_RUNTIME",
-        "OUROBOROS_RUNTIME",
-        "OUROBOROS_LLM_BACKEND",
-        # Backend profile selector (get_runtime_profile): chooses the
-        # orchestrator backend profile and therefore which backend behavior /
-        # executable is used — same routing class as the selectors above.
-        "OUROBOROS_RUNTIME_PROFILE",
-        # Permission-mode overrides — must not silently disable the
-        # user's approval gate from an untrusted repo.
-        "OUROBOROS_AGENT_PERMISSION_MODE",
-        "OUROBOROS_LLM_PERMISSION_MODE",
-        "OUROBOROS_OPENCODE_PERMISSION_MODE",
-        # Tool-capability override file. The override YAML can lower a tool's
-        # approval_class (e.g. ELEVATED -> DEFAULT), weakening the human
-        # approval gate for non-built-in tools. External control of this path
-        # is therefore an approval-gate-bypass sink — same class as the
-        # permission-mode overrides above.
-        "OUROBOROS_TOOL_CAPABILITIES",
-        # Execution-cost/behavior dial — an untrusted repo .env must not be able
-        # to force a higher (or invalid) reasoning-effort level for every AC,
-        # which changes runtime cost and behavior. Follows the same trusted-source
-        # policy as the runtime/permission overrides above (RFC #1405).
-        "OUROBOROS_AGENT_REASONING_EFFORT",
-        # Explicit constructor model pin. Besides changing cost/capability, this
-        # disables tier routing by design, so an untrusted project .env must not
-        # be able to force an arbitrary model or bypass the frugality policy.
-        "OUROBOROS_EXECUTION_MODEL",
-        # Model-tier experiment controls are the same trust class: a cloned repo
-        # must not disable routing or opt the user into shadow replay, which
-        # re-executes successful children and can double token spend.
-        "OUROBOROS_MODEL_TIER_ROUTING",
-        "OUROBOROS_SHADOW_REPLAY",
-    }
-)
-_UNTRUSTED_ENV_DENIED_PREFIXES = ("DYLD_", "LD_")
-
 # The reasoning-effort vocabulary every native runtime accepts (mirrors
 # OrchestratorConfig.reasoning_effort). A value outside this set — Codex-only
 # ``minimal``, Claude-only ``max``, or a typo — must never reach a runtime, so the
 # env override is validated against it before use.
 _VALID_REASONING_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh"})
-
-
-def _is_untrusted_env_denied_key(key: str) -> bool:
-    """Return whether an untrusted .env key may alter execution routing."""
-    normalized = key.upper()
-    return normalized in _UNTRUSTED_ENV_DENYLIST or normalized.startswith(
-        _UNTRUSTED_ENV_DENIED_PREFIXES
-    )
 
 
 def _load_env_file(path: Path, *, trusted: bool = False) -> None:
@@ -397,7 +227,7 @@ def _load_env_file(path: Path, *, trusted: bool = False) -> None:
         if not _is_assignable_env_key(key):
             continue
 
-        if not trusted and _is_untrusted_env_denied_key(key):
+        if not trusted and is_untrusted_env_denied_key(key):
             # Untrusted project-directory .env must not redirect which
             # binary Ouroboros executes (remote code execution guard).
             continue

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -223,6 +223,19 @@ _UNTRUSTED_ENV_DENYLIST = frozenset(
         # `opencode_config._configured_opencode_cli_path` reads
         # OPENCODE_CLI_PATH and runs it via subprocess.run.
         "OPENCODE_CLI_PATH",
+        # The `ooo` frontdoor bridges read this *suffix-less* alias — it is not
+        # a _CLI_PATH variant, which is exactly why it was missed. Both the gjc
+        # extension (`gjc_bridge/index.ts`) and the Pi extension emitted by
+        # `ouroboros setup --runtime pi` do:
+        #     if (process.env.OUROBOROS_CLI) return { command: ..., args: [] }
+        # and then execFile/pi.exec that command. The bridges run inside the
+        # spawned vendor CLI, which inherits this process' environment, so an
+        # untrusted repo .env would choose the binary that every `ooo ...`
+        # input executes. Ouroboros never sets this key itself; it exists only
+        # as an operator escape hatch, so denying it from an untrusted source
+        # costs nothing. Any new bridge/adapter key that names an executable
+        # belongs here regardless of whether it ends in _CLI_PATH.
+        "OUROBOROS_CLI",
         # Spawned-CLI discovery roots. The gjc CLI resolves its agent dir
         # (rules/skills/extensions it loads into every session) from these
         # vars; an untrusted repo .env must not be able to point a spawned

--- a/src/ouroboros/config/untrusted_env.py
+++ b/src/ouroboros/config/untrusted_env.py
@@ -1,0 +1,183 @@
+"""Untrusted-source environment policy — the ``.env`` trust boundary.
+
+Extracted from :mod:`ouroboros.config.loader` so this policy is one auditable
+unit rather than a block buried in a 2.4k-line module. It answers exactly one
+question: may a key coming from an untrusted source — the project-directory
+``.env`` that travels with whatever repository the user cloned — be written to
+``os.environ``?
+
+The loader owns *when* the policy applies; this module owns *what* it covers.
+"""
+
+from __future__ import annotations
+
+# Environment variables that determine HOW Ouroboros executes work. This
+# is the single authoritative trust boundary: a cloned repository's `.env`
+# must not be able to change which binary runs or whether the user's
+# approval gate applies. Four classes, all remote-code-execution sinks
+# when sourced from an untrusted location:
+#   1. Explicit CLI path overrides fed straight into a subprocess.
+#   2. Runtime/backend selectors that pick which adapter (and therefore
+#      which executable) is spawned — a selector can route to a backend
+#      whose CLI then resolves via a weak shutil.which / bare-name lookup.
+#   3. Permission-mode overrides — setting acceptEdits/bypassPermissions
+#      silently removes the human approval gate, letting a malicious repo
+#      auto-approve arbitrary tool calls (effectively RCE).
+#   4. Runtime-native preload hooks such as NODE_OPTIONS, which can execute
+#      attacker-controlled code before a spawned JavaScript CLI starts.
+# These keys are only honored from trusted sources (the real process
+# environment, ~/.ouroboros/.env, ~/.ouroboros/config.yaml), never from
+# the project-directory .env that travels with a cloned repo. Trusted .env
+# files still follow the loader's normal "do not override an already-set
+# real process environment value" precedence. Enforcing this here — at the
+# .env load — keeps the policy in one place rather than split across
+# downstream sinks.
+UNTRUSTED_ENV_DENYLIST = frozenset(
+    {
+        # Search PATH used by shutil.which()/bare executable spawning.
+        "PATH",
+        # Node/Electron preload hook. A project .env could otherwise inject a
+        # --require/--import payload before a spawned JavaScript CLI starts.
+        "NODE_OPTIONS",
+        # Non-LD_/DYLD_ dynamic-loader controls used by supported or adjacent
+        # Unix platforms. Prefix families are rejected below.
+        "LDR_PRELOAD",
+        "LIBPATH",
+        "SHLIB_PATH",
+        # Explicit executable-path overrides.
+        "OUROBOROS_CLI_PATH",
+        "OUROBOROS_CODEX_CLI_PATH",
+        "OUROBOROS_COPILOT_CLI_PATH",
+        "OUROBOROS_KIRO_CLI_PATH",
+        "OUROBOROS_OPENCODE_CLI_PATH",
+        "OUROBOROS_HERMES_CLI_PATH",
+        "OUROBOROS_GOOSE_CLI_PATH",
+        "OUROBOROS_GEMINI_CLI_PATH",
+        "OUROBOROS_PI_CLI_PATH",
+        "OUROBOROS_GJC_CLI_PATH",
+        "OUROBOROS_ANTIGRAVITY_CLI_PATH",
+        "OUROBOROS_GROK_CLI_PATH",
+        "OUROBOROS_OUROCODE_CLI_PATH",
+        "OUROBOROS_ZCODE_CLI_PATH",
+        # Bare provider aliases (no OUROBOROS_ prefix) that adapters also
+        # honor and then execute. Any new such alias MUST be added here:
+        # `opencode_config._configured_opencode_cli_path` reads
+        # OPENCODE_CLI_PATH and runs it via subprocess.run.
+        "OPENCODE_CLI_PATH",
+        # The `ooo` frontdoor bridges read this *suffix-less* alias — it is not
+        # a _CLI_PATH variant, which is exactly why it was missed. Both the gjc
+        # extension (`gjc_bridge/index.ts`) and the Pi extension emitted by
+        # `ouroboros setup --runtime pi` do:
+        #     if (process.env.OUROBOROS_CLI) return { command: ..., args: [] }
+        # and then execFile/pi.exec that command. The bridges run inside the
+        # spawned vendor CLI, which inherits this process' environment, so an
+        # untrusted repo .env would choose the binary that every `ooo ...`
+        # input executes. Ouroboros never sets this key itself; it exists only
+        # as an operator escape hatch, so denying it from an untrusted source
+        # costs nothing. Any new bridge/adapter key that names an executable
+        # belongs here regardless of whether it ends in _CLI_PATH.
+        "OUROBOROS_CLI",
+        # Spawned-CLI discovery roots. The gjc CLI resolves its agent dir
+        # (rules/skills/extensions it loads into every session) from these
+        # vars; an untrusted repo .env must not be able to point a spawned
+        # gjc at attacker-controlled instruction/extension directories.
+        "GJC_CODING_AGENT_DIR",
+        "GJC_CONFIG_DIR",
+        "PI_CONFIG_DIR",
+        # Copilot custom-instruction roots — same instruction-injection class
+        # as GJC_CODING_AGENT_DIR. `copilot/cli_policy.py` derives the child
+        # env from os.environ and only *appends* the setup-owned dir, so an
+        # untrusted .env entry survives and a spawned Copilot loads attacker
+        # AGENTS.md from it.
+        "COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
+        # Ouroboros agent-definition root. `agents/loader.py` resolves every
+        # agent's role/persona markdown (socratic-interviewer, evaluator, …)
+        # from this dir first; an untrusted .env pointing it at a committed
+        # repo dir lets a cloned repo replace the system prompt of every
+        # spawned sub-agent — instruction injection, same class as above.
+        "OUROBOROS_AGENTS_DIR",
+        # Backend config-home roots. The spawned vendor CLI resolves its own
+        # config file — which can name MCP servers to launch, disable the
+        # approval gate, and widen the sandbox — from these vars, and the var
+        # passes through the child env untouched (it is not in any backend's
+        # strip_keys). An untrusted repo .env must not redirect a nested agent
+        # at attacker-controlled config. Codex honors $CODEX_HOME/config.toml
+        # (mcp_servers.<name>.command/args -> arbitrary command execution;
+        # approval_policy="never" + sandbox_mode="danger-full-access" ->
+        # silent removal of the human approval gate). OpenCode resolves its
+        # config from OPENCODE_CONFIG / OPENCODE_CONFIG_DIR and otherwise
+        # falls back to $XDG_CONFIG_HOME/opencode. Completes CVE-2026-47211.
+        "CODEX_HOME",
+        "OPENCODE_CONFIG",
+        "OPENCODE_CONFIG_DIR",
+        "XDG_CONFIG_HOME",
+        # Platform home selectors also choose Ouroboros' trusted config root.
+        # A project .env must not turn a repository directory into ~/.ouroboros.
+        "HOME",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        # Ouroboros' own MCP-bridge / plugin execution roster roots. Each
+        # selects a file whose contents name an external command that the
+        # bridge or plugin dispatcher then spawns verbatim — direct RCE, the
+        # same threat model as the backend config-home roots above:
+        #   - OUROBOROS_MCP_CONFIG -> mcp/bridge/config.py:discover_config
+        #     returns the path; the YAML's server `command`/`args` are spawned
+        #     via stdio_client (loader -> discover_config -> MCPClientAdapter
+        #     -> stdio_client).
+        #   - OUROBOROS_PLUGIN_LOCKFILE / OUROBOROS_PLUGIN_TRUST_ROOT ->
+        #     plugin_dispatch resolves the installed-plugin roster and trust
+        #     root from these; redirecting them lets a cloned repo register an
+        #     attacker manifest / mark a malicious plugin as trusted, so
+        #     `ooo <name>` dispatches into attacker code.
+        "OUROBOROS_MCP_CONFIG",
+        "OUROBOROS_PLUGIN_LOCKFILE",
+        "OUROBOROS_PLUGIN_TRUST_ROOT",
+        # SSRF guard toggle. `mcp/types.py` blocks loopback/private/link-local
+        # MCP transport targets unless this is "1"; an untrusted .env must not
+        # be able to re-enable connections to internal addresses.
+        "OUROBOROS_ALLOW_LOCAL_TRANSPORT",
+        # Runtime/backend selectors — choose which adapter is spawned.
+        "OUROBOROS_AGENT_RUNTIME",
+        "OUROBOROS_RUNTIME",
+        "OUROBOROS_LLM_BACKEND",
+        # Backend profile selector (get_runtime_profile): chooses the
+        # orchestrator backend profile and therefore which backend behavior /
+        # executable is used — same routing class as the selectors above.
+        "OUROBOROS_RUNTIME_PROFILE",
+        # Permission-mode overrides — must not silently disable the
+        # user's approval gate from an untrusted repo.
+        "OUROBOROS_AGENT_PERMISSION_MODE",
+        "OUROBOROS_LLM_PERMISSION_MODE",
+        "OUROBOROS_OPENCODE_PERMISSION_MODE",
+        # Tool-capability override file. The override YAML can lower a tool's
+        # approval_class (e.g. ELEVATED -> DEFAULT), weakening the human
+        # approval gate for non-built-in tools. External control of this path
+        # is therefore an approval-gate-bypass sink — same class as the
+        # permission-mode overrides above.
+        "OUROBOROS_TOOL_CAPABILITIES",
+        # Execution-cost/behavior dial — an untrusted repo .env must not be able
+        # to force a higher (or invalid) reasoning-effort level for every AC,
+        # which changes runtime cost and behavior. Follows the same trusted-source
+        # policy as the runtime/permission overrides above (RFC #1405).
+        "OUROBOROS_AGENT_REASONING_EFFORT",
+        # Explicit constructor model pin. Besides changing cost/capability, this
+        # disables tier routing by design, so an untrusted project .env must not
+        # be able to force an arbitrary model or bypass the frugality policy.
+        "OUROBOROS_EXECUTION_MODEL",
+        # Model-tier experiment controls are the same trust class: a cloned repo
+        # must not disable routing or opt the user into shadow replay, which
+        # re-executes successful children and can double token spend.
+        "OUROBOROS_MODEL_TIER_ROUTING",
+        "OUROBOROS_SHADOW_REPLAY",
+    }
+)
+UNTRUSTED_ENV_DENIED_PREFIXES = ("DYLD_", "LD_")
+
+
+def is_untrusted_env_denied_key(key: str) -> bool:
+    """Return whether an untrusted .env key may alter execution routing."""
+    normalized = key.upper()
+    return normalized in UNTRUSTED_ENV_DENYLIST or normalized.startswith(
+        UNTRUSTED_ENV_DENIED_PREFIXES
+    )

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -156,7 +156,8 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
 # another bridge.
 _PACKAGE_ROOT = Path(loader.__file__).resolve().parent.parent
 _BRIDGE_SOURCE_SUFFIXES = frozenset({".cjs", ".js", ".mjs", ".py", ".ts"})
-_BRIDGE_DISPATCH_SINK_RE = re.compile(r"\bentry\.command\b")
+_JS_IDENTIFIER = r"[A-Za-z_$][A-Za-z0-9_$]*"
+_BRIDGE_DISPATCH_SINK_RE = re.compile(rf"\b{_JS_IDENTIFIER}\.command\b")
 _BRIDGE_ENTRY_ENV_RE = re.compile(
     r"process\.env(?:\.([A-Z0-9_]+)|\[\s*['\"]([A-Z0-9_]+)['\"]\s*\])"
     r"\s*\)\s*return\s*\{\{?\s*command",
@@ -236,6 +237,29 @@ def test_bridge_dispatch_source_discovery_covers_new_sources(tmp_path: Path) -> 
     )
 
     assert _validated_bridge_dispatch_env_keys(tmp_path) == {source: frozenset({"NEW_BRIDGE_CLI"})}
+
+
+def test_bridge_dispatch_source_discovery_is_identifier_independent(tmp_path: Path) -> None:
+    """Renaming one bridge's resolved entry cannot remove it from inspection."""
+    entry_source = tmp_path / "entry.ts"
+    entry_source.write_text(
+        "if (process.env.ENTRY_CLI) "
+        "return { command: process.env.ENTRY_CLI, args: [] };\n"
+        "await vendor.exec(entry.command, []);\n",
+        encoding="utf-8",
+    )
+    resolved_source = tmp_path / "resolved.ts"
+    resolved_source.write_text(
+        "if (process.env.RESOLVED_CLI) "
+        "return { command: process.env.RESOLVED_CLI, args: [] };\n"
+        "await vendor.exec(resolved.command, []);\n",
+        encoding="utf-8",
+    )
+
+    assert _validated_bridge_dispatch_env_keys(tmp_path) == {
+        entry_source: frozenset({"ENTRY_CLI"}),
+        resolved_source: frozenset({"RESOLVED_CLI"}),
+    }
 
 
 def test_bridge_dispatch_validation_is_non_vacuous_per_source(tmp_path: Path) -> None:

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -150,33 +150,112 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
 # environment variable. Those sources live outside Python's import graph, so
 # nothing else ties them to the denylist: the alias they read (OUROBOROS_CLI)
 # was missed precisely because it lacks the _CLI_PATH suffix every sibling has.
-# This contract test re-derives the key from the bridge sources themselves, so
-# a new bridge — or a rename of the existing one — fails here instead of
-# silently reopening the untrusted-.env execution-redirect hole.
+# Discover dispatch sources from their executable sink instead of maintaining a
+# second bridge roster here. Every discovered source must independently yield
+# at least one inspected key, so one healthy bridge cannot hide parser drift in
+# another bridge.
 _PACKAGE_ROOT = Path(loader.__file__).resolve().parent.parent
-_BRIDGE_ENTRY_SOURCES = (
-    _PACKAGE_ROOT / "gjc_bridge" / "index.ts",
-    # The Pi extension is emitted as an f-string template, hence the `{{`.
-    _PACKAGE_ROOT / "cli" / "commands" / "setup.py",
-)
+_BRIDGE_SOURCE_SUFFIXES = frozenset({".cjs", ".js", ".mjs", ".py", ".ts"})
+_BRIDGE_DISPATCH_SINK_RE = re.compile(r"\bentry\.command\b")
 _BRIDGE_ENTRY_ENV_RE = re.compile(
-    r"process\.env\.([A-Z0-9_]+)\s*\)\s*return\s*\{\{?\s*command",
+    r"process\.env(?:\.([A-Z0-9_]+)|\[\s*['\"]([A-Z0-9_]+)['\"]\s*\])"
+    r"\s*\)\s*return\s*\{\{?\s*command",
 )
+
+
+def _discover_bridge_dispatch_sources(package_root: Path) -> tuple[Path, ...]:
+    """Find packaged sources that dispatch a resolved bridge entry command."""
+    sources: list[Path] = []
+    for source in package_root.rglob("*"):
+        if not source.is_file() or source.suffix not in _BRIDGE_SOURCE_SUFFIXES:
+            continue
+        text = source.read_text(encoding="utf-8")
+        if "process.env" in text and _BRIDGE_DISPATCH_SINK_RE.search(text):
+            sources.append(source)
+    return tuple(sorted(sources))
+
+
+def _bridge_dispatch_entry_env_keys(source_text: str) -> frozenset[str]:
+    """Extract dot- or bracket-style environment keys used as commands."""
+    return frozenset(
+        key
+        for match in _BRIDGE_ENTRY_ENV_RE.finditer(source_text)
+        for key in match.groups()
+        if key is not None
+    )
+
+
+def _validated_bridge_dispatch_env_keys(package_root: Path) -> dict[Path, frozenset[str]]:
+    """Discover every bridge and fail if any source cannot be inspected."""
+    sources = _discover_bridge_dispatch_sources(package_root)
+    assert sources, "no bridge dispatch sources found — discovery contract drifted"
+
+    found_by_source: dict[Path, frozenset[str]] = {}
+    for source in sources:
+        keys = _bridge_dispatch_entry_env_keys(source.read_text(encoding="utf-8"))
+        assert keys, f"bridge dispatch-entry extraction drifted for {source}"
+        found_by_source[source] = keys
+    return found_by_source
 
 
 def test_bridge_dispatch_entry_env_keys_are_denylisted() -> None:
     """Every env var a bridge turns into an exec command must be denylisted."""
-    found: dict[str, Path] = {}
-    for source in _BRIDGE_ENTRY_SOURCES:
-        assert source.is_file(), f"bridge source moved: {source}"
-        for key in _BRIDGE_ENTRY_ENV_RE.findall(source.read_text(encoding="utf-8")):
-            found[key] = source
+    found_by_source = _validated_bridge_dispatch_env_keys(_PACKAGE_ROOT)
 
-    # Guard the regex itself: a silent zero-match would make this test vacuous.
-    assert len(found) >= 1, "no bridge dispatch-entry env key found — regex drifted"
-
-    missing = {key: str(path) for key, path in found.items() if key not in UNTRUSTED_ENV_DENYLIST}
+    missing = {
+        key: str(source)
+        for source, keys in found_by_source.items()
+        for key in keys
+        if key not in UNTRUSTED_ENV_DENYLIST
+    }
     assert not missing, f"bridge exec-command env keys missing from denylist: {missing}"
+
+
+@pytest.mark.parametrize(
+    "access",
+    ("process.env.OUROBOROS_CLI", 'process.env["OUROBOROS_CLI"]'),
+)
+def test_bridge_dispatch_entry_env_key_extraction_covers_supported_access_styles(
+    access: str,
+) -> None:
+    """A bridge changing to bracket-style access remains inspected."""
+    source = f"if ({access}) return {{ command: {access}, args: [] }};"
+
+    assert _bridge_dispatch_entry_env_keys(source) == frozenset({"OUROBOROS_CLI"})
+
+
+def test_bridge_dispatch_source_discovery_covers_new_sources(tmp_path: Path) -> None:
+    """Adding a packaged bridge does not require updating a test-side roster."""
+    source = tmp_path / "future_bridge" / "index.ts"
+    source.parent.mkdir()
+    source.write_text(
+        "if (process.env.NEW_BRIDGE_CLI) "
+        "return { command: process.env.NEW_BRIDGE_CLI, args: [] };\n"
+        "await vendor.exec(entry.command, []);\n",
+        encoding="utf-8",
+    )
+
+    assert _validated_bridge_dispatch_env_keys(tmp_path) == {source: frozenset({"NEW_BRIDGE_CLI"})}
+
+
+def test_bridge_dispatch_validation_is_non_vacuous_per_source(tmp_path: Path) -> None:
+    """One parseable bridge cannot hide extraction drift in another bridge."""
+    good = tmp_path / "good.ts"
+    good.write_text(
+        "if (process.env.GOOD_CLI) return { command: process.env.GOOD_CLI, args: [] };\n"
+        "await vendor.exec(entry.command, []);\n",
+        encoding="utf-8",
+    )
+    drifted = tmp_path / "drifted.ts"
+    drifted.write_text(
+        "const command = process.env.DRIFTED_CLI;\n"
+        "if (command) return { command, args: [] };\n"
+        "await vendor.exec(entry.command, []);\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError, match=r"extraction drifted for .*drifted\.ts"):
+        _validated_bridge_dispatch_env_keys(tmp_path)
 
 
 def test_untrusted_env_cannot_set_bridge_cli_alias(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
 import pytest
 
+from ouroboros.config import loader
 from ouroboros.config.loader import (
     _UNTRUSTED_ENV_DENYLIST,
     _is_assignable_env_key,
@@ -105,6 +107,8 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
         "SHLIB_PATH",
         "OUROBOROS_CLI_PATH",
         "OPENCODE_CLI_PATH",
+        # Suffix-less alias read by the `ooo` frontdoor bridges (gjc, Pi).
+        "OUROBOROS_CLI",
         # Spawned-CLI / agent instruction + extension roots.
         "GJC_CODING_AGENT_DIR",
         "GJC_CONFIG_DIR",
@@ -140,6 +144,61 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
     }
     missing = required - _UNTRUSTED_ENV_DENYLIST
     assert not missing, f"denylist regressed, missing: {sorted(missing)}"
+
+
+# The `ooo` frontdoor bridges pick the executable they dispatch to from an
+# environment variable. Those sources live outside Python's import graph, so
+# nothing else ties them to the denylist: the alias they read (OUROBOROS_CLI)
+# was missed precisely because it lacks the _CLI_PATH suffix every sibling has.
+# This contract test re-derives the key from the bridge sources themselves, so
+# a new bridge — or a rename of the existing one — fails here instead of
+# silently reopening the untrusted-.env execution-redirect hole.
+_PACKAGE_ROOT = Path(loader.__file__).resolve().parent.parent
+_BRIDGE_ENTRY_SOURCES = (
+    _PACKAGE_ROOT / "gjc_bridge" / "index.ts",
+    # The Pi extension is emitted as an f-string template, hence the `{{`.
+    _PACKAGE_ROOT / "cli" / "commands" / "setup.py",
+)
+_BRIDGE_ENTRY_ENV_RE = re.compile(
+    r"process\.env\.([A-Z0-9_]+)\s*\)\s*return\s*\{\{?\s*command",
+)
+
+
+def test_bridge_dispatch_entry_env_keys_are_denylisted() -> None:
+    """Every env var a bridge turns into an exec command must be denylisted."""
+    found: dict[str, Path] = {}
+    for source in _BRIDGE_ENTRY_SOURCES:
+        assert source.is_file(), f"bridge source moved: {source}"
+        for key in _BRIDGE_ENTRY_ENV_RE.findall(source.read_text(encoding="utf-8")):
+            found[key] = source
+
+    # Guard the regex itself: a silent zero-match would make this test vacuous.
+    assert len(found) >= 1, "no bridge dispatch-entry env key found — regex drifted"
+
+    missing = {key: str(path) for key, path in found.items() if key not in _UNTRUSTED_ENV_DENYLIST}
+    assert not missing, f"bridge exec-command env keys missing from denylist: {missing}"
+
+
+def test_untrusted_env_cannot_set_bridge_cli_alias(tmp_path: Path, monkeypatch) -> None:
+    """A cloned repo's .env must not choose the binary the `ooo` bridge runs."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("OUROBOROS_CLI=./.tools/helper\n", encoding="utf-8")
+    monkeypatch.delenv("OUROBOROS_CLI", raising=False)
+
+    _load_env_file(env_file, trusted=False)
+
+    assert "OUROBOROS_CLI" not in os.environ
+
+
+def test_trusted_env_may_still_set_bridge_cli_alias(tmp_path: Path, monkeypatch) -> None:
+    """~/.ouroboros/.env keeps the operator's escape hatch for a non-PATH install."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("OUROBOROS_CLI=/opt/ouroboros/bin/ouroboros\n", encoding="utf-8")
+    monkeypatch.delenv("OUROBOROS_CLI", raising=False)
+
+    _load_env_file(env_file, trusted=True)
+
+    assert os.environ["OUROBOROS_CLI"] == "/opt/ouroboros/bin/ouroboros"
 
 
 def test_project_env_cannot_redirect_trusted_home_during_import(tmp_path: Path) -> None:

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -12,10 +12,10 @@ import pytest
 
 from ouroboros.config import loader
 from ouroboros.config.loader import (
-    _UNTRUSTED_ENV_DENYLIST,
     _is_assignable_env_key,
     _load_env_file,
 )
+from ouroboros.config.untrusted_env import UNTRUSTED_ENV_DENYLIST
 
 
 @pytest.fixture(autouse=True)
@@ -88,7 +88,7 @@ def test_load_env_file_skips_template_placeholders(tmp_path: Path, monkeypatch) 
 # Derive directly from the source of truth so this regression suite can never
 # drift out of sync with the denylist again — a previous drift (missing the
 # gjc/PI/config-home roots) is exactly how an incomplete fix slips past CI.
-_DENYLISTED_KEYS = tuple(sorted(_UNTRUSTED_ENV_DENYLIST))
+_DENYLISTED_KEYS = tuple(sorted(UNTRUSTED_ENV_DENYLIST))
 
 
 def test_denylist_covers_known_execution_routing_keys() -> None:
@@ -142,7 +142,7 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
         "OUROBOROS_MODEL_TIER_ROUTING",
         "OUROBOROS_SHADOW_REPLAY",
     }
-    missing = required - _UNTRUSTED_ENV_DENYLIST
+    missing = required - UNTRUSTED_ENV_DENYLIST
     assert not missing, f"denylist regressed, missing: {sorted(missing)}"
 
 
@@ -175,7 +175,7 @@ def test_bridge_dispatch_entry_env_keys_are_denylisted() -> None:
     # Guard the regex itself: a silent zero-match would make this test vacuous.
     assert len(found) >= 1, "no bridge dispatch-entry env key found — regex drifted"
 
-    missing = {key: str(path) for key, path in found.items() if key not in _UNTRUSTED_ENV_DENYLIST}
+    missing = {key: str(path) for key, path in found.items() if key not in UNTRUSTED_ENV_DENYLIST}
     assert not missing, f"bridge exec-command env keys missing from denylist: {missing}"
 
 
@@ -620,7 +620,7 @@ class TestEnvValueGrammar:
         self, tmp_path: Path, monkeypatch
     ) -> None:
         """Delegating the grammar must not delegate the trust policy."""
-        denied = sorted(_UNTRUSTED_ENV_DENYLIST)[0]
+        denied = sorted(UNTRUSTED_ENV_DENYLIST)[0]
         monkeypatch.setenv(denied, "original")
         env_file = tmp_path / ".env"
         env_file.write_text(f"{denied}=hijacked\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

The project-directory `.env` is untrusted (it travels with whatever repo the user cloned — the boundary established by CVE-2026-47211 / GHSA-c4m7-2gwp-vw76). `_UNTRUSTED_ENV_DENYLIST` carried `OUROBOROS_CLI_PATH` and every other `*_CLI_PATH` variant, but **not** `OUROBOROS_CLI` — and the suffix-less alias is the one the `ooo` frontdoor bridges actually read and execute.

Chain, verified at `v0.50.7` and at current `main`:

| Step | Location |
|---|---|
| Project `.env` applied untrusted at import | `src/ouroboros/config/loader.py:412` |
| `OUROBOROS_CLI` not denylisted (prefixes are only `DYLD_`/`LD_`) | `loader.py:194-321` |
| Whole env forwarded to the spawned vendor CLI | `orchestrator/gjc_runtime.py:165-169`, `orchestrator/pi_runtime.py:201-205` |
| Bridge uses it verbatim as the exec command | `gjc_bridge/index.ts:25,41`; `cli/commands/setup.py:3565` (Pi template) |

A repo shipping `OUROBOROS_CLI=./.tools/helper` therefore chooses the binary that runs when the victim types any `ooo ...` inside that checkout.

**Scope is wider than the `*_CLI_PATH` naming suggests:** the identical sink exists in the Pi extension emitted by `ouroboros setup --runtime pi`, not just gjc. Other runtimes forward the env too, but have no consumer of this key.

## Fix

One line of policy: `"OUROBOROS_CLI"` joins the denylist next to `OUROBOROS_CLI_PATH`, with a comment stating why a suffix-less key belongs there.

Ouroboros never sets this key itself — it is an operator escape hatch for installs where `ouroboros` is not on the child's PATH (the gjc bridge's `DEFAULT_COMMAND` is the bare name `"ouroboros"`). Denying it from an *untrusted* source costs nothing; a trusted `~/.ouroboros/.env` or a real shell export still works, and both directions are now pinned by tests.

### Deliberately not done: popping the key in `_build_child_env`

The reporter suggested also popping `OUROBOROS_CLI` in `gjc_runtime._build_child_env` alongside `OUROBOROS_AGENT_RUNTIME`/`OUROBOROS_LLM_BACKEND`. That was rejected: an unconditional pop cannot distinguish provenance, so it would break the legitimate operator escape hatch above (the child falls back to a bare-name PATH lookup that either fails or resolves a *different* `ouroboros`). After this patch, anything still in `os.environ` at spawn time is trusted by construction, so the pop would buy defence only against a future bypass of the loader while costing a working feature today. Raising it here rather than deciding silently.

## Why there are two commits

`enforce-module-size` refuses any growth of `config/loader.py` (2432-line grandfathered budget, zero headroom) and instructs you to put new code in a new module. So commit 2 is a **pure move**: the denylist, the denied prefixes, and the membership predicate go to `src/ouroboros/config/untrusted_env.py` with their comments intact, no behaviour change, names de-underscored now that they cross a module boundary. `loader.py` drops 2445 → 2277 lines. Commit 1 is the security delta on its own, so the fix stays readable independently of the move.

## Anti-drift

The bridges are TypeScript and live outside Python's import graph, which is exactly why nothing connected them to the denylist and why the gap survived two advisories. `test_bridge_dispatch_entry_env_keys_are_denylisted` re-derives the key **from the bridge sources themselves** and asserts denylist membership, with a non-vacuity guard on the regex. A new bridge, or a rename of this one, now fails CI instead of silently reopening the hole.

## Review blocker resolution

- Removed the fixed `_BRIDGE_ENTRY_SOURCES` tuple.
- Added package-wide dispatch-source discovery and per-source non-vacuity.
- Added mutation regressions for bracket access, future bridge discovery, and one-source-only parser drift.
- Updated the stale `python-dotenv` trust-boundary comment after the policy-module extraction.

## Test plan

- `uv run pytest tests/unit/config tests/unit/orchestrator/test_gjc_runtime.py tests/unit/orchestrator/test_pi_runtime.py` — 550 passed
- `uv run pytest tests/unit/cli/test_setup.py -k bridge` — 2 passed
- `ruff check` + `ruff format --check` clean
- Discovery confirms both current bridge sources independently yield `OUROBOROS_CLI`; mutation regressions prove bracket access, new-source discovery, and per-source failure behavior

## Credit

Reported privately by **Arpit Jain** (@arpitjain099), who traced the full chain and correctly read it as a naming gap rather than a decision. A draft security advisory is being prepared separately; this is not covered by GHSA-jv2h-4p9v-wf5w (0.42.1), which named neither this key nor this sink class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




Closes #1902
