### PR TITLE
Add the Korean Claude Code runtime guide

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -206,7 +206,7 @@ Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 �
 <details>
 <summary><strong>다른 설치 방법</strong></summary>
 
-**Claude Code 플러그인만** (시스템 패키지 없이):
+**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`는 있어야 합니다):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -206,7 +206,7 @@ Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 �
 <details>
 <summary><strong>다른 설치 방법</strong></summary>
 
-**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`는 있어야 합니다):
+**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`와 `python3`이 있어야 합니다 — [#2001](https://github.com/Q00/ouroboros/issues/2001)):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -231,7 +231,7 @@ ouroboros setup                         # 런타임 설정
 
 호환성 참고: extras 전환 기간 동안 `ouroboros-ai[dashboard]`도 no-op alias로 계속 허용됩니다.
 
-런타임별 가이드: [Claude Code](./docs/runtime-guides/claude-code.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
+런타임별 가이드: [Claude Code](./docs/runtime-guides/claude-code.ko.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
 
 </details>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -206,7 +206,7 @@ Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 �
 <details>
 <summary><strong>다른 설치 방법</strong></summary>
 
-**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`와 `python3`이 있어야 합니다 — [#2001](https://github.com/Q00/ouroboros/issues/2001)):
+**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`와 `python3`(3.12 권장, 최소 3.11)이 있어야 합니다 — [#2001](https://github.com/Q00/ouroboros/issues/2001)):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See the [GitHub Copilot CLI runtime guide](./docs/runtime-guides/copilot.md) for
 <details>
 <summary><strong>Other install methods</strong></summary>
 
-**Claude Code plugin only** (no system package):
+**Claude Code plugin only** (no Python package to install; `uvx` must be on the host):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See the [GitHub Copilot CLI runtime guide](./docs/runtime-guides/copilot.md) for
 <details>
 <summary><strong>Other install methods</strong></summary>
 
-**Claude Code plugin only** (no Python package to install; the host needs `uvx` and `python3` — see #2001):
+**Claude Code plugin only** (no Python package to install; the host needs `uvx` and `python3` >= 3.11, 3.12 recommended — see #2001):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ See the [GitHub Copilot CLI runtime guide](./docs/runtime-guides/copilot.md) for
 <details>
 <summary><strong>Other install methods</strong></summary>
 
-**Claude Code plugin only** (no Python package to install; `uvx` must be on the host):
+**Claude Code plugin only** (no Python package to install; the host needs `uvx` and `python3` — see #2001):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,6 +168,7 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
 <summary><strong>其他安装方式</strong></summary>
 
 **仅安装 Claude Code 插件**（不装系统包）：
+主机上需要有 `uvx`。
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,7 +167,7 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
 <details>
 <summary><strong>其他安装方式</strong></summary>
 
-**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx` 和 `python3` —— 见 #2001）：
+**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx` 和 `python3`（建议 3.12，最低 3.11）—— 见 #2001）：
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,8 +167,7 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
 <details>
 <summary><strong>其他安装方式</strong></summary>
 
-**仅安装 Claude Code 插件**（不装系统包）：
-主机上需要有 `uvx`。
+**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx`）：
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,7 +167,7 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
 <details>
 <summary><strong>其他安装方式</strong></summary>
 
-**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx`）：
+**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx` 和 `python3` —— 见 #2001）：
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,11 +11,17 @@ Transform a vague idea into a verified, working codebase -- with any AI coding a
 
 ### Recommended: Claude Code (`ooo`)
 
-No Python install required. You do need `uvx` on the host — the plugin's MCP
-server is launched with it ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)),
-so `ooo setup` cannot start without it. Install uv with `pipx install uv`,
-`pip install --user uv`, or `brew install uv`; uv fetches the Python interpreter
-itself, which is why you do not install Python.
+You do not install Ouroboros with pip on this path, but the host needs two
+things: **`uvx`**, because the plugin's MCP server is launched with it
+([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and **`python3`**,
+because the bundled skills shell out to it directly — `skills/setup/SKILL.md:98`
+when recording the first-run preference and `skills/welcome/SKILL.md:68` during
+readiness detection. Install uv with `pipx install uv`, `pip install --user uv`,
+or `brew install uv`.
+
+`uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process; it
+does not create a global `python3`, so a host with uv but no system Python fails
+during the first setup/welcome flow. Tracked in #2001.
 
 Then run the install commands in your terminal, and run setup and auto inside
 Claude Code to go from idea to execution:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,10 +13,10 @@ Transform a vague idea into a verified, working codebase -- with any AI coding a
 
 You do not install Ouroboros with pip on this path, but the host needs two
 things: **`uvx`**, because the plugin's MCP server is launched with it
-([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and **`python3`**,
-because the bundled skills shell out to it directly — `skills/setup/SKILL.md:98`
-when recording the first-run preference and `skills/welcome/SKILL.md:68` during
-readiness detection. Install uv with `pipx install uv`, `pip install --user uv`,
+([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and **`python3` (3.12 recommended, 3.11 minimum)**, because the plugin's skills
+shell out to it directly (`.claude-plugin/skills/setup/SKILL.md:98`) and import
+`datetime.UTC` (`.claude-plugin/skills/welcome/SKILL.md:168`), which does not
+exist before Python 3.11. Install uv with `pipx install uv`, `pip install --user uv`,
 or `brew install uv`.
 
 `uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process; it

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,14 @@ Transform a vague idea into a verified, working codebase -- with any AI coding a
 
 ### Recommended: Claude Code (`ooo`)
 
-No Python install required. Run the install commands in your terminal, then run setup and auto inside Claude Code to go from idea to execution:
+No Python install required. You do need `uvx` on the host — the plugin's MCP
+server is launched with it ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)),
+so `ooo setup` cannot start without it. Install uv with `pipx install uv`,
+`pip install --user uv`, or `brew install uv`; uv fetches the Python interpreter
+itself, which is why you do not install Python.
+
+Then run the install commands in your terminal, and run setup and auto inside
+Claude Code to go from idea to execution:
 
 **1. Install the plugin** (in your terminal):
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,11 @@ Auto mode is hang-resistant by design: interview and repair loops are bounded, s
 
 ### Option 1: Claude Code Plugin (Recommended)
 
