### PR TITLE
fix(mcp): preserve convergence composition ownership

### DIFF
--- a/docs/hidden-checklist-convergence/architecture.md
+++ b/docs/hidden-checklist-convergence/architecture.md
@@ -24,7 +24,7 @@ start_execute_seed
 | Evaluation terminal hook | Enqueue or reconnect Ralph after explicit rejection | `src/ouroboros/mcp/tools/evaluation_handlers.py` |
 | Execution chain | Evaluate completed success/failure runs | `src/ouroboros/mcp/tools/execution_handlers.py` |
 | Plugin Seed vault | Keep the raw Seed parent-owned and give workers only an opaque, session-bound handle | `src/ouroboros/mcp/tools/seed_handoff.py` |
-| Runtime composition adapter | Reuse the production handler graph for builtin runtime interception | `src/ouroboros/mcp/tools/runtime_tool_composition.py` |
+| Runtime composition adapter | Reuse the production handler graph for builtin runtime interception and retain its explicit resource owner | `src/ouroboros/mcp/tools/runtime_tool_composition.py` |
 
 ## Key Decisions
 
@@ -39,3 +39,5 @@ start_execute_seed
 | Terminal successor recovery | Retries reconnect to both active and terminal Ralph jobs, closing the enqueue/result crash gap. |
 | Single-AC checklist absence yields no fabricated AC result | Existing full-graph focus fallback remains honest and safe. |
 | Raw Seed handoff is process-local | Persisting hidden verifier material in worker-queryable events would defeat the boundary. A server restart invalidates the opaque handle and evaluation fails closed instead of exposing the Seed. |
+| Runtime owns the full embedded composition | Handler registries retain their MCP server owner and expose deterministic shutdown, so EventStore, ControlBus, and bridge lifetimes match the builtin runtime instead of an abandoned factory local. |
+| Confidentiality is a transport boundary | Worker prompts, contexts, events, artifacts, and retries are sanitized. Filesystem isolation is an operator/runtime sandbox responsibility when raw Seed files are stored in worker-accessible locations. |

--- a/docs/hidden-checklist-convergence/implementation.md
+++ b/docs/hidden-checklist-convergence/implementation.md
@@ -25,9 +25,13 @@ constructs bare handlers at runtime, which previously caused the first real
 Ralph iteration to terminate with `EvolutionaryLoop not configured` even
 though constructor-mocked tests passed.
 
-Passive OpenCode plugin interception now resolves through the same configured
-graph rather than the former lightweight definition factory. Other runtimes
-retain their existing dispatcher/server ownership model.
+Passive OpenCode, Codex, and Hermes builtin interception now resolve through
+the same configured graph rather than the former lightweight definition
+factory. Backend handle aliases such as `codex_cli` and `hermes_cli` are
+canonicalized before deciding whether the injected runtime owner can be reused.
+Each runtime retains the complete configured tool composition, including its
+MCP server resource owner. `shutdown_configured_runtime_tools()` provides
+deterministic EventStore, ControlBus, and bridge teardown.
 
 When OpenCode passive-plugin dispatch is active, an evaluation with
 `auto_evolve: true` remains parent-owned and pollable. The parent runs the
@@ -78,7 +82,7 @@ whether it creates evaluation or Ralph successors by reading newer config.
 - Single-AC evaluations without checklist metadata use Ralph's existing
   full-graph focus fallback.
 - Plugin Seed handoffs are intentionally process-local until redemption. The
-  parent consumes the opaque handle, restores the raw Seed into its private
+  parent consumes the opaque handle exactly once, restores the raw Seed into its private
   evaluation request, and gives a detached evaluation owner no process-local
   handle to resolve. If evaluation itself is delegated, the parent derives its
   checklist from the raw Seed but passes only the same worker-safe projection.
@@ -87,6 +91,14 @@ whether it creates evaluation or Ralph successors by reading newer config.
   artifacts, and separately rendered checklist text using the same longest-first
   contract redactor as retry hints. Raw verifier material remains absent from
   plugin-worker prompts and worker-queryable events.
+
+- The confidentiality boundary covers data transported by Ouroboros into
+  worker prompts, contexts, events, artifacts, and retry surfaces. It is not a
+  filesystem sandbox: if an operator stores the original raw Seed in a location
+  that the worker's Read/Bash capabilities can access, the worker may still
+  discover that file independently. Strong holdout isolation therefore also
+  requires placing raw Seeds outside the worker-visible workspace or running
+  the worker with an appropriate filesystem sandbox.
 
 - Run-to-evaluation arguments retain the source execution completion status.
   A failed-but-evaluable run can be formally judged and evolved without being

--- a/docs/hidden-checklist-convergence/requirements.md
+++ b/docs/hidden-checklist-convergence/requirements.md
@@ -12,8 +12,10 @@ the preceding verdict remains authoritative if successor chaining fails.
 
 ## Clarified Specification
 
-- Hide every harness-owned `verify_command` and `output_assertion` from initial
-  and retry worker prompts without a configuration escape hatch.
+- Hide every harness-owned `verify_command` and `output_assertion` from every
+  Ouroboros-transported worker prompt, context, event, artifact, and retry
+  surface without a configuration escape hatch. This contract does not claim
+  to sandbox independently accessible raw Seed files.
 - Build retry guidance from missing artifacts, sanitized verification output,
   and read-only worker tool/file evidence.
 - Formally evaluate completed runs even when AC execution failed, provided an
@@ -39,3 +41,5 @@ the preceding verdict remains authoritative if successor chaining fails.
   detached evaluation request and cannot flip when configuration changes.
 - Approved/unjudged/opted-out evaluations do not enqueue Ralph.
 - Static checks and the bounded target test suites pass.
+- Builtin runtimes retain and can deterministically close the configured
+  composition owner; backend handle aliases do not cause nested runtime creation.

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -2367,6 +2367,10 @@ class JobManager:
             )
         )
 
