### PR TITLE
docs(i18n): add the Chinese evaluation pipeline guide

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -372,7 +372,10 @@ src/ouroboros/
 - **Agent OS runtime** —— 跨能力发现、策略、指令、事件日志、agent 进程的可重放执行契约
 - **Runtime backends** —— 可插拔抽象层（`orchestrator.runtime_backend` 配置），原生支持 Claude Code、Codex CLI、OpenCode、Hermes；同一份工作流规约，跑在不同执行引擎上
 
-完整设计文档见 [Architecture](./docs/architecture.md)（英文）。中文设计说明：[隐藏清单收敛（Hidden-Checklist Convergence）](./docs/hidden-checklist-convergence/README.zh-CN.md) —— run → 评估 → 有预算的 Ralph 链，以及为什么判分用的断言对 worker 无条件隐藏。
+完整设计文档见 [Architecture](./docs/architecture.md)（英文）。中文文档：
+
+- [评估流水线指南（Evaluation Pipeline）](./docs/guides/evaluation-pipeline.zh-CN.md) —— 三阶段关卡的完整参考：每个阶段验什么、阈值和配置项、失败模式与排查、以及事件审计轨迹
+- [隐藏清单收敛（Hidden-Checklist Convergence）](./docs/hidden-checklist-convergence/README.zh-CN.md) —— run → 评估 → 有预算的 Ralph 链，以及为什么判分用的断言对 worker 无条件隐藏
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ replayable execution contract on your choice of runtime backend.
 - [Seed Authoring Guide](./guides/seed-authoring.md) - YAML structure, field reference, examples
 - [Evolutionary Loop & Ralph](./guides/evolution-loop.md) - Wonder/Reflect cycle, convergence detection, persistent evolution
 - [Evaluation Pipeline Guide](./guides/evaluation-pipeline.md) - Three-stage evaluation, failure modes, and configuration
+- [Evaluation Pipeline Guide (简体中文)](./guides/evaluation-pipeline.zh-CN.md) - 同一份指南的中文版
 - [Execution vs. Evaluation Contract](./guides/execution-vs-evaluation.md) - Task completion, AC verdict, and drift terminology boundaries
 - [Hidden-Checklist Convergence](./hidden-checklist-convergence/architecture.md) - Run → evaluation → bounded Ralph chaining with hidden harness grading inputs
 - [Hidden-Checklist Convergence (简体中文)](./hidden-checklist-convergence/README.zh-CN.md) - 同一设计的中文说明

--- a/docs/guides/evaluation-pipeline.md
+++ b/docs/guides/evaluation-pipeline.md
@@ -5,6 +5,8 @@ doc_metadata:
 
 # Evaluation Pipeline Guide
 
+> 中文说明：[evaluation-pipeline.zh-CN.md](./evaluation-pipeline.zh-CN.md)
+
 Ouroboros Phase 4 runs every execution result through a **three-stage progressive evaluation pipeline** before assigning formal acceptance-criterion (AC) verdicts. Cheaper checks gate the expensive ones: Stage 1 is free, Stage 2 uses one LLM call, and Stage 3 (multi-model consensus) runs only when specifically triggered.
 
 > **Terminology boundary:** worker task completion is not a formal AC verdict, and task failure is not semantic drift. See [Execution vs. Evaluation Contract](./execution-vs-evaluation.md) for the shared `TaskResult` / `ACResult` distinction.

--- a/docs/guides/evaluation-pipeline.md
+++ b/docs/guides/evaluation-pipeline.md
@@ -46,6 +46,8 @@ Artifact ready
 APPROVED          REJECTED
 ```
 
+> The diagram shows the happy path. Two things sit outside it: `trigger_consensus=true` jumps straight to Stage 3 from either the trigger matrix or a Stage 2 AC failure, and the [reward-hacking veto](#reward-hacking-veto) can flip any `APPROVED` above back to `REJECTED`.
+
 ---
 
 ## Stage 1: Mechanical Verification
@@ -77,32 +79,31 @@ The mechanical verifier runs zero-cost automated shell commands and checks the e
 | **Coverage not parseable** | Coverage check passes but no `coverage_score` in events | Output did not match the expected pattern (`TOTAL ... XX%`); ensure `pytest-cov` or compatible tool is used |
 | **OS error** | `Check <type> failed` with "OS error" | Permissions problem or missing working directory; verify `working_dir` config |
 
-### Language Auto-Detection
+### Where Stage 1 Commands Come From
 
-When `build_mechanical_config(working_dir)` is used (the default when running via `ouroboros run`), Stage 1 commands are **automatically populated** by scanning the project directory for known marker files. You do not need to configure commands manually for supported toolchains.
+Ouroboros does **not** ship hardcoded per-language presets. Stage 1 trusts exactly one source: `.ouroboros/mechanical.toml` in the project root. `build_mechanical_config(working_dir)` is the deterministic reader for that file — when the file is absent, every command resolves to `None` and Stage 1 skips gracefully rather than running the wrong tool.
 
-**Detection priority** (first match wins):
+The file is written by `ouroboros.evaluation.detector`, which makes **one AI call** that inspects the project's manifest files (`pyproject.toml`, `uv.lock`, `package.json`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`, `Makefile`, `justfile`, `Taskfile.yml`, `build.zig`, `CMakeLists.txt`, `mix.exs`, `Gemfile`, and others) and proposes commands for this specific repository. Each proposed command is validated before it is persisted — against the executable allowlist, against shell-operator and absolute-path injection, and against the repo itself (for example, a `cargo` command is only kept when `Cargo.toml` exists) — so the toml contains only commands the project can actually run.
 
-| Marker file | Detected toolchain | Default commands |
-|---|---|---|
-| `uv.lock` | `python-uv` | `uv run ruff`, `uv run pytest --cov`, `uv run mypy` |
-| `build.zig` | `zig` | `zig build`, `zig build test` |
-| `Cargo.toml` | `rust` | `cargo clippy`, `cargo build`, `cargo test` |
-| `go.mod` | `go` | `go vet ./...`, `go build ./...`, `go test ./...`, `go test -cover ./...` |
-| `bun.lockb` / `bun.lock` | `node-bun` | `bun lint`, `bun run build`, `bun test` |
-| `pnpm-lock.yaml` | `node-pnpm` | `pnpm lint`, `pnpm build`, `pnpm test` |
-| `yarn.lock` | `node-yarn` | `yarn lint`, `yarn build`, `yarn test` |
-| `package-lock.json` | `node-npm` | `npm run lint`, `npm run build`, `npm test` |
-| `pyproject.toml` / `setup.py` / `setup.cfg` | `python` | `ruff check .`, `pytest --cov`, `mypy .` |
-| `package.json` (no lockfile) | `node-npm` | `npm run lint`, `npm run build`, `npm test` |
+Generate or refresh it explicitly:
 
-If no marker file is found, all commands remain `None` and all checks are silently skipped.
+```bash
+ouroboros detect              # inspect the current directory and write .ouroboros/mechanical.toml
+ouroboros detect --force      # re-detect and overwrite an existing file
+ouroboros detect --backend codex   # use a specific LLM backend for the detect call
+```
+
+`ensure_mechanical_toml()` is idempotent: when the file already exists and `force` is false it returns immediately without an LLM call. It never raises — on any failure it returns `False`, leaving Stage 1 with no commands.
+
+> **If Stage 1 always passes, this is usually why.** With no `.ouroboros/mechanical.toml` and no explicitly configured `MechanicalConfig` commands, all five checks are skipped and treated as passed, which makes Stage 1 a no-op gate. Run `ouroboros detect`, or write the toml by hand.
+
+> **Deprecated:** `detect_language()` no longer detects anything. It is a compatibility shim that reads `.ouroboros/mechanical.toml` and emits a `DeprecationWarning`; call `ensure_mechanical_toml()` plus `build_mechanical_config()` instead.
 
 > **Go coverage note:** The `go test -cover` output format (`ok  ./... coverage: XX.X% of statements`) is not matched by the coverage parser (which expects `TOTAL ... XX%` or `Coverage: XX%`). For Go projects, `coverage_score` will always be `None` in the event payload and the coverage **threshold check is skipped even if coverage is low**. Use the `.ouroboros/mechanical.toml` override to supply a custom coverage command if you need threshold enforcement on Go projects.
 
 ### Project-Level Command Overrides
 
