### PR TITLE
fix(opencode): derive advisory child permissions

### DIFF
--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -21,6 +21,7 @@ import {
   childTimeout,
   cfg,
   childOutput,
+  deriveSubagentSessionPermission,
   dupe,
   fnv,
   id,
@@ -44,6 +45,7 @@ import {
 import {
   _resolveMid,
   _dispatch,
+  _authoritySnapshot,
   _patch,
   _PATCH_RETRIES,
   _RESOLVE_RETRIES,
@@ -853,16 +855,48 @@ describe("buildEnvelope — dispatch schema", () => {
 
 function mockCli(overrides: Partial<{
   create: (...a: unknown[]) => Promise<unknown>
+  get: (...a: unknown[]) => Promise<unknown>
+  agents: (...a: unknown[]) => Promise<unknown>
   prompt: (...a: unknown[]) => Promise<unknown>
   abort: (...a: unknown[]) => Promise<unknown>
   messages: (...a: unknown[]) => Promise<unknown>
 }> = {}) {
+  const authority = mockAuthority()
   return {
+    app: {
+      agents: overrides.agents ?? authority.app.agents,
+    },
     session: {
       create: overrides.create ?? (async () => ({ data: { id: "child_abc" } })),
+      get: overrides.get ?? authority.session.get,
       prompt: overrides.prompt ?? (async () => ({ data: { parts: [{ type: "text", text: "done" }] } })),
       abort: overrides.abort ?? (async () => ({})),
       messages: overrides.messages ?? (async () => ({ data: [] })),
+    },
+  }
+}
+
+const TEST_CHILD_PERMISSION = [
+  { permission: "external_directory", pattern: "/workspace/*", action: "ask" },
+  { permission: "task", pattern: "*", action: "deny" },
+] as const
+
+function mockAuthority(
+  agents: ReadonlyArray<{ name: string; permission: ReadonlyArray<unknown> }> = [
+    { name: "general", permission: [] },
+    { name: "researcher", permission: [] },
+    { name: "simplifier", permission: [] },
+    { name: "contrarian", permission: [] },
+  ],
+) {
+  return {
+    session: {
+      get: async ({ path }: { path: { id: string } }) => ({
+        data: { id: path.id, permission: [] },
+      }),
+    },
+    app: {
+      agents: async () => ({ data: agents }),
     },
   }
 }
@@ -942,6 +976,145 @@ describe("_patch — PATCH with retry", () => {
   })
 })
 
+describe("OpenCode authority snapshot", () => {
+  test("inherits parent denies and every external_directory action in original order", () => {
+    const parent = [
+      { permission: "bash", pattern: "safe", action: "allow" },
+      { permission: "edit", pattern: "secret", action: "deny" },
+      { permission: "external_directory", pattern: "/ask/*", action: "ask" },
+      { permission: "read", pattern: "later", action: "ask" },
+      { permission: "external_directory", pattern: "/allow/*", action: "allow" },
+      { permission: "external_directory", pattern: "/deny/*", action: "deny" },
+      { permission: "webfetch", pattern: "blocked", action: "deny" },
+    ] as const
+    const derived = deriveSubagentSessionPermission(parent, [])
+
+    expect(derived).toEqual([
+      { permission: "edit", pattern: "secret", action: "deny" },
+      { permission: "external_directory", pattern: "/ask/*", action: "ask" },
+      { permission: "external_directory", pattern: "/allow/*", action: "allow" },
+      { permission: "external_directory", pattern: "/deny/*", action: "deny" },
+      { permission: "webfetch", pattern: "blocked", action: "deny" },
+      { permission: "todowrite", pattern: "*", action: "deny" },
+      { permission: "task", pattern: "*", action: "deny" },
+    ])
+  })
+
+  test.each([
+    { exactTask: false, exactTodo: false, expected: ["todowrite", "task"] },
+    { exactTask: true, exactTodo: false, expected: ["todowrite"] },
+    { exactTask: false, exactTodo: true, expected: ["task"] },
+    { exactTask: true, exactTodo: true, expected: [] },
+  ])("exact recursive rules control defaults: $exactTask/$exactTodo", ({ exactTask, exactTodo, expected }) => {
+    const agent = [
+      { permission: "*", pattern: "*", action: "allow" as const },
+      ...(exactTask ? [{ permission: "task", pattern: "worker", action: "ask" as const }] : []),
+      ...(exactTodo ? [{ permission: "todowrite", pattern: "*", action: "deny" as const }] : []),
+    ]
+    const derived = deriveSubagentSessionPermission([], agent)
+    expect(derived.map((rule) => rule.permission)).toEqual([...expected])
+  })
+
+  test("does not copy target-agent rules into the session snapshot", () => {
+    const agent = [
+      { permission: "bash", pattern: "*", action: "deny" as const },
+      { permission: "task", pattern: "worker", action: "allow" as const },
+      { permission: "todowrite", pattern: "*", action: "ask" as const },
+    ]
+    expect(deriveSubagentSessionPermission([], agent)).toEqual([])
+  })
+
+  test("loads parent and catalog once and derives all target agents from one snapshot", async () => {
+    let parentCalls = 0
+    let agentCalls = 0
+    const cli = {
+      session: {
+        get: async () => {
+          parentCalls++
+          return { data: { id: "parent", permission: [
+            { permission: "bash", pattern: "danger", action: "deny" },
+          ] } }
+        },
+      },
+      app: {
+        agents: async () => {
+          agentCalls++
+          return { data: [
+            { name: "general", permission: [] },
+            { name: "researcher", permission: [
+              { permission: "task", pattern: "researcher", action: "ask" },
+            ] },
+          ] }
+        },
+      },
+    }
+
+    const snapshot = await _authoritySnapshot(cli as never, "parent", ["general", "researcher", "general"])
+    expect(parentCalls).toBe(1)
+    expect(agentCalls).toBe(1)
+    expect(snapshot.get("general")).toEqual([
+      { permission: "bash", pattern: "danger", action: "deny" },
+      { permission: "todowrite", pattern: "*", action: "deny" },
+      { permission: "task", pattern: "*", action: "deny" },
+    ])
+    expect(snapshot.get("researcher")).toEqual([
+      { permission: "bash", pattern: "danger", action: "deny" },
+      { permission: "todowrite", pattern: "*", action: "deny" },
+    ])
+    expect(Object.isFrozen(snapshot.get("general"))).toBe(true)
+  })
+
+  test("uses OpenCode's native empty-session default when permission is absent", async () => {
+    const authority = mockAuthority()
+    const cli = {
+      ...authority,
+      session: { get: async () => ({ data: { id: "parent" } }) },
+    }
+    const snapshot = await _authoritySnapshot(cli as never, "parent", ["general"])
+    expect(snapshot.get("general")).toEqual([
+      { permission: "todowrite", pattern: "*", action: "deny" },
+      { permission: "task", pattern: "*", action: "deny" },
+    ])
+  })
+
+  test.each([
+    ["missing APIs", {}],
+    ["missing parent", { session: { get: async () => ({}) }, app: { agents: async () => ({ data: [] }) } }],
+    ["parent mismatch", { session: { get: async () => ({ data: { id: "other", permission: [] } }) }, app: { agents: async () => ({ data: [] }) } }],
+    ["malformed parent ruleset", { session: { get: async () => ({ data: { id: "parent", permission: {} } }) }, app: { agents: async () => ({ data: [] }) } }],
+    ["missing catalog", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({}) } }],
+    ["malformed catalog", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({ data: [{}] }) } }],
+    ["missing agent ruleset", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({ data: [{ name: "general" }] }) } }],
+    ["malformed agent rule", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({ data: [{ name: "general", permission: [{ permission: "task", pattern: "*", action: "sometimes" }] }] }) } }],
+    ["missing target", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({ data: [{ name: "other", permission: [] }] }) } }],
+    ["duplicate target", { session: { get: async () => ({ data: { id: "parent", permission: [] } }) }, app: { agents: async () => ({ data: [{ name: "general", permission: [] }, { name: "general", permission: [] }] }) } }],
+  ])("fails closed for %s", async (_label, cli) => {
+    await expect(_authoritySnapshot(cli as never, "parent", ["general"])).rejects.toThrow(
+      /^authority snapshot unavailable:/,
+    )
+  })
+
+  test.each([
+    [{ permission: 7, pattern: "*", action: "deny" }, "permission"],
+    [{ permission: "bash", pattern: null, action: "deny" }, "pattern"],
+    [{ permission: "bash", pattern: "TOP-SECRET-PATTERN", action: "later" }, "action"],
+    [null, "rule"],
+  ])("rejects malformed rules without echoing their payload: %o", async (rule, reason) => {
+    const cli = {
+      session: { get: async () => ({ data: { id: "parent", permission: [rule] } }) },
+      app: { agents: async () => ({ data: [{ name: "general", permission: [] }] }) },
+    }
+    let message = ""
+    try {
+      await _authoritySnapshot(cli as never, "parent", ["general"])
+    } catch (error) {
+      message = String(error)
+    }
+    expect(message).toContain(String(reason))
+    expect(message).not.toContain("TOP-SECRET-PATTERN")
+  })
+})
+
 describe("_dispatch — child session lifecycle", () => {
   test("success: creates child, patches running, fires prompt", async () => {
     const patchCalls: string[] = []
@@ -958,14 +1131,14 @@ describe("_dispatch — child session lifecycle", () => {
       return {}
     })
     const sub = { tool: "ouroboros_qa", title: "QA", prompt: "check it", agent: "general" }
-    const result = await _dispatch(cli as never, b as never, "pid", "mid", sub as never)
+    const result = await _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION)
     expect(result.childID).toBe("child_123")
     expect(createCalls).toEqual([
       {
         body: {
           parentID: "pid",
           title: "QA",
-          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          permission: TEST_CHILD_PERMISSION,
         },
       },
     ])
@@ -973,12 +1146,7 @@ describe("_dispatch — child session lifecycle", () => {
     expect(patchCalls.length).toBeGreaterThanOrEqual(1)
   })
 
-  test("the data lane is created with the same permission as its siblings", async () => {
-    // It used to be created with `*:* deny`, matching a contract that had no
-    // field for a fetched value. The contract changed (#1825): the lane takes
-    // the measurement. A denial left behind would tell the child to measure on
-    // the one transport where every call is refused — and no `no_evidence_reason`
-    // means "I was blocked", so it would have to pick a reason that is false.
+  test("the data lane receives the supplied OpenCode-derived permission", async () => {
     const createCalls: unknown[] = []
     const cli = mockCli({
       create: async (args: unknown) => {
@@ -995,17 +1163,77 @@ describe("_dispatch — child session lifecycle", () => {
       agent: "general",
     }
 
-    await _dispatch(cli as never, b as never, "pid", "mid", sub as never)
+    await _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION)
 
     expect(createCalls).toEqual([
       {
         body: {
           parentID: "pid",
           title: "Interview advisory: data_context",
-          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          permission: TEST_CHILD_PERMISSION,
         },
       },
     ])
+  })
+
+  test("returns after create and running patch while an ask remains unresolved", async () => {
+    const patchBodies: any[] = []
+    let resolvePrompt: ((value: unknown) => void) | undefined
+    const cli = mockCli({
+      create: async () => ({ data: { id: "child_ask" } }),
+      prompt: async () => new Promise((resolve) => { resolvePrompt = resolve }),
+    })
+    const b = mockBase(async (a: unknown) => {
+      patchBodies.push((a as { body: unknown }).body)
+      return {}
+    })
+    const sub = { tool: "ouroboros_qa", title: "QA", prompt: "ask", agent: "general" }
+
+    await expect(_dispatch(
+      cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION,
+    )).resolves.toEqual({ childID: "child_ask" })
+    expect(patchBodies.map((body) => body.state.status)).toEqual(["running"])
+
+    resolvePrompt?.({ data: { parts: [{ type: "text", text: "allowed" }] } })
+    for (let i = 0; i < 20 && patchBodies.length < 2; i++) await _sleep(5)
+    expect(patchBodies.map((body) => body.state.status)).toEqual(["running", "completed"])
+  })
+
+  test("a rejected ask follows the existing error-widget path", async () => {
+    const patchBodies: any[] = []
+    const cli = mockCli({
+      create: async () => ({ data: { id: "child_rejected" } }),
+      prompt: async () => { throw new Error("permission rejected") },
+    })
+    const b = mockBase(async (a: unknown) => {
+      patchBodies.push((a as { body: unknown }).body)
+      return {}
+    })
+    const sub = { tool: "ouroboros_qa", title: "QA", prompt: "ask", agent: "general" }
+
+    await _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION)
+    for (let i = 0; i < 20 && patchBodies.length < 2; i++) await _sleep(5)
+    const errorPatch = patchBodies.find((body) => body?.state?.status === "error")
+    expect(errorPatch.state.error).toContain("permission rejected")
+  })
+
+  test("does not infer a blocked result from child prose", async () => {
+    const patchBodies: any[] = []
+    const cli = mockCli({
+      create: async () => ({ data: { id: "child_prose" } }),
+      prompt: async () => ({ data: { parts: [{ type: "text", text: "I was blocked" }] } }),
+    })
+    const b = mockBase(async (a: unknown) => {
+      patchBodies.push((a as { body: unknown }).body)
+      return {}
+    })
+    const sub = { tool: "ouroboros_qa", title: "QA", prompt: "run", agent: "general" }
+
+    await _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION)
+    for (let i = 0; i < 20 && patchBodies.length < 2; i++) await _sleep(5)
+    const finalPatch = patchBodies.at(-1)
+    expect(finalPatch.state.status).toBe("completed")
+    expect(finalPatch.state.output).toContain("I was blocked")
   })
 
   test("throws when child session create returns no id", async () => {
@@ -1013,7 +1241,7 @@ describe("_dispatch — child session lifecycle", () => {
     const b = mockBase()
     const sub = { tool: "ouroboros_qa", title: "QA", prompt: "check", agent: "general" }
     await expect(
-      _dispatch(cli as never, b as never, "pid", "mid", sub as never),
+      _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION),
     ).rejects.toThrow(/child session create returned no id/)
   })
 
@@ -1022,7 +1250,7 @@ describe("_dispatch — child session lifecycle", () => {
     const b = mockBase(async () => ({ error: "server error" }))
     const sub = { tool: "ouroboros_qa", title: "QA", prompt: "check", agent: "general" }
     await expect(
-      _dispatch(cli as never, b as never, "pid", "mid", sub as never),
+      _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION),
     ).rejects.toThrow(/PATCH failed/)
   })
 
@@ -1040,7 +1268,7 @@ describe("_dispatch — child session lifecycle", () => {
       hash: "h",
     }
 
-    await _dispatch(cli as never, b as never, "ralph_child", "mid", sub as never)
+    await _dispatch(cli as never, b as never, "ralph_child", "mid", sub as never, TEST_CHILD_PERMISSION)
 
     expect(isRalphOwnedSession("grandchild_123")).toBe(true)
     expect(isNestedRalphDispatch("grandchild_123", [{ ...sub, tool: "ouroboros_ralph" }])).toBe(true)
@@ -1080,7 +1308,7 @@ describe("_dispatch — child session lifecycle", () => {
       },
     }
 
-    await _dispatch(cli as never, b as never, "pid", "mid", sub as never)
+    await _dispatch(cli as never, b as never, "pid", "mid", sub as never, TEST_CHILD_PERMISSION)
     for (let i = 0; i < 20 && patchBodies.length < 2; i++) await _sleep(5)
 
     expect(abortCalled).toBe(true)
@@ -1095,17 +1323,45 @@ describe("OuroborosBridge hook — metadata advisory fanout", () => {
   test("preserves interview question text while dispatching metadata subagents", async () => {
     _resetDedupe()
     let created = 0
+    let parentFetches = 0
+    let agentFetches = 0
     const promptCalls: unknown[] = []
+    const createCalls: any[] = []
     const patchBodies: unknown[] = []
-    const cli = {
+    const authority = {
       session: {
+        get: async () => {
+          parentFetches++
+          return { data: { id: "parent_1", permission: [
+            { permission: "bash", pattern: "danger", action: "deny" },
+            { permission: "external_directory", pattern: "/shared/*", action: "ask" },
+          ] } }
+        },
+      },
+      app: {
+        agents: async () => {
+          agentFetches++
+          return { data: [
+            { name: "researcher", permission: [{ permission: "task", pattern: "researcher", action: "ask" }] },
+            { name: "simplifier", permission: [{ permission: "todowrite", pattern: "*", action: "deny" }] },
+          ] }
+        },
+      },
+    }
+    const cli = {
+      app: authority.app,
+      session: {
+        ...authority.session,
         _client: {
           patch: async (a: unknown) => {
             patchBodies.push((a as { body?: unknown }).body)
             return {}
           },
         },
-        create: async () => ({ data: { id: `child_${++created}` } }),
+        create: async (args: unknown) => {
+          createCalls.push(args)
+          return { data: { id: `child_${++created}` } }
+        },
         prompt: async (a: unknown) => {
           promptCalls.push(a)
           return { data: { parts: [{ type: "text", text: "done" }] } }
@@ -1166,10 +1422,66 @@ describe("OuroborosBridge hook — metadata advisory fanout", () => {
       { title: "Interview advisory: answer_simplifier", childID: "child_2" },
     ])
     expect(promptCalls.length).toBe(2)
+    expect(parentFetches).toBe(1)
+    expect(agentFetches).toBe(1)
+    expect(createCalls.map((call) => call.body.permission)).toEqual([
+      [
+        { permission: "bash", pattern: "danger", action: "deny" },
+        { permission: "external_directory", pattern: "/shared/*", action: "ask" },
+        { permission: "todowrite", pattern: "*", action: "deny" },
+      ],
+      [
+        { permission: "bash", pattern: "danger", action: "deny" },
+        { permission: "external_directory", pattern: "/shared/*", action: "ask" },
+        { permission: "task", pattern: "*", action: "deny" },
+      ],
+    ])
     const runningPatches = patchBodies.filter(
       (body) => (body as { state?: { status?: string } })?.state?.status === "running",
     )
     expect(runningPatches).toHaveLength(2)
+  })
+
+  test("authority failure is dispatch_failed before create and does not echo policy", async () => {
+    _resetDedupe()
+    let created = 0
+    const secretPattern = "/private/customer-secret/*"
+    const cli = {
+      app: { agents: async () => ({ data: [{ name: "general", permission: [] }] }) },
+      session: {
+        _client: { patch: async () => ({}) },
+        get: async () => ({ data: { id: "parent_1", permission: [
+          { permission: "bash", pattern: secretPattern, action: "invalid" },
+        ] } }),
+        create: async () => {
+          created++
+          return { data: { id: "child_forbidden" } }
+        },
+        prompt: async () => ({ data: { parts: [] } }),
+        abort: async () => ({}),
+        messages: async () => ({ data: [{
+          info: { id: "msg_1", role: "assistant" },
+          parts: [{ type: "tool", callID: "call_authority" }],
+        }] }),
+      },
+    }
+    const plugin = await OuroborosBridge({ client: cli, directory: "/tmp/ouroboros-test" } as never)
+    const hook = (plugin as Record<string, (...args: unknown[]) => Promise<void>>)["tool.execute.after"]
+    const output = {
+      content: [{ type: "text", text: JSON.stringify({
+        _subagent: { tool_name: "ouroboros_qa", title: "QA", agent: "general", prompt: "review" },
+      }) }],
+      metadata: {},
+    }
+
+    await hook({ tool: "ouroboros_qa", sessionID: "parent_1", callID: "call_authority" }, output)
+
+    const metadata = output.metadata as Record<string, any>
+    expect(created).toBe(0)
+    expect(metadata.ouroboros_dispatch.status).toBe("dispatch_failed")
+    expect(metadata.ouroboros_dispatch.failed).toHaveLength(1)
+    expect(metadata.ouroboros_dispatch.failed[0].reason).toContain("invalid parent action")
+    expect(JSON.stringify(output)).not.toContain(secretPattern)
   })
 
   test("preserves interview question text when metadata advisory dispatch fails early", async () => {
@@ -1230,8 +1542,11 @@ describe("bridge appends declare themselves", () => {
 
   function liveCli() {
     let created = 0
+    const authority = mockAuthority()
     return {
+      app: authority.app,
       session: {
+        ...authority.session,
         _client: { patch: async () => ({}) },
         create: async () => ({ data: { id: `child_${++created}` } }),
         prompt: async () => ({ data: { parts: [{ type: "text", text: "done" }] } }),

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -1095,6 +1095,32 @@ describe("OpenCode authority snapshot", () => {
   })
 
   test.each([
+    ["parent lookup", true, false],
+    ["agent catalog lookup", false, true],
+    ["both authority lookups", true, true],
+  ])("fails closed when %s stalls", async (_label, stallParent, stallAgents) => {
+    const never = new Promise<never>(() => {})
+    const cli = {
+      session: {
+        get: stallParent
+          ? () => never
+          : async () => ({ data: { id: "parent", permission: [] } }),
+      },
+      app: {
+        agents: stallAgents
+          ? () => never
+          : async () => ({ data: [{ name: "general", permission: [] }] }),
+      },
+    }
+    const started = Date.now()
+
+    await expect(_authoritySnapshot(cli as never, "parent", ["general"], 20)).rejects.toThrow(
+      "authority snapshot unavailable: lookup timed out",
+    )
+    expect(Date.now() - started).toBeLessThan(500)
+  })
+
+  test.each([
     [{ permission: 7, pattern: "*", action: "deny" }, "permission"],
     [{ permission: "bash", pattern: null, action: "deny" }, "pattern"],
     [{ permission: "bash", pattern: "TOP-SECRET-PATTERN", action: "later" }, "action"],

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
@@ -36,6 +36,7 @@ export function num(v: string | undefined, d: number): number {
   return Number.isFinite(n) && n >= 0 ? n : d
 }
 export const CHILD_TIMEOUT_MS = num(process.env.OUROBOROS_CHILD_TIMEOUT_MS, 20 * 60 * 1000)
+const AUTHORITY_TIMEOUT_MS = 5_000
 const PATCH_RETRIES = 3
 const RESOLVE_RETRIES = 5
 const BACKOFF_MS = 100
@@ -477,6 +478,18 @@ function authorityError(reason: string): Error {
   return new Error(`authority snapshot unavailable: ${reason}`)
 }
 
+async function authorityDeadline<T>(lookup: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(authorityError("lookup timed out")), timeoutMs)
+  })
+  try {
+    return await Promise.race([lookup, timeout])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
 function record(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v)
 }
@@ -524,14 +537,16 @@ async function authoritySnapshot(
   cli: Cli,
   parentID: string,
   targetAgents: ReadonlyArray<string>,
+  timeoutMs = AUTHORITY_TIMEOUT_MS,
 ): Promise<ReadonlyMap<string, PermissionRuleset>> {
   if (typeof cli?.session?.get !== "function" || typeof cli?.app?.agents !== "function")
     throw authorityError("client API missing")
 
-  const [parentResult, agentsResult] = await Promise.all([
-    cli.session.get({ path: { id: parentID } }).catch(() => null),
-    cli.app.agents().catch(() => null),
+  const lookup = Promise.all([
+    Promise.resolve().then(() => cli.session.get!({ path: { id: parentID } })).catch(() => null),
+    Promise.resolve().then(() => cli.app!.agents!()).catch(() => null),
   ])
+  const [parentResult, agentsResult] = await authorityDeadline(lookup, timeoutMs)
   if (!parentResult || parentResult.error || !record(parentResult.data))
     throw authorityError("parent lookup failed")
   if (parentResult.data.id !== parentID)

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
@@ -31,27 +31,6 @@ export const ID_LEN = 26
 // skipped-only banners start with their own words.
 export const OUROBOROS_DISPATCH_MARKER = "<!-- ouroboros-question-advisory-dispatch-v1 -->"
 export const BRIDGE_NOTICE_OPENING = "> **Bridge dispatch — plugin_subagent:** "
-
-export const BYPASS_PERMISSION_RULESET = [
-  { permission: "*", pattern: "*", action: "allow" },
-] as const
-// The `read_data` child used to be created with `*:* deny`, because its answer
-// contract had no field for a fetched value and a call it made anyway was pure
-// cost before the user had confirmed anything. That reasoning was sound for the
-// contract it defended and the contract changed: the lane executes and carries
-// aggregates now (Q00/ouroboros#1825).
-//
-// So the denial is removed rather than narrowed. Leaving it would recreate the
-// defect it was part of, mirrored — a child told to take the measurement on a
-// transport where every call is refused, which cannot report "I was blocked"
-// because no `no_evidence_reason` means that, so it would have to pick one
-// that is false. Every reason the lane can give is a statement about itself,
-// which is exactly why none of them can carry "this transport refused me".
-//
-// What replaces it is what the sibling lanes already run on: the user
-// registered these tools, and registering one is the willingness to have it
-// called. The boundary that survives is downstream of every transport — a
-// number is material for the user's judgment and never the interview answer.
 export function num(v: string | undefined, d: number): number {
   const n = !v ? d : Number(v)
   return Number.isFinite(n) && n >= 0 ? n : d
@@ -461,6 +440,14 @@ export function base(client: unknown): Base | null {
   return b && typeof b.patch === "function" ? b : null
 }
 
+export type PermissionAction = "allow" | "deny" | "ask"
+export type PermissionRule = Readonly<{
+  permission: string
+  pattern: string
+  action: PermissionAction
+}>
+export type PermissionRuleset = ReadonlyArray<PermissionRule>
+
 type Cli = {
   session: {
     create: (a: {
@@ -470,14 +457,109 @@ type Cli = {
         permission?: ReadonlyArray<{
           permission: string
           pattern: string
-          action: "allow" | "deny" | "ask"
+          action: PermissionAction
         }>
       }
     }) => Promise<{ data?: { id: string } }>
+    get?: (a: { path: { id: string } }) => Promise<{ data?: unknown; error?: unknown }>
     prompt: (a: { path: { id: string }; body: { agent?: string; parts: Array<{ type: string; text: string }> }; signal?: AbortSignal }) => Promise<{ data?: { info?: unknown; parts?: Array<{ type: string; text?: string }> } }>
     abort: (a: { path: { id: string } }) => Promise<{ data?: unknown }>
     messages: (a: { path: { id: string } }) => Promise<{ data?: Array<{ info: { id: string; role: string }; parts: Array<{ type: string; callID?: string }> }> }>
   }
+  app?: {
+    agents?: () => Promise<{ data?: unknown; error?: unknown }>
+  }
+}
+
+function authorityError(reason: string): Error {
+  // Never include response bodies or permission patterns in user-visible
+  // dispatch failures. The reason is deliberately a closed vocabulary.
+  return new Error(`authority snapshot unavailable: ${reason}`)
+}
+
+function record(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+function permissionRuleset(value: unknown, scope: "parent" | "agent"): PermissionRuleset {
+  if (!Array.isArray(value)) throw authorityError(`invalid ${scope} ruleset`)
+  return Object.freeze(value.map((raw) => {
+    if (!record(raw)) throw authorityError(`invalid ${scope} rule`)
+    const permission = raw.permission
+    const pattern = raw.pattern
+    const action = raw.action
+    if (typeof permission !== "string" || permission.length === 0)
+      throw authorityError(`invalid ${scope} permission`)
+    if (typeof pattern !== "string" || pattern.length === 0)
+      throw authorityError(`invalid ${scope} pattern`)
+    if (action !== "allow" && action !== "deny" && action !== "ask")
+      throw authorityError(`invalid ${scope} action`)
+    return Object.freeze({ permission, pattern, action })
+  }))
+}
+
+// Mirrors OpenCode's deriveSubagentSessionPermission(). Agent rules are only
+// inspected for exact recursive-tool declarations; they remain agent-owned and
+// are not copied into the child session ruleset.
+export function deriveSubagentSessionPermission(
+  parentPermission: PermissionRuleset,
+  agentPermission: PermissionRuleset,
+): PermissionRuleset {
+  const canTodo = agentPermission.some((rule) => rule.permission === "todowrite")
+  const canTask = agentPermission.some((rule) => rule.permission === "task")
+  return Object.freeze([
+    ...parentPermission.filter(
+      (rule) => rule.permission === "external_directory" || rule.action === "deny",
+    ),
+    ...(canTodo ? [] : [Object.freeze({ permission: "todowrite", pattern: "*", action: "deny" as const })]),
+    ...(canTask ? [] : [Object.freeze({ permission: "task", pattern: "*", action: "deny" as const })]),
+  ])
+}
+
+// Load one immutable authority snapshot for the complete fan-out. SDK v1 does
+// not type the permission fields but its runtime client forwards and returns
+// them; v2 types the same wire values. We therefore shape-check the wire data
+// instead of guessing from SDK types or local configuration.
+async function authoritySnapshot(
+  cli: Cli,
+  parentID: string,
+  targetAgents: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, PermissionRuleset>> {
+  if (typeof cli?.session?.get !== "function" || typeof cli?.app?.agents !== "function")
+    throw authorityError("client API missing")
+
+  const [parentResult, agentsResult] = await Promise.all([
+    cli.session.get({ path: { id: parentID } }).catch(() => null),
+    cli.app.agents().catch(() => null),
+  ])
+  if (!parentResult || parentResult.error || !record(parentResult.data))
+    throw authorityError("parent lookup failed")
+  if (parentResult.data.id !== parentID)
+    throw authorityError("parent mismatch")
+
+  // Native OpenCode treats an absent optional session permission as []. This
+  // is upstream's explicit derivation rule, not inferred authority.
+  const parentPermission = parentResult.data.permission === undefined
+    ? Object.freeze([]) as PermissionRuleset
+    : permissionRuleset(parentResult.data.permission, "parent")
+
+  if (!agentsResult || agentsResult.error || !Array.isArray(agentsResult.data))
+    throw authorityError("agent catalog lookup failed")
+  const catalog = new Map<string, PermissionRuleset>()
+  for (const rawAgent of agentsResult.data) {
+    if (!record(rawAgent) || typeof rawAgent.name !== "string" || rawAgent.name.length === 0)
+      throw authorityError("invalid agent catalog")
+    if (catalog.has(rawAgent.name)) throw authorityError("duplicate agent")
+    catalog.set(rawAgent.name, permissionRuleset(rawAgent.permission, "agent"))
+  }
+
+  const snapshot = new Map<string, PermissionRuleset>()
+  for (const name of new Set(targetAgents)) {
+    const agentPermission = catalog.get(name)
+    if (!agentPermission) throw authorityError("target agent missing")
+    snapshot.set(name, deriveSubagentSessionPermission(parentPermission, agentPermission))
+  }
+  return snapshot
 }
 
 // Walk parts for the last text entry — mirrors opencode src/tool/task.ts:158.
@@ -560,7 +642,14 @@ async function resolveMid(cli: Cli, pid: string, callID: string): Promise<string
 // Post-dispatch failures get PATCHed to error state — widget reflects it,
 // no silent loss. If the user wants retry-on-prompt-failure, that would
 // need a new dispatch call (same shape as a fresh invocation).
-async function dispatch(cli: Cli, b: Base, pid: string, mid: string, s: Sub): Promise<{ childID: string }> {
+async function dispatch(
+  cli: Cli,
+  b: Base,
+  pid: string,
+  mid: string,
+  s: Sub,
+  permission: PermissionRuleset,
+): Promise<{ childID: string }> {
   const partID = id("prt")
   const callID = id("tool")
   const start = Date.now()
@@ -572,7 +661,7 @@ async function dispatch(cli: Cli, b: Base, pid: string, mid: string, s: Sub): Pr
     body: {
       parentID: pid,
       title: s.title,
-      permission: BYPASS_PERMISSION_RULESET,
+      permission,
     },
   })
   const childID = created?.data?.id
@@ -740,7 +829,19 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         // fire-and-forget. Promise.allSettled here resolves when each child
         // is registered (widget running), NOT when each child finishes.
         // Hook returns to opencode in ~100ms regardless of child runtime.
-        const results = await Promise.allSettled(subs.map((s) => dispatch(cli, b, pid, mid, s)))
+        let results: Array<PromiseSettledResult<{ childID: string }>>
+        try {
+          const authority = await authoritySnapshot(cli, pid, subs.map((s) => s.agent))
+          results = await Promise.allSettled(subs.map((s) => {
+            const permission = authority.get(s.agent)
+            // The snapshot loader proves every target exists. Keep this guard
+            // at the use site so a future refactor cannot silently omit policy.
+            if (!permission) return Promise.reject(authorityError("target authority missing"))
+            return dispatch(cli, b, pid, mid, s, permission)
+          }))
+        } catch (e) {
+          results = subs.map(() => ({ status: "rejected", reason: e }))
+        }
         const ok: OkResult[] = results.flatMap((r, i) => r.status === "fulfilled"
           ? [{ sub: subs[i], childID: r.value.childID }]
           : [])
@@ -782,4 +883,12 @@ export default {
 }
 
 // Test-only exports for mocked-client coverage.
-export { resolveMid as _resolveMid, dispatch as _dispatch, patch as _patch, sleep as _sleep, PATCH_RETRIES as _PATCH_RETRIES, RESOLVE_RETRIES as _RESOLVE_RETRIES }
+export {
+  resolveMid as _resolveMid,
+  dispatch as _dispatch,
+  authoritySnapshot as _authoritySnapshot,
+  patch as _patch,
+  sleep as _sleep,
+  PATCH_RETRIES as _PATCH_RETRIES,
+  RESOLVE_RETRIES as _RESOLVE_RETRIES,
+}


### PR DESCRIPTION
## Summary

- Replace the OpenCode advisory child `*:* allow` override with native-parity permission derivation.
- Treat OpenCode's parent session and target-agent catalog as the only authority source; no MCP/capability classification or inferred grants.
- Fail closed before child creation when authority APIs or wire shapes are unavailable/malformed, without echoing policy patterns.

Fixes #1845.

## Changes

- Snapshot the parent session and agent catalog once per fan-out.
- Preserve parent deny rules and all `external_directory` rules in original order.
- Add `todowrite:* deny` and `task:* deny` unless the target agent has an exact rule for that permission.
- Keep target-agent rules agent-owned instead of copying them into the child session.
- Preserve fire-and-forget prompt behavior: unresolved asks do not block the hook; rejection/abort/timeout use the existing error-widget path; child prose is never classified as a blocked result.
- Add strict validation and regression coverage for ordering, all external-directory actions, recursive-rule matrices, malformed inputs, missing agents/APIs, multi-agent snapshot reuse, sensitive-policy non-disclosure, ask/reject/timeout, and prose handling.

## Verification

Exact local head before push: `89783820caafbf0b852b721d5d0f01ffd0efdabc`.

- `bun test`: 149 passed
- `bunx tsc --noEmit`: passed
- `uv run pytest -q tests/unit/cli/test_bridge_plugin_lifecycle.py tests/unit/cli/test_bridge_plugin_hardening.py`: 34 passed
- OpenCode 1.14.19 runtime smoke: SDK v1 persisted the derived ruleset; `parentID` alone did not inherit permission.
- OpenCode 1.18.15 runtime smoke: SDK v1 and v2 both persisted the same derived ruleset; `parentID` alone did not inherit permission.
- R3 pre-PR review: mechanical checks clean; independent correctness/security/design/performance/test/intent lenses completed. One availability trade-off candidate was independently debated and refuted because whole-catalog malformed-data rejection is the RFC's explicit fail-closed contract.

## Design review requested

This Draft PR implements RFC Option A from the issue comment:

- OpenCode is the sole authority.
- Derivation follows native OpenCode semantics.
- Unknown/malformed authority fails closed.
- One immutable create-time snapshot is used per fan-out.
- No permission or blocked state is guessed.

Please review the authority contract and implementation before marking the PR ready. Every review-bot finding will be treated as an acceptance criterion and resolved individually.

## Merge gates

Do not merge without all of:

- aggregate `reviewDecision=APPROVED`;
- required CI success on the exact PR head;
- independent verification on that same exact head.

