### PR TITLE
chore(pypi): fill in missing project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,38 @@
 [project]
 name = "ouroboros-ai"
 dynamic = ["version"]
-description = "Specification-first workflow engine for AI coding agents. Works with Claude Code and Codex CLI."
+description = "Specification-first workflow engine for AI coding agents -- works across Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Pi, Zcode, Goose, GJC, Antigravity, and Grok."
 readme = "README.md"
 authors = [
     { name = "Q00", email = "jqyu.lee@gmail.com" }
 ]
 requires-python = ">=3.12"
+keywords = [
+    "agent-os",
+    "ai-agent",
+    "ai-coding-agent",
+    "claude-code",
+    "cli",
+    "developer-tools",
+    "llm-orchestration",
+    "mcp",
+    "prompt-engineering",
+    "socratic-method",
+    "spec-driven-development",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Code Generators",
+]
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "anyio>=4.0.0,<5.0.0",
@@ -28,6 +54,12 @@ dependencies = [
     "structlog>=24.0.0,<27.0.0",
     "typer>=0.12.0,<0.28.0",
 ]
+
+[project.urls]
+Homepage = "https://ouroboros.page/"
+Repository = "https://github.com/Q00/ouroboros"
+"Bug Tracker" = "https://github.com/Q00/ouroboros/issues"
+Sponsor = "https://github.com/sponsors/Q00"
 
 [project.optional-dependencies]
 # Exact-pinned (not ranges) on purpose: a future compromised "latest" must not


### PR DESCRIPTION
## Summary
Checked the live PyPI page (`pypi.org/pypi/ouroboros-ai/json`) and found:
- `classifiers`: empty
- `keywords`: null
- `project_urls`: null (PyPI's sidebar has no links back to the repo, issues, or docs at all)
- `summary`: "Works with Claude Code and Codex CLI" -- stale, project now supports 13 runtime families

## Changes
- `description`: lists all 13 supported runtimes (matches `VALID_RUNTIME_BACKENDS`)
- `keywords`: aligned with the GitHub repo topics
- `classifiers`: standard trove classifiers (dev status, MIT license, Python 3.12-3.14, topic)
- `[project.urls]`: Homepage, Repository, Bug Tracker, Sponsor

## Why
Anyone finding the package via `pip search`-adjacent tooling or the PyPI page itself currently can't click through to the repo, and the classifiers/keywords gap hurts PyPI's own search/filtering.

## Test plan
- [x] Validated the edited TOML with `tomllib.load`
- [x] Diffed the JSON API response against the new fields to confirm every prior gap (`classifiers: []`, `project_urls: null`, no `keywords`) is addressed
- [x] Takes effect on the next release; no runtime/installed-behavior change


Closes #1953