+Requires `uvx` on the host — the plugin's MCP manifest launches the server with
+it ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)). Install uv with
+`pipx install uv`, `pip install --user uv`, or `brew install uv`. You do not need
+to install Python yourself; the manifest uses `uvx --python '>=3.12'`.
+
 ```bash
 # Terminal
 claude plugin marketplace add Q00/ouroboros

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,10 +131,7 @@ Auto mode is hang-resistant by design: interview and repair loops are bounded, s
 
 ### Option 1: Claude Code Plugin (Recommended)
 
-Requires `uvx` on the host — the plugin's MCP manifest launches the server with
-it ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)). Install uv with
-`pipx install uv`, `pip install --user uv`, or `brew install uv`. You do not need
-to install Python yourself; the manifest uses `uvx --python '>=3.12'`.
+Requires `uvx` **and** a global `python3` on the host: the plugin's MCP manifest launches the server with `uvx` ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and the bundled skills shell out to `python3` directly (`skills/setup/SKILL.md:98`, `skills/welcome/SKILL.md:32`). `uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process only — it does not create a global `python3`. Install uv with `pipx install uv`, `pip install --user uv`, or `brew install uv`. Tracked in #2001.
 
 ```bash
 # Terminal
@@ -148,7 +145,7 @@ ooo setup
 ooo help        # verify installation
 ```
 
-No Python, pip, or API key configuration needed -- Claude Code handles the runtime.
+No pip install of Ouroboros and no API key configuration needed -- Claude Code handles the runtime. The host still needs `uvx` and `python3`, as above.
 
 ### Option 2: pip Install
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,7 +131,7 @@ Auto mode is hang-resistant by design: interview and repair loops are bounded, s
 
 ### Option 1: Claude Code Plugin (Recommended)
 
-Requires `uvx` **and** a global `python3` on the host: the plugin's MCP manifest launches the server with `uvx` ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and the bundled skills shell out to `python3` directly (`skills/setup/SKILL.md:98`, `skills/welcome/SKILL.md:32`). `uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process only — it does not create a global `python3`. Install uv with `pipx install uv`, `pip install --user uv`, or `brew install uv`. Tracked in #2001.
+Requires `uvx` **and** a global `python3` (3.12 recommended, **3.11 minimum**) on the host: the plugin's MCP manifest launches the server with `uvx` ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and the bundled skills shell out to `python3` directly (`skills/setup/SKILL.md:98`, `skills/welcome/SKILL.md:32`). `uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process only — it does not create a global `python3`. Install uv with `pipx install uv`, `pip install --user uv`, or `brew install uv`. Tracked in #2001.
 
 ```bash
 # Terminal
@@ -145,7 +145,7 @@ ooo setup
 ooo help        # verify installation
 ```
 
