### PR TITLE
fix(cli): apply persisted logging level at startup

### DIFF
--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -50,6 +50,14 @@ from ouroboros.cli.commands import (
 from ouroboros.cli.commands.plugin_dispatch import build_plugin_dispatch_command
 from ouroboros.cli.formatters import console
 from ouroboros.cli.streams import UnicodeSafeTyperGroup
+from ouroboros.config import load_config
+from ouroboros.core.errors import ConfigError
+from ouroboros.observability import (
+    LoggingConfig as RuntimeLoggingConfig,
+)
+from ouroboros.observability import (
+    configure_logging,
+)
 
 
 class _PluginAwareGroup(UnicodeSafeTyperGroup):
@@ -149,9 +157,24 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def _configure_cli_logging() -> None:
+    """Bridge the persisted CLI log level into the observability runtime."""
+    try:
+        log_level = load_config().logging.level.upper()
+    except ConfigError:
+        log_level = "INFO"
+
+    configure_logging(
+        RuntimeLoggingConfig(
+            log_level=log_level,
+            enable_file_logging=False,
+        )
+    )
+
+
 @app.callback()
 def main(
-    version: Annotated[
+    _version: Annotated[
         bool | None,
         typer.Option(
             "--version",
@@ -176,7 +199,7 @@ def main(
 
     Use [bold cyan]ouroboros COMMAND --help[/] for command-specific help.
     """
-    pass
+    _configure_cli_logging()
 
 
 __all__ = ["app", "main"]

--- a/tests/unit/cli/test_root_logging.py
+++ b/tests/unit/cli/test_root_logging.py
@@ -1,0 +1,147 @@
+"""Root CLI logging configuration regressions."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.cli.main import app, main
+from ouroboros.core.errors import ConfigError
+from ouroboros.observability.logging import (
+    LoggingConfig as RuntimeLoggingConfig,
+)
+from ouroboros.observability.logging import (
+    configure_logging,
+    get_current_config,
+    get_logger,
+    reset_logging,
+    set_console_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_state() -> Any:
+    """Keep process-global logging configuration isolated between CLI tests."""
+    reset_logging()
+    set_console_logging(True)
+    yield
+    reset_logging()
+    set_console_logging(True)
+
+
+def _persisted_config(level: str) -> SimpleNamespace:
+    return SimpleNamespace(logging=SimpleNamespace(level=level))
+
+
+def test_root_callback_filters_info_at_persisted_warning_level(capsys: Any) -> None:
+    """The saved config level must govern already-imported application loggers."""
+    with patch("ouroboros.cli.main.load_config", return_value=_persisted_config("warning")):
+        main()
+
+    config = get_current_config()
+    assert config is not None
+    assert config.log_level == "WARNING"
+    assert config.enable_file_logging is False
+
+    logger = get_logger("root-logging-test")
+    logger.info("root.info_should_be_filtered")
+    logger.warning("root.warning_should_remain")
+    captured = capsys.readouterr()
+
+    assert "root.info_should_be_filtered" not in captured.out + captured.err
+    assert "root.warning_should_remain" not in captured.out
+    assert "root.warning_should_remain" in captured.err
+
+
+def test_root_callback_defaults_to_info_when_config_is_missing() -> None:
+    """First-run and repair commands must survive a missing or invalid config."""
+    with patch(
+        "ouroboros.cli.main.load_config",
+        side_effect=ConfigError("configuration unavailable"),
+    ):
+        main()
+
+    config = get_current_config()
+    assert config is not None
+    assert config.log_level == "INFO"
+    assert config.enable_file_logging is False
+
+
+def test_pm_debug_flag_overrides_persisted_warning_level() -> None:
+    """Command-local debug configuration must run after the root callback."""
+
+    def fake_run(coro: object) -> None:
+        coro.close()  # type: ignore[union-attr]
+
+    def configure_debug_without_file(config: RuntimeLoggingConfig) -> None:
+        configure_logging(
+            RuntimeLoggingConfig(
+                log_level=config.log_level,
+                enable_file_logging=False,
+            )
+        )
+
+    with (
+        patch("ouroboros.cli.main.load_config", return_value=_persisted_config("warning")),
+        patch("ouroboros.cli.commands.pm.asyncio.run", side_effect=fake_run),
+        patch(
+            "ouroboros.cli.commands.pm.configure_logging",
+            side_effect=configure_debug_without_file,
+        ),
+    ):
+        result = CliRunner().invoke(app, ["pm", "--debug"])
+
+    assert result.exit_code == 0, result.output
+    config = get_current_config()
+    assert config is not None
+    assert config.log_level == "DEBUG"
+
+
+def test_cli_subprocess_filters_info_and_keeps_stdout_clean(tmp_path: Path) -> None:
+    """A real CLI process must apply warning before application logging begins."""
+    home = tmp_path / "home"
+    config_dir = home / ".ouroboros"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yaml").write_text(
+        "logging:\n  level: warning\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    repo_root = Path(__file__).parents[3]
+    env["PYTHONPATH"] = str(repo_root / "src")
+    script = """
+from ouroboros.cli.main import app
+from ouroboros.observability import get_logger
+
+app(args=["config", "show", "--json"], standalone_mode=False)
+logger = get_logger("issue1955-subprocess")
+logger.info("subprocess.info_should_be_filtered")
+logger.warning("subprocess.warning_should_remain")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    json.loads(result.stdout)
+    assert "subprocess.info_should_be_filtered" not in result.stdout + result.stderr
+    assert "subprocess.warning_should_remain" not in result.stdout
+    assert "subprocess.warning_should_remain" in result.stderr


### PR DESCRIPTION
## Summary

- Apply the persisted `logging.level` from `~/.ouroboros/config.yaml` during the central CLI root callback.
- Bridge the persisted config model to the observability runtime with an explicit `RuntimeLoggingConfig` alias, `enable_file_logging=False`, and an `INFO` fallback when configuration is missing or invalid.
- Preserve the existing stderr sink and later command-local `--debug` overrides while preventing configured `warning` and `error` levels from silently behaving as `info`.

## Changes

- Add a small root-startup logging bridge in `src/ouroboros/cli/main.py`.
- Add isolated unit, CLI, and real-subprocess regressions for:
  - persisted warning-level filtering;
  - structured logs staying off stdout;
  - missing-config fallback to INFO;
  - PM debug precedence after the root callback;
  - process-global logging reset between tests.

## Verification

Exact candidate:

- HEAD: `8b7a0891d7d52b7749f2c96715779fa54084c008`
- Tree: `4eda2e48b9b7d8a05e6f32140fd812c45f7d23ba`
- Base: `c6306afe78cb64925e905e8c96cf92f5603b3853`

Before/after subprocess reproduction with persisted `warning`:

- INFO marker on stderr: `true` → `false`
- warning marker on stderr: `true` → `true`
- stdout remains clean, parseable JSON: `true` → `true`

Primary verification:

- `204 passed` across root CLI, config subprocess, PM logging, and observability logging suites.
- Ruff check and format: passed.
- MyPy with cache disabled: passed.
- `git diff --check`: passed.

Independent read-only verification of the exact committed tree:

- `129 passed`.
- Independently confirmed WARNING filtering, clean stdout, missing-config INFO fallback, PM/init DEBUG precedence, and reset/reconfiguration behavior.
- Ruff, MyPy, diff integrity, ancestry, clean status, and no local environment/cache: passed.

## Notes

- No logging sink or stderr-routing implementation was changed.
- No PM snapshot code or tests were changed.
- File logging remains disabled for the root CLI bridge; existing command-local debug behavior remains a later override.

Closes #1955
