### PR TITLE
feat(dashboard): add multi-run live kanban picker

### DIFF
--- a/docs/auto-live-kanban/architecture.md
+++ b/docs/auto-live-kanban/architecture.md
@@ -1,0 +1,34 @@
+# Auto Live Kanban Architecture
+
+> Generated: 2026-08-06
+
+## Overview
+
+The existing DB-scoped singleton daemon remains the only HTTP server. The read-only
+reader now projects recent execution summaries for the picker, while the existing
+`EventTail` and `reduce_board` path remains the source of truth for a selected run.
+
+```text
+EventStore SQLite (read-only)
+        ├── /api/runs → recent summaries → run list
+        └── /events?run=id → EventTail → reduce_board → live detail Kanban
+```
+
+## Components
+
+| Component | Responsibility |
+|---|---|
+| `dashboard_web/reader.py` | Preserve start-event `seed_goal`; project status/progress/provider summaries for concurrent runs |
+| `dashboard_web/page.py` | Render list by default, detail when `?run=` is present, and keep goal text untrimmed |
+| `dashboard_web/server.py` | Continue serving `/api/runs`, `/events`, and snapshots from one daemon |
+| `cli/commands/run.py` | Print a pinned detail URL before execution begins |
+| `cli/commands/auto.py` | Print the unpinned list URL while interview/Seed work has no execution ID |
+
+## URL Contract
+
+- `/` — live run picker
+- `/?run=<execution_id>` — live detail board
+- `/snapshot?run=<execution_id>` — frozen detail board
+
+Execution IDs are URL-encoded at URL construction and again when the browser opens
+the SSE stream.

--- a/docs/auto-live-kanban/implementation.md
+++ b/docs/auto-live-kanban/implementation.md
@@ -1,0 +1,34 @@
+# Auto Live Kanban Implementation
+
+> Completed: 2026-08-06
+
+## Summary
+
+Added a multi-run live dashboard picker. The singleton daemon now exposes rich run
+summaries, the browser shows the picker at the base URL, and each row links to a
+query-parameter-pinned live Kanban. Goal text is preserved without trimming or
+client-side truncation.
+
+## Files Modified
+
+- `src/ouroboros/dashboard_web/reader.py` — run summary projection and terminal event coverage.
+- `src/ouroboros/dashboard_web/page.py` — list/detail views and concurrent-run polling UI.
+- `src/ouroboros/dashboard_web/daemon.py` — safe query encoding for detail URLs.
+- `src/ouroboros/dashboard_web/__main__.py` — CLI run list output.
+- `src/ouroboros/cli/commands/run.py` — pinned live dashboard guidance.
+- `src/ouroboros/cli/commands/auto.py` — list dashboard guidance before execution ID allocation.
+- `src/ouroboros/mcp/tools/_dashboard.py` — updated base URL contract.
+
+## Testing
+
+```text
+uv run pytest -q tests/unit/dashboard_web/test_page.py tests/unit/dashboard_web/test_daemon.py tests/unit/dashboard_web/test_reader_readonly_uri.py tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_start_auto.py
+127 passed
+```
+
+Static analysis:
+
+```text
+uv run ruff check <changed Python files>
+All checks passed
+```

