### PR TITLE
fix(verification): stop remembering an unreadable extraction as an answer

### DIFF
--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -136,6 +136,17 @@ class AssertionExtractor:
             return Result.err(f"Extraction failed: {result.error}")
 
         assertions = self._parse_response(result.value.content, acceptance_texts)
+        if assertions is None:
+            # The response could not be read at all, which is not an answer
+            # about this seed — it is the absence of one. Remembering it would
+            # answer every later generation from a reply nobody understood, and
+            # the caller cannot tell that empty apart from "nothing here needs
+            # verifying", so spec verification would stay skipped for the life
+            # of the seed. The transport-failure path above already retries;
+            # this one now does too.
+            logger.warning("AssertionExtractor response unreadable, not caching: %s", seed_id)
+            return Result.ok(())
+
         self._cache[seed_id] = assertions
         # LRU eviction: remove oldest entry if cache exceeds max size
         while len(self._cache) > self.max_cache_size:
@@ -146,8 +157,15 @@ class AssertionExtractor:
         self,
         content: str,
         acceptance_criteria: tuple[str, ...],
-    ) -> tuple[SpecAssertion, ...]:
-        """Parse LLM response into SpecAssertions."""
+    ) -> tuple[SpecAssertion, ...] | None:
+        """Parse LLM response into SpecAssertions.
+
+        Returns ``None`` when the response could not be read as an extraction
+        at all — no JSON payload, malformed JSON, or a payload that is not the
+        expected array. That is distinct from an empty tuple, which is a
+        response that *was* read and offered nothing verifiable, and which the
+        caller is right to remember.
+        """
         try:
             # Extract the JSON payload, tolerating markdown fences and prose
             # that surround it (e.g. Gemini-style ``Here is ...`` prefixes).
@@ -157,7 +175,7 @@ class AssertionExtractor:
             data = json.loads(json_str)
             if not isinstance(data, list):
                 logger.warning("Expected JSON array, got: %s", type(data))
-                return ()
+                return None
 
             assertions: list[SpecAssertion] = []
             for item in data:
@@ -247,7 +265,7 @@ class AssertionExtractor:
 
         except (ValueError, KeyError, TypeError, ValidationError) as e:
             logger.warning("Failed to parse extraction response: %s", e)
-            return ()
+            return None
 
 
 def _is_usable_regex_pattern(pattern: str) -> bool:

--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -160,11 +160,15 @@ class AssertionExtractor:
     ) -> tuple[SpecAssertion, ...] | None:
         """Parse LLM response into SpecAssertions.
 
-        Returns ``None`` when the response could not be read as an extraction
-        at all — no JSON payload, malformed JSON, or a payload that is not the
-        expected array. That is distinct from an empty tuple, which is a
-        response that *was* read and offered nothing verifiable, and which the
-        caller is right to remember.
+        Returns ``None`` when the response could not be read as an extraction:
+        no JSON payload, malformed JSON, a payload that is not the expected
+        array, or an array that offered assertions and had every one of them
+        rejected. In none of those cases did the model answer in the schema
+        this asks for.
+
+        An empty tuple means the opposite — the array was read and was empty,
+        the model saying there is nothing here to verify. That is an answer,
+        and the caller is right to remember it.
         """
         try:
             # Extract the JSON payload, tolerating markdown fences and prose
@@ -260,6 +264,14 @@ class AssertionExtractor:
                 except ValidationError as e:
                     logger.warning("Ignoring invalid assertion object: %s", e)
                     continue
+
+            if data and not assertions:
+                # The model offered assertions and every one was thrown out, so
+                # nothing it said arrived in the schema this asks for. Read as
+                # "nothing to verify" that would be indistinguishable from a
+                # criterion set with nothing mechanical in it.
+                logger.warning("Every assertion in the extraction response was rejected")
+                return None
 
             return tuple(assertions)
 

--- a/tests/unit/test_llm_response_fence_robustness.py
+++ b/tests/unit/test_llm_response_fence_robustness.py
@@ -2100,7 +2100,7 @@ class TestAssertionExtractorFenceRobustness:
         )
 
         if expected_description is None:
-            assert assertions == ()
+            assert assertions is None
         else:
             assert len(assertions) == 1
             assert assertions[0].description == expected_description
