### PR TITLE
docs(history): archive superseded planning snapshots

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,8 +34,7 @@ replayable execution contract on your choice of runtime backend.
 - [CLI Reference](./cli-reference.md) - Command-line interface flags and options
 - [Configuration Reference](./config-reference.md) - All `config.yaml` options and environment variables
 - [Agent OS Profile Taxonomy](./agentos/profile-taxonomy.md) - Locked 4-slot vocabulary (`runtime_backend`, `stage_runtime`, `llm_profile`, `provider_profile`) for the historically-overloaded "profile" concepts; tiebreaker for #573
-- [AgentOS Release Readiness](./agentos/release-readiness.md) - #961-aligned release gate, verification pack, and open issue triage
-- [AgentOS Issue Sequencing Graph](./agentos/issue-sequencing-graph.md) - Non-normative, dated #961/#1256 snapshot of track sequencing, merged-PR evidence, and recommended work order
+- [AgentOS Sequencing SSOT](https://github.com/Q00/ouroboros/issues/961) - Living authority for AgentOS ownership, approval gates, and bounded-slice sequencing
 
 ### API Reference
 
@@ -66,6 +65,16 @@ replayable execution contract on your choice of runtime backend.
 - [Key Patterns](./contributing/key-patterns.md) - Result type, immutability, event sourcing, protocols
 - [Findings Registry](./contributing/findings-registry.md) - Documentation audit findings registry
 - [Issue Quality Policy](./contributing/issue-quality-policy.md) - Quality bar for actionable issues and PRD-lite feature requests
+
+### Historical Planning Snapshots
+
+These documents preserve point-in-time evidence and work orders. They are
+immutable, non-normative history; use [#961](https://github.com/Q00/ouroboros/issues/961)
+for current AgentOS sequencing.
+
+- [AgentOS Release Readiness (2026-05-29)](./history/agentos/release-readiness.md) - Historical release triage and verification snapshot
+- [AgentOS Issue Sequencing Graph (2026-05-29)](./history/agentos/issue-sequencing-graph.md) - Historical issue-state and work-order snapshot
+- [Master Roadmap 2026-07](./history/master-roadmap-2026-07.md) - Superseded PR-A through PR-K execution plan with final dispositions
 
 
 ## Key Concepts

--- a/docs/history/agentos/issue-sequencing-graph.md
+++ b/docs/history/agentos/issue-sequencing-graph.md
@@ -1,3 +1,16 @@
+> [!WARNING]
+> **Immutable historical snapshot — non-normative.**
+>
+> - Snapshot date: 2026-05-29 18:40 KST
+> - Source commit: [`3dd8917eb32158fb526ce23620e898a2687480c6`](https://github.com/Q00/ouroboros/commit/3dd8917eb32158fb526ce23620e898a2687480c6)
+> - Original publication commit: [`4dbf76d2c615aba536e6fd7e7018bd61c88f1076`](https://github.com/Q00/ouroboros/commit/4dbf76d2c615aba536e6fd7e7018bd61c88f1076)
+> - Imported from: [GitHub issue #1291](https://github.com/Q00/ouroboros/issues/1291)
+> - Current sequencing SSOT: [GitHub issue #961](https://github.com/Q00/ouroboros/issues/961)
+>
+> The content below is preserved as point-in-time evidence. Do not refresh its
+> issue states, sequencing graph, or recommendations, and do not use it as
+> current planning policy.
+
 # AgentOS Issue Sequencing Graph
 
 > Snapshot documentation imported from #1291. This page is informational only; #961 remains the canonical AgentOS roadmap SSOT, and #1256 remains the product-policy SSOT for the `ooo auto` closure ladder.

--- a/docs/history/agentos/release-readiness.md
+++ b/docs/history/agentos/release-readiness.md
@@ -1,3 +1,16 @@
+> [!WARNING]
+> **Immutable historical snapshot — non-normative.**
+>
+> - Snapshot date: 2026-05-29 09:19 KST
+> - Source commit: [`3dd8917eb32158fb526ce23620e898a2687480c6`](https://github.com/Q00/ouroboros/commit/3dd8917eb32158fb526ce23620e898a2687480c6)
+> - Original publication commit: [`84c90602357d54217767538eae75192deb24f87b`](https://github.com/Q00/ouroboros/commit/84c90602357d54217767538eae75192deb24f87b)
+> - Repository baseline captured by the snapshot: `837e56a88aad9214e41dc4b948f551510a50f755`
+> - Current sequencing SSOT: [GitHub issue #961](https://github.com/Q00/ouroboros/issues/961)
+>
+> The content below is preserved as point-in-time evidence. Do not refresh its
+> issue states, release gates, or recommendations, and do not use it as current
+> release policy.
+
 # AgentOS Release Readiness
 
 This note records a dated, non-normative triage snapshot of the live #961

--- a/docs/history/master-roadmap-2026-07.md
+++ b/docs/history/master-roadmap-2026-07.md
@@ -1,3 +1,30 @@
+> [!WARNING]
+> **Immutable historical snapshot — non-normative and superseded.**
+>
+> - Snapshot date: 2026-07-02
+> - Source commit: [`715a0c63556d330c529085dfb83d066890703a72`](https://github.com/Q00/ouroboros/commit/715a0c63556d330c529085dfb83d066890703a72)
+> - Repository baseline captured by the plan: `aa4aa20b` (v0.44.0)
+> - Current sequencing SSOT: [GitHub issue #961](https://github.com/Q00/ouroboros/issues/961)
+>
+> The original work orders below are retained verbatim for traceability. They
+> must not be executed or treated as current repository guidance.
+
+## Final work-order dispositions
+
+| Work order | Final disposition | Evidence |
+| --- | --- | --- |
+| PR-A | Landed | [#1540](https://github.com/Q00/ouroboros/pull/1540) deleted the confirmed dead code. |
+| PR-B | Superseded / partially landed | [#1571](https://github.com/Q00/ouroboros/pull/1571) landed the valid JSONL and child-environment deduplication; the prompt-composition target was rejected because the implementations were not behaviorally identical. |
+| PR-C | Landed | [#1543](https://github.com/Q00/ouroboros/pull/1543) emitted provider-neutral sequential subagent contracts. |
+| PR-D | Landed | [#1547](https://github.com/Q00/ouroboros/pull/1547) added bounded automatic evaluation chaining after successful runs. |
+| PR-E | Landed | [#1549](https://github.com/Q00/ouroboros/pull/1549) extracted the evidence helper library. |
+| PR-F | Landed | [#1551](https://github.com/Q00/ouroboros/pull/1551) added structured acceptance criteria. |
+| PR-G | Landed | [#1548](https://github.com/Q00/ouroboros/pull/1548) made the executor consume AC success contracts through verify-by-default gates and retries. |
+| PR-H | Landed | [#1572](https://github.com/Q00/ouroboros/pull/1572) made evaluation judge declared AC contracts and enforce the reward-hacking veto. |
+| PR-I | Landed | [#1574](https://github.com/Q00/ouroboros/pull/1574) split the interview authoring handler by action. |
+| PR-J | Landed | [#1578](https://github.com/Q00/ouroboros/pull/1578) added the generic fan-out core and correlated result re-entry. |
+| PR-K | Landed | [#1580](https://github.com/Q00/ouroboros/pull/1580) added the bounded interview fan-out injection points. |
+
 # Master Roadmap 2026-07 — Dead Code → Provider Parity → Verifiable Loop → Interview Fan-out
 
 > Status: APPROVED PLAN (2026-07-02). Baseline: `main` @ `aa4aa20b` (v0.44.0).

--- a/docs/run-metaharness-plan-2026-07.md
+++ b/docs/run-metaharness-plan-2026-07.md
@@ -3,7 +3,8 @@
 > Status: PROPOSED PLAN (2026-07-02). Baseline: `main` @ `7bc011dc`.
 > Origin: 6-agent fan-out audit (run failure modes, injection points, brownfield gap,
 > dashboard overlap, meta-harness brainstorm, external harness-landscape research).
-> Companion to `docs/master-roadmap-2026-07.md` — this plan BUILDS ON PR-E/F/G/H
+> Companion to the [historical master roadmap](./history/master-roadmap-2026-07.md)
+> snapshot — this plan BUILDS ON PR-E/F/G/H
 > (AC success contract) and PR-D (run→eval chain); it does not replace them.
 
 ---


### PR DESCRIPTION
## Summary

- Archive three dated planning documents as immutable, non-normative history so old release gates and work orders cannot be mistaken for current policy.
- Make issue #961 the living AgentOS sequencing authority in the docs index.
- Record the final PR-A through PR-K dispositions and repair the remaining moved roadmap link.

## Changes

### SSOT boundary

- Replace current-index links to dated AgentOS snapshots with the living #961 authority.
- Add a dedicated historical planning section that clearly labels the snapshots as immutable and non-normative.

### Historical provenance

- Move the AgentOS readiness, issue-sequencing, and July roadmap documents under `docs/history/`.
- Preserve each original body while adding snapshot dates, source/publication commits, and current-authority links before the historical content.
- Reconcile PR-A through PR-K with their final merged or superseded outcomes.

### Link integrity

- Point the meta-harness plan at the moved historical roadmap.
- Verify all 44 relative links across the changed Markdown files.

## Verification

- Independent verifier: PASS, no blockers.
- Original historical bodies remain byte-identical after the metadata prefixes.
- PR-A through PR-K dispositions checked against GitHub merge history.
- Changed Markdown relative links: 44 passed.
- Focused docs/progress tests: 86 passed in implementation verification; 25 passed independently.
- Ruff, format check, and `git diff --check`: passed.
- Stable patch ID: `fe8b9b4cc17eb1e983bdc8ed687b0e775295bcc8`.
- Five-file manifest: `d5a2f7976c0117c6dfb704ae2c6bda6f0648d2f0a07d334c29eb4e7eea3352c2`.

## Notes

This is docs-only and does not alter runtime or policy behavior. Once merged, it removes the stale authoritative-document contradiction that remains in #1256; closure of #1256 should still verify the narrowed terminal-liveness contract on then-current main.

Closes #1860
Refs #1256