--- a/docs/auto-live-kanban/requirements.md
+++ b/docs/auto-live-kanban/requirements.md
@@ -1,0 +1,26 @@
+# Auto Live Kanban Requirements
+
+> Generated: 2026-08-06
+> Status: Clarified from the implementation request
+
+## Original Request
+
+Auto 라이브 칸반은 동시에 여러 실행이 가능하므로 실행 목록을 제공하고, `run`과 `auto`의 안내가 실제 화면 흐름과 맞는지 확인한다. query parameter로 특정 실행 상세에 바로 들어갈 수 있게 하며, 목록에서는 goal 기반 제목을 잘라내거나 `strip()`하지 않는다.
+
+## Clarified Specification
+
+- 하나의 dashboard daemon이 여러 실행을 제공한다.
+- 기본 dashboard URL(`/`)은 최신 실행으로 자동 이동하지 않고 최근 실행 목록을 보여준다.
+- `/?run=<execution_id>`는 해당 실행의 live Kanban 상세 화면을 직접 연다.
+- 목록에는 실행 ID, goal 원문, 상태, 단계/activity, AC 진행률, provider를 표시한다.
+- 목록은 주기적으로 갱신되어 동시 실행을 함께 관찰할 수 있다.
+- `ooo run`은 실행 시작 전에 pinned detail URL을 안내한다.
+- `ooo auto`는 실행 ID가 생기기 전에도 목록 URL을 안내한다.
+
+## Success Criteria
+
+- 두 개 이상의 실행이 `/api/runs`와 목록 화면에 동시에 나타난다.
+- goal의 앞뒤 공백과 줄바꿈이 reader/UI 경계에서 제거되지 않는다.
+- 목록 항목을 클릭하면 `?run=` 상세 화면으로 이동한다.
+- 기존 SSE 상세 화면과 snapshot 렌더링이 유지된다.
+- 관련 단위 테스트와 정적 분석이 통과한다.

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -72,6 +72,7 @@ from ouroboros.cli.formatters.panels import (
 )
 from ouroboros.config import get_opencode_mode
 from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
+from ouroboros.mcp.tools._dashboard import resolve_dashboard_base_url
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
@@ -658,6 +659,12 @@ async def _run_auto(
     ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
     watchdog_event_store = EventStore()
     await watchdog_event_store.initialize()
+    # Auto does not have an execution id until interview/Seed handoff finishes.
+    # Publish the picker now; it polls until the eventual run appears, and the
+    # selected row supplies the pinned ?run=<execution_id> detail URL.
+    dashboard_url = await resolve_dashboard_base_url(watchdog_event_store)
+    if dashboard_url:
+        console.print(f"Live Dashboard (all runs): {dashboard_url}")
     watchdog = Watchdog(
         controls=load_runtime_controls(None),
         event_appender=watchdog_event_store,

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -738,6 +738,18 @@ async def _run_orchestrator(
         fat_harness_mode=resolved_fat_harness_mode,
     )
 
+    # The URL is emitted before execution starts so it can be opened while the
+    # board is still empty. It is pinned with ?run= and therefore remains
+    # correct when other run/auto invocations use the same singleton daemon.
+    try:
+        from ouroboros.mcp.tools._dashboard import resolve_dashboard_run_url
+
+        dashboard_url = await resolve_dashboard_run_url(execution_id, event_store)
+    except Exception:  # noqa: BLE001 - observability must never block execution
+        dashboard_url = None
+    if dashboard_url:
+        print_info(f"Live Dashboard: {dashboard_url}")
+
     # Execute
     try:
         if resume_session:

--- a/src/ouroboros/dashboard_web/__main__.py
+++ b/src/ouroboros/dashboard_web/__main__.py
@@ -45,7 +45,10 @@ def main() -> None:
         return
     print("Recent runs:")
     for item in recent:
-        print(f"  {info.run_url(item['execution_id'])}   ({item['node_count']} nodes)")
+        goal = item.get("goal") or "(goal unavailable)"
+        status = item.get("status", "running")
+        progress = f"{item.get('completed_count', 0)}/{item.get('total_count', item.get('node_count', 0))} ACs"
+        print(f"  {info.run_url(item['execution_id'])}   [{status}] {progress}  {goal}")
 
 
 if __name__ == "__main__":

--- a/src/ouroboros/dashboard_web/daemon.py
+++ b/src/ouroboros/dashboard_web/daemon.py
@@ -27,6 +27,7 @@ import socket
 import subprocess
 import sys
 import time
+from urllib.parse import quote
 
 from ouroboros.dashboard_web.reader import default_db_path
 
@@ -54,7 +55,7 @@ class DashboardInfo:
     reused: bool
 
     def run_url(self, run_id: str) -> str:
-        return f"{self.url}/?run={run_id}"
+        return f"{self.url}/?run={quote(run_id, safe='')}"
 
 
 def _free_port(host: str = "127.0.0.1") -> int:

--- a/src/ouroboros/dashboard_web/page.py
+++ b/src/ouroboros/dashboard_web/page.py
@@ -26,6 +26,8 @@ _PAGE_TEMPLATE = """<!doctype html>
     display: flex; gap: 18px; align-items: center; flex-wrap: wrap; }
   header h1 { font-size: 15px; margin: 0; letter-spacing: .5px; }
   .meta { color: var(--muted); font-size: 12px; }
+  .view-link { color: var(--text); text-decoration: none; font-size: 12px; }
+  .view-link:hover { color: #58a6ff; }
   .dot { display:inline-block; width:7px; height:7px; border-radius:50%;
     margin-right:5px; vertical-align:middle; }
   .live { color: var(--completed); }
@@ -35,6 +37,30 @@ _PAGE_TEMPLATE = """<!doctype html>
     margin-right:4px; vertical-align:middle; }
   #board { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px;
     padding: 18px; align-items: start; }