@@ -2130,7 +2130,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     @pytest.mark.parametrize("prefixes", BLOCKQUOTE_INDENTED_PREFIX_VARIANTS)
     def test_blockquote_indented_example_stale_only_is_excluded(
@@ -2152,7 +2152,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     @pytest.mark.parametrize("prefixes", QUOTED_LIST_FENCE_VARIANTS)
     def test_quoted_list_example_is_excluded_and_releases_actual(
@@ -2193,7 +2193,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert stale_only == ()
+        assert stale_only is None
         assert len(actual) == 1
         assert actual[0].description == "actual assertion"
 
@@ -2258,7 +2258,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     def test_disconnected_quoted_list_closer_cannot_release_later_stale(self) -> None:
         stale_payload = json.dumps(
@@ -2291,7 +2291,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     def test_tab_continued_plain_list_fence_is_authoritative(self) -> None:
         actual_payload = json.dumps(
@@ -2354,7 +2354,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert stale_only == ()
+        assert stale_only is None
         assert len(actual) == 1
         assert actual[0].description == "actual assertion"
 
@@ -2390,7 +2390,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert stale_only == ()
+        assert stale_only is None
         assert len(actual) == 1
         assert actual[0].description == "ACTUAL_ASSERTION"
 
@@ -2431,7 +2431,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert stale_only == ()
+        assert stale_only is None
         assert len(actual) == 1
         assert actual[0].description == "ACTUAL_ASSERTION"
 
@@ -2468,7 +2468,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert stale_only == ()
+        assert stale_only is None
         assert len(actual) == 1
         assert actual[0].description == "ACTUAL_ASSERTION"
 
@@ -2501,7 +2501,7 @@ class TestAssertionExtractorFenceRobustness:
         )
 
         if case == "escaped":
-            assert result == ()
+            assert result is None
         else:
             assert len(result) == 1
             assert result[0].description == "ACTUAL_ASSERTION"
@@ -2526,7 +2526,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     def test_unfenced_example_before_actual_answer_returns_empty(self) -> None:
         example_payload = json.dumps(
@@ -2555,7 +2555,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     @pytest.mark.parametrize(
         "indentation",
@@ -2697,7 +2697,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1",),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     def test_oversized_json_integer_returns_empty(self) -> None:
         content = (
@@ -2710,7 +2710,7 @@ class TestAssertionExtractorFenceRobustness:
             content, ("AC number 1",)
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     def test_incidental_non_object_array_is_ignored(self) -> None:
         assertions = AssertionExtractor(llm_adapter=AsyncMock())._parse_response(
@@ -2718,7 +2718,7 @@ class TestAssertionExtractorFenceRobustness:
             ("AC number 1", "AC number 2"),
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     @pytest.mark.parametrize("wrapper", MALFORMED_UNFENCED_WRAPPERS)
     def test_invalid_wrapper_does_not_create_nested_assertion(self, wrapper: str) -> None:
@@ -2731,7 +2731,7 @@ class TestAssertionExtractorFenceRobustness:
             content, ("AC number 1",)
         )
 
-        assert assertions == ()
+        assert assertions is None
 
     @pytest.mark.parametrize(
         "payload",
@@ -2759,4 +2759,4 @@ class TestAssertionExtractorFenceRobustness:
             json.dumps(payload), ("AC number 1",)
         )
 
-        assert assertions == ()
+        assert assertions is None

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -646,6 +646,86 @@ class TestAssertionExtractor:
         extractor.llm_adapter.complete.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "unreadable",
+        [
+            "Sorry, I cannot help with that.",
+            "[{",
+            '{"assertions": []}',
+            "",
+        ],
+        ids=["prose", "malformed-json", "object-instead-of-array", "nothing-at-all"],
+    )
+    async def test_an_unreadable_response_is_not_remembered_as_an_extraction(
+        self, unreadable: str
+    ) -> None:
+        """A reply nobody could read must not answer every later generation.
+
+        The cache exists so a seed is extracted once. But the empty tuple a
+        failed parse returns is indistinguishable, to the caller, from "nothing
+        here needs verifying" — it makes `_verify_spec_compliance` return None
+        and the evaluator fall back to the agent's own self-report. Cached, that
+        single unreadable reply silently disables spec verification for every
+        later generation of the seed, and the log even calls it a cache hit.
+
+        The transport-failure path above is already retried on the next
+        generation. Only this path was permanent.
+        """
+        good = json.dumps(
+            [
+                {
+                    "ac_index": 0,
+                    "tier": "t2_structural",
+                    "pattern": "class Foo",
+                    "expected_value": "",
+                    "file_hint": "*.py",
+                    "description": "",
+                }
+            ]
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(
+                    CompletionResponse(
+                        content=content, model="test", usage={"input": 0, "output": 0}
+                    )
+                )
+                for content in (unreadable, good, good)
+            ]
+        )
+        extractor = AssertionExtractor(llm_adapter=mock_adapter)
+
+        first = await extractor.extract("seed_unreadable", ("Has class Foo",))
+        assert first.is_ok
+        assert first.value == ()
+
+        second = await extractor.extract("seed_unreadable", ("Has class Foo",))
+        assert second.is_ok
+        assert len(second.value) == 1, "the next generation must be allowed to ask again"
+
+        third = await extractor.extract("seed_unreadable", ("Has class Foo",))
+        assert third.value is second.value, "the reply that was read is remembered"
+        assert mock_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_a_readable_empty_extraction_is_still_remembered(self) -> None:
+        """An empty array is an answer — the model read the ACs and found nothing.
+
+        This is the boundary of the rule above: only a response that could not
+        be read is retried. Otherwise a seed whose criteria are genuinely not
+        machine-verifiable would pay for an extraction on every generation.
+        """
+        extractor = self._make_extractor([])
+
+        first = await extractor.extract("seed_nothing_verifiable", ("Looks nice",))
+        second = await extractor.extract("seed_nothing_verifiable", ("Looks nice",))
+
+        assert first.is_ok and second.is_ok
+        assert first.value == () and second.value == ()
+        extractor.llm_adapter.complete.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_llm_failure_returns_error(self) -> None:
         """LLM failure → Result.err."""
         mock_adapter = AsyncMock()

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -459,6 +459,19 @@ class TestSpecVerifier:
 
 # -- Extractor Tests --
 
+_GOOD_EXTRACTION = json.dumps(
+    [
+        {
+            "ac_index": 0,
+            "tier": "t2_structural",
+            "pattern": "class Foo",
+            "expected_value": "",
+            "file_hint": "*.py",
+            "description": "",
+        }
+    ]
+)
+
 
 class TestAssertionExtractor:
     """Tests for LLM-based assertion extraction."""
@@ -478,6 +491,21 @@ class TestAssertionExtractor:
                     usage={"input": 0, "output": 0},
                 )
             )
+        )
+        return AssertionExtractor(llm_adapter=mock_adapter)
+
+    def _make_extractor_sequence(self, *contents: str) -> AssertionExtractor:
+        """Create extractor whose mocked LLM answers each call in turn."""
+        mock_adapter = AsyncMock()
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(
+                    CompletionResponse(
+                        content=content, model="test", usage={"input": 0, "output": 0}
+                    )
+                )
+                for content in contents
+            ]
         )
         return AssertionExtractor(llm_adapter=mock_adapter)
 
