### PR TITLE
fix(cli): apply the saved logging.level instead of ignoring it

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -27,6 +27,7 @@ from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
+from ouroboros.cli.logging_setup import configure_cli_logging
 from ouroboros.config import get_clarification_model, get_llm_backend
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.hitl_contract import (
@@ -47,7 +48,6 @@ from ouroboros.events.hitl import (
     create_hitl_answered_event,
     create_hitl_requested_event,
 )
-from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.package_profiles import (
     PublicAgentRuntimeBackend as AgentRuntimeBackend,
 )
@@ -982,9 +982,9 @@ def start(
         print_error("Initial context is required when not resuming.")
         raise typer.Exit(code=1)
 
-    # Configure logging based on debug flag
+    # Apply the saved logging.level, with --debug overriding it.
+    configure_cli_logging(debug=debug)
     if debug:
-        configure_logging(LoggingConfig(log_level="DEBUG"))
         print_info("Debug mode enabled - showing verbose logs")
 
     if runtime and not orchestrator:

--- a/src/ouroboros/cli/commands/pm.py
+++ b/src/ouroboros/cli/commands/pm.py
@@ -26,10 +26,10 @@ from ouroboros.bigbang.pm_interview import PM_UNCERTAINTY_GUIDANCE
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
+from ouroboros.cli.logging_setup import configure_cli_logging
 from ouroboros.config import get_clarification_model, get_llm_backend
 from ouroboros.core.owner_only import secure_directory, write_owner_only
 from ouroboros.core.types import Result
-from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.pm.handoff import build_pm_dev_handoff_command
 from ouroboros.providers.factory import (
     create_llm_adapter,
@@ -128,8 +128,8 @@ def pm_command(
     if ctx.invoked_subcommand is not None:
         return
 
+    configure_cli_logging(debug=debug)
     if debug:
-        configure_logging(LoggingConfig(log_level="DEBUG"))
         print_info("Debug mode enabled - showing verbose logs")
 
     console.print("\n[bold cyan]Ouroboros PM Generator[/] - Product Requirements Document\n")

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
+from ouroboros.cli.logging_setup import configure_cli_logging
 from ouroboros.config.loader import (
     get_config_dir,
     get_max_parallel_workers,
@@ -978,6 +979,11 @@ def workflow(
         # Skip ACs already satisfied by the working tree
         ouroboros run seed.yaml --skip-completed docs/completed.yaml
     """
+    # Apply the saved logging.level before the orchestrator is imported: its
+    # module-level get_logger() auto-configures logging at the default level,
+    # and whichever runs first wins.
+    configure_cli_logging(debug=debug)
+
     # Validate MCP config requires orchestrator mode
     if mcp_config and not orchestrator and not resume_session:
         print_warning("--mcp-config requires --orchestrator flag. Enabling orchestrator mode.")

--- a/src/ouroboros/cli/logging_setup.py
+++ b/src/ouroboros/cli/logging_setup.py
@@ -1,0 +1,63 @@
+"""Bridge the saved logging level into the structlog configuration.
+
+Why this exists: two unrelated classes are both named ``LoggingConfig``. The one
+in ``ouroboros.config.models`` carries ``level`` and is what ``ouroboros config
+set logging.level`` writes to ``~/.ouroboros/config.yaml``. The one in
+``ouroboros.observability.logging`` carries ``log_level`` and is what actually
+sets the handler level. Nothing connected them, and the CLI only called
+``configure_logging`` behind ``--debug``, so the saved value never reached the
+logger: ``config set logging.level warning`` reported success, persisted, and
+changed nothing about what the CLI printed (#1955).
+
+Every CLI entry point that accepts ``--debug`` should call
+:func:`configure_cli_logging` instead of calling ``configure_logging`` directly,
+so the two field names cannot drift apart again at the call sites.
+"""
+
+from __future__ import annotations
+
+from ouroboros.observability import LoggingConfig, configure_logging
+
+__all__ = ["configure_cli_logging", "resolve_cli_log_level"]
+
+_DEBUG_LEVEL = "DEBUG"
+_FALLBACK_LEVEL = "INFO"
+
+
+def resolve_cli_log_level(*, debug: bool) -> str:
+    """Resolve the log level for a CLI invocation.
+
+    ``--debug`` always wins so the flag stays usable for reporting a problem
+    regardless of what is saved in the config file. Otherwise the saved
+    ``logging.level`` applies.
+
+    A config that cannot be read must not take the command down with it --
+    logging setup is not the user's goal -- so an unreadable config falls back
+    to the previous default of INFO.
+
+    Args:
+        debug: Whether the caller passed ``--debug``.
+
+    Returns:
+        Log level name in the upper-case form ``configure_logging`` expects.
+    """
+    if debug:
+        return _DEBUG_LEVEL
+
+    # Imported lazily: loading the config touches the filesystem, and the
+    # --debug path has no reason to pay for it.
+    from ouroboros.config import load_config
+
+    try:
+        return str(load_config().logging.level).upper()
+    except Exception:
+        return _FALLBACK_LEVEL
+
+
+def configure_cli_logging(*, debug: bool) -> None:
+    """Configure structlog for a CLI invocation.
+
+    Args:
+        debug: Whether the caller passed ``--debug``.
+    """
+    configure_logging(LoggingConfig(log_level=resolve_cli_log_level(debug=debug)))

--- a/src/ouroboros/cli/logging_setup.py
+++ b/src/ouroboros/cli/logging_setup.py
@@ -11,12 +11,14 @@ changed nothing about what the CLI printed (#1955).
 
 Every CLI entry point that accepts ``--debug`` should call
 :func:`configure_cli_logging` instead of calling ``configure_logging`` directly,
-so the two field names cannot drift apart again at the call sites.
+so the two field names cannot drift apart again at the call sites. ``run`` must
+call it before importing the orchestrator, whose module-level ``get_logger()``
+would otherwise auto-configure logging at the default level first.
 """
 
 from __future__ import annotations
 
-from ouroboros.observability import LoggingConfig, configure_logging
+from ouroboros.observability import configure_logging, default_logging_config
 
 __all__ = ["configure_cli_logging", "resolve_cli_log_level"]
 
@@ -57,7 +59,13 @@ def resolve_cli_log_level(*, debug: bool) -> str:
 def configure_cli_logging(*, debug: bool) -> None:
     """Configure structlog for a CLI invocation.
 
+    Only the level is replaced. Everything else -- most importantly the mode
+    selected by ``OUROBOROS_LOG_MODE`` -- is carried over from the config
+    ``configure_logging()`` would have chosen, so applying a saved level cannot
+    knock an operator's ``prod`` JSON output back to human-readable ``dev``.
+
     Args:
         debug: Whether the caller passed ``--debug``.
     """
-    configure_logging(LoggingConfig(log_level=resolve_cli_log_level(debug=debug)))
+    base = default_logging_config()
+    configure_logging(base.model_copy(update={"log_level": resolve_cli_log_level(debug=debug)}))

--- a/src/ouroboros/observability/__init__.py
+++ b/src/ouroboros/observability/__init__.py
@@ -24,6 +24,7 @@ from ouroboros.observability.logging import (
     LogMode,
     bind_context,
     configure_logging,
+    default_logging_config,
     get_logger,
     unbind_context,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "LoggingConfig",
     "bind_context",
     "configure_logging",
+    "default_logging_config",
     "get_logger",
     "unbind_context",
     # Drift

--- a/src/ouroboros/observability/logging.py
+++ b/src/ouroboros/observability/logging.py
@@ -633,6 +633,22 @@ class _FileWritingPrintLoggerFactory:
         return _FileWritingPrintLogger()
 
 
+def default_logging_config() -> LoggingConfig:
+    """Return the config ``configure_logging()`` would pick on its own.
+
+    Callers that want to change one field must start from this rather than
+    constructing a fresh ``LoggingConfig``: the mode comes from
+    ``OUROBOROS_LOG_MODE`` and is an operator override, so building a new config
+    with only a level set would silently drop an operator's ``prod`` selection
+    back to ``dev``.
+
+    Returns:
+        The active config if logging is already configured, otherwise the
+        environment-derived default.
+    """
+    return _current_config or LoggingConfig(mode=_get_mode_from_env())
+
+
 def configure_logging(config: LoggingConfig | None = None) -> None:
     """Configure structlog for the application.
 

--- a/tests/unit/cli/test_logging_setup.py
+++ b/tests/unit/cli/test_logging_setup.py
@@ -1,0 +1,76 @@
+"""Tests for the bridge between the saved logging level and structlog (#1955).
+
+The regression these guard: `ouroboros config set logging.level warning` wrote
+to the config file and reported success, but the CLI kept printing INFO records
+because the saved value never reached `configure_logging`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from ouroboros.cli import logging_setup
+
+
+def _stub_config(level: str) -> SimpleNamespace:
+    return SimpleNamespace(logging=SimpleNamespace(level=level))
+
+
+def test_saved_level_is_used_when_debug_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "ouroboros.config.load_config", lambda: _stub_config("warning"), raising=False
+    )
+
+    assert logging_setup.resolve_cli_log_level(debug=False) == "WARNING"
+
+
+@pytest.mark.parametrize("saved", ["debug", "info", "warning", "error"])
+def test_every_saved_level_survives_the_field_name_gap(
+    monkeypatch: pytest.MonkeyPatch, saved: str
+) -> None:
+    """`config.models.LoggingConfig.level` must reach `observability`'s `log_level`."""
+    monkeypatch.setattr("ouroboros.config.load_config", lambda: _stub_config(saved), raising=False)
+
+    assert logging_setup.resolve_cli_log_level(debug=False) == saved.upper()
+
+
+def test_debug_flag_overrides_the_saved_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--debug has to stay usable for reporting a problem, whatever is saved."""
+
+    def _fail() -> SimpleNamespace:  # pragma: no cover - must not be reached
+        raise AssertionError("--debug must not need to read the config file")
+
+    monkeypatch.setattr("ouroboros.config.load_config", _fail, raising=False)
+
+    assert logging_setup.resolve_cli_log_level(debug=True) == "DEBUG"
+
+
+def test_unreadable_config_falls_back_instead_of_failing_the_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Logging setup is not the user's goal; a broken config must not abort the run."""
+
+    def _raise() -> SimpleNamespace:
+        raise OSError("config file is not readable")
+
+    monkeypatch.setattr("ouroboros.config.load_config", _raise, raising=False)
+
+    assert logging_setup.resolve_cli_log_level(debug=False) == "INFO"
+
+
+def test_configure_passes_the_resolved_level_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ouroboros.config.load_config", lambda: _stub_config("error"), raising=False
+    )
+    seen: list[str] = []
+    monkeypatch.setattr(
+        logging_setup, "configure_logging", lambda config: seen.append(config.log_level)
+    )
+
+    logging_setup.configure_cli_logging(debug=False)
+
+    assert seen == ["ERROR"]

--- a/tests/unit/cli/test_logging_setup.py
+++ b/tests/unit/cli/test_logging_setup.py
@@ -7,11 +7,13 @@ because the saved value never reached `configure_logging`.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from ouroboros.cli import logging_setup
+from ouroboros.observability import LoggingConfig, LogMode
 
 
 def _stub_config(level: str) -> SimpleNamespace:
@@ -74,3 +76,74 @@ def test_configure_passes_the_resolved_level_through(
     logging_setup.configure_cli_logging(debug=False)
 
     assert seen == ["ERROR"]
+
+
+@pytest.mark.parametrize("debug", [False, True])
+def test_operator_prod_mode_survives_applying_a_level(
+    monkeypatch: pytest.MonkeyPatch, debug: bool
+) -> None:
+    """OUROBOROS_LOG_MODE is an operator override and must not be reset to dev.
+
+    Replacing the whole config with a fresh `LoggingConfig(log_level=...)` used
+    the default mode, so every `init`/`pm`/`run` invocation silently turned
+    production JSON logging back into human-readable output.
+    """
+    monkeypatch.setenv("OUROBOROS_LOG_MODE", "prod")
+    monkeypatch.setattr(
+        "ouroboros.config.load_config", lambda: _stub_config("warning"), raising=False
+    )
+    # A previous test may have left logging configured; the env default only
+    # applies when it has not been.
+    monkeypatch.setattr("ouroboros.observability.logging._current_config", None)
+    seen: list[LoggingConfig] = []
+    monkeypatch.setattr(logging_setup, "configure_logging", seen.append)
+
+    logging_setup.configure_cli_logging(debug=debug)
+
+    assert seen[0].mode is LogMode.PROD
+    assert seen[0].log_level == ("DEBUG" if debug else "WARNING")
+
+
+def test_only_the_level_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Everything the base config carries other than the level is preserved."""
+    monkeypatch.delenv("OUROBOROS_LOG_MODE", raising=False)
+    monkeypatch.setattr("ouroboros.observability.logging._current_config", None)
+    monkeypatch.setattr(
+        "ouroboros.config.load_config", lambda: _stub_config("warning"), raising=False
+    )
+    base = logging_setup.default_logging_config()
+    seen: list[LoggingConfig] = []
+    monkeypatch.setattr(logging_setup, "configure_logging", seen.append)
+
+    logging_setup.configure_cli_logging(debug=False)
+
+    assert seen[0].model_dump(exclude={"log_level"}) == base.model_dump(exclude={"log_level"})
+
+
+def test_run_command_applies_logging_before_importing_the_orchestrator(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`run` also takes --debug, and its orchestrator import auto-configures logging.
+
+    Whichever happens first wins, so the seam has to run before the import or the
+    saved level is ignored for the primary execution path (#1955 follow-up).
+    """
+    from ouroboros.cli.commands import run as run_cmd
+
+    order: list[str] = []
+    monkeypatch.setattr(
+        run_cmd, "configure_cli_logging", lambda *, debug: order.append(f"seam:{debug}")
+    )
+
+    def _fake_asyncio_run(coro: object) -> None:
+        coro.close()  # type: ignore[union-attr]
+        order.append("orchestrator")
+
+    monkeypatch.setattr(run_cmd.asyncio, "run", _fake_asyncio_run)
+
+    seed_file = tmp_path / "seed.yaml"
+    seed_file.write_text("goal: demo\n", encoding="utf-8")
+
+    run_cmd.workflow(seed_file=seed_file, orchestrator=True, debug=False)
+
+    assert order == ["seam:False", "orchestrator"]

--- a/tests/unit/cli/test_pm_interactive_logging.py
+++ b/tests/unit/cli/test_pm_interactive_logging.py
@@ -67,7 +67,9 @@ def test_pm_command_enables_debug_logging_when_requested() -> None:
 
     with (
         patch("ouroboros.cli.commands.pm.asyncio.run", side_effect=fake_run),
-        patch("ouroboros.cli.commands.pm.configure_logging") as mock_configure,
+        # pm now routes through the shared bridge (#1955), so patch the
+        # structlog call inside it and keep asserting the effective level.
+        patch("ouroboros.cli.logging_setup.configure_logging") as mock_configure,
         patch("ouroboros.cli.commands.pm.print_info") as mock_print_info,
     ):
         pm_command(_build_ctx(), model="test-model", debug=True)


### PR DESCRIPTION
## Summary

`ouroboros config set logging.level warning` reports success, writes to `~/.ouroboros/config.yaml`, and changes nothing about what the CLI prints. Every command keeps emitting INFO records.

## Cause

Two unrelated classes are both named `LoggingConfig`:

- `config/models.py` — `LoggingConfig.level`. This is the field `config set` writes and `config show` displays.
- `observability/logging.py` — `LoggingConfig.log_level`, which is what reaches `handler.setLevel(...)`.

Nothing bridged the two, and the CLI only called `configure_logging` behind `--debug`:

```python
if debug:
    configure_logging(LoggingConfig(log_level="DEBUG"))
```

Without `--debug` the logger kept the module default (INFO), so the saved level was never read. Same shape in `init.py` and `pm.py`.

## Changes

- New `src/ouroboros/cli/logging_setup.py` — the single seam between the two field names. `resolve_cli_log_level(debug=...)` returns `DEBUG` when the flag is set, otherwise the saved `logging.level`, upper-cased.
- `init.py` and `pm.py` now call `configure_cli_logging(debug=debug)` unconditionally instead of configuring only under `--debug`. The debug banner still prints only with the flag.
- `config` is imported lazily inside the resolver so the `--debug` path does not pay for a filesystem read.
- An unreadable config falls back to INFO rather than aborting the command. Logging setup is not what the user asked for, so it should not be able to take the run down.

## Why it goes through one helper

The two names drifted apart once already and nothing caught it. Routing every `--debug` entry point through one function means a future call site cannot reintroduce the gap by picking the wrong field name.

## Impact beyond the config key

These records go to **stdout**, not stderr, so they interleave with the interview UI and `2>/dev/null` does not clean them up. With this change, `logging.level: warning` gives a clean `ooo interview` session, which is what unblocks recording a terminal demo.

Routing the records to stderr is a larger behavioural change and is deliberately not in this PR.

## Test plan

- [x] New `tests/unit/cli/test_logging_setup.py` (8 cases): saved level is applied; every level survives the field-name gap (parametrized `debug`/`info`/`warning`/`error`); `--debug` overrides and does not read the config at all; unreadable config falls back to INFO; the resolved level reaches `configure_logging`.
- [x] `tests/unit/cli/test_pm_interactive_logging.py` updated to patch `configure_logging` inside the bridge, so it still asserts the effective level (`DEBUG`) rather than just the call.
- [x] `tests/unit/cli/test_logging_setup.py`, `test_pm_interactive_logging.py`, `tests/unit/observability/` — 160 passed.
- [x] `ruff check` and `ruff format --check` clean; `mypy` clean on the three touched modules.

Note on local runs: `tests/unit/cli/test_setup.py` has 21 failures on unmodified `main` on my machine, and `tests/unit/cli/test_status.py` is flaky here with sqlalchemy errors that vary run to run. Both reproduce without this change, so I left them alone and am relying on CI for the authoritative matrix.

Closes #1955
