### PR TITLE
docs(mcp): clarify shipped session signal modes

### DIFF
--- a/src/ouroboros/mcp/tools/synapse_handler.py
+++ b/src/ouroboros/mcp/tools/synapse_handler.py
@@ -78,13 +78,18 @@ class SynapseSignalHandler:
             name=_TOOL_NAME,
             description=(
                 "Send one audited Ouroboros Synapse intent signal to an exact active "
-                "AC session attempt. The only delivery modes advertised by shipped runtime "
-                "adapters are inform and after_turn, and support is attempt-specific. redirect "
-                "and replace are reserved, capability-gated future modes. Unsupported requests "
-                "fail closed. A redirect falls back only when fallback_mode=after_turn is "
-                "explicit and the selected attempt advertises after_turn. Query "
-                "ouroboros_session_signal_targets for live capabilities before sending. A "
-                "queued result does not mean the signal was applied."
+                "AC session attempt. Shipped runtime adapters currently advertise and apply "
+                "only inform and after_turn; direct requested modes require the selected exact "
+                "attempt to advertise that mode. redirect and replace remain reserved, "
+                "capability-gated advertised/effective modes; no shipped adapter currently "
+                "advertises or applies either directly. redirect nevertheless remains a valid "
+                "requested mode on one explicit fallback path: fallback_mode=after_turn must "
+                "be present and that exact attempt must advertise after_turn, which becomes "
+                "the effective queued mode. All other unsupported requests fail closed, "
+                "including redirect without that fallback and replace without its "
+                "capabilities. Query ouroboros_session_signal_targets for the selected exact "
+                "attempt's live capabilities before sending. A queued result does not mean "
+                "the signal was applied."
             ),
             parameters=(
                 MCPToolParameter(
@@ -106,9 +111,13 @@ class SynapseSignalHandler:
                     name="mode",
                     type=ToolInputType.STRING,
                     description=(
-                        "Requested Synapse delivery mode. Shipped modes: inform and after_turn. "
-                        "Reserved future modes: redirect and replace. Select only a mode "
-                        "advertised by ouroboros_session_signal_targets for the exact attempt."
+                        "Requested Synapse delivery mode. For the direct path, the exact attempt "
+                        "must advertise the requested mode in ouroboros_session_signal_targets. "
+                        "For the sole fallback path, redirect may be requested while omitted "
+                        "from discovery only when fallback_mode=after_turn is explicit and that "
+                        "attempt advertises after_turn; its effective mode is then after_turn. "
+                        "Shipped adapters currently advertise/effect only inform and after_turn; "
+                        "redirect and replace remain reserved advertised/effective capabilities."
                     ),
                     enum=tuple(mode.value for mode in SessionSignalMode),
                 ),
@@ -283,9 +292,14 @@ class SynapseTargetsHandler:
             name="ouroboros_session_signal_targets",
             description=(
                 "List exact active AC attempts and each attempt's live SessionSignal "
-                "capabilities for one execution before sending a signal. The main session "
-                "should select only an advertised mode, match the user's intent to AC content, "
-                "and ask only when multiple candidates remain genuinely ambiguous."
+                "capabilities for one execution before sending a signal. Advertised modes are "
+                "valid direct requested modes for that exact attempt. One explicit fallback "
+                "path is also valid: redirect may be requested while omitted from discovery "
+                "only with fallback_mode=after_turn when after_turn is advertised, and the "
+                "effective queued mode is after_turn. Shipped adapters currently do not "
+                "advertise or effect redirect or replace; other unsupported requests fail "
+                "closed. Match the user's intent to AC content, and ask only when multiple "
+                "candidates remain genuinely ambiguous."
             ),
             parameters=(
                 MCPToolParameter(

--- a/src/ouroboros/mcp/tools/synapse_handler.py
+++ b/src/ouroboros/mcp/tools/synapse_handler.py
@@ -78,7 +78,13 @@ class SynapseSignalHandler:
             name=_TOOL_NAME,
             description=(
                 "Send one audited Ouroboros Synapse intent signal to an exact active "
-                "AC session attempt. A queued result does not mean the signal was applied."
+                "AC session attempt. The only delivery modes advertised by shipped runtime "
+                "adapters are inform and after_turn, and support is attempt-specific. redirect "
+                "and replace are reserved, capability-gated future modes. Unsupported requests "
+                "fail closed. A redirect falls back only when fallback_mode=after_turn is "
+                "explicit and the selected attempt advertises after_turn. Query "
+                "ouroboros_session_signal_targets for live capabilities before sending. A "
+                "queued result does not mean the signal was applied."
             ),
             parameters=(
                 MCPToolParameter(
@@ -99,13 +105,20 @@ class SynapseSignalHandler:
                 MCPToolParameter(
                     name="mode",
                     type=ToolInputType.STRING,
-                    description="Requested Synapse delivery mode.",
+                    description=(
+                        "Requested Synapse delivery mode. Shipped modes: inform and after_turn. "
+                        "Reserved future modes: redirect and replace. Select only a mode "
+                        "advertised by ouroboros_session_signal_targets for the exact attempt."
+                    ),
                     enum=tuple(mode.value for mode in SessionSignalMode),
                 ),
                 MCPToolParameter(
                     name="fallback_mode",
                     type=ToolInputType.STRING,
-                    description="Explicit redirect fallback; only after_turn is valid.",
+                    description=(
+                        "Explicit redirect-only fallback; after_turn is the sole valid value "
+                        "and is used only when the selected attempt advertises after_turn."
+                    ),
                     required=False,
                     enum=(SessionSignalMode.AFTER_TURN.value,),
                 ),
@@ -269,9 +282,10 @@ class SynapseTargetsHandler:
         return MCPToolDefinition(
             name="ouroboros_session_signal_targets",
             description=(
-                "List exact active AC attempts for one execution before sending a "
-                "Synapse signal. The main session should match the user's intent to "
-                "AC content and ask only when multiple candidates remain genuinely ambiguous."
+                "List exact active AC attempts and each attempt's live SessionSignal "
+                "capabilities for one execution before sending a signal. The main session "
+                "should select only an advertised mode, match the user's intent to AC content, "
+                "and ask only when multiple candidates remain genuinely ambiguous."
             ),
             parameters=(
                 MCPToolParameter(

--- a/tests/unit/mcp/tools/test_synapse_handler.py
+++ b/tests/unit/mcp/tools/test_synapse_handler.py
@@ -70,6 +70,33 @@ def test_definition_exposes_clean_room_vocabulary() -> None:
     assert params["contract_effect"].enum == ("additive", "specification_change")
 
 
+def test_public_schema_distinguishes_shipped_reserved_and_fallback_modes() -> None:
+    signal = SynapseSignalHandler(_Mailbox()).definition  # type: ignore[arg-type]
+    targets = SynapseTargetsHandler(SessionSignalHub()).definition
+    schema = signal.to_input_schema()
+    mode = schema["properties"]["mode"]
+    fallback = schema["properties"]["fallback_mode"]
+    description = signal.description
+
+    assert (
+        "only delivery modes advertised by shipped runtime adapters are inform and after_turn"
+        in description
+    )
+    assert "redirect and replace are reserved, capability-gated future modes" in description
+    assert "Unsupported requests fail closed" in description
+    assert "fallback_mode=after_turn is explicit" in description
+    assert "selected attempt advertises after_turn" in description
+    assert "ouroboros_session_signal_targets for live capabilities" in description
+    assert mode["enum"] == ["inform", "after_turn", "redirect", "replace"]
+    assert "Shipped modes: inform and after_turn" in mode["description"]
+    assert "Reserved future modes: redirect and replace" in mode["description"]
+    assert "ouroboros_session_signal_targets" in mode["description"]
+    assert fallback["enum"] == ["after_turn"]
+    assert "Explicit redirect-only fallback" in fallback["description"]
+    assert "live SessionSignal capabilities" in targets.description
+    assert "select only an advertised mode" in targets.description
+
+
 @pytest.mark.asyncio
 async def test_valid_request_returns_queued_not_applied() -> None:
     mailbox = _Mailbox()

--- a/tests/unit/mcp/tools/test_synapse_handler.py
+++ b/tests/unit/mcp/tools/test_synapse_handler.py
@@ -13,8 +13,13 @@ from ouroboros.core.session_signal import (
     SessionSignalState,
 )
 from ouroboros.core.session_signal_projection import SessionSignalProjection
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.synapse_handler import SynapseSignalHandler, SynapseTargetsHandler
-from ouroboros.orchestrator.synapse import SessionSignalHub, SessionSignalTarget
+from ouroboros.orchestrator.synapse import (
+    SessionSignalHub,
+    SessionSignalMailbox,
+    SessionSignalTarget,
+)
 
 
 @dataclass
@@ -40,6 +45,24 @@ class _Mailbox:
             event_ids=("evt_1",),
             reply=self.reply,
         )
+
+
+@dataclass
+class _Store:
+    events: list[BaseEvent] = field(default_factory=list)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:
+        return [
+            event
+            for event in self.events
+            if event.aggregate_type == aggregate_type and event.aggregate_id == aggregate_id
+        ]
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+    async def append_batch(self, events: list[BaseEvent]) -> None:
+        self.events.extend(events)
 
 
 def _arguments(**overrides: object) -> dict[str, object]:
@@ -78,23 +101,86 @@ def test_public_schema_distinguishes_shipped_reserved_and_fallback_modes() -> No
     fallback = schema["properties"]["fallback_mode"]
     description = signal.description
 
-    assert (
-        "only delivery modes advertised by shipped runtime adapters are inform and after_turn"
-        in description
-    )
-    assert "redirect and replace are reserved, capability-gated future modes" in description
-    assert "Unsupported requests fail closed" in description
-    assert "fallback_mode=after_turn is explicit" in description
-    assert "selected attempt advertises after_turn" in description
-    assert "ouroboros_session_signal_targets for live capabilities" in description
+    assert "advertise and apply only inform and after_turn" in description
+    assert "direct requested modes require" in description
+    assert "redirect and replace remain reserved" in description
+    assert "redirect nevertheless remains a valid requested mode" in description
+    assert "fallback_mode=after_turn must be present" in description
+    assert "effective queued mode" in description
+    assert "unsupported requests fail closed" in description
+    assert "selected exact attempt's live capabilities" in description
     assert mode["enum"] == ["inform", "after_turn", "redirect", "replace"]
-    assert "Shipped modes: inform and after_turn" in mode["description"]
-    assert "Reserved future modes: redirect and replace" in mode["description"]
+    assert "For the direct path" in mode["description"]
+    assert "For the sole fallback path" in mode["description"]
+    assert "redirect may be requested while omitted from discovery" in mode["description"]
+    assert "effective mode is then after_turn" in mode["description"]
+    assert "advertise/effect only inform and after_turn" in mode["description"]
     assert "ouroboros_session_signal_targets" in mode["description"]
     assert fallback["enum"] == ["after_turn"]
     assert "Explicit redirect-only fallback" in fallback["description"]
     assert "live SessionSignal capabilities" in targets.description
-    assert "select only an advertised mode" in targets.description
+    assert "Advertised modes are valid direct requested modes" in targets.description
+    assert "redirect may be requested while omitted from discovery" in targets.description
+    assert "effective queued mode is after_turn" in targets.description
+    assert "other unsupported requests fail closed" in targets.description
+    assert "select only an advertised mode" not in targets.description
+
+
+@pytest.mark.asyncio
+async def test_public_discovery_guidance_and_mailbox_share_redirect_fallback_contract() -> None:
+    store = _Store()
+    hub = SessionSignalHub()
+    target = SessionSignalTarget(
+        execution_id="exec_1",
+        session_scope_id="scope_1",
+        session_attempt_id="scope_1_attempt_1",
+        runtime_backend="codex_cli",
+        capabilities=SessionSignalCapabilities(
+            after_turn_delivery=True,
+            checkpoint_redirect=False,
+        ),
+    )
+    hub.register(target)
+    mailbox = SessionSignalMailbox(store, hub, delivery_queue=hub)  # type: ignore[arg-type]
+    signal_handler = SynapseSignalHandler(mailbox)
+    targets_handler = SynapseTargetsHandler(hub)
+
+    discovered = await targets_handler.handle({"execution_id": "exec_1"})
+    queued = await signal_handler.handle(_arguments())
+    rejected = await signal_handler.handle(
+        _arguments(fallback_mode=None, idempotency_key="turn_8_scope_1")
+    )
+
+    assert discovered.is_ok
+    assert "[modes: after_turn]" in discovered.value.text_content
+    capabilities = discovered.value.meta["targets"][0]["capabilities"]
+    assert capabilities["after_turn_delivery"] is True
+    assert capabilities["checkpoint_redirect"] is False
+    mode_description = next(
+        parameter.description
+        for parameter in signal_handler.definition.parameters
+        if parameter.name == "mode"
+    )
+    assert "redirect may be requested while omitted from discovery" in mode_description
+    assert "redirect may be requested while omitted from discovery" in (
+        targets_handler.definition.description
+    )
+    assert queued.is_ok
+    assert queued.value.meta["requested_mode"] == "redirect"
+    assert queued.value.meta["effective_mode"] == "after_turn"
+    pending = hub.pop_pending(target)
+    assert pending is not None
+    assert pending.signal.mode is SessionSignalMode.REDIRECT
+    assert pending.effective_mode is SessionSignalMode.AFTER_TURN
+    assert rejected.is_ok
+    assert rejected.value.is_error is True
+    assert rejected.value.meta["state"] == "rejected"
+    assert rejected.value.meta["effective_mode"] is None
+    rejected_events = await store.replay(
+        "session_signal",
+        rejected.value.meta["signal_id"],
+    )
+    assert rejected_events[-1].data["rejection_code"] == "capability_unsupported"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_session_signal_capabilities.py
+++ b/tests/unit/orchestrator/test_session_signal_capabilities.py
@@ -1,13 +1,16 @@
 """Runtime capability guards for Ouroboros Synapse."""
 
 from dataclasses import replace
+import sys
 
+from ouroboros.backends import runtime_backend_choices
 from ouroboros.core.session_signal import SessionSignalCapabilities
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     ClaudeAgentAdapter,
     RuntimeCapabilities,
 )
+from ouroboros.orchestrator.runtime_factory import create_agent_runtime
 
 
 def test_runtime_capabilities_default_synapse_to_unsupported() -> None:
@@ -46,3 +49,20 @@ def test_claude_sdk_declares_after_turn_delivery() -> None:
         background_reply=True,
         after_turn_delivery=True,
     )
+
+
+def test_shipped_runtime_registry_does_not_advertise_redirect_or_replace() -> None:
+    """Adding either direct capability requires revising the public mode contract."""
+    for backend in runtime_backend_choices():
+        runtime = create_agent_runtime(
+            backend=backend,
+            cli_path=sys.executable,
+            cwd="/tmp",
+            permission_mode="bypassPermissions",
+            model="test-model",
+            llm_backend="test-llm",
+        )
+        capabilities = runtime.capabilities.session_signals
+
+        assert capabilities.checkpoint_redirect is False, backend
+        assert not (capabilities.owned_turn_abort and capabilities.replacement_resume), backend


### PR DESCRIPTION
## Summary

- distinguish the shipped, attempt-specific `inform` and `after_turn` delivery modes from reserved `redirect` and `replace` modes in the public `ouroboros_session_signal` schema
- state the fail-closed behavior and the exact explicit `redirect -> after_turn` fallback condition
- direct callers to `ouroboros_session_signal_targets` and describe its capability snapshot as the live authority for the selected exact attempt
- preserve the four-mode enum and all runtime behavior unchanged

This is the narrowly scoped public wording/schema change requested by the reconciled issue. It does not claim to make `redirect` or `replace` reachable in a shipped adapter.

Closes #1685

## Verification

- focused public schema handler suite: 11 passed
- SessionSignal schema, projection, events, capability, mailbox, after-turn, and MCP registration selection: 87 passed, 46 deselected
- Ruff check and format: passed
- MyPy for the changed handler: passed
- module-size against current main: passed
- git diff check: passed