### PR TITLE
fix: resolve release-blocking integration contract regressions

### DIFF
--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -245,7 +245,10 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `status="invalid_result_entry"` with `invalid_keys`, listing every bad entry
    at once so one resubmission fixes them all.
 
-   A complete set returns the correlated synthesis to continue with; a partial
+   A complete set returns a bounded artifact envelope. Call
+   `ouroboros_fetch_artifact` with its `contract_id`, then continue from the
+   correlated synthesis in the fetched `body`. This explicit MCP fetch is
+   required even when the host has no shell. A partial
    set returns `status="partial"` with `missing_required_keys`. **Retry with
    every lane you hold, not only the missing ones** — no submitted output is
    kept between calls, so each call is judged on what it carries. (The record
@@ -253,7 +256,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    result state, deferred with its sanitization duties to a later slice.)
    Sequential hosts submit after processing payloads one-by-one — same tool,
    same contract, so accumulate the outputs on your side and send the growing
-   set. Continue the interview from the returned synthesis; keep the
+   set. Continue the interview from the fetched synthesis; keep the
    user-facing question visible throughout.
 
    Only lanes marked `required: true` in the request block completion. A lane

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -245,7 +245,10 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `status="invalid_result_entry"` with `invalid_keys`, listing every bad entry
    at once so one resubmission fixes them all.
 
-   A complete set returns the correlated synthesis to continue with; a partial
+   A complete set returns a bounded artifact envelope. Call
+   `ouroboros_fetch_artifact` with its `contract_id`, then continue from the
+   correlated synthesis in the fetched `body`. This explicit MCP fetch is
+   required even when the host has no shell. A partial
    set returns `status="partial"` with `missing_required_keys`. **Retry with
    every lane you hold, not only the missing ones** — no submitted output is
    kept between calls, so each call is judged on what it carries. (The record
@@ -253,7 +256,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    result state, deferred with its sanitization duties to a later slice.)
    Sequential hosts submit after processing payloads one-by-one — same tool,
    same contract, so accumulate the outputs on your side and send the growing
-   set. Continue the interview from the returned synthesis; keep the
+   set. Continue the interview from the fetched synthesis; keep the
    user-facing question visible throughout.
 
    Only lanes marked `required: true` in the request block completion. A lane

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -2588,7 +2588,12 @@ def _config_execute_runtime_backend(config_dict: dict) -> str:
     return "codex" if backend.strip().lower() in {"codex", "codex_cli"} else backend
 
 
-def _setup_codex(codex_path: str, *, mcp_mode: CodexMcpMode = "auto") -> bool:
+def _setup_codex(
+    codex_path: str,
+    *,
+    mcp_mode: CodexMcpMode = "auto",
+    preserve_existing_llm: bool = False,
+) -> bool:
     """Configure Ouroboros for the Codex runtime."""
     from ouroboros.config.loader import ensure_config_dir, get_default_config
     from ouroboros.config.models import get_config_dir, get_default_credentials
@@ -2638,13 +2643,16 @@ def _setup_codex(codex_path: str, *, mcp_mode: CodexMcpMode = "auto") -> bool:
 
     try:
         previous_execute_backend = _config_execute_runtime_backend(config_dict)
-        # Set runtime and LLM backend to codex
+        # Runtime integration and authoring/evaluation provider selection are
+        # independent. Interactive setup keeps its historical behavior, while
+        # updater-driven refreshes preserve an explicitly split LLM backend.
         orchestrator_config = _ensure_mapping_section(config_dict, "orchestrator")
         orchestrator_config["runtime_backend"] = "codex"
         orchestrator_config["codex_cli_path"] = codex_path
 
         llm_config = _ensure_mapping_section(config_dict, "llm")
-        llm_config["backend"] = "codex"
+        if not preserve_existing_llm or fresh_config or not llm_config.get("backend"):
+            llm_config["backend"] = "codex"
 
         if fresh_config:
             _neutralize_fresh_codex_model_defaults(config_dict)
@@ -4652,6 +4660,14 @@ def setup(
             help="Codex MCP config mode: auto preserves user-managed entries, preserve skips MCP changes, stdio replaces with the managed stdio entry.",
         ),
     ] = "auto",
