### PR TITLE
fix(dashboard): expose and repair picker degradation

### DIFF
--- a/src/ouroboros/dashboard_web/page.py
+++ b/src/ouroboros/dashboard_web/page.py
@@ -64,6 +64,12 @@ _PAGE_TEMPLATE = """<!doctype html>
   .run-status.cancelled { color:var(--cancelled); }
   .list-empty { color:var(--muted); border:1px dashed var(--border); border-radius:7px;
     padding:28px 16px; text-align:center; font-size:12px; }
+  .list-unavailable { color:var(--failed); border:1px solid var(--failed); border-radius:7px;
+    padding:22px 16px; text-align:center; font-size:12px; }
+  .list-unavailable p { color:var(--muted); margin:7px 0 14px; }
+  .retry-picker { color:var(--text); background:var(--panel); border:1px solid var(--border);
+    border-radius:5px; padding:6px 11px; font:inherit; cursor:pointer; }
+  .retry-picker:hover { border-color:#58a6ff; }
   #detail-view[hidden], #run-list[hidden] { display:none; }
   .col { background: var(--panel); border: 1px solid var(--border);
     border-radius: 8px; min-height: 120px; display:flex; flex-direction:column; }
@@ -246,6 +252,28 @@ function renderRuns(runs) {
     : '<div class="list-empty">waiting for run… (ooo run / ooo auto)</div>');
 }
 
+function renderPickerUnavailable() {
+  const list = document.getElementById("run-list");
+  list.innerHTML = `<div class="list-head"><h2>Recent runs</h2></div>
+    <div class="list-unavailable" role="alert">
+      <strong>Run picker temporarily unavailable</strong>
+      <p>The dashboard remains read-only. Ask the active writer to retry dashboard index setup, then retry this view.</p>
+      <button class="retry-picker" type="button">Retry now</button>
+    </div>`;
+  list.querySelector(".retry-picker").addEventListener("click", refreshRunList);
+}
+
+function renderRunListError() {
+  const list = document.getElementById("run-list");
+  list.innerHTML = `<div class="list-head"><h2>Recent runs</h2></div>
+    <div class="list-unavailable" role="alert">
+      <strong>Run list request failed</strong>
+      <p>Check the dashboard connection, then retry this view.</p>
+      <button class="retry-picker" type="button">Retry now</button>
+    </div>`;
+  list.querySelector(".retry-picker").addEventListener("click", refreshRunList);
+}
+
 __BOOTSTRAP__
 </script>
 </body>
@@ -256,6 +284,7 @@ __BOOTSTRAP__
 # shared SQLite file is cheap to observe even when several runs are concurrent.
 _LIVE_BOOTSTRAP = """
 const WAIT_POLL_MS = 3000;
