### PR TITLE
Carry the crypto disclaimer and Agent OS Stack section into ko/zh READMEs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -44,6 +44,33 @@ Ouroboros는 **명세 우선 AI 개발 시스템**입니다. 이 시스템은 �
 
 ---
 
+## Ouroboros Agent OS 스택
+
+여느 OS와 마찬가지로 Ouroboros도 세 층으로 나뉩니다. 원시 기능을 제공하는 안정적인 **OS 층**, 도메인 워크플로우를 담는 **애플리케이션 층**, 그리고 사람이 실제로 마주 앉는 **셸**입니다. 저장소 셋, 스택 하나입니다.
+
+| 층 | 저장소 | 역할 | 얻는 것 |
+| :--- | :--- | :--- | :--- |
+| **Shell** (터미널 클라이언트) | [`Ouro-labs/ourocode`](https://github.com/Ouro-labs/ourocode) | 한 세션 안에서 Claude / Codex / Gemini CLI를 넘나들며 `ooo` 워크플로우를 실행하는 네이티브 터미널 UI | TUI, wonderTool 결정 선택기, MCP 패널 상태, 명령 탐색 |
+| **Apps** (도메인 워크플로우) | [`Ouro-labs/ouroboros-plugins`](https://github.com/Ouro-labs/ouroboros-plugins) | UserLevel 플러그인 계약 — 코어 원시 기능을 설치 가능한 도메인 프로그램(PR 작업, Jira 동기화, 장애 대응, 릴리스)으로 조립 | 플러그인 매니페스트, 범위 한정 권한, 감사/출처 추적, 참조 플러그인 |
+| **OS** (이 저장소) | [`Q00/ouroboros`](https://github.com/Q00/ouroboros) | Agent OS 코어 — Seed, Ledger, Runtime, MCP, 안전 경계 | `ooo` 명령어, 명세 우선 워크플로우 엔진, 다중 런타임 어댑터 |
+
+**어떻게 연결되나:**
+
+```
+  ourocode  ──►  ooo / ouroboros-plugins  ──►  ouroboros core (Seed · Ledger · MCP · Runtime)
+   shell             user-level apps                        kernel
+```
+
+- **커널**(`ouroboros`)이 계약을 소유합니다. 최종 실행을 어느 LLM이 맡든, 모든 행위는 seed에 묶이고 ledger에 기록되는 재생 가능한 이벤트가 됩니다.
+- **플러그인**(`ouroboros-plugins`)은 그 계약에 대고 필요한 권한 범위를 선언합니다. 그래서 도메인 워크플로우(PR 리뷰, Linear 티켓 분류, 릴리스 실행)가 일회성 프롬프트가 아니라 감사 가능하고 정책에 묶인 상태로 남습니다.
+- **Ourocode**는 터미널 셸입니다. MCP 상태, 인터뷰 질문, wonderTool 결정을 일급 TUI 요소로 드러내므로, 키보드를 떠나거나 여러 CLI를 오가지 않고도 이 OS를 몰 수 있습니다.
+
+지원되는 CLI에 `ouroboros`만 얹어 써도 되고, 도메인 워크플로우가 필요하면 플러그인을 더하고, 통합된 터미널 조종석을 원하면 `ourocode`를 설치하면 됩니다.
+
+> **고지.** Ouroboros 프로젝트와 커뮤니티는 **어떤 암호화폐, 토큰, 밈코인, 트레이딩 커뮤니티와도 무관합니다** — pump.fun을 비롯한 런치패드에 올라온 "ouroboros" 티커도 여기 포함됩니다. 이것은 오픈소스 개발자 도구입니다. 우리는 어떤 코인도 발행하거나, 보증하거나, 보유하지 않습니다. 이 프로젝트와 관련이 있다고 주장하는 토큰은 전부 무단입니다.
+
+---
+
 ## Wonder에서 온톨로지로
 
 > *Wonder → "어떻게 살아야 하는가?" → "'삶'이란 무엇인가?" → 온톨로지*

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ sit in front of. Three repos, one stack:
 
 | Layer | Repo | Role | What it gives you |
 | :--- | :--- | :--- | :--- |
-| **Shell** (terminal client) | [`Q00/ourocode`](https://github.com/Q00/ourocode) | Native terminal UI for running `ooo` workflows across Claude / Codex / Gemini CLIs in one session | TUI, wonderTool decision pickers, MCP pane state, command discovery |
-| **Apps** (domain workflows) | [`Q00/ouroboros-plugins`](https://github.com/Q00/ouroboros-plugins) | UserLevel plugin contract — composes core primitives into installable domain programs (PR ops, Jira sync, incidents, releases) | Plugin manifest, scoped permissions, audit/provenance, reference plugins |
+| **Shell** (terminal client) | [`Ouro-labs/ourocode`](https://github.com/Ouro-labs/ourocode) | Native terminal UI for running `ooo` workflows across Claude / Codex / Gemini CLIs in one session | TUI, wonderTool decision pickers, MCP pane state, command discovery |
+| **Apps** (domain workflows) | [`Ouro-labs/ouroboros-plugins`](https://github.com/Ouro-labs/ouroboros-plugins) | UserLevel plugin contract — composes core primitives into installable domain programs (PR ops, Jira sync, incidents, releases) | Plugin manifest, scoped permissions, audit/provenance, reference plugins |
 | **OS** (this repo) | [`Q00/ouroboros`](https://github.com/Q00/ouroboros) | Agent OS core — Seed, Ledger, Runtime, MCP, safety boundaries | `ooo` commands, spec-first workflow engine, multi-runtime adapter |
 
 **How they connect:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,6 +43,33 @@ Ouroboros 是面向 AI 编码的 Agent OS：一层本地优先的运行时，把
 
 ---
 
+## Ouroboros Agent OS 技术栈
+
+和任何操作系统一样，Ouroboros 分成三层：一层稳定的、提供原语的 **OS 层**，一层承载领域工作流的**应用层**，还有一个人真正坐在前面的 **shell**。三个仓库，一个技术栈：
+
+| 层级 | 仓库 | 职责 | 你得到什么 |
+| :--- | :--- | :--- | :--- |
+| **Shell**（终端客户端） | [`Ouro-labs/ourocode`](https://github.com/Ouro-labs/ourocode) | 原生终端 UI，在一个会话里跨 Claude / Codex / Gemini CLI 运行 `ooo` 工作流 | TUI、wonderTool 决策选择器、MCP 面板状态、命令发现 |
+| **Apps**（领域工作流） | [`Ouro-labs/ouroboros-plugins`](https://github.com/Ouro-labs/ouroboros-plugins) | UserLevel 插件契约 —— 把核心原语组合成可安装的领域程序（PR 操作、Jira 同步、故障处理、发布） | 插件清单、按范围授权、审计与溯源、参考插件 |
+| **OS**（本仓库） | [`Q00/ouroboros`](https://github.com/Q00/ouroboros) | Agent OS 内核 —— Seed、Ledger、Runtime、MCP、安全边界 | `ooo` 命令、规约优先的工作流引擎、多运行时适配 |
+
+**它们怎么连起来：**
+
+```
+  ourocode  ──►  ooo / ouroboros-plugins  ──►  ouroboros core (Seed · Ledger · MCP · Runtime)
+   shell             user-level apps                        kernel
+```
+
+- **内核**（`ouroboros`）持有契约：不管最终由哪个 LLM 执行，每一个动作都会变成一个绑定 seed、记入 ledger、可回放的事件。
+- **插件**（`ouroboros-plugins`）针对这份契约声明自己需要的能力范围，所以领域工作流（review 一个 PR、分诊一张 Linear 工单、跑一次发布）始终是可审计、受策略约束的，而不是一次性的 prompt。
+- **Ourocode** 是终端 shell：它把 MCP 状态、访谈问题、wonderTool 决策都做成一等公民的 TUI 元素，让你不用离开键盘、也不用在多个 CLI 之间来回切换就能驱动这套 OS。
+
+你可以只用 `ouroboros` 配任意受支持的 CLI；需要领域工作流时叠加插件；想要一个统一的终端驾驶舱时再装 `ourocode`。
+
+> **免责声明。** Ouroboros 项目及其社区**与任何加密货币、代币、meme 币或交易社群均无关联** —— 包括但不限于 pump.fun 及其他发射平台上任何名为 "ouroboros" 的代币。这是一个开源开发者工具。我们不发行、不背书、也不持有任何代币。任何声称与本项目有关联的代币都是未经授权的。
+
+---
+
 ## 为什么选 Ouroboros？
 
 绝大多数 AI 编码失败在**输入**，不在输出。瓶颈不是 AI 能力不够，而是人没把事情想清楚。


### PR DESCRIPTION
The English README warns that no token trading on this project's name is affiliated with it. The Korean and Chinese READMEs did not carry that warning at all.

```
$ grep -ci "memecoin\|cryptocurrency" README.md README.ko.md README.zh-CN.md
README.md:1
README.ko.md:0
README.zh-CN.md:0
```

That is not ordinary translation drift. The disclaimer exists because someone can lose money to a token trading on this name, and the readers who had no warning are exactly the ones who cannot easily go read the English original. The repo is currently listed on several Chinese-language channels, so `README.zh-CN.md` is a real landing page, not a courtesy translation.

The disclaimer lives at the end of `## The Ouroboros Agent OS Stack`, which was also English-only — so non-English readers were still seeing the older single-repo framing instead of the `ourocode` / `ouroboros-plugins` / `ouroboros` split. Both are translated here, matching each file's existing terminology (the Chinese file already uses 规约 for spec and 运行时 for runtime; the Korean file already uses 명세 and 런타임).

## Also fixed

The English section linked `Q00/ourocode` and `Q00/ouroboros-plugins`, but both repos now live under `Ouro-labs`:

```
$ gh repo view Q00/ourocode --json nameWithOwner -q .nameWithOwner
Ouro-labs/ourocode
```

Those still resolve today by GitHub redirect, but a redirect stops resolving the moment a new repo claims the old name. All three READMEs now use the canonical URLs.

## Test plan

- [x] `grep -ci "memecoin\|밈코인\|meme 币"` returns 1 for all three READMEs
- [x] The stack table, the ASCII connection diagram, the three explanatory bullets, and the closing "use it alone / add plugins / add ourocode" line are all present in each translation
- [x] `https://github.com/Ouro-labs/ourocode` and `https://github.com/Ouro-labs/ouroboros-plugins` both return 200
- [x] Section is placed before the "why" section in each file, matching the English ordering
- [x] No content outside this section was touched

Closes #1967