-Create `.ouroboros/mechanical.toml` in your project root to override auto-detected commands without modifying Ouroboros configuration:
+`.ouroboros/mechanical.toml` in your project root is where Stage 1 commands live. The detector writes it, and you can edit it or author it by hand without modifying Ouroboros configuration:
 
 ```toml
 # .ouroboros/mechanical.toml
@@ -116,18 +117,17 @@ timeout = 120
 **Override priority** (highest to lowest):
 1. Explicit `overrides` dict passed programmatically (from MCP params)
 2. `.ouroboros/mechanical.toml` in the project root
-3. Auto-detected language preset
-4. All `None` (all checks skip gracefully)
+3. All `None` (all checks skip gracefully)
 
-**TOML parse errors** are logged as a warning (`mechanical.toml_parse_error`) and silently ignored; the auto-detected preset commands are still used.
+**TOML parse errors** are logged as a warning (`mechanical.toml_parse_error`) and silently ignored. There is no preset to fall back to, so every command stays `None` and Stage 1 skips all checks.
 
-**Security: executable allowlist.** Commands in `.ouroboros/mechanical.toml` may only use executables from a built-in allowlist (e.g., `pytest`, `ruff`, `cargo`, `go`, `npm`, `make`). If a command specifies an executable not in the allowlist, it is silently blocked (logged as `mechanical.blocked_executable`) and the check is skipped. Hardcoded language presets bypass this check. This prevents untrusted repository configs from running arbitrary commands in CI/CD environments.
+**Security: executable allowlist.** Commands in `.ouroboros/mechanical.toml` may only use executables from a built-in allowlist (e.g., `pytest`, `ruff`, `cargo`, `go`, `npm`, `make`). If a command specifies an executable not in the allowlist — or uses shell operators or an absolute path — it is silently blocked (logged as `mechanical.blocked_executable`) and the check is skipped. Commands passed programmatically through `MechanicalConfig` or the MCP `overrides` dict bypass this check, because they are vetted upstream. This prevents untrusted repository configs from running arbitrary commands in CI/CD environments.
 
 | Override failure mode | Symptom | Cause / Action |
 |---|---|---|
-| **TOML parse error** | Auto-detected preset used; no error raised | Malformed `.ouroboros/mechanical.toml`; check TOML syntax |
+| **TOML parse error** | All Stage 1 checks skipped; no error raised | Malformed `.ouroboros/mechanical.toml`; check TOML syntax |
 | **Blocked executable** | Check silently skipped | Executable not in allowlist; use an allowed tool or set the command in `MechanicalConfig` directly |
-| **Language not detected** | All Stage 1 checks skipped | No marker file found; add a `pyproject.toml` / `Cargo.toml` / etc., or set commands explicitly |
+| **No toml present** | All Stage 1 checks skipped | Run `ouroboros detect`, or set commands explicitly in `MechanicalConfig` |
 
 ### Stage 1 Configuration
 
@@ -144,7 +144,7 @@ mechanical:
   coverage_command: ["pytest", "--cov=src", "--cov-report=term-missing", "tests/"]
 ```
 
-> **Important:** When using `ouroboros run`, commands are auto-detected from the project directory. All Stage 1 checks are silently skipped (and treated as passed) only when no marker file is found **and** no explicit commands are configured. Use `.ouroboros/mechanical.toml` or `MechanicalConfig` overrides to customize behavior.
+> **Important:** These fields are the programmatic escape hatch. In the normal `ouroboros run` path the commands come from `.ouroboros/mechanical.toml`, and Stage 1 silently skips every check (treating it as passed) when that file is absent **and** no explicit commands are configured.
 
 ### Diagnosing Stage 1 Failures
 
