### PR TITLE
fix(cli): persist the ambiguity score computed by ouroboros init

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 import click
 from rich.prompt import Confirm, Prompt
+import structlog
 import typer
 import yaml
 
@@ -49,6 +50,8 @@ from ouroboros.events.hitl import (
 from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.providers.base import LLMAdapter
+
+log = structlog.get_logger(__name__)
 
 
 class SeedGenerationResult(Enum):
@@ -486,7 +489,9 @@ async def _run_interview(
                 return
 
             # Generate Seed
-            seed_path, result = await _generate_seed_from_interview(state, llm_adapter, llm_backend)
+            seed_path, result = await _generate_seed_from_interview(
+                state, llm_adapter, llm_backend, engine=engine
+            )
 
             if result == SeedGenerationResult.CONTINUE_INTERVIEW:
                 # Re-open interview for more questions
@@ -541,12 +546,15 @@ async def _generate_seed_from_interview(
     state: InterviewState,
     llm_adapter: LLMAdapter,
     llm_backend: str | None = None,
+    *,
+    engine: InterviewEngine,
 ) -> tuple[Path | None, SeedGenerationResult]:
     """Generate Seed from completed interview.
 
     Args:
         state: Completed interview state.
         llm_adapter: LLM adapter for scoring and generation.
+        engine: Interview engine that owns durable state persistence.
 
     Returns:
         Tuple of (path to generated seed file or None, result status).
@@ -569,6 +577,21 @@ async def _generate_seed_from_interview(
     ambiguity_score = score_result.value
     console.print(f"[muted]Ambiguity score: {ambiguity_score.overall_score:.2f}[/]")
 
+    # Persist the evaluation like the MCP path does (#1901): without this the
+    # state file reads ambiguity_score: null and the score only survives in
+    # rotating logs. A save failure must never block seed generation.
+    state.store_ambiguity(
+        score=ambiguity_score.overall_score,
+        breakdown=ambiguity_score.breakdown.model_dump(mode="json"),
+    )
+    save_result = await engine.save_state(state)
+    if save_result.is_err:
+        log.warning(
+            "cli.init.persist_ambiguity_failed",
+            interview_id=state.interview_id,
+            error=str(save_result.error),
+        )
+
     if not ambiguity_score.is_ready_for_seed:
         print_warning(
             f"Ambiguity score ({ambiguity_score.overall_score:.2f}) is too high. "
@@ -588,6 +611,17 @@ async def _generate_seed_from_interview(
         )
 
         if choice == "1":
+            # Reopening bypasses record_response's reopen contract, so the
+            # snapshot persisted above must be invalidated here: an in-progress
+            # interview must never carry a live score.
+            state.clear_stored_ambiguity()
+            clear_result = await engine.save_state(state)
+            if clear_result.is_err:
+                log.warning(
+                    "cli.init.clear_ambiguity_failed",
+                    interview_id=state.interview_id,
+                    error=str(clear_result.error),
+                )
             return None, SeedGenerationResult.CONTINUE_INTERVIEW
         elif choice == "3":
             return None, SeedGenerationResult.CANCELLED

--- a/src/ouroboros/cli/commands/seed.py
+++ b/src/ouroboros/cli/commands/seed.py
@@ -89,7 +89,9 @@ async def _run_seed_generation(
         )
         raise typer.Exit(code=1)
 
-    seed_path, result = await _generate_seed_from_interview(state, llm_adapter, llm_backend)
+    seed_path, result = await _generate_seed_from_interview(
+        state, llm_adapter, llm_backend, engine=engine
+    )
     if seed_path is None:
         raise typer.Exit(code=1)
 

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -18,7 +18,7 @@ from ouroboros.cli.commands.init import (
     _start_workflow,
 )
 from ouroboros.cli.main import app
-from ouroboros.core.errors import ProviderError
+from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.types import Result
 
 runner = CliRunner()
@@ -356,7 +356,9 @@ class TestInitWorkflowRuntimeHandoff:
             patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
             patch("ouroboros.cli.commands.init.print_error") as mock_print_error,
         ):
-            seed_path, result = await _generate_seed_from_interview(state, llm_adapter)
+            seed_path, result = await _generate_seed_from_interview(
+                state, llm_adapter, engine=_persistence_engine()
+            )
 
         assert seed_path is None
         assert result == SeedGenerationResult.CANCELLED
@@ -412,7 +414,9 @@ class TestInitWorkflowRuntimeHandoff:
             patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
             patch("ouroboros.cli.commands.init.Prompt.ask", return_value="2"),
         ):
-            seed_path, result = await _generate_seed_from_interview(state, llm_adapter)
+            seed_path, result = await _generate_seed_from_interview(
+                state, llm_adapter, engine=_persistence_engine()
+            )
 
         assert result == SeedGenerationResult.SUCCESS
         assert seed_path is not None
@@ -422,3 +426,147 @@ class TestInitWorkflowRuntimeHandoff:
         assert call_kwargs.get("force") is True
         passed_score = mock_generator.generate.call_args.args[1]
         assert passed_score.overall_score == 0.45
+
+
+def _scored(overall: float, clarity: float, justification: str) -> AmbiguityScore:
+    def component(name: str, weight: float) -> ComponentScore:
+        return ComponentScore(
+            name=name,
+            clarity_score=clarity,
+            weight=weight,
+            justification=justification,
+        )
+
+    return AmbiguityScore(
+        overall_score=overall,
+        breakdown=ScoreBreakdown(
+            goal_clarity=component("Goal", 0.4),
+            constraint_clarity=component("Constraints", 0.3),
+            success_criteria_clarity=component("Success", 0.3),
+        ),
+    )
+
+
+def _persistence_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.save_state = AsyncMock(return_value=Result.ok(Path("/tmp/interview.json")))
+    return engine
+
+
+class TestSeedGenerationPersistsAmbiguity:
+    """CLI seed generation must persist the score like the MCP path (#1901)."""
+
+    @pytest.mark.asyncio
+    async def test_successful_generation_persists_score_and_breakdown(self) -> None:
+        state = InterviewState(
+            interview_id="interview_persist_success",
+            initial_context="Build a CLI",
+        )
+        score = _scored(0.05, 0.95, "clear")
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(score))
+        mock_seed = MagicMock()
+        mock_seed.metadata.seed_id = "seed_persist_success"
+        mock_generator = MagicMock()
+        mock_generator.generate = AsyncMock(return_value=Result.ok(mock_seed))
+        mock_generator.save_seed = AsyncMock(return_value=Result.ok(Path("/tmp/seed.yaml")))
+        engine = _persistence_engine()
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
+        ):
+            seed_path, result = await _generate_seed_from_interview(
+                state, MagicMock(), engine=engine
+            )
+
+        assert result == SeedGenerationResult.SUCCESS
+        assert seed_path is not None
+        assert state.ambiguity_score == pytest.approx(0.05)
+        assert state.ambiguity_breakdown == score.breakdown.model_dump(mode="json")
+        engine.save_state.assert_awaited_once_with(state)
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_is_nonfatal(self) -> None:
+        state = InterviewState(
+            interview_id="interview_persist_warn",
+            initial_context="Build a CLI",
+        )
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(_scored(0.05, 0.95, "clear")))
+        mock_seed = MagicMock()
+        mock_seed.metadata.seed_id = "seed_persist_warn"
+        mock_generator = MagicMock()
+        mock_generator.generate = AsyncMock(return_value=Result.ok(mock_seed))
+        mock_generator.save_seed = AsyncMock(return_value=Result.ok(Path("/tmp/seed.yaml")))
+        engine = MagicMock()
+        engine.save_state = AsyncMock(
+            return_value=Result.err(ValidationError("disk full", field="state"))
+        )
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
+        ):
+            seed_path, result = await _generate_seed_from_interview(
+                state, MagicMock(), engine=engine
+            )
+
+        assert result == SeedGenerationResult.SUCCESS
+        assert seed_path is not None
+        assert state.ambiguity_score == pytest.approx(0.05)
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_scoring_still_persists_score(self) -> None:
+        # The reporter's monitor scenario: even without a generated seed, a
+        # completed interview that scored must not read as never-scored.
+        state = InterviewState(
+            interview_id="interview_persist_cancel",
+            initial_context="Build a CLI",
+        )
+        score = _scored(0.45, 0.5, "unclear")
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(score))
+        engine = _persistence_engine()
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=MagicMock()),
+            patch("ouroboros.cli.commands.init.Prompt.ask", return_value="3"),
+        ):
+            seed_path, result = await _generate_seed_from_interview(
+                state, MagicMock(), engine=engine
+            )
+
+        assert result == SeedGenerationResult.CANCELLED
+        assert seed_path is None
+        assert state.ambiguity_score == pytest.approx(0.45)
+        engine.save_state.assert_awaited_once_with(state)
+
+    @pytest.mark.asyncio
+    async def test_continue_interview_invalidates_persisted_score(self) -> None:
+        # Reopening bypasses record_response's reopen contract, so the helper
+        # must clear the snapshot it just persisted; an in-progress interview
+        # with a live score would be exactly the staleness #1901 fixes.
+        state = InterviewState(
+            interview_id="interview_persist_reopen",
+            initial_context="Build a CLI",
+        )
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(_scored(0.45, 0.5, "unclear")))
+        engine = _persistence_engine()
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=MagicMock()),
+            patch("ouroboros.cli.commands.init.Prompt.ask", return_value="1"),
+        ):
+            seed_path, result = await _generate_seed_from_interview(
+                state, MagicMock(), engine=engine
+            )
+
+        assert result == SeedGenerationResult.CONTINUE_INTERVIEW
+        assert seed_path is None
+        assert state.ambiguity_score is None
+        assert state.ambiguity_breakdown is None
+        assert engine.save_state.await_count == 2


