### PR TITLE
fix(mcp): register checklist verifier in Claude server

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1642,7 +1642,6 @@ def create_ouroboros_server(
         AutoHandler,
         CancelExecutionHandler,
         CancelJobHandler,
-        ChecklistVerifyHandler,
         EvaluateHandler,
         EvolveRewindHandler,
         EvolveStepHandler,
@@ -1667,6 +1666,7 @@ def create_ouroboros_server(
         StartRalphHandler,
         create_fanout_handlers,
     )
+    from ouroboros.mcp.tools.evaluation_composition import create_shared_evaluation_handlers
     from ouroboros.mcp.tools.fanout import FanoutRegistry
     from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
     from ouroboros.mcp.tools.qa import QAHandler
@@ -2337,15 +2337,8 @@ def create_ouroboros_server(
         agent_runtime_backend=execute_runtime_backend,
         opencode_mode=None,
     )
-    evaluate_handler = EvaluateHandler(
-        event_store=event_store,
-        llm_backend=evaluate_llm_backend,
-        agent_runtime_backend=evaluate_runtime_backend,
-        opencode_mode=opencode_mode,
-    )
-    checklist_verify_handler = ChecklistVerifyHandler(
-        evaluate_handler=evaluate_handler,
-        llm_backend=evaluate_llm_backend,
+    evaluate_handler, checklist_verify_handler = create_shared_evaluation_handlers(
+        EvaluateHandler, event_store, evaluate_llm_backend, evaluate_runtime_backend, opencode_mode
     )
     start_evaluate_handler = StartEvaluateHandler(
         evaluate_handler=evaluate_handler,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1642,6 +1642,7 @@ def create_ouroboros_server(
         AutoHandler,
         CancelExecutionHandler,
         CancelJobHandler,
+        ChecklistVerifyHandler,
         EvaluateHandler,
         EvolveRewindHandler,
         EvolveStepHandler,
@@ -2342,6 +2343,10 @@ def create_ouroboros_server(
         agent_runtime_backend=evaluate_runtime_backend,
         opencode_mode=opencode_mode,
     )
+    checklist_verify_handler = ChecklistVerifyHandler(
+        evaluate_handler=evaluate_handler,
+        llm_backend=evaluate_llm_backend,
+    )
     start_evaluate_handler = StartEvaluateHandler(
         evaluate_handler=evaluate_handler,
         event_store=event_store,
@@ -2490,6 +2495,7 @@ def create_ouroboros_server(
         BrownfieldHandler(_store=brownfield_store),
         evaluate_handler,
         start_evaluate_handler,
+        checklist_verify_handler,
         LateralThinkHandler(
             agent_runtime_backend=reflect_runtime_backend,
             opencode_mode=opencode_mode,

--- a/src/ouroboros/mcp/tools/evaluation_composition.py
+++ b/src/ouroboros/mcp/tools/evaluation_composition.py
@@ -1,0 +1,35 @@
+"""Shared evaluation handlers for executable MCP composition roots."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ouroboros.mcp.tools.evaluation_handlers import (
+    ChecklistVerifyHandler,
+    EvaluateHandler,
+)
+
+
+def create_shared_evaluation_handlers(
+    evaluate_factory: Callable[..., EvaluateHandler],
+    event_store: Any,
+    llm_backend: str,
+    agent_runtime_backend: str,
+    opencode_mode: str | None,
+) -> tuple[EvaluateHandler, ChecklistVerifyHandler]:
+    """Create one evaluator authority and its checklist-verification facade."""
+    evaluate = evaluate_factory(
+        event_store=event_store,
+        llm_backend=llm_backend,
+        agent_runtime_backend=agent_runtime_backend,
+        opencode_mode=opencode_mode,
+    )
+    checklist = ChecklistVerifyHandler(
+        evaluate_handler=evaluate,
+        llm_backend=llm_backend,
+    )
+    return evaluate, checklist
+
+
+__all__ = ["create_shared_evaluation_handlers"]

--- a/src/ouroboros/mcp/tools/runtime_tool_composition.py
+++ b/src/ouroboros/mcp/tools/runtime_tool_composition.py
@@ -137,7 +137,6 @@ def configured_runtime_tools(
         project_dir = runtime_adapter.working_directory
 
     from ouroboros.mcp.server.adapter import create_ouroboros_server
-    from ouroboros.mcp.tools.evaluation_handlers import ChecklistVerifyHandler
 
     compose_token = _COMPOSING_RUNTIME_TOOLS.set(True)
     try:
@@ -163,10 +162,6 @@ def configured_runtime_tools(
         _COMPOSING_RUNTIME_TOOLS.reset(compose_token)
 
     configured = dict(server._tool_handlers)  # noqa: SLF001 - composition reuse
-    configured["ouroboros_checklist_verify"] = ChecklistVerifyHandler(
-        evaluate_handler=configured["ouroboros_evaluate"],
-        llm_backend=llm_backend,
-    )
     ordered_names = (
         "ouroboros_execute_seed",
         "ouroboros_start_execute_seed",

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -694,6 +694,7 @@ class TestCreateOuroborosServer:
         "ouroboros_brownfield",
         "ouroboros_cancel_execution",
         "ouroboros_cancel_job",
+        "ouroboros_checklist_verify",
         "ouroboros_evaluate",
         "ouroboros_evolve_rewind",
         "ouroboros_evolve_step",
@@ -736,7 +737,50 @@ class TestCreateOuroborosServer:
         assert server.info.name == "ouroboros-mcp"
         assert server.info.version == __version__
         tool_names = {tool.name for tool in server.info.tools}
+        assert len(tool_names) == 36
         assert tool_names == self.EXPECTED_OUROBOROS_SERVER_TOOLS
+
+    def test_checklist_verify_reuses_the_registered_evaluator(self) -> None:
+        """Checklist verification must not create a parallel evaluation authority."""
+        from ouroboros.mcp.tools.evaluation_handlers import (
+            ChecklistVerifyHandler,
+            EvaluateHandler,
+        )
+
+        server = create_ouroboros_server()
+        evaluate = server._tool_handlers["ouroboros_evaluate"]
+        checklist = server._tool_handlers["ouroboros_checklist_verify"]
+
+        assert isinstance(evaluate, EvaluateHandler)
+        assert isinstance(checklist, ChecklistVerifyHandler)
+        assert checklist.evaluate_handler is evaluate
+
+    @pytest.mark.asyncio
+    async def test_public_client_initializes_lists_and_routes_checklist_verify(self) -> None:
+        """The shipped server exposes and invokes checklist verify across MCP v2."""
+        from mcp import Client
+        from mcp.server import MCPServer
+
+        server = create_ouroboros_server(runtime_backend="claude_mcp")
+        with patch.object(MCPServer, "run_stdio_async", new=AsyncMock()):
+            await server.serve(transport="stdio")
+
+        async with Client(server._mcp_server, mode="auto") as client:
+            tool_names = {tool.name for tool in (await client.list_tools()).tools}
+            result = await client.call_tool(
+                "ouroboros_checklist_verify",
+                {
+                    "session_id": "ses_issue_1978",
+                    "seed_content": "goal: missing acceptance criteria",
+                    "artifact": "candidate",
+                },
+            )
+
+            assert client.server_info.name == "ouroboros-mcp"
+
+        assert "ouroboros_checklist_verify" in tool_names
+        assert result.is_error is True
+        assert "Seed validation failed" in result.content[0].text
 
     @pytest.mark.asyncio
     async def test_synapse_control_and_execution_paths_use_durable_relay(self) -> None:

--- a/tests/unit/mcp/tools/test_evaluate_ralph_chaining.py
+++ b/tests/unit/mcp/tools/test_evaluate_ralph_chaining.py
@@ -475,6 +475,26 @@ def test_runtime_factory_reuses_configured_parent_owned_convergence_graph(
 
 @pytest.mark.parametrize(
     ("runtime_backend", "opencode_mode"),
+    [("opencode", "plugin"), ("codex", None), ("hermes", None)],
+)
+def test_runtime_factory_reuses_server_owned_checklist_handler(
+    runtime_backend: str,
+    opencode_mode: str | None,
+) -> None:
+    """Builtin interception must retain the server's configured handler identity."""
+    runtime = _builtin_runtime(runtime_backend, opencode_mode)
+    handlers = runtime._get_builtin_mcp_handlers()
+    composition = runtime._builtin_mcp_tool_composition
+
+    assert composition is not None
+    assert (
+        handlers["ouroboros_checklist_verify"]
+        is composition.server_owner._tool_handlers["ouroboros_checklist_verify"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("runtime_backend", "opencode_mode"),
     [("codex", None), ("hermes", None), ("opencode", "plugin")],
 )
 def test_builtin_composition_reuses_canonicalized_runtime_owner(


### PR DESCRIPTION
## Summary

- Expose `ouroboros_checklist_verify` from the shipped Claude CLI MCP server.
- Reuse the registered `EvaluateHandler` so checklist verification shares the same evaluation authority and EventStore.

## Changes

- Register `ChecklistVerifyHandler` in `create_ouroboros_server()`.
- Expand the integration catalogue contract to 36 unique tools.
- Cover dependency identity plus MCP initialize, list, and checklist call paths.

## Verification

- Independent verifier: PASS at `7cfc174b47d2a85170e4e8cea6f0339b7c48d023`
- MCP suites: 1,967 passed, 1 skipped, 1 xfailed
- Additional focused suites: 212 passed and 230 passed
- Ruff, format, and MyPy: PASS

Closes #1978