### PR TITLE
fix(mcp): preserve Seed handoff after accepted receipt failure

### DIFF
--- a/src/ouroboros/mcp/detached_jobs.py
+++ b/src/ouroboros/mcp/detached_jobs.py
@@ -18,6 +18,7 @@ import asyncio
 import contextlib
 from dataclasses import asdict, dataclass
 import json
+import logging
 import os
 from pathlib import Path
 import subprocess
@@ -31,6 +32,8 @@ from ouroboros.persistence.event_store import EventStore
 _STARTUP_TIMEOUT_SECONDS = 20.0
 _POLL_INTERVAL_SECONDS = 0.05
 _STATE_DIR_NAME = "detached-jobs"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -174,11 +177,24 @@ def _spawn_worker(request_path: Path, *, cwd: str) -> subprocess.Popen[bytes]:
     )
     # Reap the child if this MCP process remains alive.  If the MCP process
     # exits first, the detached worker is reparented and the OS reaps it.
-    threading.Thread(
-        target=process.wait,
-        name=f"ooo-detached-reaper-{process.pid}",
-        daemon=True,
-    ).start()
+    try:
+        threading.Thread(
+            target=process.wait,
+            name=f"ooo-detached-reaper-{process.pid}",
+            daemon=True,
+        ).start()
+    except BaseException:
+        # Popen already transferred ownership to an independent process. A
+        # best-effort local reaper failure must not report definitive launch
+        # rejection and allow a duplicate job to start.
+        try:
+            logger.warning(
+                "detached worker reaper registration failed after spawn",
+                extra={"worker_pid": process.pid},
+                exc_info=True,
+            )
+        except BaseException:
+            pass
     return process
 
 
@@ -190,26 +206,37 @@ async def launch_detached_job(
     startup_timeout_seconds: float = _STARTUP_TIMEOUT_SECONDS,
 ) -> JobSnapshot:
     """Spawn a durable owner and wait for its persisted acceptance receipt."""
-    if request.database_url != event_store.database_url:
-        raise ValueError("Detached worker request must use the accepting EventStore database URL")
-
-    request_path = request_path_for(request.job_id)
-    status_path = status_path_for(request_path)
-    for stale in (request_path, status_path):
-        try:
-            stale.unlink()
-        except FileNotFoundError:
-            pass
+    request_path: Path | None = None
+    status_path: Path | None = None
     try:
+        if request.database_url != event_store.database_url:
+            raise ValueError(
+                "Detached worker request must use the accepting EventStore database URL"
+            )
+        request_path = request_path_for(request.job_id)
+        status_path = status_path_for(request_path)
+        for stale in (request_path, status_path):
+            try:
+                stale.unlink()
+            except FileNotFoundError:
+                pass
         write_private_json(request_path, asdict(request), exclusive=True)
         process = _spawn_worker(request_path, cwd=request.cwd)
     except BaseException:
         job_manager.abandon_reserved_job_id(request.job_id)
-        try:
-            request_path.unlink()
-        except OSError:
-            pass
+        for artifact in (request_path, status_path):
+            if artifact is None:
+                continue
+            try:
+                artifact.unlink()
+            except OSError:
+                pass
         raise
+
+    # From successful Popen onward, the worker may accept independently. No
+    # ordinary receipt/read failure below is definitive launch rejection.
+    assert request_path is not None
+    assert status_path is not None
 
     deadline = asyncio.get_running_loop().time() + max(0.1, startup_timeout_seconds)
     while True:
