### PR TITLE
Show contribution activity instead of star history

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -505,14 +505,16 @@ Ouroboros는 MIT 라이선스로 공개 개발되는 오픈소스입니다. 이 
 
 ---
 
-## Star 히스토리
+## 활동
 
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-light-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=light" alt="Star History Chart" width="100%" />
-</a>
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-dark-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=dark" alt="Star History Chart" width="100%" />
-</a>
+여기 있는 숫자는 이 페이지를 열 때 GitHub API에서 실시간으로 읽어옵니다.
+
+<p align="center">
+  <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/commit-activity/m/Q00/ouroboros?color=orange" alt="Commit activity"></a>
+  <a href="https://github.com/Q00/ouroboros/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/Q00/ouroboros?color=orange" alt="Closed pull requests"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/last-commit/Q00/ouroboros?color=orange" alt="Last commit"></a>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -564,14 +564,16 @@ Every sponsor keeps the serpent evolving. Thank you.
 
 ---
 
-## Star History
+## Activity
 
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-light-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=light" alt="Star History Chart" width="100%" />
-</a>
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-dark-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=dark" alt="Star History Chart" width="100%" />
-</a>
+Every number here is read live from the GitHub API when you load this page.
+
+<p align="center">
+  <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/commit-activity/m/Q00/ouroboros?color=orange" alt="Commit activity"></a>
+  <a href="https://github.com/Q00/ouroboros/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/Q00/ouroboros?color=orange" alt="Closed pull requests"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/last-commit/Q00/ouroboros?color=orange" alt="Last commit"></a>
+</p>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -521,14 +521,16 @@ Ouroboros 采用 MIT 许可证，完全开源开发。如果它为你减少了�
 
 ---
 
-## Star 历史
+## 活跃度
 
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-light-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=light" alt="Star History Chart" width="100%" />
-</a>
-<a href="https://www.star-history.com/?repos=Q00/ouroboros&type=Date#gh-dark-mode-only">
-  <img src="https://api.star-history.com/svg?repos=Q00/ouroboros&type=Date&theme=dark" alt="Star History Chart" width="100%" />
-</a>
+这里的数字在你打开这个页面时从 GitHub API 实时读取。
+
+<p align="center">
+  <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/commit-activity/m/Q00/ouroboros?color=orange" alt="Commit activity"></a>
+  <a href="https://github.com/Q00/ouroboros/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/Q00/ouroboros?color=orange" alt="Closed pull requests"></a>
+  <a href="https://github.com/Q00/ouroboros/commits/main"><img src="https://img.shields.io/github/last-commit/Q00/ouroboros?color=orange" alt="Last commit"></a>
+</p>
 
 ---
 


### PR DESCRIPTION
All three READMEs ended on a star-history chart. Stars measure attention, not whether the project is alive, and the activity numbers underneath were not shown anywhere:

```
contributors                69
commits (last month)       296
merged pull requests     1,096
closed issues              620
forks                      535
last commit              today
```

Replaces the section with four shields.io badges: contributors, monthly commit activity, closed pull requests, last commit. Section heading is localized (`Activity` / `활동` / `活跃度`) with a one-line note that the numbers are read live.

## Why badges and not another chart

- **They update themselves.** No asset to regenerate, nothing to go stale.
- **They cannot flatter.** The value is whatever the API returns the day someone loads the page.
- **They do not misread during a quiet week.** A monthly-event chart plots the partially elapsed current month against complete months and renders as a cliff. A reader has no way to discount that. `last commit: today` has no such failure mode.

## Alternatives I actually checked

| Option | Result |
|---|---|
| OSS Insight activity trends (`repo_id=1133901637`) | 200, but shows the partial-month cliff described above |
| OSS Insight top contributors | 200, renders with no name labels; reads as a one-person project |
| Repobeats | needs an account to mint an embed id |

## Test plan

- [x] All four badge endpoints fetched: 200, values `contributors: 69`, `commit activity: 296/month`, `pull requests: 1.3k closed`, `last commit: today`
- [x] `grep -c star-history` returns 0 in all three READMEs
- [x] Each badge links to the corresponding GitHub view (contributors graph, commits, closed PRs)
- [x] Heading and blurb localized per file; badge markup identical across the three
- [x] Nothing outside the replaced section touched

Closes #1980