@@ -176,16 +176,30 @@ Stage 2 calls a Standard-tier LLM (default: `OUROBOROS_SEMANTIC_MODEL` / config 
 | `drift_score` | float | 0.0–1.0 | Deviation from seed intent (lower is better) |
 | `uncertainty` | float | 0.0–1.0 | Model's uncertainty about its own evaluation |
 | `reasoning` | string | — | Free-text explanation |
+| `reward_hacking_risk` | float | 0.0–1.0 | Suspicion that the artifact games the evaluator instead of solving the task. Distinct from `drift_score`, and vetoes approval at `>= 0.7` |
+| `questions_used` | list | — | Questions the evaluator asked while verifying the artifact — it has to show its work |
+| `evidence` | list | — | File snippets and observations the verdict relied on |
 
 ### Approval Logic
 
 ```
-if ac_compliance == False  → REJECTED (Stage 3 not attempted)
-if score < 0.8             → REJECTED (unless Stage 3 is triggered and approves)
-if score >= 0.8 and no trigger → APPROVED
+if ac_compliance == False and not trigger_consensus  → REJECTED (Stage 3 not attempted)
+if score < 0.8                    → REJECTED (unless Stage 3 is triggered and approves)
+if score >= 0.8 and no trigger    → APPROVED
+if reward_hacking_risk >= 0.7     → REJECTED (final veto, overrides any approval)
 ```
 
-> The `satisfaction_threshold` (default `0.8`) is in `SemanticConfig`. Values between 0.0–1.0 are clamped after parsing; out-of-range model responses are corrected automatically.
+> **The score gate is hardcoded at `0.8`.** `SemanticConfig.satisfaction_threshold` (default `0.8`) exists and is validated, but the pipeline compares against a literal `0.8` and never reads the field. Changing it has no effect on approval today — do not rely on it to loosen or tighten the gate.
+
+> **`ac_compliance=False` is not always final.** When the evaluation context sets `trigger_consensus=True`, the pipeline continues to the trigger matrix instead of rejecting, so Stage 3 can deliver a second opinion on an AC the Stage 2 model failed.
+
+> Scores are clamped to 0.0–1.0 after parsing; out-of-range model responses are corrected automatically.
+
+### Reward-Hacking Veto
+
+`_build_result()` applies one final gate that every approval path funnels through: if Stage 2 reported `reward_hacking_risk >= 0.7` (`REWARD_HACKING_VETO_THRESHOLD`), an otherwise-approved result is flipped to rejected. The threshold is deliberately high so that mild suspicion never blocks a genuine pass.
+
+The veto only turns approve into reject — it never rescues an already-rejected result, so a Stage 3 consensus rejection stays a rejection. When it fires, `failure_reason` names it explicitly rather than reporting `"Unknown failure"`.
 
 ### Stage 2 Failure Modes
 
@@ -203,10 +217,10 @@ if score >= 0.8 and no trigger → APPROVED
 ```yaml
 # In PipelineConfig.semantic (SemanticConfig)
 semantic:
-  model: "claude-3-5-sonnet-20241022"   # Standard tier model
+  model: null                            # null = resolve from OUROBOROS_SEMANTIC_MODEL / config
   temperature: 0.2                       # Low for consistency
   max_tokens: 2048                       # Response token budget
-  satisfaction_threshold: 0.8           # Minimum score to approve
+  satisfaction_threshold: 0.8           # Currently inert — the gate is hardcoded to 0.8
 ```
 
 ### Diagnosing Stage 2 Failures
@@ -220,10 +234,11 @@ If `ac_compliance` is `false` but `score` seems high, the LLM may have found a p
 
 ## Consensus Trigger Matrix (Stage 2 → Stage 3 Gate)
 
-After Stage 2 passes (`ac_compliance=True`, `score >= 0.8`), six trigger conditions are evaluated **in priority order**. The first matching condition triggers Stage 3. If none match, the artifact is approved immediately.
+After Stage 2 passes (`ac_compliance=True`, `score >= 0.8`), trigger conditions are evaluated **in priority order**. The first matching condition triggers Stage 3. If none match, the artifact is approved immediately.
 
 | Priority | Trigger | Condition |
 |----------|---------|-----------|
+| 0 | `manual_request` | `manual_consensus_request=True`, set from `trigger_consensus=true` on the evaluation context |
 | 1 | `seed_modification` | `seed_modified=True` in context |
 | 2 | `ontology_evolution` | `ontology_changed=True` in context |
 | 3 | `goal_interpretation` | `goal_reinterpreted=True` in context |
@@ -231,7 +246,11 @@ After Stage 2 passes (`ac_compliance=True`, `score >= 0.8`), six trigger conditi
 | 5 | `stage2_uncertainty` | `uncertainty > uncertainty_threshold` (default **0.3**) |
 | 6 | `lateral_thinking_adoption` | `lateral_thinking_adopted=True` in context |
 
+> **`manual_request` short-circuits everything.** It is checked before the other six, so asking for consensus explicitly always reaches Stage 3 regardless of drift, uncertainty, or Stage 2's verdict.
+
 > **Only the first matching trigger fires.** If drift is 0.5 and lateral thinking was also adopted, only `seed_drift_alert` (priority 4) is reported.
+
+> **Both threshold comparisons are strict (`>`).** A `drift_score` exactly equal to `drift_threshold` does not trigger Stage 3. When Stage 2 ran, its `drift_score` and `uncertainty` take precedence over any values pre-populated on the `TriggerContext`.
 
 ### Trigger Configuration
 
@@ -260,9 +279,19 @@ Stage 3 calls multiple Frontier-tier models concurrently. Each votes independent
 
 ### Simple Consensus (Default)
 
-Three models are queried in parallel (default: `gpt-4o`, `claude-sonnet-4`, `gemini-2.5-pro`). Each returns `{ approved, confidence, reasoning }`.
+Three models are queried in parallel. The defaults route through OpenRouter so the voters come from three different vendors:
 
-**Approval rule:** `approving_votes / total_votes >= 0.66` (i.e., at least 2 of 3).
+```
+openrouter/openai/gpt-4o
+openrouter/anthropic/claude-opus-4.8
+openrouter/google/gemini-2.5-pro
+```
+
+Each returns `{ approved, confidence, reasoning }`.
+
+**Approval rule:** `approving_votes / total_votes >= 0.66` (i.e., at least 2 of 3). The ratio is computed over the votes actually **collected**, not over the number of configured models — see [Parallel Consensus Failure Tolerance](#parallel-consensus-failure-tolerance).
+
+> **Single-model fallback.** When the configured models are `openrouter/*` but `OPENROUTER_API_KEY` is missing or still a `YOUR_…` placeholder, `ConsensusEvaluator` silently switches to a single-model mode: the session model is queried three times with the advocate, devil's advocate, and judge system prompts, and those three perspectives vote. The 2-of-3 rule and the `<2` votes error are unchanged, but the reviewers are the same vendor by construction, so reviewer independence is reported as unavailable. Stage 3 events carry `session/<perspective>` model names and a `single-model-perspectives:` trigger reason — check for those if Stage 3 looks cheaper than expected. Configuring non-`openrouter/*` models skips the check and uses them as-is.
 
 ### Deliberative Consensus
 
@@ -294,14 +323,16 @@ An alternative two-round mode:
 # In PipelineConfig.consensus (ConsensusConfig)
 consensus:
   models:
-    - "gpt-4o"
-    - "claude-sonnet-4-20250514"
-    - "gemini/gemini-2.5-pro"
+    - "openrouter/openai/gpt-4o"
+    - "openrouter/anthropic/claude-opus-4.8"
+    - "openrouter/google/gemini-2.5-pro"
   temperature: 0.3
   max_tokens: 1024
   majority_threshold: 0.66     # 2/3 majority
-  diversity_required: true     # Prefer models from different providers
+  diversity_required: true     # Currently inert — see note below
 ```
+
+> **`diversity_required` is not enforced.** The field exists on `ConsensusConfig` and in the config schema, but nothing reads it. Provider diversity comes from the default model roster itself, not from this flag. If you replace the roster with three models from one vendor, setting `diversity_required: true` will not object.
 
 **Deliberative Consensus (`DeliberativeConfig`)**
 
@@ -311,9 +342,9 @@ Used with `DeliberativeConsensus` (not `ConsensusEvaluator`). Each role uses a s
 from ouroboros.evaluation.consensus import DeliberativeConfig, DeliberativeConsensus
 
 config = DeliberativeConfig(
-    advocate_model="claude-sonnet-4-20250514",   # Advocate role
-    devil_model="claude-sonnet-4-20250514",       # Devil's Advocate (ontological analysis)
-    judge_model="gpt-4o",                         # Final judgment
+    advocate_model="openrouter/anthropic/claude-opus-4.8",  # Advocate role
+    devil_model="openrouter/openai/gpt-4o",                 # Devil's Advocate (ontological analysis)
+    judge_model="openrouter/google/gemini-2.5-pro",         # Final judgment
     temperature=0.3,
     max_tokens=2048,
 )
@@ -342,11 +373,12 @@ Before Stage 2 runs, the `ArtifactCollector` attempts to read the actual source 
 
 | Limit | Value | Effect when exceeded |
 |-------|-------|---------------------|
-| Max files | 30 | Files beyond 30th are silently skipped |
-| Max file size | 50 KB | Files larger than 50 KB are silently skipped |
-| Max total content | 150,000 chars (~37K tokens) | Files are truncated at budget; `FileArtifact.truncated=True` |
+| Max file size (`MAX_FILE_SIZE`) | 100 KB | Files larger than 100 KB are silently skipped |
+| Max total content (`MAX_TOTAL_CHARS`) | 150,000 chars (~37K tokens) | Content is truncated at the remaining budget; `FileArtifact.truncated=True` |
 
-> Files that exceed the per-file size limit are **skipped entirely** (not truncated). If a critical file is always skipped, check whether it is a generated binary or minified output that should be excluded from evaluation.
+There is **no cap on the number of files**. The character budget is the sole limiter, so a change touching many small files is collected in full while one oversized file is dropped.
+
+> The two limits behave differently. A file over the per-file size limit is **skipped entirely** (never truncated); a file that only exhausts the shared character budget is **truncated** and marked `truncated=True`. If a critical file is always missing, check whether it is a generated binary or minified output that should be excluded from evaluation.
 
 ### Artifact Collection Failure Modes
 
@@ -356,7 +388,7 @@ Before Stage 2 runs, the `ArtifactCollector` attempts to read the actual source 
 | **No file paths extracted** | Same as above | Execution output did not contain recognizable `Write:` / `Edit:` / `file_path:` patterns. The fallback is the text summary. |
 | **Path traversal blocked** | File silently skipped | File path resolves outside `project_dir`. This is a security boundary, not a bug. |
 | **Permission error** | File silently skipped | Execution ran as a different user. Verify file permissions. |
-| **Large files skipped** | Missing context in evaluation | File > 50 KB. Refactor to split large files, or accept that the evaluator works from the text summary. |
+| **Large files skipped** | Missing context in evaluation | File > 100 KB. Refactor to split large files, or accept that the evaluator works from the text summary. |
 
 ---
 
@@ -393,7 +425,7 @@ config = PipelineConfig(stage3_enabled=False)
 
 > **Warning:** Disabling Stage 1 means that broken code can pass through to semantic evaluation. Disabling Stage 3 means that high-drift or high-uncertainty outputs will never be submitted to multi-model review.
 
-> **Stage 2 disabled → Stage 3 implicitly disabled.** Stage 3 runs only when a `TriggerContext` is available. When `stage2_enabled=False`, the pipeline never builds a `TriggerContext`, so Stage 3 will not run even if `stage3_enabled=True` and no external `trigger_context` is passed in. To use Stage 3 without Stage 2, pass a pre-populated `TriggerContext` explicitly to `EvaluationPipeline.evaluate()`.
+> **Stage 2 disabled does not disable Stage 3.** The trigger context is built outside the Stage 2 block precisely so that `trigger_consensus=True` still works when `stage2_enabled=False` — it fires the `manual_request` trigger and Stage 3 runs on its own. What does silently disable Stage 3 is the combination of `stage2_enabled=False`, `trigger_consensus=False`, and no external `trigger_context`: every trigger field is left at its default, so nothing matches. To reach Stage 3 without Stage 2, either set `trigger_consensus=True` or pass a pre-populated `TriggerContext` to `EvaluationPipeline.evaluate()`.
 
 ### Failure Reason Lookup
 
@@ -405,6 +437,7 @@ config = PipelineConfig(stage3_enabled=False)
 | Stage 2 AC non-compliance (`ac_compliance=False`) | `"Stage 2 failed: AC non-compliance (score=0.62)"` |
 | Stage 2 score below threshold (`ac_compliance=True` but `score < 0.8`) | `"Unknown failure"` — the score check runs after Stage 2 but the `failure_reason` property only tests `ac_compliance`. Inspect `stage2_result.score` directly to distinguish this case. |
 | Stage 3 consensus not reached | `"Stage 3 failed: Consensus not reached (44%)"` |
+| Reward-hacking veto (`reward_hacking_risk >= 0.7`) | A message naming the risk score and the 0.70 threshold — the veto is reported, not hidden behind `"Unknown failure"` |
 | All stages passed/skipped but `final_approved=False` | `"Unknown failure"` |
 
 ---
@@ -470,19 +503,23 @@ config = PipelineConfig(
 
     # Stage 2: Semantic evaluation
     semantic=SemanticConfig(
-        model="claude-3-5-sonnet-20241022",
+        model=None,                  # None = resolved from the semantic_evaluation role
         temperature=0.2,
         max_tokens=2048,
-        satisfaction_threshold=0.8,  # Minimum score for approval
+        satisfaction_threshold=0.8,  # Currently inert — the gate is hardcoded to 0.8
     ),
 
     # Stage 3: Simple consensus evaluation
     consensus=ConsensusConfig(
-        models=("gpt-4o", "claude-sonnet-4-20250514", "gemini/gemini-2.5-pro"),
+        models=(
+            "openrouter/openai/gpt-4o",
+            "openrouter/anthropic/claude-opus-4.8",
+            "openrouter/google/gemini-2.5-pro",
+        ),
         temperature=0.3,
         max_tokens=1024,
         majority_threshold=0.66,     # 2/3 majority required
-        diversity_required=True,
+        diversity_required=True,     # Currently inert
     ),
 
     # Consensus trigger thresholds
@@ -499,9 +536,9 @@ For deliberative consensus (separate from `EvaluationPipeline`):
 from ouroboros.evaluation.consensus import DeliberativeConfig, DeliberativeConsensus
 
 deliberative_config = DeliberativeConfig(
-    advocate_model="claude-sonnet-4-20250514",  # Advocate role
-    devil_model="claude-sonnet-4-20250514",      # Devil's Advocate (ontological analysis)
-    judge_model="gpt-4o",                        # Final judgment
+    advocate_model="openrouter/anthropic/claude-opus-4.8",  # Advocate role
+    devil_model="openrouter/openai/gpt-4o",                 # Devil's Advocate (ontological analysis)
+    judge_model="openrouter/google/gemini-2.5-pro",         # Final judgment
     temperature=0.3,
     max_tokens=2048,
 )

--- a/docs/guides/evaluation-pipeline.md
+++ b/docs/guides/evaluation-pipeline.md
@@ -26,7 +26,7 @@ Artifact ready
              │ passed
              ▼
         ┌────┴────┐
-        │ Trigger │ ← 6 conditions checked
+        │ Trigger │ ← 7 conditions checked
         │ matrix  │
         └────┬────┘
              │ triggered?

--- a/docs/guides/evaluation-pipeline.zh-CN.md
+++ b/docs/guides/evaluation-pipeline.zh-CN.md
@@ -1,0 +1,587 @@
+<!--
+doc_metadata:
+  runtime_scope: [all]
+-->
+
+# 评估流水线指南（Evaluation Pipeline）
+
+> 这是评估流水线指南的中文版。英文原文在同一目录下：[evaluation-pipeline.md](./evaluation-pipeline.md)。
+> 两份文档描述同一套实现；如果发现不一致，以 `src/ouroboros/evaluation/` 的代码为准。
+
+Ouroboros 的 Phase 4 会把每一次执行结果送进一条**三阶段递进式评估流水线**，然后才给出正式的验收标准（acceptance criterion，AC）判定。便宜的检查为昂贵的检查把关：Stage 1 免费，Stage 2 花一次 LLM 调用，Stage 3（多模型共识）只在被明确触发时才跑。
+
+> **术语边界：** worker 报告「任务完成」不等于正式的 AC 判定，任务失败也不等于语义漂移。`TaskResult` 与 `ACResult` 的区分见 [Execution vs. Evaluation Contract](./execution-vs-evaluation.md)（英文）。
+
+```
+Artifact ready
+      │
+      ▼
+┌─────────────────────────────┐
+│  Stage 1: Mechanical ($0)   │ lint / build / test / static / coverage
+│  All checks must pass       │
+└────────────┬────────────────┘
+             │ passed
+             ▼
+┌─────────────────────────────┐
+│  Stage 2: Semantic ($$)     │ LLM evaluates AC compliance, goal
+│  score ≥ 0.8 + ac_compliance│ alignment, drift, uncertainty
+└────────────┬────────────────┘
+             │ passed
+             ▼
+        ┌────┴────┐
+        │ Trigger │ ← 7 conditions checked
+        │ matrix  │
+        └────┬────┘
+             │ triggered?
+        ┌────┴────────────────────────────┐
+       YES                               NO
+        │                                 │
+        ▼                                 ▼
+┌───────────────────────┐          ┌───────────────┐
+│  Stage 3: Consensus   │          │   APPROVED    │
+│  ($$$, 2/3 majority)  │          └───────────────┘
+└───────────┬───────────┘
+            │
+   ┌────────┴────────┐
+  YES               NO
+   │                 │
+   ▼                 ▼
+APPROVED          REJECTED
+```
+
+（图中保留英文以维持等宽对齐。`Artifact ready` = 产物就绪，`All checks must pass` = 所有检查都必须通过，`passed` = 通过，`Trigger matrix` = 触发矩阵，`7 conditions checked` = 检查 7 个条件，`triggered?` = 触发了吗，`APPROVED` / `REJECTED` = 通过 / 拒绝。）
+
+> 这张图画的是主干路径。有两件事在图外：`trigger_consensus=true` 会从触发矩阵、或者从 Stage 2 的 AC 未通过处直接跳到 Stage 3；而 [reward hacking 否决](#reward-hacking-否决)可以把上面任何一个 `APPROVED` 翻回 `REJECTED`。
+
+---
+
+## Stage 1：机械验证（Mechanical Verification）
+
+机械验证器运行零成本的自动化 shell 命令，只看退出码。它**不调用任何 LLM**。
+
+### 检查项
+
+| 检查 | 运行什么 | 失败条件 |
+|-------|-------------|-------------------|
+| `lint` | 配置里的 `lint_command` | 退出码非 0 |
+| `build` | 配置里的 `build_command` | 退出码非 0 |
+| `test` | 配置里的 `test_command` | 退出码非 0 |
+| `static` | 配置里的 `static_command` | 退出码非 0 |
+| `coverage` | 配置里的 `coverage_command` | 退出码非 0，**或**解析出的覆盖率低于 `coverage_threshold`（默认 **70%**） |
+
+**流水线行为：** 只要**任意一项**检查失败，Stage 2 和 Stage 3 会被整个跳过，产物立即被拒绝。
+
+**被跳过的检查：** 如果某项检查没有配置命令（`None`），它会被静默跳过并**当作通过处理**。在没有于 `PipelineConfig.mechanical` 设置命令时，这就是默认状态。
+
+### Stage 1 失败模式
+
+| 失败模式 | 现象 | 原因 |
+|---|---|---|
+| **命令不存在** | `Check <type> failed`，附带 "Command not found" | 可执行文件不在 PATH 中；检查环境 |
+| **命令超时** | `Check <type> timed out after Ns` | 命令超过 `timeout_seconds`（默认 300 秒）；调大超时或修掉慢测试 |
+| **退出码非 0** | `Check <type> failed (exit code N)` | 工具发现了真实错误；查看事件负载里的 `stdout_preview` / `stderr_preview` |
+| **覆盖率低于阈值** | `Coverage X.X% below threshold Y.Y%` | 测试套件没达到最低覆盖率要求；补测试或调低 `coverage_threshold` |
+| **覆盖率无法解析** | coverage 检查通过，但事件里没有 `coverage_score` | 输出不匹配预期格式（`TOTAL ... XX%`）；确认使用的是 `pytest-cov` 或兼容工具 |
+| **OS 错误** | `Check <type> failed`，附带 "OS error" | 权限问题或工作目录不存在；检查 `working_dir` 配置 |
+
+### Stage 1 的命令从哪来
+
+Ouroboros **不再内置**按语言硬编码的预设（preset）。Stage 1 只信任一个来源：项目根目录下的 `.ouroboros/mechanical.toml`。`build_mechanical_config(working_dir)` 只是这个文件的确定性读取器——文件不存在时，所有命令解析为 `None`，Stage 1 优雅跳过，而不是去猜一个工具来跑。
+
+这个文件由 `ouroboros.evaluation.detector` 写入：它发起**一次 AI 调用**，读取项目的清单文件（`pyproject.toml`、`uv.lock`、`package.json`、`Cargo.toml`、`go.mod`、`pom.xml`、`build.gradle`、`Makefile`、`justfile`、`Taskfile.yml`、`build.zig`、`CMakeLists.txt`、`mix.exs`、`Gemfile` 等），为这个具体仓库提出命令。每条被提出的命令在落盘前都要过校验——可执行文件白名单、shell 操作符与绝对路径注入、以及仓库本身（例如只有存在 `Cargo.toml` 时才保留 `cargo` 命令）——所以 toml 里只会留下这个项目真的跑得起来的命令。
+
+显式生成或刷新：
+
+```bash
+ouroboros detect              # 检查当前目录并写入 .ouroboros/mechanical.toml
+ouroboros detect --force      # 重新检测并覆盖已有文件
+ouroboros detect --backend codex   # 为这次 detect 调用指定 LLM 后端
+```
+
+`ensure_mechanical_toml()` 是幂等的：文件已存在且 `force` 为假时，它立即返回，不发起 LLM 调用。它从不抛异常——任何失败都只是返回 `False`，Stage 1 因此没有命令可用。
+
+> **如果 Stage 1 永远通过，通常就是这个原因。** 既没有 `.ouroboros/mechanical.toml`，也没有显式配置 `MechanicalConfig` 命令时，五项检查全部被跳过并当作通过，Stage 1 就成了一道什么都不验的空关卡。跑 `ouroboros detect`，或者手写这个 toml。
+
+> **已废弃：** `detect_language()` 现在什么也检测不了。它只是一个兼容垫片，读取 `.ouroboros/mechanical.toml` 并发出 `DeprecationWarning`；请改用 `ensure_mechanical_toml()` 加 `build_mechanical_config()`。
+
+> **Go 覆盖率注意：** `go test -cover` 的输出格式（`ok  ./... coverage: XX.X% of statements`）不被覆盖率解析器匹配（它期望 `TOTAL ... XX%` 或 `Coverage: XX%`）。因此在 Go 项目里，事件负载中的 `coverage_score` 永远是 `None`，**即使覆盖率很低，阈值检查也会被跳过**。如果 Go 项目需要强制阈值，请用 `.ouroboros/mechanical.toml` 覆写一条自定义的 coverage 命令。
+
+### 项目级命令覆写
+
+Stage 1 的命令就住在项目根目录的 `.ouroboros/mechanical.toml` 里。detector 会写它，你也可以直接编辑或手写，不需要改动 Ouroboros 的配置：
+
+```toml
+# .ouroboros/mechanical.toml
+lint = "ruff check src/"
+test = "pytest tests/unit -q"
+coverage = "pytest --cov=src --cov-report=term-missing tests/"
+coverage_threshold = 0.85
+timeout = 120
+```
+
+**覆写优先级**（从高到低）：
+1. 以编程方式传入的显式 `overrides` 字典（来自 MCP 参数）
+2. 项目根目录的 `.ouroboros/mechanical.toml`
+3. 全部为 `None`（所有检查优雅跳过）
+
+**TOML 解析错误**会被记为一条警告（`mechanical.toml_parse_error`）后静默忽略。没有预设可以回退，所以所有命令保持 `None`，Stage 1 跳过全部检查。
+
+**安全：可执行文件白名单。** `.ouroboros/mechanical.toml` 中的命令只能使用内置白名单里的可执行文件（如 `pytest`、`ruff`、`cargo`、`go`、`npm`、`make`）。如果命令指定了不在白名单里的可执行文件——或者用了 shell 操作符、绝对路径——它会被静默拦截（记为 `mechanical.blocked_executable`），该项检查被跳过。通过 `MechanicalConfig` 或 MCP `overrides` 字典以编程方式传入的命令绕过这道检查，因为它们在上游已经过审。这道机制防止不受信任的仓库配置在 CI/CD 环境里执行任意命令。
+
+| 覆写失败模式 | 现象 | 原因 / 处理 |
+|---|---|---|
+| **TOML 解析错误** | 所有 Stage 1 检查被跳过；不抛错 | `.ouroboros/mechanical.toml` 格式有误；检查 TOML 语法 |
+| **可执行文件被拦截** | 该项检查被静默跳过 | 可执行文件不在白名单；换成允许的工具，或直接在 `MechanicalConfig` 里设置命令 |
+| **没有 toml 文件** | 所有 Stage 1 检查被跳过 | 跑 `ouroboros detect`，或在 `MechanicalConfig` 里显式设置命令 |
+
+### Stage 1 配置
+
+```yaml
+# 位于 PipelineConfig.mechanical（MechanicalConfig）
+mechanical:
+  coverage_threshold: 0.7           # 最低 70%（NFR9）；老项目可调低
+  timeout_seconds: 300              # 单条命令的超时秒数
+  working_dir: /path/to/project     # 省略时默认为进程 cwd
+  lint_command: ["ruff", "check", "."]
+  build_command: ["python", "-m", "build"]
+  test_command: ["pytest", "tests/"]
+  static_command: ["mypy", "src/"]
+  coverage_command: ["pytest", "--cov=src", "--cov-report=term-missing", "tests/"]
+```
+
+> **重要：** 这些字段是编程侧的逃生舱。在正常的 `ouroboros run` 路径上，命令来自 `.ouroboros/mechanical.toml`；当该文件不存在**且**没有显式配置命令时，Stage 1 会静默跳过每一项检查（并视为通过）。
+
+### 诊断 Stage 1 失败
+
+用事件查询看看发生了什么：
+
+```bash
+uv run ouroboros status execution <exec_id> --events
+```
+
+找类型为 `evaluation.stage1.completed` 的事件，负载里包含：
+- `passed`：整体结果
+- `checks`：每项检查的 `check_type`、`passed`、`message` 列表
+- `coverage_score`：解析成功时的覆盖率数值
+- `failed_count`：失败检查的数量
+
+---
+
+## Stage 2：语义评估（Semantic Evaluation）
+
+Stage 2 调用一个 Standard 档位的 LLM（默认取 `OUROBOROS_SEMANTIC_MODEL` / 配置值），针对验收标准评估产物。模型返回一个结构化 JSON 对象。
+
+### 打分字段
+
+| 字段 | 类型 | 范围 | 含义 |
+|-------|------|-------|---------|
+| `score` | float | 0.0–1.0 | 总体质量分 |
+| `ac_compliance` | bool | — | 验收标准是否被满足 |
+| `goal_alignment` | float | 0.0–1.0 | 与原始 seed 目标的一致程度 |
+| `drift_score` | float | 0.0–1.0 | 偏离 seed 意图的程度（越低越好） |
+| `uncertainty` | float | 0.0–1.0 | 模型对自己这次评估的不确定度 |
+| `reasoning` | string | — | 自由文本解释 |
+| `reward_hacking_risk` | float | 0.0–1.0 | 产物在糊弄评估器而非真正解决任务的嫌疑。与 `drift_score` 是两回事；`>= 0.7` 时否决通过 |
+| `questions_used` | list | — | 评估器在验证产物时实际问过的问题——它必须把自己的工作过程摊开 |
+| `evidence` | list | — | 判定所依据的文件片段与观察结果 |
+
+### 通过逻辑
+
+```
+if ac_compliance == False 且 not trigger_consensus  → REJECTED（不尝试 Stage 3）
+if score < 0.8                    → REJECTED（除非 Stage 3 被触发并通过）
+if score >= 0.8 且没有触发        → APPROVED
+if reward_hacking_risk >= 0.7     → REJECTED（最终否决，压过任何通过结论）
+```
+
+> **分数关卡是硬编码的 `0.8`。** `SemanticConfig.satisfaction_threshold`（默认 `0.8`）确实存在，也会被校验，但流水线比较的是字面量 `0.8`，从不读取这个字段。今天改它对通过与否没有任何影响——不要指望用它来放宽或收紧关卡。
+
+> **`ac_compliance=False` 并不总是终局。** 当评估上下文设置了 `trigger_consensus=True` 时，流水线不会就此拒绝，而是继续走到触发矩阵，让 Stage 3 对这条 Stage 2 判失败的 AC 给出第二意见。
+
+> 分数在解析后会被钳制到 0.0–1.0；模型返回的越界值会被自动纠正。
+
+### Reward hacking 否决
+
+`_build_result()` 施加了一道所有通过路径都必经的最终关卡：如果 Stage 2 报告 `reward_hacking_risk >= 0.7`（`REWARD_HACKING_VETO_THRESHOLD`），一个本来会通过的结果会被翻成拒绝。这个阈值定得刻意偏高，好让评估器轻微的疑心不至于挡下一次真实的通过。
+
+这道否决只把「通过」变成「拒绝」——它从不挽救一个已经被拒绝的结果，所以 Stage 3 共识的拒绝仍然是拒绝。它触发时，`failure_reason` 会明确点出它，而不是报一句 `"Unknown failure"`。
+
+### Stage 2 失败模式
+
+| 失败模式 | 现象 | 原因 / 处理 |
+|---|---|---|
+| **LLM API 错误** | 返回 `ProviderError` | 网络问题、限流或 API key 无效。检查 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`。错误会向上传播——流水线停止，但不会标记为拒绝。 |
+| **响应里没有 JSON** | `ValidationError: Could not find JSON in response` | LLM 的回复里没有 JSON 对象。某些「供应商 + 模型」组合会这样。确认模型对 `json_schema` 响应格式的兼容性。 |
+| **JSON 非法** | `ValidationError: Invalid JSON in response` | 模型输出的 JSON 解析失败。可能是输出被截断；试着调大 `max_tokens`。 |
+| **缺少必填字段** | `ValidationError: Missing required fields: [...]` | 模型漏掉了必填字段（`score`、`ac_compliance` 等）。通常意味着该模型对结构化输出的支持不稳定。 |
+| **AC 未满足** | `Stage 2 failed: AC non-compliance (score=X.XX)` | LLM 判定产物没有满足验收标准。查看 Stage 2 完成事件里的 `reasoning`。 |
+| **分数低于阈值** | `ac_compliance=True` 但 `final_approved=False` | 分数落在 0.0–0.79。要么产物质量确实不行，要么这条 AC 写得太宽。 |
+
+### Stage 2 配置
+
+```yaml
+# 位于 PipelineConfig.semantic（SemanticConfig）
+semantic:
+  model: null                            # null = 从 OUROBOROS_SEMANTIC_MODEL / 配置解析
+  temperature: 0.2                       # 调低以保持一致性
+  max_tokens: 2048                       # 响应 token 预算
+  satisfaction_threshold: 0.8           # 目前不生效 —— 关卡硬编码为 0.8
+```
+
+### 诊断 Stage 2 失败
+
+找 `evaluation.stage2.completed` 事件，关键字段：
+- `score`、`ac_compliance`、`goal_alignment`、`drift_score`、`uncertainty`
+
+如果 `ac_compliance` 是 `false` 但 `score` 看起来不低，可能是 LLM 发现了一个「部分实现」。读完整事件负载里的 `reasoning` 字段看解释。
+
+---
+
+## 共识触发矩阵（Stage 2 → Stage 3 关卡）
+
+Stage 2 通过之后（`ac_compliance=True`、`score >= 0.8`），触发条件会**按优先级顺序**逐个评估。第一个命中的条件触发 Stage 3。一个都没命中，产物立即通过。
+
+| 优先级 | 触发器 | 条件 |
+|----------|---------|-----------|
+| 0 | `manual_request` | `manual_consensus_request=True`，由评估上下文的 `trigger_consensus=true` 设置 |
+| 1 | `seed_modification` | 上下文中 `seed_modified=True` |
+| 2 | `ontology_evolution` | 上下文中 `ontology_changed=True` |
+| 3 | `goal_interpretation` | 上下文中 `goal_reinterpreted=True` |
+| 4 | `seed_drift_alert` | `drift_score > drift_threshold`（默认 **0.3**） |
+| 5 | `stage2_uncertainty` | `uncertainty > uncertainty_threshold`（默认 **0.3**） |
+| 6 | `lateral_thinking_adoption` | 上下文中 `lateral_thinking_adopted=True` |
+
+> **`manual_request` 会短路掉其余一切。** 它排在其他六个之前被检查，所以只要显式要求共识，无论漂移、不确定度、还是 Stage 2 的判定如何，都一定会走到 Stage 3。
+
+> **只有第一个命中的触发器会生效。** 如果漂移是 0.5，同时又采纳了 lateral thinking，只会报告 `seed_drift_alert`（优先级 4）。
+
+> **两个阈值比较都是严格的 `>`。** `drift_score` 正好等于 `drift_threshold` 不会触发 Stage 3。当 Stage 2 跑过时，它的 `drift_score` 和 `uncertainty` 优先于 `TriggerContext` 上预填的值。
+
+### 触发器配置
+
+```yaml
+# 位于 PipelineConfig.trigger（TriggerConfig）
+trigger:
+  drift_threshold: 0.3        # 调高可减少 Stage 3 的调用
+  uncertainty_threshold: 0.3  # 调高可减少 Stage 3 的调用
+```
+
+调高这些阈值能省下 Stage 3 的成本，但也可能让低置信度的输出绕过共识。
+
+### 触发器失败模式
+
+| 失败模式 | 现象 | 原因 / 处理 |
+|---|---|---|
+| **Stage 3 意外被触发** | 成本意外偏高 | Stage 2 的不确定度超过阈值。查 `evaluation.consensus.triggered` 事件里的 `trigger_type`。 |
+| **Stage 3 从不触发** | 质量疑虑无人复核 | 所有触发条件都为假；确认 `drift_score` 和 `uncertainty` 字段确实从 Stage 2 正确传了下来。 |
+| **触发器校验错误** | 触发器抛出 `ValidationError` | `TriggerContext` 结构有误；确认 `execution_id` 和各数值字段合法。 |
+
+---
+
+## Stage 3：多模型共识（Multi-Model Consensus）
+
+Stage 3 并发调用多个 Frontier 档位的模型。每个模型独立投票，需要 **2/3 多数**才算通过。
+
+### 简单共识（默认）
+
+三个模型并行被问询。默认模型都经由 OpenRouter 路由，因此三位投票者来自三个不同厂商：
+
+```
+openrouter/openai/gpt-4o
+openrouter/anthropic/claude-opus-4.8
+openrouter/google/gemini-2.5-pro
+```
+
+每个模型返回 `{ approved, confidence, reasoning }`。
+
+**通过规则：** `approving_votes / total_votes >= 0.66`（即至少 3 票中的 2 票）。这个比例是在**实际收集到**的票数上计算的，而不是配置的模型数量——见[并行共识的失败容忍](#并行共识的失败容忍)。
+
+> **单模型回退。** 当配置的模型是 `openrouter/*`，但 `OPENROUTER_API_KEY` 缺失、或仍是 `YOUR_…` 占位符时，`ConsensusEvaluator` 会静默切换到单模型模式：用 advocate、devil's advocate、judge 三套 system prompt 把会话模型问三次，由这三个视角投票。2/3 规则和「不足 2 票报错」的行为不变，但这三位审阅者在构造上就是同一厂商，所以「审阅者独立性」会被报告为不可用。此时 Stage 3 事件里的模型名是 `session/<perspective>`，触发原因带 `single-model-perspectives:` 前缀——如果 Stage 3 便宜得不合常理，就查这两处。配置非 `openrouter/*` 的模型会跳过这道检查，直接按配置使用。
+
+### 审议式共识（Deliberative Consensus）
+
+一种可选的两轮模式：
+1. **第 1 轮（并行）：** Advocate（找出优点）和 Devil's Advocate（用本体论分析做根因验证）各自独立陈述立场。
+2. **第 2 轮：** Judge 复核两方立场，给出判定：`approved`、`rejected` 或 `conditional`。
+
+> **注意：** `conditional` 是审议模式下 Judge 的合法判定。在 `DeliberationResult.approved` 属性里，`conditional` 映射为**拒绝**（该属性只有 `approved` 时才返回 `True`）。附加条件列在 `JudgmentResult.conditions` 中。
+
+### Stage 3 失败模式
+
+| 失败模式 | 现象 | 原因 / 处理 |
+|---|---|---|
+| **收集到的票数少于 2** | `ValidationError: Not enough votes collected: N/3` | 多个模型返回了 API 错误。检查所有已配置共识模型的 API key。3 个模型中至少要有 2 个响应。 |
+| **各模型意见完全分歧** | `majority_ratio` 在 0.33–0.50 附近 | 真实的分歧。查看事件负载里的 `disagreements` 列表。考虑打磨这条 AC 或产物本身。 |
+| **多数比例低于阈值** | `Stage 3 failed: Consensus not reached (XX%)` | 通过票不足 2/3。`ConsensusResult` 的 `disagreements` 元组里有反对者的理由。 |
+| **单个模型 API 错误** | 记日志但被容忍 | 一个模型失败，用剩下的票。如果只剩 1 票，抛出 `ValidationError`。 |
+| **审议式：Advocate 失败** | `ValidationError: Advocate failed: ...` | Advocate 模型 API 错误。审议模式不容忍这个错误——整个 Stage 3 失败。 |
+| **审议式：Devil's Advocate 的 LLM 错误** | Devil 投出 `approved=False` 且置信度很低的一票 | `DevilAdvocateStrategy` 在内部消化 LLM 错误，返回 `AnalysisResult.invalid`（软失败）而不向上传播。Devil 的 LLM 失败**不会**中止 Stage 3；它变成 Devil 投出的一张反对票，这可能导致 Judge 拒绝。 |
+| **审议式：Judge 失败** | `ProviderError` 或 `ValidationError` | Judge 模型出错，Stage 3 失败。审议模式对 Judge 没有部分投票容忍。 |
+| **投票者返回非法 JSON** | `ValidationError: Could not find JSON in vote from <model>` | 模型返回了格式错误的 JSON。重试，或在 `ConsensusConfig.models` 里换个模型。 |
+| **Judge 返回非法判定** | `ValidationError: Invalid verdict '<x>' from <model>` | Judge 回了一个无法识别的判定字符串。可接受的值：`approved`、`rejected`、`conditional`。 |
+
+### Stage 3 配置
+
+**简单共识（`ConsensusConfig`）**
+
+```yaml
+# 位于 PipelineConfig.consensus（ConsensusConfig）
+consensus:
+  models:
+    - "openrouter/openai/gpt-4o"
+    - "openrouter/anthropic/claude-opus-4.8"
+    - "openrouter/google/gemini-2.5-pro"
+  temperature: 0.3
+  max_tokens: 1024
+  majority_threshold: 0.66     # 2/3 多数
+  diversity_required: true     # 目前不生效 —— 见下方说明
+```
+
+> **`diversity_required` 并未被强制执行。** 这个字段在 `ConsensusConfig` 和配置 schema 里都存在，但没有任何代码读它。厂商多样性来自默认模型名单本身，而不是这个开关。如果你把名单换成同一厂商的三个模型，`diversity_required: true` 不会提出任何异议。
+
+**审议式共识（`DeliberativeConfig`）**
+
+配合 `DeliberativeConsensus` 使用（不是 `ConsensusEvaluator`）。每个角色用各自的模型：
+
+```python
+from ouroboros.evaluation.consensus import DeliberativeConfig, DeliberativeConsensus
+
+config = DeliberativeConfig(
+    advocate_model="openrouter/anthropic/claude-opus-4.8",  # Advocate 角色
+    devil_model="openrouter/openai/gpt-4o",                 # Devil's Advocate（本体论分析）
+    judge_model="openrouter/google/gemini-2.5-pro",         # 最终判定
+    temperature=0.3,
+    max_tokens=2048,
+)
+evaluator = DeliberativeConsensus(llm_adapter, config)
+```
+
+`DeliberativeConfig` 的默认模型读自 `OUROBOROS_CONSENSUS_ADVOCATE_MODEL`、`OUROBOROS_CONSENSUS_DEVIL_MODEL`、`OUROBOROS_CONSENSUS_JUDGE_MODEL` 三个环境变量（或 [Config Reference](../config-reference.md) 里记录的配置值）。
+
+### 诊断 Stage 3 失败
+
+找 `evaluation.stage3.completed` 事件，关键字段：
+- `approved`：最终决定
+- `votes`：`{ model, approved, confidence, reasoning }` 的列表
+- `majority_ratio`：通过票占比
+- `disagreements`：反对票的理由
+
+> **审议模式下 `majority_ratio` 的注意事项：** 在审议式共识里，`evaluation.stage3.completed` 事件的 `majority_ratio` 永远是 `1.0`（通过）或 `0.0`（拒绝）——它并不反映真实的票数比例。要看 Advocate 和 Devil's Advocate 的立场，请用 `votes` 列表以及其中每一项的 `approved` 字段。
+
+---
+
+## 产物收集（Artifact Collection）
+
+在 Stage 2 运行之前，`ArtifactCollector` 会尝试读取本次执行真正改动过的源文件。这样语义评估器拿到的是真实代码，而不只是 agent 的文字摘要。
+
+### 收集上限
+
+| 上限 | 值 | 超出后的效果 |
+|-------|-------|---------------------|
+| 单文件大小上限（`MAX_FILE_SIZE`） | 100 KB | 超过 100 KB 的文件被静默跳过 |
+| 内容总量上限（`MAX_TOTAL_CHARS`） | 150,000 字符（约 37K token） | 内容按剩余预算截断，`FileArtifact.truncated=True` |
+
+**文件数量没有上限。** 字符预算是唯一的限制器，所以一次改动很多小文件会被完整收集，而一个超大文件会被丢掉。
+
+> 这两条上限的行为不一样。超过单文件大小上限的文件被**整个跳过**（绝不截断）；只是耗尽了共享字符预算的文件会被**截断**并标记 `truncated=True`。如果某个关键文件总是缺席，先看看它是不是应该被排除在评估之外的生成物、二进制或压缩产物。
+
+### 产物收集失败模式
+
+| 失败模式 | 现象 | 原因 / 处理 |
+|---|---|---|
+| **未设置 project_dir** | 评估只用到文字摘要 | 构建 `ArtifactBundle` 时没有文件内容；语义评估器退回到 agent 的文字输出。在执行上下文里设置 `project_dir`。 |
+| **没有抽取到文件路径** | 同上 | 执行输出里没有可识别的 `Write:` / `Edit:` / `file_path:` 模式。回退到文字摘要。 |
+| **路径穿越被拦截** | 文件被静默跳过 | 文件路径解析后落在 `project_dir` 之外。这是安全边界，不是 bug。 |
+| **权限错误** | 文件被静默跳过 | 执行时用的是另一个用户身份。检查文件权限。 |
+| **大文件被跳过** | 评估缺少上下文 | 文件超过 100 KB。拆分大文件，或者接受评估器只能依据文字摘要工作。 |
+
+---
+
+## 流水线级错误处理
+
+### 错误（Error）与失败（Failure）
+
+Ouroboros 区分**失败**（产物没达到标准）与**错误**（流水线自身跑不完）：
+
+| 结果 | 类型 | 会发生什么 |
+|---------|------|-------------|
+| Stage 1 检查未通过 | 失败 | `EvaluationResult.final_approved=False`，并设置 `failure_reason` |
+| Stage 2 AC 未满足 | 失败 | 同上 —— `EvaluationResult.final_approved=False` |
+| Stage 3 少数票 | 失败 | 同上 —— `EvaluationResult.final_approved=False` |
+| LLM API 错误（Stage 2/3） | 错误 | `Result.err(ProviderError)` 向上传播 —— runner 收到的是错误，而不是一个失败结果 |
+| 票数不足（Stage 3） | 错误 | `Result.err(ValidationError)` —— 共识根本无从尝试 |
+| JSON 解析失败（Stage 2/3） | 错误 | `Result.err(ValidationError)` —— 本次评估被放弃 |
+
+**错误**会让这条 AC 处于未定状态。orchestrator 的 runner 通过档位升级（换更强的模型重试）来处理；重试耗尽后则交给停滞检测。
+
+### 关闭某些阶段
+
+各阶段可以在 `PipelineConfig` 里单独关闭：
+
+```python
+from ouroboros.evaluation.pipeline import PipelineConfig
+
+# 跳过机械验证（例如产物是文档类的）
+config = PipelineConfig(stage1_enabled=False)
+
+# 跳过共识（成本受限的运行）
+config = PipelineConfig(stage3_enabled=False)
+```
+
+> **警告：** 关闭 Stage 1 意味着坏掉的代码可以直接进入语义评估。关闭 Stage 3 意味着高漂移、高不确定度的输出永远不会被送去多模型复核。
+
+> **关闭 Stage 2 并不会关闭 Stage 3。** 触发上下文被刻意构建在 Stage 2 代码块之外，正是为了让 `trigger_consensus=True` 在 `stage2_enabled=False` 时依然有效——它会触发 `manual_request`，Stage 3 独立跑起来。真正会悄悄关掉 Stage 3 的是这个组合：`stage2_enabled=False`、`trigger_consensus=False`、且没有外部 `trigger_context`——此时所有触发字段都是默认值，没有一条能命中。要在不跑 Stage 2 的情况下到达 Stage 3，要么设置 `trigger_consensus=True`，要么向 `EvaluationPipeline.evaluate()` 传入一个预填好的 `TriggerContext`。
+
+### failure_reason 对照表
+
+`EvaluationResult.failure_reason` 返回一个人类可读的字符串：
+
+| 条件 | `failure_reason` 的值 |
+|-----------|------------------------|
+| Stage 1 未通过 | `"Stage 1 failed: lint, test"`（逗号分隔的失败检查名） |
+| Stage 2 AC 未满足（`ac_compliance=False`） | `"Stage 2 failed: AC non-compliance (score=0.62)"` |
+| Stage 2 分数低于阈值（`ac_compliance=True` 但 `score < 0.8`） | `"Unknown failure"` —— 分数检查发生在 Stage 2 之后，但 `failure_reason` 属性只判断 `ac_compliance`。要区分这种情况，请直接查 `stage2_result.score`。 |
+| Stage 3 未达成共识 | `"Stage 3 failed: Consensus not reached (44%)"` |
+| Reward hacking 否决（`reward_hacking_risk >= 0.7`） | 一条点名风险分与 0.70 阈值的消息 —— 这道否决会被如实报告，不会藏在 `"Unknown failure"` 后面 |
+| 所有阶段都通过或跳过，但 `final_approved=False` | `"Unknown failure"` |
+
+---
+
+## 评估中的边界情况
+
+### 按 AC 独立评估
+
+AC 树里的每一条 AC 都被**独立**评估。`EvaluationContext` 只携带一个 `current_ac` 字符串。即使一个产物包（artifact bundle）引用了跨多条 AC 的文件，语义评估器也只针对当前这一条 AC 打分。
+
+### 数值分数的钳制
+
+无论 LLM 返回什么，Stage 2 的分数都会被自动钳制到 [0.0, 1.0]。模型给出的越界值不会报错，而是被静默纠正。如果你看到分数正好是 0.0 或 1.0，检查一下模型是不是在返回越界值。
+
+### Stage 2 不确定度的传播
+
+如果外部传入的 `TriggerContext` 已经设置了 `uncertainty_score`，但 `semantic_result` 字段同时也有值，那么在漂移和不确定度的触发判断中，**`semantic_result`** 的值优先。预填的 `TriggerContext` 字段只在没有 `semantic_result` 时才被使用。
+
+### 审议模式的 `conditional` 判定
+
+在审议式共识里，Judge 可以返回 `conditional`。这表示 Judge 认为有价值，但要求先做出特定修改才能通过。这些条件列在 `JudgmentResult.conditions` 里。**在流水线中 `conditional` 被当作拒绝处理**（`DeliberationResult.approved == False`）。这些条件应该作为可执行的反馈呈现给用户；它们出现在 `evaluation.stage3.completed` 事件负载的 `votes` 列表中。
+
+### 覆盖率分数的解析
+
+Stage 1 从 `pytest-cov` 的输出里按 `TOTAL  N  N  XX%` 或 `Coverage: XX%` 的模式解析覆盖率。如果你的覆盖率工具输出的是别的格式，`coverage_score` 会是 `None`，并且**即使覆盖率是零，coverage 检查也会通过**。请配置一个格式兼容的覆盖率命令，或者查事件负载里的 `coverage_score` 字段来确认解析是否成功。
+
+### 并行共识的失败容忍
+
+在**简单共识**下，只要至少有 2 个模型成功响应，个别模型的失败是被容忍的。`majority_ratio` 只在收集到的票上计算（`approving / len(votes)`），而不是按配置的模型数量。这意味着：
+- 2 个模型响应，1 个通过 → `majority_ratio = 0.5` → **拒绝**（低于 0.66）
+- 2 个模型响应，都通过 → `majority_ratio = 1.0` → **通过**
+
+在**审议式共识**下，Advocate 和 Judge 两个角色必须成功完成——任一失败都会让 Stage 3 返回错误。Devil's Advocate 角色在内部消化 LLM 错误（返回一张反对票而非向上传播错误），所以单是 Devil 模型失败不会中止 Stage 3。
+
+---
+
+## 完整配置参考
+
+```python
+from ouroboros.evaluation.pipeline import PipelineConfig
+from ouroboros.evaluation.mechanical import MechanicalConfig
+from ouroboros.evaluation.semantic import SemanticConfig
+from ouroboros.evaluation.consensus import ConsensusConfig
+from ouroboros.evaluation.trigger import TriggerConfig
+
+config = PipelineConfig(
+    # 启用 / 关闭各阶段
+    stage1_enabled=True,
+    stage2_enabled=True,
+    stage3_enabled=True,
+
+    # Stage 1：机械验证
+    mechanical=MechanicalConfig(
+        coverage_threshold=0.7,       # NFR9 最低要求；0.0 表示关闭阈值
+        lint_command=("ruff", "check", "."),
+        build_command=None,           # None = 跳过这项检查
+        test_command=("pytest", "tests/"),
+        static_command=("mypy", "src/"),
+        coverage_command=("pytest", "--cov=src", "--cov-report=term-missing", "tests/"),
+        timeout_seconds=300,          # 单条命令超时
+        working_dir=None,             # 默认为进程 cwd
+    ),
+
+    # Stage 2：语义评估
+    semantic=SemanticConfig(
+        model=None,                  # None = 由 semantic_evaluation 角色解析
+        temperature=0.2,
+        max_tokens=2048,
+        satisfaction_threshold=0.8,  # 目前不生效 —— 关卡硬编码为 0.8
+    ),
+
+    # Stage 3：简单共识评估
+    consensus=ConsensusConfig(
+        models=(
+            "openrouter/openai/gpt-4o",
+            "openrouter/anthropic/claude-opus-4.8",
+            "openrouter/google/gemini-2.5-pro",
+        ),
+        temperature=0.3,
+        max_tokens=1024,
+        majority_threshold=0.66,     # 需要 2/3 多数
+        diversity_required=True,     # 目前不生效
+    ),
+
+    # 共识触发阈值
+    trigger=TriggerConfig(
+        drift_threshold=0.3,         # stage2 的 drift_score 高于此值触发 Stage 3
+        uncertainty_threshold=0.3,   # stage2 的 uncertainty 高于此值触发 Stage 3
+    ),
+)
+```
+
+审议式共识（独立于 `EvaluationPipeline`）：
+
+```python
+from ouroboros.evaluation.consensus import DeliberativeConfig, DeliberativeConsensus
+
+deliberative_config = DeliberativeConfig(
+    advocate_model="openrouter/anthropic/claude-opus-4.8",  # Advocate 角色
+    devil_model="openrouter/openai/gpt-4o",                 # Devil's Advocate（本体论分析）
+    judge_model="openrouter/google/gemini-2.5-pro",         # 最终判定
+    temperature=0.3,
+    max_tokens=2048,
+)
+# 直接使用，不经由 EvaluationPipeline
+evaluator = DeliberativeConsensus(llm_adapter, deliberative_config)
+result = await evaluator.deliberate(context, trigger_reason="seed_drift_alert")
+```
+
+---
+
+## 事件审计轨迹
+
+每个阶段都会向 SQLite 事件存储发出事件。用它们可以还原任何一次评估到底发生了什么：
+
+| 事件类型 | 何时发出 | 关键负载字段 |
+|---|---|---|
+| `evaluation.stage1.started` | Stage 1 开始 | `checks_to_run` |
+| `evaluation.stage1.completed` | Stage 1 结束 | `passed`、`checks`、`coverage_score`、`failed_count` |
+| `evaluation.stage2.started` | Stage 2 开始 | `model`、`current_ac` |
+| `evaluation.stage2.completed` | Stage 2 结束 | `score`、`ac_compliance`、`goal_alignment`、`drift_score`、`uncertainty` |
+| `evaluation.consensus.triggered` | 触发矩阵命中 | `trigger_type`、`trigger_details` |
+| `evaluation.stage3.started` | Stage 3 开始 | `models`、`trigger_reason` |
+| `evaluation.stage3.completed` | Stage 3 结束 | `approved`、`votes`、`majority_ratio`、`disagreements` |
+| `evaluation.pipeline.completed` | 整条流水线跑完 | `final_approved`、`highest_stage`、`failure_reason` |
+
+查询某次执行的事件：
+
+```bash
+uv run ouroboros status execution <exec_id> --events
+```
+
+---
+
+## 延伸阅读
+
+- [evaluation-pipeline.md](./evaluation-pipeline.md) —— 本文的英文原文
+- [隐藏清单收敛（Hidden-Checklist Convergence）](../hidden-checklist-convergence/README.zh-CN.md) —— run → 评估 → 有预算的 Ralph 链，以及判分用的断言为什么对 worker 无条件隐藏
+- [Architecture Guide](../architecture.md)（英文）—— 六阶段架构里的 Phase 4
+- [Seed Authoring Guide](./seed-authoring.md)（英文）—— 验收标准写得好，AC 未满足的情况就少
+- [Getting Started](../getting-started.md)（英文）—— 新用户的首次上手流程
+- [Config Reference](../config-reference.md)（英文）—— 模型覆写用的环境变量（`OUROBOROS_SEMANTIC_MODEL`、`OUROBOROS_CONSENSUS_MODELS`）


### PR DESCRIPTION
**Severity:** medium

> **Stacked on #1972.** Base branch is `docs/eval-pipeline-code-accuracy`, so the diff shown here includes that PR's commits until it merges. The only commit belonging to this PR is `docs(i18n): add the Chinese evaluation pipeline guide`. The stacking is deliberate: #1972 corrects the places where the English guide no longer matched the code, and this translation is written against the corrected text so the two versions do not disagree on the day they land.
>
> **No checks have run on this PR yet, and that is expected.** Every workflow in `.github/workflows/` is gated on `pull_request: branches: [main, develop]`, so a PR based on another branch triggers nothing — including the issue-link gate, even though `Closes #1973` is present below. Merging #1972 first auto-retargets this PR to `main`, at which point the full suite runs. Please merge #1972 before this one.

## Summary

Adds `docs/guides/evaluation-pipeline.zh-CN.md`, following the pattern #1961 established. #1960 named the evaluation pipeline as one of the next two most-asked-about guides; this is the first of them.

## What the page covers

A full companion, not a summary — same structure and the same claims as the English guide:

- All three stages: what Stage 1 actually runs and where its commands come from, Stage 2's scoring fields and approval logic, Stage 3's simple and deliberative consensus modes
- The complete consensus trigger matrix including `manual_request` and the strict `>` comparisons
- Every failure-mode table, which is the part users reach for when a verdict looks wrong
- The reward-hacking veto, artifact collection limits, error-vs-failure distinction, edge cases, the full config reference, and the event audit trail

Identifiers, file paths, config keys, event type names, CLI commands, and error strings stay in their original form — those are what a reader greps for. Terminology follows `README.zh-CN.md` (`验收标准`, `漂移`, `产物`, `三阶段关卡`) so the vocabulary matches what a Chinese reader already saw on the front page.

## Navigation

- `docs/README.md` lists the Chinese page beside the English entry in the Guides index
- The English guide links to it from directly under the title
- `README.zh-CN.md` promotes its design-docs line into a list and puts this guide above the existing hidden-checklist entry

Neither direction dead-ends.

## Test plan

- [x] All seven relative links resolve from `docs/guides/`: `./evaluation-pipeline.md`, `./execution-vs-evaluation.md`, `./seed-authoring.md`, `../architecture.md`, `../config-reference.md`, `../getting-started.md`, `../hidden-checklist-convergence/README.zh-CN.md`
- [x] Both in-page anchors match their headings (`#reward-hacking-否决`, `#并行共识的失败容忍`)
- [x] The ASCII diagram is byte-identical to the English one — verified by comparison, not by eye. Full-width CJK punctuation inside box-drawing characters would break the alignment, so the diagram keeps its English labels and a Chinese legend sits underneath it
- [x] 15 fenced code blocks in each version; every markdown table has a consistent column count across header, separator, and body rows
- [x] Technical claims come from the corrected English guide and #1971's source citations, not restated from memory — including the hardcoded `0.8` gate, the inert `satisfaction_threshold` and `diversity_required`, `MAX_FILE_SIZE = 100 KB` with no file-count cap, and the single-model consensus fallback
- [x] English guide untouched apart from the one added link line

Closes #1973