-No pip install of Ouroboros and no API key configuration needed -- Claude Code handles the runtime. The host still needs `uvx` and `python3`, as above.
+No pip install of Ouroboros and no API key configuration needed -- Claude Code handles the runtime. The host still needs `uvx` and `python3` >= 3.11, as above — the shipped `.claude-plugin/skills/welcome/SKILL.md` imports `datetime.UTC`, which does not exist before 3.11.
 
 ### Option 2: pip Install
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -25,7 +25,7 @@ Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **C
 시작하기 전에 호스트에 두 가지가 있어야 합니다:
 
 - **`uvx`** — 플러그인의 MCP 매니페스트가 이걸로 서버를 띄웁니다([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)).
-- **`python3`** — 번들 스킬들이 셸에서 직접 호출합니다. setup 스킬이 첫 실행 설정을 기록할 때([`skills/setup/SKILL.md:98`](../../.claude-plugin/skills/setup/SKILL.md)), welcome 스킬이 준비 상태를 판별할 때([`skills/welcome/SKILL.md:68`](../../.claude-plugin/skills/welcome/SKILL.md)) 모두 `python3`을 씁니다.
+- **`python3` (3.12 이상 권장, 최소 3.11)** — 마켓플레이스 플러그인이 싣는 스킬들이 셸에서 직접 호출합니다([`.claude-plugin/skills/setup/SKILL.md:98`](../../.claude-plugin/skills/setup/SKILL.md), [`.claude-plugin/skills/welcome/SKILL.md`](../../.claude-plugin/skills/welcome/SKILL.md)). 이 welcome 스킬은 `from datetime import UTC`를 쓰는데(`:168`, `:468`, `:495`), **`datetime.UTC`는 Python 3.11부터 존재합니다.** 3.10 호스트는 사전 조건을 만족한 채로 MCP 프로세스는 뜨지만 `ooo` welcome 흐름에서 `ImportError`로 실패합니다.
 
 ```bash
 pipx install uv
@@ -61,7 +61,7 @@ ooo
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
 - **`uvx`** (uv에 포함) — 위에서 설명한 대로 플러그인 MCP 매니페스트가 이걸로 서버를 띄웁니다
-- **`python3`** — 번들 스킬이 셸에서 직접 호출합니다. `uvx`가 이걸 대신하지 않습니다 ([#2001](https://github.com/Q00/ouroboros/issues/2001))
+- **`python3` (3.12 이상 권장, 최소 3.11)** — 플러그인이 싣는 스킬이 셸에서 직접 호출하고, `datetime.UTC` 때문에 3.11 미만은 실패합니다. `uvx`가 이걸 대신하지 않습니다 ([#2001](https://github.com/Q00/ouroboros/issues/2001))
 
 아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -1,0 +1,143 @@
+<!--
+doc_metadata:
+  runtime_scope: [claude]
+-->
+
+# Claude Code로 Ouroboros 실행하기
+
+> English: [claude-code.md](./claude-code.md)
+
+Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **Claude Code Pro 또는 Max Plan** 구독을 그대로 활용하므로 별도 API 키가 필요 없습니다.
+
+> 설치와 첫 실행은 [Getting Started](../getting-started.md)(영문)를 보세요.
+
+> **명령어를 어디서 치는지 구분하세요.** 이 문서에는 두 가지 맥락의 명령이 섞여 있습니다.
+>
+> - **터미널** — 평소 쓰는 셸(bash, zsh 등)에서 치는 명령
+> - **Claude Code 세션 안** — `claude`로 세션을 연 다음, 그 안에서만 동작하는 `ooo` 스킬 명령
+>
+> 아래 코드 블록마다 어디서 치는지 표시했습니다.
+
+## 사전 조건
+
+- Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
+- Python >= 3.12
+- Ouroboros 설치 (설치 방법은 [Getting Started](../getting-started.md) 참고)
+
+> 기본값인 in-process SDK 런타임(MCP 1.x)을 쓰려면 `ouroboros-ai[claude]`를 설치하세요. 마켓플레이스 플러그인은 격리된 `ouroboros-ai[mcp]` 환경에서 MCP 2 서버를 띄우고 `[claude-cli]` 워커를 고릅니다. **`[mcp]`를 `[claude]`·`[claude-sdk]`·`[all]`과 한 인터프리터에 같이 넣지 마세요.**
+
+## 설정
+
+런타임 백엔드로 Claude Code를 고르려면 설정에 이렇게 씁니다.
+
+```yaml
+orchestrator:
+  runtime_backend: claude  # `ouroboros setup --runtime claude`가 써주는 값
+```
+
+CLI에서 `--orchestrator` 플래그를 쓰면 Claude Code가 기본 런타임 백엔드입니다.
+
+## 동작 방식
+
+```
++-----------------+     +------------------+     +-----------------+
+|   Seed YAML     | --> |   Orchestrator   | --> |  Claude Code    |
+|  (your task)    |     |   (adapter.py)   |     |  (Pro/Max Plan) |
++-----------------+     +------------------+     +-----------------+
+                                |
+                                v
+                        +------------------+
+                        |  Tools Available |
+                        |  - Read          |
+                        |  - Write         |
+                        |  - Edit          |
+                        |  - Bash          |
+                        |  - Glob          |
+                        |  - Grep          |
+                        +------------------+
+```
+
+기본 프로필은 Agent SDK와 거기 딸린 인증된 Claude Code 전송을 씁니다. SDK는 MCP 1.x에 머물러 있습니다. 플러그인이 소유하는 MCP 2 서버는 별도 `uvx` 프로세스이고 `--runtime claude-cli`를 쓰기 때문에, 한 인터프리터가 MCP 두 메이저 버전을 동시에 로드하는 일은 없습니다. LiteLLM 합의 모델은 [`credentials.yaml`](../config-reference.md#credentialsyaml)을 보세요.
+
+> 런타임 백엔드를 나란히 비교하려면 [runtime capability matrix](../runtime-capability-matrix.md)를 보세요.
+
+## Claude Code를 쓸 때의 이점
+
+- **API 키 관리가 없다** — Pro/Max Plan 구독을 그대로 씁니다.
+- **툴이 풍부하다** — 파일·셸·검색 툴 전체를 Claude Code를 통해 씁니다.
+- **세션이 이어진다** — 중단된 워크플로우를 `--resume`으로 재개합니다.
+
+## CLI 옵션
+
+이 절의 명령은 전부 **평소 쓰는 터미널**에서 칩니다. Claude Code 세션 안이 아닙니다.
+
+### 인터뷰 명령
+
+**터미널:**
+
+```bash
+# 대화형 인터뷰 시작 (Claude Code 런타임)
+uv run ouroboros init start --orchestrator "만들고 싶은 것"
+
+# 중단된 인터뷰 재개
+uv run ouroboros init start --resume interview_20260127_120000
+
+# 인터뷰 목록
+uv run ouroboros init list
+```
+
+### 워크플로우 명령
+
+**터미널:**
+
+```bash
+# 워크플로우 실행 (Claude Code 런타임)
+uv run ouroboros run workflow --orchestrator seed.yaml
+
+# 드라이런 (실행하지 않고 seed만 검증)
+uv run ouroboros run workflow --dry-run seed.yaml
+
+# 디버그 출력 (로그와 에이전트 추론 표시)
+uv run ouroboros run workflow --orchestrator --debug seed.yaml
+
+# 이전 세션 재개
+uv run ouroboros run workflow --orchestrator --resume <session_id> seed.yaml
+```
+
+## 문제 해결
+
+### 헬스체크에 "Providers: warning"이 뜬다
+
+LiteLLM 프로바이더를 안 쓸 때 나오는 정상 메시지입니다. orchestrator 모드는 Claude Code를 직접 씁니다.
+
+### 세션이 빈 에러와 함께 실패한다
+
+프로젝트 디렉터리에서 실행하고 있는지 확인하세요.
+
+**터미널:**
+
+```bash
+cd /path/to/ouroboros
+uv run ouroboros run workflow --orchestrator seed.yaml
+```
+
+### "EventStore not initialized"
+
+데이터베이스는 `ouroboros config show`가 알려주는 경로에 자동으로 생성됩니다.
+
+## 비용
+
+Pro 또는 Max Plan으로 Claude Code를 런타임 백엔드로 쓰면:
+
+- **추가 API 비용이 없습니다** — 구독을 그대로 씁니다.
+- 실행 시간은 작업 복잡도에 따라 다릅니다.
+- 간단한 작업: 보통 15~30초
+- 여러 파일을 건드리는 복잡한 작업: 1~3분
+
+> **참고**: Pro 플랜(월 $20)로도 동작하지만 사용량 한도가 낮습니다. 오래 도는 에이전틱 워크플로우라면 세션 중간에 한도에 걸리지 않도록 **Max 플랜을 권장합니다.**
+
+## Active Conductor와 Synapse
+
+Claude Agent SDK와 지속된 Claude 워커 세션은 Synapse의 `inform`/`after_turn` 전송으로 검증된 경로입니다. 전달은 **현재 턴이 끝난 뒤에야** 같은 네이티브 세션을 재개합니다. 재개 가능성을 실시간 체크포인트 `redirect`처럼 내세우지 않으며, 강제 `replace`는 여전히 지원하지 않습니다.
+
+메인 Claude 대화는 읽기 전용 관찰자를 정확히 하나만 위임하고, 사용자에게는 계속 응답할 수 있는 상태로 남습니다. 그러면서 현재 런타임과 모델, 효율성 보증, 범위가 정해진 Discover 목표, 의존성·병렬 수준, 처음 스케줄된 AC들, 주의 사항, 종료 시 보증을 전달합니다. AC는 내부 ID를 묻지 않고 의미로 고릅니다. 안내 문구의 정본은 영어이고, 호스트는 사용자가 지금 쓰고 있는 대화 언어로 자연스럽게 답합니다.

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -47,8 +47,17 @@ ooo
 ### 사전 조건 (권장 경로)
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
+- **`uvx`** (uv에 포함). 플러그인의 MCP 매니페스트가 `uvx`로 서버를 띄웁니다 ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json))
 
-그게 전부입니다. **Python 요구사항은 아래 독립 CLI 경로에만 해당합니다.**
+`uvx`가 없으면 다음 중 하나로 uv를 설치하세요:
+
+```bash
+pipx install uv
+pip install --user uv
+brew install uv          # macOS / Linuxbrew
+```
+
+**Python은 미리 깔아둘 필요가 없습니다.** 매니페스트가 `uvx --python '>=3.12'`로 띄우기 때문에, uv가 필요한 인터프리터를 알아서 가져옵니다. 아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
 
 ## 독립 CLI로 쓰기 (선택)
 
@@ -62,7 +71,16 @@ Claude Code 세션 밖, 평소 쓰는 셸에서 `ouroboros` 명령을 직접 치
 
 > 기본값인 in-process SDK 런타임(MCP 1.x)을 쓰려면 `ouroboros-ai[claude]`를 설치하세요. 마켓플레이스 플러그인은 격리된 `ouroboros-ai[mcp]` 환경에서 MCP 2 서버를 띄우고 `[claude-cli]` 워커를 고릅니다. **`[mcp]`를 `[claude]`·`[claude-sdk]`·`[all]`과 한 인터프리터에 같이 넣지 마세요.**
 
-### 동작 방식
+## 설정
+
+Claude Code를 런타임 백엔드로 고르려면 Ouroboros 설정에 다음을 넣습니다:
+
+```yaml
+orchestrator:
+  runtime_backend: claude  # `ouroboros setup --runtime claude`가 써 줍니다
+```
+
+`--orchestrator` CLI 플래그를 쓸 때는 Claude Code가 기본 런타임 백엔드입니다.
 
 ## 동작 방식
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -22,6 +22,16 @@ Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **C
 
 대부분의 사람은 이 길로 오면 됩니다. **Python도 pip도 API 키 설정도 필요 없습니다** — 런타임은 Claude Code가 맡습니다.
 
+시작하기 전에 호스트에 **`uvx`가 있어야 합니다.** 플러그인의 MCP 매니페스트가 `uvx`로 서버를 띄우기 때문에([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), 이게 없으면 아래 `ooo setup`이 뜨지 않습니다. 없으면 다음 중 하나로 uv를 설치하세요:
+
+```bash
+pipx install uv
+pip install --user uv
+brew install uv          # macOS / Linuxbrew
+```
+
+`uvx`가 `--python '>=3.12'`로 띄우므로 **Python은 uv가 알아서 가져옵니다.** 위의 "Python 필요 없음"은 그래서 성립합니다.
+
 **터미널:**
 
 ```bash
