### PR TITLE
fix(setup): pin a Python floor on every generated uvx launcher

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -3,6 +3,8 @@
     "ouroboros": {
       "command": "uvx",
       "args": [
+        "--python",
+        ">=3.12",
         "--from",
         "ouroboros-ai[mcp]",
         "ouroboros",

--- a/.claude-plugin/skills/brownfield/SKILL.md
+++ b/.claude-plugin/skills/brownfield/SKILL.md
@@ -210,7 +210,7 @@ directly. Run it explicitly when:
 **Implementation:** invoke the CLI via Bash.
 
 ```
-uvx --from ouroboros-ai ouroboros detect [path]
+uvx --python '>=3.12' --from ouroboros-ai ouroboros detect [path]
 # or, if already installed:
 ouroboros detect [path] [--force]
 ```

--- a/.claude-plugin/skills/config/SKILL.md
+++ b/.claude-plugin/skills/config/SKILL.md
@@ -31,7 +31,7 @@ question: **can the user open a browser pointed at this machine?**
    if command -v ouroboros >/dev/null 2>&1; then
      ouroboros config
    else
-     uvx --from 'ouroboros-ai[tui]' ouroboros config
+     uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros config
    fi
    ```
 

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -175,7 +175,7 @@ Then re-run: ooo setup
 **IMPORTANT**: Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or `[all,mcp]`
 together and never write a direct
 `ouroboros` or `python -m ouroboros` MCP fallback. MCP 2 launchers must use an
-isolated `uvx --from 'ouroboros-ai[mcp]' ...` or
+isolated `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
 `pipx run --spec 'ouroboros-ai[mcp]' ...` process. Only `[mcp,claude-cli]` is
 supported because the CLI worker is out of process. Do not write
 an Ouroboros entry to `~/.claude/mcp.json`; the plugin owns that registration.

--- a/.claude-plugin/skills/welcome/SKILL.md
+++ b/.claude-plugin/skills/welcome/SKILL.md
@@ -532,7 +532,7 @@ Just include these naturally in your request:
 
 REAL-TIME MONITORING (TUI):
 When running ooo run or ooo evolve, open a separate terminal:
-  uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor
+  uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros tui monitor
 Press 1-4 to switch screens (Dashboard, Execution, Logs, Debug).
 
 READY TO BUILD:

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,8 @@
 [mcp_servers.ouroboros]
 command = "uvx"
 args = [
+    "--python",
+    ">=3.12",
     "--from",
     "ouroboros-ai[mcp]",
     "ouroboros",

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,8 @@
     "ouroboros": {
       "command": "uvx",
       "args": [
+        "--python",
+        ">=3.12",
         "--from",
         "ouroboros-ai[mcp]",
         "ouroboros",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -685,13 +685,13 @@ if [ -t 0 ] && [ -z "${OUROBOROS_INSTALL_SKIP_CONFIG_GUI:-}" ]; then
         # The selected extras may not include [tui]; run the GUI from an
         # ephemeral env with the tui extra instead of fattening the install.
         _info "Settings GUI needs the tui extra; running it via uvx..."
-        if uvx --from "${PACKAGE_NAME}[tui]" ouroboros config; then
+        if uvx --python "$DEFAULT_PYTHON_SPEC" --from "${PACKAGE_NAME}[tui]" ouroboros config; then
           GUI_OK=true
         fi
       fi
       if [ "$GUI_OK" = false ]; then
         _warn "Could not open the settings GUI."
-        _info "Run it later with: uvx --from '${PACKAGE_NAME}[tui]' ouroboros config"
+        _info "Run it later with: uvx --python '>=3.12' --from '${PACKAGE_NAME}[tui]' ouroboros config"
       fi
       ;;
     *)

--- a/skills/brownfield/SKILL.md
+++ b/skills/brownfield/SKILL.md
@@ -217,7 +217,7 @@ directly. Run it explicitly when:
 **Implementation:** invoke the CLI via Bash.
 
 ```
-uvx --from ouroboros-ai ouroboros detect [path]
+uvx --python '>=3.12' --from ouroboros-ai ouroboros detect [path]
 # or, if already installed:
 ouroboros detect [path] [--force]
 ```

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -31,7 +31,7 @@ question: **can the user open a browser pointed at this machine?**
    if command -v ouroboros >/dev/null 2>&1; then
      ouroboros config
    else
-     uvx --from 'ouroboros-ai[tui]' ouroboros config
+     uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros config
    fi
    ```
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -175,7 +175,7 @@ Then re-run: ooo setup
 **IMPORTANT**: Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or `[all,mcp]`
 together and never write a direct
 `ouroboros` or `python -m ouroboros` MCP fallback. MCP 2 launchers must use an
-isolated `uvx --from 'ouroboros-ai[mcp]' ...` or
+isolated `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
 `pipx run --spec 'ouroboros-ai[mcp]' ...` process. Only `[mcp,claude-cli]` is
 supported because the CLI worker is out of process. Do not write
 an Ouroboros entry to `~/.claude/mcp.json`; the plugin owns that registration.

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -694,7 +694,7 @@ runtime. For a Korean conversation, use:
 - **설정하고 시작하기**: Run the setup command for the active host. In Codex
   App or Codex CLI, use `ouroboros setup --runtime codex` when the executable
   is installed. For a Marketplace-plugin-only install, use
-  `uvx --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex` instead.
+  `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex` instead.
   In Claude Code, follow `../setup/SKILL.md`. Do not ask the user to copy a
   command when the current host can run it.
 - **나중에**: Continue with the welcome flow, but do not claim that MCP-only
@@ -960,7 +960,7 @@ Just include these naturally in your request:
 
 REAL-TIME MONITORING (TUI):
 When running ooo run or ooo evolve, open a separate terminal:
-  uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor
+  uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros tui monitor
 Press 1-4 to switch screens (Dashboard, Execution, Logs, Debug).
 
 READY TO BUILD:

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -1018,7 +1018,7 @@ def serve(
         _stderr_console.print(f"[red]MCP dependencies not installed: {e}[/red]")
         _stderr_console.print(
             "[blue]Run MCP 2 in an isolated profile:\n"
-            "  uvx --from 'ouroboros-ai\\[mcp]' ouroboros mcp serve "
+            "  uvx --python '>=3.12' --from 'ouroboros-ai\\[mcp]' ouroboros mcp serve "
             "--runtime claude-cli\n"
             "or:\n"
             "  pipx run --spec 'ouroboros-ai\\[mcp]' ouroboros mcp serve "

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -121,7 +121,7 @@ def check_mcp_import() -> CheckResult:
             message="mcp package not importable",
             remediation=(
                 "Run the server in its isolated profile: "
-                "uvx --from 'ouroboros-ai[mcp]' ouroboros mcp serve"
+                "uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros mcp serve"
             ),
         )
 
@@ -145,8 +145,8 @@ def check_mcp_import() -> CheckResult:
             message=f"mcp {version} is not the required MCP 2 runtime",
             remediation=(
                 "Do not add MCP 2 to the Claude SDK environment. Launch the "
-                "separate server process with: uvx --from 'ouroboros-ai[mcp]' "
-                "ouroboros mcp serve"
+                "separate server process with: uvx --python '>=3.12' --from "
+                "'ouroboros-ai[mcp]' ouroboros mcp serve"
             ),
         )
     return CheckResult(

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -87,6 +87,7 @@ from ouroboros.config._model_defaults import (
 from ouroboros.core.errors import ConfigError
 from ouroboros.package_profiles import (
     UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE,
+    UVX_PYTHON_FLOOR,
     has_unsupported_claude_sdk_mcp_mix,
 )
 from ouroboros.persistence.brownfield import BrownfieldStore
@@ -105,7 +106,7 @@ class _SetupCodexCliLogger:
 
 def _build_uvx_mcp_args(package_spec: str) -> list[str]:
     """Return the canonical uvx args for the requested Ouroboros package spec."""
-    return ["--from", package_spec, "ouroboros", "mcp", "serve"]
+    return ["--python", UVX_PYTHON_FLOOR, "--from", package_spec, "ouroboros", "mcp", "serve"]
 
 
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
@@ -434,9 +435,18 @@ _CODEX_MCP_COMMENT_LINES = (
 
 CodexMcpMode = Literal["auto", "preserve", "stdio"]
 _CODEX_APP_CLI_PATH = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
-_CODEX_UVX_MCP_ARGS = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]
+_CODEX_UVX_MCP_ARGS = [
+    "--python",
+    UVX_PYTHON_FLOOR,
+    "--from",
+    "ouroboros-ai[mcp]",
+    "ouroboros",
+    "mcp",
+    "serve",
+]
 _CODEX_LEGACY_UVX_MCP_ARGS: tuple[tuple[str, ...], ...] = (
     tuple(_CODEX_UVX_MCP_ARGS),
+    ("--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
     ("--from", "ouroboros-ai", "ouroboros", "mcp", "serve"),
     ("ouroboros", "mcp", "serve"),
 )
@@ -4042,7 +4052,18 @@ def _detect_opencode_mcp_command() -> dict[str, list[str]] | None:
     stale global binary and a newer uvx install use the newer one.
     """
     if shutil.which("uvx"):
-        return {"command": ["uvx", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]}
+        return {
+            "command": [
+                "uvx",
+                "--python",
+                UVX_PYTHON_FLOOR,
+                "--from",
+                "ouroboros-ai[mcp]",
+                "ouroboros",
+                "mcp",
+                "serve",
+            ]
+        }
     if shutil.which("pipx"):
         return {
             "command": [

--- a/src/ouroboros/cli/commands/tui.py
+++ b/src/ouroboros/cli/commands/tui.py
@@ -18,6 +18,7 @@ import typer
 
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
 from ouroboros.config.models import resolve_event_store_path
+from ouroboros.package_profiles import UVX_PYTHON_FLOOR
 from ouroboros.persistence.event_store import EventStore, sqlite_database_url
 
 app = typer.Typer(
@@ -82,7 +83,7 @@ def monitor_command(
             "Install with:\n"
             "  pip install 'ouroboros-ai[tui]'\n\n"
             "Or run directly with uvx:\n"
-            "  uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor",
+            "  uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros tui monitor",
         )
         raise typer.Exit(1) from e
 
@@ -214,6 +215,8 @@ def _monitor_argv(db_path: Path) -> list[str]:
         return [entrypoint, "tui", "monitor", "--db-path", str(db_path)]
     return [
         "uvx",
+        "--python",
+        UVX_PYTHON_FLOOR,
         "--from",
         "ouroboros-ai[tui]",
         "ouroboros",

--- a/src/ouroboros/config_tui/launcher.py
+++ b/src/ouroboros/config_tui/launcher.py
@@ -26,7 +26,7 @@ _TUI_INSTALL_HINT = (
     "Install with:\n"
     "  pip install 'ouroboros-ai\\[tui]'\n\n"
     "Or run directly with uvx:\n"
-    "  uvx --from 'ouroboros-ai\\[tui]' ouroboros config"
+    "  uvx --python '>=3.12' --from 'ouroboros-ai\\[tui]' ouroboros config"
 )
 
 

--- a/src/ouroboros/package_profiles.py
+++ b/src/ouroboros/package_profiles.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from enum import Enum
 from importlib import metadata as importlib_metadata
 
+# uvx resolves tool dependencies against its default interpreter, which can be
+# an older system Python even when a compatible one is installed. Every
+# generated ``uvx`` launch must carry this floor so uv selects — or downloads —
+# an interpreter satisfying the package's requires-python (pyproject.toml).
+UVX_PYTHON_FLOOR = ">=3.12"
+
 MCP_PROFILE = "mcp"
 CLAUDE_CLI_PROFILE = "claude-cli"
 CLAUDE_SDK_COMPAT_PROFILE = "claude"

--- a/tests/unit/cli/commands/test_tui_command.py
+++ b/tests/unit/cli/commands/test_tui_command.py
@@ -29,7 +29,7 @@ def test_monitor_command_reports_optional_tui_dependency() -> None:
     print_error.assert_called_once()
     error_message = print_error.call_args.args[0]
     assert "ouroboros-ai[tui]" in error_message
-    assert "uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor" in error_message
+    assert "uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros tui monitor" in error_message
 
 
 def test_tui_open_ghostty_uses_argv_and_working_directory(tmp_path: Path) -> None:
@@ -102,7 +102,10 @@ def test_tui_open_headless_prints_manual_command(tmp_path: Path) -> None:
 
     assert launch.argv is None
     assert "SSH/headless" in launch.message
-    assert "uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor" in launch.manual_command
+    assert (
+        "uvx --python '>=3.12' --from 'ouroboros-ai[tui]' ouroboros tui monitor"
+        in launch.manual_command
+    )
     assert str(db_path) in launch.manual_command
 
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -299,7 +299,10 @@ class TestCodexSetup:
         assert 'OUROBOROS_LLM_BACKEND = "codex"' in contents
         assert "tool_timeout_sec" not in contents
         assert 'command = "/usr/local/bin/uvx"' in contents
-        assert 'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]' in contents
+        assert (
+            'args = ["--python", ">=3.12", "--from", "ouroboros-ai[mcp]", '
+            '"ouroboros", "mcp", "serve"]' in contents
+        )
 
     def test_register_codex_mcp_server_uses_direct_executable_for_dev_build(
         self, tmp_path: Path
@@ -5052,6 +5055,8 @@ class TestHermesSetup:
         config = yaml.safe_load((hermes_dir / "config.yaml").read_text(encoding="utf-8"))
         assert config["mcp_servers"]["ouroboros"]["command"] == "uvx"
         assert config["mcp_servers"]["ouroboros"]["args"] == [
+            "--python",
+            ">=3.12",
             "--from",
             "ouroboros-ai[mcp]",
             "ouroboros",
@@ -5140,6 +5145,8 @@ class TestHermesSetup:
         result = yaml.safe_load((hermes_dir / "config.yaml").read_text(encoding="utf-8"))
         assert result["mcp_servers"]["ouroboros"]["command"] == "uvx"
         assert result["mcp_servers"]["ouroboros"]["args"] == [
+            "--python",
+            ">=3.12",
             "--from",
             "ouroboros-ai[mcp]",
             "ouroboros",
@@ -7029,6 +7036,8 @@ class TestGjcSetup:
 
         assert entry["command"] == "uvx"
         assert entry["args"] == [
+            "--python",
+            ">=3.12",
             "--from",
             "ouroboros-ai[mcp]",
             "ouroboros",

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -248,7 +248,7 @@ def test_first_use_onboarding_has_host_specific_model_settings_handoffs() -> Non
         "CODEX_SETUP_REQUIRED",
         "mcp_servers\\.ouroboros",
         "ouroboros setup --runtime codex",
-        "uvx --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex",
+        "uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex",
         "설정하고 시작하기",
         "직접 모델 설정하기",
         "모델은 언제든 나중에 바꿀 수 있어요",

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -194,6 +194,8 @@ def test_shipped_mcp_launchers_use_the_isolated_mcp_profile() -> None:
     """Repository and plugin launchers must never combine MCP 2 with Claude."""
     root = Path(__file__).parent.parent.parent
     expected_args = [
+        "--python",
+        ">=3.12",
         "--from",
         "ouroboros-ai[mcp]",
         "ouroboros",


### PR DESCRIPTION
Refs #1390

## Problem

A community report (Codex CLI, 0.51.0) showed the Ouroboros MCP server dying **before the JSON-RPC `initialize` response**. The reporter's machine had Python 3.12 installed, yet `uvx` resolved against Python 3.11:

```
× No solution found when resolving tool dependencies:
╰─▶ Because the current Python version (3.11.14) does not satisfy Python>=3.12
    and you require ouroboros-ai[mcp]==0.51.0, we can conclude that your
    requirements are unsatisfiable.
```

**Root cause:** `uvx` resolves tool dependencies against its *default* interpreter (first on PATH), and does not automatically switch to another installed Python that satisfies `requires-python`. Users whose default interpreter is 3.10/3.11 hit this on every generated MCP launcher — while the CLI itself works fine, because `scripts/install.sh` already pins `uv tool install --python ">=3.12"`. The launchers were the only uvx spawns without a floor. Reproduced locally with `uvx --python 3.11 --from 'ouroboros-ai[mcp]==0.51.0' ouroboros --version`.

## Fix

Every generated `uvx` launch now carries `--python '>=3.12'` (new shared constant `UVX_PYTHON_FLOOR` in `package_profiles.py`, mirroring the `requires-python` floor in `pyproject.toml` / `MIN_PYTHON` in install.sh):

- On machines with 3.13/3.14, uv keeps using the existing compatible interpreter (no forced 3.12 download — this is why the range beats the reporter's suggested exact `--python 3.12`).
- On machines with only 3.10/3.11, uv downloads a satisfying interpreter automatically.

Verified locally: `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]==0.51.0' ouroboros --version` resolves and runs on a machine whose default interpreter is 3.11.

### Updated launch sites
- `setup.py`: `_build_uvx_mcp_args` (Claude `.mcp.json`), `_CODEX_UVX_MCP_ARGS` (Codex `config.toml` — the reported case), `_detect_opencode_mcp_command` (OpenCode); also consumed by the Hermes/Kiro/GJC writers.
- `tui.py` `_monitor_argv` uvx fallback.
- Shipped configs: `.mcp.json`, `.claude-plugin/.mcp.json`, `.codex/config.toml`.
- `scripts/install.sh` config-GUI uvx launch.
- User guidance strings (`mcp.py`, `mcp_doctor.py`, `tui.py`, `config_tui/launcher.py`) and SKILL.md command examples (+ `.claude-plugin` mirrors).

### Migration for existing broken configs
The old arg shape `["--from", "ouroboros-ai[mcp]", ...]` is added to `_CODEX_LEGACY_UVX_MCP_ARGS`, so re-running `ooo setup` (or a plugin update, for plugin users) rewrites stale entries to the new canonical shape. Entries a user customized by hand (e.g. the reporter's manual `--python 3.12` fix) are *not* recognized as setup-owned and stay untouched.

### Deliberately out of scope
- The `pipx run --spec` fallback is unchanged: pipx's `--python` wants a concrete interpreter (`python3.12`), so pinning one there would *break* machines whose newest Python is 3.13+.
- Historical docstrings/RFC prose describing the old topology.

## Tests
- Updated exact-args expectations in `test_setup.py`, `test_dependencies_configured.py`, `test_skill_artifacts.py`, `test_tui_command.py`.
- `tests/unit` (minus `mcp`): 16,475 passed; 3 `test_codex_cli_runtime` failures under xdist are pre-existing parallel flakes (pass serially on both this branch and main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Czos7tQayWsaJeZMKaaidd