### PR TITLE
fix(runtime): distinguish probe failure from executable drift

### DIFF
--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -216,6 +216,25 @@ ouroboros --help
 
 The `CodexCliRuntime` adapter launches `codex` (or `codex-cli`) as its transport layer, but wraps it with session handles, resume support, and deterministic skill/MCP dispatch so the runtime behaves like a persistent Ouroboros session.
 
+### Executable version attestation
+
+The adapter records successful `codex --version` evidence together with the
+selected path, effective target's device/inode pair, content digest, and
+symlink identity when the runtime is created, then verifies that evidence
+before each launch. The policy is fail-closed but does not confuse unavailable
+evidence with confirmed drift:
+
+- A timeout or execution failure during initialization leaves no positive
+  baseline, so execution is blocked and a new runtime session is required.
+- A timeout or execution failure during a later check blocks that attempt but
+  is reported as unavailable attestation evidence; the same runtime may be
+  retried.
+- Executable drift is reported only when two successful attestations differ.
+  Two missing attestations never count as proof that the executable is
+  unchanged.
+
+The Copilot runtime inherits the same attestation and comparison policy.
+
 > For a side-by-side comparison of all runtime backends, see the [runtime capability matrix](../runtime-capability-matrix.md).
 
 ## Codex CLI Strengths

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -229,9 +229,10 @@ evidence with confirmed drift:
 - A timeout or execution failure during a later check blocks that attempt but
   is reported as unavailable attestation evidence; the same runtime may be
   retried.
-- Executable drift is reported only when two successful attestations differ.
-  Two missing attestations never count as proof that the executable is
-  unchanged.
+- Version drift is reported only when two successful version attestations
+  differ. Path, content, symlink, device/inode, or probe-window generation
+  drift can fail closed before a second successful version probe. Two missing
+  attestations never count as proof that the executable is unchanged.
 
 The Copilot runtime inherits the same attestation and comparison policy.
 

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -236,12 +236,17 @@ evidence with confirmed drift:
 - Every started probe is post-sampled even when it times out or fails. If that
   evidence proves probe-window mutation, mutation takes precedence over the
   transient probe outcome.
+- A containing-directory generation change alone is broader than executable
+  identity: it can come from an unrelated sibling or an entry swap-and-restore.
+  The attempt therefore fails closed as retryable, indeterminate authority
+  without claiming confirmed executable drift.
 - Version drift is reported only when two successful version attestations
   differ. Path, content, symlink, device/inode, or probe-window generation
   drift can fail closed before a second successful version probe. Two missing
   attestations never count as proof that the executable is unchanged.
 
-The Copilot runtime inherits the same attestation and comparison policy.
+The Copilot, Gemini, Goose, and Grok runtimes inherit the same attestation and
+comparison policy.
 
 > For a side-by-side comparison of all runtime backends, see the [runtime capability matrix](../runtime-capability-matrix.md).
 

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -229,6 +229,13 @@ evidence with confirmed drift:
 - A timeout or execution failure during a later check blocks that attempt but
   is reported as unavailable attestation evidence; the same runtime may be
   retried.
+- Before running the selected executable for `--version`, the adapter compares
+  its non-executing path, content, device/inode, and complete semantic symlink
+  evidence with the verified initialization baseline. Known drift is rejected
+  without executing the changed candidate.
+- Every started probe is post-sampled even when it times out or fails. If that
+  evidence proves probe-window mutation, mutation takes precedence over the
+  transient probe outcome.
 - Version drift is reported only when two successful version attestations
   differ. Path, content, symlink, device/inode, or probe-window generation
   drift can fail closed before a second successful version probe. Two missing

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -158,8 +158,9 @@ version-attestation policy as Codex: initialization-time probe failure blocks
 the runtime because no positive baseline exists; a later timeout or execution
 failure blocks only the current attempt and is not reported as executable
 drift; only two successful, different attestations confirm a version change.
-This ensures that two missing `copilot --version` results never authorize a
-launch under load.
+Path, content, symlink, device/inode, or probe-window generation drift can fail
+closed before a second successful version probe. This ensures that two missing
+`copilot --version` results never authorize a launch under load.
 
 ### MCP registration
 

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -157,7 +157,12 @@ Before launching that command, the runtime applies the same executable
 version-attestation policy as Codex: initialization-time probe failure blocks
 the runtime because no positive baseline exists; a later timeout or execution
 failure blocks only the current attempt and is not reported as executable
-drift; only two successful, different attestations confirm a version change.
+drift; only a version-output change requires two successful, different
+attestations.
+The runtime rejects non-executing path/content/device/inode/symlink evidence
+that differs from initialization before running `copilot --version`, and it
+post-samples every started probe so mutation takes precedence over a concurrent
+timeout or execution failure.
 Path, content, symlink, device/inode, or probe-window generation drift can fail
 closed before a second successful version probe. This ensures that two missing
 `copilot --version` results never authorize a launch under load.

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -153,6 +153,14 @@ copilot --no-color --log-level none \
 | `--agent`           | Custom agent profile; takes precedence over `--model`        |
 | `-p`                | One-shot prompt (no interactive REPL)                        |
 
+Before launching that command, the runtime applies the same executable
+version-attestation policy as Codex: initialization-time probe failure blocks
+the runtime because no positive baseline exists; a later timeout or execution
+failure blocks only the current attempt and is not reported as executable
+drift; only two successful, different attestations confirm a version change.
+This ensures that two missing `copilot --version` results never authorize a
+launch under load.
+
 ### MCP registration
 
 `ouroboros setup --runtime copilot` writes

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -163,6 +163,10 @@ The runtime rejects non-executing path/content/device/inode/symlink evidence
 that differs from initialization before running `copilot --version`, and it
 post-samples every started probe so mutation takes precedence over a concurrent
 timeout or execution failure.
+If only a containing-directory generation changed, the evidence cannot
+distinguish unrelated sibling churn from an executable-entry swap-and-restore.
+That attempt fails closed as retryable, indeterminate authority without
+claiming confirmed executable drift.
 Path, content, symlink, device/inode, or probe-window generation drift can fail
 closed before a second successful version probe. This ensures that two missing
 `copilot --version` results never authorize a launch under load.

--- a/src/ouroboros/orchestrator/cli_version_attestation.py
+++ b/src/ouroboros/orchestrator/cli_version_attestation.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 import hashlib
 import os
 from pathlib import Path
+import stat
 import subprocess
 
 
