### PR TITLE
fix(mcp): preserve zero-time job snapshots under load

### DIFF
--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -31,6 +31,10 @@ from ouroboros.mcp.tools.attention_relay import (
     RELAY_SOURCE_EVENT_TYPES,
     classify_relay_events,
 )
+from ouroboros.mcp.tools.job_wait_guard import (
+    JOB_WAIT_GUARD_VERSION,
+    await_job_wait_request,
+)
 from ouroboros.mcp.types import (
     ContentType,
     MCPContentItem,
@@ -54,7 +58,6 @@ log = structlog.get_logger(__name__)
 
 _DEFAULT_JOB_VIEW = "full"
 _MAX_JOB_WAIT_TIMEOUT_SECONDS = 5
-_JOB_WAIT_GUARD_VERSION = "detached-branch-timeout-v2"
 _JOB_WAIT_RESPONSE_GRACE_SECONDS = 1.0
 _JOB_WAIT_EXECUTION_SCAN_TIMEOUT_SECONDS = 1.0
 _JOB_WAIT_RENDER_TIMEOUT_SECONDS = 2.0
@@ -231,69 +234,6 @@ def _job_wait_internal_timeout_result(
             "result_available": False,
         },
     )
-
-
-def _consume_detached_wait_task(task: asyncio.Task[Any]) -> None:
-    try:
-        task.result()
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        log.warning("mcp.tool.job_wait.detached_wait_failed", exc_info=True)
-
-
-async def _await_job_wait_branch(
-    awaitable: Any,
-    *,
-    timeout: float,
-    job_id: str,
-    branch: str,
-) -> Any:
-    """Await a job wait branch without waiting for slow cancellation cleanup."""
-    log.debug(
-        "mcp.tool.job_wait.guard.enter",
-        job_id=job_id,
-        branch=branch,
-        timeout_seconds=timeout,
-        guard_version=_JOB_WAIT_GUARD_VERSION,
-        pid=os.getpid(),
-    )
-    task = asyncio.create_task(awaitable)
-    log.debug(
-        "mcp.tool.job_wait.guard.task_created",
-        job_id=job_id,
-        branch=branch,
-        guard_version=_JOB_WAIT_GUARD_VERSION,
-        pid=os.getpid(),
-    )
-    try:
-        done, _pending = await asyncio.wait({task}, timeout=timeout)
-    except asyncio.CancelledError:
-        task.cancel()
-        task.add_done_callback(_consume_detached_wait_task)
-        raise
-    log.debug(
-        "mcp.tool.job_wait.guard.wait_returned",
-        job_id=job_id,
-        branch=branch,
-        done=task in done,
-        guard_version=_JOB_WAIT_GUARD_VERSION,
-        pid=os.getpid(),
-    )
-    if task in done:
-        return task.result()
-
-    task.cancel()
-    task.add_done_callback(_consume_detached_wait_task)
-    log.debug(
-        "mcp.tool.job_wait.wait.branch_timeout",
-        job_id=job_id,
-        branch=branch,
-        timeout_seconds=timeout,
-        guard_version=_JOB_WAIT_GUARD_VERSION,
-        pid=os.getpid(),
-    )
-    raise TimeoutError
 
 
 async def _query_all_execution_subtask_events(
@@ -1466,7 +1406,7 @@ class JobWaitHandler:
             stream=stream,
             wait_for=wait_for,
             wait_response_timeout=wait_response_timeout,
-            guard_version=_JOB_WAIT_GUARD_VERSION,
+            guard_version=JOB_WAIT_GUARD_VERSION,
             pid=os.getpid(),
         )
 
@@ -1517,7 +1457,7 @@ class JobWaitHandler:
                         asyncio.get_running_loop().time() - started_at,
                         3,
                     ),
-                    guard_version=_JOB_WAIT_GUARD_VERSION,
+                    guard_version=JOB_WAIT_GUARD_VERSION,
                     pid=os.getpid(),
                 )
                 return Result.ok(result)
@@ -1539,14 +1479,15 @@ class JobWaitHandler:
                     stream_events,
                     stream_cursor,
                     stream_has_more,