@@ -47,17 +57,9 @@ ooo
 ### 사전 조건 (권장 경로)
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
-- **`uvx`** (uv에 포함). 플러그인의 MCP 매니페스트가 `uvx`로 서버를 띄웁니다 ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json))
+- **`uvx`** (uv에 포함) — 위에서 설명한 대로 플러그인 MCP 매니페스트가 이걸로 서버를 띄웁니다
 
-`uvx`가 없으면 다음 중 하나로 uv를 설치하세요:
-
-```bash
-pipx install uv
-pip install --user uv
-brew install uv          # macOS / Linuxbrew
-```
-
-**Python은 미리 깔아둘 필요가 없습니다.** 매니페스트가 `uvx --python '>=3.12'`로 띄우기 때문에, uv가 필요한 인터프리터를 알아서 가져옵니다. 아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
+아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
 
 ## 독립 CLI로 쓰기 (선택)
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -20,9 +20,12 @@ Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **C
 
 ## 시작하기 (권장 경로)
 
-대부분의 사람은 이 길로 오면 됩니다. **Python도 pip도 API 키 설정도 필요 없습니다** — 런타임은 Claude Code가 맡습니다.
+대부분의 사람은 이 길로 오면 됩니다. **Ouroboros를 pip로 설치할 필요도, API 키를 설정할 필요도 없습니다** — 런타임은 Claude Code가 맡습니다.
 