@@ -671,30 +699,7 @@ class TestAssertionExtractor:
         The transport-failure path above is already retried on the next
         generation. Only this path was permanent.
         """
-        good = json.dumps(
-            [
-                {
-                    "ac_index": 0,
-                    "tier": "t2_structural",
-                    "pattern": "class Foo",
-                    "expected_value": "",
-                    "file_hint": "*.py",
-                    "description": "",
-                }
-            ]
-        )
-        mock_adapter = AsyncMock()
-        mock_adapter.complete = AsyncMock(
-            side_effect=[
-                Result.ok(
-                    CompletionResponse(
-                        content=content, model="test", usage={"input": 0, "output": 0}
-                    )
-                )
-                for content in (unreadable, good, good)
-            ]
-        )
-        extractor = AssertionExtractor(llm_adapter=mock_adapter)
+        extractor = self._make_extractor_sequence(unreadable, _GOOD_EXTRACTION, _GOOD_EXTRACTION)
 
         first = await extractor.extract("seed_unreadable", ("Has class Foo",))
         assert first.is_ok
@@ -706,7 +711,82 @@ class TestAssertionExtractor:
 
         third = await extractor.extract("seed_unreadable", ("Has class Foo",))
         assert third.value is second.value, "the reply that was read is remembered"
-        assert mock_adapter.complete.await_count == 2
+        assert extractor.llm_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "wrong_schema",
+        [
+            json.dumps([{"ac_index": 0}]),
+            json.dumps([{"ac_index": 0, "tier": "t9_imaginary", "pattern": "class Foo"}]),
+            json.dumps([{"ac_index": 7, "tier": "t2_structural", "pattern": "class Foo"}]),
+            json.dumps(["just a string"]),
+            json.dumps([{"ac_index": 0, "tier": "t2_structural", "pattern": ""}]),
+        ],
+        ids=[
+            "no-tier",
+            "tier-that-does-not-exist",
+            "ac_index-past-the-end",
+            "item-that-is-not-an-object",
+            "structural-assertion-with-no-pattern",
+        ],
+    )
+    async def test_an_array_whose_every_entry_is_rejected_is_not_remembered(
+        self, wrong_schema: str
+    ) -> None:
+        """An array the model filled with the wrong shape was never read either.
+
+        The JSON parses and the outer array is right, so the old code walked it,
+        threw every entry away, and returned the same empty tuple an honest
+        "nothing to verify" returns — then cached it. The seed is then answered
+        forever from a reply in which nothing arrived in the schema this asks
+        for, which is the same permanent silence as unreadable prose.
+        """
+        extractor = self._make_extractor_sequence(wrong_schema, _GOOD_EXTRACTION, _GOOD_EXTRACTION)
+
+        first = await extractor.extract("seed_wrong_schema", ("Has class Foo",))
+        assert first.is_ok
+        assert first.value == ()
+
+        second = await extractor.extract("seed_wrong_schema", ("Has class Foo",))
+        assert second.is_ok
+        assert len(second.value) == 1, "a wrong-schema reply must stay retryable"
+
+        third = await extractor.extract("seed_wrong_schema", ("Has class Foo",))
+        assert third.value is second.value
+        assert extractor.llm_adapter.complete.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_an_array_only_partly_rejected_is_remembered_as_what_survived(self) -> None:
+        """One good entry among bad ones is still an extraction that was read.
+
+        The rule is about a reply in which *nothing* arrived, not about every
+        entry being perfect. If one assertion survives, the model answered in
+        this schema and the seed should not pay for a second extraction.
+        """
+        extractor = self._make_extractor_sequence(
+            json.dumps(
+                [
+                    {"ac_index": 0},
+                    {
+                        "ac_index": 0,
+                        "tier": "t2_structural",
+                        "pattern": "class Foo",
+                        "expected_value": "",
+                        "file_hint": "*.py",
+                        "description": "",
+                    },
+                    {"ac_index": 99, "tier": "t2_structural", "pattern": "class Bar"},
+                ]
+            )
+        )
+
+        first = await extractor.extract("seed_partly_rejected", ("Has class Foo",))
+        second = await extractor.extract("seed_partly_rejected", ("Has class Foo",))
+
+        assert first.is_ok and len(first.value) == 1
+        assert second.value is first.value
+        extractor.llm_adapter.complete.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_a_readable_empty_extraction_is_still_remembered(self) -> None:


### PR DESCRIPTION
Fixes #1914.

## The defect

`_parse_response` returns an empty tuple for two situations that are not alike: a reply that **could not be read at all**, and a reply that **was read** and held nothing verifiable. `extract` caches either one under the seed id (`extractor.py:139`).

So one unreadable reply becomes that seed's extraction result forever. The caller cannot tell the two empties apart — `_verify_spec_compliance` returns `None` for an empty extraction and the evaluator falls back to the agent's own self-report — so spec verification stays off for every later generation of the seed, and the debug log reports it as a cache hit.

The transport-failure path three lines above already retries on the next generation. Only the parse-failure path was permanent.

## The change

`_parse_response` returns `None` when the response could not be read as an extraction at all — no JSON payload, malformed JSON, or a payload that is not the expected array. `extract` declines to cache that and returns the same `Result.ok(())` it always did, so nothing downstream changes shape; the next generation is simply allowed to ask again.

A response that _was_ read and offered nothing is still cached. That boundary is deliberate and pinned: a seed whose criteria are genuinely not machine-verifiable still costs exactly one extraction, not one per generation.

## Verification

Reproduction through the public `extract()` path — generation 1 gets an unreadable reply, generations 2 and 3 get a good one:

|              | before                   | after                                     |
| ------------ | ------------------------ | ----------------------------------------- |
| generation 1 | 0 assertions, 1 LLM call | 0 assertions, 1 LLM call                  |
| generation 2 | 0 assertions, 1 LLM call | **1 assertion**, 2 LLM calls              |
| generation 3 | 0 assertions, 1 LLM call | 1 assertion, 2 LLM calls (real cache hit) |

Reverting only `extractor.py` turns the four new cases red (`prose`, `malformed-json`, `object-instead-of-array`, `nothing-at-all`). With the change, `tests/unit/test_verification.py` and `tests/unit/mcp/server/test_adapter.py` are **124 passed** together.

The existing pinned invariant `test_invalid_json_returns_empty` — malformed response → `Result.ok(())`, no crash — is unchanged and still green.

`ruff check` + `ruff format --check` clean, `mypy src/ouroboros/verification/extractor.py` clean, `module-size: OK (510 modules, cap 2000)`.
