### PR TITLE
feat(provenance): bind Bash artifacts to accepted commands

### DIFF
--- a/src/ouroboros/core/filesystem_capability.py
+++ b/src/ouroboros/core/filesystem_capability.py
@@ -1,0 +1,122 @@
+"""No-follow directory capabilities for security-sensitive path checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+
+def _directory_identity(value: os.stat_result) -> tuple[int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_mode)
+
+
+def nofollow_directory_capabilities_available() -> bool:
+    """Return whether this platform can perform fail-closed dirfd traversal."""
+    return (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
+    )
+
+
+@dataclass(slots=True)
+class NoFollowDirectoryChain:
+    """Held directory fds plus the lexical parent-to-child bindings they prove."""
+
+    _directory_fds: list[int]
+    _component_names: tuple[str, ...]
+
+    @property
+    def leaf_fd(self) -> int:
+        """Return the final directory capability in the chain."""
+        if not self._directory_fds:
+            msg = "no-follow directory chain is closed"
+            raise OSError(msg)
+        return self._directory_fds[-1]
+
+    def matches_opened_directories(self, other: NoFollowDirectoryChain) -> bool:
+        """Check that two held traversals opened the same directory identities."""
+        if self._component_names != other._component_names or len(self._directory_fds) != len(
+            other._directory_fds
+        ):
+            return False
+        try:
+            return all(
+                _directory_identity(os.fstat(left_fd)) == _directory_identity(os.fstat(right_fd))
+                for left_fd, right_fd in zip(
+                    self._directory_fds,
+                    other._directory_fds,
+                    strict=True,
+                )
+            )
+        except (OSError, RuntimeError, ValueError):
+            return False
+
+    def postvalidate(self) -> bool:
+        """Confirm every held child is still named by its held parent."""
+        if len(self._directory_fds) != len(self._component_names) + 1:
+            return False
+        try:
+            return all(
+                _directory_identity(os.stat(name, dir_fd=parent_fd, follow_symlinks=False))
+                == _directory_identity(os.fstat(child_fd))
+                for parent_fd, child_fd, name in zip(
+                    self._directory_fds[:-1],
+                    self._directory_fds[1:],
+                    self._component_names,
+                    strict=True,
+                )
+            )
+        except (OSError, RuntimeError, ValueError):
+            return False
+
+    def close(self) -> None:
+        """Release all held capabilities; repeated calls are safe."""
+        directory_fds, self._directory_fds = self._directory_fds, []
+        for directory_fd in reversed(directory_fds):
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
+
+
+def open_nofollow_directory_chain(
+    absolute_directory: str | os.PathLike[str],
+    *,
+    relative_components: tuple[str, ...] = (),
+) -> NoFollowDirectoryChain:
+    """Open an absolute directory from trusted ``/`` through every component."""
+    if not nofollow_directory_capabilities_available():
+        msg = "no-follow dirfd traversal is unavailable"
+        raise OSError(msg)
+    absolute = Path(os.path.abspath(absolute_directory))
+    if absolute.anchor != os.sep:
+        msg = "no-follow capability traversal requires an absolute POSIX path"
+        raise ValueError(msg)
+    components = (*absolute.parts[1:], *relative_components)
+    if any(
+        component in {"", ".", ".."} or Path(component).name != component
+        for component in components
+    ):
+        msg = "directory capability components must be canonical names"
+        raise ValueError(msg)
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    directory_fds: list[int] = []
+    try:
+        current_fd = os.open(os.sep, flags)
+        directory_fds.append(current_fd)
+        for component in components:
+            current_fd = os.open(component, flags, dir_fd=current_fd)
+            directory_fds.append(current_fd)
+        return NoFollowDirectoryChain(directory_fds, tuple(components))
+    except BaseException:
+        for directory_fd in reversed(directory_fds):
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
+        raise

--- a/src/ouroboros/core/filesystem_capability.py
+++ b/src/ouroboros/core/filesystem_capability.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 
+DirectoryChainFingerprint = tuple[tuple[str, int, int, int], ...]
+
 
 def _directory_identity(value: os.stat_result) -> tuple[int, int, int]:
     return (value.st_dev, value.st_ino, value.st_mode)
@@ -54,6 +56,37 @@ class NoFollowDirectoryChain:
             )
         except (OSError, RuntimeError, ValueError):
             return False
+
+    def matches_opened_prefix(self, other: NoFollowDirectoryChain) -> bool:
+        """Check that this chain is the identical held prefix of another walk."""
+        prefix_length = len(self._directory_fds)
+        if self._component_names != other._component_names[
+            : len(self._component_names)
+        ] or prefix_length > len(other._directory_fds):
+            return False
+        try:
+            return all(
+                _directory_identity(os.fstat(left_fd)) == _directory_identity(os.fstat(right_fd))
+                for left_fd, right_fd in zip(
+                    self._directory_fds,
+                    other._directory_fds[:prefix_length],
+                    strict=True,
+                )
+            )
+        except (OSError, RuntimeError, ValueError):
+            return False
+
+    def fingerprint(self) -> DirectoryChainFingerprint:
+        """Snapshot component names and opened identities for durable replay."""
+        if len(self._directory_fds) != len(self._component_names) + 1:
+            msg = "no-follow directory chain is closed or malformed"
+            raise OSError(msg)
+        names = (os.sep, *self._component_names)
+        return tuple(
+            (name, identity.st_dev, identity.st_ino, identity.st_mode)
+            for name, directory_fd in zip(names, self._directory_fds, strict=True)
+            for identity in (os.fstat(directory_fd),)
+        )
 
     def postvalidate(self) -> bool:
         """Confirm every held child is still named by its held parent."""

--- a/src/ouroboros/core/filesystem_capability.py
+++ b/src/ouroboros/core/filesystem_capability.py
@@ -39,6 +39,11 @@ class NoFollowDirectoryChain:
             raise OSError(msg)
         return self._directory_fds[-1]
 
+    @property
+    def descriptor_count(self) -> int:
+        """Return the number of directory descriptors currently owned."""
+        return len(self._directory_fds)
+
     def matches_opened_directories(self, other: NoFollowDirectoryChain) -> bool:
         """Check that two held traversals opened the same directory identities."""
         if self._component_names != other._component_names or len(self._directory_fds) != len(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -809,40 +809,38 @@ def _mapping_has_failure_verdict(value: Mapping[str, Any]) -> bool:
         exit_value = value[key]
         if isinstance(exit_value, bool) or not isinstance(exit_value, int) or exit_value != 0:
             return True
-    for key in ("subtype", "status", "runtime_status", "runtime_signal", "runtime_event_type"):
+    allowed_statuses = {"completed", "success", "succeeded"}
+    allowed_values = {
+        "subtype": {*allowed_statuses, "tool_result"},
+        "status": allowed_statuses,
+        "runtime_status": allowed_statuses,
+        "runtime_signal": {"tool_completed", "session_completed"},
+        "runtime_event_type": {
+            "tool.completed",
+            "tool.output",
+            "tool.result",
+            "result.completed",
+            "run.completed",
+            "session.completed",
+            "task.completed",
+            "turn.completed",
+        },
+    }
+    for key, accepted in allowed_values.items():
         if key not in value:
             continue
         status = value[key]
         if not isinstance(status, str) or not status.strip():
             return True
         normalized = status.strip().lower()
-        if normalized in {
-            "error",
-            "failed",
-            "failure",
-            "cancelled",
-            "canceled",
-            "timeout",
-            "timed_out",
-            "aborted",
-        } or normalized.endswith(
-            (
-                ".error",
-                ".failed",
-                ".cancelled",
-                ".canceled",
-                ".timeout",
-                ".timed_out",
-                ".aborted",
-                "_error",
-                "_failed",
-                "_cancelled",
-                "_canceled",
-                "_timeout",
-                "_timed_out",
-                "_aborted",
-            )
+        if (
+            key == "runtime_status"
+            and normalized == "running"
+            and isinstance(value.get("runtime_signal"), str)
+            and str(value["runtime_signal"]).strip().lower() == "tool_completed"
         ):
+            continue
+        if normalized not in accepted:
             return True
     return False
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -707,6 +707,12 @@ def _event_has_explicit_tool_success(
     data = event.data
     if not isinstance(data, Mapping):
         return False
+    verdict_containers: list[Mapping[str, Any]] = [data]
+    data_meta = data.get("meta")
+    if data_meta is not None:
+        if not isinstance(data_meta, Mapping):
+            return False
+        verdict_containers.append(data_meta)
     if data.get("is_error_invalid") is True:
         return False
     if "is_error" in data and not isinstance(data["is_error"], bool):
@@ -717,47 +723,20 @@ def _event_has_explicit_tool_success(
     if tool_result is not None and not isinstance(tool_result, Mapping):
         return False
     if isinstance(tool_result, Mapping):
+        verdict_containers.append(tool_result)
         if tool_result.get("is_error_invalid") is True:
             return False
         if "is_error" in tool_result and not isinstance(tool_result["is_error"], bool):
             return False
         if tool_result.get("is_error") is True:
             return False
-    for key in ("subtype", "status", "runtime_status", "runtime_signal", "runtime_event_type"):
-        if key not in data:
-            continue
-        value = data[key]
-        if not isinstance(value, str) or not value.strip():
-            return False
-        normalized_failure = value.strip().lower()
-        if normalized_failure in {
-            "error",
-            "failed",
-            "failure",
-            "cancelled",
-            "canceled",
-            "timeout",
-            "timed_out",
-            "aborted",
-        } or normalized_failure.endswith(
-            (
-                ".error",
-                ".failed",
-                ".cancelled",
-                ".canceled",
-                ".timeout",
-                ".timed_out",
-                ".aborted",
-                "_error",
-                "_failed",
-                "_cancelled",
-                "_canceled",
-                "_timeout",
-                "_timed_out",
-                "_aborted",
-            )
-        ):
-            return False
+        meta = tool_result.get("meta")
+        if meta is not None:
+            if not isinstance(meta, Mapping):
+                return False
+            verdict_containers.append(meta)
+    if any(_mapping_has_failure_verdict(container) for container in verdict_containers):
+        return False
     is_completion_event = event.type == "execution.tool.completed"
     command_success_signal = is_completion_event and (
         data.get("is_error") is False
@@ -801,6 +780,71 @@ def _event_has_explicit_tool_success(
         if normalized.endswith((".completed", ".succeeded")):
             success_signal = True
     return command_success_signal if require_command_verdict else success_signal
+
+
+def _mapping_has_failure_verdict(value: Mapping[str, Any]) -> bool:
+    """Treat explicit failure flags, contradictions, and malformed verdicts as vetoes."""
+    if "success" in value:
+        success = value["success"]
+        if not isinstance(success, bool) or not success:
+            return True
+    for key in (
+        "is_error",
+        "error",
+        "failed",
+        "cancelled",
+        "canceled",
+        "timeout",
+        "timed_out",
+        "aborted",
+    ):
+        if key not in value:
+            continue
+        flag = value[key]
+        if not isinstance(flag, bool) or flag:
+            return True
+    for key in ("exit_code", "exit_status"):
+        if key not in value:
+            continue
+        exit_value = value[key]
+        if isinstance(exit_value, bool) or not isinstance(exit_value, int) or exit_value != 0:
+            return True
+    for key in ("subtype", "status", "runtime_status", "runtime_signal", "runtime_event_type"):
+        if key not in value:
+            continue
+        status = value[key]
+        if not isinstance(status, str) or not status.strip():
+            return True
+        normalized = status.strip().lower()
+        if normalized in {
+            "error",
+            "failed",
+            "failure",
+            "cancelled",
+            "canceled",
+            "timeout",
+            "timed_out",
+            "aborted",
+        } or normalized.endswith(
+            (
+                ".error",
+                ".failed",
+                ".cancelled",
+                ".canceled",
+                ".timeout",
+                ".timed_out",
+                ".aborted",
+                "_error",
+                "_failed",
+                "_cancelled",
+                "_canceled",
+                "_timeout",
+                "_timed_out",
+                "_aborted",
+            )
+        ):
+            return True
+    return False
 
 
 def _event_matches_accepted_attempt(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -791,11 +791,14 @@ def _mapping_has_failure_verdict(value: Mapping[str, Any]) -> bool:
     for key in (
         "is_error",
         "error",
+        "failure",
         "failed",
+        "cancel",
         "cancelled",
         "canceled",
         "timeout",
         "timed_out",
+        "abort",
         "aborted",
     ):
         if key not in value:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -34,6 +34,29 @@ _COMMAND_ARTIFACT_SCHEMA_VERSION = 1
 _COMMAND_ARTIFACT_CAPTURE = "ouroboros.leaf-dispatch.v1"
 _MAX_COMMAND_ARTIFACTS = 128
 _MAX_COMMAND_ARTIFACT_PATH_CHARS = 4096
+RUNTIME_FAILURE_BOOLEAN_FIELDS = (
+    "is_error",
+    "error",
+    "failure",
+    "failed",
+    "cancel",
+    "cancelled",
+    "canceled",
+    "timeout",
+    "timed_out",
+    "abort",
+    "aborted",
+)
+RUNTIME_TOOL_EXIT_STATUS_FIELDS = (
+    "exit_code",
+    "exit_status",
+    "exitCode",
+    "exitStatus",
+    "returncode",
+    "return_code",
+    "status_code",
+    "statusCode",
+)
 _FILESYSTEM_EFFECT_KEYS = frozenset(
     {
         "capture",
@@ -788,25 +811,13 @@ def _mapping_has_failure_verdict(value: Mapping[str, Any]) -> bool:
         success = value["success"]
         if not isinstance(success, bool) or not success:
             return True
-    for key in (
-        "is_error",
-        "error",
-        "failure",
-        "failed",
-        "cancel",
-        "cancelled",
-        "canceled",
-        "timeout",
-        "timed_out",
-        "abort",
-        "aborted",
-    ):
+    for key in RUNTIME_FAILURE_BOOLEAN_FIELDS:
         if key not in value:
             continue
         flag = value[key]
         if not isinstance(flag, bool) or flag:
             return True
-    for key in ("exit_code", "exit_status"):
+    for key in RUNTIME_TOOL_EXIT_STATUS_FIELDS:
         if key not in value:
             continue
         exit_value = value[key]
@@ -1682,6 +1693,8 @@ __all__ = [
     "DeliverEvidenceFact",
     "DeliverGateVerdict",
     "EventStoreEvidenceReader",
+    "RUNTIME_FAILURE_BOOLEAN_FIELDS",
+    "RUNTIME_TOOL_EXIT_STATUS_FIELDS",
     "TraceGuardResultLike",
     "TraceGuardEvidenceInput",
     "TraceGuardValidator",

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -10,10 +10,13 @@ behavior changes.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 import json
+import os
 from pathlib import Path
+import stat
 from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -25,6 +28,38 @@ from ouroboros.harness.journal import (
     EvidenceKind,
     EvidenceManifest,
     normalize_events,
+)
+
+_COMMAND_ARTIFACT_SCHEMA_VERSION = 1
+_COMMAND_ARTIFACT_CAPTURE = "ouroboros.leaf-dispatch.v1"
+_MAX_COMMAND_ARTIFACTS = 128
+_MAX_COMMAND_ARTIFACT_PATH_CHARS = 4096
+_FILESYSTEM_EFFECT_KEYS = frozenset(
+    {
+        "capture",
+        "path",
+        "workspace_relative_path",
+        "st_dev",
+        "st_ino",
+        "st_mode",
+        "st_size",
+        "st_mtime_ns",
+        "st_ctime_ns",
+    }
+)
+_COMMAND_ARTIFACT_KEYS = frozenset(
+    {"path", "st_dev", "st_ino", "st_mode", "st_size", "st_mtime_ns", "st_ctime_ns"}
+)
+_COMMAND_ARTIFACT_PROVENANCE_KEYS = frozenset(
+    {
+        "schema_version",
+        "capture",
+        "command_call_id",
+        "completion_event_id",
+        "retry_attempt",
+        "session_attempt_id",
+        "artifacts",
+    }
 )
 
 
@@ -255,6 +290,7 @@ async def load_ac_evidence_manifest(
         admitted_entries = _accepted_tool_start_entries(
             chronological,
             scope_id=normalized_scope_id,
+            execution_id=normalized_execution_id,
             retry_attempt=accepted_retry_attempt,
             session_attempt_id=accepted_session_attempt_id,
         )
@@ -286,6 +322,7 @@ def _accepted_tool_start_entries(
     events: Iterable[BaseEvent],
     *,
     scope_id: str,
+    execution_id: str,
     retry_attempt: int | None,
     session_attempt_id: str | None,
 ) -> tuple[EvidenceEntry, ...]:
@@ -299,14 +336,19 @@ def _accepted_tool_start_entries(
     correlation is omitted fail-closed.
     """
     chronological = tuple(events)
+    event_id_counts = Counter(event.id for event in chronological)
     entries: list[EvidenceEntry] = []
     for index, event in enumerate(chronological):
         if event.type != "execution.tool.started" or not _event_matches_scope(event, scope_id):
+            continue
+        if event_id_counts[event.id] != 1:
             continue
         data = event.data
         if retry_attempt is not None and data.get("retry_attempt") != retry_attempt:
             continue
         if session_attempt_id is not None and data.get("session_attempt_id") != session_attempt_id:
+            continue
+        if _event_has_conflicting_tool_call_ids(event):
             continue
         tool_name = data.get("tool_name") if isinstance(data, Mapping) else None
         tool_input = data.get("tool_input") if isinstance(data, Mapping) else None