-                ) = await _await_job_wait_branch(
+                ) = await await_job_wait_request(
                     self._wait_for_linked_change(
                         job_id,
                         cursor=cursor,
                         timeout_seconds=timeout_seconds,
                         wait_for=wait_for,
                     ),
-                    timeout=wait_response_timeout,
+                    timeout_seconds=timeout_seconds,
+                    response_timeout=wait_response_timeout,
                     job_id=job_id,
                     branch="linked",
                 )
@@ -1567,14 +1508,15 @@ class JobWaitHandler:
                     changed,
                     stream_cursor,
                     meaningful_execution_changed,
-                ) = await _await_job_wait_branch(
+                ) = await await_job_wait_request(
                     self._wait_for_meaningful_change(
                         job_id,
                         cursor=cursor,
                         timeout_seconds=timeout_seconds,
                         wait_for=wait_for,
                     ),
-                    timeout=wait_response_timeout,
+                    timeout_seconds=timeout_seconds,
+                    response_timeout=wait_response_timeout,
                     job_id=job_id,
                     branch="meaningful",
                 )
@@ -1591,13 +1533,14 @@ class JobWaitHandler:
                     wait_for=wait_for,
                     wait_response_timeout=wait_response_timeout,
                 )
-                snapshot, changed = await _await_job_wait_branch(
+                snapshot, changed = await await_job_wait_request(
                     self._job_manager.wait_for_change(
                         job_id,
                         cursor=cursor,
                         timeout_seconds=timeout_seconds,
                     ),
-                    timeout=wait_response_timeout,
+                    timeout_seconds=timeout_seconds,
+                    response_timeout=wait_response_timeout,
                     job_id=job_id,
                     branch="raw",
                 )

--- a/src/ouroboros/mcp/tools/job_wait_guard.py
+++ b/src/ouroboros/mcp/tools/job_wait_guard.py
@@ -1,0 +1,98 @@
+"""Response guards for background-job long polling."""
+
+import asyncio
+import os
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+JOB_WAIT_GUARD_VERSION = "detached-branch-timeout-v2"
+
+
+def _consume_detached_wait_task(task: asyncio.Task[Any]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        log.warning("mcp.tool.job_wait.detached_wait_failed", exc_info=True)
+
+
+async def await_job_wait_branch(
+    awaitable: Any,
+    *,
+    timeout: float,
+    job_id: str,
+    branch: str,
+) -> Any:
+    """Await a positive-time wait without blocking on slow cancellation cleanup."""
+    log.debug(
+        "mcp.tool.job_wait.guard.enter",
+        job_id=job_id,
+        branch=branch,
+        timeout_seconds=timeout,
+        guard_version=JOB_WAIT_GUARD_VERSION,
+        pid=os.getpid(),
+    )
+    task = asyncio.create_task(awaitable)
+    log.debug(
+        "mcp.tool.job_wait.guard.task_created",
+        job_id=job_id,
+        branch=branch,
+        guard_version=JOB_WAIT_GUARD_VERSION,
+        pid=os.getpid(),
+    )
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=timeout)
+    except asyncio.CancelledError:
+        task.cancel()
+        task.add_done_callback(_consume_detached_wait_task)
+        raise
+    log.debug(
+        "mcp.tool.job_wait.guard.wait_returned",
+        job_id=job_id,
+        branch=branch,
+        done=task in done,
+        guard_version=JOB_WAIT_GUARD_VERSION,
+        pid=os.getpid(),
+    )
+    if task in done:
+        return task.result()
+
+    task.cancel()
+    task.add_done_callback(_consume_detached_wait_task)
+    log.debug(
+        "mcp.tool.job_wait.wait.branch_timeout",
+        job_id=job_id,
+        branch=branch,
+        timeout_seconds=timeout,
+        guard_version=JOB_WAIT_GUARD_VERSION,
+        pid=os.getpid(),
+    )
+    raise TimeoutError
+
+
+async def await_job_wait_request(
+    awaitable: Any,
+    *,
+    timeout_seconds: int,
+    response_timeout: float,
+    job_id: str,
+    branch: str,
+) -> Any:
+    """Return zero-time snapshots without applying the long-poll guard.
+
+    Zero disables waiting for a future change; it does not bound the
+    authoritative snapshot read. Positive-time waits remain guarded so a
+    cancellation-resistant branch cannot hold the request open indefinitely.
+    """
+    if timeout_seconds == 0:
+        return await awaitable
+    return await await_job_wait_branch(
+        awaitable,
+        timeout=response_timeout,
+        job_id=job_id,
+        branch=branch,
+    )

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -33,7 +33,6 @@ from ouroboros.mcp.server.adapter import (
     _validate_parameter_constraints,
     validate_transport,
 )
-from ouroboros.mcp.tools import job_handlers as job_handlers_module
 from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobWaitHandler
 from ouroboros.mcp.types import (
     ContentType,
@@ -1299,11 +1298,10 @@ class TestMCPServerAdapterTools:
         finally:
             await store.close()
 
-    async def test_call_tool_job_wait_timeout_then_job_result_recovers_terminal_snapshot(
-        self, tmp_path, monkeypatch
+    async def test_call_tool_job_wait_delayed_zero_snapshot_then_result_recovers_terminal(
+        self, tmp_path
     ) -> None:
-        """A bounded wait response can be followed by adapter-routed terminal result fetch."""
-        monkeypatch.setattr(job_handlers_module, "_JOB_WAIT_RESPONSE_GRACE_SECONDS", 0.01)
+        """A delayed zero-time snapshot still composes with a later terminal result."""
         store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
         await store.initialize()
         try:
@@ -1346,7 +1344,7 @@ class TestMCPServerAdapterTools:
                     assert job_id == running.job_id
                     assert cursor == 4
                     assert timeout_seconds == 0
-                    await asyncio.sleep(1)
+                    await asyncio.sleep(1.05)
                     return running, False
 
             manager = RecoveringJobManager()
@@ -1362,7 +1360,9 @@ class TestMCPServerAdapterTools:
             result = await adapter.call_tool("ouroboros_job_result", {"job_id": running.job_id})
 
             assert wait_result.is_ok
-            assert wait_result.value.meta["wait_timed_out"] is True
+            assert "wait_timed_out" not in wait_result.value.meta
+            assert wait_result.value.meta["lifecycle_status"] == "running"
+            assert wait_result.value.meta["cursor"] == 4
             assert wait_result.value.meta["result_available"] is False
             assert result.is_ok
             assert result.value.text_content == "terminal result"

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -16,6 +16,7 @@ from ouroboros.events.lineage import lineage_generation_watchdog_decision
 from ouroboros.mcp import job_manager as job_manager_module
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools import job_handlers as job_handlers_module
+from ouroboros.mcp.tools import job_wait_guard as job_wait_guard_module
 from ouroboros.mcp.tools.job_handlers import (
     JobResultHandler,
     JobStatusHandler,
@@ -1564,7 +1565,7 @@ class TestJobManager:
                 stopped.set()
 
         outer = asyncio.create_task(
-            job_handlers_module._await_job_wait_branch(
+            job_wait_guard_module.await_job_wait_branch(
                 _blocking_wait(),
                 timeout=60,
                 job_id="job_cancel_wait",
@@ -4384,11 +4385,30 @@ class TestJobManager:
         assert result.value.meta["cursor"] == fresh_snapshot.cursor
         assert "live_snapshot" not in result.value.meta
 
-    async def test_job_wait_wall_clock_timeout_returns_pollable_result(
+    async def test_job_wait_zero_timeout_returns_delayed_authoritative_snapshot(
         self, tmp_path, monkeypatch
     ) -> None:
         store = _build_store(tmp_path)
         monkeypatch.setattr(job_handlers_module, "_JOB_WAIT_RESPONSE_GRACE_SECONDS", 0.01)
+        snapshot = JobSnapshot(
+            job_id="job_wait_slow",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=4,
+            links=JobLinks(session_id="auto_slow_snapshot"),
+        )
+
+        async def forbidden_long_poll_guard(*_args, **_kwargs):
+            raise AssertionError("zero-time snapshot reads must bypass the long-poll guard")
+
+        monkeypatch.setattr(
+            job_wait_guard_module,
+            "await_job_wait_branch",
+            forbidden_long_poll_guard,
+        )
 
         class SlowJobManager:
             async def wait_for_change(
@@ -4401,27 +4421,37 @@ class TestJobManager:
                 assert job_id == "job_wait_slow"
                 assert cursor == 0
                 assert timeout_seconds == 0
-                await asyncio.sleep(1)
-                raise AssertionError("job_wait should time out before this returns")
+                await asyncio.sleep(1.05)
+                return snapshot, False
 
         handler = JobWaitHandler(event_store=store, job_manager=SlowJobManager())
-        started = asyncio.get_running_loop().time()
         result = await handler.handle({"job_id": "job_wait_slow", "timeout_seconds": 0})
-        elapsed = asyncio.get_running_loop().time() - started
 
         assert result.is_ok
-        assert elapsed < 0.5
         assert result.value.is_error is False
         assert result.value.meta["job_id"] == "job_wait_slow"
-        assert result.value.meta["wait_timed_out"] is True
+        assert result.value.meta["cursor"] == 4
+        assert result.value.meta["status"] == JobStatus.RUNNING.value
         assert result.value.meta["result_available"] is False
+        assert "job_wait timed out before producing a snapshot" not in result.value.text_content
 
     async def test_job_wait_timeout_does_not_wait_for_cancel_resistant_branch(
         self, tmp_path, monkeypatch
     ) -> None:
         store = _build_store(tmp_path)
-        monkeypatch.setattr(job_handlers_module, "_JOB_WAIT_RESPONSE_GRACE_SECONDS", 0.01)
         released = asyncio.Event()
+        original_guard = job_wait_guard_module.await_job_wait_branch
+
+        async def short_guard(awaitable, *, timeout: float, job_id: str, branch: str):
+            assert timeout == 2.0
+            return await original_guard(
+                awaitable,
+                timeout=0.01,
+                job_id=job_id,
+                branch=branch,
+            )
+
+        monkeypatch.setattr(job_wait_guard_module, "await_job_wait_branch", short_guard)
 
         class CancelResistantJobManager:
             async def wait_for_change(
@@ -4433,7 +4463,7 @@ class TestJobManager:
             ) -> tuple[JobSnapshot, bool]:
                 assert job_id == "job_wait_cancel_resistant"
                 assert cursor == 0
-                assert timeout_seconds == 0
+                assert timeout_seconds == 1
                 try:
                     await asyncio.sleep(1)
                 except asyncio.CancelledError:
@@ -4443,7 +4473,7 @@ class TestJobManager:
 
         handler = JobWaitHandler(event_store=store, job_manager=CancelResistantJobManager())
         started = asyncio.get_running_loop().time()
-        result = await handler.handle({"job_id": "job_wait_cancel_resistant", "timeout_seconds": 0})
+        result = await handler.handle({"job_id": "job_wait_cancel_resistant", "timeout_seconds": 1})
         elapsed = asyncio.get_running_loop().time() - started
         released.set()
         await asyncio.sleep(0)


### PR DESCRIPTION
## Summary

- bypass the long-poll response guard when `timeout_seconds=0`, so the authoritative persisted snapshot read is never replaced by scheduler-dependent timeout text
- keep positive-time branches bounded by the existing cancellation-safe response guard
- move the guard into a focused module instead of growing the grandfathered `job_handlers.py`
- add a regression proving an initial snapshot read slower than the production one-second guard still returns the snapshot

Closes #1935

## Why

PR #1934 Python 3.14 full-suite CI naturally reproduced two identical zero-time CLI polls returning different output. The second initial SQLite snapshot read crossed the unrelated one-second long-poll guard, was canceled, and returned ordinary timeout text while cleanup was still unwinding. Zero means no wait for a future change; it must not weaken the authoritative current-state read.

## Verification

- Python 3.12: 153 related MCP/CLI tests passed with xdist
- Python 3.13: 153 related MCP/CLI tests passed with xdist
- Python 3.14: 153 related MCP/CLI tests passed with xdist
- regression delays the initial read for 1.05 seconds and asserts the guard is not invoked
- positive-time cancellation-resistant branch remains bounded
- Ruff and format checks passed
- MyPy passed for both production modules
- module-size, auto-boundary, max-turns-envelope, and diff checks passed

## Direction

The change preserves detached-job polling semantics, keeps persisted event-store state authoritative, and removes scheduler timing from a read-only snapshot contract without weakening true long-poll bounds.