+let runListRequest = 0;
 function connect(runId) {
   setView(true, runId);
   if (window.dashboardSource) window.dashboardSource.close();
@@ -268,14 +297,27 @@ function connect(runId) {
 }
 async function fetchRuns() {
   try {
-    return (await (await fetch("/api/runs", {cache:"no-store"})).json()).runs || [];
+    const response = await fetch("/api/runs", {cache:"no-store"});
+    const payload = await response.json();
+    if (response.status === 503 && payload.error === "picker_index_contract_unavailable")
+      return {state:"picker-unavailable", runs:[]};
+    if (!response.ok) throw new Error("run picker request failed");
+    return {state:"ready", runs:Array.isArray(payload.runs) ? payload.runs : []};
   } catch (_) {}
-  return [];
+  return {state:"network-error", runs:[]};
+}
+async function refreshRunList() {
+  const request = ++runListRequest;
+  const result = await fetchRuns();
+  if (request !== runListRequest) return;
+  if (result.state === "picker-unavailable") renderPickerUnavailable();
+  else if (result.state === "ready") renderRuns(result.runs);
+  else renderRunListError();
 }
 async function startList() {
   setView(false);
   while (!new URLSearchParams(location.search).get("run")) {
-    renderRuns(await fetchRuns());
+    await refreshRunList();
     await new Promise(r => setTimeout(r, WAIT_POLL_MS));
   }
 }

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -756,21 +756,15 @@ class EventStore:
     async def initialize(self, *, create_schema: bool | None = None) -> None:
         """Initialize the database connection and create tables if needed.
 
-        This method is idempotent - calling it multiple times is safe.
+        This idempotent method is also the in-process retry for deferred picker provisioning.
 
         Args:
             create_schema: When True run ``metadata.create_all`` so missing
-                tables are created. Read-only consumers (for example diagnostic
-                CLI commands that must not mutate the store) can pass ``False``
-                to skip schema creation entirely. When ``None`` (default), the
-                value follows ``read_only``: stores constructed with
-                ``read_only=True`` skip schema creation and all others create
-                it, preserving the prior default behaviour.
+                tables are created. Read-only consumers can pass ``False`` to
+                skip schema creation. When ``None``, writable stores create it.
 
-        For pathless and ``:memory:`` aiosqlite databases, backs the store with
-        SQLite's process-shared in-memory VFS (``memdb``): pooled connections
-        join one shared database with normal connection-scoped transactions,
-        and a keepalive connection anchors the database's lifetime.
+        Pathless and ``:memory:`` URLs use SQLite's process-shared ``memdb`` VFS;
+        a keepalive connection anchors their lifetime.
         """
         # Serialize with close; once work starts, settle it before surfacing cancellation.
         async with self._lifecycle_lock:
@@ -840,6 +834,12 @@ class EventStore:
             self._picker_projection_ready = await initialize_event_store_schema(
                 self._engine, logger
             )
+            # Drain writers admitted before readiness, then backfill any transition gap.
+            if self._picker_projection_ready and (writes := tuple(self._settling_writes)):
+                await asyncio.gather(*writes, return_exceptions=True)
+                self._picker_projection_ready = await initialize_event_store_schema(
+                    self._engine, logger
+                )
 
     async def append(
         self,

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -129,7 +129,7 @@ _AC_ACCEPTANCE_DISPOSITIONS = frozenset(
 async def _run_to_settlement[T](
     coro: Coroutine[Any, Any, T],
     *,
-    registry: set[asyncio.Task[Any]] | None = None,
+    registry: set[asyncio.Future[Any]] | None = None,
     refuse_when: Callable[[], bool] | None = None,
     operation: str = "append",
 ) -> T:
@@ -580,7 +580,7 @@ class EventStore:
         await store.close()
     """
 
-    _settling_writes: set[asyncio.Task[Any]]
+    _settling_writes: set[asyncio.Future[Any]]
 
     def __init__(
         self,

--- a/src/ouroboros/persistence/picker_index_provisioning.py
+++ b/src/ouroboros/persistence/picker_index_provisioning.py
@@ -271,7 +271,12 @@ async def provision_picker_indexes_best_effort(
                 await connection.commit()
                 return True
     except SQLAlchemyError as exc:
-        logger.warning("Dashboard picker projection provisioning deferred: %s", exc)
+        logger.warning(
+            "Dashboard picker projection provisioning deferred: %s; "
+            "the writer remains available and EventStore.initialize() can be called "
+            "again in-process to retry repair",
+            exc,
+        )
         return False
 
 

--- a/src/ouroboros/persistence/write_lifecycle.py
+++ b/src/ouroboros/persistence/write_lifecycle.py
@@ -12,28 +12,31 @@ from ouroboros.core.errors import PersistenceError
 async def run_with_write_lifecycle[T](
     coro: Coroutine[Any, Any, T],
     *,
-    registry: set[asyncio.Task[Any]],
+    registry: set[asyncio.Future[Any]],
     refuse_when: Callable[[], bool],
     operation: str,
 ) -> T:
-    """Keep a complete logical write registered across retries and backoff."""
+    """Keep a complete logical write registered across retries and backoff.
+
+    The registry entry is a completion token for this write, not the owning
+    task.  A caller commonly continues with another store operation after the
+    write returns; making its whole task the drain target lets initialize() or
+    close() wait on code that is itself waiting for that lifecycle operation.
+    The token settles in this wrapper's ``finally`` block, exactly at the
+    logical-write boundary, so drains cover retries without inheriting the
+    caller's unrelated lifetime.
+    """
     if refuse_when():
         coro.close()
         raise PersistenceError(
             "EventStore is closing; write refused.",
             operation=operation,
         )
-    task = asyncio.current_task()
-    if task is None:  # pragma: no cover - async functions always have a task here.
-        coro.close()
-        raise PersistenceError(
-            "EventStore write has no owning task.",
-            operation=operation,
-        )
-    already_registered = task in registry
-    registry.add(task)
+    completion = asyncio.get_running_loop().create_future()
+    registry.add(completion)
     try:
         return await coro
     finally:
-        if not already_registered:
-            registry.discard(task)
+        if not completion.done():
+            completion.set_result(None)
+        registry.discard(completion)

--- a/tests/unit/dashboard_web/page_runtime_harness.cjs
+++ b/tests/unit/dashboard_web/page_runtime_harness.cjs
@@ -1,0 +1,178 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const liveScript = fs.readFileSync(0, "utf8").replace(/\nstart\(\);\s*$/, "\n");
+assert.notEqual(liveScript.length, 0, "generated dashboard script was empty");
+
+let retryHandler = null;
+const runList = {
+  hidden: false,
+  innerHTML: "",
+  querySelector(selector) {
+    assert.equal(selector, ".retry-picker");
+    return {
+      addEventListener(event, handler) {
+        assert.equal(event, "click");
+        retryHandler = handler;
+      },
+    };
+  },
+};
+const elements = new Map([["run-list", runList]]);
+function element(id) {
+  if (!elements.has(id)) {
+    elements.set(id, { hidden: false, innerHTML: "", textContent: "" });
+  }
+  return elements.get(id);
+}
+
+const location = { search: "" };
+const scheduledDelays = [];
+const context = {
+  URLSearchParams,
+  console,
+  document: { getElementById: element },
+  fetch: async () => {
+    throw new Error("fetch response was not configured");
+  },
+  location,
+  setTimeout(callback, delay) {
+    scheduledDelays.push(delay);
+    location.search = "?run=stop-after-one-poll";
+    callback();
+    return 1;
+  },
+  window: {},
+};
+vm.createContext(context);
+vm.runInContext(
+  `${liveScript}\n` +
+    "globalThis.__dashboardTestHooks = {" +
+    "fetchRuns, refreshRunList, startList, waitPollMs: WAIT_POLL_MS};",
+  context,
+  { filename: "generated-dashboard-page.js" },
+);
+
+const hooks = context.__dashboardTestHooks;
+assert.ok(hooks, "dashboard test hooks were not exported from the generated script");
+
+function response(status, payload, { malformed = false } = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async json() {
+      if (malformed) throw new SyntaxError("malformed JSON");
+      return payload;
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function assertRequestError(responseFactory, label) {
+  context.fetch = async () => responseFactory();
+  const result = await hooks.fetchRuns();
+  assert.equal(result.state, "network-error", `${label} classification`);
+  await hooks.refreshRunList();
+  assert.match(runList.innerHTML, /Run list request failed/, `${label} visible error`);
+  assert.doesNotMatch(runList.innerHTML, /waiting for run/, `${label} is not empty success`);
+  assert.doesNotMatch(
+    runList.innerHTML,
+    /Run picker temporarily unavailable/,
+    `${label} is not the exact picker contract`,
+  );
+}
+
+async function main() {
+  context.fetch = async () =>
+    response(503, { runs: [], error: "picker_index_contract_unavailable" });
+  const unavailable = await hooks.fetchRuns();
+  assert.equal(unavailable.state, "picker-unavailable");
+  assert.equal(unavailable.runs.length, 0);
+  await hooks.refreshRunList();
+  assert.match(runList.innerHTML, /Run picker temporarily unavailable/);
+  assert.match(runList.innerHTML, /role="alert"/);
+  assert.doesNotMatch(runList.innerHTML, /waiting for run/);
+  assert.equal(typeof retryHandler, "function", "picker alert must bind manual retry");
+
+  context.fetch = async () => response(200, { runs: [] });
+  const empty = await hooks.fetchRuns();
+  assert.equal(empty.state, "ready");
+  assert.equal(empty.runs.length, 0);
+  await retryHandler();
+  assert.match(runList.innerHTML, /waiting for run/);
+  assert.doesNotMatch(runList.innerHTML, /temporarily unavailable/);
+
+  await assertRequestError(() => response(500, { error: "internal" }), "generic HTTP 500");
+  await assertRequestError(
+    () => response(503, null, { malformed: true }),
+    "malformed JSON 503",
+  );
+  await assertRequestError(
+    () => response(200, null, { malformed: true }),
+    "malformed JSON 200",
+  );
+  assert.equal(typeof retryHandler, "function", "generic alert must bind manual retry");
+  context.fetch = async () => response(200, { runs: [] });
+  await retryHandler();
+  assert.match(runList.innerHTML, /waiting for run/);
+
+  const olderUnavailable = deferred();
+  const newerReady = deferred();
+  let requestCount = 0;
+  context.fetch = () => (requestCount++ === 0 ? olderUnavailable.promise : newerReady.promise);
+  const oldRefresh = hooks.refreshRunList();
+  const newRefresh = hooks.refreshRunList();
+  newerReady.resolve(response(200, { runs: [] }));
+  await newRefresh;
+  assert.match(runList.innerHTML, /waiting for run/);
+  const newestReadyHtml = runList.innerHTML;
+  olderUnavailable.resolve(
+    response(503, { runs: [], error: "picker_index_contract_unavailable" }),
+  );
+  await oldRefresh;
+  assert.equal(runList.innerHTML, newestReadyHtml, "stale 503 overwrote newer empty success");
+
+  const olderReady = deferred();
+  const newerUnavailable = deferred();
+  requestCount = 0;
+  context.fetch = () => (requestCount++ === 0 ? olderReady.promise : newerUnavailable.promise);
+  const oldReadyRefresh = hooks.refreshRunList();
+  const newUnavailableRefresh = hooks.refreshRunList();
+  newerUnavailable.resolve(
+    response(503, { runs: [], error: "picker_index_contract_unavailable" }),
+  );
+  await newUnavailableRefresh;
+  assert.match(runList.innerHTML, /Run picker temporarily unavailable/);
+  const newestUnavailableHtml = runList.innerHTML;
+  olderReady.resolve(response(200, { runs: [] }));
+  await oldReadyRefresh;
+  assert.equal(
+    runList.innerHTML,
+    newestUnavailableHtml,
+    "stale empty success overwrote newer picker unavailability",
+  );
+
+  location.search = "";
+  scheduledDelays.length = 0;
+  context.fetch = async () => response(200, { runs: [] });
+  await hooks.startList();
+  assert.equal(hooks.waitPollMs, 3000);
+  assert.deepEqual(scheduledDelays, [3000], "list polling must stay interval-gated at 3s");
+}
+
+main()
+  .then(() => process.stdout.write("dashboard browser state machine: PASS\n"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/tests/unit/dashboard_web/test_page.py
+++ b/tests/unit/dashboard_web/test_page.py
@@ -57,6 +57,21 @@ class TestLivePage:
         assert "status-paused" in INDEX_HTML
         assert "run-status.paused" in INDEX_HTML
 
+    def test_index_html_distinguishes_picker_503_and_offers_retry(self) -> None:
+        assert "response.status === 503" in INDEX_HTML
+        assert 'payload.error === "picker_index_contract_unavailable"' in INDEX_HTML
+        assert 'state:"picker-unavailable"' in INDEX_HTML
+        assert "Run picker temporarily unavailable" in INDEX_HTML
+        assert "The dashboard remains read-only" in INDEX_HTML
+        assert "Retry now" in INDEX_HTML
+        assert 'role="alert"' in INDEX_HTML
+        assert 'addEventListener("click", refreshRunList)' in INDEX_HTML
+        assert "Run list request failed" in INDEX_HTML
+        assert "request !== runListRequest" in INDEX_HTML
+        # The unavailable state remains in the interval-gated list loop; it is
+        # neither collapsed into the empty-run state nor allowed to spin hot.
+        assert "await refreshRunList()" in INDEX_HTML
+
 
 class TestStaticSnapshot:
     def test_static_html_is_self_contained_and_sse_free(self) -> None:

--- a/tests/unit/dashboard_web/test_page_javascript.py
+++ b/tests/unit/dashboard_web/test_page_javascript.py
@@ -1,0 +1,37 @@
+"""Executable browser-state regression for the generated dashboard page."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+from ouroboros.dashboard_web.page import INDEX_HTML
+
+
+def _live_script() -> str:
+    _head, marker, tail = INDEX_HTML.partition("<script>")
+    assert marker, "dashboard page has no script element"
+    script, marker, _foot = tail.partition("</script>")
+    assert marker, "dashboard page script is not terminated"
+    return script
+
+
+def test_generated_page_executes_picker_state_machine_in_node_vm() -> None:
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required for the dashboard browser contract regression"
+    harness = Path(__file__).with_name("page_runtime_harness.cjs")
+    completed = subprocess.run(
+        [node, str(harness)],
+        input=_live_script(),
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        "generated dashboard JavaScript behavior failed\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    assert completed.stdout.strip() == "dashboard browser state machine: PASS"

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -2299,7 +2299,7 @@ class TestJobManager:
             )
 
             recovery_lock.release()
-            snapshot = await snapshot_task
+            snapshot = await asyncio.wait_for(snapshot_task, timeout=5.0)
 
             assert snapshot.status is JobStatus.CANCEL_REQUESTED
             events, _ = await store.get_events_after(

--- a/tests/unit/mcp/tools/test_run_evaluate_chaining.py
+++ b/tests/unit/mcp/tools/test_run_evaluate_chaining.py
@@ -44,7 +44,7 @@ async def _wait_terminal(job_manager: JobManager, job_id: str) -> JobSnapshot:
     # locally); 60s gives ample headroom without weakening the assertion.
     deadline = time.monotonic() + 60.0
     while time.monotonic() < deadline:
-        snapshot = await job_manager.get_snapshot(job_id)
+        snapshot = await asyncio.wait_for(job_manager.get_snapshot(job_id), timeout=5.0)
         if snapshot.is_terminal:
             return snapshot
         task = job_manager._tasks.get(job_id)

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -3038,6 +3038,51 @@ class TestCancellationSettlement:
         await reopened.close()
 
     @pytest.mark.asyncio
+    async def test_close_drains_write_without_waiting_for_owner_task_lifetime(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A writer may await close after its write-specific work has settled."""
+        from ouroboros.persistence import event_store as event_store_module
+
+        db_path = tmp_path / "settle-close-owner-cycle.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        write_settled = asyncio.Event()
+        original_insert = event_store_module._insert_event
+        close_task: asyncio.Task[None] | None = None
+
+        async def gated_insert(connection, event, projection_ready):  # noqa: ANN001, ANN202
+            entered.set()
+            await release.wait()
+            return await original_insert(connection, event, projection_ready)
+
+        async def write_then_join_close() -> None:
+            await store.append(_make_event(aggregate_id="close-owner-cycle"))
+            write_settled.set()
+            assert close_task is not None
+            await close_task
+
+        monkeypatch.setattr(event_store_module, "_insert_event", gated_insert)
+        writer_task = asyncio.create_task(write_then_join_close())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        close_task = asyncio.create_task(store.close())
+        await asyncio.sleep(0)
+
+        release.set()
+        await asyncio.wait_for(write_settled.wait(), timeout=5)
+        await asyncio.wait_for(close_task, timeout=5)
+        await asyncio.wait_for(writer_task, timeout=5)
+
+        monkeypatch.setattr(event_store_module, "_insert_event", original_insert)
+        reopened = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await reopened.initialize()
+        assert len(await reopened.replay("test", "close-owner-cycle")) == 1
+        await reopened.close()
+
+    @pytest.mark.asyncio
     async def test_close_waits_for_settling_batch(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/unit/persistence/test_picker_indexes.py
+++ b/tests/unit/persistence/test_picker_indexes.py
@@ -749,6 +749,156 @@ async def test_projection_failure_does_not_block_writer(
     assert "projection provisioning deferred" in caplog.text.lower()
 
 
+async def test_repeated_initialize_repairs_transient_projection_failure_in_process(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    from ouroboros.persistence import event_store as event_store_module
+    from ouroboros.persistence import picker_index_provisioning as provisioning_module
+
+    original_provision = provisioning_module.provision_picker_indexes
+    attempts = 0
+
+    def fail_once(connection) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OperationalError(
+                "CREATE INDEX",
+                {},
+                sqlite3.OperationalError("database is locked"),
+            )
+        original_provision(connection)
+
+    monkeypatch.setattr(provisioning_module, "provision_picker_indexes", fail_once)
+    caplog.set_level(logging.WARNING, logger=event_store_module.__name__)
+    db = tmp_path / "transient-repair.db"
+    store = EventStore(f"sqlite+aiosqlite:///{db}")
+
+    await store.initialize()
+    assert store._picker_projection_ready is False
+    deferred = BaseEvent(
+        type="orchestrator.session.started",
+        aggregate_type="session",
+        aggregate_id="orch-deferred",
+        data={"execution_id": "exec-deferred"},
+    )
+    await store.append(deferred)
+    assert [event.id for event in await store.replay("session", "orch-deferred")] == [deferred.id]
+
+    # Same store, engine, and process: no close/restart is needed. The repair
+    # transaction backfills the event accepted while projection was deferred.
+    await store.initialize()
+    assert store._picker_projection_ready is True
+    assert attempts == 2
+    assert list_recent_executions(db)[0]["execution_id"] == "exec-deferred"
+
+    projected = BaseEvent(
+        type="orchestrator.session.started",
+        aggregate_type="session",
+        aggregate_id="orch-projected",
+        data={"execution_id": "exec-projected"},
+    )
+    await store.append(projected)
+    await store.close()
+
+    conn = sqlite3.connect(db)
+    try:
+        assert conn.execute(
+            f"SELECT execution_id, session_id FROM {PICKER_START_TABLE} ORDER BY event_rowid"
+        ).fetchall() == [
+            ("exec-deferred", "orch-deferred"),
+            ("exec-projected", "orch-projected"),
+        ]
+        assert conn.execute(
+            "SELECT COUNT(*) FROM events "
+            "WHERE event_type = 'orchestrator.session.started' "
+            f"AND picker_projection_version = {PICKER_PROJECTION_VERSION}"
+        ).fetchone() == (2,)
+    finally:
+        conn.close()
+    assert "eventstore.initialize() can be called again in-process" in caplog.text.lower()
+
+
+async def test_projection_repair_drains_stale_writes_before_final_backfill(
+    tmp_path, monkeypatch
+) -> None:
+    from ouroboros.persistence import event_store as event_store_module
+    from ouroboros.persistence import picker_index_provisioning as provisioning_module
+
+    original_insert = event_store_module._insert_event
+    original_provision = provisioning_module.provision_picker_indexes
+    append_entered = asyncio.Event()
+    release_append = asyncio.Event()
+    first_repair_finished = asyncio.Event()
+    captured_readiness: list[bool] = []
+    attempts = 0
+
+    def fail_once_then_signal(connection) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OperationalError(
+                "CREATE INDEX",
+                {},
+                sqlite3.OperationalError("database is locked"),
+            )
+        original_provision(connection)
+        if attempts == 2:
+            first_repair_finished.set()
+
+    async def pause_stale_insert(connection, event, projection_ready):
+        if event.aggregate_id == "exec-race":
+            captured_readiness.append(projection_ready)
+            append_entered.set()
+            await release_append.wait()
+        return await original_insert(connection, event, projection_ready)
+
+    monkeypatch.setattr(provisioning_module, "provision_picker_indexes", fail_once_then_signal)
+    monkeypatch.setattr(event_store_module, "_insert_event", pause_stale_insert)
+    db = tmp_path / "repair-write-race.db"
+    store = EventStore(f"sqlite+aiosqlite:///{db}")
+    await store.initialize()
+    assert store._picker_projection_ready is False
+
+    event = BaseEvent(
+        type="workflow.progress.updated",
+        aggregate_type="workflow",
+        aggregate_id="exec-race",
+        data={"execution_id": "exec-race", "runtime_status": "running"},
+    )
+    append_task = asyncio.create_task(store.append(event))
+    await asyncio.wait_for(append_entered.wait(), timeout=5)
+    repair_task = asyncio.create_task(store.initialize())
+    await asyncio.wait_for(first_repair_finished.wait(), timeout=5)
+    await asyncio.sleep(0)
+    assert not repair_task.done(), "repair returned before the stale write settled"
+
+    release_append.set()
+    await asyncio.wait_for(append_task, timeout=5)
+    await asyncio.wait_for(repair_task, timeout=5)
+    assert captured_readiness == [False]
+    assert attempts == 3
+    assert store._picker_projection_ready is True
+    assert list_recent_executions(db) == []
+    await store.close()
+
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT rowid, picker_projection_version FROM events WHERE id = ?",
+            (event.id,),
+        ).fetchone()
+        assert row is not None
+        assert row[1] == PICKER_PROJECTION_VERSION
+        assert conn.execute(
+            f"SELECT latest_valid_rowid FROM {PICKER_PROGRESS_TABLE} "
+            "WHERE aggregate_id = ? AND event_type = ?",
+            (event.aggregate_id, event.type),
+        ).fetchone() == (row[0],)
+    finally:
+        conn.close()
+
+
 async def test_relevant_append_survives_deferred_repair_of_malformed_meta(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -350,12 +350,12 @@ async def test_start_evolve_links_generation_selected_after_interleaving(
         release_generation.set()
 
         job_id = started.value.meta["job_id"]
-        snapshot = await manager.get_snapshot(job_id)
+        snapshot = await asyncio.wait_for(manager.get_snapshot(job_id), timeout=5.0)
         for _ in range(100):
             if snapshot.is_terminal:
                 break
             await asyncio.sleep(0.01)
-            snapshot = await manager.get_snapshot(job_id)
+            snapshot = await asyncio.wait_for(manager.get_snapshot(job_id), timeout=5.0)
         assert snapshot.status == JobStatus.COMPLETED
         assert snapshot.links.execution_id == expected
         assert loop._run_generation.call_args.kwargs["generation_number"] == 2
@@ -709,7 +709,7 @@ async def test_start_evolve_postacceptance_cancellation_preserves_claim_owner(
         assert not runner_task.cancelled()
         assert not runner_task.done()
         assert not job_task.cancelled()
-        snapshot = await manager.get_snapshot(job_id)
+        snapshot = await asyncio.wait_for(manager.get_snapshot(job_id), timeout=5.0)
         assert snapshot.links.execution_id == expected_execution_id
 
         job_events, _ = await store.get_events_after("job", job_id, last_row_id=0)
@@ -718,7 +718,7 @@ async def test_start_evolve_postacceptance_cancellation_preserves_claim_owner(
 
         release_work.set()
         await asyncio.wait_for(asyncio.shield(job_task), timeout=1.0)
-        completed = await manager.get_snapshot(job_id)
+        completed = await asyncio.wait_for(manager.get_snapshot(job_id), timeout=5.0)
         assert completed.status == JobStatus.COMPLETED
         assert completed.links.execution_id == expected_execution_id
         assert not claim_cancelled.is_set()


### PR DESCRIPTION
## Summary

- Render the exact `picker_index_contract_unavailable` JSON `503` as a visible, actionable browser alert while preserving distinct empty, generic-error, retry, polling, and stale-response states.
- Retry deferred picker provisioning on the same live writable `EventStore`, drain writes admitted with stale projection readiness, and perform a final transactional backfill before reporting ready.
- Execute the generated production browser script in a committed Node VM regression.
- Replace owner-task lifecycle draining with dedicated logical-write completion tokens so initialize/repair and close wait for write settlement, including retries/backoff, without inheriting the caller task's unrelated lifetime.

Closes #1947.

## Direction and boundaries

The dashboard remains read-only. `/api/runs` has no repair endpoint, SQLite readers remain `mode=ro`, exact projection-contract drift/gaps fail closed as JSON `503`, and no unbounded fallback scan or duplicate projection index is added.

The browser recognizes only the exact picker JSON `503` as contract unavailability. Successful empty `200`, generic HTTP/JSON failure, retry recovery, the 3-second poll cadence, and both stale-response orderings are executed against the real generated `INDEX_HTML` script in `node:vm`.

Repeated writable `EventStore.initialize()` remains the in-process repair trigger. A first successful provisioning pass publishes readiness, writers already admitted with stale `False` are settled, and a final provisioning transaction backfills any transition gap.

## CI timeout diagnosis and accepted correction

Official exact-head review [4891356763](https://github.com/Q00/ouroboros/pull/1963#pullrequestreview-4891356763) approved previous HEAD `c28063080015196094d2ad4dc728d3c615d95786`, but the same-SHA protected test run [31312591559](https://github.com/Q00/ouroboros/actions/runs/31312591559) then timed out on Python 3.12, 3.13, and 3.14. That approval therefore did not establish merge safety.

The timeout was deterministic, not infrastructure:

- all three jobs shared the unfinished cancellation-race test `test_completed_execution_recovery_does_not_beat_concurrent_cancel_request`;
- the remaining unfinished evolve/chaining cases also hung individually on the exact commit;
- the earlier parent run `31311203253` timed out identically;
- the comparator green run `31312542469` passed the same four tests immediately;
- picker performance, EventStore cancellation settlement, stubborn agent-process, detached-worker, PM snapshot/lock, and wheel tests all completed, excluding those cross-resource theories.

The regression came from gathering `_settling_writes` during repair while that registry mixed two authorities: transaction tasks and the entire owning caller task. The exact cycle was:

`initialize → owning append caller → snapshot/recovery → initialize`

The repair now registers a dedicated completion `Future` at logical-write admission and resolves it in the write wrapper's `finally` block. That token spans the full write coroutine, including retry/backoff, but ends before the caller proceeds to unrelated work. Transactional inner tasks remain separately registered by the existing cancellation-settlement primitive. Consequently:

- repair drains stale-readiness logical writes and transaction settlement before the final backfill;
- close drains the same write-specific boundaries;
- neither operation waits for owner-task lifetime;
- post-write callers may await initialize or close without a dependency cycle;
- close admission fencing and cancellation settlement remain intact.

A new direct close-owner-cycle regression accompanies bounded versions of the four CI hang cases.

## Exact candidate

- HEAD: `6b95f49be70393e2c8bc6f6d93def98ec00efb97`
- Tree: `1e5bf83271549a00d912c1e60f00be9c67fba083`
- Protected main integrated: `4d8f2e6a0ddfd591794c2b46bf26261e235eebf3`
- Full PR diff SHA-256: `14c02b8d19dc1884714ff08771f06cb2d9148eded02a870606ee9318d62c3706`
- Deadlock-fix commit diff SHA-256: `cbdfec4519bd2fe237fd5f5c2a410ebaa5fbcf8d0b543cacfbcc8b44d2bf89db`

## Independent verification

Fresh exact-head adversarial verifier: **PASS, zero blockers**.

- Complete EventStore + picker suite: `229 passed`.
- JobManager + evolve + run/evaluate chaining suite: `229 passed`.
- Changed dashboard executable cases: `10 passed`.
- Critical close-owner-cycle, stale-writer drain, recovery/cancellation, and evolve cancellation repeated three times: `12 passed`.
- Isolated telemetry performance budget: PASS.
- Custom concurrency probe: 12 simultaneous writes created 24 unique logical-token/transaction entries; initialize waited for settlement, all registry entries drained, and no token leaked.
- Custom dependency-cycle probe: ten same-task append→initialize sequences plus close completed without deadlock.
- Ruff, format, MyPy, module-size, Node syntax, diff-check, exact ancestry, and clean status: PASS.

The local worker additionally ran the five directly affected tests (`5 passed`), the relevant JobManager/evolve/chaining/lineage set (`253 passed`), and the complete persistence/picker set sequentially (`229 passed`).

## Merge gate

Do not merge from the previous approval. Merge remains frozen until:

1. all required protected CI checks are green on exact remote HEAD `6b95f49be70393e2c8bc6f6d93def98ec00efb97`, including Python 3.12/3.13/3.14;
2. current protected main remains an ancestor;
3. no active human `CHANGES_REQUESTED` applies; and
4. a fresh detailed `ouroboros-agent[bot]` approval binds the review API `commit_id`, body `HEAD checked`, and `Review-Metadata head_sha` to this exact SHA, reports zero blockers, and explicitly recommends merge.