@@ -218,20 +245,18 @@ async def launch_detached_job(
         except ValueError:
             pass
 
-        status = read_status(status_path)
-        if status is not None and status.get("state") == "failed":
-            error = str(status.get("error") or "detached worker failed before job acceptance")
-            job_manager.abandon_reserved_job_id(request.job_id)
-            for artifact in (request_path, status_path):
-                try:
-                    artifact.unlink()
-                except OSError:
-                    pass
-            raise RuntimeError(error)
-
         if process.poll() is not None:
-            # The reaper may already have consumed the exact return code; the
-            # worker status is authoritative when present.
+            # A failed status can precede the worker's fallback created receipt,
+            # and a created commit can race the initial read immediately before
+            # process exit. Once the child is dead no further writes are
+            # possible, so only this final durable read can prove rejection.
+            try:
+                snapshot = await job_manager.get_snapshot(request.job_id)
+            except ValueError:
+                pass
+            else:
+                cleanup_worker_artifacts(request_path)
+                return snapshot
             status = read_status(status_path)
             error = (
                 str(status.get("error"))
@@ -239,6 +264,11 @@ async def launch_detached_job(
                 else "detached worker exited before persisting job acceptance"
             )
             job_manager.abandon_reserved_job_id(request.job_id)
+            for artifact in (request_path, status_path):
+                try:
+                    artifact.unlink()
+                except OSError:
+                    pass
             raise RuntimeError(error)
 
         if asyncio.get_running_loop().time() >= deadline:

--- a/src/ouroboros/mcp/detached_worker.py
+++ b/src/ouroboros/mcp/detached_worker.py
@@ -218,6 +218,7 @@ async def run_worker(request_path: Path) -> int:
             try:
                 await _record_start_failure(manager, request, error)
                 await _wait_for_terminal(manager, request.job_id)
+                cleanup_artifacts = True
             except Exception:
                 pass
         return 1

--- a/src/ouroboros/mcp/detached_worker.py
+++ b/src/ouroboros/mcp/detached_worker.py
@@ -77,6 +77,19 @@ async def _record_start_failure(
         await manager.drain(grace_seconds=0.5)
 
 
+async def _compensate_unaccepted_start_failure(
+    manager: JobManager,
+    request: DetachedJobRequest,
+    error: str,
+) -> None:
+    """Record rejection without interrupting an accepted live owner."""
+    accepted_live_owner = manager.has_accepted_job(request.job_id) and manager.has_live_job_task(
+        request.job_id
+    )
+    if not accepted_live_owner:
+        await _record_start_failure(manager, request, error)
+
+
 async def _run_probe(manager: JobManager, request: DetachedJobRequest) -> None:
     """Internal process-lifetime probe used by integration tests."""
     delay_raw = request.arguments.get("delay_seconds", 0.2)
@@ -190,7 +203,7 @@ async def run_worker(request_path: Path) -> int:
             result = await handler.handle(dict(request.arguments))
             if result.is_err:
                 error = result.error.message
-                await _record_start_failure(manager, request, error)
+                await _compensate_unaccepted_start_failure(manager, request, error)
             else:
                 returned_job_id = result.value.meta.get("job_id")
                 if returned_job_id != request.job_id:
@@ -216,7 +229,7 @@ async def run_worker(request_path: Path) -> int:
             pass
         if manager is not None and request is not None:
             try:
-                await _record_start_failure(manager, request, error)
+                await _compensate_unaccepted_start_failure(manager, request, error)
                 await _wait_for_terminal(manager, request.job_id)
                 cleanup_artifacts = True
             except Exception:

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -30,7 +30,7 @@ from ouroboros.orchestrator.heartbeat import (
     is_owned_by_current_process,
 )
 from ouroboros.orchestrator.persisted_process_identity import (
-    current_persisted_process_owner,
+    current_persisted_process_owner,  # noqa: F401 - compatibility patch seam
     persisted_process_owner_alive,
 )
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
@@ -543,6 +543,12 @@ class JobManager:
         self._forced_inline_allocations.discard(job_id)
         self._known_job_ids.discard(job_id)
 
+    def settle_external_job_acceptance(self, job_id: str) -> None:
+        """Convert a detached reservation into a known externally owned job."""
+        self._reserved_job_ids.discard(job_id)
+        self._forced_inline_allocations.discard(job_id)
+        self._known_job_ids.add(job_id)
+
     async def start_job(
         self,
         *,
@@ -553,63 +559,16 @@ class JobManager:
         job_id: str | None = None,
     ) -> JobSnapshot:
         """Create and start a new background job."""
-        await self._ensure_initialized()
+        from ouroboros.mcp.job_start import start_managed_job
 
-        if job_id is None:
-            job_id = await self.allocate_job_id()
-        elif job_id not in self._reserved_job_ids:
-            if job_id in self._known_job_ids or await self._job_exists(job_id):
-                raise ValueError(f"Job already exists: {job_id}")
-            self._known_job_ids.add(job_id)
-        self._reserved_job_ids.discard(job_id)
-        job_links = links or JobLinks()
-
-        await self._append_event(
-            "mcp.job.created",
-            job_id,
-            {
-                "job_type": job_type,
-                "status": JobStatus.QUEUED.value,
-                "message": initial_message,
-                "links": {
-                    "session_id": job_links.session_id,
-                    "execution_id": job_links.execution_id,
-                    "lineage_id": job_links.lineage_id,
-                    "preserve_runner_result": job_links.preserve_runner_result,
-                },
-                # Stable Linux identity plus legacy non-Linux fields (#1699).
-                **current_persisted_process_owner(),
-            },
+        return await start_managed_job(
+            self,
+            job_type=job_type,
+            initial_message=initial_message,
+            runner=runner,
+            links=links,
+            job_id=job_id,
         )
-
-        # Normalise ``runner`` to a Task so ``_run_job`` can rely on Task
-        # semantics (cancellation, ``done()``). Coroutines are wrapped via
-        # ``create_task``; pre-built Tasks are reused; bare awaitables (e.g.
-        # ``Future``) are wrapped through an inner coroutine so cancellation
-        # and GC remain consistent.
-        if isinstance(runner, asyncio.Task):
-            runner_task = runner
-        elif inspect.iscoroutine(runner):
-            runner_task = asyncio.create_task(runner)
-        else:
-
-            async def _await_runner(_awaitable: Any = runner) -> Any:
-                return await _awaitable
-
-            runner_task = asyncio.create_task(_await_runner())
-        self._runner_tasks[job_id] = runner_task
-        task = asyncio.create_task(self._run_job(job_id, job_type, runner_task))
-        self._tasks[job_id] = task
-        self._monitors[job_id] = asyncio.create_task(self._monitor_job(job_id))
-        # Registered synchronously with the task dicts above: marks THIS manager
-        # instance as the runner owner, so the in-process stranded-job
-        # reconciliation in get_snapshot only ever applies to jobs whose live
-        # tasks this instance owned and released (another instance in the same
-        # process cannot prove task liveness and must never terminalize live
-        # work).
-        self._started_job_ids.add(job_id)
-
-        return await self.get_snapshot(job_id)
 
     async def _job_exists(self, job_id: str) -> bool:
         events, _ = await self._event_store.get_events_after("job", job_id, last_row_id=0)
@@ -2371,6 +2330,15 @@ class JobManager:
         """Return whether this manager crossed the local enqueue boundary."""
         return job_id in self._started_job_ids
 
+    def has_unresolved_job_acceptance(self, job_id: str) -> bool:
+        """Return whether a reserved job was not definitively rejected.
+
+        Detached launch keeps the parent reservation while worker acceptance
+        is pending or externally owned. Definitive launch failures abandon it;
+        local acceptance instead moves the id into ``_started_job_ids``.
+        """
+        return job_id in self._reserved_job_ids or job_id in self._started_job_ids
+
     async def cancel_job(self, job_id: str) -> JobSnapshot:
         """Request cancellation for a running job."""
         snapshot = await self.get_snapshot(job_id)
@@ -2904,6 +2872,8 @@ class JobManager:
             self._monitor_terminalized_jobs.discard(job_id)
             self._drained_job_ids.discard(job_id)
             self._started_job_ids.discard(job_id)
+            self._reserved_job_ids.discard(job_id)
+            self._forced_inline_allocations.discard(job_id)
         return len(expired)
 
     async def _append_event(

--- a/src/ouroboros/mcp/job_start.py
+++ b/src/ouroboros/mcp/job_start.py
@@ -1,0 +1,149 @@
+"""Atomic acceptance boundary for starting an in-process MCP job."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+
+def _create_task(awaitable: Any) -> asyncio.Task[Any]:
+    """Narrow task-factory seam for deterministic partial-registration tests."""
+    return asyncio.create_task(awaitable)
+
+
+async def _created_receipt_state(manager: Any, job_id: str) -> bool | None:
+    """Resolve a settled created write; ``None`` means unobservable ambiguity."""
+    for _attempt in range(3):
+        try:
+            return await manager._job_exists(job_id)
+        except BaseException:
+            pass
+    return None
+
+
+async def _terminalize_registration_failure(manager: Any, job_id: str) -> bool:
+    """Make a zero-runner created receipt truthful before allowing retry."""
+    from ouroboros.mcp import job_manager as jobs
+
+    try:
+        await manager._append_event(
+            "mcp.job.interrupted",
+            job_id,
+            jobs._stranded_job_interrupted_data(),
+            event_id=f"{jobs._STRANDED_INTERRUPTED_EVENT_ID_PREFIX}{job_id}",
+        )
+        return True
+    except BaseException:
+        try:
+            return bool((await manager.get_snapshot(job_id)).is_terminal)
+        except BaseException:
+            return False
+
+
+async def start_managed_job(
+    manager: Any,
+    *,
+    job_type: str,
+    initial_message: str,
+    runner: Any,
+    links: Any,
+    job_id: str | None,
+) -> Any:
+    """Persist acceptance, register ownership, and surface a job snapshot."""
+    from ouroboros.mcp import job_manager as jobs
+
+    await manager._ensure_initialized()
+    if job_id is None:
+        job_id = await manager.allocate_job_id()
+    elif job_id not in manager._reserved_job_ids:
+        if job_id in manager._known_job_ids or await manager._job_exists(job_id):
+            raise ValueError(f"Job already exists: {job_id}")
+        manager._known_job_ids.add(job_id)
+    manager._reserved_job_ids.discard(job_id)
+    job_links = links or jobs.JobLinks()
+
+    creation_error: BaseException | None = None
+    try:
+        await manager._append_event(
+            "mcp.job.created",
+            job_id,
+            {
+                "job_type": job_type,
+                "status": jobs.JobStatus.QUEUED.value,
+                "message": initial_message,
+                "links": {
+                    "session_id": job_links.session_id,
+                    "execution_id": job_links.execution_id,
+                    "lineage_id": job_links.lineage_id,
+                    "preserve_runner_result": job_links.preserve_runner_result,
+                },
+                **jobs.current_persisted_process_owner(),
+            },
+        )
+    except BaseException as exc:
+        created_state = await _created_receipt_state(manager, job_id)
+        if created_state is False:
+            raise
+        if created_state is None:
+            # Publication cannot be proved, so running would create an
+            # unobservable side-effect owner. Keep the one-shot handoff
+            # fail-closed, but do not start work until durable state is known.
+            manager._started_job_ids.add(job_id)
+            if inspect.iscoroutine(runner):
+                runner.close()
+            elif isinstance(runner, asyncio.Future):
+                runner.cancel()
+            raise
+        creation_error = exc
+
+    # The created receipt is provisionally owned until registration either
+    # succeeds or is durably terminalized as a definitive zero-runner failure.
+    manager._started_job_ids.add(job_id)
+    try:
+        if isinstance(runner, asyncio.Task):
+            runner_task = runner
+        elif inspect.iscoroutine(runner):
+            runner_task = _create_task(runner)
+        else:
+
+            async def _await_runner(_awaitable: Any = runner) -> Any:
+                return await _awaitable
+
+            runner_task = _create_task(_await_runner())
+    except BaseException as registration_error:
+        if inspect.iscoroutine(runner):
+            runner.close()
+        elif isinstance(runner, asyncio.Future):
+            runner.cancel()
+        if await _terminalize_registration_failure(manager, job_id):
+            manager._started_job_ids.discard(job_id)
+        raise registration_error
+
+    manager._runner_tasks[job_id] = runner_task
+    job_coro = manager._run_job(job_id, job_type, runner_task)
+    try:
+        task = _create_task(job_coro)
+    except BaseException as registration_error:
+        job_coro.close()
+        runner_task.cancel()
+        try:
+            await runner_task
+        except BaseException:
+            pass
+        manager._runner_tasks.pop(job_id, None)
+        if await _terminalize_registration_failure(manager, job_id):
+            manager._started_job_ids.discard(job_id)
+        raise registration_error
+
+    manager._tasks[job_id] = task
+    monitor_coro = manager._monitor_job(job_id)
+    try:
+        manager._monitors[job_id] = _create_task(monitor_coro)
+    except BaseException:
+        # Monitoring carries no terminal authority once the job task is live.
+        monitor_coro.close()
+
+    if creation_error is not None:
+        raise creation_error
+    return await manager.get_snapshot(job_id)

--- a/src/ouroboros/mcp/tools/background.py
+++ b/src/ouroboros/mcp/tools/background.py
@@ -71,8 +71,10 @@ class BackgroundJobAcceptanceState:
     job_manager: JobManager | None = None
     job_id: str | None = None
 
-    def begin_detached_acceptance(self) -> None:
+    def begin_detached_acceptance(self, job_manager: JobManager, job_id: str) -> None:
         self.phase = "detached_pending"
+        self.job_manager = job_manager
+        self.job_id = job_id
 
     def begin_local_acceptance(self, job_manager: JobManager, job_id: str) -> None:
         self.phase = "local_pending"
@@ -82,10 +84,19 @@ class BackgroundJobAcceptanceState:
     def mark_accepted(self) -> None:
         self.phase = "accepted"
 
-    def cancellation_may_have_accepted(self) -> bool:
-        """Return true only after a transport may own the requested job."""
-        if self.phase in {"detached_pending", "accepted"}:
+    def may_have_accepted(self, _exc: BaseException) -> bool:
+        """Classify ownership from the transport phase, not exception type alone."""
+        if self.phase == "accepted":
             return True
+        if self.phase == "detached_pending":
+            if self.job_manager is None or self.job_id is None:
+                return True
+            has_unresolved_acceptance = getattr(
+                type(self.job_manager), "has_unresolved_job_acceptance", None
+            )
+            return not callable(has_unresolved_acceptance) or bool(
+                has_unresolved_acceptance(self.job_manager, self.job_id)
+            )
         if self.phase != "local_pending" or self.job_manager is None or self.job_id is None:
             return False
         has_accepted_job = getattr(type(self.job_manager), "has_accepted_job", None)
@@ -188,24 +199,37 @@ async def start_background_tool_job(
                 f"Durable background job {job_type!r} is missing its detached invocation"
             )
         try:
+            request = DetachedJobRequest(
+                job_id=job_id,
+                tool_name=detached_tool_name,
+                arguments=dict(detached_arguments),
+                database_url=event_store.database_url,
+                cwd=str(Path.cwd()),
+                runtime_backend=runtime_backend,
+                llm_backend=llm_backend,
+                opencode_mode=opencode_mode,
+            )
             if on_detaching is not None:
                 await on_detaching()
-            acceptance_state.begin_detached_acceptance()
+            acceptance_state.begin_detached_acceptance(job_manager, job_id)
             snapshot = await launch_detached_job(
                 job_manager=job_manager,
                 event_store=event_store,
-                request=DetachedJobRequest(
-                    job_id=job_id,
-                    tool_name=detached_tool_name,
-                    arguments=dict(detached_arguments),
-                    database_url=event_store.database_url,
-                    cwd=str(Path.cwd()),
-                    runtime_backend=runtime_backend,
-                    llm_backend=llm_backend,
-                    opencode_mode=opencode_mode,
-                ),
+                request=request,
             )
+            acceptance_state.mark_accepted()
+            settle_external_acceptance = getattr(
+                job_manager, "settle_external_job_acceptance", None
+            )
+            if callable(settle_external_acceptance):
+                settle_external_acceptance(job_id)
         except DetachedJobAcceptanceTimeout as exc:
+            acceptance_state.mark_accepted()
+            settle_external_acceptance = getattr(
+                job_manager, "settle_external_job_acceptance", None
+            )
+            if callable(settle_external_acceptance):
+                settle_external_acceptance(job_id)
             if on_enqueue_failure is not None:
                 try:
                     await on_enqueue_failure(exc)
@@ -223,6 +247,15 @@ async def start_background_tool_job(
                 details=exc.receipt,
             ) from exc
         except BaseException as exc:
+            if acceptance_state.may_have_accepted(exc):
+                acceptance_state.mark_accepted()
+                settle_external_acceptance = getattr(
+                    job_manager, "settle_external_job_acceptance", None
+                )
+                if callable(settle_external_acceptance):
+                    settle_external_acceptance(job_id)
+            else:
+                job_manager.abandon_reserved_job_id(job_id)
             if on_enqueue_failure is not None:
                 try:
                     await on_enqueue_failure(exc)
@@ -233,7 +266,6 @@ async def start_background_tool_job(
                         exc_info=True,
                     )
             raise
-        acceptance_state.mark_accepted()
         if on_started is not None:
             await on_started(snapshot)
         return snapshot
@@ -268,8 +300,10 @@ async def start_background_tool_job(
         # the caller release any compose-around bookkeeping before we re-raise.
         # Once ``start_job`` registers ownership it has wrapped this coroutine
         # in a live Task; closing the same coroutine here would strand that job.
-        if inspect.iscoroutine(runner) and not acceptance_state.cancellation_may_have_accepted():
-            runner.close()
+        if not acceptance_state.may_have_accepted(exc):
+            job_manager.abandon_reserved_job_id(job_id)
+            if inspect.iscoroutine(runner):
+                runner.close()
         if on_enqueue_failure is not None:
             try:
                 await on_enqueue_failure(exc)

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -2163,7 +2163,22 @@ class StartEvaluateHandler:
                 )
             )
 
-        from ouroboros.mcp.tools.evaluation_job import restore_seed_handoff
+        from ouroboros.mcp.tools.evaluation_job import (
+            dispatch_plugin_evaluation,
+            resolve_auto_evolve_policy,
+            restore_seed_handoff,
+        )
+
+        try:
+            arguments, auto_evolve_enabled = resolve_auto_evolve_policy(
+                arguments, configured_enabled=get_auto_evolve_enabled()
+            )
+            plugin_dispatch = should_dispatch_via_plugin(
+                self.agent_runtime_backend, self.opencode_mode
+            )
+            background_acceptance = background_jobs.BackgroundJobAcceptanceState()
+        except ValueError as exc:
+            return Result.err(MCPToolError(str(exc), tool_name="ouroboros_start_evaluate"))
 
         try:
             arguments, seed_handoff = restore_seed_handoff(
@@ -2172,25 +2187,11 @@ class StartEvaluateHandler:
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_start_evaluate"))
 
-        from ouroboros.mcp.tools.evaluation_job import resolve_auto_evolve_policy
-
-        try:
-            arguments, auto_evolve_enabled = resolve_auto_evolve_policy(
-                arguments, configured_enabled=get_auto_evolve_enabled()
-            )
-        except ValueError as exc:
-            seed_handoff.rollback()
-            return Result.err(MCPToolError(str(exc), tool_name="ouroboros_start_evaluate"))
-
-        # --- Subagent dispatch: gate on runtime + opencode_mode ---
         # Plugin mode is terminal only when no convergence successor is needed:
         # return the delegation envelope without enqueuing a background job,
         # matching StartExecuteSeedHandler / StartEvolveStepHandler. Polling a
         # fake job_id would break the ouroboros_job_status contract.
-        plugin_dispatch = should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode)
         if plugin_dispatch and not auto_evolve_enabled:
-            from ouroboros.mcp.tools.evaluation_job import dispatch_plugin_evaluation
-
             return await seed_handoff.accept(
                 dispatch_plugin_evaluation(
                     arguments=arguments,
@@ -2200,7 +2201,7 @@ class StartEvaluateHandler:
                     resolve_working_dir=_resolve_evaluate_working_dir,
                 ),
                 require_ok=True,
-                cancellation_may_have_accepted=False,
+                acceptance_may_have_occurred=False,
             )
 
         # The shared helper preserves job-scoped cancellation across restart.
@@ -2219,7 +2220,6 @@ class StartEvaluateHandler:
                 start_ralph_handler=self.start_ralph_handler,
             )
 
-        background_acceptance = background_jobs.BackgroundJobAcceptanceState()
         snapshot = await seed_handoff.accept(
             background_jobs.start_background_tool_job(
                 job_manager=self._job_manager,
@@ -2238,7 +2238,7 @@ class StartEvaluateHandler:
                 opencode_mode=self.opencode_mode,
                 acceptance_state=background_acceptance,
             ),
-            cancellation_may_have_accepted=(background_acceptance.cancellation_may_have_accepted),
+            acceptance_may_have_occurred=background_acceptance.may_have_accepted,
         )
 
         text = (

--- a/src/ouroboros/mcp/tools/evaluation_job.py
+++ b/src/ouroboros/mcp/tools/evaluation_job.py
@@ -56,27 +56,26 @@ class SeedHandoffRedemption:
         operation: Awaitable[Any],
         *,
         require_ok: bool = False,
-        cancellation_may_have_accepted: bool | Callable[[], bool] = True,
+        acceptance_may_have_occurred: bool | Callable[[BaseException], bool] = True,
     ) -> Any:
         """Commit redemption once the selected transport accepts ownership.
 
-        Detached transports may spawn an external owner before cancellation is
-        observed, so their cancellation remains ambiguous.  Plugin dispatch is
-        different: no owner exists until the ``_subagent`` envelope is returned,
-        and its caller therefore opts into compensation on pre-envelope cancel.
+        The transport callback classifies every exceptional exit against its
+        authoritative acceptance phase. Detached transports can become
+        ambiguous before an exception is observed; local transports can prove
+        acceptance through JobManager even if their receipt read then fails.
+        Plugin dispatch is different: no owner exists until the ``_subagent``
+        envelope is returned, so every pre-envelope exception is compensable.
         """
         try:
             result = await operation
         except BaseException as exc:
-            cancellation_is_ambiguous = (
-                cancellation_may_have_accepted()
-                if callable(cancellation_may_have_accepted)
-                else cancellation_may_have_accepted
+            acceptance_is_authoritative_or_ambiguous = (
+                acceptance_may_have_occurred(exc)
+                if callable(acceptance_may_have_occurred)
+                else acceptance_may_have_occurred
             )
-            acceptance_unknown = (
-                isinstance(exc, asyncio.CancelledError) and cancellation_is_ambiguous
-            ) or (getattr(exc, "error_code", None) == "detached_job_acceptance_pending")
-            if not acceptance_unknown:
+            if not acceptance_is_authoritative_or_ambiguous:
                 self.rollback()
             raise
         if require_ok and result.is_err:

--- a/tests/integration/mcp/test_detached_job_worker.py
+++ b/tests/integration/mcp/test_detached_job_worker.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ouroboros.core.types import Result
 from ouroboros.mcp.detached_jobs import (
     DetachedJobAcceptanceTimeout,
     DetachedJobRequest,
@@ -22,6 +23,7 @@ from ouroboros.mcp.detached_jobs import (
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.tools.background import start_background_tool_job
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.heartbeat import is_process_identity_alive
 from ouroboros.orchestrator.persisted_process_identity import (
     persisted_process_owner_alive,
@@ -241,6 +243,122 @@ async def test_dead_child_final_read_error_remains_fail_closed(
         )
 
     assert manager.abandoned == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_surface", "expected_exit_code"),
+    (("exception", 1), ("structured_error", 0)),
+)
+async def test_worker_preserves_live_job_after_postaccept_receipt_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_surface: str,
+    expected_exit_code: int,
+) -> None:
+    """Worker compensation cannot interrupt a durably accepted live owner."""
+    from ouroboros.mcp import detached_worker
+
+    request = DetachedJobRequest(
+        job_id="job_worker_postaccept_receipt",
+        tool_name="ouroboros_start_evaluate",
+        arguments={"session_id": "orch_worker_postaccept", "artifact": "partial"},
+        database_url=f"sqlite+aiosqlite:///{tmp_path / 'worker-postaccept.db'}",
+        cwd=str(tmp_path),
+    )
+    state: dict[str, object] = {"runner_calls": 0, "live_before_failure": False}
+    final: dict[str, object] = {}
+
+    class ReceiptFailureManager(JobManager):
+        fail_receipt = True
+
+        async def get_snapshot(self, job_id: str):
+            snapshot = await super().get_snapshot(job_id)
+            if self.fail_receipt and self.has_live_job_task(job_id):
+                self.fail_receipt = False
+                state["live_before_failure"] = True
+                raise RuntimeError("accepted receipt unavailable")
+            return snapshot
+
+    class AcceptedThenReceiptFailureHandler:
+        def __init__(self, manager: ReceiptFailureManager) -> None:
+            self.manager = manager
+
+        async def handle(self, _arguments):
+            job_id = await self.manager.allocate_job_id()
+            assert job_id == request.job_id
+            assert self.manager.claim_forced_inline_allocation(job_id)
+            release = asyncio.Event()
+            asyncio.get_running_loop().call_later(0.05, release.set)
+
+            async def accepted_work() -> MCPToolResult:
+                state["runner_calls"] = int(state["runner_calls"]) + 1
+                await release.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="evaluation completed"),),
+                    is_error=False,
+                    meta={"final_approved": True},
+                )
+
+            try:
+                await self.manager.start_job(
+                    job_type="evaluate",
+                    initial_message="Queued evaluation",
+                    runner=accepted_work(),
+                    links=JobLinks(session_id="orch_worker_postaccept"),
+                    job_id=job_id,
+                )
+            except RuntimeError as exc:
+                if failure_surface == "exception":
+                    raise
+                return Result.err(MCPToolError(str(exc), tool_name=request.tool_name))
+            raise AssertionError("accepted receipt failure was not surfaced")
+
+    class FakeServer:
+        def __init__(self, event_store: EventStore) -> None:
+            self.event_store = event_store
+            self.job_manager = ReceiptFailureManager(
+                event_store,
+                durable_jobs=True,
+                forced_inline_job_id=request.job_id,
+            )
+            self._tool_handlers = {
+                request.tool_name: AcceptedThenReceiptFailureHandler(self.job_manager)
+            }
+
+        async def shutdown(self) -> None:
+            final["snapshot"] = await self.job_manager.get_snapshot(request.job_id)
+            final["events"] = await self.event_store.replay("job", request.job_id)
+            await self.event_store.close()
+
+    server_ref: dict[str, FakeServer] = {}
+
+    def create_server(*, event_store: EventStore, **_kwargs) -> FakeServer:
+        server = FakeServer(event_store)
+        server_ref["server"] = server
+        return server
+
+    monkeypatch.setattr(detached_worker, "_load_request", MagicMock(return_value=request))
+    monkeypatch.setattr(detached_worker.os, "chdir", MagicMock())
+    monkeypatch.setattr(detached_worker, "create_ouroboros_server", create_server)
+    monkeypatch.setattr(detached_worker, "_status", MagicMock())
+    cleanup = MagicMock()
+    monkeypatch.setattr(detached_worker, "cleanup_worker_artifacts", cleanup)
+    compensate = AsyncMock(wraps=detached_worker._record_start_failure)
+    monkeypatch.setattr(detached_worker, "_record_start_failure", compensate)
+
+    exit_code = await detached_worker.run_worker(tmp_path / "request.json")
+
+    assert exit_code == expected_exit_code
+    assert state == {"runner_calls": 1, "live_before_failure": True}
+    compensate.assert_not_awaited()
+    snapshot = final["snapshot"]
+    assert snapshot.status == JobStatus.COMPLETED  # type: ignore[union-attr]
+    assert snapshot.result_text == "evaluation completed"  # type: ignore[union-attr]
+    events = final["events"]
+    assert all(event.type != "mcp.job.interrupted" for event in events)  # type: ignore[union-attr]
+    assert not server_ref["server"].job_manager.has_live_job_task(request.job_id)
+    cleanup.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/mcp/test_detached_job_worker.py
+++ b/tests/integration/mcp/test_detached_job_worker.py
@@ -10,11 +10,15 @@ import subprocess
 import sys
 import textwrap
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ouroboros.mcp.detached_jobs import DetachedJobAcceptanceTimeout
+from ouroboros.mcp.detached_jobs import (
+    DetachedJobAcceptanceTimeout,
+    DetachedJobRequest,
+    launch_detached_job,
+)
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.tools.background import start_background_tool_job
@@ -78,6 +82,165 @@ async def _wait_terminal(
         if asyncio.get_running_loop().time() >= deadline:
             raise AssertionError(f"job {job_id} did not become terminal")
         await asyncio.sleep(0.05)
+
+
+def test_reaper_registration_failure_does_not_reject_spawned_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once Popen succeeds, local reaper setup cannot reopen acceptance."""
+    from ouroboros.mcp import detached_jobs
+
+    process = SimpleNamespace(pid=4242, wait=lambda: 0)
+    popen = MagicMock(return_value=process)
+    monkeypatch.setattr(detached_jobs.subprocess, "Popen", popen)
+
+    def fail_reaper_start(_thread) -> None:
+        raise RuntimeError("reaper unavailable")
+
+    monkeypatch.setattr(detached_jobs.threading.Thread, "start", fail_reaper_start)
+
+    spawned = detached_jobs._spawn_worker(tmp_path / "request.json", cwd=str(tmp_path))
+
+    assert spawned is process
+    popen.assert_called_once()
+
+
+class _AcceptanceProbeManager:
+    def __init__(self, outcomes: list[object]) -> None:
+        self.outcomes = outcomes
+        self.abandoned: list[str] = []
+
+    async def get_snapshot(self, _job_id: str):
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def abandon_reserved_job_id(self, job_id: str) -> None:
+        self.abandoned.append(job_id)
+
+
+def _detached_request(tmp_path: Path) -> DetachedJobRequest:
+    return DetachedJobRequest(
+        job_id="job_acceptance_probe",
+        tool_name="ouroboros_start_evaluate",
+        arguments={"session_id": "orch_probe", "artifact": "partial"},
+        database_url="sqlite+aiosqlite:///acceptance-probe.db",
+        cwd=str(tmp_path),
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_failed_status_waits_for_fallback_created_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live child can publish failed status before its fallback job receipt."""
+    from ouroboros.mcp import detached_jobs
+
+    snapshot = SimpleNamespace(job_id="job_acceptance_probe")
+    manager = _AcceptanceProbeManager([ValueError("not yet"), snapshot])
+    process = SimpleNamespace(pid=4242, poll=lambda: None)
+    monkeypatch.setattr(detached_jobs, "write_private_json", MagicMock())
+    monkeypatch.setattr(detached_jobs, "_spawn_worker", MagicMock(return_value=process))
+    monkeypatch.setattr(
+        detached_jobs,
+        "read_status",
+        MagicMock(return_value={"state": "failed", "error": "worker fallback pending"}),
+    )
+    monkeypatch.setattr(detached_jobs.asyncio, "sleep", AsyncMock())
+
+    accepted = await launch_detached_job(
+        job_manager=manager,  # type: ignore[arg-type]
+        event_store=SimpleNamespace(database_url=_detached_request(tmp_path).database_url),  # type: ignore[arg-type]
+        request=_detached_request(tmp_path),
+    )
+
+    assert accepted is snapshot
+    assert manager.abandoned == []
+
+
+@pytest.mark.asyncio
+async def test_dead_child_gets_final_durable_read_before_abandon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A created commit between the initial miss and exit remains accepted."""
+    from ouroboros.mcp import detached_jobs
+
+    snapshot = SimpleNamespace(job_id="job_acceptance_probe")
+    manager = _AcceptanceProbeManager([ValueError("stale miss"), snapshot])
+    process = SimpleNamespace(pid=4242, poll=lambda: 1)
+    monkeypatch.setattr(detached_jobs, "write_private_json", MagicMock())
+    monkeypatch.setattr(detached_jobs, "_spawn_worker", MagicMock(return_value=process))
+    cleanup = MagicMock()
+    monkeypatch.setattr(detached_jobs, "cleanup_worker_artifacts", cleanup)
+
+    accepted = await launch_detached_job(
+        job_manager=manager,  # type: ignore[arg-type]
+        event_store=SimpleNamespace(database_url=_detached_request(tmp_path).database_url),  # type: ignore[arg-type]
+        request=_detached_request(tmp_path),
+    )
+
+    assert accepted is snapshot
+    assert manager.abandoned == []
+    cleanup.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dead_child_abandons_only_after_final_durable_absence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ouroboros.mcp import detached_jobs
+
+    manager = _AcceptanceProbeManager([ValueError("stale miss"), ValueError("final absence")])
+    process = SimpleNamespace(pid=4242, poll=lambda: 1)
+    monkeypatch.setattr(detached_jobs, "write_private_json", MagicMock())
+    monkeypatch.setattr(detached_jobs, "_spawn_worker", MagicMock(return_value=process))
+    monkeypatch.setattr(
+        detached_jobs,
+        "read_status",
+        MagicMock(return_value={"state": "failed", "error": "worker rejected"}),
+    )
+
+    with pytest.raises(RuntimeError, match="worker rejected"):
+        await launch_detached_job(
+            job_manager=manager,  # type: ignore[arg-type]
+            event_store=SimpleNamespace(  # type: ignore[arg-type]
+                database_url=_detached_request(tmp_path).database_url
+            ),
+            request=_detached_request(tmp_path),
+        )
+
+    assert manager.abandoned == ["job_acceptance_probe"]
+
+
+@pytest.mark.asyncio
+async def test_dead_child_final_read_error_remains_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ouroboros.mcp import detached_jobs
+
+    manager = _AcceptanceProbeManager(
+        [ValueError("stale miss"), RuntimeError("final receipt unreadable")]
+    )
+    process = SimpleNamespace(pid=4242, poll=lambda: 1)
+    monkeypatch.setattr(detached_jobs, "write_private_json", MagicMock())
+    monkeypatch.setattr(detached_jobs, "_spawn_worker", MagicMock(return_value=process))
+
+    with pytest.raises(RuntimeError, match="final receipt unreadable"):
+        await launch_detached_job(
+            job_manager=manager,  # type: ignore[arg-type]
+            event_store=SimpleNamespace(  # type: ignore[arg-type]
+                database_url=_detached_request(tmp_path).database_url
+            ),
+            request=_detached_request(tmp_path),
+        )
+
+    assert manager.abandoned == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -115,6 +115,9 @@ class TestDefinition:
             assert request.arguments["seed_content"].startswith("goal: parent only")
             assert request.arguments["auto_evolve"] is True
             assert request.arguments["_auto_evolve_max_generations"] >= 1
+            assert manager._reserved_job_ids == set()
+            assert manager._forced_inline_allocations == set()
+            assert manager._known_job_ids == {request.job_id}
         finally:
             await store.close()
 
@@ -133,11 +136,21 @@ class TestDefinition:
         )
         snapshot = MagicMock(job_id="job_handoff_retry", cursor=0)
         snapshot.status.value = "queued"
-        launch = AsyncMock(side_effect=[RuntimeError("not accepted"), snapshot])
+        manager = JobManager(store, durable_jobs=True)
+
+        async def launch_with_definitive_rejection(*, request, **_kwargs):
+            if not launch_with_definitive_rejection.rejected:
+                launch_with_definitive_rejection.rejected = True
+                manager.abandon_reserved_job_id(request.job_id)
+                raise RuntimeError("not accepted")
+            return snapshot
+
+        launch_with_definitive_rejection.rejected = False
+        launch = AsyncMock(side_effect=launch_with_definitive_rejection)
         handler = StartEvaluateHandler(
             evaluate_handler=fake_inner_handler,
             event_store=store,
-            job_manager=JobManager(store, durable_jobs=True),
+            job_manager=manager,
             seed_handoff_registry=registry,
         )
         arguments = {
@@ -160,6 +173,245 @@ class TestDefinition:
             await store.close()
 
     @pytest.mark.asyncio
+    async def test_detached_request_construction_failure_restores_without_reservation_leak(
+        self, tmp_path: Path, fake_inner_handler
+    ) -> None:
+        """Failure before worker launch is definitive non-acceptance."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'handoff-prespawn.db'}")
+        await store.initialize()
+        manager = JobManager(store, durable_jobs=True)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_handoff_prespawn"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: retry after pre-spawn failure\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        try:
+            with patch(
+                "ouroboros.mcp.tools.background.Path.cwd",
+                side_effect=FileNotFoundError("cwd vanished"),
+            ):
+                with pytest.raises(FileNotFoundError, match="cwd vanished"):
+                    await handler.handle(arguments)
+
+            assert registry.resolve(handoff_id, session_id=session_id) is not None
+            assert manager._known_job_ids == set()
+            assert manager._reserved_job_ids == set()
+            assert manager._started_job_ids == set()
+            assert manager._tasks == {}
+            assert manager._runner_tasks == {}
+            assert manager._monitors == {}
+            assert await store.query_events(aggregate_type="job") == []
+
+            snapshot = MagicMock(job_id="job_retry_after_prespawn", cursor=0)
+            snapshot.status.value = "queued"
+            with patch(
+                "ouroboros.mcp.tools.background.launch_detached_job",
+                new=AsyncMock(return_value=snapshot),
+            ):
+                retry = await handler.handle(arguments)
+
+            assert retry.is_ok
+            assert registry.resolve(handoff_id, session_id=session_id) is None
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("path_method", "failure"),
+        (("mkdir", "state directory denied"), ("unlink", "stale cleanup denied")),
+    )
+    async def test_detached_prespawn_filesystem_failure_restores_without_reservation_leak(
+        self,
+        tmp_path: Path,
+        fake_inner_handler,
+        monkeypatch: pytest.MonkeyPatch,
+        path_method: str,
+        failure: str,
+    ) -> None:
+        """A failure before detached spawn abandons the reserved job id."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'handoff-stale-cleanup.db'}")
+        await store.initialize()
+        manager = JobManager(store, durable_jobs=True)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_handoff_stale_cleanup"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: retry after detached cleanup failure\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        try:
+            with patch(
+                f"ouroboros.mcp.detached_jobs.Path.{path_method}",
+                side_effect=PermissionError(failure),
+            ):
+                with pytest.raises(PermissionError, match=failure):
+                    await handler.handle(arguments)
+
+            assert registry.resolve(handoff_id, session_id=session_id) is not None
+            assert manager._known_job_ids == set()
+            assert manager._reserved_job_ids == set()
+            assert manager._started_job_ids == set()
+            assert manager._tasks == {}
+            assert await store.query_events(aggregate_type="job") == []
+
+            snapshot = MagicMock(job_id="job_retry_after_cleanup", cursor=0)
+            snapshot.status.value = "queued"
+            with patch(
+                "ouroboros.mcp.tools.background.launch_detached_job",
+                new=AsyncMock(return_value=snapshot),
+            ):
+                retry = await handler.handle(arguments)
+
+            assert retry.is_ok
+            assert registry.resolve(handoff_id, session_id=session_id) is None
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_detached_receipt_failure_keeps_handoff_consumed(
+        self, tmp_path: Path, fake_inner_handler
+    ) -> None:
+        """A non-abandoned detached reservation is fail-closed on receipt error."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'handoff-ambiguous.db'}")
+        await store.initialize()
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_handoff_ambiguous",
+            seed_content="goal: do not duplicate an unresolved detached owner\n",
+        )
+        manager = JobManager(store, durable_jobs=True)
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_handoff_ambiguous",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        try:
+            with patch(
+                "ouroboros.mcp.tools.background.launch_detached_job",
+                new=AsyncMock(side_effect=RuntimeError("accepted receipt unreadable")),
+            ):
+                with pytest.raises(RuntimeError, match="accepted receipt unreadable"):
+                    await handler.handle(arguments)
+
+            assert registry.resolve(handoff_id, session_id="orch_handoff_ambiguous") is None
+            retry = await handler.handle(arguments)
+            assert retry.is_err
+            assert "unknown or does not belong" in retry.error.message
+            assert manager._reserved_job_ids == set()
+            assert len(manager._known_job_ids) == 1
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_post_created_detached_snapshot_failure_keeps_handoff_consumed(
+        self, tmp_path: Path, fake_inner_handler
+    ) -> None:
+        """Snapshot reconstruction failure cannot erase durable acceptance."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class PostCreatedSnapshotFailureManager(JobManager):
+            async def get_snapshot(self, job_id: str):
+                await super().get_snapshot(job_id)
+                raise RuntimeError("post-created snapshot reconstruction failed")
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'post-created-failure.db'}")
+        await store.initialize()
+        registry = SeedHandoffRegistry()
+        handoff_id = registry.register(
+            session_id="orch_post_created_failure",
+            seed_content="goal: preserve durable detached acceptance\n",
+        )
+        manager = PostCreatedSnapshotFailureManager(store, durable_jobs=True)
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": "orch_post_created_failure",
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        async def persist_then_fail_snapshot(**kwargs):
+            job_manager = kwargs["job_manager"]
+            request = kwargs["request"]
+            await job_manager._append_event(
+                "mcp.job.created",
+                request.job_id,
+                {
+                    "job_type": "evaluate",
+                    "status": "queued",
+                    "message": "Queued evaluation",
+                    "links": {},
+                },
+            )
+            return await job_manager.get_snapshot(request.job_id)
+
+        try:
+            with patch(
+                "ouroboros.mcp.tools.background.launch_detached_job",
+                new=persist_then_fail_snapshot,
+            ):
+                with pytest.raises(
+                    RuntimeError, match="post-created snapshot reconstruction failed"
+                ):
+                    await handler.handle(arguments)
+
+            assert registry.resolve(handoff_id, session_id="orch_post_created_failure") is None
+            assert manager._reserved_job_ids == set()
+            assert len(manager._known_job_ids) == 1
+            assert len(await store.query_events(aggregate_type="job")) == 1
+            retry = await handler.handle(arguments)
+            assert retry.is_err
+            assert "unknown or does not belong" in retry.error.message
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
     async def test_pending_detached_acceptance_keeps_handoff_consumed(
         self, tmp_path: Path, fake_inner_handler
     ) -> None:
@@ -173,10 +425,11 @@ class TestDefinition:
             session_id="orch_handoff_pending",
             seed_content="goal: do not duplicate\n",
         )
+        manager = JobManager(store, durable_jobs=True)
         handler = StartEvaluateHandler(
             evaluate_handler=fake_inner_handler,
             event_store=store,
-            job_manager=JobManager(store, durable_jobs=True),
+            job_manager=manager,
             seed_handoff_registry=registry,
         )
 
@@ -203,6 +456,8 @@ class TestDefinition:
 
             assert raised.value.error_code == "detached_job_acceptance_pending"
             assert registry.resolve(handoff_id, session_id="orch_handoff_pending") is None
+            assert manager._reserved_job_ids == set()
+            assert len(manager._known_job_ids) == 1
         finally:
             await store.close()
 
@@ -225,6 +480,70 @@ class TestRequiredArguments:
 
 class TestBackgroundJobPath:
     """Non-plugin runtime: a JobManager-backed job is enqueued."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("failure_target", "failure"),
+        (
+            (
+                "ouroboros.mcp.tools.evaluation_handlers.get_auto_evolve_enabled",
+                "config unavailable",
+            ),
+            (
+                "ouroboros.mcp.tools.evaluation_handlers.should_dispatch_via_plugin",
+                "routing unavailable",
+            ),
+        ),
+    )
+    async def test_preallocation_runtime_error_restores_handoff(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+        failure_target: str,
+        failure: str,
+    ) -> None:
+        """Synchronous routing setup cannot consume an unaccepted handoff."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        manager = JobManager(event_store, durable_jobs=False)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_policy_failure"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: retry after policy failure\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        with patch(
+            failure_target,
+            side_effect=RuntimeError(failure),
+        ):
+            with pytest.raises(RuntimeError, match=failure):
+                await handler.handle(arguments)
+
+        assert registry.resolve(handoff_id, session_id=session_id) is not None
+        assert manager._known_job_ids == set()
+        assert manager._reserved_job_ids == set()
+        assert manager._started_job_ids == set()
+        assert manager._tasks == {}
+        assert await event_store.query_events(aggregate_type="job") == []
+
+        retry = await handler.handle(arguments)
+
+        assert retry.is_ok
+        assert registry.resolve(handoff_id, session_id=session_id) is None
+        await manager.drain()
 
     @pytest.mark.asyncio
     async def test_preallocation_cancellation_restores_handoff_for_retry(
@@ -331,6 +650,9 @@ class TestBackgroundJobPath:
             await pending
 
         assert registry.resolve(handoff_id, session_id="orch_local_preenqueue_cancel") is not None
+        assert manager._known_job_ids == set()
+        assert manager._reserved_job_ids == set()
+        assert manager._forced_inline_allocations == set()
         assert manager._started_job_ids == set()
         assert manager._tasks == {}
         assert await event_store.query_events(aggregate_type="job") == []
@@ -341,6 +663,398 @@ class TestBackgroundJobPath:
         assert retry.is_ok
         assert registry.resolve(handoff_id, session_id="orch_local_preenqueue_cancel") is None
         await manager.drain()
+
+    @pytest.mark.asyncio
+    async def test_local_created_commit_cancellation_keeps_runner_and_handoff_consumed(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+    ) -> None:
+        """A settled created receipt crosses local acceptance atomically."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class CreatedCommitBarrierJobManager(JobManager):
+            def __init__(self, store: EventStore) -> None:
+                super().__init__(store, durable_jobs=False)
+                self.created_committed = asyncio.Event()
+                self._blocked_created = False
+
+            async def _append_event(self, event_type, job_id, data, *, event_id=None):
+                await super()._append_event(
+                    event_type,
+                    job_id,
+                    data,
+                    event_id=event_id,
+                )
+                if event_type == "mcp.job.created" and not self._blocked_created:
+                    self._blocked_created = True
+                    self.created_committed.set()
+                    await asyncio.Event().wait()
+
+        work_started = asyncio.Event()
+        release_work = asyncio.Event()
+
+        async def finish_after_release(_arguments):
+            work_started.set()
+            await release_work.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="evaluated"),),
+                    is_error=False,
+                    meta={"final_approved": True},
+                )
+            )
+
+        fake_inner_handler.handle = AsyncMock(side_effect=finish_after_release)
+        manager = CreatedCommitBarrierJobManager(event_store)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_created_commit_cancel"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: preserve accepted created receipt\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        pending = asyncio.create_task(handler.handle(arguments))
+        await manager.created_committed.wait()
+        pending.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+
+        await work_started.wait()
+        assert len(manager._started_job_ids) == 1
+        job_id = next(iter(manager._started_job_ids))
+        assert registry.resolve(handoff_id, session_id=session_id) is None
+        assert manager.has_live_job_task(job_id)
+
+        retry = await handler.handle(arguments)
+        assert retry.is_err
+        assert "unknown or does not belong" in retry.error.message
+        created_events = await event_store.query_events(
+            aggregate_type="job", event_type="mcp.job.created"
+        )
+        assert [event.aggregate_id for event in created_events] == [job_id]
+
+        release_work.set()
+        for _ in range(100):
+            snapshot = await manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("accepted created-receipt job did not terminalize")
+
+        await manager.drain()
+        await asyncio.sleep(0)
+        assert not manager.has_live_job_task(job_id)
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
+
+    @pytest.mark.asyncio
+    async def test_local_created_commit_confirmation_error_fails_closed(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+    ) -> None:
+        """An unreadable committed receipt cannot reopen the Seed handoff."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class UnreadableCreatedReceiptJobManager(JobManager):
+            def __init__(self, store: EventStore) -> None:
+                super().__init__(store, durable_jobs=False)
+                self.fail_confirmation = False
+
+            async def _append_event(self, event_type, job_id, data, *, event_id=None):
+                await super()._append_event(
+                    event_type,
+                    job_id,
+                    data,
+                    event_id=event_id,
+                )
+                if event_type == "mcp.job.created":
+                    self.fail_confirmation = True
+                    raise RuntimeError("created receipt response lost")
+
+            async def _job_exists(self, job_id: str) -> bool:
+                if self.fail_confirmation:
+                    self.fail_confirmation = False
+                    raise RuntimeError("created receipt confirmation unavailable")
+                return await super()._job_exists(job_id)
+
+        manager = UnreadableCreatedReceiptJobManager(event_store)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_created_confirmation_error"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: fail closed on unreadable created receipt\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        with pytest.raises(RuntimeError, match="created receipt response lost"):
+            await handler.handle(arguments)
+
+        assert len(manager._started_job_ids) == 1
+        job_id = next(iter(manager._started_job_ids))
+        fake_inner_handler.handle.assert_not_called()
+        assert registry.resolve(handoff_id, session_id=session_id) is None
+        retry = await handler.handle(arguments)
+        assert retry.is_err
+        assert "unknown or does not belong" in retry.error.message
+
+        for _ in range(100):
+            snapshot = await manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("fail-closed accepted job did not terminalize")
+
+        await manager.drain()
+        await asyncio.sleep(0)
+        assert not manager.has_live_job_task(job_id)
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
+
+    @pytest.mark.asyncio
+    async def test_local_transient_confirmation_failure_restores_handoff(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+    ) -> None:
+        """A retry that proves no receipt exists makes rejection definitive."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class UnconfirmedCreatedReceiptJobManager(JobManager):
+            def __init__(self, store: EventStore) -> None:
+                super().__init__(store, durable_jobs=False)
+                self.fail_confirmation = False
+
+            async def _append_event(self, event_type, job_id, data, *, event_id=None):
+                if event_type == "mcp.job.created":
+                    self.fail_confirmation = True
+                    raise RuntimeError("created append rejected")
+                await super()._append_event(
+                    event_type,
+                    job_id,
+                    data,
+                    event_id=event_id,
+                )
+
+            async def _job_exists(self, job_id: str) -> bool:
+                if self.fail_confirmation:
+                    self.fail_confirmation = False
+                    raise RuntimeError("created confirmation unavailable")
+                return await super()._job_exists(job_id)
+
+        manager = UnconfirmedCreatedReceiptJobManager(event_store)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_unconfirmed_created"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: never run without a durable receipt\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        with pytest.raises(RuntimeError, match="created append rejected"):
+            await handler.handle(arguments)
+
+        fake_inner_handler.handle.assert_not_called()
+        assert manager._started_job_ids == set()
+        assert manager._known_job_ids == set()
+        assert manager._reserved_job_ids == set()
+        assert registry.resolve(handoff_id, session_id=session_id) is not None
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
+        assert await event_store.query_events(aggregate_type="job") == []
+
+    @pytest.mark.asyncio
+    async def test_local_persistently_unreadable_confirmation_stays_fail_closed(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+    ) -> None:
+        """Persistent receipt ambiguity consumes the handoff without starting work."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class PersistentlyUnreadableReceiptJobManager(JobManager):
+            def __init__(self, store: EventStore) -> None:
+                super().__init__(store, durable_jobs=False)
+                self.fail_confirmation = False
+
+            async def _append_event(self, event_type, job_id, data, *, event_id=None):
+                if event_type == "mcp.job.created":
+                    self.fail_confirmation = True
+                    raise RuntimeError("created append outcome unknown")
+                await super()._append_event(event_type, job_id, data, event_id=event_id)
+
+            async def _job_exists(self, job_id: str) -> bool:
+                if self.fail_confirmation:
+                    raise RuntimeError("created confirmation unavailable")
+                return await super()._job_exists(job_id)
+
+        manager = PersistentlyUnreadableReceiptJobManager(event_store)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_persistently_unreadable_created"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: fail closed while receipt state is unknowable\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        with pytest.raises(RuntimeError, match="created append outcome unknown"):
+            await handler.handle(arguments)
+
+        fake_inner_handler.handle.assert_not_called()
+        assert len(manager._started_job_ids) == 1
+        assert registry.resolve(handoff_id, session_id=session_id) is None
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
+        assert await event_store.query_events(aggregate_type="job") == []
+        retry = await handler.handle(arguments)
+        assert retry.is_err
+        assert "unknown or does not belong" in retry.error.message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failed_create_task_call", (1, 2, 3))
+    async def test_local_created_receipt_task_registration_failures_stay_owned(
+        self,
+        event_store: EventStore,
+        fake_inner_handler,
+        monkeypatch: pytest.MonkeyPatch,
+        failed_create_task_call: int,
+    ) -> None:
+        """Partial task setup cannot reopen a durable created receipt."""
+        from ouroboros.mcp import job_start
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        manager = JobManager(event_store, durable_jobs=False)
+        registry = SeedHandoffRegistry()
+        session_id = f"orch_registration_failure_{failed_create_task_call}"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content="goal: keep durable receipt single-owner\n",
+        )
+        handler = StartEvaluateHandler(
+            evaluate_handler=fake_inner_handler,
+            event_store=event_store,
+            job_manager=manager,
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+        original_create_task = job_start._create_task
+        create_task_calls = 0
+
+        def fail_selected_create_task(coro):
+            nonlocal create_task_calls
+            create_task_calls += 1
+            if create_task_calls == failed_create_task_call:
+                raise RuntimeError(f"create_task {failed_create_task_call} failed")
+            return original_create_task(coro)
+
+        monkeypatch.setattr(job_start, "_create_task", fail_selected_create_task)
+        if failed_create_task_call < 3:
+            with pytest.raises(
+                RuntimeError,
+                match=rf"create_task {failed_create_task_call} failed",
+            ):
+                await handler.handle(arguments)
+        else:
+            started = await handler.handle(arguments)
+            assert started.is_ok
+        monkeypatch.setattr(job_start, "_create_task", original_create_task)
+
+        created_events = await event_store.query_events(
+            aggregate_type="job", event_type="mcp.job.created"
+        )
+        assert len(created_events) == 1
+        job_id = created_events[0].aggregate_id
+
+        if failed_create_task_call < 3:
+            assert registry.resolve(handoff_id, session_id=session_id) is not None
+            assert job_id not in manager._started_job_ids
+            assert not manager.has_live_job_task(job_id)
+            failed_snapshot = await manager.get_snapshot(job_id)
+            assert failed_snapshot.status.value == "interrupted"
+            retry = await handler.handle(arguments)
+            assert retry.is_ok
+            assert retry.value.meta["job_id"] != job_id
+            assert registry.resolve(handoff_id, session_id=session_id) is None
+            job_id = retry.value.meta["job_id"]
+        else:
+            assert manager._started_job_ids == {job_id}
+            assert registry.resolve(handoff_id, session_id=session_id) is None
+            retry = await handler.handle(arguments)
+            assert retry.is_err
+            assert "unknown or does not belong" in retry.error.message
+
+        for _ in range(100):
+            snapshot = await manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("partially registered job did not terminalize")
+
+        await manager.drain()
+        await asyncio.sleep(0)
+        assert not manager.has_live_job_task(job_id)
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
 
     @pytest.mark.asyncio
     async def test_local_postacceptance_cancellation_keeps_handoff_consumed(
@@ -410,6 +1124,130 @@ class TestBackgroundJobPath:
         await asyncio.wait_for(asyncio.shield(job_task), timeout=1.0)
         assert (await manager.get_snapshot(job_id)).is_terminal
         await manager.drain()
+
+    @pytest.mark.asyncio
+    async def test_local_postacceptance_receipt_failure_keeps_single_handoff_chain(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        """An accepted runner survives an ordinary receipt-read failure (#1938)."""
+        from ouroboros.mcp.tools.seed_handoff import SeedHandoffRegistry
+
+        class ReceiptFailingJobManager(JobManager):
+            def __init__(self, store: EventStore) -> None:
+                super().__init__(store, durable_jobs=False)
+                self.receipt_owner: asyncio.Task[object] | None = None
+                self.accepted_receipt_read = asyncio.Event()
+                self.release_receipt_read = asyncio.Event()
+                self.receipt_failed = False
+
+            async def get_snapshot(self, job_id: str):
+                if (
+                    not self.receipt_failed
+                    and asyncio.current_task() is self.receipt_owner
+                    and self.has_accepted_job(job_id)
+                ):
+                    self.accepted_receipt_read.set()
+                    await self.release_receipt_read.wait()
+                    self.receipt_failed = True
+                    raise RuntimeError("accepted receipt snapshot failed")
+                return await super().get_snapshot(job_id)
+
+        evaluation_started = asyncio.Event()
+        release_evaluation = asyncio.Event()
+        evaluation_calls = 0
+
+        async def reject_after_release(_arguments):
+            nonlocal evaluation_calls
+            evaluation_calls += 1
+            evaluation_started.set()
+            await release_evaluation.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="REJECTED"),),
+                    meta={"final_approved": False, "highest_stage": 2},
+                )
+            )
+
+        ralph_calls: list[dict[str, object]] = []
+
+        class FakeStartRalphHandler:
+            async def handle(self, arguments):
+                ralph_calls.append(arguments)
+                return Result.ok(MCPToolResult(meta={"job_id": "job_ralph_once"}))
+
+        manager = ReceiptFailingJobManager(event_store)
+        registry = SeedHandoffRegistry()
+        session_id = "orch_accepted_receipt_failure"
+        handoff_id = registry.register(
+            session_id=session_id,
+            seed_content=(
+                "goal: converge once\n"
+                "acceptance_criteria: [receipt ownership is safe]\n"
+                "ontology_schema:\n"
+                "  name: ReceiptOwnership\n"
+                "  description: Accepted background evaluation ownership\n"
+                "metadata:\n"
+                "  seed_id: seed-receipt-once\n"
+                "  ambiguity_score: 0.1\n"
+            ),
+        )
+        inner = MagicMock(spec=EvaluateHandler)
+        inner.handle = AsyncMock(side_effect=reject_after_release)
+        handler = StartEvaluateHandler(
+            evaluate_handler=inner,
+            event_store=event_store,
+            job_manager=manager,
+            start_ralph_handler=FakeStartRalphHandler(),  # type: ignore[arg-type]
+            seed_handoff_registry=registry,
+        )
+        arguments = {
+            "session_id": session_id,
+            "artifact": "partial artifact",
+            "seed_handoff_id": handoff_id,
+            "auto_evolve": True,
+        }
+
+        first = asyncio.create_task(handler.handle(arguments))
+        manager.receipt_owner = first
+        await manager.accepted_receipt_read.wait()
+        await evaluation_started.wait()
+
+        assert len(manager._started_job_ids) == 1
+        job_id = next(iter(manager._started_job_ids))
+        assert manager.has_live_job_task(job_id)
+
+        manager.release_receipt_read.set()
+        with pytest.raises(RuntimeError, match="accepted receipt snapshot failed"):
+            await first
+
+        assert registry.resolve(handoff_id, session_id=session_id) is None
+        retry = await handler.handle(arguments)
+        assert retry.is_err
+        assert "unknown or does not belong" in retry.error.message
+        assert manager._started_job_ids == {job_id}
+        assert evaluation_calls == 1
+
+        release_evaluation.set()
+        for _ in range(100):
+            snapshot = await manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("accepted evaluation did not terminalize")
+
+        assert snapshot.result_meta["chained_ralph_job_id"] == "job_ralph_once"
+        assert len(ralph_calls) == 1
+        job_events = await event_store.query_events(aggregate_type="job")
+        assert {event.aggregate_id for event in job_events} == {job_id}
+
+        await manager.drain()
+        await asyncio.sleep(0)
+        assert not manager.has_live_job_task(job_id)
+        assert manager._tasks == {}
+        assert manager._runner_tasks == {}
+        assert manager._monitors == {}
 
     @pytest.mark.asyncio
     async def test_returns_job_id_immediately(self, event_store, fake_inner_handler) -> None:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -8417,6 +8417,7 @@ class TestOrchestratorRunner:
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
         sample_seed: Seed,
+        tmp_path: Path,
     ) -> None:
         """Delegated child runs should fork from the inherited parent runtime handle."""
         inherited_handle = RuntimeHandle(
@@ -8428,7 +8429,9 @@ class TestOrchestratorRunner:
         mock_adapter.runtime_backend = "claude"
         mock_adapter.llm_backend = "test-llm"
         mock_adapter._model = "test-model"
-        mock_adapter.working_directory = "/tmp/project"
+        project = tmp_path / "project"
+        project.mkdir()
+        mock_adapter.working_directory = str(project)
         mock_adapter.permission_mode = "acceptEdits"
         captured_kwargs: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

- Make Seed handoff redemption follow the background jobs actual acceptance authority.
- Prevent receipt and cancellation races from restoring an already-consumed handoff and launching a duplicate evaluation or Ralph chain.
- Preserve accepted detached work across both raised exceptions and structured handler errors.

## Changes

- Add explicit local and detached acceptance phases around StartEvaluateHandler handoff redemption.
- Harden local job creation, task registration, terminal compensation, and ownership cleanup.
- Harden detached startup, final durable receipt reads, reservation settlement, and artifact cleanup.
- Centralize worker startup-failure compensation behind accepted-and-live ownership checks for both exception and Result.err surfaces.
- Add production-shaped regressions for post-acceptance receipt failures, structured StartAuto-style errors, detached races, duplicate retries, and task registration failures.
- Remove an order-dependent test assumption by giving the inherited-runtime test an isolated tmp_path project identity.

## Verification

- Independent exact-head verifier PASS on 7ddc5ea0cf29527dd22618e0507fce3a2a1d0fb2.
- Python 3.14 affected suite: 366 passed.
- Python 3.12 StartEvaluate plus detached-worker suite: 53 passed.
- Detached-worker integration: 11 passed.
- Orchestrator runner under xdist worksteal: 277 passed, 1 skipped.
- MyPy: 536 source files passed.
- Ruff, format, module-size, and git diff checks passed.
- Includes protected main 618ecf32f1b917f91e9f44edcd6a2794bbf3356a.

## Notes

The prior Python 3.14 CI failure was an order-dependent test fixture and is fixed with an isolated project directory. The exact-head review blocker is also addressed: detached-worker compensation now preserves an accepted live owner whether the handler raises or converts the failure into Result.err, while definitive and partial no-live startup failures retain compensation.

Merge remains frozen until the official ouroboros-agent bot approves this exact head and all required checks pass.

Closes #1938