### PR TITLE
docs(readme): clarify activity badge freshness

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -507,7 +507,7 @@ Ouroboros는 MIT 라이선스로 공개 개발되는 오픈소스입니다. 이 
 
 ## 활동
 
-여기 있는 숫자는 이 페이지를 열 때 GitHub API에서 실시간으로 읽어옵니다.
+여기 있는 숫자는 GitHub 데이터를 바탕으로 생성되어 자동으로 갱신되며, 캐시로 인해 업데이트가 지연될 수 있습니다.
 
 <p align="center">
   <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Every sponsor keeps the serpent evolving. Thank you.
 
 ## Activity
 
-Every number here is read live from the GitHub API when you load this page.
+These numbers are generated from GitHub data and refreshed automatically; caching may delay updates.
 
 <p align="center">
   <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -523,7 +523,7 @@ Ouroboros 采用 MIT 许可证，完全开源开发。如果它为你减少了�
 
 ## 活跃度
 
-这里的数字在你打开这个页面时从 GitHub API 实时读取。
+这里的数字基于 GitHub 数据生成并自动更新；缓存可能会导致更新延迟。
 
 <p align="center">
   <a href="https://github.com/Q00/ouroboros/graphs/contributors"><img src="https://img.shields.io/github/contributors/Q00/ouroboros?color=orange" alt="Contributors"></a>


### PR DESCRIPTION
## Summary

- Replace the overclaim that activity badges read GitHub APIs in real time.
- Keep the English, Korean, and Chinese README descriptions semantically aligned.

## Changes

- Describe the badges as generated from GitHub data and refreshed automatically.
- State that intermediary caches can delay visible updates.

## Verification

- Independent verifier: PASS at `b31c256042d8b2a78a9a6b792569697d47da6724`
- All Shields and GitHub targets returned HTTP 200
- Observed Shields cache headers: `max-age=120, s-maxage=120`
- README badge blocks remain byte-identical across EN/KO/ZH
- Related test: 31 passed

Follow-up to official bot review #4892552515 on #1981.
Refs #1980