@@ -53,34 +55,79 @@ def read_cli_executable_filesystem_identity(
     return value.st_dev, value.st_ino
 
 
-def read_cli_executable_generation_identity(
+def _stat_generation(value: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def read_cli_executable_resolution_chain_identity(
     executable_path: str | None,
-) -> tuple[int, ...] | None:
-    """Return target and directory metadata that exposes probe-window ABA."""
+) -> tuple[tuple[object, ...], ...] | None:
+    """Resolve every path/symlink hop with generation-bearing evidence.
+
+    The terminal executable and every visited symlink are paired with their
+    containing directory generation. That makes an atomic swap-and-restore of
+    an authority-bearing entry visible even when its original inode is put
+    back unchanged, without treating unrelated churn in ordinary ancestors as
+    executable churn. Resolution is lexical and bounded to 40 symlink
+    traversals; loops and read errors fail closed.
+    """
     if executable_path is None:
         return None
-    path = Path(executable_path)
+    absolute_path = Path(os.path.abspath(os.path.expanduser(executable_path)))
+    pending = deque(absolute_path.parts[1:])
+    resolved_parent = Path(absolute_path.anchor)
+    evidence: list[tuple[object, ...]] = []
+    symlink_count = 0
+
     try:
-        target = path.stat()
-        launch_parent = path.parent.stat()
-        resolved_parent = path.resolve(strict=True).parent.stat()
-    except (OSError, RuntimeError):
+        while pending:
+            component = pending.popleft()
+            if component in {"", "."}:
+                continue
+            if component == "..":
+                resolved_parent = resolved_parent.parent
+                continue
+
+            candidate = resolved_parent / component
+            parent_generation = _stat_generation(resolved_parent.stat())
+            node_stat = candidate.lstat()
+            raw_target: str | None = None
+            if stat.S_ISLNK(node_stat.st_mode):
+                symlink_count += 1
+                if symlink_count > 40:
+                    return None
+                raw_target = os.readlink(candidate)
+            if raw_target is not None or not pending:
+                evidence.append(
+                    (
+                        str(candidate),
+                        raw_target,
+                        parent_generation,
+                        _stat_generation(node_stat),
+                    )
+                )
+
+            if raw_target is None:
+                resolved_parent = candidate
+                continue
+
+            target = Path(raw_target)
+            if target.is_absolute():
+                resolved_parent = Path(target.anchor)
+                target_parts = target.parts[1:]
+            else:
+                target_parts = target.parts
+            pending.extendleft(reversed(target_parts))
+    except OSError:
         return None
-    return (
-        target.st_dev,
-        target.st_ino,
-        target.st_size,
-        target.st_mtime_ns,
-        target.st_ctime_ns,
-        launch_parent.st_dev,
-        launch_parent.st_ino,
-        launch_parent.st_mtime_ns,
-        launch_parent.st_ctime_ns,
-        resolved_parent.st_dev,
-        resolved_parent.st_ino,
-        resolved_parent.st_mtime_ns,
-        resolved_parent.st_ctime_ns,
-    )
+    return tuple(evidence)
 
 
 def read_cli_executable_symlink_identity(executable_path: str | None) -> dict[str, str] | None:
@@ -103,22 +150,6 @@ def read_cli_executable_symlink_identity(executable_path: str | None) -> dict[st
     }
 
 
-def read_cli_executable_symlink_generation_identity(
-    executable_path: str | None,
-) -> tuple[int, int, int, int, int] | None:
-    """Return launch-symlink metadata, or ``None`` for a direct path."""
-    if executable_path is None:
-        return None
-    path = Path(executable_path)
-    try:
-        if not path.is_symlink():
-            return None
-        value = path.lstat()
-    except OSError:
-        return None
-    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
-
-
 def read_cli_executable_content_identity(executable_path: str | None) -> str | None:
     """Return the selected CLI byte digest without executing it."""
     if executable_path is None:
@@ -134,35 +165,28 @@ def probe_cli_executable_version_attestation(
     executable_path: str | None,
     *,
     filesystem_identity: FilesystemIdentityReader,
-    filesystem_generation_identity: IdentityReader,
+    resolution_chain_identity: IdentityReader,
     content_identity: IdentityReader,
     symlink_identity: IdentityReader,
-    symlink_generation_identity: IdentityReader,
     hash_payload: HashPayload,
 ) -> CliExecutableVersionAttestation:
     """Probe one executable generation and reject mixed or ABA evidence.
 
     The version process spans multiple syscalls. Positive evidence is emitted
-    only when the effective target, bytes, and launch symlink are unchanged
-    before and after the process. Generation identities include ctime, which
-    makes an in-probe mutate-and-restore (ABA) visible even when the final
-    bytes, symlink text, device, and inode equal their initial values.
+    only when the effective target, bytes, and complete symlink chain are
+    unchanged before and after the process. Generation identities include
+    ctime and containing-directory state, making an in-probe swap-and-restore
+    visible even when final bytes, symlink text, device, and inode match.
     """
     failed = CliExecutableVersionAttestation(CliExecutableVersionState.EXECUTION_FAILED)
     if executable_path is None:
         return failed
 
     before_filesystem = filesystem_identity()
-    before_generation = filesystem_generation_identity()
+    before_resolution_chain = resolution_chain_identity()
     before_content = content_identity()
     before_symlink = symlink_identity()
-    before_symlink_generation = symlink_generation_identity()
-    if (
-        before_filesystem is None
-        or before_generation is None
-        or before_content is None
-        or (before_symlink is None) != (before_symlink_generation is None)
-    ):
+    if before_filesystem is None or before_resolution_chain is None or before_content is None:
         return failed
 
     try:
@@ -182,24 +206,25 @@ def probe_cli_executable_version_attestation(
     if result.returncode != 0 or not version_output:
         return failed
 
-    # Sample in reverse order after the process so every component is bounded
-    # by generation checks. This rejects same-inode writes, symlink retargets,
-    # atomic replacement, and mutate/restore ABA during the probe window.
-    after_symlink_generation = symlink_generation_identity()
+    # Sample in reverse order after the process so authority-bearing entries
+    # are bounded by generation checks. This rejects same-inode writes,
+    # symlink retargets, atomic replacement, and probe-window ABA.
     after_symlink = symlink_identity()
     after_content = content_identity()
-    after_generation = filesystem_generation_identity()
+    after_resolution_chain = resolution_chain_identity()
     after_filesystem = filesystem_identity()
     if (
         after_filesystem != before_filesystem
-        or after_generation != before_generation
+        or after_resolution_chain != before_resolution_chain
         or after_content != before_content
         or after_symlink != before_symlink
-        or after_symlink_generation != before_symlink_generation
     ):
         return failed
 
     device, inode = before_filesystem
+    semantic_symlink_chain = tuple(
+        (entry[0], entry[1]) for entry in before_resolution_chain if entry[1] is not None
+    )
     return CliExecutableVersionAttestation(
         CliExecutableVersionState.VERIFIED,
         hash_payload(
@@ -207,6 +232,7 @@ def probe_cli_executable_version_attestation(
                 "content_sha256": before_content,
                 "filesystem": {"device": device, "inode": inode},
                 "symlink": before_symlink,
+                "symlink_chain": semantic_symlink_chain,
                 "version_output": version_output,
             }
         ),

--- a/src/ouroboros/orchestrator/cli_version_attestation.py
+++ b/src/ouroboros/orchestrator/cli_version_attestation.py
@@ -55,15 +55,32 @@ def read_cli_executable_filesystem_identity(
 
 def read_cli_executable_generation_identity(
     executable_path: str | None,
-) -> tuple[int, int, int, int, int] | None:
-    """Return target metadata that exposes same-inode mutate/restore ABA."""
+) -> tuple[int, ...] | None:
+    """Return target and directory metadata that exposes probe-window ABA."""
     if executable_path is None:
         return None
+    path = Path(executable_path)
     try:
-        value = Path(executable_path).stat()
-    except OSError:
+        target = path.stat()
+        launch_parent = path.parent.stat()
+        resolved_parent = path.resolve(strict=True).parent.stat()
+    except (OSError, RuntimeError):
         return None
-    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
+    return (
+        target.st_dev,
+        target.st_ino,
+        target.st_size,
+        target.st_mtime_ns,
+        target.st_ctime_ns,
+        launch_parent.st_dev,
+        launch_parent.st_ino,
+        launch_parent.st_mtime_ns,
+        launch_parent.st_ctime_ns,
+        resolved_parent.st_dev,
+        resolved_parent.st_ino,
+        resolved_parent.st_mtime_ns,
+        resolved_parent.st_ctime_ns,
+    )
 
 
 def read_cli_executable_symlink_identity(executable_path: str | None) -> dict[str, str] | None:
@@ -140,7 +157,12 @@ def probe_cli_executable_version_attestation(
     before_content = content_identity()
     before_symlink = symlink_identity()
     before_symlink_generation = symlink_generation_identity()
-    if before_filesystem is None or before_generation is None or before_content is None:
+    if (
+        before_filesystem is None
+        or before_generation is None
+        or before_content is None
+        or (before_symlink is None) != (before_symlink_generation is None)
+    ):
         return failed
 
     try:

--- a/src/ouroboros/orchestrator/cli_version_attestation.py
+++ b/src/ouroboros/orchestrator/cli_version_attestation.py
@@ -17,14 +17,17 @@ class CliExecutableVersionState(StrEnum):
     """Outcome of probing or comparing one CLI version attestation.
 
     Probe unavailability is deliberately not represented by ``None``. A
-    timeout and an execution failure have different operational meaning, and
-    neither is positive evidence that an executable stayed the same. The
-    ``CHANGED`` state is produced only by comparing two successful probes.
+    timeout, execution failure, and indeterminate authority evidence have
+    different operational meaning, and none is positive evidence that an
+    executable stayed the same. ``CHANGED`` is reserved for evidence tied to
+    the executable or its semantic symlink chain, not broad parent-directory
+    generation churn that could have come from an unrelated sibling.
     """
 
     VERIFIED = "verified"
     TIMED_OUT = "timed_out"
     EXECUTION_FAILED = "execution_failed"
+    INDETERMINATE = "indeterminate"
     CHANGED = "changed"
 
 
@@ -41,6 +44,33 @@ class CliExecutableVersionAttestation:
 type IdentityReader = Callable[[], object]
 type FilesystemIdentityReader = Callable[[], tuple[int, int] | None]
 type HashPayload = Callable[[object], str]
+
+
+def _only_parent_generations_changed(
+    before: object,
+    after: object,
+) -> bool:
+    """Return whether resolution evidence differs only in parent generations.
+
+    A containing directory's generation changes for both authority-entry ABA
+    and unrelated sibling churn. It is therefore useful fail-closed evidence,
+    but cannot truthfully prove that the executable itself changed.
+    """
+    if not isinstance(before, tuple) or not isinstance(after, tuple) or before == after:
+        return False
+    if len(before) != len(after):
+        return False
+    for before_entry, after_entry in zip(before, after, strict=True):
+        if (
+            not isinstance(before_entry, tuple)
+            or not isinstance(after_entry, tuple)
+            or len(before_entry) != 4
+            or len(after_entry) != 4
+            or (before_entry[0], before_entry[1], before_entry[3])
+            != (after_entry[0], after_entry[1], after_entry[3])
+        ):
+            return False
+    return True
 
 
 def read_cli_executable_filesystem_identity(
@@ -243,14 +273,21 @@ def probe_cli_executable_version_attestation(
     after_content = content_identity()
     after_resolution_chain = resolution_chain_identity()
     after_filesystem = filesystem_identity()
-    if (
+    authority_changed = (
         after_filesystem != before_filesystem
-        or after_resolution_chain != before_resolution_chain
         or after_content != before_content
         or after_symlink != before_symlink
-    ):
+    )
+    resolution_changed = after_resolution_chain != before_resolution_chain
+    if authority_changed or resolution_changed:
+        state = CliExecutableVersionState.CHANGED
+        if not authority_changed and _only_parent_generations_changed(
+            before_resolution_chain,
+            after_resolution_chain,
+        ):
+            state = CliExecutableVersionState.INDETERMINATE
         return CliExecutableVersionAttestation(
-            CliExecutableVersionState.CHANGED,
+            state,
             filesystem_identity=before_filesystem,
             nonexecuting_identity=nonexecuting_identity,
         )
@@ -328,6 +365,12 @@ def require_unchanged_cli_version_attestation(
             "initialization; execution is blocked without claiming executable drift; "
             "start a new execution session"
         )
+    if initialized.state is CliExecutableVersionState.INDETERMINATE:
+        raise RuntimeError(
+            f"{display_name} executable authority was indeterminate during runtime "
+            "initialization; execution is blocked without claiming executable drift; "
+            "start a new execution session"
+        )
     if initialized.state is CliExecutableVersionState.CHANGED:
         raise RuntimeError(
             f"{display_name} executable changed during runtime initialization; "
@@ -348,6 +391,12 @@ def require_unchanged_cli_version_attestation(
             f"{display_name} version attestation failed while verifying the "
             "executable; execution is blocked without claiming executable drift; retry "
             "the execution or start a new execution session"
+        )
+    if comparison is CliExecutableVersionState.INDETERMINATE:
+        raise RuntimeError(
+            f"{display_name} executable authority became indeterminate while verifying "
+            "the executable; execution is blocked without claiming executable drift; "
+            "retry the execution or start a new execution session"
         )
     raise RuntimeError(
         f"{display_name} executable version changed after runtime initialization; "

--- a/src/ouroboros/orchestrator/cli_version_attestation.py
+++ b/src/ouroboros/orchestrator/cli_version_attestation.py
@@ -35,6 +35,7 @@ class CliExecutableVersionAttestation:
     state: CliExecutableVersionState
     identity: str | None = None
     filesystem_identity: tuple[int, int] | None = None
+    nonexecuting_identity: str | None = None
 
 
 type IdentityReader = Callable[[], object]
@@ -164,10 +165,10 @@ def read_cli_executable_content_identity(executable_path: str | None) -> str | N
 def probe_cli_executable_version_attestation(
     executable_path: str | None,
     *,
+    initialized: CliExecutableVersionAttestation | None,
     filesystem_identity: FilesystemIdentityReader,
     resolution_chain_identity: IdentityReader,
     content_identity: IdentityReader,
-    symlink_identity: IdentityReader,
     hash_payload: HashPayload,
 ) -> CliExecutableVersionAttestation:
     """Probe one executable generation and reject mixed or ABA evidence.
@@ -185,10 +186,39 @@ def probe_cli_executable_version_attestation(
     before_filesystem = filesystem_identity()
     before_resolution_chain = resolution_chain_identity()
     before_content = content_identity()
-    before_symlink = symlink_identity()
+    before_symlink = read_cli_executable_symlink_identity(executable_path)
     if before_filesystem is None or before_resolution_chain is None or before_content is None:
         return failed
 
+    device, inode = before_filesystem
+    semantic_symlink_chain = tuple(
+        (entry[0], entry[1]) for entry in before_resolution_chain if entry[1] is not None
+    )
+    nonexecuting_chain = tuple((entry[0], entry[1], entry[3]) for entry in before_resolution_chain)
+    nonexecuting_identity = hash_payload(
+        {
+            "content_sha256": before_content,
+            "executable_path": executable_path,
+            "filesystem": {"device": device, "inode": inode},
+            "resolution_chain": nonexecuting_chain,
+            "symlink_chain": semantic_symlink_chain,
+        }
+    )
+    if initialized is not None:
+        if (
+            initialized.state is not CliExecutableVersionState.VERIFIED
+            or initialized.nonexecuting_identity is None
+        ):
+            return failed
+        if initialized.nonexecuting_identity != nonexecuting_identity:
+            return CliExecutableVersionAttestation(
+                CliExecutableVersionState.CHANGED,
+                filesystem_identity=before_filesystem,
+                nonexecuting_identity=nonexecuting_identity,
+            )
+
+    probe_state = CliExecutableVersionState.VERIFIED
+    version_output: str | None = None
     try:
         result = subprocess.run(
             [executable_path, "--version"],
@@ -198,18 +228,18 @@ def probe_cli_executable_version_attestation(
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return CliExecutableVersionAttestation(CliExecutableVersionState.TIMED_OUT)
+        probe_state = CliExecutableVersionState.TIMED_OUT
     except (OSError, UnicodeError):
-        return failed
-
-    version_output = (result.stdout or result.stderr).strip()
-    if result.returncode != 0 or not version_output:
-        return failed
+        probe_state = CliExecutableVersionState.EXECUTION_FAILED
+    else:
+        version_output = (result.stdout or result.stderr).strip()
+        if result.returncode != 0 or not version_output:
+            probe_state = CliExecutableVersionState.EXECUTION_FAILED
 
     # Sample in reverse order after the process so authority-bearing entries
     # are bounded by generation checks. This rejects same-inode writes,
     # symlink retargets, atomic replacement, and probe-window ABA.
-    after_symlink = symlink_identity()
+    after_symlink = read_cli_executable_symlink_identity(executable_path)
     after_content = content_identity()
     after_resolution_chain = resolution_chain_identity()
     after_filesystem = filesystem_identity()
@@ -219,12 +249,19 @@ def probe_cli_executable_version_attestation(
         or after_content != before_content
         or after_symlink != before_symlink
     ):
-        return failed
+        return CliExecutableVersionAttestation(
+            CliExecutableVersionState.CHANGED,
+            filesystem_identity=before_filesystem,
+            nonexecuting_identity=nonexecuting_identity,
+        )
+    if probe_state is not CliExecutableVersionState.VERIFIED:
+        return CliExecutableVersionAttestation(
+            probe_state,
+            filesystem_identity=before_filesystem,
+            nonexecuting_identity=nonexecuting_identity,
+        )
 
-    device, inode = before_filesystem
-    semantic_symlink_chain = tuple(
-        (entry[0], entry[1]) for entry in before_resolution_chain if entry[1] is not None
-    )
+    assert version_output is not None
     return CliExecutableVersionAttestation(
         CliExecutableVersionState.VERIFIED,
         hash_payload(
@@ -237,6 +274,7 @@ def probe_cli_executable_version_attestation(
             }
         ),
         (device, inode),
+        nonexecuting_identity,
     )
 
 
@@ -254,9 +292,13 @@ def compare_cli_executable_version_attestations(
         or current.identity is None
         or initialized.filesystem_identity is None
         or current.filesystem_identity is None
+        or initialized.nonexecuting_identity is None
+        or current.nonexecuting_identity is None
     ):
         return CliExecutableVersionState.EXECUTION_FAILED
     if initialized.filesystem_identity != current.filesystem_identity:
+        return CliExecutableVersionState.CHANGED
+    if initialized.nonexecuting_identity != current.nonexecuting_identity:
         return CliExecutableVersionState.CHANGED
     if initialized.identity == current.identity:
         return CliExecutableVersionState.VERIFIED
@@ -284,6 +326,11 @@ def require_unchanged_cli_version_attestation(
         raise RuntimeError(
             f"{display_name} version attestation failed during runtime "
             "initialization; execution is blocked without claiming executable drift; "
+            "start a new execution session"
+        )
+    if initialized.state is CliExecutableVersionState.CHANGED:
+        raise RuntimeError(
+            f"{display_name} executable changed during runtime initialization; "
             "start a new execution session"
         )
 

--- a/src/ouroboros/orchestrator/cli_version_attestation.py
+++ b/src/ouroboros/orchestrator/cli_version_attestation.py
@@ -1,0 +1,260 @@
+"""Fail-closed executable version attestation for CLI runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+
+
+class CliExecutableVersionState(StrEnum):
+    """Outcome of probing or comparing one CLI version attestation.
+
+    Probe unavailability is deliberately not represented by ``None``. A
+    timeout and an execution failure have different operational meaning, and
+    neither is positive evidence that an executable stayed the same. The
+    ``CHANGED`` state is produced only by comparing two successful probes.
+    """
+
+    VERIFIED = "verified"
+    TIMED_OUT = "timed_out"
+    EXECUTION_FAILED = "execution_failed"
+    CHANGED = "changed"
+
+
+@dataclass(frozen=True, slots=True)
+class CliExecutableVersionAttestation:
+    """Structured version evidence for the selected CLI executable."""
+
+    state: CliExecutableVersionState
+    identity: str | None = None
+    filesystem_identity: tuple[int, int] | None = None
+
+
+type IdentityReader = Callable[[], object]
+type FilesystemIdentityReader = Callable[[], tuple[int, int] | None]
+type HashPayload = Callable[[object], str]
+
+
+def read_cli_executable_filesystem_identity(
+    executable_path: str | None,
+) -> tuple[int, int] | None:
+    """Return the effective executable target's device/inode pair."""
+    if executable_path is None:
+        return None
+    try:
+        value = Path(executable_path).stat()
+    except OSError:
+        return None
+    return value.st_dev, value.st_ino
+
+
+def read_cli_executable_generation_identity(
+    executable_path: str | None,
+) -> tuple[int, int, int, int, int] | None:
+    """Return target metadata that exposes same-inode mutate/restore ABA."""
+    if executable_path is None:
+        return None
+    try:
+        value = Path(executable_path).stat()
+    except OSError:
+        return None
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
+
+
+def read_cli_executable_symlink_identity(executable_path: str | None) -> dict[str, str] | None:
+    """Return launch-path symlink target identity without dereferencing it."""
+    if executable_path is None:
+        return None
+    path = Path(executable_path)
+    try:
+        if not path.is_symlink():
+            return None
+        raw_target = os.readlink(path)
+    except OSError:
+        return None
+    target_path = Path(raw_target)
+    if not target_path.is_absolute():
+        target_path = path.parent / target_path
+    return {
+        "raw_target": raw_target,
+        "resolved_target": str(target_path.expanduser().absolute()),
+    }
+
+
+def read_cli_executable_symlink_generation_identity(
+    executable_path: str | None,
+) -> tuple[int, int, int, int, int] | None:
+    """Return launch-symlink metadata, or ``None`` for a direct path."""
+    if executable_path is None:
+        return None
+    path = Path(executable_path)
+    try:
+        if not path.is_symlink():
+            return None
+        value = path.lstat()
+    except OSError:
+        return None
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
+
+
+def read_cli_executable_content_identity(executable_path: str | None) -> str | None:
+    """Return the selected CLI byte digest without executing it."""
+    if executable_path is None:
+        return None
+    try:
+        executable_bytes = Path(executable_path).read_bytes()
+    except OSError:
+        return None
+    return hashlib.sha256(executable_bytes).hexdigest()
+
+
+def probe_cli_executable_version_attestation(
+    executable_path: str | None,
+    *,
+    filesystem_identity: FilesystemIdentityReader,
+    filesystem_generation_identity: IdentityReader,
+    content_identity: IdentityReader,
+    symlink_identity: IdentityReader,
+    symlink_generation_identity: IdentityReader,
+    hash_payload: HashPayload,
+) -> CliExecutableVersionAttestation:
+    """Probe one executable generation and reject mixed or ABA evidence.
+
+    The version process spans multiple syscalls. Positive evidence is emitted
+    only when the effective target, bytes, and launch symlink are unchanged
+    before and after the process. Generation identities include ctime, which
+    makes an in-probe mutate-and-restore (ABA) visible even when the final
+    bytes, symlink text, device, and inode equal their initial values.
+    """
+    failed = CliExecutableVersionAttestation(CliExecutableVersionState.EXECUTION_FAILED)
+    if executable_path is None:
+        return failed
+
+    before_filesystem = filesystem_identity()
+    before_generation = filesystem_generation_identity()
+    before_content = content_identity()
+    before_symlink = symlink_identity()
+    before_symlink_generation = symlink_generation_identity()
+    if before_filesystem is None or before_generation is None or before_content is None:
+        return failed
+
+    try:
+        result = subprocess.run(
+            [executable_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return CliExecutableVersionAttestation(CliExecutableVersionState.TIMED_OUT)
+    except (OSError, UnicodeError):
+        return failed
+
+    version_output = (result.stdout or result.stderr).strip()
+    if result.returncode != 0 or not version_output:
+        return failed
+
+    # Sample in reverse order after the process so every component is bounded
+    # by generation checks. This rejects same-inode writes, symlink retargets,
+    # atomic replacement, and mutate/restore ABA during the probe window.
+    after_symlink_generation = symlink_generation_identity()
+    after_symlink = symlink_identity()
+    after_content = content_identity()
+    after_generation = filesystem_generation_identity()
+    after_filesystem = filesystem_identity()
+    if (
+        after_filesystem != before_filesystem
+        or after_generation != before_generation
+        or after_content != before_content
+        or after_symlink != before_symlink
+        or after_symlink_generation != before_symlink_generation
+    ):
+        return failed
+
+    device, inode = before_filesystem
+    return CliExecutableVersionAttestation(
+        CliExecutableVersionState.VERIFIED,
+        hash_payload(
+            {
+                "content_sha256": before_content,
+                "filesystem": {"device": device, "inode": inode},
+                "symlink": before_symlink,
+                "version_output": version_output,
+            }
+        ),
+        (device, inode),
+    )
+
+
+def compare_cli_executable_version_attestations(
+    initialized: CliExecutableVersionAttestation,
+    current: CliExecutableVersionAttestation,
+) -> CliExecutableVersionState:
+    """Compare positive evidence without equating two missing probes."""
+    if initialized.state is not CliExecutableVersionState.VERIFIED:
+        return initialized.state
+    if current.state is not CliExecutableVersionState.VERIFIED:
+        return current.state
+    if (
+        initialized.identity is None
+        or current.identity is None
+        or initialized.filesystem_identity is None
+        or current.filesystem_identity is None
+    ):
+        return CliExecutableVersionState.EXECUTION_FAILED
+    if initialized.filesystem_identity != current.filesystem_identity:
+        return CliExecutableVersionState.CHANGED
+    if initialized.identity == current.identity:
+        return CliExecutableVersionState.VERIFIED
+    return CliExecutableVersionState.CHANGED
+
+
+def require_unchanged_cli_version_attestation(
+    display_name: str,
+    initialized: CliExecutableVersionAttestation | None,
+    current_probe: Callable[[], CliExecutableVersionAttestation],
+) -> None:
+    """Apply the shared initialization/check-time fail-closed policy."""
+    if initialized is None:
+        raise RuntimeError(
+            f"{display_name} version attestation was not captured during "
+            "runtime initialization; start a new execution session"
+        )
+    if initialized.state is CliExecutableVersionState.TIMED_OUT:
+        raise RuntimeError(
+            f"{display_name} version attestation timed out during runtime "
+            "initialization; execution is blocked without claiming executable drift; "
+            "start a new execution session"
+        )
+    if initialized.state is CliExecutableVersionState.EXECUTION_FAILED:
+        raise RuntimeError(
+            f"{display_name} version attestation failed during runtime "
+            "initialization; execution is blocked without claiming executable drift; "
+            "start a new execution session"
+        )
+
+    comparison = compare_cli_executable_version_attestations(initialized, current_probe())
+    if comparison is CliExecutableVersionState.VERIFIED:
+        return
+    if comparison is CliExecutableVersionState.TIMED_OUT:
+        raise RuntimeError(
+            f"{display_name} version attestation timed out while verifying the "
+            "executable; execution is blocked without claiming executable drift; retry "
+            "the execution or start a new execution session"
+        )
+    if comparison is CliExecutableVersionState.EXECUTION_FAILED:
+        raise RuntimeError(
+            f"{display_name} version attestation failed while verifying the "
+            "executable; execution is blocked without claiming executable drift; retry "
+            "the execution or start a new execution session"
+        )
+    raise RuntimeError(
+        f"{display_name} executable version changed after runtime initialization; "
+        "start a new execution session"
+    )

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -58,8 +58,7 @@ from ouroboros.orchestrator.cli_version_attestation import (
     probe_cli_executable_version_attestation,
     read_cli_executable_content_identity,
     read_cli_executable_filesystem_identity,
-    read_cli_executable_generation_identity,
-    read_cli_executable_symlink_generation_identity,
+    read_cli_executable_resolution_chain_identity,
     read_cli_executable_symlink_identity,
     require_unchanged_cli_version_attestation,
 )
@@ -540,18 +539,17 @@ class CodexCliRuntime:
         return probe_cli_executable_version_attestation(
             self._cli_executable_identity(),
             filesystem_identity=self._cli_executable_filesystem_identity,
-            filesystem_generation_identity=self._cli_executable_generation_identity,
+            resolution_chain_identity=self._cli_executable_resolution_chain_identity,
             content_identity=self._cli_executable_content_identity,
             symlink_identity=self._cli_executable_symlink_identity,
-            symlink_generation_identity=self._cli_executable_symlink_generation_identity,
             hash_payload=self._hash_json_payload,
         )
 
     def _cli_executable_filesystem_identity(self) -> tuple[int, int] | None:
         return read_cli_executable_filesystem_identity(self._cli_executable_identity())
 
-    def _cli_executable_generation_identity(self) -> tuple[int, ...] | None:
-        return read_cli_executable_generation_identity(self._cli_executable_identity())
+    def _cli_executable_resolution_chain_identity(self) -> tuple[tuple[object, ...], ...] | None:
+        return read_cli_executable_resolution_chain_identity(self._cli_executable_identity())
 
     _compare_cli_executable_version_attestations = staticmethod(
         compare_cli_executable_version_attestations
@@ -559,11 +557,6 @@ class CodexCliRuntime:
 
     def _cli_executable_symlink_identity(self) -> dict[str, str] | None:
         return read_cli_executable_symlink_identity(self._cli_executable_identity())
-
-    def _cli_executable_symlink_generation_identity(
-        self,
-    ) -> tuple[int, int, int, int, int] | None:
-        return read_cli_executable_symlink_generation_identity(self._cli_executable_identity())
 
     def _cli_executable_content_identity(self) -> str | None:
         return read_cli_executable_content_identity(self._cli_executable_identity())

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -550,7 +550,7 @@ class CodexCliRuntime:
     def _cli_executable_filesystem_identity(self) -> tuple[int, int] | None:
         return read_cli_executable_filesystem_identity(self._cli_executable_identity())
 
-    def _cli_executable_generation_identity(self) -> tuple[int, int, int, int, int] | None:
+    def _cli_executable_generation_identity(self) -> tuple[int, ...] | None:
         return read_cli_executable_generation_identity(self._cli_executable_identity())
 
     _compare_cli_executable_version_attestations = staticmethod(

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -59,7 +59,6 @@ from ouroboros.orchestrator.cli_version_attestation import (
     read_cli_executable_content_identity,
     read_cli_executable_filesystem_identity,
     read_cli_executable_resolution_chain_identity,
-    read_cli_executable_symlink_identity,
     require_unchanged_cli_version_attestation,
 )
 from ouroboros.orchestrator.frugality_runtime_attestation import (
@@ -534,14 +533,17 @@ class CodexCliRuntime:
         """
         return self._cli_executable_version_attestation().identity
 
-    def _cli_executable_version_attestation(self) -> _CliExecutableVersionAttestation:
+    def _cli_executable_version_attestation(
+        self,
+        initialized: _CliExecutableVersionAttestation | None = None,
+    ) -> _CliExecutableVersionAttestation:
         """Return bounded evidence for one stable executable generation."""
         return probe_cli_executable_version_attestation(
             self._cli_executable_identity(),
+            initialized=initialized,
             filesystem_identity=self._cli_executable_filesystem_identity,
             resolution_chain_identity=self._cli_executable_resolution_chain_identity,
             content_identity=self._cli_executable_content_identity,
-            symlink_identity=self._cli_executable_symlink_identity,
             hash_payload=self._hash_json_payload,
         )
 
@@ -554,9 +556,6 @@ class CodexCliRuntime:
     _compare_cli_executable_version_attestations = staticmethod(
         compare_cli_executable_version_attestations
     )
-
-    def _cli_executable_symlink_identity(self) -> dict[str, str] | None:
-        return read_cli_executable_symlink_identity(self._cli_executable_identity())
 
     def _cli_executable_content_identity(self) -> str | None:
         return read_cli_executable_content_identity(self._cli_executable_identity())
@@ -1120,16 +1119,20 @@ class CodexCliRuntime:
                         "Codex CLI executable was unresolved at runtime initialization; "
                         "start a new execution session"
                     )
-                return
-            if cli_candidate.exists():
+            elif cli_candidate.exists():
                 raise RuntimeError(
-                    "Codex CLI executable appeared after runtime initialization; "
+                    f"{self._display_name} executable appeared after runtime initialization; "
                     "start a new execution session"
                 )
+            require_unchanged_cli_version_attestation(
+                self._display_name,
+                self._cli_executable_version_attestation_snapshot,
+                self._cli_executable_version_attestation,
+            )
             return
         if self._cli_executable_identity() != self._cli_executable_path_identity:
             raise RuntimeError(
-                "Codex CLI executable changed after runtime initialization; "
+                f"{self._display_name} executable changed after runtime initialization; "
                 "start a new execution session"
             )
         if (
@@ -1137,13 +1140,15 @@ class CodexCliRuntime:
             != self._cli_executable_content_identity_snapshot
         ):
             raise RuntimeError(
-                "Codex CLI executable changed after runtime initialization; "
+                f"{self._display_name} executable changed after runtime initialization; "
                 "start a new execution session"
             )
         require_unchanged_cli_version_attestation(
             self._display_name,
             self._cli_executable_version_attestation_snapshot,
-            self._cli_executable_version_attestation,
+            lambda: self._cli_executable_version_attestation(
+                self._cli_executable_version_attestation_snapshot
+            ),
         )
 
     def _fingerprint_skill_dispatch_registry(self) -> str | None:

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator, Mapping
 import contextlib
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from enum import StrEnum
 import hashlib
 import json
 import math
@@ -215,6 +216,30 @@ _ITEM_FAILURE_STATUSES = frozenset(
 _ITEM_SUCCESS_STATUSES = frozenset({"completed", "success", "succeeded"})
 
 
+class _CliExecutableVersionState(StrEnum):
+    """Outcome of probing or comparing one CLI version attestation.
+
+    Probe unavailability is deliberately not represented by ``None``.  A
+    timeout and an execution failure have different operational meaning, and
+    neither is positive evidence that an executable stayed the same.  The
+    ``CHANGED`` state is produced only by comparing two successful probes.
+    """
+
+    VERIFIED = "verified"
+    TIMED_OUT = "timed_out"
+    EXECUTION_FAILED = "execution_failed"
+    CHANGED = "changed"
+
+
+@dataclass(frozen=True, slots=True)
+class _CliExecutableVersionAttestation:
+    """Structured version evidence for the selected CLI executable."""
+
+    state: _CliExecutableVersionState
+    identity: str | None = None
+    filesystem_identity: tuple[int, int] | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class _CodexToolCall:
     """One normalized tool invocation derived from a Codex thread item."""
@@ -318,8 +343,13 @@ class CodexCliRuntime:
         self._cli_executable_content_identity_snapshot = (
             self._cli_executable_content_identity() if snapshots_cli_execution_identity else None
         )
+        self._cli_executable_version_attestation_snapshot = (
+            self._cli_executable_version_attestation() if snapshots_cli_execution_identity else None
+        )
         self._cli_executable_version_identity_snapshot = (
-            self._cli_executable_version_identity() if snapshots_cli_execution_identity else None
+            self._cli_executable_version_attestation_snapshot.identity
+            if self._cli_executable_version_attestation_snapshot is not None
+            else None
         )
         # Freeze the role-default model/profile once per runtime. Without this,
         # every ``codex exec`` call re-reads mutable profile config, so a long
@@ -512,12 +542,24 @@ class CodexCliRuntime:
         deliberately unavailable when the executable cannot provide a stable
         version response or content digest.
         """
+        return self._cli_executable_version_attestation().identity
+
+    def _cli_executable_version_attestation(self) -> _CliExecutableVersionAttestation:
+        """Return explicit success, timeout, or execution-failure evidence.
+
+        The probe remains bounded, but a transient failure is preserved as its
+        own state instead of being collapsed to ``None``.  Callers can therefore
+        fail closed without reporting an unchanged executable as mutated.
+        """
         executable_path = self._cli_executable_identity()
         if executable_path is None:
-            return None
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
+        filesystem_identity = self._cli_executable_filesystem_identity()
+        if filesystem_identity is None:
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
         content_digest = self._cli_executable_content_identity()
         if content_digest is None:
-            return None
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
         symlink_identity = self._cli_executable_symlink_identity()
         try:
             result = subprocess.run(
@@ -527,18 +569,73 @@ class CodexCliRuntime:
                 timeout=2,
                 check=False,
             )
-        except (OSError, subprocess.TimeoutExpired):
-            return None
+        except subprocess.TimeoutExpired:
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.TIMED_OUT)
+        except (OSError, UnicodeError):
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
         version_output = (result.stdout or result.stderr).strip()
         if result.returncode != 0 or not version_output:
-            return None
-        return self._hash_json_payload(
-            {
-                "content_sha256": content_digest,
-                "symlink": symlink_identity,
-                "version_output": version_output,
-            }
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
+        # The content read and version subprocess span multiple syscalls. An
+        # atomic replacement during that window would otherwise produce a
+        # mixed attestation. Only publish evidence when the effective target's
+        # device/inode pair is stable across the entire probe.
+        if self._cli_executable_filesystem_identity() != filesystem_identity:
+            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
+        return _CliExecutableVersionAttestation(
+            _CliExecutableVersionState.VERIFIED,
+            self._hash_json_payload(
+                {
+                    "content_sha256": content_digest,
+                    "filesystem": {
+                        "device": filesystem_identity[0],
+                        "inode": filesystem_identity[1],
+                    },
+                    "symlink": symlink_identity,
+                    "version_output": version_output,
+                }
+            ),
+            filesystem_identity,
         )
+
+    def _cli_executable_filesystem_identity(self) -> tuple[int, int] | None:
+        """Return the effective executable target's stable device/inode pair.
+
+        ``Path.stat`` follows a launch-path symlink, so replacing either a
+        direct executable or its symlink target changes this identity even
+        when replacement bytes and ``--version`` output are identical.
+        """
+        executable_path = self._cli_executable_identity()
+        if executable_path is None:
+            return None
+        try:
+            executable_stat = Path(executable_path).stat()
+        except OSError:
+            return None
+        return executable_stat.st_dev, executable_stat.st_ino
+
+    @staticmethod
+    def _compare_cli_executable_version_attestations(
+        initialized: _CliExecutableVersionAttestation,
+        current: _CliExecutableVersionAttestation,
+    ) -> _CliExecutableVersionState:
+        """Compare positive evidence without equating two missing probes."""
+        if initialized.state is not _CliExecutableVersionState.VERIFIED:
+            return initialized.state
+        if current.state is not _CliExecutableVersionState.VERIFIED:
+            return current.state
+        if (
+            initialized.identity is None
+            or current.identity is None
+            or initialized.filesystem_identity is None
+            or current.filesystem_identity is None
+        ):
+            return _CliExecutableVersionState.EXECUTION_FAILED
+        if initialized.filesystem_identity != current.filesystem_identity:
+            return _CliExecutableVersionState.CHANGED
+        if initialized.identity == current.identity:
+            return _CliExecutableVersionState.VERIFIED
+        return _CliExecutableVersionState.CHANGED
 
     def _cli_executable_symlink_identity(self) -> dict[str, str] | None:
         """Return launch-path symlink target identity without dereferencing it away."""
@@ -1114,7 +1211,13 @@ class CodexCliRuntime:
         )
 
     def _assert_cli_executable_identity_unchanged(self) -> None:
-        """Fail closed if the selected CLI executable changed in place."""
+        """Fail closed on drift or unavailable version-attestation evidence.
+
+        Initialization and check-time probe failures both block execution, but
+        use errors distinct from verified drift.  A caller may retry a
+        check-time transient failure on the same runtime; an initialization
+        failure has no trustworthy baseline and requires a new runtime.
+        """
         if self._cli_executable_path_identity is None:
             cli_path = str(self._cli_path)
             cli_candidate = Path(cli_path).expanduser()
@@ -1144,13 +1247,43 @@ class CodexCliRuntime:
                 "Codex CLI executable changed after runtime initialization; "
                 "start a new execution session"
             )
-        if (
-            self._cli_executable_version_identity()
-            == self._cli_executable_version_identity_snapshot
-        ):
+        initialized = self._cli_executable_version_attestation_snapshot
+        if initialized is None:
+            raise RuntimeError(
+                f"{self._display_name} version attestation was not captured during "
+                "runtime initialization; start a new execution session"
+            )
+        if initialized.state is _CliExecutableVersionState.TIMED_OUT:
+            raise RuntimeError(
+                f"{self._display_name} version attestation timed out during runtime "
+                "initialization; execution is blocked without claiming executable drift; "
+                "start a new execution session"
+            )
+        if initialized.state is _CliExecutableVersionState.EXECUTION_FAILED:
+            raise RuntimeError(
+                f"{self._display_name} version attestation failed during runtime "
+                "initialization; execution is blocked without claiming executable drift; "
+                "start a new execution session"
+            )
+
+        current = self._cli_executable_version_attestation()
+        comparison = self._compare_cli_executable_version_attestations(initialized, current)
+        if comparison is _CliExecutableVersionState.VERIFIED:
             return
+        if comparison is _CliExecutableVersionState.TIMED_OUT:
+            raise RuntimeError(
+                f"{self._display_name} version attestation timed out while verifying the "
+                "executable; execution is blocked without claiming executable drift; retry "
+                "the execution or start a new execution session"
+            )
+        if comparison is _CliExecutableVersionState.EXECUTION_FAILED:
+            raise RuntimeError(
+                f"{self._display_name} version attestation failed while verifying the "
+                "executable; execution is blocked without claiming executable drift; retry "
+                "the execution or start a new execution session"
+            )
         raise RuntimeError(
-            "Codex CLI executable changed after runtime initialization; "
+            f"{self._display_name} executable version changed after runtime initialization; "
             "start a new execution session"
         )
 
@@ -1355,7 +1488,7 @@ class CodexCliRuntime:
                 "kind": f"{self._runtime_handle_backend}_v1",
                 "cli_executable_path": self._cli_executable_identity(),
                 "cli_executable_content_sha256": self._cli_executable_content_identity(),
-                "cli_executable_version": self._cli_executable_version_identity(),
+                "cli_executable_version": self._cli_executable_version_identity_snapshot,
                 "fallback_model": None if native_agent else constructor_model,
                 "native_agent": native_agent,
                 "effective_model_observed": constructor_model is not None and native_agent is None,
@@ -1386,7 +1519,7 @@ class CodexCliRuntime:
             # could resume the same native thread under different defaults.
             "cli_executable_path": self._cli_executable_identity(),
             "cli_executable_content_sha256": self._cli_executable_content_identity(),
-            "cli_executable_version": self._cli_executable_version_identity(),
+            "cli_executable_version": self._cli_executable_version_identity_snapshot,
             "runtime_profile": self._runtime_profile.strip()
             if isinstance(self._runtime_profile, str) and self._runtime_profile.strip()
             else None,

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncIterator, Mapping
 import contextlib
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from enum import StrEnum
 import hashlib
 import json
 import math
@@ -17,7 +16,7 @@ from pathlib import Path
 import re
 import shlex
 import stat
-import subprocess
+import subprocess  # noqa: F401  # compatibility: tests patch this shared module
 import sys
 import tempfile
 import tomllib
@@ -51,6 +50,18 @@ from ouroboros.orchestrator.adapter import (
     TaskResult,
     resolve_worker_cwd,
     worker_cwd_failure_message,
+)
+from ouroboros.orchestrator.cli_version_attestation import (
+    CliExecutableVersionAttestation,
+    CliExecutableVersionState,
+    compare_cli_executable_version_attestations,
+    probe_cli_executable_version_attestation,
+    read_cli_executable_content_identity,
+    read_cli_executable_filesystem_identity,
+    read_cli_executable_generation_identity,
+    read_cli_executable_symlink_generation_identity,
+    read_cli_executable_symlink_identity,
+    require_unchanged_cli_version_attestation,
 )
 from ouroboros.orchestrator.frugality_runtime_attestation import (
     attested_codex_child_environment,
@@ -216,28 +227,8 @@ _ITEM_FAILURE_STATUSES = frozenset(
 _ITEM_SUCCESS_STATUSES = frozenset({"completed", "success", "succeeded"})
 
 
-class _CliExecutableVersionState(StrEnum):
-    """Outcome of probing or comparing one CLI version attestation.
-
-    Probe unavailability is deliberately not represented by ``None``.  A
-    timeout and an execution failure have different operational meaning, and
-    neither is positive evidence that an executable stayed the same.  The
-    ``CHANGED`` state is produced only by comparing two successful probes.
-    """
-
-    VERIFIED = "verified"
-    TIMED_OUT = "timed_out"
-    EXECUTION_FAILED = "execution_failed"
-    CHANGED = "changed"
-
-
-@dataclass(frozen=True, slots=True)
-class _CliExecutableVersionAttestation:
-    """Structured version evidence for the selected CLI executable."""
-
-    state: _CliExecutableVersionState
-    identity: str | None = None
-    filesystem_identity: tuple[int, int] | None = None
+_CliExecutableVersionState = CliExecutableVersionState
+_CliExecutableVersionAttestation = CliExecutableVersionAttestation
 
 
 @dataclass(frozen=True, slots=True)
@@ -545,128 +536,37 @@ class CodexCliRuntime:
         return self._cli_executable_version_attestation().identity
 
     def _cli_executable_version_attestation(self) -> _CliExecutableVersionAttestation:
-        """Return explicit success, timeout, or execution-failure evidence.
-
-        The probe remains bounded, but a transient failure is preserved as its
-        own state instead of being collapsed to ``None``.  Callers can therefore
-        fail closed without reporting an unchanged executable as mutated.
-        """
-        executable_path = self._cli_executable_identity()
-        if executable_path is None:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        filesystem_identity = self._cli_executable_filesystem_identity()
-        if filesystem_identity is None:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        content_digest = self._cli_executable_content_identity()
-        if content_digest is None:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        symlink_identity = self._cli_executable_symlink_identity()
-        try:
-            result = subprocess.run(
-                [executable_path, "--version"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-                check=False,
-            )
-        except subprocess.TimeoutExpired:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.TIMED_OUT)
-        except (OSError, UnicodeError):
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        version_output = (result.stdout or result.stderr).strip()
-        if result.returncode != 0 or not version_output:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        # The content read and version subprocess span multiple syscalls. An
-        # atomic replacement during that window would otherwise produce a
-        # mixed attestation. Only publish evidence when the effective target's
-        # device/inode pair is stable across the entire probe.
-        if self._cli_executable_filesystem_identity() != filesystem_identity:
-            return _CliExecutableVersionAttestation(_CliExecutableVersionState.EXECUTION_FAILED)
-        return _CliExecutableVersionAttestation(
-            _CliExecutableVersionState.VERIFIED,
-            self._hash_json_payload(
-                {
-                    "content_sha256": content_digest,
-                    "filesystem": {
-                        "device": filesystem_identity[0],
-                        "inode": filesystem_identity[1],
-                    },
-                    "symlink": symlink_identity,
-                    "version_output": version_output,
-                }
-            ),
-            filesystem_identity,
+        """Return bounded evidence for one stable executable generation."""
+        return probe_cli_executable_version_attestation(
+            self._cli_executable_identity(),
+            filesystem_identity=self._cli_executable_filesystem_identity,
+            filesystem_generation_identity=self._cli_executable_generation_identity,
+            content_identity=self._cli_executable_content_identity,
+            symlink_identity=self._cli_executable_symlink_identity,
+            symlink_generation_identity=self._cli_executable_symlink_generation_identity,
+            hash_payload=self._hash_json_payload,
         )
 
     def _cli_executable_filesystem_identity(self) -> tuple[int, int] | None:
-        """Return the effective executable target's stable device/inode pair.
+        return read_cli_executable_filesystem_identity(self._cli_executable_identity())
 
-        ``Path.stat`` follows a launch-path symlink, so replacing either a
-        direct executable or its symlink target changes this identity even
-        when replacement bytes and ``--version`` output are identical.
-        """
-        executable_path = self._cli_executable_identity()
-        if executable_path is None:
-            return None
-        try:
-            executable_stat = Path(executable_path).stat()
-        except OSError:
-            return None
-        return executable_stat.st_dev, executable_stat.st_ino
+    def _cli_executable_generation_identity(self) -> tuple[int, int, int, int, int] | None:
+        return read_cli_executable_generation_identity(self._cli_executable_identity())
 
-    @staticmethod
-    def _compare_cli_executable_version_attestations(
-        initialized: _CliExecutableVersionAttestation,
-        current: _CliExecutableVersionAttestation,
-    ) -> _CliExecutableVersionState:
-        """Compare positive evidence without equating two missing probes."""
-        if initialized.state is not _CliExecutableVersionState.VERIFIED:
-            return initialized.state
-        if current.state is not _CliExecutableVersionState.VERIFIED:
-            return current.state
-        if (
-            initialized.identity is None
-            or current.identity is None
-            or initialized.filesystem_identity is None
-            or current.filesystem_identity is None
-        ):
-            return _CliExecutableVersionState.EXECUTION_FAILED
-        if initialized.filesystem_identity != current.filesystem_identity:
-            return _CliExecutableVersionState.CHANGED
-        if initialized.identity == current.identity:
-            return _CliExecutableVersionState.VERIFIED
-        return _CliExecutableVersionState.CHANGED
+    _compare_cli_executable_version_attestations = staticmethod(
+        compare_cli_executable_version_attestations
+    )
 
     def _cli_executable_symlink_identity(self) -> dict[str, str] | None:
-        """Return launch-path symlink target identity without dereferencing it away."""
-        executable_path = self._cli_executable_identity()
-        if executable_path is None:
-            return None
-        path = Path(executable_path)
-        try:
-            if not path.is_symlink():
-                return None
-            raw_target = os.readlink(path)
-        except OSError:
-            return None
-        target_path = Path(raw_target)
-        if not target_path.is_absolute():
-            target_path = path.parent / target_path
-        return {
-            "raw_target": raw_target,
-            "resolved_target": str(target_path.expanduser().absolute()),
-        }
+        return read_cli_executable_symlink_identity(self._cli_executable_identity())
+
+    def _cli_executable_symlink_generation_identity(
+        self,
+    ) -> tuple[int, int, int, int, int] | None:
+        return read_cli_executable_symlink_generation_identity(self._cli_executable_identity())
 
     def _cli_executable_content_identity(self) -> str | None:
-        """Return the selected CLI byte digest without executing it."""
-        executable_path = self._cli_executable_identity()
-        if executable_path is None:
-            return None
-        try:
-            executable_bytes = Path(executable_path).read_bytes()
-        except OSError:
-            return None
-        return hashlib.sha256(executable_bytes).hexdigest()
+        return read_cli_executable_content_identity(self._cli_executable_identity())
 
     def _resolve_skills_dir(self, skills_dir: str | Path | None) -> Path | None:
         """Resolve an optional explicit skill override directory for intercept metadata."""
@@ -1247,44 +1147,10 @@ class CodexCliRuntime:
                 "Codex CLI executable changed after runtime initialization; "
                 "start a new execution session"
             )
-        initialized = self._cli_executable_version_attestation_snapshot
-        if initialized is None:
-            raise RuntimeError(
-                f"{self._display_name} version attestation was not captured during "
-                "runtime initialization; start a new execution session"
-            )
-        if initialized.state is _CliExecutableVersionState.TIMED_OUT:
-            raise RuntimeError(
-                f"{self._display_name} version attestation timed out during runtime "
-                "initialization; execution is blocked without claiming executable drift; "
-                "start a new execution session"
-            )
-        if initialized.state is _CliExecutableVersionState.EXECUTION_FAILED:
-            raise RuntimeError(
-                f"{self._display_name} version attestation failed during runtime "
-                "initialization; execution is blocked without claiming executable drift; "
-                "start a new execution session"
-            )
-
-        current = self._cli_executable_version_attestation()
-        comparison = self._compare_cli_executable_version_attestations(initialized, current)
-        if comparison is _CliExecutableVersionState.VERIFIED:
-            return
-        if comparison is _CliExecutableVersionState.TIMED_OUT:
-            raise RuntimeError(
-                f"{self._display_name} version attestation timed out while verifying the "
-                "executable; execution is blocked without claiming executable drift; retry "
-                "the execution or start a new execution session"
-            )
-        if comparison is _CliExecutableVersionState.EXECUTION_FAILED:
-            raise RuntimeError(
-                f"{self._display_name} version attestation failed while verifying the "
-                "executable; execution is blocked without claiming executable drift; retry "
-                "the execution or start a new execution session"
-            )
-        raise RuntimeError(
-            f"{self._display_name} executable version changed after runtime initialization; "
-            "start a new execution session"
+        require_unchanged_cli_version_attestation(
+            self._display_name,
+            self._cli_executable_version_attestation_snapshot,
+            self._cli_executable_version_attestation,
         )
 
     def _fingerprint_skill_dispatch_registry(self) -> str | None:

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -57,6 +57,13 @@ class _FakeProcess:
         return self._returncode
 
 
+def _make_fake_codex_cli(tmp_path: Path) -> Path:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\nprintf '%s\\n' 'codex 0.0.0-test'\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    return cli_path
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("prompt", "expected_warning", "expected_error"),
@@ -81,6 +88,7 @@ async def test_unhandled_ooo_commands_pass_through_to_codex_unchanged(
 ) -> None:
     """Unsupported and plugin-only `ooo` commands should bypass intercept dispatch."""
     captured_processes: list[_FakeProcess] = []
+    cli_path = _make_fake_codex_cli(tmp_path)
 
     async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> _FakeProcess:
         assert kwargs["cwd"] == str(tmp_path)
@@ -103,7 +111,7 @@ async def test_unhandled_ooo_commands_pass_through_to_codex_unchanged(
     ):
         runtime = create_agent_runtime(
             backend="codex",
-            cli_path="/tmp/codex",
+            cli_path=str(cli_path),
             permission_mode="acceptEdits",
             cwd=tmp_path,
         )
@@ -135,6 +143,7 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     tmp_path: Path,
 ) -> None:
     """Packaged `ooo auto` must not fall through to Codex when the MCP tool is absent."""
+    cli_path = _make_fake_codex_cli(tmp_path)
     fake_server = AsyncMock()
     fake_server.call_tool = AsyncMock(
         side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
@@ -149,7 +158,7 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     ):
         runtime = create_agent_runtime(
             backend="codex",
-            cli_path="/tmp/codex",
+            cli_path=str(cli_path),
             permission_mode="acceptEdits",
             cwd=tmp_path,
         )

--- a/tests/unit/orchestrator/conftest.py
+++ b/tests/unit/orchestrator/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def fake_codex_cli_on_path(tmp_path, monkeypatch):
-    """Give Codex runtime tests a stable executable identity on CI.
+    """Give CLI runtime tests stable executable identities on CI.
 
     Most runtime tests patch subprocess creation and assert command-shaping
     behavior; they should not depend on whether the CI image happens to install
@@ -19,7 +19,9 @@ def fake_codex_cli_on_path(tmp_path, monkeypatch):
     """
     bin_dir = tmp_path / ".fake-codex-bin"
     bin_dir.mkdir()
-    codex = bin_dir / "codex"
-    codex.write_text("#!/bin/sh\necho codex test\n", encoding="utf-8")
-    codex.chmod(0o755)
+    for cli_name in ("codex", "copilot", "gemini", "goose", "grok"):
+        cli = bin_dir / cli_name
+        cli.write_text(f"#!/bin/sh\necho {cli_name} test\n", encoding="utf-8")
+        cli.chmod(0o755)
+    monkeypatch.setenv("OUROBOROS_TEST_CLI_DIR", str(bin_dir))
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -34,6 +34,10 @@ _EXPECTED_CODEX_PATH = str(Path("/usr/local/bin/codex"))
 _EXPECTED_PROJECT_CWD = str(Path("/tmp/project").resolve())
 
 
+def _test_cli_path(name: str = "codex") -> str:
+    return str(Path(os.environ["OUROBOROS_TEST_CLI_DIR"]) / name)
+
+
 def test_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
     runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
 
@@ -478,10 +482,10 @@ def test_in_place_mutation_during_version_probe_is_not_authorized(
         return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
 
     monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", mutate_during_probe)
-    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
 
-    assert "executable changed" not in str(excinfo.value)
+    assert "failed while verifying" not in str(excinfo.value)
     assert cli_path.stat().st_ino == original_inode
     assert cli_path.read_text(encoding="utf-8") != original
 
@@ -509,12 +513,43 @@ def test_in_place_aba_during_version_probe_is_not_authorized(
         "run",
         mutate_and_restore_during_probe,
     )
-    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
 
-    assert "executable changed" not in str(excinfo.value)
+    assert "failed while verifying" not in str(excinfo.value)
     assert cli_path.stat().st_ino == original_inode
     assert cli_path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize("probe_outcome", ["timeout", "os_error", "nonzero", "empty"])
+def test_probe_window_aba_takes_precedence_over_probe_failure(
+    probe_outcome: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    original = "#!/bin/sh\necho codex 1.0\n"
+    cli_path.write_text(original, encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    def mutate_and_fail(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        cli_path.write_text("#!/bin/sh\necho compromised\n", encoding="utf-8")
+        cli_path.write_text(original, encoding="utf-8")
+        if probe_outcome == "timeout":
+            raise subprocess.TimeoutExpired(str(cli_path), timeout=2)
+        if probe_outcome == "os_error":
+            raise OSError("deterministic probe failure")
+        if probe_outcome == "nonzero":
+            return subprocess.CompletedProcess(args, 7, stdout="", stderr="failed")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", mutate_and_fail)
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "timed out" not in str(excinfo.value)
+    assert "failed while verifying" not in str(excinfo.value)
 
 
 def test_atomic_aba_during_version_probe_is_not_authorized(
@@ -546,12 +581,39 @@ def test_atomic_aba_during_version_probe_is_not_authorized(
         "run",
         replace_and_restore_during_probe,
     )
-    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
 
-    assert "executable changed" not in str(excinfo.value)
+    assert "failed while verifying" not in str(excinfo.value)
     assert cli_path.stat().st_ino == original_inode
     assert cli_path.read_text(encoding="utf-8") == original
+
+
+def test_changed_symlink_target_is_rejected_before_version_execution(
+    tmp_path: Path,
+) -> None:
+    effects_dir = tmp_path / "effects"
+    effects_dir.mkdir()
+    marker = effects_dir / "version-probe-ran"
+    script = f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\necho codex 1.0\n"
+    good_target = tmp_path / "good"
+    replacement_target = tmp_path / "replacement"
+    good_target.write_text(script, encoding="utf-8")
+    replacement_target.write_text(script, encoding="utf-8")
+    good_target.chmod(0o755)
+    replacement_target.chmod(0o755)
+    cli_link = tmp_path / "codex"
+    cli_link.symlink_to(good_target.name)
+    runtime = CodexCliRuntime(cli_path=cli_link, cwd=tmp_path, model="gpt-5")
+    assert marker.exists()
+    marker.unlink()
+
+    cli_link.unlink()
+    cli_link.symlink_to(replacement_target.name)
+
+    with pytest.raises(RuntimeError, match="executable version changed"):
+        runtime._build_command(str(tmp_path / "last-message"))
+    assert not marker.exists()
 
 
 def test_intermediate_symlink_atomic_aba_during_probe_is_not_authorized(
@@ -600,7 +662,7 @@ def test_intermediate_symlink_atomic_aba_during_probe_is_not_authorized(
         "run",
         swap_and_restore_intermediate_hop,
     )
-    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
 
     assert "executable changed" not in str(excinfo.value)
@@ -636,7 +698,7 @@ def test_sibling_churn_during_probe_fails_closed_but_is_retryable(
         return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
 
     monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", churn_sibling)
-    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
     assert "executable changed" not in str(excinfo.value)
 
@@ -820,6 +882,31 @@ def test_build_command_rejects_bare_cli_that_remains_unresolved(
 
     with pytest.raises(RuntimeError, match="unresolved at runtime initialization"):
         runtime._build_command("/tmp/last-message")
+
+
+def test_copilot_unresolved_initialization_never_authorizes_later_path_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_path = tmp_path / "empty-path"
+    hostile_path = tmp_path / "hostile-path"
+    empty_path.mkdir()
+    hostile_path.mkdir()
+    marker = tmp_path / "hostile-ran"
+    monkeypatch.setenv("PATH", str(empty_path))
+    runtime = CopilotCliRuntime(cli_path="copilot", cwd=tmp_path, model="test-model")
+
+    hostile_cli = hostile_path / "copilot"
+    hostile_cli.write_text(
+        f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\necho copilot 1.0\n",
+        encoding="utf-8",
+    )
+    hostile_cli.chmod(0o755)
+    monkeypatch.setenv("PATH", str(hostile_path))
+
+    with pytest.raises(RuntimeError, match="failed during runtime initialization"):
+        runtime._build_command(str(tmp_path / "last-message"), prompt="test")
+    assert not marker.exists()
 
 
 def test_skill_dispatch_registry_fingerprint_tracks_mcp_tool_changes(
@@ -1565,7 +1652,7 @@ class TestCodexCliRuntime:
     def test_build_command_for_new_session(self) -> None:
         """Builds a new-session exec command (prompt fed via stdin, not args)."""
         runtime = CodexCliRuntime(
-            cli_path="/usr/local/bin/codex",
+            cli_path=_test_cli_path(),
             permission_mode="acceptEdits",
             model="o3",
             cwd="/tmp/project",
@@ -1575,7 +1662,7 @@ class TestCodexCliRuntime:
             output_last_message_path="/tmp/out.txt",
         )
 
-        assert command[:2] == [_EXPECTED_CODEX_PATH, "exec"]
+        assert command[:2] == [_test_cli_path(), "exec"]
         assert "--json" in command
         assert "--full-auto" in command
         assert "--model" in command
@@ -2157,7 +2244,7 @@ class TestCodexCliRuntime:
     @pytest.mark.asyncio
     async def test_execute_task_surfaces_model_pin_version_guidance(self) -> None:
         """Execute-stage model pins receive the same App/CLI mismatch guidance."""
-        runtime = CodexCliRuntime(cli_path="/usr/local/bin/codex", cwd="/tmp/project")
+        runtime = CodexCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project")
 
         async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
             del command, kwargs
@@ -2168,7 +2255,7 @@ class TestCodexCliRuntime:
             )
 
         versions = {
-            "/usr/local/bin/codex": "codex-cli 0.139.0",
+            _test_cli_path(): "codex-cli 0.139.0",
             "/Applications/ChatGPT.app/Contents/Resources/codex": "codex-cli 0.140.0",
         }
         with (
@@ -2192,7 +2279,7 @@ class TestCodexCliRuntime:
     @pytest.mark.asyncio
     async def test_execute_task_surfaces_model_guidance_from_turn_failed_event(self) -> None:
         """JSONL turn failures must not bypass App/CLI mismatch diagnostics."""
-        runtime = CodexCliRuntime(cli_path="/usr/local/bin/codex", cwd="/tmp/project")
+        runtime = CodexCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project")
 
         async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
             del command, kwargs
@@ -2205,7 +2292,7 @@ class TestCodexCliRuntime:
             )
 
         versions = {
-            "/usr/local/bin/codex": "codex-cli 0.139.0",
+            _test_cli_path(): "codex-cli 0.139.0",
             "/Applications/ChatGPT.app/Contents/Resources/codex": "codex-cli 0.140.0",
         }
         with (
@@ -4085,8 +4172,8 @@ class TestCodexCliRuntime:
         assert runtime._llm_backend == "litellm"
 
     @pytest.mark.asyncio
-    async def test_execute_task_file_not_found_yields_error(self) -> None:
-        """FileNotFoundError when codex binary is missing yields an error result."""
+    async def test_execute_task_missing_executable_fails_before_launch(self) -> None:
+        """A missing executable fails closed before subprocess launch."""
         runtime = CodexCliRuntime(cli_path="/nonexistent/codex", cwd="/tmp/project")
 
         with patch(
@@ -4098,6 +4185,4 @@ class TestCodexCliRuntime:
         assert len(messages) == 1
         assert messages[0].type == "result"
         assert messages[0].is_error
-        assert (
-            "not found" in messages[0].content.lower() or "FileNotFoundError" in messages[0].content
-        )
+        assert "version attestation failed during runtime initialization" in messages[0].content

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -443,6 +443,61 @@ def test_check_time_execution_failure_is_not_reported_as_drift(
     assert "executable changed" not in str(excinfo.value)
 
 
+def test_in_place_mutation_during_version_probe_is_not_authorized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    original = "#!/bin/sh\necho codex 1.0\n"
+    cli_path.write_text(original, encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+    original_inode = cli_path.stat().st_ino
+
+    def mutate_during_probe(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        cli_path.write_text("#!/bin/sh\necho compromised\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", mutate_during_probe)
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+    assert cli_path.stat().st_ino == original_inode
+    assert cli_path.read_text(encoding="utf-8") != original
+
+
+def test_in_place_aba_during_version_probe_is_not_authorized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    original = "#!/bin/sh\necho codex 1.0\n"
+    cli_path.write_text(original, encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+    original_inode = cli_path.stat().st_ino
+
+    def mutate_and_restore_during_probe(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        cli_path.write_text("#!/bin/sh\necho compromised\n", encoding="utf-8")
+        cli_path.write_text(original, encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
+
+    monkeypatch.setattr(
+        codex_cli_runtime_module.subprocess,
+        "run",
+        mutate_and_restore_during_probe,
+    )
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+    assert cli_path.stat().st_ino == original_inode
+    assert cli_path.read_text(encoding="utf-8") == original
+
+
 def test_repeated_probe_timeouts_never_converge_to_false_drift(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -345,6 +345,13 @@ def test_missing_attestations_never_compare_as_positive_identity_evidence() -> N
         )
         is state.TIMED_OUT
     )
+    assert (
+        CodexCliRuntime._compare_cli_executable_version_attestations(
+            attestation(state.VERIFIED, "baseline", (1, 1), "baseline"),
+            attestation(state.INDETERMINATE),
+        )
+        is state.INDETERMINATE
+    )
     # Even an internally malformed "verified" value cannot turn None == None
     # into positive identity evidence.
     assert (
@@ -693,14 +700,27 @@ def test_sibling_churn_during_probe_fails_closed_but_is_retryable(
     runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
     successful_run = codex_cli_runtime_module.subprocess.run
 
+    sibling_number = 0
+
     def churn_sibling(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        (tmp_path / "unrelated-sibling").write_text("unrelated", encoding="utf-8")
+        nonlocal sibling_number
+        sibling_number += 1
+        (tmp_path / f"unrelated-sibling-{sibling_number}").write_text(
+            "unrelated",
+            encoding="utf-8",
+        )
         return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
 
     monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", churn_sibling)
-    with pytest.raises(RuntimeError, match="executable version changed") as excinfo:
+    current = runtime._cli_executable_version_attestation(
+        runtime._cli_executable_version_attestation_snapshot
+    )
+    assert current.state is codex_cli_runtime_module._CliExecutableVersionState.INDETERMINATE
+
+    with pytest.raises(RuntimeError, match="authority became indeterminate") as excinfo:
         runtime._build_command(str(tmp_path / "last-message"))
-    assert "executable changed" not in str(excinfo.value)
+    assert "without claiming executable drift" in str(excinfo.value)
+    assert "retry the execution" in str(excinfo.value)
 
     monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", successful_run)
     assert runtime._build_command(str(tmp_path / "last-message"))

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import shlex
 import signal
+import subprocess
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -21,6 +22,7 @@ from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
 import ouroboros.orchestrator.codex_cli_runtime as codex_cli_runtime_module
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
 from ouroboros.orchestrator.skill_tool_mapping import SkillToolMapping
 from ouroboros.router import Resolved, ResolveRequest
 from ouroboros.router.dispatch import SkillDispatchRouter as SharedSkillDispatchRouter
@@ -293,6 +295,263 @@ def test_build_command_rejects_cli_content_drift_before_version_probe(
     with pytest.raises(RuntimeError, match="Codex CLI executable changed"):
         runtime._build_command("/tmp/last-message")
     assert not side_effect.exists()
+
+
+def test_version_attestation_distinguishes_timeout_from_execution_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    def timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(str(cli_path), timeout=2)
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", timeout)
+    timed_out = runtime._cli_executable_version_attestation()
+    assert timed_out.state is codex_cli_runtime_module._CliExecutableVersionState.TIMED_OUT
+    assert timed_out.identity is None
+
+    def execution_failure(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise OSError("deterministic probe failure")
+
+    monkeypatch.setattr(
+        codex_cli_runtime_module.subprocess,
+        "run",
+        execution_failure,
+    )
+    failed = runtime._cli_executable_version_attestation()
+    assert failed.state is codex_cli_runtime_module._CliExecutableVersionState.EXECUTION_FAILED
+    assert failed.identity is None
+
+
+def test_missing_attestations_never_compare_as_positive_identity_evidence() -> None:
+    state = codex_cli_runtime_module._CliExecutableVersionState
+    attestation = codex_cli_runtime_module._CliExecutableVersionAttestation
+
+    assert (
+        CodexCliRuntime._compare_cli_executable_version_attestations(
+            attestation(state.TIMED_OUT),
+            attestation(state.TIMED_OUT),
+        )
+        is state.TIMED_OUT
+    )
+    # Even an internally malformed "verified" value cannot turn None == None
+    # into positive identity evidence.
+    assert (
+        CodexCliRuntime._compare_cli_executable_version_attestations(
+            attestation(state.VERIFIED),
+            attestation(state.VERIFIED),
+        )
+        is state.EXECUTION_FAILED
+    )
+
+
+def test_initialization_timeout_blocks_without_claiming_executable_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    calls = 0
+
+    def timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        raise subprocess.TimeoutExpired(str(cli_path), timeout=2)
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", timeout)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    with pytest.raises(RuntimeError, match="timed out during runtime initialization") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+    # A missing baseline cannot be repaired by comparing it to another missing
+    # probe: command construction fails before performing a second probe.
+    assert calls == 1
+
+
+def test_initialization_execution_failure_has_distinct_fail_closed_error(tmp_path: Path) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\nexit 7\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    with pytest.raises(RuntimeError, match="failed during runtime initialization") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("runtime_class", "display_name"),
+    [
+        (CodexCliRuntime, "Codex CLI"),
+        (CopilotCliRuntime, "Copilot CLI"),
+    ],
+)
+def test_check_time_timeout_is_fail_closed_but_retryable_for_codex_family(
+    runtime_class: type[CodexCliRuntime],
+    display_name: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "runtime-cli"
+    cli_path.write_text("#!/bin/sh\necho runtime 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = runtime_class(cli_path=cli_path, cwd=tmp_path, model="test-model")
+    successful_run = codex_cli_runtime_module.subprocess.run
+
+    def timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(str(cli_path), timeout=2)
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", timeout)
+    assert (
+        runtime.execution_identity_contract()["cli_executable_version"]
+        == runtime._cli_executable_version_identity_snapshot
+    )
+    with pytest.raises(RuntimeError, match="timed out while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"), prompt="test")
+    assert str(excinfo.value).startswith(display_name)
+    assert "executable changed" not in str(excinfo.value)
+
+    # A transient check-time failure does not poison the initialization
+    # baseline. The same runtime succeeds after the probe becomes available.
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", successful_run)
+    assert runtime._build_command(str(tmp_path / "last-message"), prompt="test")
+
+
+def test_check_time_execution_failure_is_not_reported_as_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    def failed_probe(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 7, stdout="", stderr="temporary failure")
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", failed_probe)
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+    assert "executable changed" not in str(excinfo.value)
+
+
+def test_repeated_probe_timeouts_never_converge_to_false_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Model an overloaded 16-way probe burst without wall-clock races."""
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    def timeout(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(str(cli_path), timeout=2)
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", timeout)
+    for _ in range(16):
+        with pytest.raises(RuntimeError, match="timed out while verifying") as excinfo:
+            runtime._build_command(str(tmp_path / "last-message"))
+        assert "executable changed" not in str(excinfo.value)
+
+
+def test_successful_version_change_has_distinct_changed_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho ignored\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    outputs = iter(("codex 1.0\n", "codex 2.0\n"))
+
+    def version_probe(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 0, stdout=next(outputs), stderr="")
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", version_probe)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    with pytest.raises(RuntimeError, match="executable version changed"):
+        runtime._build_command(str(tmp_path / "last-message"))
+
+
+@pytest.mark.parametrize("runtime_class", [CodexCliRuntime, CopilotCliRuntime])
+def test_atomic_executable_replacement_with_identical_evidence_is_changed(
+    runtime_class: type[CodexCliRuntime],
+    tmp_path: Path,
+) -> None:
+    """A same-bytes/same-version replacement still changes execution authority."""
+    script = "#!/bin/sh\necho runtime 1.0\n"
+    cli_path = tmp_path / "runtime-cli"
+    cli_path.write_text(script, encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = runtime_class(cli_path=cli_path, cwd=tmp_path, model="test-model")
+    initialized = runtime._cli_executable_version_attestation_snapshot
+    assert initialized is not None
+    assert initialized.filesystem_identity == (cli_path.stat().st_dev, cli_path.stat().st_ino)
+
+    replacement = tmp_path / "replacement-cli"
+    replacement.write_text(script, encoding="utf-8")
+    replacement.chmod(0o755)
+    replacement_identity = (replacement.stat().st_dev, replacement.stat().st_ino)
+    assert replacement_identity != initialized.filesystem_identity
+    os.replace(replacement, cli_path)
+
+    current = runtime._cli_executable_version_attestation()
+    assert current.state is codex_cli_runtime_module._CliExecutableVersionState.VERIFIED
+    assert current.filesystem_identity == replacement_identity
+    assert (
+        runtime._compare_cli_executable_version_attestations(initialized, current)
+        is codex_cli_runtime_module._CliExecutableVersionState.CHANGED
+    )
+    with pytest.raises(RuntimeError, match="executable version changed"):
+        runtime._build_command(str(tmp_path / "last-message"), prompt="test")
+
+
+def test_atomic_symlink_target_replacement_with_identical_evidence_is_changed(
+    tmp_path: Path,
+) -> None:
+    """Target inode drift remains visible through an unchanged launch symlink."""
+    script = "#!/bin/sh\necho codex 1.0\n"
+    target = tmp_path / "codex-target"
+    target.write_text(script, encoding="utf-8")
+    target.chmod(0o755)
+    cli_link = tmp_path / "codex"
+    cli_link.symlink_to(target.name)
+    runtime = CodexCliRuntime(cli_path=cli_link, cwd=tmp_path, model="gpt-5")
+    initialized = runtime._cli_executable_version_attestation_snapshot
+    assert initialized is not None
+    assert initialized.filesystem_identity == (target.stat().st_dev, target.stat().st_ino)
+
+    replacement = tmp_path / "replacement-target"
+    replacement.write_text(script, encoding="utf-8")
+    replacement.chmod(0o755)
+    replacement_identity = (replacement.stat().st_dev, replacement.stat().st_ino)
+    assert replacement_identity != initialized.filesystem_identity
+    os.replace(replacement, target)
+
+    # The launch path and its textual target did not change, but the effective
+    # executable object did.
+    assert cli_link.readlink() == Path(target.name)
+    assert (
+        runtime._cli_executable_content_identity()
+        == runtime._cli_executable_content_identity_snapshot
+    )
+    current = runtime._cli_executable_version_attestation()
+    assert current.filesystem_identity == replacement_identity
+    assert (
+        runtime._compare_cli_executable_version_attestations(initialized, current)
+        is codex_cli_runtime_module._CliExecutableVersionState.CHANGED
+    )
+    with pytest.raises(RuntimeError, match="executable version changed"):
+        runtime._build_command(str(tmp_path / "last-message"))
 
 
 def test_execution_identity_tracks_launch_symlink_target(

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -498,6 +498,43 @@ def test_in_place_aba_during_version_probe_is_not_authorized(
     assert cli_path.read_text(encoding="utf-8") == original
 
 
+def test_atomic_aba_during_version_probe_is_not_authorized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    original = "#!/bin/sh\necho codex 1.0\n"
+    cli_path.write_text(original, encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+    original_inode = cli_path.stat().st_ino
+    replacement = tmp_path / "replacement"
+    replacement.write_text("#!/bin/sh\necho compromised\n", encoding="utf-8")
+    replacement.chmod(0o755)
+    parked_original = tmp_path / "parked-original"
+
+    def replace_and_restore_during_probe(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        os.replace(cli_path, parked_original)
+        os.replace(replacement, cli_path)
+        os.replace(cli_path, replacement)
+        os.replace(parked_original, cli_path)
+        return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
+
+    monkeypatch.setattr(
+        codex_cli_runtime_module.subprocess,
+        "run",
+        replace_and_restore_during_probe,
+    )
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+    assert cli_path.stat().st_ino == original_inode
+    assert cli_path.read_text(encoding="utf-8") == original
+
+
 def test_repeated_probe_timeouts_never_converge_to_false_drift(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -20,6 +20,9 @@ from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
+from ouroboros.orchestrator.cli_version_attestation import (
+    read_cli_executable_resolution_chain_identity,
+)
 import ouroboros.orchestrator.codex_cli_runtime as codex_cli_runtime_module
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
@@ -349,6 +352,22 @@ def test_missing_attestations_never_compare_as_positive_identity_evidence() -> N
     )
 
 
+def test_resolution_chain_symlink_loop_fails_closed(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.symlink_to(second.name)
+    second.symlink_to(first.name)
+
+    assert read_cli_executable_resolution_chain_identity(str(first)) is None
+
+
+def test_resolution_chain_broken_symlink_fails_closed(tmp_path: Path) -> None:
+    broken = tmp_path / "broken"
+    broken.symlink_to("missing")
+
+    assert read_cli_executable_resolution_chain_identity(str(broken)) is None
+
+
 def test_initialization_timeout_blocks_without_claiming_executable_drift(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -533,6 +552,96 @@ def test_atomic_aba_during_version_probe_is_not_authorized(
     assert "executable changed" not in str(excinfo.value)
     assert cli_path.stat().st_ino == original_inode
     assert cli_path.read_text(encoding="utf-8") == original
+
+
+def test_intermediate_symlink_atomic_aba_during_probe_is_not_authorized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launch_dir = tmp_path / "launch"
+    middle_dir = tmp_path / "middle"
+    targets_dir = tmp_path / "targets"
+    launch_dir.mkdir()
+    middle_dir.mkdir()
+    targets_dir.mkdir()
+    good_target = targets_dir / "good"
+    bad_target = targets_dir / "bad"
+    script = "#!/bin/sh\necho codex 1.0\n"
+    good_target.write_text(script, encoding="utf-8")
+    bad_target.write_text(script, encoding="utf-8")
+    good_target.chmod(0o755)
+    bad_target.chmod(0o755)
+
+    launch_path = launch_dir / "codex"
+    intermediate_hop = middle_dir / "hop"
+    launch_path.symlink_to("../middle/hop")
+    intermediate_hop.symlink_to("../targets/good")
+    runtime = CodexCliRuntime(cli_path=launch_path, cwd=tmp_path, model="gpt-5")
+    initialized = runtime._cli_executable_version_attestation_snapshot
+    assert initialized is not None
+    assert runtime._build_command(str(tmp_path / "stable-last-message"))
+    original_hop_inode = intermediate_hop.lstat().st_ino
+
+    bad_hop = middle_dir / "bad-hop"
+    parked_hop = middle_dir / "parked-hop"
+    bad_hop.symlink_to("../targets/bad")
+
+    def swap_and_restore_intermediate_hop(
+        args: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        os.replace(intermediate_hop, parked_hop)
+        os.replace(bad_hop, intermediate_hop)
+        os.replace(intermediate_hop, bad_hop)
+        os.replace(parked_hop, intermediate_hop)
+        return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
+
+    monkeypatch.setattr(
+        codex_cli_runtime_module.subprocess,
+        "run",
+        swap_and_restore_intermediate_hop,
+    )
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+
+    assert "executable changed" not in str(excinfo.value)
+    assert intermediate_hop.lstat().st_ino == original_hop_inode
+    assert intermediate_hop.readlink() == Path("../targets/good")
+
+
+def test_sibling_churn_between_attestations_does_not_claim_executable_drift(
+    tmp_path: Path,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+
+    (tmp_path / "unrelated-sibling").write_text("unrelated", encoding="utf-8")
+
+    assert runtime._build_command(str(tmp_path / "last-message"))
+
+
+def test_sibling_churn_during_probe_fails_closed_but_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "codex"
+    cli_path.write_text("#!/bin/sh\necho codex 1.0\n", encoding="utf-8")
+    cli_path.chmod(0o755)
+    runtime = CodexCliRuntime(cli_path=cli_path, cwd=tmp_path, model="gpt-5")
+    successful_run = codex_cli_runtime_module.subprocess.run
+
+    def churn_sibling(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        (tmp_path / "unrelated-sibling").write_text("unrelated", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, stdout="codex 1.0\n", stderr="")
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", churn_sibling)
+    with pytest.raises(RuntimeError, match="failed while verifying") as excinfo:
+        runtime._build_command(str(tmp_path / "last-message"))
+    assert "executable changed" not in str(excinfo.value)
+
+    monkeypatch.setattr(codex_cli_runtime_module.subprocess, "run", successful_run)
+    assert runtime._build_command(str(tmp_path / "last-message"))
 
 
 def test_repeated_probe_timeouts_never_converge_to_false_drift(

--- a/tests/unit/orchestrator/test_copilot_cli_runtime.py
+++ b/tests/unit/orchestrator/test_copilot_cli_runtime.py
@@ -13,6 +13,8 @@ what the orchestrator runtime adds on top.
 from __future__ import annotations
 
 from dataclasses import replace
+import os
+from pathlib import Path
 
 import pytest
 
@@ -24,8 +26,12 @@ from ouroboros.orchestrator.copilot_cli_runtime import (
 from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
 
 
+def _test_cli_path() -> str:
+    return str(Path(os.environ["OUROBOROS_TEST_CLI_DIR"]) / "copilot")
+
+
 def _make_runtime(model: str | None = None, cwd: str = "/work") -> CopilotCliRuntime:
-    return CopilotCliRuntime(cli_path="/usr/bin/copilot", model=model, cwd=cwd)
+    return CopilotCliRuntime(cli_path=_test_cli_path(), model=model, cwd=cwd)
 
 
 def test_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
@@ -64,7 +70,7 @@ def test_resolve_agent_runtime_backend_rejection_lists_copilot() -> None:
 
 def test_build_command_emits_copilot_flags_in_documented_order(tmp_path) -> None:
     cwd = str(tmp_path)
-    runtime = CopilotCliRuntime(cli_path="/usr/bin/copilot", cwd=cwd)
+    runtime = CopilotCliRuntime(cli_path=_test_cli_path(), cwd=cwd)
     command = runtime._build_command(
         output_last_message_path="/tmp/ignored",
         prompt="hello world",
@@ -119,7 +125,7 @@ def test_build_command_ignores_resume_session_id() -> None:
 
 def test_constructor_runtime_profile_emits_copilot_agent_flag() -> None:
     runtime = CopilotCliRuntime(
-        cli_path="/usr/bin/copilot",
+        cli_path=_test_cli_path(),
         cwd="/work",
         runtime_profile="worker",
     )

--- a/tests/unit/orchestrator/test_gemini_cli_runtime.py
+++ b/tests/unit/orchestrator/test_gemini_cli_runtime.py
@@ -14,6 +14,9 @@ These tests cover the regressions surfaced during PR #312 review:
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 
 from ouroboros.orchestrator.adapter import ParamSupport
@@ -30,7 +33,11 @@ from ouroboros.orchestrator.runtime_message_projection import project_runtime_me
 
 
 def _make_runtime() -> GeminiCLIRuntime:
-    return GeminiCLIRuntime(cli_path="/usr/bin/gemini")
+    return GeminiCLIRuntime(cli_path=_test_cli_path())
+
+
+def _test_cli_path() -> str:
+    return str(Path(os.environ["OUROBOROS_TEST_CLI_DIR"]) / "gemini")
 
 
 def test_convert_event_surfaces_result_response_as_terminal_assistant_message() -> None:
@@ -178,7 +185,7 @@ def _approval_flag(cmd: list[str]) -> str:
 
 def test_build_command_maps_bypass_permissions_to_yolo() -> None:
     runtime = GeminiCLIRuntime(
-        cli_path="/usr/bin/gemini",
+        cli_path=_test_cli_path(),
         permission_mode="bypassPermissions",
     )
     cmd = runtime._build_command("/tmp/unused", prompt="x")
@@ -188,7 +195,7 @@ def test_build_command_maps_bypass_permissions_to_yolo() -> None:
 
 def test_build_command_maps_accept_edits_to_auto_edit() -> None:
     runtime = GeminiCLIRuntime(
-        cli_path="/usr/bin/gemini",
+        cli_path=_test_cli_path(),
         permission_mode="acceptEdits",
     )
     cmd = runtime._build_command("/tmp/unused", prompt="x")
@@ -207,7 +214,7 @@ def test_default_permission_mode_normalized_to_accept_edits() -> None:
     from structlog.testing import capture_logs
 
     with capture_logs() as cap_logs:
-        runtime = GeminiCLIRuntime(cli_path="/usr/bin/gemini", permission_mode="default")
+        runtime = GeminiCLIRuntime(cli_path=_test_cli_path(), permission_mode="default")
 
     assert runtime.permission_mode == "acceptEdits"
     cmd = runtime._build_command("/tmp/unused", prompt="x")
@@ -226,7 +233,7 @@ def test_build_command_uses_auto_edit_when_permission_mode_omitted() -> None:
     ``auto_edit`` is non-blocking under ``--non-interactive`` so this stays
     headless-safe without escalating to full ``yolo`` bypass.
     """
-    runtime = GeminiCLIRuntime(cli_path="/usr/bin/gemini")
+    runtime = GeminiCLIRuntime(cli_path=_test_cli_path())
     cmd = runtime._build_command("/tmp/unused", prompt="x")
     assert _approval_flag(cmd) == "auto_edit"
 
@@ -236,21 +243,21 @@ def test_unknown_permission_mode_raises_value_error() -> None:
     a permissive default would escalate any unchecked input."""
     with pytest.raises(ValueError, match="Unsupported Gemini permission mode"):
         GeminiCLIRuntime(
-            cli_path="/usr/bin/gemini",
+            cli_path=_test_cli_path(),
             permission_mode="acceptedits",  # plausible typo of "acceptEdits"
         )
 
 
 def test_omitted_permission_mode_resolves_to_accept_edits() -> None:
     """``None`` aligns with the orchestrator-wide ``acceptEdits`` default."""
-    runtime = GeminiCLIRuntime(cli_path="/usr/bin/gemini")
+    runtime = GeminiCLIRuntime(cli_path=_test_cli_path())
     assert runtime.permission_mode == "acceptEdits"
 
 
 def test_empty_string_permission_mode_raises() -> None:
     """Empty/whitespace-only strings are not a valid mode either."""
     with pytest.raises(ValueError, match="Unsupported Gemini permission mode"):
-        GeminiCLIRuntime(cli_path="/usr/bin/gemini", permission_mode="   ")
+        GeminiCLIRuntime(cli_path=_test_cli_path(), permission_mode="   ")
 
 
 def test_factory_built_runtime_uses_accept_edits_default() -> None:

--- a/tests/unit/orchestrator/test_goose_runtime.py
+++ b/tests/unit/orchestrator/test_goose_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,10 @@ import pytest
 
 from ouroboros.orchestrator.adapter import ParamSupport, RuntimeHandle
 from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+
+
+def _test_cli_path() -> str:
+    return str(Path(os.environ["OUROBOROS_TEST_CLI_DIR"]) / "goose")
 
 
 class _FakeStream:
@@ -59,14 +64,14 @@ class _FakeProcess:
 
 
 def test_goose_default_permission_mode_preserves_approval_gate() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project")
 
     assert runtime.permission_mode == "approve"
     assert runtime._build_child_env()["GOOSE_MODE"] == "approve"
 
 
 def test_goose_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project")
 
     assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
     assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
@@ -75,7 +80,7 @@ def test_goose_capabilities_report_prompt_only_tool_restrictions_as_translated()
 
 @pytest.mark.parametrize("mode", ["default", "acceptEdits", "accept_edits", "acceptedits"])
 def test_goose_safe_permission_aliases_preserve_approval_gate(mode: str) -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode)
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode=mode)
 
     assert runtime.permission_mode == "approve"
     assert runtime._build_child_env()["GOOSE_MODE"] == "approve"
@@ -83,18 +88,18 @@ def test_goose_safe_permission_aliases_preserve_approval_gate(mode: str) -> None
 
 @pytest.mark.parametrize("mode", ["auto", "bypassPermissions", "bypass_permissions"])
 def test_goose_explicit_bypass_permission_aliases_map_to_auto(mode: str) -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode)
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode=mode)
 
     assert runtime.permission_mode == "auto"
     assert runtime._build_child_env()["GOOSE_MODE"] == "auto"
 
 
 def test_goose_command_uses_run_stream_json_and_stdin() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     command = runtime._build_command("/tmp/out.txt", resume_session_id="session-1")
 
-    assert command[:4] == ["/tmp/goose", "run", "--output-format", "stream-json"]
+    assert command[:4] == [_test_cli_path(), "run", "--output-format", "stream-json"]
     assert "--resume" in command
     assert "--no-profile" not in command
     assert "--quiet" not in command
@@ -103,7 +108,7 @@ def test_goose_command_uses_run_stream_json_and_stdin() -> None:
 
 
 def test_goose_runtime_makes_streamed_generated_handle_resumable() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
     initial_handle = runtime._build_runtime_handle(None)
 
     assert initial_handle is not None
@@ -122,7 +127,7 @@ def test_goose_runtime_makes_streamed_generated_handle_resumable() -> None:
 
 
 def test_goose_runtime_derives_stable_name_for_executor_seeded_handle() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
     seeded = RuntimeHandle(
         backend="goose",
         metadata={"session_attempt_id": "exec_1_ac_1_attempt_1"},
@@ -162,7 +167,7 @@ async def test_goose_runtime_collects_stream_json_messages() -> None:
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -173,7 +178,12 @@ async def test_goose_runtime_collects_stream_json_messages() -> None:
     ):
         messages = [m async for m in runtime.execute_task("do it", tools=["Bash"])]
 
-    assert mock_exec.call_args.args[:4] == ("/tmp/goose", "run", "--output-format", "stream-json")
+    assert mock_exec.call_args.args[:4] == (
+        _test_cli_path(),
+        "run",
+        "--output-format",
+        "stream-json",
+    )
     assert b"do it" in fake_process.stdin.written
     assert any(m.type == "system" and m.resume_handle for m in messages)
     assert any(m.content == "Working" for m in messages)
@@ -193,7 +203,7 @@ async def test_goose_runtime_preserves_generated_session_name_without_name_echo(
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -239,7 +249,7 @@ async def test_goose_runtime_honors_explicit_resume_session_id() -> None:
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -265,7 +275,7 @@ async def test_goose_runtime_completion_event_does_not_mask_nonzero_exit() -> No
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -294,7 +304,7 @@ async def test_goose_runtime_accumulates_stream_chunks_for_final_fallback() -> N
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -322,7 +332,7 @@ async def test_goose_runtime_keeps_tool_output_out_of_final_fallback() -> None:
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -352,7 +362,7 @@ async def test_goose_runtime_preserves_nested_completion_payload() -> None:
     async def fake_exec(*args: object, **kwargs: object) -> _FakeProcess:
         return fake_process
 
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     with (
         patch(
@@ -368,7 +378,7 @@ async def test_goose_runtime_preserves_nested_completion_payload() -> None:
 
 
 def test_goose_runtime_classifies_tool_failed_as_error_result() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     messages = runtime._convert_event({"type": "tool.failed", "error": "permission denied"}, None)
 
@@ -383,7 +393,9 @@ def test_goose_child_env_sets_nested_guard(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "goose")
     monkeypatch.setenv("OUROBOROS_RUNTIME", "goose")
     monkeypatch.setenv("GOOSE_PROVIDER", "anthropic")
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="approve")
+    runtime = GooseCliRuntime(
+        cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="approve"
+    )
 
     env = runtime._build_child_env()
 
@@ -401,7 +413,7 @@ def test_goose_child_env_does_not_map_ouroboros_llm_backend_to_provider(
 ) -> None:
     monkeypatch.delenv("GOOSE_PROVIDER", raising=False)
     runtime = GooseCliRuntime(
-        cli_path="/tmp/goose",
+        cli_path=_test_cli_path(),
         cwd="/tmp/project",
         permission_mode="auto",
         llm_backend="claude_code",
@@ -411,7 +423,7 @@ def test_goose_child_env_does_not_map_ouroboros_llm_backend_to_provider(
 
 
 def test_goose_session_id_extraction_ignores_generic_tool_and_message_ids() -> None:
-    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
+    runtime = GooseCliRuntime(cli_path=_test_cli_path(), cwd="/tmp/project", permission_mode="auto")
 
     assert (
         runtime._extract_event_session_id({"type": "session.started", "session_name": "sess-1"})

--- a/tests/unit/orchestrator/test_grok_cli_runtime.py
+++ b/tests/unit/orchestrator/test_grok_cli_runtime.py
@@ -10,6 +10,8 @@ Covers the ``grok`` headless contract that differs from the Codex base:
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -70,7 +72,11 @@ class _FakeProcess:
 
 
 def _make_runtime() -> GrokCliRuntime:
-    return GrokCliRuntime(cli_path="/usr/bin/grok")
+    return GrokCliRuntime(cli_path=_test_cli_path())
+
+
+def _test_cli_path() -> str:
+    return str(Path(os.environ["OUROBOROS_TEST_CLI_DIR"]) / "grok")
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +94,7 @@ def test_build_command_uses_single_prompt_and_streaming_json() -> None:
 
 
 def test_build_command_forwards_permission_mode() -> None:
-    runtime = GrokCliRuntime(cli_path="/usr/bin/grok", permission_mode="bypassPermissions")
+    runtime = GrokCliRuntime(cli_path=_test_cli_path(), permission_mode="bypassPermissions")
     cmd = runtime._build_command("/tmp/unused", prompt="x")
     assert "--permission-mode" in cmd
     assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
@@ -101,13 +107,13 @@ def test_build_command_defaults_to_accept_edits() -> None:
 
 
 def test_build_command_omits_sentinel_model() -> None:
-    runtime = GrokCliRuntime(cli_path="/usr/bin/grok", model="default")
+    runtime = GrokCliRuntime(cli_path=_test_cli_path(), model="default")
     cmd = runtime._build_command("/tmp/unused", prompt="x")
     assert "-m" not in cmd
 
 
 def test_build_command_forwards_explicit_model() -> None:
-    runtime = GrokCliRuntime(cli_path="/usr/bin/grok", model="grok-build")
+    runtime = GrokCliRuntime(cli_path=_test_cli_path(), model="grok-build")
     cmd = runtime._build_command("/tmp/unused", prompt="x")
     assert "-m" in cmd
     assert cmd[cmd.index("-m") + 1] == "grok-build"
@@ -133,7 +139,7 @@ def test_default_permission_mode_is_coerced_with_audit_log() -> None:
     from structlog.testing import capture_logs
 
     with capture_logs() as cap_logs:
-        runtime = GrokCliRuntime(cli_path="/usr/bin/grok", permission_mode="default")
+        runtime = GrokCliRuntime(cli_path=_test_cli_path(), permission_mode="default")
 
     assert runtime.permission_mode == "acceptEdits"
     coerced = [e for e in cap_logs if e.get("event") == "grok_cli_runtime.permission_mode_coerced"]
@@ -143,7 +149,7 @@ def test_default_permission_mode_is_coerced_with_audit_log() -> None:
 
 def test_unknown_permission_mode_raises_value_error() -> None:
     with pytest.raises(ValueError, match="Unsupported Grok permission mode"):
-        GrokCliRuntime(cli_path="/usr/bin/grok", permission_mode="yolo")
+        GrokCliRuntime(cli_path=_test_cli_path(), permission_mode="yolo")
 
 
 # ---------------------------------------------------------------------------
@@ -296,7 +302,7 @@ async def test_execute_task_to_result_accumulates_streamed_text() -> None:
     Reproduces the reviewer's finding: without accumulation, only the last
     token (`" world"`) would survive into TaskResult.final_message.
     """
-    runtime = GrokCliRuntime(cli_path="/usr/bin/grok", cwd="/tmp")
+    runtime = GrokCliRuntime(cli_path=_test_cli_path(), cwd="/tmp")
 
     async def fake_exec(*command: str, **kwargs: object) -> _FakeProcess:
         del command, kwargs

--- a/tests/unit/orchestrator/test_model_override_routing.py
+++ b/tests/unit/orchestrator/test_model_override_routing.py
@@ -11,6 +11,9 @@ enforce it, so the distinction is tested directly rather than assumed.
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
+
+import pytest
 
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
@@ -21,6 +24,15 @@ from ouroboros.orchestrator.adapter import (
 from ouroboros.orchestrator.claude_worker_runtime import build_claude_worker_runtime
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.codex_mcp_runtime import build_codex_mcp_worker_runtime
+
+
+@pytest.fixture
+def fake_cli_path(tmp_path: Path) -> str:
+    """Provide stable version evidence without invoking an installed host CLI."""
+    cli = tmp_path / "fake-agent-cli"
+    cli.write_text("#!/bin/sh\necho fake-agent-cli 1.0\n", encoding="utf-8")
+    cli.chmod(0o755)
+    return str(cli)
 
 
 class TestCapabilityDeclarations:
@@ -42,8 +54,8 @@ class TestCapabilityDeclarations:
         adapter = ClaudeAgentAdapter(api_key="test", cwd="/tmp")
         assert adapter.capabilities.model_override_support is ParamSupport.NATIVE
 
-    def test_codex_runtime_declares_native_model_override(self) -> None:
-        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp")
+    def test_codex_runtime_declares_native_model_override(self, fake_cli_path: str) -> None:
+        runtime = CodexCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
         assert runtime.capabilities.model_override_support is ParamSupport.NATIVE
 
     def test_claude_worker_declares_native_model_override(self) -> None:
@@ -56,14 +68,14 @@ class TestCapabilityDeclarations:
         rt = build_codex_mcp_worker_runtime(cwd="/tmp")
         assert rt.capabilities.model_override_support is ParamSupport.IGNORED
 
-    def test_advised_codex_subclasses_ignore_model_override(self) -> None:
+    def test_advised_codex_subclasses_ignore_model_override(self, fake_cli_path: str) -> None:
         """Gemini/Goose share the codex base but do not opt in, so they stay
         IGNORED (the orchestrator therefore never routes them a model)."""
         from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
         from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
 
-        gemini = GeminiCLIRuntime(cli_path="gemini", cwd="/tmp")
-        goose = GooseCliRuntime(cli_path="goose", cwd="/tmp")
+        gemini = GeminiCLIRuntime(cli_path=fake_cli_path, cwd="/tmp")
+        goose = GooseCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
         assert gemini.capabilities.model_override_support is ParamSupport.IGNORED
         assert goose.capabilities.model_override_support is ParamSupport.IGNORED
 
@@ -77,42 +89,36 @@ class TestCapabilityDeclarations:
 
 
 class TestCodexModelOverrideEnforcement:
-    def _runtime(self, *, model: str | None = None) -> CodexCliRuntime:
-        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp", model=model)
-        # These tests exercise command construction, not live executable drift.
-        # Keep the initialization snapshot stable so an App/CLI updater cannot
-        # make this unit suite depend on a second external ``codex --version``.
-        version_snapshot = runtime._cli_executable_version_identity_snapshot  # noqa: SLF001
-        runtime._cli_executable_version_identity = lambda: version_snapshot  # type: ignore[method-assign]  # noqa: SLF001
-        return runtime
+    def _runtime(self, fake_cli_path: str, *, model: str | None = None) -> CodexCliRuntime:
+        return CodexCliRuntime(cli_path=fake_cli_path, cwd="/tmp", model=model)
 
-    def test_per_call_model_is_enforced_via_flag(self) -> None:
-        command = self._runtime()._build_command(
+    def test_per_call_model_is_enforced_via_flag(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
             output_last_message_path="/tmp/out.txt",
             model="claude-haiku-4-5",
         )
         assert "--model" in command
         assert command[command.index("--model") + 1] == "claude-haiku-4-5"
 
-    def test_per_call_model_wins_over_constructor_pin(self) -> None:
-        command = self._runtime(model="o3")._build_command(
+    def test_per_call_model_wins_over_constructor_pin(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path, model="o3")._build_command(
             output_last_message_path="/tmp/out.txt",
             model="gpt-5.5",
         )
         assert command[command.index("--model") + 1] == "gpt-5.5"
         assert "o3" not in command
 
-    def test_no_per_call_model_falls_back_to_constructor(self) -> None:
-        command = self._runtime(model="o3")._build_command(
+    def test_no_per_call_model_falls_back_to_constructor(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path, model="o3")._build_command(
             output_last_message_path="/tmp/out.txt",
         )
         assert command[command.index("--model") + 1] == "o3"
 
-    def test_default_sentinel_per_call_model_is_a_noop(self) -> None:
+    def test_default_sentinel_per_call_model_is_a_noop(self, fake_cli_path: str) -> None:
         """``_normalize_model`` collapses the ``default`` sentinel to None, so a
         ``model="default"`` override is byte-identical to passing no override —
         both fall through to the unchanged constructor/runtime-profile fallback."""
-        runtime = self._runtime()
+        runtime = self._runtime(fake_cli_path)
         with_sentinel = runtime._build_command(
             output_last_message_path="/tmp/out.txt", model="default"
         )

--- a/tests/unit/orchestrator/test_reasoning_effort_routing.py
+++ b/tests/unit/orchestrator/test_reasoning_effort_routing.py
@@ -11,6 +11,9 @@ directly rather than assumed.
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
+
+import pytest
 
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
@@ -21,6 +24,15 @@ from ouroboros.orchestrator.codex_cli_runtime import (
     _CODEX_REASONING_EFFORT_LEVELS,
     CodexCliRuntime,
 )
+
+
+@pytest.fixture
+def fake_cli_path(tmp_path: Path) -> str:
+    """Provide stable version evidence without invoking an installed host CLI."""
+    cli = tmp_path / "fake-agent-cli"
+    cli.write_text("#!/bin/sh\necho fake-agent-cli 1.0\n", encoding="utf-8")
+    cli.chmod(0o755)
+    return str(cli)
 
 
 class TestCapabilityDeclarations:
@@ -39,17 +51,17 @@ class TestCapabilityDeclarations:
         inherited = replace(FULL_CAPABILITIES, system_prompt_support=ParamSupport.TRANSLATED)
         assert inherited.reasoning_effort_support is ParamSupport.IGNORED
 
-    def test_codex_runtime_declares_native_effort(self) -> None:
-        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp")
+    def test_codex_runtime_declares_native_effort(self, fake_cli_path: str) -> None:
+        runtime = CodexCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
         assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
 
-    def test_copilot_runtime_declares_native_effort(self) -> None:
+    def test_copilot_runtime_declares_native_effort(self, fake_cli_path: str) -> None:
         from ouroboros.orchestrator.copilot_cli_runtime import (
             _COPILOT_REASONING_EFFORT_LEVELS,
             CopilotCliRuntime,
         )
 
-        runtime = CopilotCliRuntime(cli_path="copilot", cwd="/tmp")
+        runtime = CopilotCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
         assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
         # The enforceable vocabulary must be declared so a level the flag does not
         # accept is downgraded to advised instead of recorded as a false "enforced"
@@ -58,39 +70,43 @@ class TestCapabilityDeclarations:
             runtime.capabilities.enforceable_reasoning_efforts == _COPILOT_REASONING_EFFORT_LEVELS
         )
 
-    def test_gemini_and_goose_declare_advised_effort(self) -> None:
+    def test_gemini_and_goose_declare_advised_effort(self, fake_cli_path: str) -> None:
         from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
         from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
 
-        gemini = GeminiCLIRuntime(cli_path="gemini", cwd="/tmp")
-        goose = GooseCliRuntime(cli_path="goose", cwd="/tmp")
+        gemini = GeminiCLIRuntime(cli_path=fake_cli_path, cwd="/tmp")
+        goose = GooseCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
         assert gemini.capabilities.reasoning_effort_support is ParamSupport.IGNORED
         assert goose.capabilities.reasoning_effort_support is ParamSupport.IGNORED
 
 
 class TestCopilotEffortEnforcement:
-    def _runtime(self):
+    def _runtime(self, fake_cli_path: str):
         from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
 
-        return CopilotCliRuntime(cli_path="copilot", cwd="/tmp")
+        return CopilotCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
 
-    def test_known_level_is_enforced_via_flag(self) -> None:
-        command = self._runtime()._build_command("out.txt", prompt="hi", reasoning_effort="high")
+    def test_known_level_is_enforced_via_flag(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
+            "out.txt", prompt="hi", reasoning_effort="high"
+        )
         assert "--reasoning-effort" in command
         idx = command.index("--reasoning-effort")
         assert command[idx + 1] == "high"
 
-    def test_unknown_level_is_not_injected(self) -> None:
-        command = self._runtime()._build_command(
+    def test_unknown_level_is_not_injected(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
             "out.txt", prompt="hi", reasoning_effort="; rm -rf /"
         )
         assert "--reasoning-effort" not in command
 
-    def test_no_effort_emits_no_flag(self) -> None:
-        command = self._runtime()._build_command("out.txt", prompt="hi", reasoning_effort=None)
+    def test_no_effort_emits_no_flag(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
+            "out.txt", prompt="hi", reasoning_effort=None
+        )
         assert "--reasoning-effort" not in command
 
-    def test_subclasses_accept_effort_kwarg_without_error(self) -> None:
+    def test_subclasses_accept_effort_kwarg_without_error(self, fake_cli_path: str) -> None:
         """codex execute_task forwards reasoning_effort to _build_command on every
         CodexCliRuntime subclass — each override must accept it (regression guard).
         """
@@ -98,8 +114,8 @@ class TestCopilotEffortEnforcement:
         from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
 
         for runtime in (
-            GeminiCLIRuntime(cli_path="gemini", cwd="/tmp"),
-            GooseCliRuntime(cli_path="goose", cwd="/tmp"),
+            GeminiCLIRuntime(cli_path=fake_cli_path, cwd="/tmp"),
+            GooseCliRuntime(cli_path=fake_cli_path, cwd="/tmp"),
         ):
             # Must not raise; gemini/goose accept-and-ignore (no per-call flag).
             runtime._build_command("out.txt", prompt="hi", reasoning_effort="high")
@@ -138,11 +154,11 @@ class TestCopilotEffortEnforcement:
 
 
 class TestCodexEffortEnforcement:
-    def _runtime(self) -> CodexCliRuntime:
-        return CodexCliRuntime(cli_path="codex", cwd="/tmp")
+    def _runtime(self, fake_cli_path: str) -> CodexCliRuntime:
+        return CodexCliRuntime(cli_path=fake_cli_path, cwd="/tmp")
 
-    def test_known_level_is_enforced_via_config_override(self) -> None:
-        command = self._runtime()._build_command(
+    def test_known_level_is_enforced_via_config_override(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
             output_last_message_path="/tmp/out.txt",
             reasoning_effort="high",
         )
@@ -151,8 +167,8 @@ class TestCodexEffortEnforcement:
         idx = command.index("-c")
         assert command[idx + 1] == "model_reasoning_effort=high"
 
-    def test_no_effort_emits_no_override(self) -> None:
-        command = self._runtime()._build_command(
+    def test_no_effort_emits_no_override(self, fake_cli_path: str) -> None:
+        command = self._runtime(fake_cli_path)._build_command(
             output_last_message_path="/tmp/out.txt",
             reasoning_effort=None,
         )
@@ -161,9 +177,9 @@ class TestCodexEffortEnforcement:
             isinstance(arg, str) and arg.startswith("model_reasoning_effort=") for arg in command
         )
 
-    def test_unknown_level_is_not_injected(self) -> None:
+    def test_unknown_level_is_not_injected(self, fake_cli_path: str) -> None:
         """An unexpected token must never reach the ``key=value`` override."""
-        command = self._runtime()._build_command(
+        command = self._runtime(fake_cli_path)._build_command(
             output_last_message_path="/tmp/out.txt",
             reasoning_effort="; rm -rf /",
         )
@@ -171,8 +187,8 @@ class TestCodexEffortEnforcement:
             isinstance(arg, str) and arg.startswith("model_reasoning_effort=") for arg in command
         )
 
-    def test_every_advertised_level_is_accepted(self) -> None:
-        runtime = self._runtime()
+    def test_every_advertised_level_is_accepted(self, fake_cli_path: str) -> None:
+        runtime = self._runtime(fake_cli_path)
         for level in _CODEX_REASONING_EFFORT_LEVELS:
             command = runtime._build_command(
                 output_last_message_path="/tmp/out.txt",


### PR DESCRIPTION
## Summary

- Stop transient CLI version-probe timeouts and execution failures from masquerading as confirmed executable drift.
- Fail closed with explicit, retryable attestation states while preserving detection of path, content, version, symlink, device, inode, and probe-window executable/symlink-entry changes.
- Prevent already-drifted executable authority from running during `--version`, enforce the same initialization baseline across derived adapters, and retain stronger mutation evidence after every started probe outcome.
- Classify parent-directory-only probe-window churn as retryable `INDETERMINATE` authority without weakening direct executable or symlink ABA detection.

## Changes

### Attestation contract

- Represent version probes as `VERIFIED`, `TIMED_OUT`, `EXECUTION_FAILED`, `INDETERMINATE`, or `CHANGED`.
- Require a verified initialization attestation uniformly for Codex, Copilot, Gemini, Goose, and Grok; unresolved and relative commands cannot bypass a failed baseline.
- Compare all available non-executing path, content, effective device/inode, full semantic symlink-chain, and node-generation evidence with initialization before invoking `--version`.
- Resolve the complete executable symlink chain and re-sample the terminal executable plus every symlink hop around the version process.
- Post-sample every started probe, including timeout, launch error, nonzero exit, and empty output, with proven mutation taking precedence over retryable probe unavailability.
- Bind each authority-bearing entry to raw symlink target, lstat generation, and immediate parent-directory generation, rejecting same-inode mutation, terminal atomic ABA, and intermediate-symlink atomic ABA as mixed evidence.
- Keep volatile probe-window generations out of the long-lived identity hash; only content, effective device/inode, semantic symlink chain, and version evidence determine cross-attestation identity.
- Preserve valid stable multi-hop symlink launch paths and share the same guard semantics across the Codex-family runtimes through a dedicated attestation module.

### Official review blockers closed

1. **No execution before baseline comparison:** an identical-byte symlink retarget/replacement is rejected from non-executing evidence before its `--version` behavior can run; the regression uses a side-effect marker to prove non-execution.
2. **No derived-adapter baseline bypass:** relative or unresolved Copilot-family commands now consult the failed initialization attestation and fail closed instead of authorizing a later PATH candidate.
3. **No lost mixed evidence on exceptional exits:** timeout, `OSError`, nonzero exit, and empty output all post-sample, and probe-window mutation returns `CHANGED` with precedence over the weaker failure state.
4. **No false drift from parent-only churn:** unrelated sibling generation changes fail closed as retryable `INDETERMINATE`; direct executable, terminal ABA, and intermediate-symlink ABA evidence remain `CHANGED`.

### Deterministic regressions

- Cover pre-execution rejection of an identical-byte hostile symlink target, including proof that the candidate was never executed.
- Cover unresolved relative-path initialization followed by hostile PATH installation for inherited adapters.
- Cover mutation-plus-timeout, mutation-plus-`OSError`, mutation-plus-nonzero-exit, and mutation-plus-empty-output precedence.
- Cover stable multi-hop execution, symlink loop/breakage fail-closed behavior, intermediate-symlink atomic ABA, sibling churn between attestations, and retryable fail-closed sibling churn during a probe.
- Use shared hermetic fake executables for Codex, Copilot, Gemini, Goose, and Grok runtime tests.

### Documentation

- Document the pre-execution non-executing comparison and mandatory post-sampling for every started probe.
- Clarify that only version-output drift requires two successful version probes; path, content, symlink, or generation drift can fail closed earlier.
- Document retryable parent-generation uncertainty and name the full Codex, Copilot, Gemini, Goose, and Grok inheritance set.

## Validation

Exact HEAD: `dcf25c6ffef0db371205cc02da2e2fa41a7be7e2`  
Exact tree: `a0022e5c9b1d6e36ab632c38c707851f33954a3f`

- Changed attestation/routing test modules: **167 passed**
- Codex-family compatibility modules: **90 passed**
- Prior pre-main related runtime suite: **257 passed**
- Current exact-head Codex runtime module: **143 passed**
- Current exact-head derived-adapter and passthrough suite: **93 passed**
- Current exact-head adversarial classification selection: **4 passed**
- Independent exact-head verifier: **PASS** (CRITICAL/HIGH 0)
- Module-size ratchet: **passed** (`codex_cli_runtime.py` 4,137 / 4,140 lines)
- Ruff: passed
- Ruff format: passed
- Targeted MyPy: passed
- `git diff --check`: passed

- Python 3.14 passthrough smoke regression: **3 passed** (cache disabled)

Closes #1943