+    preserve_existing_llm: Annotated[
+        bool,
+        typer.Option(
+            "--preserve-existing-llm",
+            help="Preserve an existing independent LLM backend during runtime refresh.",
+            hidden=True,
+        ),
+    ] = False,
 ) -> None:
     """Set up Ouroboros for your environment.
 
@@ -4774,7 +4790,11 @@ def setup(
             else:
                 print_error("Codex CLI not found in PATH or Codex App bundle.")
             raise typer.Exit(1)
-        if not _setup_codex(codex_path, mcp_mode=_normalize_codex_mcp_mode(mcp_mode)):
+        if not _setup_codex(
+            codex_path,
+            mcp_mode=_normalize_codex_mcp_mode(mcp_mode),
+            preserve_existing_llm=preserve_existing_llm,
+        ):
             raise typer.Exit(1)
     elif selected in ("opencode", "opencode_cli"):
         opencode_path = available.get("opencode")

--- a/src/ouroboros/cli/commands/update.py
+++ b/src/ouroboros/cli/commands/update.py
@@ -498,6 +498,8 @@ def _refresh_runtime_config(
     command = [str(identity.console_path), "setup", "--runtime", runtime]
     if runtime in {"opencode", "opencode_cli"} and opencode_mode is not None:
         command.extend(["--opencode-mode", opencode_mode])
+    if runtime in {"codex", "codex_cli"}:
+        command.append("--preserve-existing-llm")
     command.append("--non-interactive")
     return _run_step(
         command,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1664,6 +1664,7 @@ def create_ouroboros_server(
         StartEvolveStepHandler,
         StartExecuteSeedHandler,
         StartRalphHandler,
+        create_artifact_fetch_handler,
         create_fanout_handler,
     )
     from ouroboros.mcp.tools.fanout import FanoutRegistry
@@ -2497,6 +2498,7 @@ def create_ouroboros_server(
             fanout_registry=fanout_registry,
         ),
         create_fanout_handler(fanout_registry, effective_cwd, event_store),
+        create_artifact_fetch_handler(effective_cwd),
         evolve_step,
         StartEvolveStepHandler(
             evolve_handler=evolve_step,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1664,8 +1664,7 @@ def create_ouroboros_server(
         StartEvolveStepHandler,
         StartExecuteSeedHandler,
         StartRalphHandler,
-        create_artifact_fetch_handler,
-        create_fanout_handler,
+        create_fanout_handlers,
     )
     from ouroboros.mcp.tools.fanout import FanoutRegistry
     from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
@@ -2497,8 +2496,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             fanout_registry=fanout_registry,
         ),
-        create_fanout_handler(fanout_registry, effective_cwd, event_store),
-        create_artifact_fetch_handler(effective_cwd),
+        *create_fanout_handlers(fanout_registry, effective_cwd, event_store),
         evolve_step,
         StartEvolveStepHandler(
             evolve_handler=evolve_step,

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -52,6 +52,7 @@ from ouroboros.mcp.tools.execution_handlers import (
 from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
     create_artifact_fetch_handler,
     create_fanout_handler,
+    create_fanout_handlers,
 )
 from ouroboros.mcp.tools.job_handlers import (
     CancelExecutionHandler,

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -33,6 +33,7 @@ from ouroboros.mcp.tools.authoring_handlers import (
 from ouroboros.mcp.tools.evaluation_handlers import (
     ChecklistVerifyHandler,
     EvaluateHandler,
+    FetchArtifactHandler,
     LateralThinkHandler,
     MeasureDriftHandler,
     StartEvaluateHandler,
@@ -48,7 +49,10 @@ from ouroboros.mcp.tools.execution_handlers import (
     ExecuteSeedHandler,
     StartExecuteSeedHandler,
 )
-from ouroboros.mcp.tools.fanout_handler import create_fanout_handler  # noqa: F401
+from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
+    create_artifact_fetch_handler,
+    create_fanout_handler,
+)
 from ouroboros.mcp.tools.job_handlers import (
     CancelExecutionHandler,
     CancelJobHandler,
@@ -432,6 +436,8 @@ OuroborosToolHandlers = tuple[
     | StartEvaluateHandler
     | ChecklistVerifyHandler
     | LateralThinkHandler
+    | SubmitFanoutResultsHandler
+    | FetchArtifactHandler
     | EvolveStepHandler
     | StartEvolveStepHandler
     | RalphHandler
@@ -610,6 +616,7 @@ def get_ouroboros_tools(
             fanout_registry=fanout_registry,
             disposable_memory=fanout_disposable_memory,
         ),
+        FetchArtifactHandler(disposable_memory=fanout_disposable_memory),
         EvolveStepHandler(
             agent_runtime_backend=runtime_backend,
             opencode_mode=opencode_mode,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -31,7 +31,10 @@ from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
 from ouroboros.mcp.tools import background as background_jobs
 from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
-from ouroboros.mcp.tools.fanout_handler import SubmitFanoutResultsHandler  # noqa: F401
+from ouroboros.mcp.tools.fanout_handler import (  # noqa: F401
+    FetchArtifactHandler,
+    SubmitFanoutResultsHandler,
+)
 from ouroboros.mcp.tools.job_observer import build_job_observer_contract
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,

--- a/src/ouroboros/mcp/tools/fanout_handler.py
+++ b/src/ouroboros/mcp/tools/fanout_handler.py
@@ -310,9 +310,20 @@ def create_artifact_fetch_handler(project_dir: Any) -> FetchArtifactHandler:
     )
 
 
+def create_fanout_handlers(
+    fanout_registry: FanoutRegistry,
+    project_dir: Any,
+    event_store: Any,
+) -> tuple[SubmitFanoutResultsHandler, FetchArtifactHandler]:
+    """Build the paired submit/fetch production boundary for one workspace."""
+    submit = create_fanout_handler(fanout_registry, project_dir, event_store)
+    return submit, FetchArtifactHandler(disposable_memory=submit.disposable_memory)
+
+
 __all__ = [
     "FetchArtifactHandler",
     "SubmitFanoutResultsHandler",
     "create_artifact_fetch_handler",
     "create_fanout_handler",
+    "create_fanout_handlers",
 ]

--- a/src/ouroboros/mcp/tools/fanout_handler.py
+++ b/src/ouroboros/mcp/tools/fanout_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 import hashlib
 import json
@@ -27,6 +28,7 @@ from ouroboros.mcp.types import (
 )
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.disposable_memory import DisposableMemory
+from ouroboros.persistence.artifact_errors import ArtifactStoreError
 
 log = structlog.get_logger(__name__)
 
@@ -77,7 +79,7 @@ class SubmitFanoutResultsHandler:
                 "at all is exactly {key, undispatched: true}; never invent output. "
                 "Missing required keys return `status=partial`; retry with EVERY lane. "
                 "A complete submission returns a bounded disposable artifact envelope; "
-                "fetch its body explicitly with `ouroboros artifacts fetch CONTRACT_ID`."
+                "fetch its body with the MCP tool `ouroboros_fetch_artifact`."
             ),
             parameters=(
                 MCPToolParameter(
@@ -204,6 +206,82 @@ class SubmitFanoutResultsHandler:
         return envelope.model_dump(mode="json")
 
 
+@dataclass
+class FetchArtifactHandler:
+    """Expose explicit disposable-artifact reads to MCP-only hosts."""
+
+    disposable_memory: DisposableMemory | None = field(default=None, repr=False)
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        """Return the public explicit-fetch contract."""
+        return MCPToolDefinition(
+            name="ouroboros_fetch_artifact",
+            description=(
+                "Fetch and integrity-check a disposable Ouroboros artifact by the "
+                "contract_id returned in an artifact envelope. For fan-out completion, "
+                "continue from the synthesis in the returned `body`. This is an explicit "
+                "read and never re-executes the originating work."
+            ),
+            parameters=(
+                MCPToolParameter(
+                    name="contract_id",
+                    type=ToolInputType.STRING,
+                    description="The contract_id from a disposable artifact envelope.",
+                    required=True,
+                ),
+            ),
+        )
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Fetch one verified body without requiring shell access."""
+        contract_id = str(arguments.get("contract_id") or "").strip()
+        if not contract_id:
+            return Result.err(
+                MCPToolError(
+                    "contract_id is required",
+                    tool_name="ouroboros_fetch_artifact",
+                )
+            )
+        if self.disposable_memory is None:
+            return Result.err(
+                MCPToolError(
+                    "artifact fetch requires a configured project artifact service",
+                    tool_name="ouroboros_fetch_artifact",
+                )
+            )
+        try:
+            fetched = await asyncio.to_thread(self.disposable_memory.fetch, contract_id)
+        except (ArtifactStoreError, OSError, ValueError) as exc:
+            return Result.err(
+                MCPToolError(
+                    f"artifact fetch failed: {exc}",
+                    tool_name="ouroboros_fetch_artifact",
+                )
+            )
+
+        payload = {
+            "contract_id": fetched.envelope.contract_id,
+            "artifact_ref": fetched.envelope.artifact_ref,
+            "body": fetched.body,
+        }
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                    ),
+                ),
+                is_error=False,
+                meta=payload,
+            )
+        )
+
+
 def create_fanout_handler(
     fanout_registry: FanoutRegistry,
     project_dir: Any,
@@ -221,4 +299,20 @@ def create_fanout_handler(
     )
 
 
-__all__ = ["SubmitFanoutResultsHandler", "create_fanout_handler"]
+def create_artifact_fetch_handler(project_dir: Any) -> FetchArtifactHandler:
+    """Build the production explicit-fetch boundary for a resolved workspace."""
+    from ouroboros.persistence.artifact_store import ContentAddressedArtifactStore
+
+    return FetchArtifactHandler(
+        disposable_memory=DisposableMemory(
+            artifact_store=ContentAddressedArtifactStore.for_project(project_dir),
+        )
+    )
+
+
+__all__ = [
+    "FetchArtifactHandler",
+    "SubmitFanoutResultsHandler",
+    "create_artifact_fetch_handler",
+    "create_fanout_handler",
+]

--- a/src/ouroboros/mcp/tools/runtime_tool_composition.py
+++ b/src/ouroboros/mcp/tools/runtime_tool_composition.py
@@ -188,6 +188,7 @@ def configured_runtime_tools(
         "ouroboros_checklist_verify",
         "ouroboros_lateral_think",
         "ouroboros_submit_fanout_results",
+        "ouroboros_fetch_artifact",
         "ouroboros_evolve_step",
         "ouroboros_start_evolve_step",
         "ouroboros_ralph",

--- a/src/ouroboros/orchestrator/capabilities/tool_specs.py
+++ b/src/ouroboros/orchestrator/capabilities/tool_specs.py
@@ -805,11 +805,23 @@ _OUROBOROS_TOOL_CAPABILITY_SPECS: Mapping[str, _OuroborosToolCapabilitySpec] = {
         interrupt=_OUROBOROS_DEFAULT_INTERRUPT_METADATA,
     ),
     "ouroboros_submit_fanout_results": _OuroborosToolCapabilitySpec(
-        # Re-entry synthesis is a read-only routing step: it reads persisted
-        # fan-out state and returns the correlated synthesis. The fan-out state
-        # write happens on the producer side, not here.
+        # Terminal re-entry publishes a project-local artifact and appends its
+        # reference to the EventStore. Policy must therefore authorize both
+        # writes before dispatching the tool.
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_interview",
+            "ouroboros_lateral_think",
+            "ouroboros_fetch_artifact",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.WORKSPACE_WRITE,
+    ),
+    "ouroboros_fetch_artifact": _OuroborosToolCapabilitySpec(
         execution_mode="status",
-        companions=("ouroboros_interview", "ouroboros_lateral_think"),
+        companions=("ouroboros_submit_fanout_results",),
         side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
         retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
         interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
@@ -995,6 +1007,7 @@ _OUROBOROS_CANCEL_METADATA: Mapping[str, Mapping[str, Any]] = {
     "ouroboros_start_execute_seed": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
     "ouroboros_start_ralph": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
     "ouroboros_submit_fanout_results": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_fetch_artifact": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
 }
 
 _OUROBOROS_BACKGROUND_BLOCKING_COMPANIONS: Mapping[str, str] = {

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -698,6 +698,7 @@ class TestCreateOuroborosServer:
         "ouroboros_evolve_rewind",
         "ouroboros_evolve_step",
         "ouroboros_execute_seed",
+        "ouroboros_fetch_artifact",
         "ouroboros_generate_seed",
         "ouroboros_interview",
         "ouroboros_job_result",

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -4143,6 +4143,43 @@ class TestCodexSetup:
         assert "consensus_judge" not in config_dict["llm_role_profiles"]
         assert "ontology_analysis" not in config_dict["llm_role_profiles"]
 
+    def test_setup_codex_update_refresh_preserves_split_llm_backend(self, tmp_path: Path) -> None:
+        """Updater refreshes Codex integration without rerouting LLM traffic."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "orchestrator": {"runtime_backend": "codex"},
+                    "llm": {"backend": "litellm", "qa_model": "openai/gpt-5.4"},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts"),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server"),
+            patch("ouroboros.cli.commands.setup._register_codex_worker_profile"),
+        ):
+            assert (
+                setup_cmd._setup_codex(
+                    "/usr/local/bin/codex",
+                    preserve_existing_llm=True,
+                )
+                is True
+            )
+
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config_dict["orchestrator"]["runtime_backend"] == "codex"
+        assert config_dict["orchestrator"]["codex_cli_path"] == "/usr/local/bin/codex"
+        assert config_dict["llm"]["backend"] == "litellm"
+        assert config_dict["llm"]["qa_model"] == "openai/gpt-5.4"
+
     def test_setup_codex_clears_execute_default_model_when_execute_switches_to_codex(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_update.py
+++ b/tests/unit/cli/test_update.py
@@ -1149,7 +1149,11 @@ class TestUpdateFlow:
 
         assert result.exit_code == 0
         output = _plain(result.output)
-        assert f"setup --runtime {configured_backend} --non-interactive" in output
+        expected_refresh = f"setup --runtime {configured_backend}"
+        if configured_backend == "codex":
+            expected_refresh += " --preserve-existing-llm"
+        expected_refresh += " --non-interactive"
+        assert expected_refresh in output
         expected_env_key = (
             "OUROBOROS_CLI_PATH"
             if configured_backend == "claude"

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2960,6 +2960,7 @@ async def test_production_fanout_returns_only_disposable_envelope(
         project_dir=project,
     )
     handler = server._tool_handlers["ouroboros_submit_fanout_results"]
+    fetch_handler = server._tool_handlers["ouroboros_fetch_artifact"]
     assert handler.disposable_memory is not None
     assert handler.disposable_memory.artifact_store.root == (
         project.resolve() / ".ouroboros" / "artifacts"
@@ -3005,8 +3006,11 @@ async def test_production_fanout_returns_only_disposable_envelope(
         assert marker not in first_result.content[0].text
         assert marker not in json.dumps(first_result.meta)
 
-        fetched = handler.disposable_memory.fetch(envelope.contract_id)
-        assert marker in json.dumps(fetched.body)
+        fetched = await fetch_handler.handle({"contract_id": envelope.contract_id})
+        assert fetched.is_ok
+        fetched_body = fetched.unwrap().meta["body"]
+        assert marker in json.dumps(fetched_body)
+        assert fetched_body["status"] == "complete"
         events = await event_store.replay("contract", envelope.contract_id)
         assert len(events) == 1
         assert marker not in json.dumps(events[0].data)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1873,6 +1873,7 @@ class TestOuroborosTools:
         "ouroboros_evolve_rewind",
         "ouroboros_evolve_step",
         "ouroboros_execute_seed",
+        "ouroboros_fetch_artifact",
         "ouroboros_generate_seed",
         "ouroboros_interview",
         "ouroboros_job_result",

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -24,6 +24,7 @@ from ouroboros.mcp.tools.authoring_handlers import (
     _attach_question_assist_requests,
 )
 from ouroboros.mcp.tools.evaluation_handlers import (
+    FetchArtifactHandler,
     LateralThinkHandler,
     SubmitFanoutResultsHandler,
 )
@@ -971,6 +972,14 @@ async def test_submit_tool_requires_fanout_id() -> None:
     submit = SubmitFanoutResultsHandler()
     result = await submit.handle({"results": []})
     assert result.is_err
+
+
+@pytest.mark.asyncio
+async def test_fetch_tool_without_project_artifact_service_fails_closed() -> None:
+    result = await FetchArtifactHandler().handle({"contract_id": "fanout:missing"})
+
+    assert result.is_err
+    assert "requires a configured project artifact service" in str(result.error)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_round5_fixes.py
+++ b/tests/unit/mcp/tools/test_round5_fixes.py
@@ -237,8 +237,9 @@ class TestGetOuroborosToolsPluginWiring:
 
         tools = get_ouroboros_tools()
         names = {tool.definition.name for tool in tools}
-        assert len(tools) == 31
+        assert len(tools) == 32
         assert "ouroboros_auto" in names
+        assert "ouroboros_fetch_artifact" in names
         assert "ouroboros_query_projection" in names
         assert "ouroboros_project_status" in names
         assert "ouroboros_start_auto" in names

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -74,6 +74,7 @@ _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES = {
     "ouroboros_evolve_rewind": "blocking",
     "ouroboros_evolve_step": "blocking",
     "ouroboros_execute_seed": "blocking",
+    "ouroboros_fetch_artifact": "status",
     "ouroboros_generate_seed": "blocking",
     "ouroboros_interview": "subagent_orchestration",
     "ouroboros_job_result": "status",
@@ -94,7 +95,7 @@ _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES = {
     "ouroboros_start_evolve_step": "background",
     "ouroboros_start_execute_seed": "background",
     "ouroboros_start_ralph": "background",
-    "ouroboros_submit_fanout_results": "status",
+    "ouroboros_submit_fanout_results": "blocking",
 }
 
 _VALID_OUROBOROS_TOOL_EXECUTION_MODES = frozenset(
@@ -228,6 +229,7 @@ _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS = {
         "session_id",
     ),
     "ouroboros_start_ralph": ("lineage_id",),
+    "ouroboros_fetch_artifact": ("contract_id",),
     "ouroboros_submit_fanout_results": ("fanout_id", "results"),
 }
 
@@ -461,7 +463,9 @@ _EXPECTED_OUROBOROS_TOOL_COMPANIONS = {
     "ouroboros_submit_fanout_results": (
         "ouroboros_interview",
         "ouroboros_lateral_think",
+        "ouroboros_fetch_artifact",
     ),
+    "ouroboros_fetch_artifact": ("ouroboros_submit_fanout_results",),
 }
 
 _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
@@ -484,6 +488,7 @@ _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
     "ouroboros_evolve_rewind": ("session_state_write",),
     "ouroboros_evolve_step": ("workspace_write", "event_store_write"),
     "ouroboros_execute_seed": ("workspace_write", "event_store_write"),
+    "ouroboros_fetch_artifact": (),
     "ouroboros_generate_seed": ("workspace_write", "event_store_write"),
     "ouroboros_interview": ("subagent_dispatch", "session_state_write"),
     "ouroboros_job_result": (),
@@ -504,7 +509,7 @@ _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
     "ouroboros_start_evolve_step": ("workspace_write", "event_store_write"),
     "ouroboros_start_execute_seed": ("workspace_write", "event_store_write"),
     "ouroboros_start_ralph": ("workspace_write", "event_store_write"),
-    "ouroboros_submit_fanout_results": (),
+    "ouroboros_submit_fanout_results": ("workspace_write", "event_store_write"),
 }
 
 _EXPECTED_MUTATION_TARGETS_BY_SIDE_EFFECT = {
@@ -805,6 +810,7 @@ _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS = {
 
 _EXPECTED_READ_ONLY_OUROBOROS_TOOLS = {
     "ouroboros_ac_tree_hud",
+    "ouroboros_fetch_artifact",
     "ouroboros_job_result",
     "ouroboros_job_status",
     "ouroboros_job_wait",
@@ -813,7 +819,6 @@ _EXPECTED_READ_ONLY_OUROBOROS_TOOLS = {
     "ouroboros_query_events",
     "ouroboros_query_projection",
     "ouroboros_session_status",
-    "ouroboros_submit_fanout_results",
 }
 
 _EXPECTED_OUROBOROS_TOOL_RETRY = {
@@ -827,6 +832,7 @@ _EXPECTED_OUROBOROS_TOOL_RETRY = {
     "ouroboros_evolve_rewind": {"supported": True, "mode": "handler_owned"},
     "ouroboros_evolve_step": {"supported": True, "mode": "handler_owned"},
     "ouroboros_execute_seed": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_fetch_artifact": {"supported": True, "mode": "handler_owned"},
     "ouroboros_generate_seed": {"supported": True, "mode": "handler_owned"},
     "ouroboros_interview": {"supported": True, "mode": "handler_owned"},
     "ouroboros_job_result": {"supported": True, "mode": "handler_owned"},
@@ -919,6 +925,7 @@ _EXPECTED_OUROBOROS_TOOL_INTERRUPT = {
     "ouroboros_evolve_rewind": _blocking_interrupt(),
     "ouroboros_evolve_step": _blocking_interrupt("ouroboros_start_evolve_step"),
     "ouroboros_execute_seed": _blocking_interrupt("ouroboros_start_execute_seed"),
+    "ouroboros_fetch_artifact": _READ_ONLY_INTERRUPT,
     "ouroboros_generate_seed": _blocking_interrupt(),
     "ouroboros_interview": {"supported": True, "mode": "soft"},
     "ouroboros_job_result": _READ_ONLY_INTERRUPT,
@@ -939,7 +946,7 @@ _EXPECTED_OUROBOROS_TOOL_INTERRUPT = {
     "ouroboros_start_evolve_step": _BACKGROUND_INTERRUPT,
     "ouroboros_start_execute_seed": _BACKGROUND_INTERRUPT,
     "ouroboros_start_ralph": _BACKGROUND_INTERRUPT,
-    "ouroboros_submit_fanout_results": _READ_ONLY_INTERRUPT,
+    "ouroboros_submit_fanout_results": _blocking_interrupt(),
 }
 
 _UNSUPPORTED_CANCEL = {
@@ -991,6 +998,7 @@ _EXPECTED_OUROBOROS_TOOL_CANCEL = {
     "ouroboros_evolve_rewind": _UNSUPPORTED_CANCEL,
     "ouroboros_evolve_step": _UNSUPPORTED_CANCEL,
     "ouroboros_execute_seed": _EXECUTION_SESSION_CANCEL,
+    "ouroboros_fetch_artifact": _UNSUPPORTED_CANCEL,
     "ouroboros_generate_seed": _UNSUPPORTED_CANCEL,
     "ouroboros_interview": _UNSUPPORTED_CANCEL,
     "ouroboros_job_result": _UNSUPPORTED_CANCEL,
@@ -2842,6 +2850,7 @@ def test_read_only_query_status_projection_tools_have_non_mutating_interrupt_met
     descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
     expected_query_status_projection_tools = {
         "ouroboros_ac_tree_hud",
+        "ouroboros_fetch_artifact",
         "ouroboros_job_result",
         "ouroboros_job_status",
         "ouroboros_job_wait",
@@ -2850,7 +2859,6 @@ def test_read_only_query_status_projection_tools_have_non_mutating_interrupt_met
         "ouroboros_query_events",
         "ouroboros_query_projection",
         "ouroboros_session_status",
-        "ouroboros_submit_fanout_results",
     }
 
     assert expected_query_status_projection_tools == _EXPECTED_READ_ONLY_OUROBOROS_TOOLS
@@ -3022,6 +3030,7 @@ def test_blocking_ouroboros_tools_have_synchronous_interrupt_metadata() -> None:
         "ouroboros_evolve_rewind",
         "ouroboros_evolve_step",
         "ouroboros_execute_seed",
+        "ouroboros_submit_fanout_results",
         "ouroboros_generate_seed",
         "ouroboros_measure_drift",
         "ouroboros_qa",
@@ -3269,6 +3278,7 @@ def test_non_cancel_ouroboros_owned_tools_explicitly_do_not_expose_cancel_semant
         "ouroboros_evaluate",
         "ouroboros_evolve_rewind",
         "ouroboros_evolve_step",
+        "ouroboros_fetch_artifact",
         "ouroboros_generate_seed",
         "ouroboros_interview",
         "ouroboros_job_result",

--- a/tests/unit/orchestrator/test_runtime_artifact_workspace.py
+++ b/tests/unit/orchestrator/test_runtime_artifact_workspace.py
@@ -34,7 +34,9 @@ def test_builtin_handlers_use_runtime_cwd_when_launcher_cwd_differs(
     monkeypatch.chdir(launcher)
 
     runtime = runtime_type(cli_path=cli_name, cwd=project)
-    submit = runtime._get_builtin_mcp_handlers()["ouroboros_submit_fanout_results"]
+    handlers = runtime._get_builtin_mcp_handlers()
+    submit = handlers["ouroboros_submit_fanout_results"]
+    fetch = handlers["ouroboros_fetch_artifact"]
 
     assert submit.disposable_memory is not None
     assert submit.disposable_memory.artifact_store.root == (
@@ -42,4 +44,7 @@ def test_builtin_handlers_use_runtime_cwd_when_launcher_cwd_differs(
     )
     assert submit.disposable_memory.artifact_store.root != (
         launcher.resolve() / ".ouroboros" / "artifacts"
+    )
+    assert fetch.disposable_memory.artifact_store.root == (
+        project.resolve() / ".ouroboros" / "artifacts"
     )

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -198,6 +198,20 @@ def test_codex_plugin_manifest_starts_a_codex_composed_mcp_server() -> None:
     assert (repo_root / ".claude-plugin" / "skills" / "config" / "SKILL.md").is_file()
 
 
+def test_fanout_synthesis_fetch_contract_is_shipped_to_every_host() -> None:
+    """Every MCP-only host must be able to consume a completed fan-out."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    for skill_root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
+        skill_path = skill_root / "interview" / "SKILL.md"
+        content = skill_path.read_text(encoding="utf-8")
+        assert "A complete set returns a bounded artifact envelope" in content, skill_path
+        assert "`ouroboros_fetch_artifact` with its `contract_id`" in content, skill_path
+        assert "correlated synthesis in the fetched `body`" in content, skill_path
+        assert "Continue the interview from the fetched synthesis" in content, skill_path
+        assert "Continue the interview from the returned synthesis" not in content, skill_path
+
+
 def test_shipped_skill_metadata_never_claims_claude_reserved_command_names() -> None:
     """Primary names and aliases must leave Claude's built-in commands reachable."""
     repo_root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary

- Restore a consumable fan-out completion path for MCP-only hosts without expanding the bounded submit envelope.
- Align fan-out capability metadata with its project artifact and EventStore writes.
- Preserve an independently configured LLM backend when ouroboros update refreshes Codex runtime integration.

## Changes

### Fan-out MCP contract

- Add the ouroboros_fetch_artifact MCP tool and register it on production and runtime-owned surfaces.
- Update the interview skill to fetch terminal synthesis by contract ID.
- Classify ouroboros_submit_fanout_results as a workspace and EventStore mutation.

### Updater topology preservation

- Add an updater-only preserve-existing-llm setup mode for Codex.
- Keep direct setup behavior unchanged while retaining split runtime/LLM configurations during updates.

## Verification

- Related suite: 1062 passed.
- Final focused regression suite: 375 passed.
- Module-size gate and 180 focused MCP tests passed after handler composition adjustment.
- Ruff lint/format and git diff checks passed.

## Notes

This PR addresses three release-blocking integration contract gaps found during code review after the disposable artifact lifecycle work. No tracking issue was created for these review findings.