-시작하기 전에 호스트에 **`uvx`가 있어야 합니다.** 플러그인의 MCP 매니페스트가 `uvx`로 서버를 띄우기 때문에([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), 이게 없으면 아래 `ooo setup`이 뜨지 않습니다. 없으면 다음 중 하나로 uv를 설치하세요:
+시작하기 전에 호스트에 두 가지가 있어야 합니다:
+
+- **`uvx`** — 플러그인의 MCP 매니페스트가 이걸로 서버를 띄웁니다([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)).
+- **`python3`** — 번들 스킬들이 셸에서 직접 호출합니다. setup 스킬이 첫 실행 설정을 기록할 때([`skills/setup/SKILL.md:98`](../../.claude-plugin/skills/setup/SKILL.md)), welcome 스킬이 준비 상태를 판별할 때([`skills/welcome/SKILL.md:68`](../../.claude-plugin/skills/welcome/SKILL.md)) 모두 `python3`을 씁니다.
 
 ```bash
 pipx install uv
@@ -30,7 +33,7 @@ pip install --user uv
 brew install uv          # macOS / Linuxbrew
 ```
 
-`uvx`가 `--python '>=3.12'`로 띄우므로 **Python은 uv가 알아서 가져옵니다.** 위의 "Python 필요 없음"은 그래서 성립합니다.
+> **`uvx`가 Python 요구를 대신하지 않습니다.** `uvx --python '>=3.12'`는 **격리된 MCP 프로세스에** 인터프리터를 붙여 줄 뿐, 전역 `python3` 명령을 만들어 주지 않습니다. 위 스킬 스니펫들은 셸에서 `python3`을 직접 찾으므로, `uvx`만 있고 시스템 Python이 없는 호스트는 **첫 setup/welcome 흐름에서 실패합니다.** 스킬 쪽 인터프리터 탐색을 고치는 건 [#2001](https://github.com/Q00/ouroboros/issues/2001)에서 추적합니다.
 
 **터미널:**
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -18,24 +18,51 @@ Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **C
 >
 > 아래 코드 블록마다 어디서 치는지 표시했습니다.
 
-## 사전 조건
+## 시작하기 (권장 경로)
+
+대부분의 사람은 이 길로 오면 됩니다. **Python도 pip도 API 키 설정도 필요 없습니다** — 런타임은 Claude Code가 맡습니다.
+
+**터미널:**
+
+```bash
+claude plugin marketplace add Q00/ouroboros
+claude plugin install ouroboros@ouroboros
+```
+
+그다음 **Claude Code 세션 안에서:**
+
+```
+ooo setup
+ooo help        # 설치 확인
+```
+
+여기까지 하면 끝입니다. 첫 워크플로우도 세션 안에서 `ooo`로 시작합니다.
+
+```
+ooo
+```
+
+전체 첫 실행 흐름(인터뷰 → seed → 실행)은 [Getting Started](../getting-started.md)(영문)를 보세요.
+
+### 사전 조건 (권장 경로)
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
-- Python >= 3.12
+
+그게 전부입니다. **Python 요구사항은 아래 독립 CLI 경로에만 해당합니다.**
+
+## 독립 CLI로 쓰기 (선택)
+
+Claude Code 세션 밖, 평소 쓰는 셸에서 `ouroboros` 명령을 직접 치고 싶을 때만 이 경로를 씁니다.
+
+### 사전 조건 (독립 CLI 경로)
+
+- Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
+- **Python >= 3.12**
 - Ouroboros 설치 (설치 방법은 [Getting Started](../getting-started.md) 참고)
 
 > 기본값인 in-process SDK 런타임(MCP 1.x)을 쓰려면 `ouroboros-ai[claude]`를 설치하세요. 마켓플레이스 플러그인은 격리된 `ouroboros-ai[mcp]` 환경에서 MCP 2 서버를 띄우고 `[claude-cli]` 워커를 고릅니다. **`[mcp]`를 `[claude]`·`[claude-sdk]`·`[all]`과 한 인터프리터에 같이 넣지 마세요.**
 
-## 설정
-
-런타임 백엔드로 Claude Code를 고르려면 설정에 이렇게 씁니다.
-
-```yaml
-orchestrator:
-  runtime_backend: claude  # `ouroboros setup --runtime claude`가 써주는 값
-```
-
-CLI에서 `--orchestrator` 플래그를 쓰면 Claude Code가 기본 런타임 백엔드입니다.
+### 동작 방식
 
 ## 동작 방식
 
@@ -69,7 +96,7 @@ CLI에서 `--orchestrator` 플래그를 쓰면 Claude Code가 기본 런타임 �
 
 ## CLI 옵션
 
-이 절의 명령은 전부 **평소 쓰는 터미널**에서 칩니다. Claude Code 세션 안이 아닙니다.
+이 절의 명령은 전부 **독립 CLI 경로**용입니다. 평소 쓰는 터미널에서 치며, Claude Code 세션 안이 아닙니다. 플러그인으로 설치했다면 세션 안에서 `ooo` 명령을 쓰세요.
 
 ### 인터뷰 명령
 

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -61,6 +61,7 @@ ooo
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
 - **`uvx`** (uv에 포함) — 위에서 설명한 대로 플러그인 MCP 매니페스트가 이걸로 서버를 띄웁니다
+- **`python3`** — 번들 스킬이 셸에서 직접 호출합니다. `uvx`가 이걸 대신하지 않습니다 ([#2001](https://github.com/Q00/ouroboros/issues/2001))
 
 아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
 

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -5,6 +5,8 @@ doc_metadata:
 
 # Running Ouroboros with Claude Code
 
+> 한국어: [claude-code.ko.md](./claude-code.ko.md)
+
 Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude Code Pro or Max Plan** subscription to execute workflows without requiring a separate API key.
 
 > For installation and first-run onboarding, see [Getting Started](../getting-started.md).

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -25,8 +25,13 @@ Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude
   ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), so a host with
   only Claude Code cannot start it. Install uv with `pipx install uv`,
   `pip install --user uv`, or `brew install uv`.
-- Python >= 3.12 **for the standalone CLI only**. The plugin manifest launches
-  `uvx --python '>=3.12'`, so uv fetches the interpreter itself.
+- **`python3` on `PATH`** for the marketplace plugin as well. The bundled skills
+  shell out to it directly (`skills/setup/SKILL.md:98`,
+  `skills/welcome/SKILL.md:68`). `uvx --python '>=3.12'` supplies an interpreter
+  to the isolated MCP process only and does not create a global `python3`, so a
+  host with uv but no system Python fails during the first setup/welcome flow.
+  Tracked in #2001.
+- Python >= 3.12 specifically, **for the standalone CLI**.
 - Ouroboros installed, for the standalone CLI (see [Getting Started](../getting-started.md) for install options)
 
 > Install `ouroboros-ai[claude]` for the default in-process SDK runtime on MCP

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -25,12 +25,15 @@ Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude
   ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), so a host with
   only Claude Code cannot start it. Install uv with `pipx install uv`,
   `pip install --user uv`, or `brew install uv`.
-- **`python3` on `PATH`** for the marketplace plugin as well. The bundled skills
-  shell out to it directly (`skills/setup/SKILL.md:98`,
-  `skills/welcome/SKILL.md:68`). `uvx --python '>=3.12'` supplies an interpreter
-  to the isolated MCP process only and does not create a global `python3`, so a
-  host with uv but no system Python fails during the first setup/welcome flow.
-  Tracked in #2001.
+- **`python3` on `PATH`, 3.12 recommended and 3.11 minimum**, for the marketplace
+  plugin as well. `.claude-plugin/plugin.json` selects `.claude-plugin/skills/`,
+  whose snippets shell out to `python3` directly
+  (`.claude-plugin/skills/setup/SKILL.md:98`) and import `datetime.UTC`
+  (`.claude-plugin/skills/welcome/SKILL.md:168`, `:468`, `:495`), which does not
+  exist before 3.11. `uvx --python '>=3.12'` supplies an interpreter to the
+  isolated MCP process only; it does not create a global `python3`. A host with
+  uv but no system Python, or with Python 3.10, satisfies neither. Tracked in
+  #2001.
 - Python >= 3.12 specifically, **for the standalone CLI**.
 - Ouroboros installed, for the standalone CLI (see [Getting Started](../getting-started.md) for install options)
 

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -20,8 +20,14 @@ Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude
 ## Prerequisites
 
 - Claude Code CLI installed and authenticated (Pro or Max Plan)
-- Python >= 3.12
-- Ouroboros installed (see [Getting Started](../getting-started.md) for install options)
+- **`uvx`** (ships with uv) if you use the marketplace plugin. The plugin's MCP
+  manifest launches the server with `uvx`
+  ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), so a host with
+  only Claude Code cannot start it. Install uv with `pipx install uv`,
+  `pip install --user uv`, or `brew install uv`.
+- Python >= 3.12 **for the standalone CLI only**. The plugin manifest launches
+  `uvx --python '>=3.12'`, so uv fetches the interpreter itself.
+- Ouroboros installed, for the standalone CLI (see [Getting Started](../getting-started.md) for install options)
 
 > Install `ouroboros-ai[claude]` for the default in-process SDK runtime on MCP
 > 1.x. The marketplace plugin launches the MCP 2 server from an isolated


### PR DESCRIPTION
Second Korean doc, following #1984. Refs #1983.

#1984 covers the TUI guide, which is where `README.ko.md` sends a reader who is **already running**. This covers where a reader gets stuck **first**: install and first run.

## Why Claude Code out of the twelve runtime guides

The Korean Quick Start hands the reader this as the default path:

```
claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
```

So Claude Code is the runtime a Korean reader actually lands on. Picking by measured entry path rather than by guide length.

## Why Korean docs at all

From the traffic API, 14-day window:

| views | uniques | path |
|---:|---:|---|
| 1,855 | 1,202 | `/blob/main/README.ko.md` |

Second most-read page in the repository, six times the next one. Before #1984 there were zero Korean files under `docs/`.

## What this adds

`docs/runtime-guides/claude-code.ko.md`.

- `doc_metadata` header preserved verbatim (`runtime_scope: [claude]`)
- Cross-linked both ways: `> 한국어:` on the English guide, `> English:` on the Korean one
- `README.ko.md` now points at the Korean version
- Terminology follows `README.ko.md` and `docs/guides/tui-usage.ko.md`

Identifiers, config keys, YAML, and CLI commands are left in original form.

## On two passages

**The extras warning.** "Never combine `[mcp]` with `[claude]`, `[claude-sdk]`, or `[all]` in one interpreter" is the one line where a soft translation causes a broken install, so it is bolded and kept imperative rather than advisory.

**Active Conductor / Synapse.** The English is deliberately precise about what is *not* claimed: delivery resumes the same session only after the current turn, resumability is not live checkpoint `redirect`, and hard `replace` stays unsupported. I kept all three negatives explicit instead of compressing them into "supports resumption", which would be the easy and wrong rendering.

## Test plan

- [x] Every relative link in the three touched files resolves (checked programmatically, 0 broken)
- [x] `doc_metadata` block byte-identical to the English guide
- [ ] ~~Section structure matches the English guide one-to-one~~ — **no longer true, deliberately.** The Korean guide has 24 headings and 18 fenced blocks against the English 21 and 10. The divergence is the restructuring this PR went through in review: the recommended plugin path and the standalone CLI path are separated into their own sections with their own prerequisites, the `uvx` requirement and its install options appear before the first command, and the restored `## 설정` section carries the `runtime_backend` block. The English guide still presents one flat prerequisite list written for the standalone install, which is the defect that produced three review rounds here.
- [ ] ~~Every code block that exists in the English guide is preserved verbatim~~ — **not accurate.** Three of the five English blocks differ, because in-block comments and the interview placeholder text were translated. That is the right call for a Korean guide, but the parity claim as written was false. The remaining blocks — commands, flags, config keys, package names — are byte-identical.
- [x] Nothing outside the added file and two link lines touched