+    def has_accepted_job(self, job_id: str) -> bool:
+        """Return whether this manager crossed the local enqueue boundary."""
+        return job_id in self._started_job_ids
+
     async def cancel_job(self, job_id: str) -> JobSnapshot:
         """Request cancellation for a running job."""
         snapshot = await self.get_snapshot(job_id)

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1750,14 +1750,14 @@ def create_ouroboros_server(
     # project root, so _safe_cwd() falls back to $HOME.
     effective_cwd = _safe_cwd()
 
-    # Materialize the default runtime once at server creation so backend wiring
-    # is validated up front and composition-root tests can assert the selected
-    # runtime backend without waiting for a tool invocation.
+    # Materialize the default runtime once so composition validates backend wiring.
     default_execute_runtime = runtime_adapter
-    if (
-        default_execute_runtime is None
-        or default_execute_runtime.runtime_backend != execute_runtime_backend
-    ):
+    runtime_adapter_backend = (
+        resolve_agent_runtime_backend(default_execute_runtime.runtime_backend)
+        if default_execute_runtime is not None
+        else None
+    )
+    if default_execute_runtime is None or runtime_adapter_backend != execute_runtime_backend:
         default_execute_runtime = create_agent_runtime(
             backend=execute_runtime_backend,
             model=None,

--- a/src/ouroboros/mcp/tools/background.py
+++ b/src/ouroboros/mcp/tools/background.py
@@ -35,6 +35,7 @@ control of the receipt and of any compose-around bookkeeping.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 import inspect
 import logging
 from pathlib import Path
@@ -60,6 +61,35 @@ if TYPE_CHECKING:
 # work can re-check cancellation mid-flight if it wants) and returns the
 # tool result.
 WorkFn = Callable[["AgentProcessHandle"], Awaitable[MCPToolResult]]
+
+
+@dataclass(slots=True)
+class BackgroundJobAcceptanceState:
+    """Track whether cancellation may race an accepted background owner."""
+
+    phase: str = "pre_acceptance"
+    job_manager: JobManager | None = None
+    job_id: str | None = None
+
+    def begin_detached_acceptance(self) -> None:
+        self.phase = "detached_pending"
+
+    def begin_local_acceptance(self, job_manager: JobManager, job_id: str) -> None:
+        self.phase = "local_pending"
+        self.job_manager = job_manager
+        self.job_id = job_id
+
+    def mark_accepted(self) -> None:
+        self.phase = "accepted"
+
+    def cancellation_may_have_accepted(self) -> bool:
+        """Return true only after a transport may own the requested job."""
+        if self.phase in {"detached_pending", "accepted"}:
+            return True
+        if self.phase != "local_pending" or self.job_manager is None or self.job_id is None:
+            return False
+        has_accepted_job = getattr(type(self.job_manager), "has_accepted_job", None)
+        return bool(callable(has_accepted_job) and has_accepted_job(self.job_manager, self.job_id))
 
 
 def make_cancelled_result(text: str) -> MCPToolResult:
@@ -97,6 +127,7 @@ async def start_background_tool_job(
     on_detaching: Callable[[], Awaitable[None]] | None = None,
     on_started: Callable[[JobSnapshot], Awaitable[None]] | None = None,
     on_enqueue_failure: Callable[[BaseException], Awaitable[None]] | None = None,
+    acceptance_state: BackgroundJobAcceptanceState | None = None,
 ) -> JobSnapshot:
     """Run the shared allocate -> guard -> agent-process -> start_job pipeline.
 
@@ -130,6 +161,9 @@ async def start_background_tool_job(
             raises, *before* the exception is re-raised — used by auto to
             release its start lease.  The helper always closes the pending
             runner coroutine on failure regardless of this hook.
+        acceptance_state: Optional caller-owned phase tracker used to classify
+            cancellation as definitive non-acceptance or potentially accepted
+            ownership without exposing transport internals to the caller.
 
     Returns:
         The :class:`JobSnapshot` from a successful enqueue.
@@ -138,6 +172,7 @@ async def start_background_tool_job(
         Re-raises any exception from ``start_job`` after running
         ``on_enqueue_failure`` and closing the runner coroutine.
     """
+    acceptance_state = acceptance_state or BackgroundJobAcceptanceState()
     job_id = await job_manager.allocate_job_id()
     claim_inline = getattr(job_manager, "claim_forced_inline_allocation", None)
     forced_inline = bool(claim_inline(job_id)) if callable(claim_inline) else False
@@ -155,6 +190,7 @@ async def start_background_tool_job(
         try:
             if on_detaching is not None:
                 await on_detaching()
+            acceptance_state.begin_detached_acceptance()
             snapshot = await launch_detached_job(
                 job_manager=job_manager,
                 event_store=event_store,
@@ -197,6 +233,7 @@ async def start_background_tool_job(
                         exc_info=True,
                     )
             raise
+        acceptance_state.mark_accepted()
         if on_started is not None:
             await on_started(snapshot)
         return snapshot
@@ -216,6 +253,7 @@ async def start_background_tool_job(
         cancel_key=f"mcp_job:{job_id}",
     )
 
+    acceptance_state.begin_local_acceptance(job_manager, job_id)
     try:
         snapshot = await job_manager.start_job(
             job_type=job_type,
@@ -228,7 +266,9 @@ async def start_background_tool_job(
         # Mirror the pre-extraction auto handler's failure path: close the
         # un-started runner coroutine so it is not left un-awaited, then let
         # the caller release any compose-around bookkeeping before we re-raise.
-        if inspect.iscoroutine(runner):
+        # Once ``start_job`` registers ownership it has wrapped this coroutine
+        # in a live Task; closing the same coroutine here would strand that job.
+        if inspect.iscoroutine(runner) and not acceptance_state.cancellation_may_have_accepted():
             runner.close()
         if on_enqueue_failure is not None:
             try:
@@ -243,6 +283,7 @@ async def start_background_tool_job(
                 )
         raise
 
+    acceptance_state.mark_accepted()
     if on_started is not None:
         await on_started(snapshot)
 

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -476,9 +476,10 @@ def get_ouroboros_tools(
     resolved_manager, resolved_prefix = _resolve_bridge_fields(
         context, mcp_manager, mcp_tool_prefix
     )
-    needs_configured_runtime_graph = (
-        runtime_adapter is not None and runtime_backend in {"codex", "hermes"}
-    ) or (runtime_backend == "opencode" and opencode_mode == "plugin")
+    needs_configured_runtime_graph = runtime_adapter is not None and (
+        runtime_backend in {"codex", "hermes"}
+        or (runtime_backend == "opencode" and opencode_mode == "plugin")
+    )
     if needs_configured_runtime_graph and (
         resolved_manager is None or (context is not None and context.mcp_bridge is not None)
     ):

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -29,10 +29,7 @@ from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
-from ouroboros.mcp.tools.background import (
-    BackgroundJobAcceptanceState,
-    start_background_tool_job,
-)
+from ouroboros.mcp.tools import background as background_jobs
 from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
 from ouroboros.mcp.tools.job_observer import build_job_observer_contract
 from ouroboros.mcp.tools.subagent import (
@@ -2222,9 +2219,9 @@ class StartEvaluateHandler:
                 start_ralph_handler=self.start_ralph_handler,
             )
 
-        background_acceptance = BackgroundJobAcceptanceState()
+        background_acceptance = background_jobs.BackgroundJobAcceptanceState()
         snapshot = await seed_handoff.accept(
-            start_background_tool_job(
+            background_jobs.start_background_tool_job(
                 job_manager=self._job_manager,
                 event_store=self._event_store,
                 job_type="evaluate",
@@ -2245,11 +2242,9 @@ class StartEvaluateHandler:
         )
 
         text = (
-            f"Started background evaluation.\n\n"
-            f"Job ID: {snapshot.job_id}\n"
-            f"Session ID: {session_id}\n\n"
-            "Use ouroboros_job_status, ouroboros_job_wait, or ouroboros_job_result "
-            "to monitor it."
+            f"Started background evaluation.\n\nJob ID: {snapshot.job_id}\n"
+            f"Session ID: {session_id}\n\nUse ouroboros_job_status, ouroboros_job_wait, "
+            "or ouroboros_job_result to monitor it."
         )
         meta = {
             "job_id": snapshot.job_id,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -2200,6 +2200,7 @@ class StartEvaluateHandler:
                     resolve_working_dir=_resolve_evaluate_working_dir,
                 ),
                 require_ok=True,
+                cancellation_may_have_accepted=False,
             )
 
         # The shared helper preserves job-scoped cancellation across restart.

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -29,7 +29,10 @@ from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
-from ouroboros.mcp.tools.background import start_background_tool_job
+from ouroboros.mcp.tools.background import (
+    BackgroundJobAcceptanceState,
+    start_background_tool_job,
+)
 from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
 from ouroboros.mcp.tools.job_observer import build_job_observer_contract
 from ouroboros.mcp.tools.subagent import (
@@ -2219,6 +2222,7 @@ class StartEvaluateHandler:
                 start_ralph_handler=self.start_ralph_handler,
             )
 
+        background_acceptance = BackgroundJobAcceptanceState()
         snapshot = await seed_handoff.accept(
             start_background_tool_job(
                 job_manager=self._job_manager,
@@ -2235,7 +2239,9 @@ class StartEvaluateHandler:
                 runtime_backend=self.agent_runtime_backend,
                 llm_backend=self.llm_backend,
                 opencode_mode=self.opencode_mode,
-            )
+                acceptance_state=background_acceptance,
+            ),
+            cancellation_may_have_accepted=(background_acceptance.cancellation_may_have_accepted),
         )
 
         text = (

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -2166,7 +2166,7 @@ class StartEvaluateHandler:
         from ouroboros.mcp.tools.evaluation_job import restore_seed_handoff
 
         try:
-            arguments = restore_seed_handoff(
+            arguments, seed_handoff = restore_seed_handoff(
                 arguments, session_id=session_id, registry=self.seed_handoff_registry
             )
         except ValueError as exc:
@@ -2179,6 +2179,7 @@ class StartEvaluateHandler:
                 arguments, configured_enabled=get_auto_evolve_enabled()
             )
         except ValueError as exc:
+            seed_handoff.rollback()
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_start_evaluate"))
 
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
@@ -2190,23 +2191,18 @@ class StartEvaluateHandler:
         if plugin_dispatch and not auto_evolve_enabled:
             from ouroboros.mcp.tools.evaluation_job import dispatch_plugin_evaluation
 
-            return await dispatch_plugin_evaluation(
-                arguments=arguments,
-                session_id=session_id,
-                artifact=artifact,
-                event_store=self._event_store,
-                resolve_working_dir=_resolve_evaluate_working_dir,
+            return await seed_handoff.accept(
+                dispatch_plugin_evaluation(
+                    arguments=arguments,
+                    session_id=session_id,
+                    artifact=artifact,
+                    event_store=self._event_store,
+                    resolve_working_dir=_resolve_evaluate_working_dir,
+                ),
+                require_ok=True,
             )
 
-        # Fall-through: real background job path.
-        #
-        # NOTE: this path now routes through ``start_background_tool_job``,
-        # which gives StartEvaluate the same job-scoped ``cancel_key`` and
-        # AgentProcess ``process_id`` as evolve/execute/ralph.  Before this
-        # extraction StartEvaluate passed neither, so the durable
-        # ``mcp_job:{job_id}`` cancel marker written by
-        # ``JobManager.cancel_job`` was never observable by the evaluate
-        # agent process — a restart-visible cancel was silently dropped.
+        # The shared helper preserves job-scoped cancellation across restart.
         async def _runner(_handle) -> MCPToolResult:
             from ouroboros.mcp.tools.evaluation_job import run_evaluation_job
 
@@ -2222,21 +2218,23 @@ class StartEvaluateHandler:
                 start_ralph_handler=self.start_ralph_handler,
             )
 
-        snapshot = await start_background_tool_job(
-            job_manager=self._job_manager,
-            event_store=self._event_store,
-            job_type="evaluate",
-            intent="evaluate",
-            process_scope=f"evaluate:{session_id}",
-            initial_message=f"Queued evaluation for {session_id}",
-            links=JobLinks(session_id=session_id),
-            work_fn=_runner,
-            cancelled_text="Evaluation cancelled before work began.",
-            detached_tool_name="ouroboros_start_evaluate",
-            detached_arguments=arguments,
-            runtime_backend=self.agent_runtime_backend,
-            llm_backend=self.llm_backend,
-            opencode_mode=self.opencode_mode,
+        snapshot = await seed_handoff.accept(
+            start_background_tool_job(
+                job_manager=self._job_manager,
+                event_store=self._event_store,
+                job_type="evaluate",
+                intent="evaluate",
+                process_scope=f"evaluate:{session_id}",
+                initial_message=f"Queued evaluation for {session_id}",
+                links=JobLinks(session_id=session_id),
+                work_fn=_runner,
+                cancelled_text="Evaluation cancelled before work began.",
+                detached_tool_name="ouroboros_start_evaluate",
+                detached_arguments=arguments,
+                runtime_backend=self.agent_runtime_backend,
+                llm_backend=self.llm_backend,
+                opencode_mode=self.opencode_mode,
+            )
         )
 
         text = (

--- a/src/ouroboros/mcp/tools/evaluation_job.py
+++ b/src/ouroboros/mcp/tools/evaluation_job.py
@@ -51,13 +51,26 @@ class SeedHandoffRedemption:
                 seed_content=self.seed_content,
             )
 
-    async def accept(self, operation: Awaitable[Any], *, require_ok: bool = False) -> Any:
+    async def accept(
+        self,
+        operation: Awaitable[Any],
+        *,
+        require_ok: bool = False,
+        cancellation_may_have_accepted: bool = True,
+    ) -> Any:
+        """Commit redemption once the selected transport accepts ownership.
+
+        Detached transports may spawn an external owner before cancellation is
+        observed, so their cancellation remains ambiguous.  Plugin dispatch is
+        different: no owner exists until the ``_subagent`` envelope is returned,
+        and its caller therefore opts into compensation on pre-envelope cancel.
+        """
         try:
             result = await operation
         except BaseException as exc:
-            acceptance_unknown = isinstance(exc, asyncio.CancelledError) or (
-                getattr(exc, "error_code", None) == "detached_job_acceptance_pending"
-            )
+            acceptance_unknown = (
+                isinstance(exc, asyncio.CancelledError) and cancellation_may_have_accepted
+            ) or (getattr(exc, "error_code", None) == "detached_job_acceptance_pending")
             if not acceptance_unknown:
                 self.rollback()
             raise

--- a/src/ouroboros/mcp/tools/evaluation_job.py
+++ b/src/ouroboros/mcp/tools/evaluation_job.py
@@ -56,7 +56,7 @@ class SeedHandoffRedemption:
         operation: Awaitable[Any],
         *,
         require_ok: bool = False,
-        cancellation_may_have_accepted: bool = True,
+        cancellation_may_have_accepted: bool | Callable[[], bool] = True,
     ) -> Any:
         """Commit redemption once the selected transport accepts ownership.
 
@@ -68,8 +68,13 @@ class SeedHandoffRedemption:
         try:
             result = await operation
         except BaseException as exc:
+            cancellation_is_ambiguous = (
+                cancellation_may_have_accepted()
+                if callable(cancellation_may_have_accepted)
+                else cancellation_may_have_accepted
+            )
             acceptance_unknown = (
-                isinstance(exc, asyncio.CancelledError) and cancellation_may_have_accepted
+                isinstance(exc, asyncio.CancelledError) and cancellation_is_ambiguous
             ) or (getattr(exc, "error_code", None) == "detached_job_acceptance_pending")
             if not acceptance_unknown:
                 self.rollback()

--- a/src/ouroboros/mcp/tools/evaluation_job.py
+++ b/src/ouroboros/mcp/tools/evaluation_job.py
@@ -34,6 +34,38 @@ class WorkerSafeEvaluationInputs:
     artifact: str
 
 
+@dataclass(slots=True)
+class SeedHandoffRedemption:
+    """Compensate a one-shot handoff until downstream ownership is accepted."""
+
+    registry: Any | None
+    handoff_id: str | None
+    session_id: str
+    seed_content: str | None
+
+    def rollback(self) -> None:
+        if self.registry is not None and self.handoff_id and self.seed_content is not None:
+            self.registry.restore(
+                self.handoff_id,
+                session_id=self.session_id,
+                seed_content=self.seed_content,
+            )
+
+    async def accept(self, operation: Awaitable[Any], *, require_ok: bool = False) -> Any:
+        try:
+            result = await operation
+        except BaseException as exc:
+            acceptance_unknown = isinstance(exc, asyncio.CancelledError) or (
+                getattr(exc, "error_code", None) == "detached_job_acceptance_pending"
+            )
+            if not acceptance_unknown:
+                self.rollback()
+            raise
+        if require_ok and result.is_err:
+            self.rollback()
+        return result
+
+
 def worker_safe_evaluation_inputs(
     seed_content: object,
     acceptance_criterion: str | None,
@@ -56,14 +88,14 @@ def restore_seed_handoff(
     *,
     session_id: str,
     registry: Any | None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], SeedHandoffRedemption]:
     """Restore a raw Seed only inside the parent process that minted its handle."""
 
     restored = dict(arguments)
     handoff_id = arguments.get("seed_handoff_id")
     if not isinstance(handoff_id, str) or not handoff_id:
-        return restored
-    seed_content = registry.resolve(handoff_id, session_id=session_id) if registry else None
+        return restored, SeedHandoffRedemption(registry, None, session_id, None)
+    seed_content = registry.consume(handoff_id, session_id=session_id) if registry else None
     if seed_content is None:
         raise ValueError("seed_handoff_id is unknown or does not belong to this session")
     restored["seed_content"] = seed_content
@@ -72,7 +104,7 @@ def restore_seed_handoff(
     # a fresh worker can use the restored parent-owned Seed without consulting
     # an empty process-local registry.
     restored.pop("seed_handoff_id", None)
-    return restored
+    return restored, SeedHandoffRedemption(registry, handoff_id, session_id, seed_content)
 
 
 def snapshot_auto_evolve_policy(

--- a/src/ouroboros/mcp/tools/runtime_tool_composition.py
+++ b/src/ouroboros/mcp/tools/runtime_tool_composition.py
@@ -7,13 +7,85 @@ same configured run -> evaluate -> Ralph -> evolve graph as the MCP server.
 
 from __future__ import annotations
 
+import asyncio
 from contextvars import ContextVar
+import inspect
 from typing import Any
 
 _COMPOSING_RUNTIME_TOOLS: ContextVar[bool] = ContextVar(
     "ouroboros_composing_runtime_tools",
     default=False,
 )
+
+
+class ConfiguredRuntimeTools(tuple[Any, ...]):
+    """Configured handlers plus the composition root that owns their resources.
+
+    Builtin runtimes index the handlers into a local registry, but the handlers
+    retain EventStore, ControlBus, bridge, and JobManager dependencies owned by
+    the temporary :class:`MCPServerAdapter`.  Keeping that adapter here provides
+    a deterministic shutdown path instead of discarding the only resource owner.
+    """
+
+    server_owner: Any
+    _closed: bool
+    _shutdown_lock: asyncio.Lock
+
+    def __new__(
+        cls,
+        handlers: tuple[Any, ...],
+        *,
+        server_owner: Any,
+    ) -> ConfiguredRuntimeTools:
+        instance = super().__new__(cls, handlers)
+        instance.server_owner = server_owner
+        instance._closed = False
+        instance._shutdown_lock = asyncio.Lock()
+        return instance
+
+    async def shutdown(self) -> None:
+        """Drain live jobs, then close the composed resources exactly once."""
+        async with self._shutdown_lock:
+            if self._closed:
+                return
+            job_manager = getattr(self.server_owner, "job_manager", None)
+            drain = getattr(job_manager, "drain", None)
+            if callable(drain):
+                await drain()
+            await self.server_owner.shutdown()
+            self._closed = True
+
+
+def _retain_runtime_tool_composition(
+    runtime_adapter: Any,
+    composition: ConfiguredRuntimeTools,
+) -> None:
+    existing = getattr(runtime_adapter, "_builtin_mcp_tool_composition", None)
+    if existing is not None and existing is not composition:
+        raise RuntimeError("Builtin MCP tool composition is already configured")
+    runtime_adapter._builtin_mcp_tool_composition = composition  # noqa: SLF001
+    previous_aclose = getattr(runtime_adapter, "aclose", None)
+
+    async def close_runtime() -> None:
+        await shutdown_configured_runtime_tools(runtime_adapter)
+        if getattr(runtime_adapter, "aclose", None) is close_runtime:
+            runtime_adapter.aclose = previous_aclose
+        if inspect.iscoroutinefunction(previous_aclose):
+            await previous_aclose()
+
+    runtime_adapter.aclose = close_runtime
+
+
+async def shutdown_configured_runtime_tools(runtime_adapter: Any) -> None:
+    """Release and clear a runtime's configured builtin handler resources."""
+    composition = getattr(runtime_adapter, "_builtin_mcp_tool_composition", None)
+    if composition is None:
+        return
+    await composition.shutdown()
+    if getattr(runtime_adapter, "_builtin_mcp_tool_composition", None) is composition:
+        runtime_adapter._builtin_mcp_tool_composition = None  # noqa: SLF001
+        if hasattr(runtime_adapter, "_builtin_mcp_handlers"):
+            runtime_adapter._builtin_mcp_handlers = None  # noqa: SLF001
 
 
 def lightweight_runtime_tool_map(
@@ -39,7 +111,7 @@ def configured_runtime_tools(
     include_auto: bool,
     mcp_bridge: Any | None,
     runtime_adapter: Any | None = None,
-) -> tuple[Any, ...] | None:
+) -> ConfiguredRuntimeTools | None:
     """Return the production handler graph, or ``None`` for lightweight fallback.
 
     ``create_ouroboros_server`` constructs runtime adapters whose registry
@@ -52,9 +124,10 @@ def configured_runtime_tools(
     # using it only for capability discovery. They therefore need the complete
     # parent-owned run -> evaluate -> Ralph -> evolve graph. OpenCode also uses
     # the graph as the process-local vault behind its opaque hidden-Seed handoff.
-    executing_builtin_runtime = (
-        runtime_adapter is not None and runtime_backend in {"codex", "hermes"}
-    ) or (runtime_backend == "opencode" and opencode_mode == "plugin")
+    executing_builtin_runtime = runtime_adapter is not None and (
+        runtime_backend in {"codex", "hermes"}
+        or (runtime_backend == "opencode" and opencode_mode == "plugin")
+    )
     if not executing_builtin_runtime or _COMPOSING_RUNTIME_TOOLS.get():
         return None
 
@@ -120,4 +193,10 @@ def configured_runtime_tools(
         "ouroboros_pm_interview",
         "ouroboros_qa",
     )
-    return tuple(configured[name] for name in ordered_names)
+    tools = ConfiguredRuntimeTools(
+        tuple(configured[name] for name in ordered_names),
+        server_owner=server,
+    )
+    if runtime_adapter is not None:
+        _retain_runtime_tool_composition(runtime_adapter, tools)
+    return tools

--- a/src/ouroboros/mcp/tools/seed_handoff.py
+++ b/src/ouroboros/mcp/tools/seed_handoff.py
@@ -189,3 +189,21 @@ class SeedHandoffRegistry:
             return None
         self._entries.move_to_end(handoff_id)
         return entry[1]
+
+    def consume(self, handoff_id: str, *, session_id: str) -> str | None:
+        """Redeem a session-bound handoff exactly once."""
+        entry = self._entries.get(handoff_id)
+        if entry is None or entry[0] != session_id:
+            return None
+        del self._entries[handoff_id]
+        return entry[1]
+
+    def restore(self, handoff_id: str, *, session_id: str, seed_content: str) -> bool:
+        """Compensate a failed redemption without replacing another claim."""
+        if handoff_id in self._entries:
+            return False
+        self._entries[handoff_id] = (session_id, seed_content)
+        self._entries.move_to_end(handoff_id)
+        while len(self._entries) > max(1, self.max_entries):
+            self._entries.popitem(last=False)
+        return True

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -812,6 +812,7 @@ class OpenCodeRuntime:
                     runtime_backend=self._runtime_backend,
                     llm_backend=self._llm_backend,
                     opencode_mode=self._opencode_mode,
+                    runtime_adapter=self,
                 )
             }
         return self._builtin_mcp_handlers

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -9333,7 +9333,10 @@ class OrchestratorRunner:
                 ):
                     parallel_kwargs["force_sequential_levels"] = True
 
-                return await self._execute_parallel(**parallel_kwargs)
+                try:
+                    return await self._execute_parallel(**parallel_kwargs)
+                finally:
+                    await self._close_adapter()
 
             from ouroboros.orchestrator.dependency_analyzer import (
                 ACNode,
@@ -10454,28 +10457,25 @@ class OrchestratorRunner:
             tracker = tracker.with_progress(resume_owner_progress)
 
         try:
-            try:
-                parallel_result = await parallel_executor.execute_parallel(
-                    seed=seed,
-                    execution_plan=execution_plan,
-                    session_id=tracker.session_id,
-                    execution_id=exec_id,
-                    tools=merged_tools,
-                    tool_catalog=tool_catalog.tools,
-                    system_prompt=system_prompt,
-                    externally_satisfied_acs=externally_satisfied_acs,
-                    published_coordinator_pause_owner=published_coordinator_pause_owner,
-                )
-            except ParallelExecutionCancelled as cancelled:
-                return await self._handle_cancellation(
-                    session_id=tracker.session_id,
-                    execution_id=exec_id,
-                    messages_processed=cancelled.messages_processed,
-                    start_time=start_time,
-                    expected_root_indices=range(len(seed.acceptance_criteria)),
-                )
-        finally:
-            await self._close_adapter()
+            parallel_result = await parallel_executor.execute_parallel(
+                seed=seed,
+                execution_plan=execution_plan,
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                tools=merged_tools,
+                tool_catalog=tool_catalog.tools,
+                system_prompt=system_prompt,
+                externally_satisfied_acs=externally_satisfied_acs,
+                published_coordinator_pause_owner=published_coordinator_pause_owner,
+            )
+        except ParallelExecutionCancelled as cancelled:
+            return await self._handle_cancellation(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                messages_processed=cancelled.messages_processed,
+                start_time=start_time,
+                expected_root_indices=range(len(seed.acceptance_criteria)),
+            )
 
         # Check for cancellation after parallel execution
         if await self._check_cancellation(tracker.session_id):
@@ -11323,19 +11323,22 @@ Note: This is a resumed session. Please continue from where execution was interr
                     seed,
                     tracker.progress.get("routing_parallel_externally_satisfied_acs"),
                 )
-                return await self._execute_parallel(
-                    seed=seed,
-                    exec_id=tracker.execution_id,
-                    tracker=tracker,
-                    merged_tools=merged_tools,
-                    tool_catalog=tool_catalog,
-                    system_prompt=system_prompt,
-                    start_time=start_time,
-                    execution_contract=execution_contract,
-                    externally_satisfied_acs=resume_externally_satisfied_acs,
-                    force_sequential_levels=force_sequential,
-                    resume_execution_plan=resume_execution_plan,
-                )
+                try:
+                    return await self._execute_parallel(
+                        seed=seed,
+                        exec_id=tracker.execution_id,
+                        tracker=tracker,
+                        merged_tools=merged_tools,
+                        tool_catalog=tool_catalog,
+                        system_prompt=system_prompt,
+                        start_time=start_time,
+                        execution_contract=execution_contract,
+                        externally_satisfied_acs=resume_externally_satisfied_acs,
+                        force_sequential_levels=force_sequential,
+                        resume_execution_plan=resume_execution_plan,
+                    )
+                finally:
+                    await self._close_adapter()
         except asyncio.CancelledError:
             cancellation_result = (
                 await self._drain_requested_cancellation_before_pre_execution_cleanup(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -8539,6 +8539,11 @@ class OrchestratorRunner:
             )
         )
 
+    async def _close_adapter(self) -> None:
+        adapter_aclose = getattr(self._adapter, "aclose", None)
+        if inspect.iscoroutinefunction(adapter_aclose):
+            await adapter_aclose()
+
     async def execute_seed(
         self,
         seed: Seed,
@@ -10138,6 +10143,7 @@ class OrchestratorRunner:
                     session_id=tracker.session_id,
                     context="execute",
                 )
+                await self._close_adapter()
 
     async def _execute_parallel(
         self,
@@ -10469,16 +10475,7 @@ class OrchestratorRunner:
                     expected_root_indices=range(len(seed.acceptance_criteria)),
                 )
         finally:
-            # Release any warm worker-pool sessions the runtime holds (e.g. the
-            # codex-mcp persistent connection pool). The non-parallel path closes
-            # per-turn handles, but the parallel path otherwise leaves the pool to
-            # its idle TTL — a process-leak window after every run. Guard on
-            # ``iscoroutinefunction`` so this is a no-op for runtimes without a
-            # real async ``aclose`` (and so MagicMock test adapters, whose
-            # attribute access auto-creates a non-awaitable child, are skipped).
-            adapter_aclose = getattr(self._adapter, "aclose", None)
-            if inspect.iscoroutinefunction(adapter_aclose):
-                await adapter_aclose()
+            await self._close_adapter()
 
         # Check for cancellation after parallel execution
         if await self._check_cancellation(tracker.session_id):
@@ -12086,6 +12083,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                     session_id=session_id,
                     context="resume",
                 )
+                await self._close_adapter()
 
 
 __all__ = [

--- a/tests/unit/mcp/tools/test_evaluate_ralph_chaining.py
+++ b/tests/unit/mcp/tools/test_evaluate_ralph_chaining.py
@@ -383,19 +383,32 @@ async def test_server_composition_reuses_configured_chain_handlers(
     assert start_evaluate.start_ralph_handler._evolve_handler.evolutionary_loop is not None
 
 
+def _builtin_runtime(
+    runtime_backend: str,
+    opencode_mode: str | None = None,
+) -> Any:
+    if runtime_backend == "codex":
+        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+        return CodexCliRuntime(cli_path="codex")
+    if runtime_backend == "hermes":
+        from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime
+
+        return HermesCliRuntime(cli_path="hermes")
+    if runtime_backend == "opencode":
+        from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
+
+        return OpenCodeRuntime(cli_path="opencode", opencode_mode=opencode_mode)
+
+    raise AssertionError(f"unsupported builtin test runtime: {runtime_backend}")
+
+
 def _builtin_runtime_tools(
     runtime_backend: str,
     opencode_mode: str | None = None,
 ) -> tuple[Any, ...]:
-    if runtime_backend == "codex":
-        from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
-
-        runtime = CodexCliRuntime(cli_path="codex")
-        return tuple(runtime._get_builtin_mcp_handlers().values())
-    if runtime_backend == "hermes":
-        from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime
-
-        runtime = HermesCliRuntime(cli_path="hermes")
+    if runtime_backend in {"codex", "hermes", "opencode"}:
+        runtime = _builtin_runtime(runtime_backend, opencode_mode)
         return tuple(runtime._get_builtin_mcp_handlers().values())
 
     from ouroboros.mcp.tools.definitions import get_ouroboros_tools
@@ -405,6 +418,22 @@ def _builtin_runtime_tools(
         opencode_mode=opencode_mode,
         include_auto=False,
     )
+
+
+def test_ownerless_opencode_factory_stays_lightweight_and_side_effect_free() -> None:
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+
+    with patch("ouroboros.mcp.server.adapter.create_ouroboros_server") as create_server:
+        tools = get_ouroboros_tools(
+            runtime_backend="opencode",
+            opencode_mode="plugin",
+            include_auto=False,
+        )
+
+    start_evaluate = next(tool for tool in tools if isinstance(tool, StartEvaluateHandler))
+    create_server.assert_not_called()
+    assert type(tools) is tuple
+    assert start_evaluate.start_ralph_handler is None
 
 
 @pytest.mark.parametrize(
@@ -442,6 +471,82 @@ def test_runtime_factory_reuses_configured_parent_owned_convergence_graph(
     assert start_execute._event_store is start_evaluate._event_store
     assert execute.seed_handoff_registry is start_execute.seed_handoff_registry
     assert execute.seed_handoff_registry is start_evaluate.seed_handoff_registry
+
+
+@pytest.mark.parametrize(
+    ("runtime_backend", "opencode_mode"),
+    [("codex", None), ("hermes", None), ("opencode", "plugin")],
+)
+def test_builtin_composition_reuses_canonicalized_runtime_owner(
+    runtime_backend: str,
+    opencode_mode: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handle aliases such as codex_cli must not materialize a nested runtime."""
+    runtime = _builtin_runtime(runtime_backend, opencode_mode)
+
+    def unexpected_runtime_factory(**_: Any) -> Any:
+        raise AssertionError("configured composition replaced its injected runtime owner")
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.create_agent_runtime",
+        unexpected_runtime_factory,
+    )
+
+    handlers = runtime._get_builtin_mcp_handlers()
+
+    assert handlers
+    assert runtime._builtin_mcp_tool_composition is not None
+
+
+@pytest.mark.parametrize(
+    ("runtime_backend", "opencode_mode"),
+    [("codex", None), ("hermes", None), ("opencode", "plugin")],
+)
+async def test_builtin_runtime_owns_and_shuts_down_composed_resources(
+    runtime_backend: str,
+    opencode_mode: str | None,
+) -> None:
+    runtime = _builtin_runtime(runtime_backend, opencode_mode)
+    runtime._get_builtin_mcp_handlers()
+    composition = runtime._builtin_mcp_tool_composition
+    assert composition is not None
+    close_order: list[str] = []
+
+    async def drain() -> None:
+        close_order.append("drain")
+
+    async def shutdown() -> None:
+        close_order.append("shutdown")
+
+    composition.server_owner.job_manager.drain = AsyncMock(side_effect=drain)
+    composition.server_owner.shutdown = AsyncMock(side_effect=shutdown)
+
+    await runtime.aclose()
+    await composition.shutdown()
+
+    composition.server_owner.job_manager.drain.assert_awaited_once()
+    composition.server_owner.shutdown.assert_awaited_once()
+    assert close_order == ["drain", "shutdown"]
+    assert runtime._builtin_mcp_handlers is None
+    assert runtime._builtin_mcp_tool_composition is None
+    assert runtime.aclose is None
+
+
+async def test_builtin_runtime_preserves_composition_owner_when_shutdown_fails() -> None:
+    runtime = _builtin_runtime("codex")
+    handlers = runtime._get_builtin_mcp_handlers()
+    composition = runtime._builtin_mcp_tool_composition
+    assert composition is not None
+    composition.server_owner.job_manager.drain = AsyncMock(side_effect=RuntimeError("drain"))
+    composition.server_owner.shutdown = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="drain"):
+        await runtime.aclose()
+
+    composition.server_owner.shutdown.assert_not_awaited()
+    assert runtime._builtin_mcp_handlers is handlers
+    assert runtime._builtin_mcp_tool_composition is composition
 
 
 @pytest.mark.parametrize("runtime_backend", ["codex", "hermes"])

--- a/tests/unit/mcp/tools/test_seed_handoff.py
+++ b/tests/unit/mcp/tools/test_seed_handoff.py
@@ -82,14 +82,18 @@ def test_restore_consumes_process_local_handoff_handle() -> None:
     handoff_id = registry.register(session_id="orch-restore", seed_content="goal: private")
     original = {"session_id": "orch-restore", "seed_handoff_id": handoff_id}
 
-    restored = restore_seed_handoff(
+    restored, redemption = restore_seed_handoff(
         original,
         session_id="orch-restore",
         registry=registry,
     )
 
     assert restored == {"session_id": "orch-restore", "seed_content": "goal: private"}
+    assert redemption.handoff_id == handoff_id
     assert original["seed_handoff_id"] == handoff_id
+    assert registry.resolve(handoff_id, session_id="orch-restore") is None
+    with pytest.raises(ValueError, match="unknown or does not belong"):
+        restore_seed_handoff(original, session_id="orch-restore", registry=registry)
 
 
 def test_disabled_auto_evolve_snapshot_survives_enabled_config_on_reentry() -> None:

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -311,6 +311,55 @@ class TestPluginModeDispatch:
         assert result.value.meta["job_id"] is None
 
     @pytest.mark.asyncio
+    async def test_pre_envelope_cancellation_restores_handoff_for_retry(
+        self,
+        event_store: EventStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_plugin_cancel",
+            seed_content="goal: retry plugin dispatch safely\n",
+        )
+        handler = StartEvaluateHandler(
+            event_store=event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_plugin_cancel",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": False,
+        }
+        initialize_started = asyncio.Event()
+        original_initialize = event_store.initialize
+
+        async def blocking_initialize() -> None:
+            initialize_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(event_store, "initialize", blocking_initialize)
+        dispatch = asyncio.create_task(handler.handle(arguments))
+        await initialize_started.wait()
+        dispatch.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await dispatch
+
+        assert registry.resolve(handoff_id, session_id="orch_plugin_cancel") is not None
+
+        monkeypatch.setattr(event_store, "initialize", original_initialize)
+        retry = await handler.handle(arguments)
+
+        assert retry.is_ok
+        assert retry.value.meta["status"] == "delegated_to_plugin"
+        assert registry.resolve(handoff_id, session_id="orch_plugin_cancel") is None
+
+    @pytest.mark.asyncio
     async def test_status_delegated_to_plugin(self, handler) -> None:
         result = await handler.handle({"session_id": "orch_xyz", "artifact": "code"})
         assert result.value.meta["status"] == "delegated_to_plugin"

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -227,6 +227,191 @@ class TestBackgroundJobPath:
     """Non-plugin runtime: a JobManager-backed job is enqueued."""
 
     @pytest.mark.asyncio
+    async def test_preallocation_cancellation_restores_handoff_for_retry(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cancellation before job allocation is definitive non-acceptance."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        manager = JobManager(event_store, durable_jobs=False)
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_preallocation_cancel",
+            seed_content="goal: retry after definitive cancellation\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_preallocation_cancel",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+        allocation_started = asyncio.Event()
+        original_allocate = manager.allocate_job_id
+
+        async def block_allocation() -> str:
+            allocation_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(manager, "allocate_job_id", block_allocation)
+        pending = asyncio.create_task(handler.handle(arguments))
+        await allocation_started.wait()
+        pending.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        assert registry.resolve(handoff_id, session_id="orch_preallocation_cancel") is not None
+        assert manager._known_job_ids == set()
+        assert manager._reserved_job_ids == set()
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
+        assert await event_store.query_events(aggregate_type="job") == []
+
+        monkeypatch.setattr(manager, "allocate_job_id", original_allocate)
+        retry = await handler.handle(arguments)
+
+        assert retry.is_ok
+        assert retry.value.meta["job_id"]
+        assert registry.resolve(handoff_id, session_id="orch_preallocation_cancel") is None
+        await manager.drain()
+
+    @pytest.mark.asyncio
+    async def test_local_preenqueue_cancellation_restores_handoff_for_retry(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cancellation before local ownership is definitive non-acceptance."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        manager = JobManager(event_store, durable_jobs=False)
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_local_preenqueue_cancel",
+            seed_content="goal: retry before local ownership\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_local_preenqueue_cancel",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+        enqueue_started = asyncio.Event()
+        original_start_job = manager.start_job
+
+        async def block_enqueue(**_kwargs):
+            enqueue_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(manager, "start_job", block_enqueue)
+        pending = asyncio.create_task(handler.handle(arguments))
+        await enqueue_started.wait()
+        pending.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        assert registry.resolve(handoff_id, session_id="orch_local_preenqueue_cancel") is not None
+        assert manager._started_job_ids == set()
+        assert manager._tasks == {}
+        assert await event_store.query_events(aggregate_type="job") == []
+
+        monkeypatch.setattr(manager, "start_job", original_start_job)
+        retry = await handler.handle(arguments)
+
+        assert retry.is_ok
+        assert registry.resolve(handoff_id, session_id="orch_local_preenqueue_cancel") is None
+        await manager.drain()
+
+    @pytest.mark.asyncio
+    async def test_local_postacceptance_cancellation_keeps_handoff_consumed(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cancellation after local ownership must not permit a duplicate retry."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        manager = JobManager(event_store, durable_jobs=False)
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_local_accepted_cancel",
+            seed_content="goal: do not retry after local ownership\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_local_accepted_cancel",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+        accepted = asyncio.Event()
+        work_started = asyncio.Event()
+        release_work = asyncio.Event()
+        original_start_job = manager.start_job
+
+        async def finish_after_release(_arguments):
+            work_started.set()
+            await release_work.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="evaluated"),),
+                    is_error=False,
+                    meta={"final_approved": True},
+                )
+            )
+
+        fake_inner_handler.handle = AsyncMock(side_effect=finish_after_release)
+
+        async def block_after_acceptance(**kwargs):
+            await original_start_job(**kwargs)
+            accepted.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(manager, "start_job", block_after_acceptance)
+        pending = asyncio.create_task(handler.handle(arguments))
+        await accepted.wait()
+        await work_started.wait()
+        job_id = next(iter(manager._started_job_ids))
+        job_task = manager._tasks[job_id]
+        pending.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        assert registry.resolve(handoff_id, session_id="orch_local_accepted_cancel") is None
+        release_work.set()
+        await asyncio.wait_for(asyncio.shield(job_task), timeout=1.0)
+        assert (await manager.get_snapshot(job_id)).is_terminal
+        await manager.drain()
+
+    @pytest.mark.asyncio
     async def test_returns_job_id_immediately(self, event_store, fake_inner_handler) -> None:
         job_manager = MagicMock()
         job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.job_manager import JobManager
 from ouroboros.mcp.tools.evaluation_handlers import (
     EvaluateHandler,
@@ -114,6 +115,94 @@ class TestDefinition:
             assert request.arguments["seed_content"].startswith("goal: parent only")
             assert request.arguments["auto_evolve"] is True
             assert request.arguments["_auto_evolve_max_generations"] >= 1
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_failed_detached_acceptance_restores_handoff_for_retry(
+        self, tmp_path: Path, fake_inner_handler
+    ) -> None:
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'handoff-retry.db'}")
+        await store.initialize()
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_handoff_retry",
+            seed_content="goal: retry safely\n",
+        )
+        snapshot = MagicMock(job_id="job_handoff_retry", cursor=0)
+        snapshot.status.value = "queued"
+        launch = AsyncMock(side_effect=[RuntimeError("not accepted"), snapshot])
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=JobManager(store, durable_jobs=True),
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_handoff_retry",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        try:
+            with patch("ouroboros.mcp.tools.background.launch_detached_job", new=launch):
+                with pytest.raises(RuntimeError, match="not accepted"):
+                    await handler.handle(arguments)
+                assert registry.resolve(handoff_id, session_id="orch_handoff_retry") is not None
+                result = await handler.handle(arguments)
+
+            assert result.is_ok
+            assert registry.resolve(handoff_id, session_id="orch_handoff_retry") is None
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_pending_detached_acceptance_keeps_handoff_consumed(
+        self, tmp_path: Path, fake_inner_handler
+    ) -> None:
+        from ouroboros.mcp.detached_jobs import DetachedJobAcceptanceTimeout
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'handoff-pending.db'}")
+        await store.initialize()
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_handoff_pending",
+            seed_content="goal: do not duplicate\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=JobManager(store, durable_jobs=True),
+            seed_handoff_registry=registry,
+        )
+
+        try:
+            with patch(
+                "ouroboros.mcp.tools.background.launch_detached_job",
+                new=AsyncMock(
+                    side_effect=DetachedJobAcceptanceTimeout(
+                        job_id="job_handoff_pending",
+                        worker_pid=4242,
+                        timeout_seconds=0.1,
+                    )
+                ),
+            ):
+                with pytest.raises(MCPToolError, match="acceptance is still pending") as raised:
+                    await handler.handle(
+                        {
+                            "session_id": "orch_handoff_pending",
+                            "artifact": "partial artifact",
+                            "seed_handoff_id": handoff_id,
+                            "auto_evolve": True,
+                        }
+                    )
+
+            assert raised.value.error_code == "detached_job_acceptance_pending"
+            assert registry.resolve(handoff_id, session_id="orch_handoff_pending") is None
         finally:
             await store.close()
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -721,6 +721,13 @@ class TestOrchestratorRunner:
         _allow_mocked_precreated_durable_state(runner)
         return runner
 
+    async def test_close_adapter_awaits_runtime_lifecycle(self, runner) -> None:
+        runner._adapter.aclose = AsyncMock()
+
+        await runner._close_adapter()
+
+        runner._adapter.aclose.assert_awaited_once()
+
     def test_param_degradation_notice_surfaces_for_serial_runner(
         self,
         mock_adapter: MagicMock,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1929,6 +1929,7 @@ class TestOrchestratorRunner:
             mock_console,
             enable_decomposition=False,
         )
+        mock_adapter.aclose = AsyncMock()
         tracker = SessionTracker.create(
             "execution-external-resume",
             seed.metadata.seed_id,
@@ -1986,6 +1987,7 @@ class TestOrchestratorRunner:
 
         assert result.is_ok
         assert parallel_resume.await_args.kwargs["externally_satisfied_acs"] == external
+        mock_adapter.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_direct_bounded_paused_route_actually_resumes_same_provider_handle(
@@ -7506,6 +7508,7 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        mock_adapter.aclose = AsyncMock()
         tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
         dependency_graph = DependencyGraph(
             nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
@@ -7561,6 +7564,7 @@ class TestOrchestratorRunner:
 
         assert result.is_ok
         assert captured_init["fat_harness_mode"] is True
+        mock_adapter.aclose.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fat_harness_uses_profile_backed_prompt_contract(
@@ -7577,6 +7581,7 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
+        mock_adapter.aclose = AsyncMock()
         tracker = SessionTracker.create("exec_profile_prompt", sample_seed.metadata.seed_id)
         tracker = _attach_live_process_local_contract(
             runner,
@@ -7620,6 +7625,7 @@ class TestOrchestratorRunner:
         assert "tests_passed" in system_prompt
         assert "evidence record as a receipt" in system_prompt
         assert "exact successful test command" in system_prompt
+        mock_adapter.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_fat_harness_single_ac_uses_ac_executor_path(


### PR DESCRIPTION
## Summary

- Retain the parent-owned convergence composition for the full builtin runtime lifecycle instead of discarding its resource owner.
- Consume opaque Seed handoffs exactly once while compensating only definitive downstream rejection.
- Keep ownerless capability discovery lightweight and avoid nested runtimes for canonical backend aliases.

## Changes

- Add an explicit configured-tool composition owner with ordered JobManager drain and server shutdown, wired into sequential, parallel, and resume cleanup.
- Canonicalize Codex/Hermes/OpenCode runtime identities before deciding whether the injected owner can be reused.
- Make Seed handoff redemption one-shot; restore it after definitive dispatch/enqueue failure, but preserve consumption when acceptance is ambiguous.
- Document the transport confidentiality boundary and filesystem-sandbox limitation.
- Add lifecycle, owner reuse, ownerless factory, and handoff acceptance regressions.

## Verification

- Full pre-restack suite: 17,155 passed, 93 skipped, 1 xfailed.
- Latest main focused suite: 346 passed, 1 skipped.
- Ruff check and format check passed.
- Mypy passed across 530 source files.
- Module-size, ooo-auto-boundary, max-turns-envelope, and diff checks passed.
- Independent broad architecture audit: PASS, no blocking findings.

Follow-up to #1916.
Refs #1917.