+  #run-list { padding: 18px; max-width: 1100px; margin: 0 auto; }
+  .list-head { display:flex; align-items:baseline; justify-content:space-between;
+    gap:12px; margin:0 0 12px; }
+  .list-head h2 { font-size:14px; margin:0; }
+  .list-hint { color:var(--muted); font-size:11px; }
+  .runs { display:flex; flex-direction:column; gap:9px; }
+  .run-row { display:block; color:var(--text); text-decoration:none; background:var(--panel);
+    border:1px solid var(--border); border-left:3px solid var(--muted); border-radius:7px;
+    padding:12px 14px; }
+  .run-row:hover { border-color:#58a6ff; background:#1b2430; }
+  .run-row.status-running { border-left-color:var(--executing); }
+  .run-row.status-completed { border-left-color:var(--completed); }
+  .run-row.status-failed { border-left-color:var(--failed); }
+  .run-goal { font-size:13px; white-space:pre-wrap; overflow-wrap:anywhere; }
+  .run-details { display:flex; flex-wrap:wrap; gap:8px 14px; margin-top:7px;
+    color:var(--muted); font-size:11px; }
+  .run-id { color:#8b949e; }
+  .run-status { text-transform:uppercase; letter-spacing:.4px; }
+  .run-status.running { color:var(--executing); }
+  .run-status.completed { color:var(--completed); }
+  .run-status.failed { color:var(--failed); }
+  .list-empty { color:var(--muted); border:1px dashed var(--border); border-radius:7px;
+    padding:28px 16px; text-align:center; font-size:12px; }
+  #detail-view[hidden], #run-list[hidden] { display:none; }
   .col { background: var(--panel); border: 1px solid var(--border);
     border-radius: 8px; min-height: 120px; display:flex; flex-direction:column; }
   .col-head { padding: 10px 12px; font-size: 12px; text-transform: uppercase;
@@ -67,7 +93,8 @@ _PAGE_TEMPLATE = """<!doctype html>
 </head>
 <body>
 <header>
-  <h1>OUROBOROS · LIVE AGENTS</h1>
+  <h1><a class="view-link" href="./">OUROBOROS</a> · <span id="view-title">LIVE AGENTS</span></h1>
+  <a class="view-link" id="all-runs" href="./" hidden>all runs</a>
   <span class="meta" id="m-status"><span class="dot" style="background:var(--muted)"></span>connecting…</span>
   <span class="meta" id="m-progress"></span>
   <span class="meta" id="m-phase"></span>
@@ -76,7 +103,8 @@ _PAGE_TEMPLATE = """<!doctype html>
   <span class="meta" id="m-frugality-evidence"></span>
   <div id="legend"></div>
 </header>
-<div id="board"></div>
+<main id="run-list" hidden></main>
+<main id="detail-view" hidden><div id="board"></div></main>
 <script>
 const COLS = [
   ["pending", "To Do"], ["executing", "In Progress"],
@@ -160,47 +188,97 @@ function cardHtml(c) {
     <div class="sub">${prov}${tier}${ac}${tokHtml}${tool}</div></div>`;
 }
 
+function setView(detail, runId) {
+  const list = document.getElementById("run-list");
+  const detailView = document.getElementById("detail-view");
+  const allRuns = document.getElementById("all-runs");
+  const viewTitle = document.getElementById("view-title");
+  list.hidden = detail;
+  detailView.hidden = !detail;
+  allRuns.hidden = !detail;
+  viewTitle.textContent = detail ? "LIVE AGENTS" : "RUNS";
+  if (!detail) {
+    document.getElementById("m-status").innerHTML =
+      '<span class="dot" style="background:var(--muted)"></span>run list';
+    document.getElementById("m-progress").textContent = "";
+    document.getElementById("m-phase").textContent = "";
+    document.getElementById("m-tokens").textContent = "";
+    document.getElementById("m-frugality").textContent = "";
+    document.getElementById("m-frugality-evidence").textContent = "";
+    document.getElementById("legend").innerHTML = "";
+  }
+}
+
+function fmtRunProgress(run) {
+  const total = Number(run.total_count || 0);
+  const completed = Number(run.completed_count || 0);
+  return total ? `${completed}/${total} ACs` : `${Number(run.node_count || 0)} nodes`;
+}
+
+function runRowHtml(run) {
+  const id = run.execution_id || "";
+  const goal = run.goal == null || run.goal === "" ? "(goal unavailable)" : run.goal;
+  const phase = [run.phase, run.activity].filter(Boolean).join(" · ");
+  const provider = run.provider ? ` · ${esc(run.provider)}` : "";
+  const phaseHtml = phase ? `<span>${esc(phase)}</span>` : "";
+  return `<a class="run-row status-${esc(run.status || "running")}" href="?run=${encodeURIComponent(id)}">
+    <div class="run-goal">${esc(goal)}</div>
+    <div class="run-details">
+      <span class="run-status ${esc(run.status || "running")}">${esc(run.status || "running")}</span>
+      <span>${esc(fmtRunProgress(run))}</span>${phaseHtml}
+      <span>${esc(run.status === "failed" ? `${Number(run.failed_count || 0)} failed` : "")}</span>
+      <span>${provider}</span>
+      <span class="run-id">${esc(id)}</span>
+    </div>
+  </a>`;
+}
+
+function renderRuns(runs) {
+  const list = document.getElementById("run-list");
+  const rows = Array.isArray(runs) ? runs : [];
+  const head = `<div class="list-head"><h2>Recent runs</h2><span class="list-hint">updates every ${WAIT_POLL_MS / 1000}s · click a run for live details</span></div>`;
+  list.innerHTML = head + (rows.length
+    ? `<div class="runs">${rows.map(runRowHtml).join("")}</div>`
+    : '<div class="list-empty">waiting for run… (ooo run / ooo auto)</div>');
+}
+
 __BOOTSTRAP__
 </script>
 </body>
 </html>"""
 
-# Live bootstrap: open an SSE stream and re-render on every pushed snapshot.
-#
-# The daemon's base URL is published to the user BEFORE any run exists (the auto
-# flow links it while interview/seed are still running), so the page must never
-# resolve "no run yet" into a dead end: it polls /api/runs until a run appears,
-# then attaches. The poll is interval-gated (setTimeout) so an idle page never
-# spins hot against the shared SQLite file.
+# Live bootstrap: show the multi-run picker by default, or open one run directly
+# when ``?run=<execution_id>`` is present. Both views are interval-gated so the
+# shared SQLite file is cheap to observe even when several runs are concurrent.
 _LIVE_BOOTSTRAP = """
 const WAIT_POLL_MS = 3000;
 function connect(runId) {
+  setView(true, runId);
+  if (window.dashboardSource) window.dashboardSource.close();
   const src = new EventSource("/events?run=" + encodeURIComponent(runId));
+  window.dashboardSource = src;
   const st = document.getElementById("m-status");
   src.onopen = () => st.innerHTML = '<span class="dot" style="background:var(--completed)"></span><span class="live">live</span> · ' + esc(runId);
   src.onmessage = (e) => { try { render(JSON.parse(e.data)); } catch (_) {} };
   src.onerror = () => st.innerHTML = '<span class="dot" style="background:var(--failed)"></span>reconnecting…';
 }
-async function pickRun() {
-  // One daemon serves every run; an explicit ?run= wins, else the latest run.
-  const explicit = new URLSearchParams(location.search).get("run");
-  if (explicit) return explicit;
+async function fetchRuns() {
   try {
-    const runs = (await (await fetch("/api/runs")).json()).runs || [];
-    if (runs.length) return runs[0].execution_id;
+    return (await (await fetch("/api/runs", {cache:"no-store"})).json()).runs || [];
   } catch (_) {}
-  return null;
+  return [];
 }
-async function start() {
-  const st = document.getElementById("m-status");
-  // Poll until a run exists — the base URL can be opened before one is created.
-  let runId = await pickRun();
-  while (!runId) {
-    st.innerHTML = '<span class="dot" style="background:var(--muted)"></span>waiting for run… (ooo run / ooo auto)';
+async function startList() {
+  setView(false);
+  while (!new URLSearchParams(location.search).get("run")) {
+    renderRuns(await fetchRuns());
     await new Promise(r => setTimeout(r, WAIT_POLL_MS));
-    runId = await pickRun();
   }
-  connect(runId);
+}
+function start() {
+  const runId = new URLSearchParams(location.search).get("run");
+  if (runId) connect(runId);
+  else startList();
 }
 start();
 """
@@ -231,6 +309,7 @@ def static_html(board: dict, *, run_id: str | None = None) -> str:
         status_html += f" · {label}"
     status_js = _json.dumps(status_html).replace("</", "<\\/")
     bootstrap = (
+        "setView(true);\n"
         f'document.getElementById("m-status").innerHTML = {status_js};\nrender({board_json});\n'
     )
     return _PAGE_TEMPLATE.replace("__BOOTSTRAP__", bootstrap)

--- a/src/ouroboros/dashboard_web/reader.py
+++ b/src/ouroboros/dashboard_web/reader.py
@@ -19,6 +19,7 @@ from typing import Any
 from urllib.parse import quote
 
 from ouroboros.config.models import resolve_event_store_path
+from ouroboros.dashboard.board import reduce_board
 
 # Events relevant to the execution Kanban. Filtering at the SQL layer keeps the
 # tail cheap even on a mult-hundred-MB DB shared by many runs.
@@ -33,6 +34,9 @@ _RELEVANT_EVENT_TYPES: tuple[str, ...] = (
     "orchestrator.tool.called",
     "workflow.progress.updated",
     "execution.session.completed",
+    "orchestrator.session.completed",
+    "orchestrator.session.failed",
+    "orchestrator.session.cancelled",
     # Carries the run-level runtime_backend (provider) — lets the board tag the
     # provider on SIMPLE runs that emit no per-worker execution.session.started.
     "orchestrator.session.started",
@@ -160,33 +164,132 @@ class EventTail:
 
 
 def list_recent_executions(db_path: str | Path, *, limit: int = 10) -> list[dict[str, Any]]:
-    """Most-recently-active execution ids (for the CLI/picker).
+    """Return recent execution summaries for the dashboard run picker.
 
     Sources execution ids from ``orchestrator.session.started`` (present for EVERY
-    run, simple or decomposed) and counts AC nodes from ``execution.node.created``
-    when available — so simple, non-decomposed runs are listed too.
+    run, simple or decomposed). The start event also owns the unmodified
+    ``seed_goal`` shown by the list view. Each selected run is reduced from its
+    read-only event cluster so concurrent runs can be compared without opening
+    every SSE stream.
     """
     path = Path(db_path).expanduser()
     if not path.exists():
         return []
-    sql = (
-        "SELECT eid, MAX(last_row) AS last_row, SUM(n) AS n FROM ("
-        "  SELECT json_extract(payload, '$.execution_id') AS eid, "
-        "         rowid AS last_row, 0 AS n "
-        "  FROM events WHERE event_type = 'orchestrator.session.started' "
-        "  UNION ALL "
-        "  SELECT json_extract(payload, '$.execution_id') AS eid, "
-        "         rowid AS last_row, 1 AS n "
-        "  FROM events WHERE event_type = 'execution.node.created' "
-        ") WHERE eid IS NOT NULL "
-        "GROUP BY eid ORDER BY last_row DESC LIMIT ?"
+    start_sql = (
+        "SELECT rowid, aggregate_id, payload "
+        "FROM events WHERE event_type = 'orchestrator.session.started' "
+        "ORDER BY rowid DESC LIMIT ?"
+    )
+    event_types = (
+        "orchestrator.session.started",
+        "orchestrator.session.completed",
+        "orchestrator.session.failed",
+        "orchestrator.session.cancelled",
+        "execution.node.created",
+        "execution.node.updated",
+        "execution.subtask.updated",
+        "execution.session.started",
+        "execution.ac.completed",
+        "workflow.progress.updated",
     )
     conn = _connect_readonly(path)
     try:
-        rows = conn.execute(sql, [limit]).fetchall()
+        starts = conn.execute(start_sql, [max(1, limit)]).fetchall()
+        summaries: list[dict[str, Any]] = []
+        seen_execution_ids: set[str] = set()
+        type_ph = ",".join("?" for _ in event_types)
+        for start in starts:
+            start_payload = _decode_payload(start["payload"])
+            if not isinstance(start_payload, dict):
+                continue
+            execution_id = start_payload.get("execution_id")
+            if not isinstance(execution_id, str) or not execution_id:
+                continue
+            if execution_id in seen_execution_ids:
+                continue
+            seen_execution_ids.add(execution_id)
+            session_id = start["aggregate_id"] or start_payload.get("session_id")
+            ids = [value for value in (execution_id, session_id) if value]
+            id_ph = ",".join("?" for _ in ids)
+            scope = (
+                f"(aggregate_id IN ({id_ph}) "
+                f"OR json_extract(payload, '$.execution_id') IN ({id_ph}) "
+                f"OR json_extract(payload, '$.session_id') IN ({id_ph}))"
+            )
+            event_rows = conn.execute(
+                "SELECT rowid, event_type, payload FROM events "
+                f"WHERE event_type IN ({type_ph}) AND {scope} ORDER BY rowid",
+                [*event_types, *ids, *ids, *ids],
+            ).fetchall()
+            events = [
+                {
+                    "rowid": row["rowid"],
+                    "event_type": row["event_type"],
+                    "payload": payload,
+                }
+                for row in event_rows
+                if isinstance((payload := _decode_payload(row["payload"])), dict)
+            ]
+            board = reduce_board(events, execution_id=execution_id)
+            columns = board["columns"]
+            counts = {
+                key: len(columns.get(key, []))
+                for key in ("pending", "executing", "completed", "failed")
+            }
+            status = "running"
+            for event in events:
+                event_type = event["event_type"]
+                if event_type == "orchestrator.session.completed":
+                    status = "completed"
+                elif event_type in {
+                    "orchestrator.session.failed",
+                    "orchestrator.session.cancelled",
+                }:
+                    status = "failed"
+            if status == "running" and counts["executing"] == 0 and counts["pending"] == 0:
+                if counts["completed"]:
+                    status = "completed"
+                elif counts["failed"]:
+                    status = "failed"
+            meta = board["meta"]
+            goal = start_payload.get("seed_goal")
+            if not isinstance(goal, str):
+                goal = meta.get("goal") if isinstance(meta.get("goal"), str) else None
+            summaries.append(
+                {
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "goal": goal,
+                    "status": status,
+                    "node_count": sum(counts.values()),
+                    "completed_count": counts["completed"],
+                    "total_count": meta.get("total") or sum(counts.values()),
+                    "pending_count": counts["pending"],
+                    "executing_count": counts["executing"],
+                    "failed_count": counts["failed"],
+                    "phase": meta.get("phase"),
+                    "activity": meta.get("activity"),
+                    "provider": meta.get("provider"),
+                    "total_tokens": meta.get("total_tokens", 0.0),
+                    "start_time": start_payload.get("start_time"),
+                    "last_row": max(
+                        (int(event["rowid"]) for event in events), default=int(start["rowid"])
+                    ),
+                }
+            )
     finally:
         conn.close()
-    return [{"execution_id": r["eid"], "node_count": int(r["n"] or 0)} for r in rows if r["eid"]]
+    return summaries
+
+
+def _decode_payload(payload: object) -> Any:
+    """Decode one SQLite JSON payload without allowing malformed rows to break the picker."""
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    return payload
 
 
 __all__ = ["EventTail", "default_db_path", "list_recent_executions"]

--- a/src/ouroboros/mcp/tools/_dashboard.py
+++ b/src/ouroboros/mcp/tools/_dashboard.py
@@ -69,8 +69,9 @@ async def resolve_dashboard_run_url(
 async def resolve_dashboard_base_url(store: EventStore | None) -> str | None:
     """Best-effort daemon base URL (no run pinned), scoped to ``store``'s DB.
 
-    Used by ``auto``, whose execution id only appears after interview+seed: the
-    page auto-selects the latest active run, so the bare base URL is the link.
+    Used by ``auto``, whose execution id only appears after interview+seed. The
+    bare base URL opens the multi-run picker; selecting a row navigates to the
+    same daemon with ``?run=<execution_id>`` for the live detail board.
     """
     suppress, db_path = _daemon_db_target(store)
     if suppress:

--- a/tests/unit/dashboard_web/test_daemon.py
+++ b/tests/unit/dashboard_web/test_daemon.py
@@ -227,7 +227,7 @@ class TestPendingRun:
             assert status == 200
             page = body.decode("utf-8")
             assert "waiting for run" in page
-            assert "while (!runId)" in page
+            assert "startList()" in page
             assert "no active run" not in page
         finally:
             server.shutdown()

--- a/tests/unit/dashboard_web/test_page.py
+++ b/tests/unit/dashboard_web/test_page.py
@@ -44,12 +44,16 @@ class TestLivePage:
         # first empty /api/runs — it shows a waiting state and keeps polling.
         assert "waiting for run" in INDEX_HTML
         assert "no active run" not in INDEX_HTML
-        # The poll must be a real loop that re-checks /api/runs, not a one-shot.
-        assert "while (!runId)" in INDEX_HTML
-        assert "pickRun()" in INDEX_HTML
+        # The base view is a real run list that re-checks /api/runs, not a
+        # one-shot latest-run redirect. Details remain pinned by ?run=.
+        assert "startList()" in INDEX_HTML
+        assert "fetchRuns()" in INDEX_HTML
+        assert "?run=" in INDEX_HTML
         # And it must be interval-gated so an idle page never spins hot.
         assert "setTimeout" in INDEX_HTML
         assert "WAIT_POLL_MS" in INDEX_HTML
+        assert "run-goal" in INDEX_HTML
+        assert "white-space:pre-wrap" in INDEX_HTML
 
 
 class TestStaticSnapshot:
@@ -59,6 +63,7 @@ class TestStaticSnapshot:
         assert "EventSource" not in html
         assert "render(" in html
         assert "snapshot" in html
+        assert "setView(true)" in html
         # The inlined board data is present.
         assert "hermes_cli" in html
         assert "red.txt" in html and "green.txt" in html

--- a/tests/unit/dashboard_web/test_reader_readonly_uri.py
+++ b/tests/unit/dashboard_web/test_reader_readonly_uri.py
@@ -3,9 +3,14 @@ can't be misparsed as the SQLite URI's query/fragment."""
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
-from ouroboros.dashboard_web.reader import _RELEVANT_EVENT_TYPES, _connect_readonly
+from ouroboros.dashboard_web.reader import (
+    _RELEVANT_EVENT_TYPES,
+    _connect_readonly,
+    list_recent_executions,
+)
 
 
 def _make_db(path) -> None:
@@ -51,3 +56,60 @@ def test_readonly_connect_is_actually_read_only(tmp_path) -> None:
 
 def test_reader_includes_execution_frugality_retrospective() -> None:
     assert "execution.frugality_retrospective.reported" in _RELEVANT_EVENT_TYPES
+
+
+def test_list_recent_executions_preserves_goal_and_reports_concurrent_runs(tmp_path) -> None:
+    db = tmp_path / "runs.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("CREATE TABLE events (aggregate_id TEXT, event_type TEXT, payload TEXT)")
+        rows = [
+            (
+                "orch_two",
+                "orchestrator.session.started",
+                {
+                    "execution_id": "exec_two",
+                    "seed_goal": "  Keep  leading\nline  ",
+                    "start_time": "t2",
+                },
+            ),
+            (
+                "exec_two",
+                "workflow.progress.updated",
+                {
+                    "execution_id": "exec_two",
+                    "completed_count": 1,
+                    "total_count": 2,
+                    "current_phase": "Run",
+                    "acceptance_criteria": [
+                        {"node_id": "two_1", "content": "AC", "status": "completed"},
+                        {"node_id": "two_2", "content": "AC 2", "status": "executing"},
+                    ],
+                },
+            ),
+            (
+                "orch_one",
+                "orchestrator.session.started",
+                {"execution_id": "exec_one", "seed_goal": "Second goal"},
+            ),
+        ]
+        conn.executemany(
+            "INSERT INTO events (aggregate_id, event_type, payload) VALUES (?, ?, ?)",
+            [
+                (aggregate_id, event_type, json.dumps(payload))
+                for aggregate_id, event_type, payload in rows
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    runs = list_recent_executions(db, limit=10)
+
+    assert [run["execution_id"] for run in runs] == ["exec_one", "exec_two"]
+    two = runs[1]
+    assert two["goal"] == "  Keep  leading\nline  "
+    assert two["status"] == "running"
+    assert two["completed_count"] == 1
+    assert two["total_count"] == 2
+    assert two["executing_count"] == 1


### PR DESCRIPTION
## Summary

- Add a live run picker so concurrent ooo run and ooo auto executions can be monitored together.
- Keep /?run=<execution_id> as a direct, shareable live detail route and preserve goal text in the list.

## Changes

- Project recent execution summaries from the read-only EventStore, including status, progress, phase, and provider.
- Render list-by-default and query-pinned detail views in the dependency-free dashboard.
- Print correct dashboard guidance from run and auto; encode run IDs safely and deduplicate resumed runs.
- Add requirements, architecture, implementation notes, and regression coverage.

## Notes

- Validation: 246 focused tests passed; Ruff passed.
- Non-blocking status fidelity and list-view liveness follow-up: #1905.

Closes #1906.