### PR DESCRIPTION
Closes #1901

`ouroboros init` computes the ambiguity score and prints it, but the CLI seed-generation helper never calls `InterviewState.store_ambiguity`, so the state file always ends at `ambiguity_score: null` and the value survives only in logs that rotate away after ~7 days. The MCP generate-seed handler already persists the evaluation right after scoring, which is why an MCP session from the same install persists correctly while every CLI session loses it — exactly the entry-point split the report isolated.

Both CLI callers (the init flow and the seed command) already hold the `InterviewEngine`, so the fix threads the engine into `_generate_seed_from_interview` as a required keyword and mirrors the MCP pattern: `store_ambiguity` with the breakdown dump, then `save_state`, with a save failure logged as a warning (`cli.init.persist_ambiguity_failed`) and never blocking seed generation. Persistence happens immediately after scoring, before the readiness gate, so the score is durable even when the user cancels at the high-ambiguity prompt — the reporter's external monitor could otherwise still see a scored session as never-scored.

One consequence needed handling: the CLI's continue-interview option reopens a completed interview by flipping the status directly, bypassing `record_response`'s reopen contract that clears a stored score. With persistence in place that branch would leave a live score attached to an in-progress interview, so it now invalidates the just-persisted snapshot the same way (`clear_stored_ambiguity` + save) before returning to the interview loop.

The secondary event-schema asymmetry (`hitl.*` vs `interview.response.*`) is intentionally left out, as noted on the issue — the acceptance here is state-file parity.

Regressions (all verified failing before the fix): exact persisted score/breakdown values plus a single save on the success path, warning-and-continue when persistence fails, score retained on cancel, and the reopen path leaving both fields null with the invalidation save. Ruff, mypy, and the module-size check pass; the init/bigbang/CLI-main suites pass locally (1,157 tests).