@@ -325,6 +367,7 @@ def _accepted_tool_start_entries(
                     and _event_matches_accepted_attempt(
                         candidate,
                         scope_id=scope_id,
+                        execution_id=execution_id,
                         retry_attempt=retry_attempt,
                         session_attempt_id=session_attempt_id,
                     )
@@ -340,9 +383,11 @@ def _accepted_tool_start_entries(
                 chronological,
                 start_index=index,
                 scope_id=scope_id,
+                execution_id=execution_id,
                 retry_attempt=retry_attempt,
                 session_attempt_id=session_attempt_id,
                 require_command_verdict=require_command_verdict,
+                event_id_counts=event_id_counts,
             )
             if completion_veto or (completion is None and not start_success):
                 continue
@@ -351,6 +396,13 @@ def _accepted_tool_start_entries(
             "tool_name": normalized_tool_name,
             "accepted_leaf_dispatch": True,
         }
+        accepted_call_id = _event_tool_call_id(event)
+        if accepted_call_id is not None:
+            payload["tool_call_id"] = accepted_call_id
+        if retry_attempt is not None:
+            payload["retry_attempt"] = retry_attempt
+        if session_attempt_id is not None:
+            payload["session_attempt_id"] = session_attempt_id
         if normalized_input:
             payload["args_preview"] = json.dumps(
                 normalized_input,
@@ -374,6 +426,14 @@ def _accepted_tool_start_entries(
             relative_path = _event_workspace_relative_path(raw_path, data)
             if relative_path is not None:
                 payload["workspace_relative_path"] = relative_path
+        if normalized_tool_name == "Bash" and completion is not None and completion.id != event.id:
+            command_artifacts = _command_artifacts_from_completion(
+                completion,
+                retry_attempt=retry_attempt,
+                session_attempt_id=session_attempt_id,
+            )
+            if command_artifacts is not None:
+                payload["command_artifacts"] = command_artifacts
         result_preview = _event_result_preview(event, completion)
         if result_preview is not None:
             payload["result_preview"] = result_preview
@@ -392,28 +452,245 @@ def _accepted_tool_start_entries(
     return tuple(entries)
 
 
-def _event_tool_call_id(event: BaseEvent) -> str | None:
-    """Return a normalized tool-call correlation id from one execution event."""
-    data = event.data
-    if not isinstance(data, Mapping):
+def _command_artifacts_from_completion(
+    completion: BaseEvent,
+    *,
+    retry_attempt: int | None,
+    session_attempt_id: str | None,
+) -> dict[str, Any] | None:
+    """Validate and project the locally captured Bash receiver authority.
+
+    The LeafDispatcher owns capture.  This loader only closes the durable
+    schema around that existing completion payload and binds it to the accepted
+    attempt.  Any malformed entry invalidates the whole command authority.
+    """
+    if retry_attempt is None or session_attempt_id is None:
         return None
-    for key in ("tool_call_id", "tool_use_id", "call_id"):
-        value = data.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    tool_result = data.get("tool_result")
-    if isinstance(tool_result, Mapping):
-        for key in ("tool_call_id", "tool_use_id", "call_id"):
-            value = tool_result.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        meta = tool_result.get("meta")
-        if isinstance(meta, Mapping):
-            for key in ("tool_call_id", "tool_use_id", "call_id"):
-                value = meta.get(key)
-                if isinstance(value, str) and value.strip():
-                    return value.strip()
-    return None
+    if (
+        isinstance(retry_attempt, bool)
+        or not isinstance(retry_attempt, int)
+        or retry_attempt < 0
+        or not isinstance(session_attempt_id, str)
+        or not session_attempt_id.strip()
+    ):
+        return None
+    call_id = _event_tool_call_id(completion)
+    if call_id is None or not isinstance(completion.data, Mapping):
+        return None
+    raw_effects = completion.data.get("filesystem_effects")
+    if (
+        not isinstance(raw_effects, (list, tuple))
+        or not raw_effects
+        or len(raw_effects) > _MAX_COMMAND_ARTIFACTS
+    ):
+        return None
+    artifacts: list[dict[str, int | str]] = []
+    seen_paths: set[str] = set()
+    for raw in raw_effects:
+        if not isinstance(raw, Mapping) or frozenset(raw) != _FILESYSTEM_EFFECT_KEYS:
+            return None
+        path = raw.get("workspace_relative_path")
+        lexical_path = raw.get("path")
+        if (
+            raw.get("capture") != _COMMAND_ARTIFACT_CAPTURE
+            or not isinstance(lexical_path, str)
+            or not lexical_path.strip()
+            or not isinstance(path, str)
+            or not _is_canonical_command_artifact_path(path)
+            or path in seen_paths
+        ):
+            return None
+        numeric: dict[str, int] = {}
+        for key in _COMMAND_ARTIFACT_KEYS - {"path"}:
+            value = raw.get(key)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                return None
+            numeric[key] = value
+        if numeric["st_ino"] == 0 or not stat.S_ISREG(numeric["st_mode"]):
+            return None
+        seen_paths.add(path)
+        artifacts.append({"path": path, **numeric})
+    return {
+        "schema_version": _COMMAND_ARTIFACT_SCHEMA_VERSION,
+        "capture": _COMMAND_ARTIFACT_CAPTURE,
+        "command_call_id": call_id,
+        "completion_event_id": completion.id,
+        "retry_attempt": retry_attempt,
+        "session_attempt_id": session_attempt_id.strip(),
+        "artifacts": artifacts,
+    }
+
+
+def _is_canonical_command_artifact_path(value: str) -> bool:
+    if not value or len(value) > _MAX_COMMAND_ARTIFACT_PATH_CHARS or "\\" in value:
+        return False
+    path = Path(value)
+    return (
+        not path.is_absolute()
+        and value == path.as_posix()
+        and all(part not in {"", ".", ".."} for part in path.parts)
+    )
+
+
+def _journal_entry_proves_command_artifact(
+    entry: EvidenceEntry,
+    *,
+    relative_path: str,
+    task_cwd: str | None,
+) -> bool:
+    """Verify one Phase-1 command artifact still names its captured file."""
+    payload = entry.payload
+    provenance = payload.get("command_artifacts")
+    if (
+        task_cwd is None
+        or not isinstance(provenance, Mapping)
+        or frozenset(provenance) != _COMMAND_ARTIFACT_PROVENANCE_KEYS
+        or provenance.get("schema_version") != _COMMAND_ARTIFACT_SCHEMA_VERSION
+        or provenance.get("capture") != _COMMAND_ARTIFACT_CAPTURE
+        or not isinstance(provenance.get("command_call_id"), str)
+        or not str(provenance["command_call_id"]).strip()
+        or provenance.get("command_call_id") != payload.get("tool_call_id")
+        or not isinstance(provenance.get("completion_event_id"), str)
+        or not str(provenance["completion_event_id"]).strip()
+        or len(entry.source_event_ids) != 2
+        or len(set(entry.source_event_ids)) != 2
+        or provenance.get("completion_event_id") != entry.source_event_ids[-1]
+        or isinstance(provenance.get("retry_attempt"), bool)
+        or not isinstance(provenance.get("retry_attempt"), int)
+        or int(provenance["retry_attempt"]) < 0
+        or provenance.get("retry_attempt") != payload.get("retry_attempt")
+        or not isinstance(provenance.get("session_attempt_id"), str)
+        or not str(provenance["session_attempt_id"]).strip()
+        or provenance.get("session_attempt_id") != payload.get("session_attempt_id")
+    ):
+        return False
+    artifacts = provenance.get("artifacts")
+    if (
+        not isinstance(artifacts, (list, tuple))
+        or not artifacts
+        or len(artifacts) > _MAX_COMMAND_ARTIFACTS
+    ):
+        return False
+    validated: list[Mapping[str, object]] = []
+    seen_paths: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, Mapping) or frozenset(artifact) != _COMMAND_ARTIFACT_KEYS:
+            return False
+        path = artifact.get("path")
+        if (
+            not isinstance(path, str)
+            or not _is_canonical_command_artifact_path(path)
+            or path in seen_paths
+        ):
+            return False
+        for key in _COMMAND_ARTIFACT_KEYS - {"path"}:
+            value = artifact.get(key)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                return False
+        if artifact.get("st_ino") == 0 or not stat.S_ISREG(int(artifact["st_mode"])):
+            return False
+        seen_paths.add(path)
+        validated.append(artifact)
+    matches = [artifact for artifact in validated if artifact["path"] == relative_path]
+    if len(matches) != 1:
+        return False
+    artifact = matches[0]
+    if frozenset(artifact) != _COMMAND_ARTIFACT_KEYS:
+        return False
+    current = _nofollow_workspace_artifact_stat(task_cwd, relative_path)
+    if current is None:
+        return False
+    return stat.S_ISREG(current.st_mode) and all(
+        artifact.get(key) == getattr(current, key) for key in _COMMAND_ARTIFACT_KEYS - {"path"}
+    )
+
+
+def _nofollow_workspace_artifact_stat(
+    task_cwd: str,
+    relative_path: str,
+) -> os.stat_result | None:
+    """Read a current artifact through one workspace-rooted no-follow fd chain."""
+    directory_fd: int | None = None
+    try:
+        if (
+            not hasattr(os, "O_DIRECTORY")
+            or not hasattr(os, "O_NOFOLLOW")
+            or os.open not in os.supports_dir_fd
+            or os.stat not in os.supports_dir_fd
+            or os.stat not in os.supports_follow_symlinks
+        ):
+            return None
+        workspace = Path(os.path.abspath(Path(task_cwd).expanduser()))
+        relative = Path(relative_path)
+        if not _is_canonical_command_artifact_path(relative_path):
+            return None
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        directory_fd = os.open(workspace, flags)
+        for part in relative.parts[:-1]:
+            next_fd = os.open(part, flags, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = next_fd
+        return os.stat(relative.name, dir_fd=directory_fd, follow_symlinks=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    finally:
+        if directory_fd is not None:
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
+
+
+_TOOL_CALL_ID_KEYS = ("tool_call_id", "tool_use_id", "call_id")
+
+
+def _event_tool_call_aliases(event: BaseEvent) -> tuple[tuple[str, ...], bool]:
+    """Collect every supported correlation alias and flag malformed values."""
+    if not isinstance(event.data, Mapping):
+        return (), True
+    containers: list[Mapping[str, Any]] = [event.data]
+    malformed = False
+    message_meta = event.data.get("meta")
+    if message_meta is not None:
+        if not isinstance(message_meta, Mapping):
+            malformed = True
+        else:
+            containers.append(message_meta)
+    tool_result = event.data.get("tool_result")
+    if tool_result is not None:
+        if not isinstance(tool_result, Mapping):
+            malformed = True
+        else:
+            containers.append(tool_result)
+            meta = tool_result.get("meta")
+            if meta is not None:
+                if not isinstance(meta, Mapping):
+                    malformed = True
+                else:
+                    containers.append(meta)
+    values: list[str] = []
+    for container in containers:
+        for key in _TOOL_CALL_ID_KEYS:
+            if key not in container:
+                continue
+            value = container[key]
+            if not isinstance(value, str) or not value.strip():
+                malformed = True
+            else:
+                values.append(value.strip())
+    return tuple(values), malformed
+
+
+def _event_has_conflicting_tool_call_ids(event: BaseEvent) -> bool:
+    aliases, malformed = _event_tool_call_aliases(event)
+    return malformed or len(set(aliases)) > 1
+
+
+def _event_tool_call_id(event: BaseEvent) -> str | None:
+    """Return the sole normalized correlation id, rejecting alias conflicts."""
+    aliases, malformed = _event_tool_call_aliases(event)
+    distinct = set(aliases)
+    return next(iter(distinct)) if not malformed and len(distinct) == 1 else None
 
 
 def _event_has_explicit_tool_success(
@@ -445,6 +722,41 @@ def _event_has_explicit_tool_success(
         if "is_error" in tool_result and not isinstance(tool_result["is_error"], bool):
             return False
         if tool_result.get("is_error") is True:
+            return False
+    for key in ("subtype", "status", "runtime_status", "runtime_signal", "runtime_event_type"):
+        if key not in data:
+            continue
+        value = data[key]
+        if not isinstance(value, str) or not value.strip():
+            return False
+        normalized_failure = value.strip().lower()
+        if normalized_failure in {
+            "error",
+            "failed",
+            "failure",
+            "cancelled",
+            "canceled",
+            "timeout",
+            "timed_out",
+            "aborted",
+        } or normalized_failure.endswith(
+            (
+                ".error",
+                ".failed",
+                ".cancelled",
+                ".canceled",
+                ".timeout",
+                ".timed_out",
+                ".aborted",
+                "_error",
+                "_failed",
+                "_cancelled",
+                "_canceled",
+                "_timeout",
+                "_timed_out",
+                "_aborted",
+            )
+        ):
             return False
     is_completion_event = event.type == "execution.tool.completed"
     command_success_signal = is_completion_event and (
@@ -495,6 +807,7 @@ def _event_matches_accepted_attempt(
     event: BaseEvent,
     *,
     scope_id: str,
+    execution_id: str,
     retry_attempt: int | None,
     session_attempt_id: str | None,
 ) -> bool:
@@ -503,8 +816,16 @@ def _event_matches_accepted_attempt(
     data = event.data
     if not isinstance(data, Mapping):
         return False
-    if retry_attempt is not None and data.get("retry_attempt") != retry_attempt:
+    for key in ("execution_id", "parent_execution_id"):
+        if key in data and data.get(key) != execution_id:
+            return False
+    if data.get("execution_id") != execution_id:
         return False
+    if retry_attempt is not None:
+        if data.get("retry_attempt") != retry_attempt:
+            return False
+        if "attempt_number" in data and data.get("attempt_number") != retry_attempt + 1:
+            return False
     return not (
         session_attempt_id is not None and data.get("session_attempt_id") != session_attempt_id
     )
@@ -515,14 +836,20 @@ def _correlated_tool_completion(
     *,
     start_index: int,
     scope_id: str,
+    execution_id: str,
     retry_attempt: int | None,
     session_attempt_id: str | None,
     require_command_verdict: bool,
+    event_id_counts: Mapping[str, int],
 ) -> tuple[BaseEvent | None, bool]:
     """Return an exact completion and whether failure/ambiguity vetoes the start."""
     start = events[start_index]
+    if event_id_counts.get(start.id) != 1:
+        return None, True
     start_data = start.data
     if not isinstance(start_data, Mapping):
+        return None, True
+    if _event_has_conflicting_tool_call_ids(start):
         return None, True
     start_tool = start_data.get("tool_name")
     if not isinstance(start_tool, str):
@@ -534,9 +861,11 @@ def _correlated_tool_completion(
             candidate
             for candidate in events
             if candidate.type == "execution.tool.started"
+            and not _event_has_conflicting_tool_call_ids(candidate)
             and _event_matches_accepted_attempt(
                 candidate,
                 scope_id=scope_id,
+                execution_id=execution_id,
                 retry_attempt=retry_attempt,
                 session_attempt_id=session_attempt_id,
             )
@@ -544,13 +873,28 @@ def _correlated_tool_completion(
         )
         if len(matching_starts) != 1:
             return None, True
+        if any(
+            candidate.type == "execution.tool.completed"
+            and _event_matches_accepted_attempt(
+                candidate,
+                scope_id=scope_id,
+                execution_id=execution_id,
+                retry_attempt=retry_attempt,
+                session_attempt_id=session_attempt_id,
+            )
+            and _event_has_conflicting_tool_call_ids(candidate)
+            and start_call_id in _event_tool_call_aliases(candidate)[0]
+            for candidate in events
+        ):
+            return None, True
         matches = tuple(
-            candidate
-            for candidate in events[start_index + 1 :]
+            (candidate_index, candidate)
+            for candidate_index, candidate in enumerate(events)
             if candidate.type == "execution.tool.completed"
             and _event_matches_accepted_attempt(
                 candidate,
                 scope_id=scope_id,
+                execution_id=execution_id,
                 retry_attempt=retry_attempt,
                 session_attempt_id=session_attempt_id,
             )
@@ -560,7 +904,9 @@ def _correlated_tool_completion(
             return None, False
         if len(matches) != 1:
             return None, True
-        completion = matches[0]
+        completion_index, completion = matches[0]
+        if completion_index <= start_index or event_id_counts.get(completion.id) != 1:
+            return None, True
         if (
             not isinstance(completion.data, Mapping)
             or completion.data.get("tool_name") != start_tool
@@ -581,11 +927,14 @@ def _correlated_tool_completion(
         if not _event_matches_accepted_attempt(
             candidate,
             scope_id=scope_id,
+            execution_id=execution_id,
             retry_attempt=retry_attempt,
             session_attempt_id=session_attempt_id,
         ):
             continue
         if candidate.type == "execution.tool.started":
+            return None, True
+        if _event_has_conflicting_tool_call_ids(candidate):
             return None, True
         if _event_tool_call_id(candidate) is not None:
             return None, True
@@ -626,14 +975,21 @@ def _event_result_preview(start: BaseEvent, completion: BaseEvent | None) -> str
 
 
 def _event_matches_scope(event: BaseEvent, scope_id: str) -> bool:
-    if event.aggregate_id == scope_id:
-        return True
-    if not isinstance(event.data, Mapping):
+    if (
+        event.aggregate_type != "execution"
+        or event.aggregate_id != scope_id
+        or not isinstance(event.data, Mapping)
+    ):
         return False
-    return any(
-        isinstance(event.data.get(key), str) and event.data[key].strip() == scope_id
-        for key in ("ac_id", "session_scope_id")
-    )
+    aliases: list[str] = []
+    for key in ("ac_id", "session_scope_id"):
+        if key not in event.data:
+            continue
+        value = event.data[key]
+        if not isinstance(value, str) or not value.strip():
+            return False
+        aliases.append(value.strip())
+    return all(value == scope_id for value in aliases)
 
 
 def _event_workspace_relative_path(raw_path: str, data: Mapping[str, Any]) -> str | None:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -34,8 +34,10 @@ _COMMAND_ARTIFACT_SCHEMA_VERSION = 1
 _COMMAND_ARTIFACT_CAPTURE = "ouroboros.leaf-dispatch.v1"
 _MAX_COMMAND_ARTIFACTS = 128
 _MAX_COMMAND_ARTIFACT_PATH_CHARS = 4096
+RUNTIME_SUCCESS_BOOLEAN_FIELDS = ("success", "ok")
 RUNTIME_FAILURE_BOOLEAN_FIELDS = (
     "is_error",
+    "isError",
     "error",
     "failure",
     "failed",
@@ -56,6 +58,9 @@ RUNTIME_TOOL_EXIT_STATUS_FIELDS = (
     "return_code",
     "status_code",
     "statusCode",
+    "exit",
+    "errorCode",
+    "error_code",
 )
 _FILESYSTEM_EFFECT_KEYS = frozenset(
     {
@@ -632,8 +637,9 @@ def _nofollow_workspace_artifact_stat(
     task_cwd: str,
     relative_path: str,
 ) -> os.stat_result | None:
-    """Read a current artifact through one workspace-rooted no-follow fd chain."""
-    directory_fd: int | None = None
+    """Read an artifact through a stable workspace-rooted no-follow fd chain."""
+    leased_directory_fds: list[int] = []
+    current_directory_fds: list[int] = []
     try:
         if (
             not hasattr(os, "O_DIRECTORY")
@@ -648,20 +654,51 @@ def _nofollow_workspace_artifact_stat(
         if not _is_canonical_command_artifact_path(relative_path):
             return None
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-        directory_fd = os.open(workspace, flags)
+        leased_fd = os.open(workspace, flags)
+        leased_directory_fds.append(leased_fd)
         for part in relative.parts[:-1]:
-            next_fd = os.open(part, flags, dir_fd=directory_fd)
-            os.close(directory_fd)
-            directory_fd = next_fd
-        return os.stat(relative.name, dir_fd=directory_fd, follow_symlinks=False)
+            leased_fd = os.open(part, flags, dir_fd=leased_fd)
+            leased_directory_fds.append(leased_fd)
+        leased_leaf = os.stat(relative.name, dir_fd=leased_fd, follow_symlinks=False)
+
+        # A parent can be renamed and replaced after ``open`` returns.  Rewalk
+        # the current lexical path and bind every opened directory identity,
+        # plus the leaf fingerprint, to the held no-follow traversal.
+        current_fd = os.open(workspace, flags)
+        current_directory_fds.append(current_fd)
+        if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
+            os.fstat(leased_directory_fds[0])
+        ):
+            return None
+        for index, part in enumerate(relative.parts[:-1], start=1):
+            current_fd = os.open(part, flags, dir_fd=current_fd)
+            current_directory_fds.append(current_fd)
+            if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
+                os.fstat(leased_directory_fds[index])
+            ):
+                return None
+        current_leaf = os.stat(relative.name, dir_fd=current_fd, follow_symlinks=False)
+        if _command_artifact_stat_fingerprint(current_leaf) != _command_artifact_stat_fingerprint(
+            leased_leaf
+        ):
+            return None
+        return current_leaf
     except (OSError, RuntimeError, ValueError):
         return None
     finally:
-        if directory_fd is not None:
+        for directory_fd in reversed(current_directory_fds + leased_directory_fds):
             try:
                 os.close(directory_fd)
             except OSError:
                 pass
+
+
+def _filesystem_identity(value: os.stat_result) -> tuple[int, int, int]:
+    return (value.st_dev, value.st_ino, value.st_mode)
+
+
+def _command_artifact_stat_fingerprint(value: os.stat_result) -> tuple[int, ...]:
+    return tuple(getattr(value, key) for key in _COMMAND_ARTIFACT_KEYS - {"path"})
 
 
 _TOOL_CALL_ID_KEYS = ("tool_call_id", "tool_use_id", "call_id")
@@ -673,20 +710,20 @@ def _event_tool_call_aliases(event: BaseEvent) -> tuple[tuple[str, ...], bool]:
         return (), True
     containers: list[Mapping[str, Any]] = [event.data]
     malformed = False
-    message_meta = event.data.get("meta")
-    if message_meta is not None:
+    if "meta" in event.data:
+        message_meta = event.data["meta"]
         if not isinstance(message_meta, Mapping):
             malformed = True
         else:
             containers.append(message_meta)
-    tool_result = event.data.get("tool_result")
-    if tool_result is not None:
+    if "tool_result" in event.data:
+        tool_result = event.data["tool_result"]
         if not isinstance(tool_result, Mapping):
             malformed = True
         else:
             containers.append(tool_result)
-            meta = tool_result.get("meta")
-            if meta is not None:
+            if "meta" in tool_result:
+                meta = tool_result["meta"]
                 if not isinstance(meta, Mapping):
                     malformed = True
                 else:
@@ -731,8 +768,8 @@ def _event_has_explicit_tool_success(
     if not isinstance(data, Mapping):
         return False
     verdict_containers: list[Mapping[str, Any]] = [data]
-    data_meta = data.get("meta")
-    if data_meta is not None:
+    if "meta" in data:
+        data_meta = data["meta"]
         if not isinstance(data_meta, Mapping):
             return False
         verdict_containers.append(data_meta)
@@ -743,9 +780,9 @@ def _event_has_explicit_tool_success(
     if data.get("is_error") is True:
         return False
     tool_result = data.get("tool_result")
-    if tool_result is not None and not isinstance(tool_result, Mapping):
-        return False
-    if isinstance(tool_result, Mapping):
+    if "tool_result" in data:
+        if not isinstance(tool_result, Mapping):
+            return False
         verdict_containers.append(tool_result)
         if tool_result.get("is_error_invalid") is True:
             return False
@@ -753,8 +790,8 @@ def _event_has_explicit_tool_success(
             return False
         if tool_result.get("is_error") is True:
             return False
-        meta = tool_result.get("meta")
-        if meta is not None:
+        if "meta" in tool_result:
+            meta = tool_result["meta"]
             if not isinstance(meta, Mapping):
                 return False
             verdict_containers.append(meta)
@@ -807,8 +844,10 @@ def _event_has_explicit_tool_success(
 
 def _mapping_has_failure_verdict(value: Mapping[str, Any]) -> bool:
     """Treat explicit failure flags, contradictions, and malformed verdicts as vetoes."""
-    if "success" in value:
-        success = value["success"]
+    for key in RUNTIME_SUCCESS_BOOLEAN_FIELDS:
+        if key not in value:
+            continue
+        success = value[key]
         if not isinstance(success, bool) or not success:
             return True
     for key in RUNTIME_FAILURE_BOOLEAN_FIELDS:
@@ -1694,6 +1733,7 @@ __all__ = [
     "DeliverGateVerdict",
     "EventStoreEvidenceReader",
     "RUNTIME_FAILURE_BOOLEAN_FIELDS",
+    "RUNTIME_SUCCESS_BOOLEAN_FIELDS",
     "RUNTIME_TOOL_EXIT_STATUS_FIELDS",
     "TraceGuardResultLike",
     "TraceGuardEvidenceInput",

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -22,6 +22,7 @@ from typing import Any, Protocol
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ouroboros.core.filesystem_capability import (
+    DirectoryChainFingerprint,
     NoFollowDirectoryChain,
     nofollow_directory_capabilities_available,
     open_nofollow_directory_chain,
@@ -39,6 +40,7 @@ _COMMAND_ARTIFACT_SCHEMA_VERSION = 1
 _COMMAND_ARTIFACT_CAPTURE = "ouroboros.leaf-dispatch.v1"
 _MAX_COMMAND_ARTIFACTS = 128
 _MAX_COMMAND_ARTIFACT_PATH_CHARS = 4096
+_MAX_WORKSPACE_CHAIN_COMPONENTS = 256
 RUNTIME_SUCCESS_BOOLEAN_FIELDS = ("success", "ok")
 RUNTIME_FAILURE_BOOLEAN_FIELDS = (
     "is_error",
@@ -73,6 +75,7 @@ _FILESYSTEM_EFFECT_KEYS = frozenset(
         "capture",
         "path",
         "workspace_relative_path",
+        "workspace_chain",
         "st_dev",
         "st_ino",
         "st_mode",
@@ -92,9 +95,11 @@ _COMMAND_ARTIFACT_PROVENANCE_KEYS = frozenset(
         "completion_event_id",
         "retry_attempt",
         "session_attempt_id",
+        "workspace_chain",
         "artifacts",
     }
 )
+_WORKSPACE_CHAIN_COMPONENT_KEYS = frozenset({"name", "st_dev", "st_ino", "st_mode"})
 
 
 class EventStoreEvidenceReader(Protocol):
@@ -371,6 +376,15 @@ def _accepted_tool_start_entries(
     """
     chronological = tuple(events)
     event_id_counts = Counter(event.id for event in chronological)
+    idless_completion_by_start = _owned_idless_tool_completions(
+        chronological,
+        scope_id=scope_id,
+        execution_id=execution_id,
+        retry_attempt=retry_attempt,
+        session_attempt_id=session_attempt_id,
+        event_id_counts=event_id_counts,
+    )
+    owned_idless_completion_indexes = frozenset(idless_completion_by_start.values())
     entries: list[EvidenceEntry] = []
     for index, event in enumerate(chronological):
         if event.type != "execution.tool.started" or not _event_matches_scope(event, scope_id):
@@ -422,6 +436,8 @@ def _accepted_tool_start_entries(
                 session_attempt_id=session_attempt_id,
                 require_command_verdict=require_command_verdict,
                 event_id_counts=event_id_counts,
+                idless_completion_by_start=idless_completion_by_start,
+                owned_idless_completion_indexes=owned_idless_completion_indexes,
             )
             if completion_veto or (completion is None and not start_success):
                 continue
@@ -520,6 +536,7 @@ def _command_artifacts_from_completion(
         return None
     artifacts: list[dict[str, int | str]] = []
     seen_paths: set[str] = set()
+    workspace_fingerprint: DirectoryChainFingerprint | None = None
     for raw in raw_effects:
         if not isinstance(raw, Mapping) or frozenset(raw) != _FILESYSTEM_EFFECT_KEYS:
             return None
@@ -542,8 +559,17 @@ def _command_artifacts_from_completion(
             numeric[key] = value
         if numeric["st_ino"] == 0 or not stat.S_ISREG(numeric["st_mode"]):
             return None
+        current_workspace_fingerprint = _workspace_chain_fingerprint(raw.get("workspace_chain"))
+        if current_workspace_fingerprint is None:
+            return None
+        if workspace_fingerprint is None:
+            workspace_fingerprint = current_workspace_fingerprint
+        elif current_workspace_fingerprint != workspace_fingerprint:
+            return None
         seen_paths.add(path)
         artifacts.append({"path": path, **numeric})
+    if workspace_fingerprint is None:
+        return None
     return {
         "schema_version": _COMMAND_ARTIFACT_SCHEMA_VERSION,
         "capture": _COMMAND_ARTIFACT_CAPTURE,
@@ -551,8 +577,55 @@ def _command_artifacts_from_completion(
         "completion_event_id": completion.id,
         "retry_attempt": retry_attempt,
         "session_attempt_id": session_attempt_id.strip(),
+        "workspace_chain": _serialize_workspace_chain_fingerprint(workspace_fingerprint),
         "artifacts": artifacts,
     }
+
+
+def _workspace_chain_fingerprint(value: object) -> DirectoryChainFingerprint | None:
+    """Validate the closed durable workspace capability snapshot."""
+    if (
+        not isinstance(value, (list, tuple))
+        or not value
+        or len(value) > _MAX_WORKSPACE_CHAIN_COMPONENTS
+    ):
+        return None
+    fingerprint: list[tuple[str, int, int, int]] = []
+    rendered_path_chars = 0
+    for index, component in enumerate(value):
+        if (
+            not isinstance(component, Mapping)
+            or frozenset(component) != _WORKSPACE_CHAIN_COMPONENT_KEYS
+        ):
+            return None
+        name = component.get("name")
+        if not isinstance(name, str) or (
+            (index == 0 and name != os.sep)
+            or (index > 0 and (name in {"", ".", ".."} or Path(name).name != name))
+        ):
+            return None
+        rendered_path_chars += len(name) + int(index > 0)
+        if rendered_path_chars > _MAX_COMMAND_ARTIFACT_PATH_CHARS:
+            return None
+        numeric: list[int] = []
+        for key in ("st_dev", "st_ino", "st_mode"):
+            item = component.get(key)
+            if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+                return None
+            numeric.append(item)
+        if numeric[1] == 0 or not stat.S_ISDIR(numeric[2]):
+            return None
+        fingerprint.append((name, *numeric))
+    return tuple(fingerprint)
+
+
+def _serialize_workspace_chain_fingerprint(
+    fingerprint: DirectoryChainFingerprint,
+) -> list[dict[str, int | str]]:
+    return [
+        {"name": name, "st_dev": device, "st_ino": inode, "st_mode": mode}
+        for name, device, inode, mode in fingerprint
+    ]
 
 
 def _is_canonical_command_artifact_path(value: str) -> bool:
@@ -631,10 +704,14 @@ def _journal_entry_proves_command_artifact(
     artifact = matches[0]
     if frozenset(artifact) != _COMMAND_ARTIFACT_KEYS:
         return False
+    workspace_fingerprint = _workspace_chain_fingerprint(provenance.get("workspace_chain"))
+    if workspace_fingerprint is None:
+        return False
     return _nofollow_workspace_artifact_matches(
         task_cwd,
         relative_path,
         expected=artifact,
+        expected_workspace=workspace_fingerprint,
     )
 
 
@@ -643,6 +720,7 @@ def _nofollow_workspace_artifact_matches(
     relative_path: str,
     *,
     expected: Mapping[str, object],
+    expected_workspace: DirectoryChainFingerprint,
 ) -> bool:
     """Match an artifact while its no-follow directory and leaf fds stay held."""
     leased_chain: NoFollowDirectoryChain | None = None
@@ -659,15 +737,8 @@ def _nofollow_workspace_artifact_matches(
             workspace,
             relative_components=relative.parts[:-1],
         )
-        leased_fd = leased_chain.leaf_fd
-        leaf_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
-        leased_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=leased_fd)
-        leaf_fds.append(leased_leaf_fd)
-        leased_leaf = os.fstat(leased_leaf_fd)
-        if not stat.S_ISREG(leased_leaf.st_mode) or any(
-            expected.get(key) != getattr(leased_leaf, key)
-            for key in _COMMAND_ARTIFACT_KEYS - {"path"}
-        ):
+        workspace_component_count = len(workspace.parts)
+        if tuple(leased_chain.fingerprint()[:workspace_component_count]) != expected_workspace:
             return False
 
         # A parent can be renamed and replaced after ``open`` returns.  Rewalk
@@ -677,9 +748,21 @@ def _nofollow_workspace_artifact_matches(
             workspace,
             relative_components=relative.parts[:-1],
         )
-        if not leased_chain.matches_opened_directories(current_chain):
+        if tuple(
+            current_chain.fingerprint()[:workspace_component_count]
+        ) != expected_workspace or not leased_chain.matches_opened_directories(current_chain):
             return False
+        leased_fd = leased_chain.leaf_fd
         current_fd = current_chain.leaf_fd
+        leaf_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+        leased_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=leased_fd)
+        leaf_fds.append(leased_leaf_fd)
+        leased_leaf = os.fstat(leased_leaf_fd)
+        if not stat.S_ISREG(leased_leaf.st_mode) or any(
+            expected.get(key) != getattr(leased_leaf, key)
+            for key in _COMMAND_ARTIFACT_KEYS - {"path"}
+        ):
+            return False
         current_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=current_fd)
         leaf_fds.append(current_leaf_fd)
         current_leaf = os.fstat(current_leaf_fd)
@@ -943,6 +1026,78 @@ def _event_matches_accepted_attempt(
     )
 
 
+def _normalized_event_tool_name(event: BaseEvent) -> str | None:
+    """Return one non-blank tool name for correlation-only comparisons."""
+    if not isinstance(event.data, Mapping):
+        return None
+    value = event.data.get("tool_name")
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _owned_idless_tool_completions(
+    events: tuple[BaseEvent, ...],
+    *,
+    scope_id: str,
+    execution_id: str,
+    retry_attempt: int | None,
+    session_attempt_id: str | None,
+    event_id_counts: Mapping[str, int],
+) -> dict[int, int]:
+    """Pair id-less terminals owned by exactly one accepted-attempt start.
+
+    ID-bearing peers are independent and do not break the legacy id-less slot.
+    A duplicate, malformed, or second id-less start poisons that slot until the
+    next id-less terminal consumes it, matching the live lease tracker.
+    """
+    owned: dict[int, int] = {}
+    active = False
+    active_start_index: int | None = None
+    active_tool: str | None = None
+    for index, event in enumerate(events):
+        if event.type not in {"execution.tool.started", "execution.tool.completed"}:
+            continue
+        if not _event_matches_accepted_attempt(
+            event,
+            scope_id=scope_id,
+            execution_id=execution_id,
+            retry_attempt=retry_attempt,
+            session_attempt_id=session_attempt_id,
+        ):
+            continue
+        aliases, malformed_alias = _event_tool_call_aliases(event)
+        if aliases:
+            continue
+        if malformed_alias or event_id_counts.get(event.id) != 1:
+            active = True
+            active_start_index = None
+            active_tool = None
+            continue
+        if event.type == "execution.tool.started":
+            tool_name = _normalized_event_tool_name(event)
+            if active or tool_name is None:
+                active = True
+                active_start_index = None
+                active_tool = None
+            else:
+                active = True
+                active_start_index = index
+                active_tool = tool_name
+            continue
+
+        completion_tool = _normalized_event_tool_name(event)
+        if (
+            active
+            and active_start_index is not None
+            and active_tool is not None
+            and (completion_tool is None or completion_tool == active_tool)
+        ):
+            owned[active_start_index] = index
+        active = False
+        active_start_index = None
+        active_tool = None
+    return owned
+
+
 def _correlated_tool_completion(
     events: tuple[BaseEvent, ...],
     *,
@@ -953,6 +1108,8 @@ def _correlated_tool_completion(
     session_attempt_id: str | None,
     require_command_verdict: bool,
     event_id_counts: Mapping[str, int],
+    idless_completion_by_start: Mapping[int, int],
+    owned_idless_completion_indexes: frozenset[int],
 ) -> tuple[BaseEvent | None, bool]:
     """Return an exact completion and whether failure/ambiguity vetoes the start."""
     start = events[start_index]
@@ -1019,6 +1176,35 @@ def _correlated_tool_completion(
         completion_index, completion = matches[0]
         if completion_index <= start_index or event_id_counts.get(completion.id) != 1:
             return None, True
+        for candidate_index, candidate in enumerate(
+            events[start_index + 1 : completion_index],
+            start=start_index + 1,
+        ):
+            if candidate.type != "execution.tool.completed" or not _event_matches_accepted_attempt(
+                candidate,
+                scope_id=scope_id,
+                execution_id=execution_id,
+                retry_attempt=retry_attempt,
+                session_attempt_id=session_attempt_id,
+            ):
+                continue
+            if _event_tool_call_id(candidate) is not None:
+                continue
+            if candidate_index in owned_idless_completion_indexes:
+                continue
+            candidate_tool_value = (
+                candidate.data.get("tool_name") if isinstance(candidate.data, Mapping) else None
+            )
+            candidate_tool = (
+                candidate_tool_value.strip()
+                if isinstance(candidate_tool_value, str) and candidate_tool_value.strip()
+                else None
+            )
+            if candidate_tool in {None, start_tool.strip()}:
+                # An id-less same-tool (or nameless) terminal could have closed
+                # this named command.  Do not let a later matching completion
+                # revive its authority, even for a crafted durable journal.
+                return None, True
         if (
             not isinstance(completion.data, Mapping)
             or completion.data.get("tool_name") != start_tool
@@ -1031,8 +1217,18 @@ def _correlated_tool_completion(
             return None, True
         return completion, False
 
-    # Legacy id-less streams: only the next same-attempt tool event may close
-    # the start. Any intervening start or id-bearing completion is ambiguous.
+    # Legacy id-less streams keep one independent slot across concurrent named
+    # peers. Only a uniquely owned id-less terminal may close the start.
+    owned_completion_index = idless_completion_by_start.get(start_index)
+    if owned_completion_index is not None:
+        completion = events[owned_completion_index]
+        if event_id_counts.get(completion.id) != 1 or not _event_has_explicit_tool_success(
+            completion,
+            require_command_verdict=require_command_verdict,
+        ):
+            return None, True
+        return completion, False
+
     for candidate in events[start_index + 1 :]:
         if candidate.type not in {"execution.tool.started", "execution.tool.completed"}:
             continue
@@ -1044,23 +1240,9 @@ def _correlated_tool_completion(
             session_attempt_id=session_attempt_id,
         ):
             continue
-        if candidate.type == "execution.tool.started":
+        aliases, _malformed = _event_tool_call_aliases(candidate)
+        if not aliases:
             return None, True
-        if _event_has_conflicting_tool_call_ids(candidate):
-            return None, True
-        if _event_tool_call_id(candidate) is not None:
-            return None, True
-        candidate_tool = (
-            candidate.data.get("tool_name") if isinstance(candidate.data, Mapping) else None
-        )
-        if candidate_tool != start_tool:
-            return None, True
-        if not _event_has_explicit_tool_success(
-            candidate,
-            require_command_verdict=require_command_verdict,
-        ):
-            return None, True
-        return candidate, False
     return None, False
 
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -37,6 +37,7 @@ _MAX_COMMAND_ARTIFACT_PATH_CHARS = 4096
 RUNTIME_SUCCESS_BOOLEAN_FIELDS = ("success", "ok")
 RUNTIME_FAILURE_BOOLEAN_FIELDS = (
     "is_error",
+    "is_error_invalid",
     "isError",
     "error",
     "failure",
@@ -625,21 +626,23 @@ def _journal_entry_proves_command_artifact(
     artifact = matches[0]
     if frozenset(artifact) != _COMMAND_ARTIFACT_KEYS:
         return False
-    current = _nofollow_workspace_artifact_stat(task_cwd, relative_path)
-    if current is None:
-        return False
-    return stat.S_ISREG(current.st_mode) and all(
-        artifact.get(key) == getattr(current, key) for key in _COMMAND_ARTIFACT_KEYS - {"path"}
+    return _nofollow_workspace_artifact_matches(
+        task_cwd,
+        relative_path,
+        expected=artifact,
     )
 
 
-def _nofollow_workspace_artifact_stat(
+def _nofollow_workspace_artifact_matches(
     task_cwd: str,
     relative_path: str,
-) -> os.stat_result | None:
-    """Read an artifact through a stable workspace-rooted no-follow fd chain."""
+    *,
+    expected: Mapping[str, object],
+) -> bool:
+    """Match an artifact while its no-follow directory and leaf fds stay held."""
     leased_directory_fds: list[int] = []
     current_directory_fds: list[int] = []
+    leaf_fds: list[int] = []
     try:
         if (
             not hasattr(os, "O_DIRECTORY")
@@ -648,18 +651,26 @@ def _nofollow_workspace_artifact_stat(
             or os.stat not in os.supports_dir_fd
             or os.stat not in os.supports_follow_symlinks
         ):
-            return None
+            return False
         workspace = Path(os.path.abspath(Path(task_cwd).expanduser()))
         relative = Path(relative_path)
         if not _is_canonical_command_artifact_path(relative_path):
-            return None
+            return False
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         leased_fd = os.open(workspace, flags)
         leased_directory_fds.append(leased_fd)
         for part in relative.parts[:-1]:
             leased_fd = os.open(part, flags, dir_fd=leased_fd)
             leased_directory_fds.append(leased_fd)
-        leased_leaf = os.stat(relative.name, dir_fd=leased_fd, follow_symlinks=False)
+        leaf_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
+        leased_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=leased_fd)
+        leaf_fds.append(leased_leaf_fd)
+        leased_leaf = os.fstat(leased_leaf_fd)
+        if not stat.S_ISREG(leased_leaf.st_mode) or any(
+            expected.get(key) != getattr(leased_leaf, key)
+            for key in _COMMAND_ARTIFACT_KEYS - {"path"}
+        ):
+            return False
 
         # A parent can be renamed and replaced after ``open`` returns.  Rewalk
         # the current lexical path and bind every opened directory identity,
@@ -669,24 +680,51 @@ def _nofollow_workspace_artifact_stat(
         if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
             os.fstat(leased_directory_fds[0])
         ):
-            return None
+            return False
         for index, part in enumerate(relative.parts[:-1], start=1):
             current_fd = os.open(part, flags, dir_fd=current_fd)
             current_directory_fds.append(current_fd)
             if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
                 os.fstat(leased_directory_fds[index])
             ):
-                return None
-        current_leaf = os.stat(relative.name, dir_fd=current_fd, follow_symlinks=False)
+                return False
+        current_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=current_fd)
+        leaf_fds.append(current_leaf_fd)
+        current_leaf = os.fstat(current_leaf_fd)
         if _command_artifact_stat_fingerprint(current_leaf) != _command_artifact_stat_fingerprint(
             leased_leaf
         ):
-            return None
-        return current_leaf
+            return False
+
+        # Revalidate names after reading the leaf.  The lexical workspace or a
+        # child directory can be replaced after its second ``open`` and the
+        # immediate fd comparison above; held fds alone would then keep seeing
+        # the displaced tree.  Every current parent must still name the opened
+        # child, the final parent must still name the same leaf fingerprint,
+        # and the absolute workspace path must still name the current root.
+        for index, part in enumerate(relative.parts[:-1], start=1):
+            named_child = os.stat(
+                part,
+                dir_fd=current_directory_fds[index - 1],
+                follow_symlinks=False,
+            )
+            if _filesystem_identity(named_child) != _filesystem_identity(
+                os.fstat(current_directory_fds[index])
+            ):
+                return False
+        named_leaf = os.stat(relative.name, dir_fd=current_fd, follow_symlinks=False)
+        if _command_artifact_stat_fingerprint(named_leaf) != _command_artifact_stat_fingerprint(
+            current_leaf
+        ):
+            return False
+        named_workspace = os.stat(workspace, follow_symlinks=False)
+        return _filesystem_identity(named_workspace) == _filesystem_identity(
+            os.fstat(current_directory_fds[0])
+        )
     except (OSError, RuntimeError, ValueError):
-        return None
+        return False
     finally:
-        for directory_fd in reversed(current_directory_fds + leased_directory_fds):
+        for directory_fd in reversed(leaf_fds + current_directory_fds + leased_directory_fds):
             try:
                 os.close(directory_fd)
             except OSError:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -21,6 +21,11 @@ from typing import Any, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from ouroboros.core.filesystem_capability import (
+    NoFollowDirectoryChain,
+    nofollow_directory_capabilities_available,
+    open_nofollow_directory_chain,
+)
 from ouroboros.events.base import BaseEvent
 from ouroboros.harness.claim_term_guard import ClaimTermGuard, ClaimTermGuardFact
 from ouroboros.harness.journal import (
@@ -640,28 +645,21 @@ def _nofollow_workspace_artifact_matches(
     expected: Mapping[str, object],
 ) -> bool:
     """Match an artifact while its no-follow directory and leaf fds stay held."""
-    leased_directory_fds: list[int] = []
-    current_directory_fds: list[int] = []
+    leased_chain: NoFollowDirectoryChain | None = None
+    current_chain: NoFollowDirectoryChain | None = None
     leaf_fds: list[int] = []
     try:
-        if (
-            not hasattr(os, "O_DIRECTORY")
-            or not hasattr(os, "O_NOFOLLOW")
-            or os.open not in os.supports_dir_fd
-            or os.stat not in os.supports_dir_fd
-            or os.stat not in os.supports_follow_symlinks
-        ):
+        if not nofollow_directory_capabilities_available():
             return False
         workspace = Path(os.path.abspath(Path(task_cwd).expanduser()))
         relative = Path(relative_path)
         if not _is_canonical_command_artifact_path(relative_path):
             return False
-        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-        leased_fd = os.open(workspace, flags)
-        leased_directory_fds.append(leased_fd)
-        for part in relative.parts[:-1]:
-            leased_fd = os.open(part, flags, dir_fd=leased_fd)
-            leased_directory_fds.append(leased_fd)
+        leased_chain = open_nofollow_directory_chain(
+            workspace,
+            relative_components=relative.parts[:-1],
+        )
+        leased_fd = leased_chain.leaf_fd
         leaf_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0)
         leased_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=leased_fd)
         leaf_fds.append(leased_leaf_fd)
@@ -675,19 +673,13 @@ def _nofollow_workspace_artifact_matches(
         # A parent can be renamed and replaced after ``open`` returns.  Rewalk
         # the current lexical path and bind every opened directory identity,
         # plus the leaf fingerprint, to the held no-follow traversal.
-        current_fd = os.open(workspace, flags)
-        current_directory_fds.append(current_fd)
-        if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
-            os.fstat(leased_directory_fds[0])
-        ):
+        current_chain = open_nofollow_directory_chain(
+            workspace,
+            relative_components=relative.parts[:-1],
+        )
+        if not leased_chain.matches_opened_directories(current_chain):
             return False
-        for index, part in enumerate(relative.parts[:-1], start=1):
-            current_fd = os.open(part, flags, dir_fd=current_fd)
-            current_directory_fds.append(current_fd)
-            if _filesystem_identity(os.fstat(current_fd)) != _filesystem_identity(
-                os.fstat(leased_directory_fds[index])
-            ):
-                return False
+        current_fd = current_chain.leaf_fd
         current_leaf_fd = os.open(relative.name, leaf_flags, dir_fd=current_fd)
         leaf_fds.append(current_leaf_fd)
         current_leaf = os.fstat(current_leaf_fd)
@@ -702,37 +694,24 @@ def _nofollow_workspace_artifact_matches(
         # the displaced tree.  Every current parent must still name the opened
         # child, the final parent must still name the same leaf fingerprint,
         # and the absolute workspace path must still name the current root.
-        for index, part in enumerate(relative.parts[:-1], start=1):
-            named_child = os.stat(
-                part,
-                dir_fd=current_directory_fds[index - 1],
-                follow_symlinks=False,
-            )
-            if _filesystem_identity(named_child) != _filesystem_identity(
-                os.fstat(current_directory_fds[index])
-            ):
-                return False
         named_leaf = os.stat(relative.name, dir_fd=current_fd, follow_symlinks=False)
         if _command_artifact_stat_fingerprint(named_leaf) != _command_artifact_stat_fingerprint(
             current_leaf
         ):
             return False
-        named_workspace = os.stat(workspace, follow_symlinks=False)
-        return _filesystem_identity(named_workspace) == _filesystem_identity(
-            os.fstat(current_directory_fds[0])
-        )
+        return leased_chain.postvalidate() and current_chain.postvalidate()
     except (OSError, RuntimeError, ValueError):
         return False
     finally:
-        for directory_fd in reversed(leaf_fds + current_directory_fds + leased_directory_fds):
+        for directory_fd in reversed(leaf_fds):
             try:
                 os.close(directory_fd)
             except OSError:
                 pass
-
-
-def _filesystem_identity(value: os.stat_result) -> tuple[int, int, int]:
-    return (value.st_dev, value.st_ino, value.st_mode)
+        if current_chain is not None:
+            current_chain.close()
+        if leased_chain is not None:
+            leased_chain.close()
 
 
 def _command_artifact_stat_fingerprint(value: os.stat_result) -> tuple[int, ...]:

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 
 from ouroboros.core.filesystem_capability import (
+    DirectoryChainFingerprint,
     NoFollowDirectoryChain,
     nofollow_directory_capabilities_available,
     open_nofollow_directory_chain,
@@ -88,6 +89,7 @@ class _PendingBashTarget:
     reported_path: str
     workspace_relative_path: str
     pre_fingerprint: tuple[int, int, int, int, int, int] | None
+    workspace_fingerprint: DirectoryChainFingerprint
 
     @property
     def parent_fd(self) -> int | None:
@@ -104,29 +106,42 @@ def _pending_bash_filesystem_targets(
     message: AgentMessage,
     *,
     task_cwd: str | None,
+    workspace_chain: NoFollowDirectoryChain | None = None,
 ) -> tuple[_PendingBashTarget, ...]:
     """Lease Bash receiver parents and capture pre-execution file identity."""
     if message.tool_name != "Bash" or _runtime_message_is_tool_completion(message):
         return ()
     effective_cwd = _runtime_message_effective_cwd(message, task_cwd=task_cwd)
-    if effective_cwd is None:
+    if effective_cwd is None or task_cwd is None:
         return ()
+    owned_workspace_chain: NoFollowDirectoryChain | None = None
+    if workspace_chain is None:
+        try:
+            owned_workspace_chain = open_nofollow_directory_chain(Path(os.path.abspath(task_cwd)))
+        except (OSError, RuntimeError, ValueError):
+            return ()
+        workspace_chain = owned_workspace_chain
     targets: list[_PendingBashTarget] = []
-    for command in _runtime_message_command_values(message):
-        for target in _shell_command_mutation_targets(command):
-            pending = _lease_bash_target(
-                target,
-                task_cwd=task_cwd,
-                effective_cwd=effective_cwd,
-            )
-            if pending is not None:
-                targets.append(pending)
-                if len(targets) > _MAX_BASH_FILESYSTEM_EFFECTS or len(
-                    {item.workspace_relative_path for item in targets}
-                ) != len(targets):
-                    _close_pending_targets(tuple(targets))
-                    return ()
-    return tuple(targets)
+    try:
+        for command in _runtime_message_command_values(message):
+            for target in _shell_command_mutation_targets(command):
+                pending = _lease_bash_target(
+                    target,
+                    task_cwd=task_cwd,
+                    effective_cwd=effective_cwd,
+                    workspace_chain=workspace_chain,
+                )
+                if pending is not None:
+                    targets.append(pending)
+                    if len(targets) > _MAX_BASH_FILESYSTEM_EFFECTS or len(
+                        {item.workspace_relative_path for item in targets}
+                    ) != len(targets):
+                        _close_pending_targets(tuple(targets))
+                        return ()
+        return tuple(targets)
+    finally:
+        if owned_workspace_chain is not None:
+            owned_workspace_chain.close()
 
 
 def _lease_bash_target(
@@ -134,6 +149,7 @@ def _lease_bash_target(
     *,
     task_cwd: str,
     effective_cwd: str,
+    workspace_chain: NoFollowDirectoryChain,
 ) -> _PendingBashTarget | None:
     """Open a no-follow dirfd chain that survives path-component replacement."""
     directory_chain: NoFollowDirectoryChain | None = None
@@ -154,6 +170,9 @@ def _lease_bash_target(
             workspace,
             relative_components=relative.parts[:-1],
         )
+        if not workspace_chain.matches_opened_prefix(directory_chain):
+            return None
+        workspace_fingerprint = workspace_chain.fingerprint()
         parent_fd = directory_chain.leaf_fd
         try:
             pre = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
@@ -167,6 +186,7 @@ def _lease_bash_target(
             reported_path=target,
             workspace_relative_path=relative.as_posix(),
             pre_fingerprint=pre_fingerprint,
+            workspace_fingerprint=workspace_fingerprint,
         )
         directory_chain = None
         return pending
@@ -228,6 +248,15 @@ def _attach_bash_filesystem_effects(
                     "capture": "ouroboros.leaf-dispatch.v1",
                     "path": target.reported_path,
                     "workspace_relative_path": target.workspace_relative_path,
+                    "workspace_chain": [
+                        {
+                            "name": name,
+                            "st_dev": device,
+                            "st_ino": inode,
+                            "st_mode": mode,
+                        }
+                        for name, device, inode, mode in target.workspace_fingerprint
+                    ],
                     "st_dev": identity.st_dev,
                     "st_ino": identity.st_ino,
                     "st_mode": identity.st_mode,
@@ -322,18 +351,35 @@ class _BashFilesystemLeaseTracker:
 
     def __init__(self, *, task_cwd: str | None) -> None:
         self._task_cwd = task_cwd
+        self._workspace_chain: NoFollowDirectoryChain | None = None
         self._pending_by_id: dict[str, tuple[_PendingBashTarget, ...]] = {}
         self._seen_call_ids: set[str] = set()
         self._pending_bash_call_ids: set[str] = set()
         self._idless: tuple[_PendingBashTarget, ...] | None = None
         self._idless_active = False
         self._idless_bash_active = False
+        self._idless_tool_name: str | None = None
 
     def __enter__(self) -> _BashFilesystemLeaseTracker:
+        if self._task_cwd is not None and self._workspace_chain is None:
+            try:
+                self._workspace_chain = open_nofollow_directory_chain(
+                    Path(os.path.abspath(self._task_cwd))
+                )
+            except (OSError, RuntimeError, ValueError):
+                self._workspace_chain = None
         return self
 
     def __exit__(self, *_exc_info: object) -> None:
         self.close()
+
+    def _poison_pending_named_bash_leases(self) -> None:
+        """Close every active named Bash lease without making it reusable."""
+        for pending_id in tuple(self._pending_bash_call_ids):
+            _close_pending_targets(self._pending_by_id.pop(pending_id, ()))
+            self._seen_call_ids.add(pending_id)
+            self._pending_by_id[pending_id] = ()
+        self._pending_bash_call_ids.clear()
 
     def observe(self, message: AgentMessage) -> AgentMessage:
         """Lease calls, attach completion effects, and reject ambiguous pairing."""
@@ -357,22 +403,23 @@ class _BashFilesystemLeaseTracker:
                     or message_tool_name(message) == "Bash"
                 )
                 if is_bash_candidate:
-                    for pending_id in tuple(self._pending_bash_call_ids):
-                        _close_pending_targets(self._pending_by_id.pop(pending_id, ()))
-                        self._seen_call_ids.add(pending_id)
-                        self._pending_by_id[pending_id] = ()
-                    self._pending_bash_call_ids.clear()
+                    self._poison_pending_named_bash_leases()
                     _close_pending_targets(self._idless or ())
                     self._idless = ()
                     self._idless_active = True
                     self._idless_bash_active = False
+                    self._idless_tool_name = None
             return message
         call_id = _runtime_message_tool_call_id(message)
         tool_name = message_tool_name(message)
         if tool_name is not None and not _runtime_message_is_tool_completion(message):
             targets = (
-                _pending_bash_filesystem_targets(message, task_cwd=self._task_cwd)
-                if tool_name == "Bash"
+                _pending_bash_filesystem_targets(
+                    message,
+                    task_cwd=self._task_cwd,
+                    workspace_chain=self._workspace_chain,
+                )
+                if tool_name == "Bash" and self._workspace_chain is not None
                 else ()
             )
             if call_id is not None:
@@ -390,11 +437,13 @@ class _BashFilesystemLeaseTracker:
                 self._idless_active = True
                 self._idless = targets
                 self._idless_bash_active = tool_name == "Bash"
+                self._idless_tool_name = tool_name
             else:
                 _close_pending_targets(self._idless or ())
                 _close_pending_targets(targets)
                 self._idless = ()
                 self._idless_bash_active = False
+                self._idless_tool_name = None
             return message
         if not _runtime_message_is_tool_completion(message):
             return message
@@ -402,11 +451,28 @@ class _BashFilesystemLeaseTracker:
             targets = self._pending_by_id.pop(call_id, ())
             self._pending_bash_call_ids.discard(call_id)
         else:
+            unique_idless_tool = self._idless_tool_name if self._idless_active else None
+            normalized_completion_tool = (
+                tool_name.strip() if isinstance(tool_name, str) and tool_name.strip() else None
+            )
+            orphan_bash_completion = normalized_completion_tool == "Bash" or (
+                normalized_completion_tool is None and unique_idless_tool is None
+            )
+            if orphan_bash_completion and unique_idless_tool != "Bash":
+                # A terminal that cannot be assigned to one active id-less Bash
+                # call could belong to any concurrent named Bash call.  It
+                # closes every such authority boundary; a later matching ID
+                # must not extend or revive one of their receiver leases.
+                self._poison_pending_named_bash_leases()
             targets = self._idless or ()
             self._idless = None
             self._idless_active = False
             self._idless_bash_active = False
-        if tool_name not in {None, "Bash"}:
+            self._idless_tool_name = None
+        normalized_tool_name = (
+            tool_name.strip() if isinstance(tool_name, str) and tool_name.strip() else None
+        )
+        if normalized_tool_name not in {None, "Bash"}:
             _close_pending_targets(targets)
             return message
         return _attach_bash_filesystem_effects(message, targets) if targets else message
@@ -423,6 +489,10 @@ class _BashFilesystemLeaseTracker:
             self._idless = None
         self._idless_active = False
         self._idless_bash_active = False
+        self._idless_tool_name = None
+        if self._workspace_chain is not None:
+            self._workspace_chain.close()
+            self._workspace_chain = None
 
 
 def _correlated_tool_result_name(

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -28,6 +28,11 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 
+from ouroboros.core.filesystem_capability import (
+    NoFollowDirectoryChain,
+    nofollow_directory_capabilities_available,
+    open_nofollow_directory_chain,
+)
 from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.evidence.claims import (
     _runtime_message_command_values,
@@ -78,11 +83,18 @@ class LeafDispatchState:
 class _PendingBashTarget:
     """Execution-span lease on one lexical shell receiver parent."""
 
-    parent_fd: int | None
+    directory_chain: NoFollowDirectoryChain | None
     leaf_name: str
     reported_path: str
     workspace_relative_path: str
     pre_fingerprint: tuple[int, int, int, int, int, int] | None
+
+    @property
+    def parent_fd(self) -> int | None:
+        """Return the final held parent fd while this lease owns its chain."""
+        if self.directory_chain is None:
+            return None
+        return self.directory_chain.leaf_fd
 
 
 _MAX_BASH_FILESYSTEM_EFFECTS = 128
@@ -124,15 +136,9 @@ def _lease_bash_target(
     effective_cwd: str,
 ) -> _PendingBashTarget | None:
     """Open a no-follow dirfd chain that survives path-component replacement."""
-    parent_fd: int | None = None
+    directory_chain: NoFollowDirectoryChain | None = None
     try:
-        if (
-            not hasattr(os, "O_DIRECTORY")
-            or not hasattr(os, "O_NOFOLLOW")
-            or os.open not in os.supports_dir_fd
-            or os.stat not in os.supports_dir_fd
-            or os.stat not in os.supports_follow_symlinks
-        ):
+        if not nofollow_directory_capabilities_available():
             return None
         workspace = Path(os.path.abspath(task_cwd))
         candidate = Path(target)
@@ -144,37 +150,31 @@ def _lease_bash_target(
         relative = absolute.relative_to(workspace)
         if not relative.parts or relative.name in {"", ".", ".."}:
             return None
-        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-        parent_fd = os.open(workspace, flags)
-        for part in relative.parts[:-1]:
-            if part in {"", ".", ".."}:
-                return None
-            next_fd = os.open(part, flags, dir_fd=parent_fd)
-            os.close(parent_fd)
-            parent_fd = next_fd
+        directory_chain = open_nofollow_directory_chain(
+            workspace,
+            relative_components=relative.parts[:-1],
+        )
+        parent_fd = directory_chain.leaf_fd
         try:
             pre = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
         except FileNotFoundError:
             pre_fingerprint = None
         else:
             pre_fingerprint = _stat_fingerprint(pre)
-        leased_fd = parent_fd
-        parent_fd = None
-        return _PendingBashTarget(
-            parent_fd=leased_fd,
+        pending = _PendingBashTarget(
+            directory_chain=directory_chain,
             leaf_name=relative.name,
             reported_path=target,
             workspace_relative_path=relative.as_posix(),
             pre_fingerprint=pre_fingerprint,
         )
+        directory_chain = None
+        return pending
     except (OSError, RuntimeError, ValueError):
         return None
     finally:
-        if parent_fd is not None:
-            try:
-                os.close(parent_fd)
-            except OSError:
-                pass
+        if directory_chain is not None:
+            directory_chain.close()
 
 
 def _stat_fingerprint(value: os.stat_result) -> tuple[int, int, int, int, int, int]:
@@ -197,7 +197,8 @@ def _attach_bash_filesystem_effects(
     effects: list[dict[str, object]] = []
     for target in targets:
         parent_fd = target.parent_fd
-        if parent_fd is None:
+        directory_chain = target.directory_chain
+        if parent_fd is None or directory_chain is None:
             continue
         try:
             try:
@@ -220,6 +221,8 @@ def _attach_bash_filesystem_effects(
                     or post_fingerprint == target.pre_fingerprint
                 ):
                     continue
+            if not directory_chain.postvalidate():
+                continue
             effects.append(
                 {
                     "capture": "ouroboros.leaf-dispatch.v1",
@@ -302,14 +305,11 @@ def _runtime_message_has_malformed_tool_call_aliases(message: AgentMessage) -> b
 
 
 def _close_pending_target(target: _PendingBashTarget) -> None:
-    fd = target.parent_fd
-    if fd is None:
+    directory_chain = target.directory_chain
+    if directory_chain is None:
         return
-    target.parent_fd = None
-    try:
-        os.close(fd)
-    except OSError:
-        pass
+    target.directory_chain = None
+    directory_chain.close()
 
 
 def _close_pending_targets(targets: tuple[_PendingBashTarget, ...]) -> None:

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
+import errno
 import os
 from pathlib import Path
 import stat
+import threading
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -98,8 +100,68 @@ class _PendingBashTarget:
             return None
         return self.directory_chain.leaf_fd
 
+    @property
+    def descriptor_count(self) -> int:
+        """Return the descriptors held by this receiver lease."""
+        return self.directory_chain.descriptor_count if self.directory_chain is not None else 0
+
 
 _MAX_BASH_FILESYSTEM_EFFECTS = 128
+_MAX_BASH_PROVENANCE_FDS = 64
+_BASH_PROVENANCE_FD_LIMIT_DIVISOR = 4
+_MIN_RUNTIME_FD_HEADROOM = 16
+_BASH_PROVENANCE_FD_LOCK = threading.Lock()
+
+
+class _BashProvenanceFDBudgetExceeded(Exception):
+    """Signal that a command capture must be abandoned as one unit."""
+
+
+def _bash_soft_fd_limit() -> int | None:
+    """Return the process soft fd limit when it is safely observable."""
+    try:
+        soft_limit = os.sysconf("SC_OPEN_MAX")
+    except (AttributeError, OSError, ValueError):
+        return None
+    if not isinstance(soft_limit, int) or soft_limit <= 0:
+        return None
+    return soft_limit
+
+
+def _bash_provenance_fd_budget() -> int:
+    """Return one conservative per-tracker cap below the process soft limit."""
+    soft_limit = _bash_soft_fd_limit()
+    if soft_limit is None:
+        return 0
+    return min(_MAX_BASH_PROVENANCE_FDS, soft_limit // _BASH_PROVENANCE_FD_LIMIT_DIVISOR)
+
+
+def _bash_open_fd_count() -> int | None:
+    """Count process descriptors without retaining the enumeration handle."""
+    for candidate in (Path("/proc/self/fd"), Path("/dev/fd")):
+        if not candidate.exists():
+            continue
+        try:
+            with os.scandir(candidate) as entries:
+                return sum(1 for _entry in entries)
+        except OSError:
+            continue
+    return None
+
+
+def _bash_provenance_headroom_available(required_fds: int) -> bool:
+    """Keep at least half the process limit free for runtime and pipe I/O."""
+    soft_limit = _bash_soft_fd_limit()
+    open_fds = _bash_open_fd_count()
+    if soft_limit is None or open_fds is None or required_fds < 0:
+        return False
+    reserved_headroom = max(_MIN_RUNTIME_FD_HEADROOM, soft_limit // 2)
+    return open_fds + required_fds <= soft_limit - reserved_headroom
+
+
+def _absolute_directory_fd_count(path: str | os.PathLike[str]) -> int:
+    """Return descriptors required for a root-anchored absolute directory walk."""
+    return len(Path(os.path.abspath(path)).parts)
 
 
 def _pending_bash_filesystem_targets(
@@ -107,8 +169,26 @@ def _pending_bash_filesystem_targets(
     *,
     task_cwd: str | None,
     workspace_chain: NoFollowDirectoryChain | None = None,
+    target_fd_budget: int | None = None,
 ) -> tuple[_PendingBashTarget, ...]:
     """Lease Bash receiver parents and capture pre-execution file identity."""
+    with _BASH_PROVENANCE_FD_LOCK:
+        return _pending_bash_filesystem_targets_locked(
+            message,
+            task_cwd=task_cwd,
+            workspace_chain=workspace_chain,
+            target_fd_budget=target_fd_budget,
+        )
+
+
+def _pending_bash_filesystem_targets_locked(
+    message: AgentMessage,
+    *,
+    task_cwd: str | None,
+    workspace_chain: NoFollowDirectoryChain | None,
+    target_fd_budget: int | None,
+) -> tuple[_PendingBashTarget, ...]:
+    """Lease receivers while process-wide provenance admission is serialized."""
     if message.tool_name != "Bash" or _runtime_message_is_tool_completion(message):
         return ()
     effective_cwd = _runtime_message_effective_cwd(message, task_cwd=task_cwd)
@@ -116,23 +196,38 @@ def _pending_bash_filesystem_targets(
         return ()
     owned_workspace_chain: NoFollowDirectoryChain | None = None
     if workspace_chain is None:
+        total_budget = _bash_provenance_fd_budget()
+        workspace_fd_count = _absolute_directory_fd_count(task_cwd)
+        if workspace_fd_count > total_budget or not _bash_provenance_headroom_available(
+            workspace_fd_count
+        ):
+            return ()
         try:
             owned_workspace_chain = open_nofollow_directory_chain(Path(os.path.abspath(task_cwd)))
         except (OSError, RuntimeError, ValueError):
             return ()
         workspace_chain = owned_workspace_chain
+        target_fd_budget = total_budget - workspace_chain.descriptor_count
+    elif target_fd_budget is None:
+        target_fd_budget = _bash_provenance_fd_budget()
     targets: list[_PendingBashTarget] = []
     try:
         for command in _runtime_message_command_values(message):
             for target in _shell_command_mutation_targets(command):
-                pending = _lease_bash_target(
-                    target,
-                    task_cwd=task_cwd,
-                    effective_cwd=effective_cwd,
-                    workspace_chain=workspace_chain,
-                )
+                try:
+                    pending = _lease_bash_target(
+                        target,
+                        task_cwd=task_cwd,
+                        effective_cwd=effective_cwd,
+                        workspace_chain=workspace_chain,
+                        fd_budget=target_fd_budget,
+                    )
+                except _BashProvenanceFDBudgetExceeded:
+                    _close_pending_targets(tuple(targets))
+                    return ()
                 if pending is not None:
                     targets.append(pending)
+                    target_fd_budget -= pending.descriptor_count
                     if len(targets) > _MAX_BASH_FILESYSTEM_EFFECTS or len(
                         {item.workspace_relative_path for item in targets}
                     ) != len(targets):
@@ -150,6 +245,7 @@ def _lease_bash_target(
     task_cwd: str,
     effective_cwd: str,
     workspace_chain: NoFollowDirectoryChain,
+    fd_budget: int,
 ) -> _PendingBashTarget | None:
     """Open a no-follow dirfd chain that survives path-component replacement."""
     directory_chain: NoFollowDirectoryChain | None = None
@@ -166,6 +262,9 @@ def _lease_bash_target(
         relative = absolute.relative_to(workspace)
         if not relative.parts or relative.name in {"", ".", ".."}:
             return None
+        required_fds = workspace_chain.descriptor_count + len(relative.parts[:-1])
+        if required_fds > fd_budget or not _bash_provenance_headroom_available(required_fds):
+            raise _BashProvenanceFDBudgetExceeded
         directory_chain = open_nofollow_directory_chain(
             workspace,
             relative_components=relative.parts[:-1],
@@ -190,7 +289,11 @@ def _lease_bash_target(
         )
         directory_chain = None
         return pending
-    except (OSError, RuntimeError, ValueError):
+    except OSError as exc:
+        if exc.errno in {errno.EMFILE, errno.ENFILE}:
+            raise _BashProvenanceFDBudgetExceeded from exc
+        return None
+    except (RuntimeError, ValueError):
         return None
     finally:
         if directory_chain is not None:
@@ -351,6 +454,7 @@ class _BashFilesystemLeaseTracker:
 
     def __init__(self, *, task_cwd: str | None) -> None:
         self._task_cwd = task_cwd
+        self._provenance_fd_budget = _bash_provenance_fd_budget()
         self._workspace_chain: NoFollowDirectoryChain | None = None
         self._pending_by_id: dict[str, tuple[_PendingBashTarget, ...]] = {}
         self._seen_call_ids: set[str] = set()
@@ -362,12 +466,18 @@ class _BashFilesystemLeaseTracker:
 
     def __enter__(self) -> _BashFilesystemLeaseTracker:
         if self._task_cwd is not None and self._workspace_chain is None:
-            try:
-                self._workspace_chain = open_nofollow_directory_chain(
-                    Path(os.path.abspath(self._task_cwd))
-                )
-            except (OSError, RuntimeError, ValueError):
-                self._workspace_chain = None
+            workspace_fd_count = _absolute_directory_fd_count(self._task_cwd)
+            with _BASH_PROVENANCE_FD_LOCK:
+                if workspace_fd_count > self._provenance_fd_budget or not (
+                    _bash_provenance_headroom_available(workspace_fd_count)
+                ):
+                    return self
+                try:
+                    self._workspace_chain = open_nofollow_directory_chain(
+                        Path(os.path.abspath(self._task_cwd))
+                    )
+                except (OSError, RuntimeError, ValueError):
+                    self._workspace_chain = None
         return self
 
     def __exit__(self, *_exc_info: object) -> None:
@@ -380,6 +490,18 @@ class _BashFilesystemLeaseTracker:
             self._seen_call_ids.add(pending_id)
             self._pending_by_id[pending_id] = ()
         self._pending_bash_call_ids.clear()
+
+    def _held_provenance_fd_count(self) -> int:
+        """Count every workspace and receiver descriptor owned by this tracker."""
+        count = self._workspace_chain.descriptor_count if self._workspace_chain else 0
+        count += sum(
+            target.descriptor_count
+            for targets in self._pending_by_id.values()
+            for target in targets
+        )
+        if self._idless is not None:
+            count += sum(target.descriptor_count for target in self._idless)
+        return count
 
     def observe(self, message: AgentMessage) -> AgentMessage:
         """Lease calls, attach completion effects, and reject ambiguous pairing."""
@@ -418,6 +540,10 @@ class _BashFilesystemLeaseTracker:
                     message,
                     task_cwd=self._task_cwd,
                     workspace_chain=self._workspace_chain,
+                    target_fd_budget=max(
+                        0,
+                        self._provenance_fd_budget - self._held_provenance_fd_count(),
+                    ),
                 )
                 if tool_name == "Bash" and self._workspace_chain is not None
                 else ()

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -18,6 +18,7 @@ partial message list must remain visible for teardown.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 import os
 from pathlib import Path
@@ -41,7 +42,10 @@ from ouroboros.orchestrator.evidence.runtime_metadata import (
     HEARTBEAT_INTERVAL_SECONDS,
     STALL_TIMEOUT_SECONDS,
 )
-from ouroboros.orchestrator.runtime_message_projection import project_runtime_message
+from ouroboros.orchestrator.runtime_message_projection import (
+    message_tool_name,
+    project_runtime_message,
+)
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.execution_runtime_scope import (
@@ -77,7 +81,11 @@ class _PendingBashTarget:
     parent_fd: int | None
     leaf_name: str
     reported_path: str
+    workspace_relative_path: str
     pre_fingerprint: tuple[int, int, int, int, int, int] | None
+
+
+_MAX_BASH_FILESYSTEM_EFFECTS = 128
 
 
 def _pending_bash_filesystem_targets(
@@ -101,6 +109,11 @@ def _pending_bash_filesystem_targets(
             )
             if pending is not None:
                 targets.append(pending)
+                if len(targets) > _MAX_BASH_FILESYSTEM_EFFECTS or len(
+                    {item.workspace_relative_path for item in targets}
+                ) != len(targets):
+                    _close_pending_targets(tuple(targets))
+                    return ()
     return tuple(targets)
 
 
@@ -151,6 +164,7 @@ def _lease_bash_target(
             parent_fd=leased_fd,
             leaf_name=relative.name,
             reported_path=target,
+            workspace_relative_path=relative.as_posix(),
             pre_fingerprint=pre_fingerprint,
         )
     except (OSError, RuntimeError, ValueError):
@@ -210,9 +224,13 @@ def _attach_bash_filesystem_effects(
                 {
                     "capture": "ouroboros.leaf-dispatch.v1",
                     "path": target.reported_path,
+                    "workspace_relative_path": target.workspace_relative_path,
                     "st_dev": identity.st_dev,
                     "st_ino": identity.st_ino,
                     "st_mode": identity.st_mode,
+                    "st_size": identity.st_size,
+                    "st_mtime_ns": identity.st_mtime_ns,
+                    "st_ctime_ns": identity.st_ctime_ns,
                 }
             )
         finally:
@@ -225,13 +243,62 @@ def _attach_bash_filesystem_effects(
     )
 
 
-def _strip_internal_filesystem_effects(message: AgentMessage) -> AgentMessage:
-    """Remove adapter-supplied provenance reserved for local lease capture."""
-    if "filesystem_effects" not in message.data:
+def _strip_internal_filesystem_effects(
+    message: AgentMessage,
+    *,
+    force_snapshot: bool = False,
+) -> AgentMessage:
+    """Sever adapter data ownership and remove its reserved provenance field."""
+    if (
+        not force_snapshot
+        and message_tool_name(message) != "Bash"
+        and not _runtime_message_is_tool_completion(message)
+        and "filesystem_effects" not in message.data
+    ):
         return message
-    sanitized = dict(message.data)
-    sanitized.pop("filesystem_effects", None)
+    sanitized = {
+        key: _snapshot_adapter_value(value)
+        for key, value in message.data.items()
+        if key != "filesystem_effects"
+    }
     return replace(message, data=sanitized)
+
+
+def _snapshot_adapter_value(value: object) -> object:
+    """Recursively copy plain containers used by provenance-sensitive metadata."""
+    if isinstance(value, Mapping):
+        return {key: _snapshot_adapter_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_snapshot_adapter_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_snapshot_adapter_value(item) for item in value)
+    if isinstance(value, set):
+        return {_snapshot_adapter_value(item) for item in value}
+    if isinstance(value, frozenset):
+        return frozenset(_snapshot_adapter_value(item) for item in value)
+    if isinstance(value, bytearray):
+        return bytes(value)
+    return value
+
+
+def _runtime_message_has_malformed_tool_call_aliases(message: AgentMessage) -> bool:
+    """Reject present correlation aliases that are not non-blank strings."""
+    containers: list[Mapping[str, object]] = [message.data]
+    message_meta = message.data.get("meta")
+    if isinstance(message_meta, Mapping):
+        containers.append(message_meta)
+    tool_result = message.data.get("tool_result")
+    if isinstance(tool_result, Mapping):
+        containers.append(tool_result)
+        result_meta = tool_result.get("meta")
+        if isinstance(result_meta, Mapping):
+            containers.append(result_meta)
+    return any(
+        key in container
+        and (not isinstance(container[key], str) or not str(container[key]).strip())
+        for container in containers
+        for key in ("tool_call_id", "tool_use_id", "call_id")
+    )
 
 
 def _close_pending_target(target: _PendingBashTarget) -> None:
@@ -257,8 +324,10 @@ class _BashFilesystemLeaseTracker:
         self._task_cwd = task_cwd
         self._pending_by_id: dict[str, tuple[_PendingBashTarget, ...]] = {}
         self._seen_call_ids: set[str] = set()
+        self._pending_bash_call_ids: set[str] = set()
         self._idless: tuple[_PendingBashTarget, ...] | None = None
         self._idless_active = False
+        self._idless_bash_active = False
 
     def __enter__(self) -> _BashFilesystemLeaseTracker:
         return self
@@ -268,8 +337,12 @@ class _BashFilesystemLeaseTracker:
 
     def observe(self, message: AgentMessage) -> AgentMessage:
         """Lease calls, attach completion effects, and reject ambiguous pairing."""
-        message = _strip_internal_filesystem_effects(message)
-        if _runtime_message_has_conflicting_tool_call_ids(message):
+        message = _strip_internal_filesystem_effects(
+            message,
+            force_snapshot=bool(self._pending_bash_call_ids) or self._idless_bash_active,
+        )
+        malformed_alias = _runtime_message_has_malformed_tool_call_aliases(message)
+        if malformed_alias or _runtime_message_has_conflicting_tool_call_ids(message):
             # Every alias named by an ambiguous message is poisoned. Close any
             # prior lease it could otherwise consume, and retain an empty
             # sentinel so a later call/result cannot revive or donate one.
@@ -277,12 +350,29 @@ class _BashFilesystemLeaseTracker:
                 _close_pending_targets(self._pending_by_id.pop(conflicting_id, ()))
                 self._seen_call_ids.add(conflicting_id)
                 self._pending_by_id[conflicting_id] = ()
+                self._pending_bash_call_ids.discard(conflicting_id)
+            if malformed_alias and not _runtime_message_tool_call_ids(message):
+                is_bash_candidate = (
+                    _runtime_message_is_tool_completion(message)
+                    or message_tool_name(message) == "Bash"
+                )
+                if is_bash_candidate:
+                    for pending_id in tuple(self._pending_bash_call_ids):
+                        _close_pending_targets(self._pending_by_id.pop(pending_id, ()))
+                        self._seen_call_ids.add(pending_id)
+                        self._pending_by_id[pending_id] = ()
+                    self._pending_bash_call_ids.clear()
+                    _close_pending_targets(self._idless or ())
+                    self._idless = ()
+                    self._idless_active = True
+                    self._idless_bash_active = False
             return message
         call_id = _runtime_message_tool_call_id(message)
-        if message.tool_name is not None and not _runtime_message_is_tool_completion(message):
+        tool_name = message_tool_name(message)
+        if tool_name is not None and not _runtime_message_is_tool_completion(message):
             targets = (
                 _pending_bash_filesystem_targets(message, task_cwd=self._task_cwd)
-                if message.tool_name == "Bash"
+                if tool_name == "Bash"
                 else ()
             )
             if call_id is not None:
@@ -290,26 +380,33 @@ class _BashFilesystemLeaseTracker:
                     _close_pending_targets(self._pending_by_id.get(call_id, ()))
                     _close_pending_targets(targets)
                     self._pending_by_id[call_id] = ()
+                    self._pending_bash_call_ids.discard(call_id)
                 else:
                     self._seen_call_ids.add(call_id)
                     self._pending_by_id[call_id] = targets
+                    if tool_name == "Bash":
+                        self._pending_bash_call_ids.add(call_id)
             elif not self._idless_active:
                 self._idless_active = True
                 self._idless = targets
+                self._idless_bash_active = tool_name == "Bash"
             else:
                 _close_pending_targets(self._idless or ())
                 _close_pending_targets(targets)
                 self._idless = ()
+                self._idless_bash_active = False
             return message
         if not _runtime_message_is_tool_completion(message):
             return message
         if call_id is not None:
             targets = self._pending_by_id.pop(call_id, ())
+            self._pending_bash_call_ids.discard(call_id)
         else:
             targets = self._idless or ()
             self._idless = None
             self._idless_active = False
-        if message.tool_name not in {None, "Bash"}:
+            self._idless_bash_active = False
+        if tool_name not in {None, "Bash"}:
             _close_pending_targets(targets)
             return message
         return _attach_bash_filesystem_effects(message, targets) if targets else message
@@ -320,10 +417,12 @@ class _BashFilesystemLeaseTracker:
             _close_pending_targets(targets)
         self._pending_by_id.clear()
         self._seen_call_ids.clear()
+        self._pending_bash_call_ids.clear()
         if self._idless is not None:
             _close_pending_targets(self._idless)
             self._idless = None
         self._idless_active = False
+        self._idless_bash_active = False
 
 
 def _correlated_tool_result_name(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -77,6 +77,7 @@ from ouroboros.harness.claim_term_guard import strict_deterministic_claim_term_g
 from ouroboros.harness.deliver_gate import (
     DeliverEvidenceClaim,
     DeliverEvidenceFact,
+    _journal_entry_proves_command_artifact,
     evaluate_deliver_claim,
     load_ac_evidence_manifest,
 )
@@ -1434,7 +1435,9 @@ def _standard_deliver_facts(
                 continue
             seen.add(dedupe_key)
             matches = (
-                _matching_journal_entries(manifest, field=field, value=match_value)
+                _matching_journal_entries(
+                    manifest, field=field, value=match_value, task_cwd=task_cwd
+                )
                 if eligible
                 else ()
             )
@@ -1486,6 +1489,7 @@ def _matching_journal_entries(
     *,
     field: str,
     value: str,
+    task_cwd: str | None = None,
 ) -> tuple[EvidenceEntry, ...]:
     matches: list[EvidenceEntry] = []
     for entry in manifest.entries:
@@ -1494,6 +1498,11 @@ def _matching_journal_entries(
         payload = entry.payload
         tool_name = payload.get("tool_name")
         if field == "files_touched":
+            if tool_name == "Bash" and _journal_entry_proves_command_artifact(
+                entry, relative_path=value, task_cwd=task_cwd
+            ):
+                matches.append(entry)
+                continue
             if tool_name not in _FILE_MUTATION_TOOLS:
                 continue
             observed = payload.get("workspace_relative_path")

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -327,6 +327,14 @@ def serialize_runtime_message_metadata(
     if tool_result is not None:
         metadata["tool_result"] = tool_result
 
+    # This field is reserved for LeafDispatcher's locally measured dirfd lease
+    # effects.  The dispatcher strips adapter-supplied values before projection;
+    # preserve the measured completion payload so the journal verifier can reuse
+    # that existing authority instead of reconstructing provenance from prose.
+    filesystem_effects = message.data.get("filesystem_effects")
+    if isinstance(filesystem_effects, (list, tuple)):
+        metadata["filesystem_effects"] = _clone_metadata_value(filesystem_effects)
+
     tool_call_id = message.data.get("tool_call_id")
     if isinstance(tool_call_id, str) and tool_call_id.strip():
         metadata["tool_call_id"] = tool_call_id.strip()

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from ouroboros.harness.deliver_gate import (
     RUNTIME_FAILURE_BOOLEAN_FIELDS,
+    RUNTIME_SUCCESS_BOOLEAN_FIELDS,
     RUNTIME_TOOL_EXIT_STATUS_FIELDS,
 )
 from ouroboros.mcp.types import MCPToolResult
@@ -54,7 +55,6 @@ _RUNTIME_FAILED_EVENT_TYPES = frozenset(
 # are metadata only: filesystem authority still comes exclusively from the
 # LeafDispatcher's held dirfd lease.
 _RUNTIME_STATUS_VERDICT_FIELDS = (
-    "success",
     "subtype",
     "status",
     "runtime_status",
@@ -62,6 +62,7 @@ _RUNTIME_STATUS_VERDICT_FIELDS = (
     "runtime_event_type",
 )
 _RUNTIME_VERDICT_FIELDS = (
+    *RUNTIME_SUCCESS_BOOLEAN_FIELDS,
     *RUNTIME_FAILURE_BOOLEAN_FIELDS,
     *RUNTIME_TOOL_EXIT_STATUS_FIELDS,
     *_RUNTIME_STATUS_VERDICT_FIELDS,
@@ -231,15 +232,16 @@ def serialize_runtime_message_metadata(
     from ouroboros.orchestrator.workflow_state import resolve_ac_marker_update
 
     metadata = _project_runtime_verdict_fields(message.data, exclude={"is_error"})
-    raw_meta = message.data.get("meta")
-    if isinstance(raw_meta, Mapping):
-        projected_meta = _project_runtime_verdict_fields(raw_meta)
-        if projected_meta:
-            metadata["meta"] = projected_meta
-    elif raw_meta is not None:
-        # Preserve a JSON-safe poison value.  Dropping a malformed-present
-        # verdict container would let a simultaneous zero exit launder it.
-        metadata["meta"] = True
+    if "meta" in message.data:
+        raw_meta = message.data["meta"]
+        if isinstance(raw_meta, Mapping):
+            projected_meta = _project_runtime_verdict_fields(raw_meta)
+            if projected_meta:
+                metadata["meta"] = projected_meta
+        else:
+            # Preserve a JSON-safe poison value.  Dropping a malformed-present
+            # verdict container would let a simultaneous zero exit launder it.
+            metadata["meta"] = True
 
     message_runtime_event_type = runtime_event_type(message)
     if message_runtime_event_type is not None and "runtime_event_type" not in metadata:
@@ -357,7 +359,7 @@ def serialize_runtime_message_metadata(
 
     if tool_result is not None:
         metadata["tool_result"] = tool_result
-    elif message.data.get("tool_result") is not None:
+    elif "tool_result" in message.data:
         # A malformed-present result container must remain visible to the
         # verifier rather than disappearing during normalization.
         metadata["tool_result"] = True
@@ -567,11 +569,12 @@ def _normalize_tool_result_payload(tool_result: object) -> dict[str, Any] | None
             # signal launder an unknown/failing result into success.
             normalized["is_error_invalid"] = True
 
-    meta = tool_result.get("meta")
-    if isinstance(meta, Mapping):
-        normalized["meta"] = _clone_metadata_value(meta)
-    elif meta is not None:
-        normalized["meta"] = True
+    if "meta" in tool_result:
+        meta = tool_result["meta"]
+        if isinstance(meta, Mapping):
+            normalized["meta"] = _clone_metadata_value(meta)
+        else:
+            normalized["meta"] = True
 
     return normalized
 

--- a/src/ouroboros/orchestrator/runtime_message_projection.py
+++ b/src/ouroboros/orchestrator/runtime_message_projection.py
@@ -6,6 +6,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from ouroboros.harness.deliver_gate import (
+    RUNTIME_FAILURE_BOOLEAN_FIELDS,
+    RUNTIME_TOOL_EXIT_STATUS_FIELDS,
+)
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
@@ -44,6 +48,23 @@ _RUNTIME_FAILED_EVENT_TYPES = frozenset(
         "task.failed",
         "turn.failed",
     }
+)
+
+# Closed command-verdict vocabulary shared with the journal verifier.  These
+# are metadata only: filesystem authority still comes exclusively from the
+# LeafDispatcher's held dirfd lease.
+_RUNTIME_STATUS_VERDICT_FIELDS = (
+    "success",
+    "subtype",
+    "status",
+    "runtime_status",
+    "runtime_signal",
+    "runtime_event_type",
+)
+_RUNTIME_VERDICT_FIELDS = (
+    *RUNTIME_FAILURE_BOOLEAN_FIELDS,
+    *RUNTIME_TOOL_EXIT_STATUS_FIELDS,
+    *_RUNTIME_STATUS_VERDICT_FIELDS,
 )
 
 
@@ -209,9 +230,19 @@ def serialize_runtime_message_metadata(
     """Serialize shared runtime metadata for persisted progress/audit events."""
     from ouroboros.orchestrator.workflow_state import resolve_ac_marker_update
 
-    metadata: dict[str, Any] = {}
+    metadata = _project_runtime_verdict_fields(message.data, exclude={"is_error"})
+    raw_meta = message.data.get("meta")
+    if isinstance(raw_meta, Mapping):
+        projected_meta = _project_runtime_verdict_fields(raw_meta)
+        if projected_meta:
+            metadata["meta"] = projected_meta
+    elif raw_meta is not None:
+        # Preserve a JSON-safe poison value.  Dropping a malformed-present
+        # verdict container would let a simultaneous zero exit launder it.
+        metadata["meta"] = True
+
     message_runtime_event_type = runtime_event_type(message)
-    if message_runtime_event_type is not None:
+    if message_runtime_event_type is not None and "runtime_event_type" not in metadata:
         metadata["runtime_event_type"] = message_runtime_event_type
     if runtime_signal is None or runtime_status is None:
         runtime_signal, runtime_status = derive_runtime_signal(
@@ -253,7 +284,7 @@ def serialize_runtime_message_metadata(
             metadata["recovery_discontinuity"] = dict(recovery_discontinuity)
 
     subtype = message_subtype(message)
-    if subtype:
+    if subtype and "subtype" not in metadata:
         metadata["subtype"] = subtype
 
     session_id = message.data.get("session_id")
@@ -314,10 +345,10 @@ def serialize_runtime_message_metadata(
     if thinking:
         metadata["thinking"] = thinking
 
-    if runtime_signal:
+    if runtime_signal and "runtime_signal" not in metadata:
         metadata["runtime_signal"] = runtime_signal
 
-    if runtime_status:
+    if runtime_status and "runtime_status" not in metadata:
         metadata["runtime_status"] = runtime_status
 
     tool_definition = message.data.get("tool_definition")
@@ -326,6 +357,10 @@ def serialize_runtime_message_metadata(
 
     if tool_result is not None:
         metadata["tool_result"] = tool_result
+    elif message.data.get("tool_result") is not None:
+        # A malformed-present result container must remain visible to the
+        # verifier rather than disappearing during normalization.
+        metadata["tool_result"] = True
 
     # This field is reserved for LeafDispatcher's locally measured dirfd lease
     # effects.  The dispatcher strips adapter-supplied values before projection;
@@ -466,6 +501,20 @@ def _clone_metadata_value(value: Any) -> Any:
     return value
 
 
+def _project_runtime_verdict_fields(
+    value: Mapping[str, Any],
+    *,
+    exclude: set[str] | None = None,
+) -> dict[str, Any]:
+    """Copy only closed command-verdict fields without normalizing failures away."""
+    excluded = exclude or set()
+    return {
+        key: _clone_metadata_value(value[key])
+        for key in _RUNTIME_VERDICT_FIELDS
+        if key in value and key not in excluded
+    }
+
+
 def _normalize_tool_result_payload(tool_result: object) -> dict[str, Any] | None:
     """Normalize an MCP tool result object or mapping into projection-safe data."""
     if isinstance(tool_result, MCPToolResult):
@@ -479,6 +528,7 @@ def _normalize_tool_result_payload(tool_result: object) -> dict[str, Any] | None
         "text_content": "",
         "meta": {},
     }
+    normalized.update(_project_runtime_verdict_fields(tool_result, exclude={"is_error"}))
 
     raw_content = tool_result.get("content")
     if isinstance(raw_content, list | tuple):
@@ -519,7 +569,9 @@ def _normalize_tool_result_payload(tool_result: object) -> dict[str, Any] | None
 
     meta = tool_result.get("meta")
     if isinstance(meta, Mapping):
-        normalized["meta"] = dict(meta)
+        normalized["meta"] = _clone_metadata_value(meta)
+    elif meta is not None:
+        normalized["meta"] = True
 
     return normalized
 

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -1,0 +1,944 @@
+"""Journal-to-verifier coverage for command-scoped Bash artifacts (#1747)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import os
+from pathlib import Path
+import stat
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+import ouroboros.harness.deliver_gate as deliver_gate_module
+from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
+from ouroboros.harness.journal import EvidenceManifest
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor, _standard_deliver_facts
+
+
+class _EventStore:
+    def __init__(self, events: list[BaseEvent]) -> None:
+        self.events = events
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:
+        return [
+            event
+            for event in self.events
+            if event.aggregate_type == aggregate_type and event.aggregate_id == aggregate_id
+        ]
+
+    async def query_execution_related_events(
+        self,
+        execution_id: str,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        del execution_id, event_type, limit, offset
+        return self.events
+
+    async def query_session_related_events(
+        self,
+        session_id: str,
+        execution_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        del session_id, execution_id, event_type, limit, offset
+        return self.events
+
+
+def _effect(path: Path, *, relative_path: str) -> dict[str, object]:
+    current = path.lstat()
+    return {
+        "capture": "ouroboros.leaf-dispatch.v1",
+        "path": relative_path,
+        "workspace_relative_path": relative_path,
+        "st_dev": current.st_dev,
+        "st_ino": current.st_ino,
+        "st_mode": current.st_mode,
+        "st_size": current.st_size,
+        "st_mtime_ns": current.st_mtime_ns,
+        "st_ctime_ns": current.st_ctime_ns,
+    }
+
+
+def _command_events(
+    *,
+    call_id: str,
+    effects: object,
+    retry_attempt: int = 1,
+    session_attempt_id: str = "ac_1_attempt_2",
+    failed: bool = False,
+    when: datetime | None = None,
+) -> list[BaseEvent]:
+    started_at = when or datetime.now(UTC)
+    identity = {
+        "ac_id": "ac_1",
+        "execution_id": "exec_1",
+        "retry_attempt": retry_attempt,
+        "session_attempt_id": session_attempt_id,
+    }
+    return [
+        BaseEvent(
+            id=f"start-{call_id}",
+            type="execution.tool.started",
+            timestamp=started_at,
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                **identity,
+                "tool_name": "Bash",
+                "tool_call_id": call_id,
+                "tool_input": {"command": "printf accepted > claimed.txt"},
+            },
+        ),
+        BaseEvent(
+            id=f"complete-{call_id}",
+            type="execution.tool.completed",
+            timestamp=started_at + timedelta(microseconds=1),
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                **identity,
+                "tool_name": "Bash",
+                "tool_call_id": call_id,
+                "tool_result": {"is_error": failed, "meta": {"exit_status": int(failed)}},
+                "filesystem_effects": effects,
+            },
+        ),
+    ]
+
+
+async def _artifact_fact(
+    events: list[BaseEvent],
+    *,
+    task_cwd: Path,
+    claim: str = "claimed.txt",
+    retry_attempt: int = 1,
+    session_attempt_id: str = "ac_1_attempt_2",
+    ac_id: str = "ac_1",
+    execution_id: str = "exec_1",
+):
+    manifest = await load_ac_evidence_manifest(
+        _EventStore(events),
+        ac_id=ac_id,
+        execution_id=execution_id,
+        admit_accepted_tool_starts=True,
+        accepted_retry_attempt=retry_attempt,
+        accepted_session_attempt_id=session_attempt_id,
+    )
+    facts = _standard_deliver_facts(
+        EvidenceRecord(data={"files_touched": [claim]}),
+        manifest,
+        task_cwd=str(task_cwd),
+        verifier_passed=True,
+    )
+    assert facts is not None and len(facts) == 1
+    return manifest, facts[0]
+
+
+@pytest.mark.asyncio
+async def test_accepted_command_artifact_flows_from_journal_to_verifier(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+
+    manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="accepted", effects=[_effect(artifact, relative_path=artifact.name)]
+        ),
+        task_cwd=tmp_path,
+    )
+
+    assert len(manifest.entries) == 1
+    provenance = manifest.entries[0].payload["command_artifacts"]
+    assert provenance["schema_version"] == 1
+    assert provenance["command_call_id"] == "accepted"
+    assert provenance["retry_attempt"] == 1
+    assert provenance["session_attempt_id"] == "ac_1_attempt_2"
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+async def test_production_capture_persists_through_journal_to_verifier(tmp_path: Path) -> None:
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="write artifact",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": "production-call",
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", "printf accepted > claimed.txt"], cwd=tmp_path, check=True
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="created claimed.txt",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_call_id": "production-call",
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    result = await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    assert result.success is True
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    tool_completion = next(
+        event for event in store.events if event.type == "execution.tool.completed"
+    )
+    assert not deliver_gate_module._event_has_conflicting_tool_call_ids(tool_start)
+    assert not deliver_gate_module._event_has_conflicting_tool_call_ids(tool_completion)
+    assert deliver_gate_module._event_has_explicit_tool_success(
+        tool_completion, require_command_verdict=True
+    ), tool_completion.data
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert len(manifest.entries[0].source_event_ids) == 2
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+async def test_production_malformed_alias_cannot_launder_local_effect(tmp_path: Path) -> None:
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="write artifact",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": "malformed-runtime",
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", "printf accepted > claimed.txt"],
+                cwd=tmp_path,
+                check=True,
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="malformed completion",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_call_id": "malformed-runtime",
+                    "tool_use_id": 7,
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="later valid completion",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_call_id": "malformed-runtime",
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_leaf_dispatcher_stream_strips_forged_completion_effect(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("stale", encoding="utf-8")
+    forged = _effect(artifact, relative_path=artifact.name)
+
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="no mutation",
+                tool_name="Bash",
+                data={"tool_call_id": "forged-call", "tool_input": {"command": "true"}},
+            )
+            subprocess.run(["/bin/sh", "-c", "true"], cwd=tmp_path, check=True)
+            completion_data: dict[str, Any] = {
+                "subtype": "tool_result",
+                "tool_call_id": "forged-call",
+                "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+            }
+
+            def inject_after_observe() -> None:
+                completion_data["filesystem_effects"] = [forged]
+                completion_data["tool_call_id"] = "foreign"
+                completion_data["tool_result"]["meta"]["tool_use_id"] = "nested-foreign"
+
+            asyncio.get_running_loop().call_soon(inject_after_observe)
+            yield AgentMessage(
+                type="assistant",
+                content="done",
+                tool_name="Bash",
+                data=completion_data,
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Do not mutate claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_pending_bash_call_snapshots_late_promoted_completion(tmp_path: Path) -> None:
+    """An ordinary mutable message cannot become a forged result after observation."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("stale", encoding="utf-8")
+    forged = _effect(artifact, relative_path=artifact.name)
+
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="run command",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": "promoted-call",
+                    "tool_input": {"command": "true"},
+                },
+            )
+            promotion_data: dict[str, Any] = {"note": "ordinary"}
+
+            def promote_after_observe() -> None:
+                promotion_data.update(
+                    {
+                        "subtype": "tool_result",
+                        "tool_name": "Bash",
+                        "tool_call_id": "promoted-call",
+                        "tool_result": {
+                            "is_error": False,
+                            "meta": {"exit_status": 0},
+                        },
+                        "filesystem_effects": [forged],
+                    }
+                )
+
+            await executor._execution_counters_lock.acquire()
+            asyncio.get_running_loop().call_soon(promote_after_observe)
+            asyncio.get_running_loop().call_soon(executor._execution_counters_lock.release)
+            yield AgentMessage(
+                type="assistant",
+                content="ordinary before promotion",
+                data=promotion_data,
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Do not mutate claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        execution_counters={},
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_stale_file_without_completion_effect_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "claimed.txt").write_text("stale", encoding="utf-8")
+
+    manifest, fact = await _artifact_fact(
+        _command_events(call_id="stale", effects=[]),
+        task_cwd=tmp_path,
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_only_accepted_retry_artifact_is_authoritative(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    observed = _effect(artifact, relative_path=artifact.name)
+    events = [
+        *_command_events(
+            call_id="old", effects=[observed], retry_attempt=0, session_attempt_id="ac_1_attempt_1"
+        ),
+        *_command_events(call_id="accepted", effects=[observed]),
+    ]
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert len(manifest.entries) == 1
+    assert manifest.entries[0].payload["tool_call_id"] == "accepted"
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+async def test_cross_session_artifact_is_rejected(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("other session", encoding="utf-8")
+
+    manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="other-session",
+            effects=[_effect(artifact, relative_path=artifact.name)],
+            session_attempt_id="ac_1_attempt_foreign",
+        ),
+        task_cwd=tmp_path,
+    )
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda effect: {**effect, "workspace_relative_path": "../claimed.txt"},
+        lambda effect: {**effect, "workspace_relative_path": "/claimed.txt"},
+        lambda effect: {**effect, "workspace_relative_path": "./claimed.txt"},
+        lambda effect: {**effect, "workspace_relative_path": "sub\\claimed.txt"},
+        lambda effect: {**effect, "unknown": "forbidden"},
+        lambda effect: {**effect, "st_ino": "1"},
+        lambda effect: {**effect, "st_mode": stat.S_IFLNK},
+    ),
+)
+async def test_malformed_or_escaping_effect_invalidates_whole_command(
+    tmp_path: Path,
+    mutate,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    malformed = mutate(_effect(artifact, relative_path=artifact.name))
+
+    manifest, fact = await _artifact_fact(
+        _command_events(call_id="malformed", effects=[malformed]),
+        task_cwd=tmp_path,
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_crafted_nested_artifact_invalidates_otherwise_valid_target(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    manifest, _fact = await _artifact_fact(
+        _command_events(
+            call_id="crafted", effects=[_effect(artifact, relative_path=artifact.name)]
+        ),
+        task_cwd=tmp_path,
+    )
+    entry = manifest.entries[0]
+    payload = dict(entry.payload)
+    provenance = dict(payload["command_artifacts"])
+    valid_artifact = dict(provenance["artifacts"][0])
+    provenance["artifacts"] = [valid_artifact, {**valid_artifact, "unknown": "forbidden"}]
+    payload["command_artifacts"] = provenance
+    crafted = EvidenceManifest(
+        ac_id=manifest.ac_id,
+        entries=(entry.model_copy(update={"payload": payload}),),
+    )
+
+    facts = _standard_deliver_facts(
+        EvidenceRecord(data={"files_touched": [artifact.name]}),
+        crafted,
+        task_cwd=str(tmp_path),
+        verifier_passed=True,
+    )
+
+    assert facts is not None
+    assert facts[0].evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_artifact_path_invalidates_whole_command(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    observed = _effect(artifact, relative_path=artifact.name)
+
+    manifest, fact = await _artifact_fact(
+        _command_events(call_id="duplicate", effects=[observed, observed]),
+        task_cwd=tmp_path,
+    )
+
+    assert "command_artifacts" not in manifest.entries[0].payload
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_symlink_escape_is_rejected_at_verifier_boundary(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    (tmp_path / "escape.txt").symlink_to(outside)
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="symlink",
+            effects=[_effect(outside, relative_path="escape.txt")],
+        ),
+        task_cwd=tmp_path,
+        claim="escape.txt",
+    )
+
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_parent_swap_after_workspace_open_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receiver_parent = tmp_path / "sub"
+    receiver_parent.mkdir()
+    artifact = receiver_parent / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    observed = _effect(artifact, relative_path="sub/claimed.txt")
+    displaced_parent = tmp_path / "original-sub"
+    outside_parent = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside_parent.mkdir()
+    os.link(artifact, outside_parent / artifact.name)
+    original_open = deliver_gate_module.os.open
+    swapped = False
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is None and os.fspath(path) == str(tmp_path):
+            receiver_parent.rename(displaced_parent)
+            receiver_parent.symlink_to(outside_parent, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
+    monkeypatch.setattr(
+        deliver_gate_module.os,
+        "supports_dir_fd",
+        {*deliver_gate_module.os.supports_dir_fd, adversarial_open},
+    )
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(call_id="parent-swap", effects=[observed]),
+        task_cwd=tmp_path,
+        claim="sub/claimed.txt",
+    )
+
+    assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_index", (0, 1))
+async def test_conflicting_call_id_aliases_reject_command_authority(
+    tmp_path: Path, event_index: int
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="accepted", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    event = events[event_index]
+    data = dict(event.data)
+    if event_index == 0:
+        data["tool_result"] = {"meta": {"tool_use_id": "foreign"}}
+    else:
+        tool_result = dict(data["tool_result"])
+        tool_result["meta"] = {**tool_result["meta"], "tool_use_id": "foreign"}
+        data["tool_result"] = tool_result
+    events[event_index] = event.model_copy(update={"data": data})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_malformed_named_completion_poisons_later_valid_completion(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="accepted", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    malformed = events[1].model_copy(
+        update={
+            "id": "malformed-completion",
+            "timestamp": events[0].timestamp + timedelta(microseconds=1),
+            "data": {
+                **events[1].data,
+                "tool_result": {
+                    "is_error": False,
+                    "meta": {"exit_status": 0, "tool_use_id": 7},
+                },
+            },
+        }
+    )
+    events[1] = events[1].model_copy(
+        update={"timestamp": events[0].timestamp + timedelta(microseconds=2)}
+    )
+    events.insert(1, malformed)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_malformed_top_meta_alias_rejects_durable_completion(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="accepted", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    events[1] = events[1].model_copy(
+        update={"data": {**events[1].data, "meta": {"tool_use_id": 7}}}
+    )
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_index", (0, 1))
+@pytest.mark.parametrize(
+    ("field", "foreign"),
+    (
+        ("ac_id", "foreign-ac"),
+        ("session_scope_id", "foreign-scope"),
+        ("parent_execution_id", "foreign-execution"),
+        ("attempt_number", 99),
+    ),
+)
+async def test_conflicting_identity_alias_rejects_command_authority(
+    tmp_path: Path,
+    event_index: int,
+    field: str,
+    foreign: object,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="identity", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    event = events[event_index]
+    events[event_index] = event.model_copy(update={"data": {**event.data, field: foreign}})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_index", (0, 1))
+@pytest.mark.parametrize(
+    ("event_field", "foreign"),
+    (("aggregate_id", "foreign-ac"), ("aggregate_type", "session")),
+)
+async def test_conflicting_event_envelope_rejects_command_authority(
+    tmp_path: Path,
+    event_index: int,
+    event_field: str,
+    foreign: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="envelope", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    events[event_index] = events[event_index].model_copy(update={event_field: foreign})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_start_completion_event_ids_reject_command_authority(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="duplicate-id", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    events = [event.model_copy(update={"id": "duplicate-event-id"}) for event in events]
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_artifact_changed_after_completion_is_rejected(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    observed = _effect(artifact, relative_path=artifact.name)
+    artifact.write_text("later attempt", encoding="utf-8")
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(call_id="changed", effects=[observed]),
+        task_cwd=tmp_path,
+    )
+
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_failed_command_cannot_authorize_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+
+    manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="failed",
+            effects=[_effect(artifact, relative_path=artifact.name)],
+            failed=True,
+        ),
+        task_cwd=tmp_path,
+    )
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "failure"),
+    (
+        ("subtype", "error"),
+        ("status", "failed"),
+        ("runtime_status", "failed"),
+        ("runtime_signal", "session_failed"),
+        ("runtime_event_type", "tool.failed"),
+        ("runtime_status", "cancelled"),
+        ("runtime_signal", "tool_timed_out"),
+    ),
+)
+async def test_contradictory_failure_signal_vetoes_success_bits(
+    tmp_path: Path,
+    field: str,
+    failure: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+    events = _command_events(
+        call_id="contradiction", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    events[1] = events[1].model_copy(update={"data": {**events[1].data, field: failure}})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_pre_start_completion_poisons_later_valid_completion(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="out-of-order", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    stale = events[1].model_copy(
+        update={
+            "id": "stale-completion",
+            "timestamp": events[0].timestamp - timedelta(microseconds=1),
+        }
+    )
+
+    manifest, fact = await _artifact_fact([stale, *events], task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_foreign_event_reusing_pair_id_poisons_command_authority(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="target", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    duplicate_id = events[1].model_copy(
+        update={
+            "timestamp": events[1].timestamp + timedelta(microseconds=1),
+            "data": {**events[1].data, "tool_call_id": "foreign"},
+        }
+    )
+
+    manifest, fact = await _artifact_fact([*events, duplicate_id], task_cwd=tmp_path)
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_two_accepted_commands_for_same_artifact_are_ambiguous(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    observed = _effect(artifact, relative_path=artifact.name)
+    events = [
+        *_command_events(call_id="first", effects=[observed]),
+        *_command_events(
+            call_id="second", effects=[observed], when=datetime.now(UTC) + timedelta(seconds=1)
+        ),
+    ]
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert len(manifest.entries) == 2
+    assert fact.evidence_handle == "ambiguous:files_touched:0"

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 from datetime import UTC, datetime, timedelta
+import inspect
 import os
 from pathlib import Path
 import stat
 import subprocess
+import textwrap
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -18,6 +21,7 @@ import ouroboros.harness.deliver_gate as deliver_gate_module
 from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
 from ouroboros.harness.journal import EvidenceManifest
 from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor, _standard_deliver_facts
@@ -196,6 +200,77 @@ def _set_completion_verdict(
     events[1] = events[1].model_copy(update={"data": completion_data})
 
 
+async def _run_production_artifact_route(
+    tmp_path: Path,
+    *,
+    call_id: str,
+    completion_data: dict[str, Any],
+):
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="write artifact",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": call_id,
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", "printf accepted > claimed.txt"],
+                cwd=tmp_path,
+                check=True,
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="command completion",
+                tool_name="Bash",
+                data={"subtype": "tool_result", "tool_call_id": call_id, **completion_data},
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    tool_completion = next(
+        event for event in store.events if event.type == "execution.tool.completed"
+    )
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+    return tool_completion, manifest, fact
+
+
 @pytest.mark.asyncio
 async def test_accepted_command_artifact_flows_from_journal_to_verifier(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
@@ -304,7 +379,10 @@ async def test_production_capture_persists_through_journal_to_verifier(tmp_path:
             if field != "is_error"
         ),
         ("failure", "yes"),
+        ("isError", "yes"),
         ("success", False),
+        ("ok", False),
+        ("ok", "yes"),
         ("status", "failed"),
         *((field, 9) for field in deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS),
     ),
@@ -398,6 +476,72 @@ async def test_production_projection_cannot_launder_command_failure_verdict(
 
     assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
     assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("completion_data", "poison_key"),
+    (
+        ({"meta": None, "tool_result": {"is_error": False, "meta": {"exit_status": 0}}}, "meta"),
+        ({"is_error": False, "tool_result": None}, "tool_result"),
+    ),
+)
+async def test_production_projection_preserves_present_null_container_as_poison(
+    tmp_path: Path,
+    completion_data: dict[str, Any],
+    poison_key: str,
+) -> None:
+    tool_completion, manifest, fact = await _run_production_artifact_route(
+        tmp_path,
+        call_id=f"null-{poison_key}",
+        completion_data=completion_data,
+    )
+
+    assert tool_completion.data[poison_key] is True
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "neutral"),
+    (
+        ("ok", True),
+        ("isError", False),
+        ("exit", 0),
+        ("errorCode", 0),
+        ("error_code", 0),
+    ),
+)
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_production_projection_preserves_neutral_codex_verdict_alias(
+    tmp_path: Path,
+    location: str,
+    field: str,
+    neutral: object,
+) -> None:
+    completion_data: dict[str, Any] = {
+        "tool_result": {"is_error": False, "meta": {"exit_status": 0}}
+    }
+    _set_verdict_payload(
+        completion_data,
+        location=location,
+        field=field,
+        value=neutral,
+    )
+
+    tool_completion, manifest, fact = await _run_production_artifact_route(
+        tmp_path,
+        call_id=f"neutral-{location}-{field}",
+        completion_data=completion_data,
+    )
+
+    assert _verdict_payload_value(tool_completion.data, location=location, field=field) == neutral
+    assert len(manifest.entries) == 1
+    assert "command_artifacts" in manifest.entries[0].payload
+    assert fact.evidence_handle == manifest.entries[0].handle
 
 
 @pytest.mark.asyncio
@@ -829,6 +973,89 @@ async def test_parent_swap_after_workspace_open_is_rejected(
 
 
 @pytest.mark.asyncio
+async def test_parent_swap_after_child_dirfd_open_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receiver_parent = tmp_path / "sub"
+    receiver_parent.mkdir()
+    artifact = receiver_parent / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    observed = _effect(artifact, relative_path="sub/claimed.txt")
+    displaced_parent = tmp_path / "original-sub"
+    outside_parent = tmp_path.parent / f"{tmp_path.name}-outside-after-open"
+    outside_parent.mkdir()
+    os.link(artifact, outside_parent / artifact.name)
+    original_open = deliver_gate_module.os.open
+    swapped = False
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is not None and os.fspath(path) == "sub":
+            receiver_parent.rename(displaced_parent)
+            receiver_parent.symlink_to(outside_parent, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
+    monkeypatch.setattr(
+        deliver_gate_module.os,
+        "supports_dir_fd",
+        {*deliver_gate_module.os.supports_dir_fd, adversarial_open},
+    )
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(call_id="parent-swap-after-child-open", effects=[observed]),
+        task_cwd=tmp_path,
+        claim="sub/claimed.txt",
+    )
+
+    assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_workspace_swap_after_root_dirfd_open_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = workspace / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    observed = _effect(artifact, relative_path=artifact.name)
+    displaced_workspace = tmp_path / "original-workspace"
+    outside_workspace = tmp_path / "outside-workspace"
+    outside_workspace.mkdir()
+    os.link(artifact, outside_workspace / artifact.name)
+    original_open = deliver_gate_module.os.open
+    swapped = False
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is None and os.fspath(path) == str(workspace):
+            workspace.rename(displaced_workspace)
+            workspace.symlink_to(outside_workspace, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
+    monkeypatch.setattr(
+        deliver_gate_module.os,
+        "supports_dir_fd",
+        {*deliver_gate_module.os.supports_dir_fd, adversarial_open},
+    )
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(call_id="workspace-swap-after-root-open", effects=[observed]),
+        task_cwd=workspace,
+    )
+
+    assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("event_index", (0, 1))
 async def test_conflicting_call_id_aliases_reject_command_authority(
     tmp_path: Path, event_index: int
@@ -1080,7 +1307,7 @@ async def test_nested_and_boolean_failure_verdicts_veto_journal_authority(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("field", ("failure", "cancel", "abort"))
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError"))
 @pytest.mark.parametrize(
     "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
 )
@@ -1104,7 +1331,7 @@ async def test_boolean_failure_aliases_veto_journal_authority(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("field", ("failure", "cancel", "abort"))
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError"))
 @pytest.mark.parametrize(
     "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
 )
@@ -1120,6 +1347,31 @@ async def test_false_boolean_failure_aliases_are_neutral(
         effects=[_effect(artifact, relative_path=artifact.name)],
     )
     _set_completion_verdict(events, location=location, field=field, value=False)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert len(manifest.entries) == 1
+    assert "command_artifacts" in manifest.entries[0].payload
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", deliver_gate_module.RUNTIME_SUCCESS_BOOLEAN_FIELDS)
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_true_success_aliases_are_neutral(
+    tmp_path: Path,
+    location: str,
+    field: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    events = _command_events(
+        call_id=f"{location}-{field}-true",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    _set_completion_verdict(events, location=location, field=field, value=True)
 
     manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
 
@@ -1187,17 +1439,26 @@ async def test_zero_exit_status_aliases_are_neutral(
 
 def test_exit_status_alias_vocabulary_matches_runtime_normalizer() -> None:
     aliases = deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS
-
-    assert aliases == (
-        "exit_code",
-        "exit_status",
-        "exitCode",
-        "exitStatus",
-        "returncode",
-        "return_code",
-        "status_code",
-        "statusCode",
+    normalizer = ast.parse(
+        textwrap.dedent(inspect.getsource(CodexCliRuntime._resolve_item_completion_is_error))
     )
+    declared_aliases: set[str] = set()
+    for node in ast.walk(normalizer):
+        if not isinstance(node, ast.For) or not isinstance(node.target, ast.Name):
+            continue
+        if node.target.id not in {"exit_key", "fail_key"}:
+            continue
+        if not isinstance(node.iter, (ast.Tuple, ast.List)):
+            continue
+        declared_aliases.update(
+            item.value
+            for item in node.iter.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        )
+
+    assert declared_aliases
+    assert declared_aliases <= set(aliases)
+    assert {"exit", "errorCode", "error_code"} <= declared_aliases
     assert len(aliases) == len(set(aliases))
 
 

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -927,6 +927,85 @@ async def test_nested_and_boolean_failure_verdicts_veto_journal_authority(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("location", "failure"),
+    (
+        ("top_level", {"status": "mystery"}),
+        ("top_level", {"status": "running"}),
+        ("top_level", {"runtime_signal": "tool_mystery"}),
+        ("tool_result", {"status": "mystery"}),
+        ("tool_result_meta", {"status": "mystery"}),
+        ("top_level_meta", {"runtime_status": "pending"}),
+        (
+            "tool_result_meta",
+            {"status": "completed", "runtime_signal": "tool_mystery"},
+        ),
+    ),
+)
+async def test_unknown_or_in_progress_status_vetoes_journal_authority(
+    tmp_path: Path,
+    location: str,
+    failure: dict[str, str],
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+    events = _command_events(
+        call_id="unknown-status",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    completion_data = dict(events[1].data)
+    if location == "top_level":
+        completion_data.update(failure)
+    elif location == "top_level_meta":
+        completion_data["meta"] = failure
+    else:
+        tool_result = dict(completion_data["tool_result"])
+        if location == "tool_result":
+            tool_result.update(failure)
+        else:
+            tool_result["meta"] = {**tool_result["meta"], **failure}
+        completion_data["tool_result"] = tool_result
+    events[1] = events[1].model_copy(update={"data": completion_data})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "success_status",
+    (
+        {"status": "completed"},
+        {"status": "success"},
+        {"status": "succeeded"},
+        {"runtime_event_type": "tool.completed"},
+        {"runtime_event_type": "tool.output"},
+        {"runtime_event_type": "tool.result"},
+        {"runtime_event_type": "run.completed"},
+        {"runtime_signal": "tool_completed", "runtime_status": "running"},
+    ),
+)
+async def test_closed_terminal_success_status_preserves_journal_authority(
+    tmp_path: Path,
+    success_status: dict[str, str],
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    events = _command_events(
+        call_id="closed-success",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    events[1] = events[1].model_copy(update={"data": {**events[1].data, **success_status}})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries[0].payload.get("command_artifacts") is not None
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
 async def test_pre_start_completion_poisons_later_valid_completion(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
     artifact.write_text("captured", encoding="utf-8")

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -887,6 +887,46 @@ async def test_contradictory_failure_signal_vetoes_success_bits(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("location", "field", "failure"),
+    (
+        ("tool_result_meta", "status", "failed"),
+        ("tool_result_meta", "success", False),
+        ("top_level", "cancelled", True),
+        ("top_level", "timed_out", True),
+        ("top_level", "aborted", True),
+        ("tool_result_meta", "success", "false"),
+        ("top_level", "cancelled", "yes"),
+    ),
+)
+async def test_nested_and_boolean_failure_verdicts_veto_journal_authority(
+    tmp_path: Path,
+    location: str,
+    field: str,
+    failure: object,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+    events = _command_events(
+        call_id="nested-contradiction",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    completion_data = dict(events[1].data)
+    if location == "top_level":
+        completion_data[field] = failure
+    else:
+        tool_result = dict(completion_data["tool_result"])
+        tool_result["meta"] = {**tool_result["meta"], field: failure}
+        completion_data["tool_result"] = tool_result
+    events[1] = events[1].model_copy(update={"data": completion_data})
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
 async def test_pre_start_completion_poisons_later_valid_completion(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
     artifact.write_text("captured", encoding="utf-8")

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -149,6 +149,28 @@ async def _artifact_fact(
     return manifest, facts[0]
 
 
+def _set_completion_verdict(
+    events: list[BaseEvent],
+    *,
+    location: str,
+    field: str,
+    value: object,
+) -> None:
+    completion_data = dict(events[1].data)
+    if location == "top_level":
+        completion_data[field] = value
+    elif location == "top_level_meta":
+        completion_data["meta"] = {field: value}
+    else:
+        tool_result = dict(completion_data["tool_result"])
+        if location == "tool_result":
+            tool_result[field] = value
+        else:
+            tool_result["meta"] = {**tool_result["meta"], field: value}
+        completion_data["tool_result"] = tool_result
+    events[1] = events[1].model_copy(update={"data": completion_data})
+
+
 @pytest.mark.asyncio
 async def test_accepted_command_artifact_flows_from_journal_to_verifier(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
@@ -924,6 +946,55 @@ async def test_nested_and_boolean_failure_verdicts_veto_journal_authority(
 
     assert manifest.entries == ()
     assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort"))
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_boolean_failure_aliases_veto_journal_authority(
+    tmp_path: Path,
+    location: str,
+    field: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+    events = _command_events(
+        call_id=f"{location}-{field}-true",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    _set_completion_verdict(events, location=location, field=field, value=True)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort"))
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_false_boolean_failure_aliases_are_neutral(
+    tmp_path: Path,
+    location: str,
+    field: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    events = _command_events(
+        call_id=f"{location}-{field}-false",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    _set_completion_verdict(events, location=location, field=field, value=False)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert len(manifest.entries) == 1
+    assert "command_artifacts" in manifest.entries[0].payload
+    assert fact.evidence_handle == manifest.entries[0].handle
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -149,14 +149,13 @@ async def _artifact_fact(
     return manifest, facts[0]
 
 
-def _set_completion_verdict(
-    events: list[BaseEvent],
+def _set_verdict_payload(
+    completion_data: dict[str, Any],
     *,
     location: str,
     field: str,
     value: object,
 ) -> None:
-    completion_data = dict(events[1].data)
     if location == "top_level":
         completion_data[field] = value
     elif location == "top_level_meta":
@@ -168,6 +167,32 @@ def _set_completion_verdict(
         else:
             tool_result["meta"] = {**tool_result["meta"], field: value}
         completion_data["tool_result"] = tool_result
+
+
+def _verdict_payload_value(data: dict[str, Any], *, location: str, field: str) -> object:
+    if location == "top_level":
+        return data[field]
+    if location == "top_level_meta":
+        return data["meta"][field]
+    if location == "tool_result":
+        return data["tool_result"][field]
+    return data["tool_result"]["meta"][field]
+
+
+def _set_completion_verdict(
+    events: list[BaseEvent],
+    *,
+    location: str,
+    field: str,
+    value: object,
+) -> None:
+    completion_data = dict(events[1].data)
+    _set_verdict_payload(
+        completion_data,
+        location=location,
+        field=field,
+        value=value,
+    )
     events[1] = events[1].model_copy(update={"data": completion_data})
 
 
@@ -267,6 +292,112 @@ async def test_production_capture_persists_through_journal_to_verifier(tmp_path:
 
     assert len(manifest.entries[0].source_event_ids) == 2
     assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "failure"),
+    (
+        *(
+            (field, True)
+            for field in deliver_gate_module.RUNTIME_FAILURE_BOOLEAN_FIELDS
+            if field != "is_error"
+        ),
+        ("failure", "yes"),
+        ("success", False),
+        ("status", "failed"),
+        *((field, 9) for field in deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS),
+    ),
+)
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_production_projection_cannot_launder_command_failure_verdict(
+    tmp_path: Path,
+    location: str,
+    field: str,
+    failure: object,
+) -> None:
+    call_id = f"projection-{location}-{field}"
+
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="write artifact",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": call_id,
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", "printf accepted > claimed.txt"],
+                cwd=tmp_path,
+                check=True,
+            )
+            completion_data: dict[str, Any] = {
+                "subtype": "tool_result",
+                "tool_call_id": call_id,
+                "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+            }
+            _set_verdict_payload(
+                completion_data,
+                location=location,
+                field=field,
+                value=failure,
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="contradictory completion",
+                tool_name="Bash",
+                data=completion_data,
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    tool_completion = next(
+        event for event in store.events if event.type == "execution.tool.completed"
+    )
+    assert _verdict_payload_value(tool_completion.data, location=location, field=field) == failure
+
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
 
 
 @pytest.mark.asyncio
@@ -995,6 +1126,79 @@ async def test_false_boolean_failure_aliases_are_neutral(
     assert len(manifest.entries) == 1
     assert "command_artifacts" in manifest.entries[0].payload
     assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field",
+    deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS,
+)
+@pytest.mark.parametrize("failure", (True, "1", 9))
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_exit_status_aliases_veto_journal_authority(
+    tmp_path: Path,
+    location: str,
+    failure: object,
+    field: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("failed", encoding="utf-8")
+    events = _command_events(
+        call_id=f"{location}-{field}-failed",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    _set_completion_verdict(events, location=location, field=field, value=failure)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field",
+    deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS,
+)
+@pytest.mark.parametrize(
+    "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
+)
+async def test_zero_exit_status_aliases_are_neutral(
+    tmp_path: Path,
+    location: str,
+    field: str,
+) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    events = _command_events(
+        call_id=f"{location}-{field}-zero",
+        effects=[_effect(artifact, relative_path=artifact.name)],
+    )
+    _set_completion_verdict(events, location=location, field=field, value=0)
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    assert len(manifest.entries) == 1
+    assert "command_artifacts" in manifest.entries[0].payload
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+def test_exit_status_alias_vocabulary_matches_runtime_normalizer() -> None:
+    aliases = deliver_gate_module.RUNTIME_TOOL_EXIT_STATUS_FIELDS
+
+    assert aliases == (
+        "exit_code",
+        "exit_status",
+        "exitCode",
+        "exitStatus",
+        "returncode",
+        "return_code",
+        "status_code",
+        "statusCode",
+    )
+    assert len(aliases) == len(set(aliases))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -370,6 +370,116 @@ async def test_production_capture_persists_through_journal_to_verifier(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_production_route_rejects_intermediate_task_cwd_ancestor_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real dispatch-to-journal route rejects a pre-linked ancestor escape."""
+    ancestor = tmp_path / "trusted-ancestor"
+    workspace = ancestor / "workspace"
+    workspace.mkdir(parents=True)
+    artifact = workspace / "claimed.txt"
+    artifact.write_text("before", encoding="utf-8")
+    displaced_ancestor = tmp_path / "displaced-ancestor"
+    outside_ancestor = tmp_path / "outside-ancestor"
+    outside_workspace = outside_ancestor / workspace.name
+    outside_workspace.mkdir(parents=True)
+    outside_artifact = outside_workspace / artifact.name
+    os.link(artifact, outside_artifact)
+    expected_before_swap = _effect(artifact, relative_path=artifact.name)
+    assert expected_before_swap == _effect(outside_artifact, relative_path=artifact.name)
+    original_open = os.open
+    swapped = False
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is not None and os.fspath(path) == ancestor.name:
+            assert expected_before_swap == _effect(artifact, relative_path=artifact.name)
+            ancestor.rename(displaced_ancestor)
+            ancestor.symlink_to(outside_ancestor, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(os, "open", adversarial_open)
+    monkeypatch.setattr(os, "supports_dir_fd", {*os.supports_dir_fd, adversarial_open})
+
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(workspace)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="write artifact",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": "production-ancestor-swap",
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", "printf accepted > claimed.txt"],
+                cwd=workspace,
+                check=True,
+            )
+            yield AgentMessage(
+                type="assistant",
+                content="created claimed.txt",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_call_id": "production-ancestor-swap",
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(workspace),
+        run_verify_commands=False,
+    )
+    result = await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    tool_completion = next(
+        event for event in store.events if event.type == "execution.tool.completed"
+    )
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=workspace,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert result.success is False
+    assert swapped is True
+    assert _effect(outside_artifact, relative_path=artifact.name) != expected_before_swap
+    assert "filesystem_effects" not in tool_completion.data
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("field", "failure"),
     (
@@ -933,7 +1043,7 @@ async def test_symlink_escape_is_rejected_at_verifier_boundary(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_parent_swap_after_workspace_open_is_rejected(
+async def test_parent_swap_after_workspace_component_open_is_rejected(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     receiver_parent = tmp_path / "sub"
@@ -952,7 +1062,7 @@ async def test_parent_swap_after_workspace_open_is_rejected(
     def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
         nonlocal swapped
         fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if not swapped and dir_fd is None and os.fspath(path) == str(tmp_path):
+        if not swapped and dir_fd is not None and os.fspath(path) == tmp_path.name:
             receiver_parent.rename(displaced_parent)
             receiver_parent.symlink_to(outside_parent, target_is_directory=True)
             swapped = True
@@ -1026,6 +1136,57 @@ async def test_parent_swap_after_child_dirfd_open_is_rejected(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("swap_on_open", (1, 2), ids=("lease", "rewalk"))
+async def test_intermediate_workspace_ancestor_swap_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    swap_on_open: int,
+) -> None:
+    ancestor = tmp_path / "trusted-ancestor"
+    workspace = ancestor / "workspace"
+    workspace.mkdir(parents=True)
+    artifact = workspace / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    displaced_ancestor = tmp_path / "original-ancestor"
+    outside_ancestor = tmp_path / "outside-ancestor"
+    outside_workspace = outside_ancestor / workspace.name
+    outside_workspace.mkdir(parents=True)
+    os.link(artifact, outside_workspace / artifact.name)
+    observed = _effect(artifact, relative_path=artifact.name)
+    assert observed == _effect(artifact, relative_path=artifact.name)
+    original_open = deliver_gate_module.os.open
+    swapped = False
+    matching_open_count = 0
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal matching_open_count, swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if dir_fd is not None and os.fspath(path) == ancestor.name:
+            matching_open_count += 1
+            if not swapped and matching_open_count == swap_on_open:
+                assert observed == _effect(artifact, relative_path=artifact.name)
+                ancestor.rename(displaced_ancestor)
+                ancestor.symlink_to(outside_ancestor, target_is_directory=True)
+                swapped = True
+        return fd
+
+    monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
+    monkeypatch.setattr(
+        deliver_gate_module.os,
+        "supports_dir_fd",
+        {*deliver_gate_module.os.supports_dir_fd, adversarial_open},
+    )
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(call_id=f"intermediate-ancestor-swap-{swap_on_open}", effects=[observed]),
+        task_cwd=workspace,
+    )
+
+    assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("swap_on_open", (1, 2), ids=("lease", "rewalk"))
 async def test_workspace_swap_after_root_dirfd_open_is_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1048,9 +1209,10 @@ async def test_workspace_swap_after_root_dirfd_open_is_rejected(
     def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
         nonlocal matching_open_count, swapped
         fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if dir_fd is None and os.fspath(path) == str(workspace):
+        if dir_fd is not None and os.fspath(path) == workspace.name:
             matching_open_count += 1
             if not swapped and matching_open_count == swap_on_open:
+                assert observed == _effect(artifact, relative_path=artifact.name)
                 workspace.rename(displaced_workspace)
                 workspace.symlink_to(outside_workspace, target_is_directory=True)
                 swapped = True
@@ -1071,6 +1233,28 @@ async def test_workspace_swap_after_root_dirfd_open_is_rejected(
     )
 
     assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_static_intermediate_task_cwd_symlink_is_rejected(tmp_path: Path) -> None:
+    outside_ancestor = tmp_path / "outside-ancestor"
+    outside_workspace = outside_ancestor / "workspace"
+    outside_workspace.mkdir(parents=True)
+    artifact = outside_workspace / "claimed.txt"
+    artifact.write_text("outside", encoding="utf-8")
+    ancestor = tmp_path / "linked-ancestor"
+    ancestor.symlink_to(outside_ancestor, target_is_directory=True)
+    linked_workspace = ancestor / outside_workspace.name
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="static-intermediate-symlink",
+            effects=[_effect(artifact, relative_path=artifact.name)],
+        ),
+        task_cwd=linked_workspace,
+    )
+
     assert fact.evidence_handle == "missing:files_touched:0"
 
 

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -379,6 +379,7 @@ async def test_production_capture_persists_through_journal_to_verifier(tmp_path:
             if field != "is_error"
         ),
         ("failure", "yes"),
+        ("is_error_invalid", "yes"),
         ("isError", "yes"),
         ("success", False),
         ("ok", False),
@@ -507,6 +508,7 @@ async def test_production_projection_preserves_present_null_container_as_poison(
     ("field", "neutral"),
     (
         ("ok", True),
+        ("is_error_invalid", False),
         ("isError", False),
         ("exit", 0),
         ("errorCode", 0),
@@ -516,7 +518,7 @@ async def test_production_projection_preserves_present_null_container_as_poison(
 @pytest.mark.parametrize(
     "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
 )
-async def test_production_projection_preserves_neutral_codex_verdict_alias(
+async def test_production_projection_preserves_neutral_runtime_verdict_alias(
     tmp_path: Path,
     location: str,
     field: str,
@@ -938,11 +940,12 @@ async def test_parent_swap_after_workspace_open_is_rejected(
     receiver_parent.mkdir()
     artifact = receiver_parent / "claimed.txt"
     artifact.write_text("captured", encoding="utf-8")
-    observed = _effect(artifact, relative_path="sub/claimed.txt")
     displaced_parent = tmp_path / "original-sub"
     outside_parent = tmp_path.parent / f"{tmp_path.name}-outside"
     outside_parent.mkdir()
     os.link(artifact, outside_parent / artifact.name)
+    observed = _effect(artifact, relative_path="sub/claimed.txt")
+    assert observed == _effect(artifact, relative_path="sub/claimed.txt")
     original_open = deliver_gate_module.os.open
     swapped = False
 
@@ -973,28 +976,35 @@ async def test_parent_swap_after_workspace_open_is_rejected(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("swap_on_open", (1, 2), ids=("lease", "rewalk"))
 async def test_parent_swap_after_child_dirfd_open_is_rejected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    swap_on_open: int,
 ) -> None:
     receiver_parent = tmp_path / "sub"
     receiver_parent.mkdir()
     artifact = receiver_parent / "claimed.txt"
     artifact.write_text("captured", encoding="utf-8")
-    observed = _effect(artifact, relative_path="sub/claimed.txt")
     displaced_parent = tmp_path / "original-sub"
     outside_parent = tmp_path.parent / f"{tmp_path.name}-outside-after-open"
     outside_parent.mkdir()
     os.link(artifact, outside_parent / artifact.name)
+    observed = _effect(artifact, relative_path="sub/claimed.txt")
+    assert observed == _effect(artifact, relative_path="sub/claimed.txt")
     original_open = deliver_gate_module.os.open
     swapped = False
+    matching_open_count = 0
 
     def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
-        nonlocal swapped
+        nonlocal matching_open_count, swapped
         fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if not swapped and dir_fd is not None and os.fspath(path) == "sub":
-            receiver_parent.rename(displaced_parent)
-            receiver_parent.symlink_to(outside_parent, target_is_directory=True)
-            swapped = True
+        if dir_fd is not None and os.fspath(path) == "sub":
+            matching_open_count += 1
+            if not swapped and matching_open_count == swap_on_open:
+                receiver_parent.rename(displaced_parent)
+                receiver_parent.symlink_to(outside_parent, target_is_directory=True)
+                swapped = True
         return fd
 
     monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
@@ -1005,7 +1015,7 @@ async def test_parent_swap_after_child_dirfd_open_is_rejected(
     )
 
     _manifest, fact = await _artifact_fact(
-        _command_events(call_id="parent-swap-after-child-open", effects=[observed]),
+        _command_events(call_id=f"parent-swap-after-child-open-{swap_on_open}", effects=[observed]),
         task_cwd=tmp_path,
         claim="sub/claimed.txt",
     )
@@ -1015,28 +1025,35 @@ async def test_parent_swap_after_child_dirfd_open_is_rejected(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("swap_on_open", (1, 2), ids=("lease", "rewalk"))
 async def test_workspace_swap_after_root_dirfd_open_is_rejected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    swap_on_open: int,
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     artifact = workspace / "claimed.txt"
     artifact.write_text("captured", encoding="utf-8")
-    observed = _effect(artifact, relative_path=artifact.name)
     displaced_workspace = tmp_path / "original-workspace"
     outside_workspace = tmp_path / "outside-workspace"
     outside_workspace.mkdir()
     os.link(artifact, outside_workspace / artifact.name)
+    observed = _effect(artifact, relative_path=artifact.name)
+    assert observed == _effect(artifact, relative_path=artifact.name)
     original_open = deliver_gate_module.os.open
     swapped = False
+    matching_open_count = 0
 
     def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
-        nonlocal swapped
+        nonlocal matching_open_count, swapped
         fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if not swapped and dir_fd is None and os.fspath(path) == str(workspace):
-            workspace.rename(displaced_workspace)
-            workspace.symlink_to(outside_workspace, target_is_directory=True)
-            swapped = True
+        if dir_fd is None and os.fspath(path) == str(workspace):
+            matching_open_count += 1
+            if not swapped and matching_open_count == swap_on_open:
+                workspace.rename(displaced_workspace)
+                workspace.symlink_to(outside_workspace, target_is_directory=True)
+                swapped = True
         return fd
 
     monkeypatch.setattr(deliver_gate_module.os, "open", adversarial_open)
@@ -1047,10 +1064,67 @@ async def test_workspace_swap_after_root_dirfd_open_is_rejected(
     )
 
     _manifest, fact = await _artifact_fact(
-        _command_events(call_id="workspace-swap-after-root-open", effects=[observed]),
+        _command_events(
+            call_id=f"workspace-swap-after-root-open-{swap_on_open}", effects=[observed]
+        ),
         task_cwd=workspace,
     )
 
+    assert swapped is True
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("swap_target", ("parent", "workspace_root"))
+async def test_namespace_swap_after_current_leaf_fstat_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    swap_target: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    if swap_target == "parent":
+        namespace_path = workspace / "sub"
+        namespace_path.mkdir()
+        relative_path = "sub/claimed.txt"
+    else:
+        namespace_path = workspace
+        relative_path = "claimed.txt"
+    artifact = workspace / relative_path
+    artifact.write_text("captured", encoding="utf-8")
+    displaced_namespace = tmp_path / f"displaced-{swap_target}"
+    outside_namespace = tmp_path / f"outside-{swap_target}"
+    outside_namespace.mkdir()
+    os.link(artifact, outside_namespace / artifact.name)
+    observed = _effect(artifact, relative_path=relative_path)
+    assert observed == _effect(artifact, relative_path=relative_path)
+    original_fstat = deliver_gate_module.os.fstat
+    regular_fstat_count = 0
+    swapped = False
+
+    def adversarial_fstat(fd: int):
+        nonlocal regular_fstat_count, swapped
+        current = original_fstat(fd)
+        if stat.S_ISREG(current.st_mode):
+            regular_fstat_count += 1
+            if not swapped and regular_fstat_count == 2:
+                namespace_path.rename(displaced_namespace)
+                namespace_path.symlink_to(outside_namespace, target_is_directory=True)
+                swapped = True
+        return current
+
+    monkeypatch.setattr(deliver_gate_module.os, "fstat", adversarial_fstat)
+
+    _manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id=f"namespace-swap-after-current-leaf-fstat-{swap_target}",
+            effects=[observed],
+        ),
+        task_cwd=workspace,
+        claim=relative_path,
+    )
+
+    assert regular_fstat_count >= 2
     assert swapped is True
     assert fact.evidence_handle == "missing:files_touched:0"
 
@@ -1307,7 +1381,7 @@ async def test_nested_and_boolean_failure_verdicts_veto_journal_authority(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError"))
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError", "is_error_invalid"))
 @pytest.mark.parametrize(
     "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
 )
@@ -1331,7 +1405,7 @@ async def test_boolean_failure_aliases_veto_journal_authority(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError"))
+@pytest.mark.parametrize("field", ("failure", "cancel", "abort", "isError", "is_error_invalid"))
 @pytest.mark.parametrize(
     "location", ("top_level", "top_level_meta", "tool_result", "tool_result_meta")
 )

--- a/tests/unit/orchestrator/test_command_artifact_provenance.py
+++ b/tests/unit/orchestrator/test_command_artifact_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 import inspect
 import os
@@ -16,6 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ouroboros.core.filesystem_capability import open_nofollow_directory_chain
 from ouroboros.events.base import BaseEvent
 import ouroboros.harness.deliver_gate as deliver_gate_module
 from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
@@ -63,12 +65,28 @@ class _EventStore:
         return self.events
 
 
+def _workspace_chain_payload(workspace: Path) -> list[dict[str, int | str]]:
+    workspace_chain = open_nofollow_directory_chain(workspace)
+    try:
+        workspace_fingerprint = workspace_chain.fingerprint()
+    finally:
+        workspace_chain.close()
+    return [
+        {"name": name, "st_dev": device, "st_ino": inode, "st_mode": mode}
+        for name, device, inode, mode in workspace_fingerprint
+    ]
+
+
 def _effect(path: Path, *, relative_path: str) -> dict[str, object]:
     current = path.lstat()
+    workspace = path
+    for _part in Path(relative_path).parts:
+        workspace = workspace.parent
     return {
         "capture": "ouroboros.leaf-dispatch.v1",
         "path": relative_path,
         "workspace_relative_path": relative_path,
+        "workspace_chain": _workspace_chain_payload(workspace),
         "st_dev": current.st_dev,
         "st_ino": current.st_ino,
         "st_mode": current.st_mode,
@@ -205,6 +223,7 @@ async def _run_production_artifact_route(
     *,
     call_id: str,
     completion_data: dict[str, Any],
+    before_verify: Callable[[], None] | None = None,
 ):
     class StubRuntime:
         runtime_backend = "opencode"
@@ -262,6 +281,8 @@ async def _run_production_artifact_route(
     tool_completion = next(
         event for event in store.events if event.type == "execution.tool.completed"
     )
+    if before_verify is not None:
+        before_verify()
     manifest, fact = await _artifact_fact(
         store.events,
         task_cwd=tmp_path,
@@ -289,6 +310,7 @@ async def test_accepted_command_artifact_flows_from_journal_to_verifier(tmp_path
     assert provenance["command_call_id"] == "accepted"
     assert provenance["retry_attempt"] == 1
     assert provenance["session_attempt_id"] == "ac_1_attempt_2"
+    assert provenance["workspace_chain"][0]["name"] == os.sep
     assert fact.evidence_handle == manifest.entries[0].handle
 
 
@@ -372,37 +394,33 @@ async def test_production_capture_persists_through_journal_to_verifier(tmp_path:
 @pytest.mark.asyncio
 async def test_production_route_rejects_intermediate_task_cwd_ancestor_swap(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real dispatch-to-journal route rejects a pre-linked ancestor escape."""
+    """The real route rejects ordinary ancestor replacement before Bash start."""
     ancestor = tmp_path / "trusted-ancestor"
     workspace = ancestor / "workspace"
     workspace.mkdir(parents=True)
     artifact = workspace / "claimed.txt"
     artifact.write_text("before", encoding="utf-8")
     displaced_ancestor = tmp_path / "displaced-ancestor"
-    outside_ancestor = tmp_path / "outside-ancestor"
-    outside_workspace = outside_ancestor / workspace.name
-    outside_workspace.mkdir(parents=True)
-    outside_artifact = outside_workspace / artifact.name
-    os.link(artifact, outside_artifact)
+    replacement_ancestor = tmp_path / "replacement-ancestor"
+    replacement_workspace = replacement_ancestor / workspace.name
+    replacement_workspace.mkdir(parents=True)
+    replacement_artifact = replacement_workspace / artifact.name
+    os.link(artifact, replacement_artifact)
     expected_before_swap = _effect(artifact, relative_path=artifact.name)
-    assert expected_before_swap == _effect(outside_artifact, relative_path=artifact.name)
-    original_open = os.open
+    leaf_identity_keys = (
+        "st_dev",
+        "st_ino",
+        "st_mode",
+        "st_size",
+        "st_mtime_ns",
+        "st_ctime_ns",
+    )
+    replacement_before_swap = _effect(replacement_artifact, relative_path=artifact.name)
+    assert tuple(expected_before_swap[key] for key in leaf_identity_keys) == tuple(
+        replacement_before_swap[key] for key in leaf_identity_keys
+    )
     swapped = False
-
-    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
-        nonlocal swapped
-        fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if not swapped and dir_fd is not None and os.fspath(path) == ancestor.name:
-            assert expected_before_swap == _effect(artifact, relative_path=artifact.name)
-            ancestor.rename(displaced_ancestor)
-            ancestor.symlink_to(outside_ancestor, target_is_directory=True)
-            swapped = True
-        return fd
-
-    monkeypatch.setattr(os, "open", adversarial_open)
-    monkeypatch.setattr(os, "supports_dir_fd", {*os.supports_dir_fd, adversarial_open})
 
     class StubRuntime:
         runtime_backend = "opencode"
@@ -410,6 +428,18 @@ async def test_production_route_rejects_intermediate_task_cwd_ancestor_swap(
         working_directory = str(workspace)
 
         async def execute_task(self, **_kwargs: Any):
+            nonlocal swapped
+            assert expected_before_swap == _effect(artifact, relative_path=artifact.name)
+            ancestor.rename(displaced_ancestor)
+            replacement_ancestor.rename(ancestor)
+            swapped = True
+            replacement_after_swap = _effect(
+                workspace / artifact.name,
+                relative_path=artifact.name,
+            )
+            assert tuple(expected_before_swap[key] for key in leaf_identity_keys) == tuple(
+                replacement_after_swap[key] for key in leaf_identity_keys
+            )
             yield AgentMessage(
                 type="assistant",
                 content="write artifact",
@@ -471,11 +501,49 @@ async def test_production_route_rejects_intermediate_task_cwd_ancestor_swap(
         session_attempt_id=str(tool_start.data["session_attempt_id"]),
     )
 
-    assert result.success is False
+    assert result.success is True
     assert swapped is True
-    assert _effect(outside_artifact, relative_path=artifact.name) != expected_before_swap
+    assert _effect(workspace / artifact.name, relative_path=artifact.name) != expected_before_swap
     assert "filesystem_effects" not in tool_completion.data
     assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_production_route_rejects_post_capture_ordinary_ancestor_replacement(
+    tmp_path: Path,
+) -> None:
+    """Durable workspace identity rejects namespace replacement before replay."""
+    ancestor = tmp_path / "selected-ancestor"
+    workspace = ancestor / "workspace"
+    workspace.mkdir(parents=True)
+    artifact = workspace / "claimed.txt"
+    artifact.write_text("before", encoding="utf-8")
+    displaced_ancestor = tmp_path / "displaced-ancestor"
+    replacement_ancestor = tmp_path / "replacement-ancestor"
+    replacement_workspace = replacement_ancestor / workspace.name
+    replacement_workspace.mkdir(parents=True)
+    replacement_artifact = replacement_workspace / artifact.name
+    os.link(artifact, replacement_artifact)
+    swapped = False
+
+    def replace_before_verify() -> None:
+        nonlocal swapped
+        ancestor.rename(displaced_ancestor)
+        replacement_ancestor.rename(ancestor)
+        swapped = True
+
+    tool_completion, manifest, fact = await _run_production_artifact_route(
+        workspace,
+        call_id="post-capture-ancestor-replacement",
+        completion_data={"tool_result": {"is_error": False, "meta": {"exit_status": 0}}},
+        before_verify=replace_before_verify,
+    )
+
+    assert swapped is True
+    assert len(tool_completion.data["filesystem_effects"]) == 1
+    assert manifest.entries[0].payload.get("command_artifacts") is not None
+    assert artifact.read_text(encoding="utf-8") == "accepted"
     assert fact.evidence_handle == "missing:files_touched:0"
 
 
@@ -738,6 +806,93 @@ async def test_production_malformed_alias_cannot_launder_local_effect(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_orphan_idless_terminal_blocks_late_named_capture_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """A terminal without an id closes the named command before a late mutation."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("before", encoding="utf-8")
+
+    class StubRuntime:
+        runtime_backend = "opencode"
+        permission_mode = "acceptEdits"
+        working_directory = str(tmp_path)
+
+        async def execute_task(self, **_kwargs: Any):
+            yield AgentMessage(
+                type="assistant",
+                content="start named command",
+                tool_name="Bash",
+                data={
+                    "tool_call_id": "named-command",
+                    "tool_input": {"command": "printf accepted > claimed.txt"},
+                },
+            )
+            yield AgentMessage(
+                type="tool_result",
+                content="unassigned Bash completion",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            artifact.write_text("late mutation", encoding="utf-8")
+            yield AgentMessage(
+                type="tool_result",
+                content="late matching completion",
+                tool_name="Bash",
+                data={
+                    "subtype": "tool_result",
+                    "tool_call_id": "named-command",
+                    "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+                },
+            )
+            yield AgentMessage(
+                type="result", content="[TASK_COMPLETE]", data={"subtype": "success"}
+            )
+
+    store = _EventStore([])
+    executor = ParallelACExecutor(
+        adapter=StubRuntime(),
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+        run_verify_commands=False,
+    )
+    await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Create claimed.txt",
+        session_id="sess_1",
+        execution_id="exec_1",
+        tools=["Bash"],
+        system_prompt="test",
+        seed_goal="test provenance",
+        depth=0,
+        start_time=datetime.now(UTC),
+        retry_attempt=1,
+        node_identity=ExecutionNodeIdentity.root(execution_context_id="exec_1", ac_index=0),
+    )
+    tool_start = next(event for event in store.events if event.type == "execution.tool.started")
+    completions = [event for event in store.events if event.type == "execution.tool.completed"]
+    manifest, fact = await _artifact_fact(
+        store.events,
+        task_cwd=tmp_path,
+        ac_id=str(tool_start.data["ac_id"]),
+        session_attempt_id=str(tool_start.data["session_attempt_id"]),
+    )
+
+    assert len(completions) == 2
+    assert "tool_call_id" not in completions[0].data
+    assert completions[0].data["tool_name"] == "Bash"
+    assert completions[1].data["tool_call_id"] == "named-command"
+    assert "filesystem_effects" not in completions[1].data
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
 async def test_leaf_dispatcher_stream_strips_forged_completion_effect(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
     artifact.write_text("stale", encoding="utf-8")
@@ -958,6 +1113,36 @@ async def test_cross_session_artifact_is_rejected(tmp_path: Path) -> None:
         lambda effect: {**effect, "unknown": "forbidden"},
         lambda effect: {**effect, "st_ino": "1"},
         lambda effect: {**effect, "st_mode": stat.S_IFLNK},
+        lambda effect: {key: value for key, value in effect.items() if key != "workspace_chain"},
+        lambda effect: {**effect, "workspace_chain": []},
+        lambda effect: {
+            **effect,
+            "workspace_chain": [
+                effect["workspace_chain"][0],
+                *effect["workspace_chain"],
+            ],
+        },
+        lambda effect: {
+            **effect,
+            "workspace_chain": [
+                {**effect["workspace_chain"][0], "st_ino": 0},
+                *effect["workspace_chain"][1:],
+            ],
+        },
+        lambda effect: {
+            **effect,
+            "workspace_chain": [
+                {**effect["workspace_chain"][0], "unknown": "forbidden"},
+                *effect["workspace_chain"][1:],
+            ],
+        },
+        lambda effect: {
+            **effect,
+            "workspace_chain": [
+                *effect["workspace_chain"][:-1],
+                {**effect["workspace_chain"][-1], "name": "x" * 4096},
+            ],
+        },
     ),
 )
 async def test_malformed_or_escaping_effect_invalidates_whole_command(
@@ -1010,6 +1195,65 @@ async def test_crafted_nested_artifact_invalidates_otherwise_valid_target(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_crafted_workspace_chain_invalidates_durable_authority(tmp_path: Path) -> None:
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("accepted", encoding="utf-8")
+    manifest, _fact = await _artifact_fact(
+        _command_events(
+            call_id="crafted-workspace",
+            effects=[_effect(artifact, relative_path=artifact.name)],
+        ),
+        task_cwd=tmp_path,
+    )
+    entry = manifest.entries[0]
+    payload = dict(entry.payload)
+    provenance = dict(payload["command_artifacts"])
+    workspace_chain = [dict(component) for component in provenance["workspace_chain"]]
+    workspace_chain[-1]["st_ino"] += 1
+    provenance["workspace_chain"] = workspace_chain
+    payload["command_artifacts"] = provenance
+    crafted = EvidenceManifest(
+        ac_id=manifest.ac_id,
+        entries=(entry.model_copy(update={"payload": payload}),),
+    )
+
+    facts = _standard_deliver_facts(
+        EvidenceRecord(data={"files_touched": [artifact.name]}),
+        crafted,
+        task_cwd=str(tmp_path),
+        verifier_passed=True,
+    )
+
+    assert facts is not None
+    assert facts[0].evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_mixed_workspace_chains_invalidate_whole_command(tmp_path: Path) -> None:
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    first_effect = _effect(first, relative_path=first.name)
+    second_effect = _effect(second, relative_path=second.name)
+    second_chain = [dict(component) for component in second_effect["workspace_chain"]]
+    second_chain[-1]["st_ino"] += 1
+    second_effect["workspace_chain"] = second_chain
+
+    manifest, fact = await _artifact_fact(
+        _command_events(
+            call_id="mixed-workspace",
+            effects=[first_effect, second_effect],
+        ),
+        task_cwd=tmp_path,
+        claim=first.name,
+    )
+
+    assert "command_artifacts" not in manifest.entries[0].payload
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
 async def test_duplicate_artifact_path_invalidates_whole_command(tmp_path: Path) -> None:
     artifact = tmp_path / "claimed.txt"
     artifact.write_text("accepted", encoding="utf-8")
@@ -1030,10 +1274,12 @@ async def test_symlink_escape_is_rejected_at_verifier_boundary(tmp_path: Path) -
     outside.write_text("outside", encoding="utf-8")
     (tmp_path / "escape.txt").symlink_to(outside)
 
+    effect = _effect(outside, relative_path="escape.txt")
+    effect["workspace_chain"] = _workspace_chain_payload(tmp_path)
     _manifest, fact = await _artifact_fact(
         _command_events(
             call_id="symlink",
-            effects=[_effect(outside, relative_path="escape.txt")],
+            effects=[effect],
         ),
         task_cwd=tmp_path,
         claim="escape.txt",
@@ -1367,6 +1613,239 @@ async def test_malformed_named_completion_poisons_later_valid_completion(tmp_pat
     manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
 
     assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("orphan_tool_name", ("Bash", " Bash ", None, "", 7))
+async def test_crafted_orphan_idless_terminal_vetoes_named_journal_pair(
+    tmp_path: Path,
+    orphan_tool_name: object,
+) -> None:
+    """Durable events cannot revive a named Bash call after an orphan terminal."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="named", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    orphan_data = {
+        key: value
+        for key, value in events[1].data.items()
+        if key not in {"tool_call_id", "filesystem_effects", "tool_name"}
+    }
+    if orphan_tool_name is not None:
+        orphan_data["tool_name"] = orphan_tool_name
+    orphan = events[1].model_copy(
+        update={
+            "id": "orphan-idless-completion",
+            "timestamp": events[0].timestamp + timedelta(microseconds=1),
+            "data": orphan_data,
+        }
+    )
+    events[1] = events[1].model_copy(
+        update={"timestamp": events[0].timestamp + timedelta(microseconds=2)}
+    )
+
+    manifest, fact = await _artifact_fact([events[0], orphan, events[1]], task_cwd=tmp_path)
+
+    assert manifest.entries == ()
+    assert fact.evidence_handle == "missing:files_touched:0"
+
+
+@pytest.mark.asyncio
+async def test_crafted_idless_other_tool_terminal_preserves_named_journal_pair(
+    tmp_path: Path,
+) -> None:
+    """An explicit other-tool completion is not a Bash authority boundary."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    events = _command_events(
+        call_id="named", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    orphan = events[1].model_copy(
+        update={
+            "id": "unrelated-edit-completion",
+            "timestamp": events[0].timestamp + timedelta(microseconds=1),
+            "data": {
+                key: ("Edit" if key == "tool_name" else value)
+                for key, value in events[1].data.items()
+                if key not in {"tool_call_id", "filesystem_effects"}
+            },
+        }
+    )
+    events[1] = events[1].model_copy(
+        update={"timestamp": events[0].timestamp + timedelta(microseconds=2)}
+    )
+
+    manifest, fact = await _artifact_fact([events[0], orphan, events[1]], task_cwd=tmp_path)
+
+    assert manifest.entries[0].payload.get("command_artifacts") is not None
+    assert fact.evidence_handle == manifest.entries[0].handle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("idless_first", (False, True))
+async def test_owned_idless_bash_pair_preserves_named_journal_authority(
+    tmp_path: Path,
+    idless_first: bool,
+) -> None:
+    """A unique id-less Bash pair remains independent of a concurrent named pair."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    named_start, named_completion = _command_events(
+        call_id="named", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    identity = {
+        key: named_start.data[key]
+        for key in ("ac_id", "execution_id", "retry_attempt", "session_attempt_id")
+    }
+    idless_start = BaseEvent(
+        id="idless-bash-start",
+        type="execution.tool.started",
+        timestamp=named_start.timestamp,
+        aggregate_type="execution",
+        aggregate_id="ac_1",
+        data={
+            **identity,
+            "tool_name": "Bash",
+            "tool_input": {"command": "true"},
+        },
+    )
+    idless_completion = BaseEvent(
+        id="idless-bash-completion",
+        type="execution.tool.completed",
+        timestamp=named_start.timestamp,
+        aggregate_type="execution",
+        aggregate_id="ac_1",
+        data={
+            **identity,
+            "tool_name": "Bash",
+            "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+        },
+    )
+    ordered = (
+        [idless_start, named_start, idless_completion, named_completion]
+        if idless_first
+        else [named_start, idless_start, idless_completion, named_completion]
+    )
+    events = [
+        event.model_copy(
+            update={"timestamp": named_start.timestamp + timedelta(microseconds=index)}
+        )
+        for index, event in enumerate(ordered)
+    ]
+
+    manifest, fact = await _artifact_fact(events, task_cwd=tmp_path)
+
+    artifact_entries = [
+        entry for entry in manifest.entries if entry.payload.get("command_artifacts") is not None
+    ]
+    assert len(artifact_entries) == 1
+    assert fact.evidence_handle == artifact_entries[0].handle
+
+
+@pytest.mark.asyncio
+async def test_owned_idless_edit_nameless_terminal_preserves_named_journal_authority(
+    tmp_path: Path,
+) -> None:
+    """A nameless terminal owned by one id-less Edit is not an orphan Bash terminal."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    named_start, named_completion = _command_events(
+        call_id="named", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    identity = {
+        key: named_start.data[key]
+        for key in ("ac_id", "execution_id", "retry_attempt", "session_attempt_id")
+    }
+    edit_start = BaseEvent(
+        id="idless-edit-start",
+        type="execution.tool.started",
+        timestamp=named_start.timestamp + timedelta(microseconds=1),
+        aggregate_type="execution",
+        aggregate_id="ac_1",
+        data={
+            **identity,
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "other.txt"},
+        },
+    )
+    nameless_completion = BaseEvent(
+        id="idless-edit-completion",
+        type="execution.tool.completed",
+        timestamp=named_start.timestamp + timedelta(microseconds=2),
+        aggregate_type="execution",
+        aggregate_id="ac_1",
+        data={
+            **identity,
+            "tool_result": {"is_error": False},
+        },
+    )
+    named_completion = named_completion.model_copy(
+        update={"timestamp": named_start.timestamp + timedelta(microseconds=3)}
+    )
+
+    manifest, fact = await _artifact_fact(
+        [named_start, edit_start, nameless_completion, named_completion],
+        task_cwd=tmp_path,
+    )
+
+    artifact_entries = [
+        entry for entry in manifest.entries if entry.payload.get("command_artifacts") is not None
+    ]
+    assert len(artifact_entries) == 1
+    assert fact.evidence_handle == artifact_entries[0].handle
+
+
+@pytest.mark.asyncio
+async def test_duplicate_idless_starts_poison_named_journal_authority(tmp_path: Path) -> None:
+    """Two active id-less starts cannot donate their ambiguous terminal to a named peer."""
+    artifact = tmp_path / "claimed.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    named_start, named_completion = _command_events(
+        call_id="named", effects=[_effect(artifact, relative_path=artifact.name)]
+    )
+    identity = {
+        key: named_start.data[key]
+        for key in ("ac_id", "execution_id", "retry_attempt", "session_attempt_id")
+    }
+    idless_events = [
+        BaseEvent(
+            id=f"ambiguous-idless-start-{index}",
+            type="execution.tool.started",
+            timestamp=named_start.timestamp + timedelta(microseconds=index),
+            aggregate_type="execution",
+            aggregate_id="ac_1",
+            data={
+                **identity,
+                "tool_name": "Bash",
+                "tool_input": {"command": "true"},
+            },
+        )
+        for index in (1, 2)
+    ]
+    idless_completion = BaseEvent(
+        id="ambiguous-idless-completion",
+        type="execution.tool.completed",
+        timestamp=named_start.timestamp + timedelta(microseconds=3),
+        aggregate_type="execution",
+        aggregate_id="ac_1",
+        data={
+            **identity,
+            "tool_name": "Bash",
+            "tool_result": {"is_error": False, "meta": {"exit_status": 0}},
+        },
+    )
+    named_completion = named_completion.model_copy(
+        update={"timestamp": named_start.timestamp + timedelta(microseconds=4)}
+    )
+
+    manifest, fact = await _artifact_fact(
+        [named_start, *idless_events, idless_completion, named_completion],
+        task_cwd=tmp_path,
+    )
+
+    assert all("command_artifacts" not in entry.payload for entry in manifest.entries)
     assert fact.evidence_handle == "missing:files_touched:0"
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import shlex
 import subprocess
 import sys
+import textwrap
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -570,6 +571,7 @@ def test_files_touched_authenticates_every_stable_multi_receiver(
 
     with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
         observed_call = tracker.observe(call)
+        assert len(tracker._pending_by_id["multi-receiver"]) == 2
         completed = subprocess.run(  # noqa: S602
             command,
             cwd=tmp_path,
@@ -1125,6 +1127,198 @@ def test_bash_receiver_lease_cleanup_is_idempotent(tmp_path) -> None:
     for fd in fds:
         with pytest.raises(OSError):
             os.fstat(fd)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="RLIMIT_NOFILE is POSIX-only")
+def test_bash_receiver_fd_budget_preserves_pipe_headroom_under_low_rlimit(tmp_path) -> None:
+    """A wide command abandons capture before it can starve subprocess pipes."""
+    child_script = textwrap.dedent(
+        r"""
+        import os
+        from pathlib import Path
+        import resource
+        import subprocess
+        import sys
+
+        from ouroboros.orchestrator.adapter import AgentMessage
+        from ouroboros.orchestrator.leaf_dispatcher import _BashFilesystemLeaseTracker
+
+        workspace = Path(sys.argv[1])
+        _soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        limit = 256 if hard_limit == resource.RLIM_INFINITY else min(256, hard_limit)
+        if limit < 128:
+            raise SystemExit(77)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard_limit))
+
+        fd_directory = Path("/proc/self/fd")
+        if not fd_directory.exists():
+            fd_directory = Path("/dev/fd")
+        if not fd_directory.exists():
+            raise SystemExit(77)
+
+        def fd_count():
+            return len(os.listdir(fd_directory))
+
+        baseline = fd_count()
+        receivers = [f"claimed_{index}.txt" for index in range(64)]
+        command = "touch " + " ".join(receivers)
+        call = AgentMessage(
+            type="tool",
+            content=f"Bash: {command}",
+            tool_name="Bash",
+            data={"tool_input": {"command": command}, "tool_call_id": "fd-budget"},
+        )
+        completion = AgentMessage(
+            type="tool_result",
+            content="command completed with exit code 0",
+            tool_name="Bash",
+            data={"subtype": "tool_result", "exit_code": 0, "tool_call_id": "fd-budget"},
+        )
+
+        with _BashFilesystemLeaseTracker(task_cwd=str(workspace)) as tracker:
+            tracker.observe(call)
+            assert tracker._pending_by_id["fd-budget"] == ()
+            assert fd_count() < limit // 2
+            completed = subprocess.run(
+                ["/bin/sh", "-c", command],
+                cwd=workspace,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            assert completed.stdout == ""
+            assert completed.stderr == ""
+            observed = tracker.observe(completion)
+            assert "filesystem_effects" not in observed.data
+            probe = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('stdout-ok'); print('stderr-ok', file=sys.stderr)",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            assert probe.stdout == "stdout-ok\n"
+            assert probe.stderr == "stderr-ok\n"
+
+        assert fd_count() <= baseline + 1
+        print("fd-budget-ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", child_script, str(tmp_path)],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode == 77:  # pragma: no cover - constrained host fallback
+        pytest.skip("host cannot provide the isolated RLIMIT_NOFILE regression")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "fd-budget-ok\n"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="RLIMIT_NOFILE is POSIX-only")
+def test_bash_receiver_fd_budget_is_process_wide_across_trackers(tmp_path) -> None:
+    """Concurrent trackers share headroom and cannot collectively starve pipes."""
+    child_script = textwrap.dedent(
+        r"""
+        import os
+        from pathlib import Path
+        import resource
+        import subprocess
+        import sys
+
+        from ouroboros.orchestrator.adapter import AgentMessage
+        from ouroboros.orchestrator.leaf_dispatcher import _BashFilesystemLeaseTracker
+
+        workspace = Path(sys.argv[1])
+        _soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+        limit = 256 if hard_limit == resource.RLIM_INFINITY else min(256, hard_limit)
+        if limit < 128:
+            raise SystemExit(77)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard_limit))
+
+        fd_directory = Path("/proc/self/fd")
+        if not fd_directory.exists():
+            fd_directory = Path("/dev/fd")
+        if not fd_directory.exists():
+            raise SystemExit(77)
+
+        def fd_count():
+            return len(os.listdir(fd_directory))
+
+        baseline = fd_count()
+        trackers = [
+            _BashFilesystemLeaseTracker(task_cwd=str(workspace)) for _index in range(4)
+        ]
+        retained = 0
+        abandoned = 0
+        try:
+            for tracker_index, tracker in enumerate(trackers):
+                tracker.__enter__()
+                for call_index in range(20):
+                    receiver = f"tracker_{tracker_index}_{call_index}.txt"
+                    call_id = f"tracker-{tracker_index}-call-{call_index}"
+                    tracker.observe(
+                        AgentMessage(
+                            type="tool",
+                            content=f"Bash: touch {receiver}",
+                            tool_name="Bash",
+                            data={
+                                "tool_input": {"command": f"touch {receiver}"},
+                                "tool_call_id": call_id,
+                            },
+                        )
+                    )
+                    lease_count = len(tracker._pending_by_id[call_id])
+                    assert lease_count in {0, 1}
+                    retained += lease_count
+                    abandoned += lease_count == 0
+
+            assert retained > 0
+            assert abandoned > 0
+            assert fd_count() <= limit // 2
+            probe = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('stdout-ok'); print('stderr-ok', file=sys.stderr)",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            assert probe.stdout == "stdout-ok\n"
+            assert probe.stderr == "stderr-ok\n"
+        finally:
+            for tracker in reversed(trackers):
+                tracker.close()
+
+        assert fd_count() <= baseline + 1
+        print("multi-fd-budget-ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", child_script, str(tmp_path)],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode == 77:  # pragma: no cover - constrained host fallback
+        pytest.skip("host cannot provide the isolated RLIMIT_NOFILE regression")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "multi-fd-budget-ok\n"
 
 
 def test_completed_receiver_lease_cannot_close_reused_fd(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1239,6 +1239,66 @@ def test_receiver_lease_tracker_strips_forged_effect_without_local_lease(tmp_pat
     assert "filesystem_effects" not in observed.data
 
 
+def test_receiver_lease_tracker_preserves_unrelated_final_message_identity() -> None:
+    """Provenance filtering must not alter unrelated final-message semantics."""
+    nested = {"decision": "pause"}
+    data = {"subtype": "success", "routing": nested}
+    final = AgentMessage(type="result", content="done", data=data)
+
+    with _BashFilesystemLeaseTracker(task_cwd=None) as tracker:
+        observed = tracker.observe(final)
+
+    assert observed is final
+    assert observed.data is data
+    assert observed.data["routing"] is nested
+
+
+def test_receiver_lease_tracker_strips_reserved_effect_from_unrelated_message() -> None:
+    """The reserved field is removed even outside a recognizable tool event."""
+    nested = {"decision": "before"}
+    forged_effects = [{"capture": "forged"}]
+    message = AgentMessage(
+        type="assistant",
+        content="ordinary message",
+        data={"routing": nested, "filesystem_effects": forged_effects},
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=None) as tracker:
+        observed = tracker.observe(message)
+
+    nested["decision"] = "after"
+    forged_effects.append({"capture": "late-forgery"})
+    assert observed is not message
+    assert "filesystem_effects" not in observed.data
+    assert observed.data["routing"] == {"decision": "before"}
+
+
+def test_receiver_lease_tracker_snapshots_every_tool_completion() -> None:
+    """Late adapter mutation cannot rewrite even a non-Bash completion."""
+    meta = {"exit_status": 0}
+    completion = AgentMessage(
+        type="tool_result",
+        content="edit completed",
+        tool_name="Edit",
+        data={
+            "subtype": "tool_result",
+            "tool_call_id": "edit-call",
+            "tool_result": {"is_error": False, "meta": meta},
+        },
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=None) as tracker:
+        observed = tracker.observe(completion)
+
+    meta["exit_status"] = 99
+    meta["tool_use_id"] = "late-forgery"
+    assert observed is not completion
+    assert observed.data["tool_result"] == {
+        "is_error": False,
+        "meta": {"exit_status": 0},
+    }
+
+
 def test_receiver_lease_tracker_replaces_forged_effect_with_local_capture(tmp_path) -> None:
     """A real mutation reattaches only the receiver measured by the tracker."""
     forged_target = tmp_path / "forged.py"
@@ -1377,6 +1437,73 @@ def test_conflicting_call_aliases_poison_related_existing_lease(tmp_path) -> Non
         observed = tracker.observe(completion)
 
     assert "filesystem_effects" not in observed.data
+
+
+def test_malformed_call_alias_poison_cannot_be_revived(tmp_path) -> None:
+    """A present non-string alias closes the named lease before projection."""
+    target = tmp_path / "claimed.py"
+    target.write_text("before\n", encoding="utf-8")
+    call = AgentMessage(
+        type="tool",
+        content="Bash: touch claimed.py",
+        tool_name="Bash",
+        data={"tool_input": {"command": "touch claimed.py"}, "tool_call_id": "call-x"},
+    )
+    malformed = AgentMessage(
+        type="tool_result",
+        content="malformed completion",
+        data={
+            "subtype": "tool_result",
+            "exit_code": 0,
+            "tool_call_id": "call-x",
+            "tool_use_id": 7,
+        },
+    )
+    valid = AgentMessage(
+        type="tool_result",
+        content="later valid completion",
+        data={"subtype": "tool_result", "exit_code": 0, "tool_call_id": "call-x"},
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
+        tracker.observe(call)
+        os.utime(target, ns=(8_000_000_000, 8_000_000_000))
+        rejected = tracker.observe(malformed)
+        revived = tracker.observe(valid)
+
+    assert "filesystem_effects" not in rejected.data
+    assert "filesystem_effects" not in revived.data
+
+
+def test_unidentified_malformed_completion_poison_cannot_be_revived(tmp_path) -> None:
+    """A malformed completion with no usable ID closes every pending Bash lease."""
+    target = tmp_path / "claimed.py"
+    target.write_text("before\n", encoding="utf-8")
+    call = AgentMessage(
+        type="tool",
+        content="Bash: touch claimed.py",
+        tool_name="Bash",
+        data={"tool_input": {"command": "touch claimed.py"}, "tool_call_id": "call-x"},
+    )
+    malformed = AgentMessage(
+        type="tool_result",
+        content="unidentified malformed completion",
+        data={"subtype": "tool_result", "exit_code": 0, "tool_use_id": 7},
+    )
+    valid = AgentMessage(
+        type="tool_result",
+        content="later valid completion",
+        data={"subtype": "tool_result", "exit_code": 0, "tool_call_id": "call-x"},
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
+        tracker.observe(call)
+        os.utime(target, ns=(9_000_000_000, 9_000_000_000))
+        rejected = tracker.observe(malformed)
+        revived = tracker.observe(valid)
+
+    assert "filesystem_effects" not in rejected.data
+    assert "filesystem_effects" not in revived.data
 
 
 @pytest.mark.parametrize("call_id", (None, "call-1"))

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1045,16 +1045,19 @@ def test_capture_rejects_intermediate_workspace_ancestor_swap(
     os.link(artifact, outside_artifact)
     original_open = os.open
     swapped = False
+    matching_open_count = 0
     fingerprint_before_swap = None
 
     def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
-        nonlocal fingerprint_before_swap, swapped
+        nonlocal fingerprint_before_swap, matching_open_count, swapped
         fd = original_open(path, flags, mode, dir_fd=dir_fd)
-        if not swapped and dir_fd is not None and os.fspath(path) == ancestor.name:
-            fingerprint_before_swap = _stat_fingerprint(artifact.lstat())
-            ancestor.rename(displaced_ancestor)
-            ancestor.symlink_to(outside_ancestor, target_is_directory=True)
-            swapped = True
+        if dir_fd is not None and os.fspath(path) == ancestor.name:
+            matching_open_count += 1
+            if not swapped and matching_open_count == 2:
+                fingerprint_before_swap = _stat_fingerprint(artifact.lstat())
+                ancestor.rename(displaced_ancestor)
+                ancestor.symlink_to(outside_ancestor, target_is_directory=True)
+                swapped = True
         return fd
 
     monkeypatch.setattr(os, "open", adversarial_open)
@@ -1578,6 +1581,146 @@ def test_unidentified_malformed_completion_poison_cannot_be_revived(tmp_path) ->
 
     assert "filesystem_effects" not in rejected.data
     assert "filesystem_effects" not in revived.data
+
+
+@pytest.mark.parametrize("completion_tool_name", ("Bash", None))
+def test_orphan_idless_bash_terminal_poisons_all_named_leases(
+    tmp_path,
+    completion_tool_name,
+) -> None:
+    """One unassignable terminal closes, rather than donates, every named lease."""
+    targets = (tmp_path / "first.py", tmp_path / "second.py")
+    for target in targets:
+        target.write_text("before\n", encoding="utf-8")
+    calls = tuple(
+        AgentMessage(
+            type="tool",
+            content=f"Bash: touch {target.name}",
+            tool_name="Bash",
+            data={
+                "tool_input": {"command": f"touch {target.name}"},
+                "tool_call_id": f"named-{index}",
+            },
+        )
+        for index, target in enumerate(targets)
+    )
+    orphan = AgentMessage(
+        type="tool_result",
+        content="unassigned command completed",
+        tool_name=completion_tool_name,
+        data={"subtype": "tool_result", "exit_code": 0},
+    )
+    completions = tuple(
+        AgentMessage(
+            type="tool_result",
+            content="late matching completion",
+            tool_name="Bash",
+            data={
+                "subtype": "tool_result",
+                "exit_code": 0,
+                "tool_call_id": f"named-{index}",
+            },
+        )
+        for index in range(len(targets))
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
+        for call in calls:
+            tracker.observe(call)
+        tracker.observe(orphan)
+        for index, target in enumerate(targets, start=11):
+            os.utime(target, ns=(index * 1_000_000_000, index * 1_000_000_000))
+        observed = tuple(tracker.observe(completion) for completion in completions)
+
+    assert all("filesystem_effects" not in completion.data for completion in observed)
+
+
+def test_legitimate_idless_bash_pair_does_not_poison_named_lease(tmp_path) -> None:
+    """A unique id-less Bash start owns its terminal without closing a named peer."""
+    idless_target = tmp_path / "idless.py"
+    named_target = tmp_path / "named.py"
+    idless_target.write_text("before\n", encoding="utf-8")
+    named_target.write_text("before\n", encoding="utf-8")
+    idless_call = AgentMessage(
+        type="tool",
+        content="Bash: touch idless.py",
+        tool_name="Bash",
+        data={"tool_input": {"command": "touch idless.py"}},
+    )
+    named_call = AgentMessage(
+        type="tool",
+        content="Bash: touch named.py",
+        tool_name="Bash",
+        data={
+            "tool_input": {"command": "touch named.py"},
+            "tool_call_id": "named-peer",
+        },
+    )
+    idless_completion = AgentMessage(
+        type="tool_result",
+        content="idless command completed",
+        data={"subtype": "tool_result", "exit_code": 0},
+    )
+    named_completion = AgentMessage(
+        type="tool_result",
+        content="named command completed",
+        tool_name="Bash",
+        data={
+            "subtype": "tool_result",
+            "exit_code": 0,
+            "tool_call_id": "named-peer",
+        },
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
+        tracker.observe(idless_call)
+        tracker.observe(named_call)
+        os.utime(idless_target, ns=(13_000_000_000, 13_000_000_000))
+        observed_idless = tracker.observe(idless_completion)
+        os.utime(named_target, ns=(14_000_000_000, 14_000_000_000))
+        observed_named = tracker.observe(named_completion)
+
+    assert observed_idless.data["filesystem_effects"][0]["path"] == "idless.py"
+    assert observed_named.data["filesystem_effects"][0]["path"] == "named.py"
+
+
+def test_unrelated_idless_non_bash_terminal_preserves_named_lease(tmp_path) -> None:
+    """An explicitly other-tool terminal cannot close a named Bash command."""
+    target = tmp_path / "claimed.py"
+    target.write_text("before\n", encoding="utf-8")
+    call = AgentMessage(
+        type="tool",
+        content="Bash: touch claimed.py",
+        tool_name="Bash",
+        data={
+            "tool_input": {"command": "touch claimed.py"},
+            "tool_call_id": "named-bash",
+        },
+    )
+    edit_completion = AgentMessage(
+        type="tool_result",
+        content="Edit completed",
+        tool_name="Edit",
+        data={"subtype": "tool_result", "exit_code": 0},
+    )
+    bash_completion = AgentMessage(
+        type="tool_result",
+        content="Bash completed",
+        tool_name="Bash",
+        data={
+            "subtype": "tool_result",
+            "exit_code": 0,
+            "tool_call_id": "named-bash",
+        },
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(tmp_path)) as tracker:
+        tracker.observe(call)
+        tracker.observe(edit_completion)
+        os.utime(target, ns=(15_000_000_000, 15_000_000_000))
+        observed = tracker.observe(bash_completion)
+
+    assert observed.data["filesystem_effects"][0]["path"] == "claimed.py"
 
 
 @pytest.mark.parametrize("call_id", (None, "call-1"))

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -75,6 +75,7 @@ from ouroboros.orchestrator.leaf_dispatcher import (
     _close_pending_targets,
     _correlated_tool_result_name,
     _pending_bash_filesystem_targets,
+    _stat_fingerprint,
 )
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
@@ -1024,6 +1025,79 @@ def test_files_touched_rejects_parent_symlink_swap_restored_before_completion(tm
         "link/claimed.py",
         (call, result),
         task_cwd=str(tmp_path),
+    )
+
+
+def test_capture_rejects_intermediate_workspace_ancestor_swap(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-linked external inode cannot survive a task_cwd ancestor swap."""
+    ancestor = tmp_path / "trusted-ancestor"
+    workspace = ancestor / "workspace"
+    workspace.mkdir(parents=True)
+    artifact = workspace / "claimed.py"
+    artifact.write_text("before\n", encoding="utf-8")
+    displaced_ancestor = tmp_path / "displaced-ancestor"
+    outside_ancestor = tmp_path / "outside-ancestor"
+    outside_workspace = outside_ancestor / workspace.name
+    outside_workspace.mkdir(parents=True)
+    outside_artifact = outside_workspace / artifact.name
+    os.link(artifact, outside_artifact)
+    original_open = os.open
+    swapped = False
+    fingerprint_before_swap = None
+
+    def adversarial_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal fingerprint_before_swap, swapped
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        if not swapped and dir_fd is not None and os.fspath(path) == ancestor.name:
+            fingerprint_before_swap = _stat_fingerprint(artifact.lstat())
+            ancestor.rename(displaced_ancestor)
+            ancestor.symlink_to(outside_ancestor, target_is_directory=True)
+            swapped = True
+        return fd
+
+    monkeypatch.setattr(os, "open", adversarial_open)
+    monkeypatch.setattr(os, "supports_dir_fd", {*os.supports_dir_fd, adversarial_open})
+    call = AgentMessage(
+        type="tool",
+        content="Bash: touch claimed.py",
+        tool_name="Bash",
+        data={
+            "tool_input": {"command": "touch claimed.py"},
+            "tool_call_id": "ancestor-swap",
+        },
+    )
+    completion = AgentMessage(
+        type="tool_result",
+        content="command completed with exit code 0",
+        data={
+            "subtype": "tool_result",
+            "exit_code": 0,
+            "tool_call_id": "ancestor-swap",
+        },
+    )
+
+    with _BashFilesystemLeaseTracker(task_cwd=str(workspace)) as tracker:
+        tracker.observe(call)
+        pending = tracker._pending_by_id["ancestor-swap"][0]
+        assert fingerprint_before_swap == pending.pre_fingerprint
+        completed = subprocess.run(  # noqa: S602
+            "touch claimed.py",
+            cwd=workspace,
+            shell=True,
+            check=False,
+        )
+        observed_completion = tracker.observe(completion)
+
+    assert swapped is True
+    assert completed.returncode == 0
+    assert _stat_fingerprint(outside_artifact.lstat()) != fingerprint_before_swap
+    assert "filesystem_effects" not in observed_completion.data
+    assert not _runtime_messages_support_file_claim(
+        "claimed.py",
+        (call, observed_completion),
+        task_cwd=str(workspace),
     )
 
 


### PR DESCRIPTION
## Summary

- Implements Phase 1 of command-scoped Bash artifact provenance for #1747 by extending the existing #1764 pathlib receiver lease; no parallel filesystem capture or provenance authority is introduced.
- Projects a closed/versioned `command_artifacts` v1 record only for an accepted, successful Bash start/completion pair bound to the execution, AC, retry, and session attempt.
- Revalidates the artifact with workspace-rooted no-follow directory and leaf capabilities and fails closed across stale state, malformed or duplicate evidence, path/symlink/namespace escape, ambiguous correlation, and command failure.

## Changes

### Sole producer authority

- Reuses `_BashFilesystemLeaseTracker` and its held dirfd receiver lease.
- Persists canonical workspace-relative paths plus device, inode, mode, size, mtime_ns, and ctime_ns.
- Prevents adapter mutation or late ordinary-message promotion from fabricating authoritative Bash effects.

### Journal and verifier boundary

- Correlates unique start/completion events with the accepted execution, AC, retry, and session attempt before journal projection.
- Rejects conflicting or malformed aliases, foreign aggregate splices, stale/pre-start/duplicate events, contradictory success/failure metadata, cancellation, timeout, abort, and non-zero/error completion.
- Preserves the closed command-verdict vocabulary through runtime projection at top data, data.meta, tool_result, and tool_result.meta; present-null/malformed containers and `is_error_invalid` remain durable poison.
- Shares success (`success`, `ok`), error-boolean (`is_error`, `isError`, `is_error_invalid`, and failure/cancel/timeout/abort aliases), and exit vocabularies across projection and verifier. Exit fields include `exit_code`, `exit_status`, `exitCode`, `exitStatus`, `returncode`, `return_code`, `status_code`, `statusCode`, `exit`, `errorCode`, and `error_code`.
- Opens both leased and current leaves with `O_NOFOLLOW`, keeps their fds live while matching the expected Phase 1 fingerprint, and postvalidates every parent name, the leaf name, and the lexical workspace root before returning a closed boolean decision. Rename/symlink swaps cannot reuse a detached `stat_result` as authority.
- Treats malformed or duplicate artifact arrays as wholly invalid.

### Coverage

- Exercises the real executor → LeafDispatcher/subprocess → runtime projection/emitter → EventStore journal → manifest/verifier path.
- Covers stale/retry/cross-session/path escape/symlink escape/parent and root namespace swap/malformed/duplicate/accepted-attempt/command-failure and adversarial correlation cases.
- Exercises first-pass, second-rewalk, and after-current-leaf-fstat parent/root swaps with non-masked hardlink fixtures.
- Preserves and rejects present-null containers, `is_error_invalid`, and all repository-declared Codex verdict aliases across all four supported metadata containers, while keeping valid neutral compatibility.

## Test plan

- [x] `uv run pytest -q -x` — 18,020 passed, 93 skipped, 1 xfailed
- [x] Focused provenance + parallel-executor suite — 970 passed
- [x] Broader worker-focused Phase 1/projection/Codex suite — 1,145 passed
- [x] Runtime projection/journal/verifier poison, alias, neutral, and namespace-swap matrices
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/ouroboros` — 526 source files
- [x] `python3 scripts/check-module-size.py --baseline-ref origin/main`
- [x] fresh import smoke and `git diff --check`
- [ ] Exact-head CI and fresh independent verifier approval for `c185e7fec51150610fbc5b38d0e7d45b5b679213`

## Phase 2 plan

Phase 2 will not add a second capture channel. The structured wrapper receipt file must first be authorized by this Phase 1 `command_artifacts` authority. It will then be opened through the same workspace-rooted no-follow fd path and `fstat` must match the Phase 1 fingerprint before parsing a closed/versioned receipt schema. Only after matching inner/outer exit status, normalized command, call/completion identity, retry/session identity, and accepted-attempt identity may the receipt grant `tests_passed` authority.

## Merge guard

Do not merge until exact-head CI is green, the fresh independent verifier approves, all review-bot findings are resolved, and aggregate `reviewDecision=APPROVED`.

## Related issues

Part of #1747
