### PR TITLE
fix(mcp): isolate Codex launcher environments

### DIFF
--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -175,7 +175,7 @@ Then re-run: ooo setup
 **IMPORTANT**: Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or `[all,mcp]`
 together and never write a direct
 `ouroboros` or `python -m ouroboros` MCP fallback. MCP 2 launchers must use an
-isolated `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
+isolated `uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
 `pipx run --spec 'ouroboros-ai[mcp]' ...` process. Only `[mcp,claude-cli]` is
 supported because the CLI worker is out of process. Do not write
 an Ouroboros entry to `~/.claude/mcp.json`; the plugin owns that registration.

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -4,6 +4,8 @@
       "command": "uvx",
       "args": [
         "--isolated",
+        "--python",
+        ">=3.12",
         "--from",
         "ouroboros-ai[mcp]",
         "ouroboros",

--- a/README.ko.md
+++ b/README.ko.md
@@ -229,7 +229,7 @@ ouroboros setup                         # 런타임 설정
 
 기본 및 비-LiteLLM 설치는 Python 3.12-3.14를 지원합니다. LiteLLM 포함 설치(`[litellm]`, `[all]`, source `--all-extras`)는 Python 3.12-3.13을 지원하며, 현재 예시는 Python 3.13을 권장합니다. 자세한 내용은 [Platform Support](./docs/platform-support.md#python-profile-matrix)를 참고하세요.
 
-`[mcp]`와 `[claude]`는 의도적으로 분리된 프로필입니다. MCP 2와 현재 Claude Agent SDK가 서로 다른 `mcp` 메이저 버전을 요구하기 때문입니다. 지원되는 MCP 호스트 설정은 별도 프로세스에서 `uvx --from 'ouroboros-ai[mcp]' ...`를 실행합니다. 독립 Claude SDK 설정은 격리 프로세스 안에서 구성된 Claude backend를 사용할 수 없으므로 MCP를 등록하지 않습니다. MCP 실행에는 지원되는 CLI 기반 runtime과 LLM backend를 설정해야 합니다.
+`[mcp]`와 `[claude]`는 의도적으로 분리된 프로필입니다. MCP 2와 현재 Claude Agent SDK가 서로 다른 `mcp` 메이저 버전을 요구하기 때문입니다. 지원되는 MCP 호스트 설정은 별도 프로세스에서 `uvx --isolated --from 'ouroboros-ai[mcp]' ...`를 실행합니다. 독립 Claude SDK 설정은 격리 프로세스 안에서 구성된 Claude backend를 사용할 수 없으므로 MCP를 등록하지 않습니다. MCP 실행에는 지원되는 CLI 기반 runtime과 LLM backend를 설정해야 합니다.
 
 `pip install 'ouroboros-ai[mcp]'`는 이미 격리된 Python 환경에서 MCP 클라이언트/서버 라이브러리를 직접 사용할 때만 유효합니다. 호스트 등록에는 `uvx` 또는 `pipx`가 필요하므로 `ouroboros setup --runtime <kiro|copilot|hermes>` 실행 전 `pipx install 'ouroboros-ai[mcp]'` 또는 `uv tool install 'ouroboros-ai[mcp]'`를 사용하세요. 격리 launcher가 없으면 setup은 runtime 설정을 변경하지 않고 실패합니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -229,7 +229,7 @@ ouroboros setup                         # 런타임 설정
 
 기본 및 비-LiteLLM 설치는 Python 3.12-3.14를 지원합니다. LiteLLM 포함 설치(`[litellm]`, `[all]`, source `--all-extras`)는 Python 3.12-3.13을 지원하며, 현재 예시는 Python 3.13을 권장합니다. 자세한 내용은 [Platform Support](./docs/platform-support.md#python-profile-matrix)를 참고하세요.
 
-`[mcp]`와 `[claude]`는 의도적으로 분리된 프로필입니다. MCP 2와 현재 Claude Agent SDK가 서로 다른 `mcp` 메이저 버전을 요구하기 때문입니다. 지원되는 MCP 호스트 설정은 별도 프로세스에서 `uvx --isolated --from 'ouroboros-ai[mcp]' ...`를 실행합니다. 독립 Claude SDK 설정은 격리 프로세스 안에서 구성된 Claude backend를 사용할 수 없으므로 MCP를 등록하지 않습니다. MCP 실행에는 지원되는 CLI 기반 runtime과 LLM backend를 설정해야 합니다.
+`[mcp]`와 `[claude]`는 의도적으로 분리된 프로필입니다. MCP 2와 현재 Claude Agent SDK가 서로 다른 `mcp` 메이저 버전을 요구하기 때문입니다. 지원되는 MCP 호스트 설정은 별도 프로세스에서 `uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' ...`를 실행합니다. 독립 Claude SDK 설정은 격리 프로세스 안에서 구성된 Claude backend를 사용할 수 없으므로 MCP를 등록하지 않습니다. MCP 실행에는 지원되는 CLI 기반 runtime과 LLM backend를 설정해야 합니다.
 
 `pip install 'ouroboros-ai[mcp]'`는 이미 격리된 Python 환경에서 MCP 클라이언트/서버 라이브러리를 직접 사용할 때만 유효합니다. 호스트 등록에는 `uvx` 또는 `pipx`가 필요하므로 `ouroboros setup --runtime <kiro|copilot|hermes>` 실행 전 `pipx install 'ouroboros-ai[mcp]'` 또는 `uv tool install 'ouroboros-ai[mcp]'`를 사용하세요. 격리 launcher가 없으면 setup은 runtime 설정을 변경하지 않고 실패합니다.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Core and non-LiteLLM installs support Python 3.12-3.14. LiteLLM-bearing installs
 Claude is the host. Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or
 `[all,mcp]` in one interpreter. See the [package compatibility and migration matrix](./docs/platform-support.md#mcp-2-and-claude-package-profiles).
 
-`pip install 'ouroboros-ai[mcp]'` is valid for embedding the MCP client/server library in an already isolated Python environment, but host registration requires `uvx --isolated` or `pipx`. Use `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'` before `ouroboros setup --runtime <kiro|copilot|hermes>`; setup exits without changing runtime configuration when neither isolated launcher is available.
+`pip install 'ouroboros-ai[mcp]'` is valid for embedding the MCP client/server library in an already isolated Python environment, but host registration requires `uvx --isolated --python '>=3.12'` or `pipx`. Use `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'` before `ouroboros setup --runtime <kiro|copilot|hermes>`; setup exits without changing runtime configuration when neither isolated launcher is available.
 
 Legacy compatibility: `ouroboros-ai[dashboard]` is still accepted as a compatibility alias/no-op; it does not install dashboard runtime payload. `ouroboros-ai[all]` includes that no-op alias only for compatibility.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Core and non-LiteLLM installs support Python 3.12-3.14. LiteLLM-bearing installs
 Claude is the host. Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or
 `[all,mcp]` in one interpreter. See the [package compatibility and migration matrix](./docs/platform-support.md#mcp-2-and-claude-package-profiles).
 
-`pip install 'ouroboros-ai[mcp]'` is valid for embedding the MCP client/server library in an already isolated Python environment, but host registration requires `uvx` or `pipx`. Use `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'` before `ouroboros setup --runtime <kiro|copilot|hermes>`; setup exits without changing runtime configuration when neither isolated launcher is available.
+`pip install 'ouroboros-ai[mcp]'` is valid for embedding the MCP client/server library in an already isolated Python environment, but host registration requires `uvx --isolated` or `pipx`. Use `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'` before `ouroboros setup --runtime <kiro|copilot|hermes>`; setup exits without changing runtime configuration when neither isolated launcher is available.
 
 Legacy compatibility: `ouroboros-ai[dashboard]` is still accepted as a compatibility alias/no-op; it does not install dashboard runtime payload. `ouroboros-ai[all]` includes that no-op alias only for compatibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,7 +188,7 @@ pip install 'ouroboros-ai[all]'           # Claude + LiteLLM + TUI + dashboard�
 ouroboros setup                         # 配置运行时
 ```
 
-`[claude]` 与 `[mcp]` 必须保持隔离：Claude Agent SDK 使用 MCP 1.x，而协议 server 使用 MCP 2。需要 MCP 的 host 应通过 `uvx --isolated --from 'ouroboros-ai[mcp]' ...` 或 `pipx run --spec 'ouroboros-ai[mcp]' ...` 启动独立进程，不要把两个 extra 安装到同一环境。
+`[claude]` 与 `[mcp]` 必须保持隔离：Claude Agent SDK 使用 MCP 1.x，而协议 server 使用 MCP 2。需要 MCP 的 host 应通过 `uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` 或 `pipx run --spec 'ouroboros-ai[mcp]' ...` 启动独立进程，不要把两个 extra 安装到同一环境。
 
 基础包和非 LiteLLM 安装支持 Python 3.12-3.14。包含 LiteLLM 的安装（`[litellm]`、`[all]`、source `--all-extras`）支持 Python 3.12-3.13；当前示例优先使用 Python 3.13。详见 [Platform Support](./docs/platform-support.md#python-profile-matrix)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,7 +188,7 @@ pip install 'ouroboros-ai[all]'           # Claude + LiteLLM + TUI + dashboard�
 ouroboros setup                         # 配置运行时
 ```
 
-`[claude]` 与 `[mcp]` 必须保持隔离：Claude Agent SDK 使用 MCP 1.x，而协议 server 使用 MCP 2。需要 MCP 的 host 应通过 `uvx --from 'ouroboros-ai[mcp]' ...` 或 `pipx run --spec 'ouroboros-ai[mcp]' ...` 启动独立进程，不要把两个 extra 安装到同一环境。
+`[claude]` 与 `[mcp]` 必须保持隔离：Claude Agent SDK 使用 MCP 1.x，而协议 server 使用 MCP 2。需要 MCP 的 host 应通过 `uvx --isolated --from 'ouroboros-ai[mcp]' ...` 或 `pipx run --spec 'ouroboros-ai[mcp]' ...` 启动独立进程，不要把两个 extra 安装到同一环境。
 
 基础包和非 LiteLLM 安装支持 Python 3.12-3.14。包含 LiteLLM 的安装（`[litellm]`、`[all]`、source `--all-extras`）支持 Python 3.12-3.13；当前示例优先使用 Python 3.13。详见 [Platform Support](./docs/platform-support.md#python-profile-matrix)。
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1186,7 +1186,7 @@ the marketplace plugin launches an isolated server equivalent to:
   "mcpServers": {
     "ouroboros": {
       "command": "uvx",
-      "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"]
+      "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"]
     }
   }
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1186,7 +1186,7 @@ the marketplace plugin launches an isolated server equivalent to:
   "mcpServers": {
     "ouroboros": {
       "command": "uvx",
-      "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"]
+      "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve", "--runtime", "claude-cli", "--llm-backend", "claude_code"]
     }
   }
 }

--- a/docs/runtime-guides/copilot.ko.md
+++ b/docs/runtime-guides/copilot.ko.md
@@ -139,7 +139,7 @@ copilot --no-color --log-level none \
   "mcpServers": {
     "ouroboros": {
       "command": "uvx",
-      "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+      "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
       "env": {
         "OUROBOROS_AGENT_RUNTIME": "copilot",
         "OUROBOROS_LLM_BACKEND": "copilot"

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -205,7 +205,7 @@ install method the wizard detected:
   "mcpServers": {
     "ouroboros": {
       "command": "uvx",
-      "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+      "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
       "env": {
         "OUROBOROS_AGENT_RUNTIME": "copilot",
         "OUROBOROS_LLM_BACKEND": "copilot"

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -205,7 +205,7 @@ install method the wizard detected:
   "mcpServers": {
     "ouroboros": {
       "command": "uvx",
-      "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+      "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
       "env": {
         "OUROBOROS_AGENT_RUNTIME": "copilot",
         "OUROBOROS_LLM_BACKEND": "copilot"

--- a/docs/runtime-guides/hermes.md
+++ b/docs/runtime-guides/hermes.md
@@ -38,7 +38,7 @@ With `uvx`, the generated host entry is:
 mcp_servers:
   ouroboros:
     command: uvx
-    args: [--isolated, --from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
+    args: [--isolated, --python, ">=3.12", --from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
     enabled: true
 ```
 

--- a/docs/runtime-guides/hermes.md
+++ b/docs/runtime-guides/hermes.md
@@ -38,7 +38,7 @@ With `uvx`, the generated host entry is:
 mcp_servers:
   ouroboros:
     command: uvx
-    args: [--from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
+    args: [--isolated, --from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]
     enabled: true
 ```
 

--- a/docs/runtime-guides/kiro.ko.md
+++ b/docs/runtime-guides/kiro.ko.md
@@ -44,7 +44,7 @@ setup이 하는 일:
      "mcpServers": {
        "ouroboros": {
          "command": "uvx",
-         "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+         "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
          "disabled": false,
          "env": {
            "OUROBOROS_RUNTIME": "kiro",

--- a/docs/runtime-guides/kiro.md
+++ b/docs/runtime-guides/kiro.md
@@ -52,7 +52,7 @@ This will:
      "mcpServers": {
        "ouroboros": {
          "command": "uvx",
-         "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+         "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
          "disabled": false,
          "env": {
            "OUROBOROS_RUNTIME": "kiro",
@@ -73,7 +73,7 @@ This will:
    ```
 
 Setup is idempotent — re-running preserves any peer MCP entries and
-custom `env` keys. The entry always uses `uvx` or `pipx run` so the
+custom `env` keys. The entry always uses `uvx --isolated` or `pipx run` so the
 server receives the MCP 2 dependency profile in an isolated package
 environment. Kiro may need a longer timeout on the first `uvx` launch;
 setup never substitutes a faster global binary with an unknown MCP major.

--- a/docs/runtime-guides/kiro.md
+++ b/docs/runtime-guides/kiro.md
@@ -52,7 +52,7 @@ This will:
      "mcpServers": {
        "ouroboros": {
          "command": "uvx",
-         "args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+         "args": ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
          "disabled": false,
          "env": {
            "OUROBOROS_RUNTIME": "kiro",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -175,7 +175,7 @@ Then re-run: ooo setup
 **IMPORTANT**: Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or `[all,mcp]`
 together and never write a direct
 `ouroboros` or `python -m ouroboros` MCP fallback. MCP 2 launchers must use an
-isolated `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
+isolated `uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' ...` or
 `pipx run --spec 'ouroboros-ai[mcp]' ...` process. Only `[mcp,claude-cli]` is
 supported because the CLI worker is out of process. Do not write
 an Ouroboros entry to `~/.claude/mcp.json`; the plugin owns that registration.

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -694,7 +694,8 @@ runtime. For a Korean conversation, use:
 - **설정하고 시작하기**: Run the setup command for the active host. In Codex
   App or Codex CLI, use `ouroboros setup --runtime codex` when the executable
   is installed. For a Marketplace-plugin-only install, use
-  `uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex` instead.
+  `uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex`
+  instead.
   In Claude Code, follow `../setup/SKILL.md`. Do not ask the user to copy a
   command when the current host can run it.
 - **나중에**: Continue with the welcome flow, but do not claim that MCP-only

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -62,6 +62,36 @@ _CODEX_RUNTIME_ENV = {
     "OUROBOROS_LLM_BACKEND": "codex",
 }
 _CODEX_RUNTIME_SELECTOR_ENV_KEYS = frozenset({*_CODEX_RUNTIME_ENV, "OUROBOROS_RUNTIME"})
+_CODEX_MCP_APPROVAL_MODES = frozenset({"auto", "prompt", "approve"})
+_CODEX_MCP_CONFIG_FIELDS = frozenset(
+    {
+        "command",
+        "args",
+        "env",
+        "env_vars",
+        "cwd",
+        "http_headers",
+        "env_http_headers",
+        "url",
+        "bearer_token",
+        "bearer_token_env_var",
+        "experimental_environment",
+        "startup_timeout_sec",
+        "startup_timeout_ms",
+        "tool_timeout_sec",
+        "enabled",
+        "required",
+        "supports_parallel_tool_calls",
+        "default_tools_approval_mode",
+        "enabled_tools",
+        "disabled_tools",
+        "scopes",
+        "oauth",
+        "oauth_resource",
+        "name",
+        "tools",
+    }
+)
 
 
 class _StdioMcpFramingMismatch(RuntimeError):
@@ -205,6 +235,7 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append("Codex config does not contain [mcp_servers.ouroboros]")
         return failures
 
+    _check_mcp_schema_surface(ouroboros_entry, failures)
     _check_mcp_activation_surface(ouroboros_entry, failures)
     _check_mcp_execution_surface(ouroboros_entry, failures)
 
@@ -281,6 +312,160 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
     return failures
 
 
+def _check_mcp_schema_surface(ouroboros_entry: Mapping[str, object], failures: list[str]) -> None:
+    """Validate Codex 0.132's fail-closed MCP transport and shared schema."""
+    unknown_fields = sorted(set(ouroboros_entry) - _CODEX_MCP_CONFIG_FIELDS)
+    if unknown_fields:
+        failures.append(
+            "[mcp_servers.ouroboros] contains unsupported fields: " + ", ".join(unknown_fields)
+        )
+
+    has_command = "command" in ouroboros_entry
+    has_url = "url" in ouroboros_entry
+    if has_command and has_url:
+        failures.append(
+            "[mcp_servers.ouroboros] mixes stdio `command` with HTTP `url`; "
+            "Codex requires exactly one transport"
+        )
+
+    if has_command:
+        for field in (
+            "bearer_token_env_var",
+            "http_headers",
+            "env_http_headers",
+            "oauth",
+            "oauth_resource",
+        ):
+            if field in ouroboros_entry:
+                failures.append(
+                    f"[mcp_servers.ouroboros].{field} is not supported for stdio `command`"
+                )
+    elif has_url:
+        for field in ("args", "env", "env_vars", "cwd"):
+            if field in ouroboros_entry:
+                failures.append(f"[mcp_servers.ouroboros].{field} is not supported for HTTP `url`")
+
+    if "bearer_token" in ouroboros_entry:
+        failures.append(
+            "[mcp_servers.ouroboros].bearer_token is unsupported; use "
+            "`bearer_token_env_var` on an HTTP entry"
+        )
+
+    _check_optional_string_field(ouroboros_entry, "url", failures)
+    _check_optional_string_field(ouroboros_entry, "bearer_token_env_var", failures)
+    _check_optional_string_field(ouroboros_entry, "oauth_resource", failures)
+    _check_optional_string_field(ouroboros_entry, "name", failures)
+
+    for field in ("http_headers", "env_http_headers"):
+        if field in ouroboros_entry:
+            _check_string_table_field(ouroboros_entry[field], field, failures)
+
+    for field in ("required", "supports_parallel_tool_calls"):
+        if field in ouroboros_entry and not isinstance(ouroboros_entry[field], bool):
+            failures.append(f"[mcp_servers.ouroboros].{field} must be a boolean")
+
+    if "default_tools_approval_mode" in ouroboros_entry:
+        _check_mcp_approval_mode(
+            ouroboros_entry["default_tools_approval_mode"],
+            "default_tools_approval_mode",
+            failures,
+        )
+
+    if "scopes" in ouroboros_entry:
+        scopes = ouroboros_entry["scopes"]
+        if not isinstance(scopes, list):
+            failures.append("[mcp_servers.ouroboros].scopes must be an array of strings")
+        else:
+            invalid_scopes = [
+                f"index {index} ({type(scope).__name__})"
+                for index, scope in enumerate(scopes)
+                if not isinstance(scope, str) or not scope.strip()
+            ]
+            if invalid_scopes:
+                failures.append(
+                    "[mcp_servers.ouroboros].scopes contains empty or non-string values: "
+                    + ", ".join(invalid_scopes)
+                )
+
+    if "oauth" in ouroboros_entry:
+        oauth = ouroboros_entry["oauth"]
+        if not isinstance(oauth, Mapping):
+            failures.append("[mcp_servers.ouroboros].oauth must be a table")
+        else:
+            unknown_oauth_fields = sorted(set(oauth) - {"client_id"})
+            if unknown_oauth_fields:
+                failures.append(
+                    "[mcp_servers.ouroboros].oauth contains unsupported fields: "
+                    + ", ".join(unknown_oauth_fields)
+                )
+            _check_optional_string_field(oauth, "client_id", failures, prefix="oauth.")
+
+    if "tools" in ouroboros_entry:
+        tools = ouroboros_entry["tools"]
+        if not isinstance(tools, Mapping):
+            failures.append("[mcp_servers.ouroboros].tools must be a table")
+        else:
+            for tool_name, tool_config in tools.items():
+                if not isinstance(tool_name, str) or not tool_name.strip():
+                    failures.append(
+                        "[mcp_servers.ouroboros].tools contains an empty or non-string tool name"
+                    )
+                    continue
+                if not isinstance(tool_config, Mapping):
+                    failures.append(f"[mcp_servers.ouroboros].tools.{tool_name} must be a table")
+                    continue
+                unknown_tool_fields = sorted(set(tool_config) - {"approval_mode"})
+                if unknown_tool_fields:
+                    failures.append(
+                        f"[mcp_servers.ouroboros].tools.{tool_name} contains unsupported "
+                        "fields: " + ", ".join(unknown_tool_fields)
+                    )
+                if "approval_mode" in tool_config:
+                    _check_mcp_approval_mode(
+                        tool_config["approval_mode"],
+                        f"tools.{tool_name}.approval_mode",
+                        failures,
+                    )
+
+
+def _check_optional_string_field(
+    config: Mapping[object, object],
+    field: str,
+    failures: list[str],
+    *,
+    prefix: str = "",
+) -> None:
+    """Validate an optional Codex MCP string without truthy coercion."""
+    if field in config and not isinstance(config[field], str):
+        failures.append(f"[mcp_servers.ouroboros].{prefix}{field} must be a string")
+
+
+def _check_string_table_field(value: object, field: str, failures: list[str]) -> None:
+    """Validate a Codex MCP table whose keys and values must both be strings."""
+    if not isinstance(value, Mapping):
+        failures.append(f"[mcp_servers.ouroboros].{field} must be a table of strings")
+        return
+    invalid_entries = [
+        f"{key!r} ({type(item).__name__})"
+        for key, item in value.items()
+        if not isinstance(key, str) or not isinstance(item, str)
+    ]
+    if invalid_entries:
+        failures.append(
+            f"[mcp_servers.ouroboros].{field} contains non-string values: "
+            + ", ".join(invalid_entries)
+        )
+
+
+def _check_mcp_approval_mode(value: object, field: str, failures: list[str]) -> None:
+    """Require the three approval modes accepted by Codex CLI 0.132."""
+    if not isinstance(value, str) or value not in _CODEX_MCP_APPROVAL_MODES:
+        failures.append(
+            f"[mcp_servers.ouroboros].{field} must be one of: "
+            + ", ".join(sorted(_CODEX_MCP_APPROVAL_MODES))
+        )
+
+
 def _check_mcp_activation_surface(
     ouroboros_entry: Mapping[str, object], failures: list[str]
 ) -> None:
@@ -351,7 +536,7 @@ def _check_mcp_execution_surface(
     unsupported_fields = {
         "cwd": "the stdio process working directory",
         "env_vars": "which ambient environment variables Codex forwards",
-        "environment_id": "the Codex execution environment",
+        "experimental_environment": "the Codex execution environment",
         "startup_timeout_sec": "the Codex MCP initialization deadline",
         "startup_timeout_ms": "the legacy Codex MCP initialization deadline",
         "tool_timeout_sec": "the Codex MCP tool-call deadline",

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -9,7 +9,9 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import shutil
 import signal
+import sys
 import tomllib
 from typing import Annotated, Any, cast
 
@@ -316,6 +318,10 @@ def _check_mcp_runtime_dependency_surface(
     string_env = cast(Mapping[str, str], env)
 
     if command_name == "uvx":
+        if not _command_matches_path_program(command, "uvx"):
+            failures.append(
+                "Codex MCP uvx command does not resolve to the `uvx` executable on PATH"
+            )
         joined_args = " ".join(string_args)
         if "ouroboros-ai" in joined_args and "ouroboros-ai[mcp]" not in joined_args:
             failures.append(
@@ -432,6 +438,10 @@ def _check_mcp_runtime_dependency_surface(
         Path(command_name).stem if command_name.lower().endswith(".exe") else command_name
     )
     if normalized_command_name == "ouroboros":
+        if not _command_matches_path_program(command, "ouroboros"):
+            failures.append(
+                "Codex MCP direct command does not resolve to the `ouroboros` executable on PATH"
+            )
         _check_exact_codex_runtime_contract(
             string_args,
             string_env,
@@ -446,7 +456,7 @@ def _check_mcp_runtime_dependency_surface(
             )
         return
 
-    if tuple(string_args[:2]) == ("-m", "ouroboros"):
+    if _command_is_current_python(command):
         _check_exact_codex_runtime_contract(
             string_args,
             string_env,
@@ -459,6 +469,32 @@ def _check_mcp_runtime_dependency_surface(
                 "configured Python module environment cannot import `mcp`; install the "
                 "`ouroboros-ai[mcp]` profile before using it for Codex MCP"
             )
+        return
+
+    failures.append(
+        "Codex MCP command is not a setup-supported executable; use canonical `uvx`, "
+        "the `ouroboros` executable on PATH, or the current Python executable with "
+        "`-m ouroboros`"
+    )
+
+
+def _command_matches_path_program(command: str, program: str) -> bool:
+    """Return whether command resolves to the exact PATH-selected program."""
+    expected = shutil.which(program)
+    configured = shutil.which(command)
+    if expected is None or configured is None:
+        return False
+    try:
+        return Path(configured).resolve(strict=True) == Path(expected).resolve(strict=True)
+    except OSError:
+        return False
+
+
+def _command_is_current_python(command: str) -> bool:
+    """Match setup's exact ``sys.executable`` module launcher, without aliases."""
+    configured = os.path.normcase(os.path.abspath(os.path.expanduser(command)))
+    current = os.path.normcase(os.path.abspath(sys.executable))
+    return configured == current
 
 
 def _check_exact_codex_runtime_contract(
@@ -780,16 +816,49 @@ def _format_stdio_mcp_stderr(stderr_buffer: bytearray) -> str:
 
 
 async def _terminate_stdio_mcp_process(proc: asyncio.subprocess.Process) -> None:
-    if proc.returncode is not None:
-        return
     if proc.stdin is not None:
         proc.stdin.close()
+
+    if os.name != "posix":  # pragma: no cover - exercised by Windows CI/runtime
+        if proc.returncode is not None:
+            return
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+        return
+
+    process_group_id = proc.pid
     _signal_stdio_mcp_process(proc, force=False)
-    try:
-        await asyncio.wait_for(proc.wait(), timeout=2.0)
-    except TimeoutError:
+    forced = False
+    if proc.returncode is None:
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except TimeoutError:
+            forced = True
+    if not forced:
+        try:
+            await asyncio.wait_for(
+                _wait_for_stdio_mcp_process_group_exit(process_group_id), timeout=2.0
+            )
+        except TimeoutError:
+            forced = True
+    if forced:
         _signal_stdio_mcp_process(proc, force=True)
-        await proc.wait()
+        if proc.returncode is None:
+            await proc.wait()
+
+
+async def _wait_for_stdio_mcp_process_group_exit(process_group_id: int) -> None:
+    """Wait until no wrapper descendant remains in the probe's POSIX group."""
+    while True:
+        try:
+            os.killpg(process_group_id, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.02)
 
 
 def _signal_stdio_mcp_process(proc: asyncio.subprocess.Process, *, force: bool) -> None:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -48,13 +48,13 @@ _CANONICAL_CODEX_UVX_MCP_ARGS = (
     "mcp",
     "serve",
 )
+_CODEX_MCP_RUNTIME_SUFFIX = ("--runtime", "codex", "--llm-backend", "codex")
 _CANONICAL_CODEX_UVX_MCP_HOST_ARGS = (
     *_CANONICAL_CODEX_UVX_MCP_ARGS,
-    "--runtime",
-    "codex",
-    "--llm-backend",
-    "codex",
+    *_CODEX_MCP_RUNTIME_SUFFIX,
 )
+_CANONICAL_CODEX_DIRECT_MCP_ARGS = ("mcp", "serve")
+_CANONICAL_CODEX_MODULE_MCP_ARGS = ("-m", "ouroboros", "mcp", "serve")
 _CODEX_RUNTIME_ENV = {
     "OUROBOROS_AGENT_RUNTIME": "codex",
     "OUROBOROS_LLM_BACKEND": "codex",
@@ -422,16 +422,65 @@ def _check_mcp_runtime_dependency_surface(
                 "Codex MCP command installs `ouroboros-ai` without the `mcp` extra; "
                 "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
             )
-        return
-
-    if command_name != "ouroboros" or not check_local_import:
-        return
-
-    if importlib.util.find_spec("mcp") is None:
         failures.append(
-            "current `ouroboros` environment cannot import `mcp`; reinstall for Codex MCP "
-            "usage with `uv tool install --force 'ouroboros-ai[mcp]'`"
+            "Codex MCP `uv run` launchers are unsupported because they can inherit a "
+            "project environment; use the canonical isolated `uvx` launcher"
         )
+        return
+
+    normalized_command_name = (
+        Path(command_name).stem if command_name.lower().endswith(".exe") else command_name
+    )
+    if normalized_command_name == "ouroboros":
+        _check_exact_codex_runtime_contract(
+            string_args,
+            string_env,
+            base_args=_CANONICAL_CODEX_DIRECT_MCP_ARGS,
+            launcher="direct `ouroboros`",
+            failures=failures,
+        )
+        if check_local_import and importlib.util.find_spec("mcp") is None:
+            failures.append(
+                "current `ouroboros` environment cannot import `mcp`; reinstall for Codex MCP "
+                "usage with `uv tool install --force 'ouroboros-ai[mcp]'`"
+            )
+        return
+
+    if tuple(string_args[:2]) == ("-m", "ouroboros"):
+        _check_exact_codex_runtime_contract(
+            string_args,
+            string_env,
+            base_args=_CANONICAL_CODEX_MODULE_MCP_ARGS,
+            launcher="`python -m ouroboros`",
+            failures=failures,
+        )
+        if check_local_import and importlib.util.find_spec("mcp") is None:
+            failures.append(
+                "configured Python module environment cannot import `mcp`; install the "
+                "`ouroboros-ai[mcp]` profile before using it for Codex MCP"
+            )
+
+
+def _check_exact_codex_runtime_contract(
+    args: list[str],
+    env: Mapping[str, str],
+    *,
+    base_args: tuple[str, ...],
+    launcher: str,
+    failures: list[str],
+) -> None:
+    """Require one unambiguous Codex runtime selection for a local launcher."""
+    args_tuple = tuple(args)
+    if args_tuple == base_args:
+        _check_codex_runtime_env(env, failures, required=True)
+        return
+    if args_tuple == (*base_args, *_CODEX_MCP_RUNTIME_SUFFIX):
+        _check_codex_runtime_env(env, failures, required=False)
+        return
+    failures.append(
+        f"Codex MCP {launcher} command must use exactly `{' '.join(base_args)}` with "
+        "Codex selector env, or append exactly `--runtime codex --llm-backend codex`"
+    )
 
 
 def _check_codex_runtime_env(

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -354,6 +354,7 @@ def _check_mcp_execution_surface(
         "environment_id": "the Codex execution environment",
         "startup_timeout_sec": "the Codex MCP initialization deadline",
         "startup_timeout_ms": "the legacy Codex MCP initialization deadline",
+        "tool_timeout_sec": "the Codex MCP tool-call deadline",
     }
     for field, effect in unsupported_fields.items():
         if field in ouroboros_entry:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -244,6 +244,15 @@ def _check_mcp_runtime_dependency_surface(
                 "Codex MCP command installs `ouroboros-ai` without the `mcp` extra; "
                 "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
             )
+        if (
+            command_name == "uvx"
+            and "ouroboros-ai[mcp]" in string_args
+            and "--isolated" not in string_args
+        ):
+            failures.append(
+                "Codex MCP uvx command may reuse an installed MCP 1.x tool; "
+                "add `--isolated` before `--from ouroboros-ai[mcp]`"
+            )
         return
 
     if command_name != "ouroboros":
@@ -287,7 +296,7 @@ async def _list_stdio_mcp_tool_names(
     This doctor probe intentionally speaks the small MCP initialize/list_tools
     JSON-RPC sequence directly instead of using :class:`MCPClientAdapter`.
     Codex can point at a self-contained command such as
-    ``uvx --from ouroboros-ai[mcp] ouroboros mcp serve``; validating that
+    ``uvx --isolated --from ouroboros-ai[mcp] ouroboros mcp serve``; validating that
     setup must not first require the current ``ouroboros codex doctor``
     interpreter to have installed the optional local ``mcp`` extra.
     """

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -16,6 +16,7 @@ import typer
 
 from ouroboros.cli.formatters.panels import print_error, print_success, print_warning
 from ouroboros.codex import install_codex_artifacts, resolve_codex_home
+from ouroboros.package_profiles import UVX_PYTHON_FLOOR
 
 app = typer.Typer(
     name="codex",
@@ -253,6 +254,17 @@ def _check_mcp_runtime_dependency_surface(
                 "Codex MCP uvx command may reuse an installed MCP 1.x tool; "
                 "add `--isolated` before `--from ouroboros-ai[mcp]`"
             )
+        if command_name == "uvx" and "ouroboros-ai[mcp]" in string_args:
+            try:
+                python_index = string_args.index("--python")
+                python_selector = string_args[python_index + 1]
+            except (ValueError, IndexError):
+                python_selector = None
+            if python_selector != UVX_PYTHON_FLOOR:
+                failures.append(
+                    "Codex MCP uvx command does not select the supported Python floor; "
+                    "add `--python >=3.12` before `--from ouroboros-ai[mcp]`"
+                )
         return
 
     if command_name != "ouroboros":
@@ -296,7 +308,8 @@ async def _list_stdio_mcp_tool_names(
     This doctor probe intentionally speaks the small MCP initialize/list_tools
     JSON-RPC sequence directly instead of using :class:`MCPClientAdapter`.
     Codex can point at a self-contained command such as
-    ``uvx --isolated --from ouroboros-ai[mcp] ouroboros mcp serve``; validating that
+    ``uvx --isolated --python >=3.12 --from ouroboros-ai[mcp] ouroboros mcp serve``;
+    validating that
     setup must not first require the current ``ouroboros codex doctor``
     interpreter to have installed the optional local ``mcp`` extra.
     """

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -37,6 +37,16 @@ _REQUIRED_CODEX_AUTO_TOOLS = frozenset(
 )
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _MCP_STDERR_TAIL_BYTES = 8192
+_CANONICAL_CODEX_UVX_MCP_ARGS = (
+    "--isolated",
+    "--python",
+    UVX_PYTHON_FLOOR,
+    "--from",
+    "ouroboros-ai[mcp]",
+    "ouroboros",
+    "mcp",
+    "serve",
+)
 
 
 class _StdioMcpFramingMismatch(RuntimeError):
@@ -238,33 +248,102 @@ def _check_mcp_runtime_dependency_surface(
     command_name = Path(command).name
     string_args = [arg for arg in args if isinstance(arg, str)]
 
-    if command_name in {"uvx", "uv"}:
+    if command_name == "uvx":
         joined_args = " ".join(string_args)
         if "ouroboros-ai" in joined_args and "ouroboros-ai[mcp]" not in joined_args:
             failures.append(
                 "Codex MCP command installs `ouroboros-ai` without the `mcp` extra; "
                 "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
             )
-        if (
-            command_name == "uvx"
-            and "ouroboros-ai[mcp]" in string_args
-            and "--isolated" not in string_args
+
+        if tuple(string_args) == _CANONICAL_CODEX_UVX_MCP_ARGS:
+            return
+
+        command_tail = ("ouroboros", "mcp", "serve")
+        try:
+            command_index = next(
+                index
+                for index in range(len(string_args) - len(command_tail) + 1)
+                if tuple(string_args[index : index + len(command_tail)]) == command_tail
+            )
+        except StopIteration:
+            command_index = None
+
+        isolated_indices = [
+            index for index, argument in enumerate(string_args) if argument == "--isolated"
+        ]
+        if len(isolated_indices) != 1 or (
+            command_index is not None and isolated_indices[0] > command_index
         ):
             failures.append(
                 "Codex MCP uvx command may reuse an installed MCP 1.x tool; "
-                "add `--isolated` before `--from ouroboros-ai[mcp]`"
+                "use exactly one `--isolated` before the launched command"
             )
-        if command_name == "uvx" and "ouroboros-ai[mcp]" in string_args:
-            try:
-                python_index = string_args.index("--python")
-                python_selector = string_args[python_index + 1]
-            except (ValueError, IndexError):
-                python_selector = None
-            if python_selector != UVX_PYTHON_FLOOR:
-                failures.append(
-                    "Codex MCP uvx command does not select the supported Python floor; "
-                    "add `--python >=3.12` before `--from ouroboros-ai[mcp]`"
-                )
+
+        python_indices = [
+            index
+            for index, argument in enumerate(string_args)
+            if argument == "--python" or argument.startswith("--python=")
+        ]
+        python_selector = (
+            string_args[python_indices[0] + 1]
+            if len(python_indices) == 1
+            and string_args[python_indices[0]] == "--python"
+            and python_indices[0] + 1 < len(string_args)
+            else None
+        )
+        if (
+            len(python_indices) != 1
+            or python_selector != UVX_PYTHON_FLOOR
+            or (command_index is not None and python_indices[0] > command_index)
+        ):
+            failures.append(
+                "Codex MCP uvx command does not select the supported Python floor; "
+                "use exactly one `--python >=3.12` before the launched command"
+            )
+
+        from_indices = [
+            index
+            for index, argument in enumerate(string_args)
+            if argument == "--from" or argument.startswith("--from=")
+        ]
+        package_spec = (
+            string_args[from_indices[0] + 1]
+            if len(from_indices) == 1
+            and string_args[from_indices[0]] == "--from"
+            and from_indices[0] + 1 < len(string_args)
+            else None
+        )
+        if (
+            len(from_indices) != 1
+            or package_spec != "ouroboros-ai[mcp]"
+            or (command_index is not None and from_indices[0] > command_index)
+        ):
+            failures.append(
+                "Codex MCP uvx command must use exactly one unpinned "
+                "`--from ouroboros-ai[mcp]` before the launched command"
+            )
+
+        if command_index is None or tuple(string_args[command_index:]) != command_tail:
+            failures.append(
+                "Codex MCP uvx command must end with `ouroboros mcp serve`; "
+                "uvx launcher flags belong before that command"
+            )
+
+        failures.append(
+            "Codex MCP uvx command is not canonical; expected: "
+            "`uvx --isolated --python >=3.12 --from ouroboros-ai[mcp] "
+            "ouroboros mcp serve`"
+        )
+        return
+
+    if command_name == "uv":
+        joined_args = " ".join(string_args)
+        if "ouroboros-ai" in joined_args and "ouroboros-ai[mcp]" not in joined_args:
+            failures.append(
+                "Codex MCP command installs `ouroboros-ai` without the `mcp` extra; "
+                "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
+            )
         return
 
     if command_name != "ouroboros":

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 import signal
 import tomllib
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import typer
 
@@ -218,28 +218,51 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
     if not isinstance(command, str) or not command.strip():
         failures.append("[mcp_servers.ouroboros] is missing `command` or `url`")
     else:
-        args_obj = ouroboros_entry.get("args")
+        args_obj = ouroboros_entry.get("args", [])
+        args: tuple[str, ...] | None = None
         if not isinstance(args_obj, list):
-            args_obj = []
-        args = tuple(arg for arg in args_obj if isinstance(arg, str))
-        env_obj = ouroboros_entry.get("env")
-        env = (
-            {
-                key: value
+            failures.append("[mcp_servers.ouroboros].args must be an array of strings")
+        else:
+            invalid_args = [
+                f"index {index} ({type(argument).__name__})"
+                for index, argument in enumerate(args_obj)
+                if not isinstance(argument, str)
+            ]
+            if invalid_args:
+                failures.append(
+                    "[mcp_servers.ouroboros].args contains non-string values: "
+                    + ", ".join(invalid_args)
+                )
+            else:
+                args = cast(tuple[str, ...], tuple(args_obj))
+
+        env_obj = ouroboros_entry.get("env", {})
+        env: dict[str, str] | None = None
+        if not isinstance(env_obj, dict):
+            failures.append("[mcp_servers.ouroboros].env must be a table of string values")
+        else:
+            invalid_env = [
+                f"{key!r} ({type(value).__name__})"
                 for key, value in env_obj.items()
-                if isinstance(key, str) and isinstance(value, str)
-            }
-            if isinstance(env_obj, dict)
-            else {}
-        )
-        command_entry = _CodexMCPCommandEntry(command=command, args=args, env=env)
-        _check_mcp_runtime_dependency_surface(
-            command,
-            list(args),
-            env,
-            failures,
-            check_local_import=not live_mcp,
-        )
+                if not isinstance(key, str) or not isinstance(value, str)
+            ]
+            if invalid_env:
+                failures.append(
+                    "[mcp_servers.ouroboros].env contains non-string values: "
+                    + ", ".join(invalid_env)
+                )
+            else:
+                env = cast(dict[str, str], dict(env_obj))
+
+        if args is not None and env is not None:
+            command_entry = _CodexMCPCommandEntry(command=command, args=args, env=env)
+            _check_mcp_runtime_dependency_surface(
+                command,
+                list(args),
+                env,
+                failures,
+                check_local_import=not live_mcp,
+            )
 
     if live_mcp and command_entry is not None and not failures:
         _check_live_mcp_tool_exposure(command_entry, failures)
@@ -256,7 +279,7 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
 def _check_mcp_runtime_dependency_surface(
     command: str,
     args: list[object],
-    env: Mapping[str, str],
+    env: object,
     failures: list[str],
     *,
     check_local_import: bool = True,
@@ -268,8 +291,29 @@ def _check_mcp_runtime_dependency_surface(
     while the installed ``ouroboros-ai`` environment lacks the optional ``mcp``
     extra, causing Codex's real stdio handshake to close before tools are listed.
     """
+    invalid_args = [
+        f"index {index} ({type(argument).__name__})"
+        for index, argument in enumerate(args)
+        if not isinstance(argument, str)
+    ]
+    if invalid_args:
+        failures.append("Codex MCP args contains non-string values: " + ", ".join(invalid_args))
+        return
+    if not isinstance(env, Mapping):
+        failures.append("Codex MCP env must be a mapping of string values")
+        return
+    invalid_env = [
+        f"{key!r} ({type(value).__name__})"
+        for key, value in env.items()
+        if not isinstance(key, str) or not isinstance(value, str)
+    ]
+    if invalid_env:
+        failures.append("Codex MCP env contains non-string values: " + ", ".join(invalid_env))
+        return
+
     command_name = Path(command).name
-    string_args = [arg for arg in args if isinstance(arg, str)]
+    string_args = cast(list[str], args)
+    string_env = cast(Mapping[str, str], env)
 
     if command_name == "uvx":
         joined_args = " ".join(string_args)
@@ -281,10 +325,10 @@ def _check_mcp_runtime_dependency_surface(
 
         args_tuple = tuple(string_args)
         if args_tuple == _CANONICAL_CODEX_UVX_MCP_ARGS:
-            _check_codex_runtime_env(env, failures, required=True)
+            _check_codex_runtime_env(string_env, failures, required=True)
             return
         if args_tuple == _CANONICAL_CODEX_UVX_MCP_HOST_ARGS:
-            _check_codex_runtime_env(env, failures, required=False)
+            _check_codex_runtime_env(string_env, failures, required=False)
             return
 
         command_tail = ("ouroboros", "mcp", "serve")

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -62,6 +62,7 @@ _CODEX_RUNTIME_ENV = {
     "OUROBOROS_LLM_BACKEND": "codex",
 }
 _CODEX_RUNTIME_SELECTOR_ENV_KEYS = frozenset({*_CODEX_RUNTIME_ENV, "OUROBOROS_RUNTIME"})
+_OUROBOROS_NESTED_ENV_KEY = "_OUROBOROS_NESTED"
 _CODEX_MCP_APPROVAL_MODES = frozenset({"auto", "prompt", "approve"})
 _CODEX_MCP_CONFIG_FIELDS = frozenset(
     {
@@ -794,6 +795,14 @@ def _check_codex_runtime_env(
     env: Mapping[str, str], failures: list[str], *, required: bool
 ) -> None:
     """Validate runtime selectors accompanying a canonical Codex uvx launcher."""
+    if _OUROBOROS_NESTED_ENV_KEY in env:
+        failures.append(
+            "Codex MCP runtime environment persists `_OUROBOROS_NESTED`, but this "
+            "reserved internal recursion sentinel can make the server exit before MCP "
+            "initialization; "
+            "remove it from [mcp_servers.ouroboros.env]"
+        )
+
     hostile = {
         key: value
         for key, value in env.items()

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -9,6 +9,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import signal
 import tomllib
 from typing import Annotated, Any
 
@@ -47,6 +48,18 @@ _CANONICAL_CODEX_UVX_MCP_ARGS = (
     "mcp",
     "serve",
 )
+_CANONICAL_CODEX_UVX_MCP_HOST_ARGS = (
+    *_CANONICAL_CODEX_UVX_MCP_ARGS,
+    "--runtime",
+    "codex",
+    "--llm-backend",
+    "codex",
+)
+_CODEX_RUNTIME_ENV = {
+    "OUROBOROS_AGENT_RUNTIME": "codex",
+    "OUROBOROS_LLM_BACKEND": "codex",
+}
+_CODEX_RUNTIME_SELECTOR_ENV_KEYS = frozenset({*_CODEX_RUNTIME_ENV, "OUROBOROS_RUNTIME"})
 
 
 class _StdioMcpFramingMismatch(RuntimeError):
@@ -220,8 +233,13 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
             else {}
         )
         command_entry = _CodexMCPCommandEntry(command=command, args=args, env=env)
-        if not live_mcp:
-            _check_mcp_runtime_dependency_surface(command, list(args), failures)
+        _check_mcp_runtime_dependency_surface(
+            command,
+            list(args),
+            env,
+            failures,
+            check_local_import=not live_mcp,
+        )
 
     if live_mcp and command_entry is not None and not failures:
         _check_live_mcp_tool_exposure(command_entry, failures)
@@ -236,7 +254,12 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
 
 
 def _check_mcp_runtime_dependency_surface(
-    command: str, args: list[object], failures: list[str]
+    command: str,
+    args: list[object],
+    env: Mapping[str, str],
+    failures: list[str],
+    *,
+    check_local_import: bool = True,
 ) -> None:
     """Detect Codex MCP server entries that cannot import the MCP runtime.
 
@@ -256,7 +279,12 @@ def _check_mcp_runtime_dependency_surface(
                 "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
             )
 
-        if tuple(string_args) == _CANONICAL_CODEX_UVX_MCP_ARGS:
+        args_tuple = tuple(string_args)
+        if args_tuple == _CANONICAL_CODEX_UVX_MCP_ARGS:
+            _check_codex_runtime_env(env, failures, required=True)
+            return
+        if args_tuple == _CANONICAL_CODEX_UVX_MCP_HOST_ARGS:
+            _check_codex_runtime_env(env, failures, required=False)
             return
 
         command_tail = ("ouroboros", "mcp", "serve")
@@ -324,16 +352,22 @@ def _check_mcp_runtime_dependency_surface(
                 "`--from ouroboros-ai[mcp]` before the launched command"
             )
 
-        if command_index is None or tuple(string_args[command_index:]) != command_tail:
+        allowed_command_tails = {
+            command_tail,
+            (*command_tail, "--runtime", "codex", "--llm-backend", "codex"),
+        }
+        if command_index is None or tuple(string_args[command_index:]) not in allowed_command_tails:
             failures.append(
-                "Codex MCP uvx command must end with `ouroboros mcp serve`; "
-                "uvx launcher flags belong before that command"
+                "Codex MCP uvx command must end with `ouroboros mcp serve` or the exact "
+                "Codex host selector `--runtime codex --llm-backend codex`; uvx launcher "
+                "flags and arbitrary arguments are not allowed after that command"
             )
 
         failures.append(
-            "Codex MCP uvx command is not canonical; expected: "
+            "Codex MCP uvx command is not canonical; expected the isolated base launcher "
+            "with Codex runtime env, or: "
             "`uvx --isolated --python >=3.12 --from ouroboros-ai[mcp] "
-            "ouroboros mcp serve`"
+            "ouroboros mcp serve --runtime codex --llm-backend codex`"
         )
         return
 
@@ -346,13 +380,41 @@ def _check_mcp_runtime_dependency_surface(
             )
         return
 
-    if command_name != "ouroboros":
+    if command_name != "ouroboros" or not check_local_import:
         return
 
     if importlib.util.find_spec("mcp") is None:
         failures.append(
             "current `ouroboros` environment cannot import `mcp`; reinstall for Codex MCP "
             "usage with `uv tool install --force 'ouroboros-ai[mcp]'`"
+        )
+
+
+def _check_codex_runtime_env(
+    env: Mapping[str, str], failures: list[str], *, required: bool
+) -> None:
+    """Validate runtime selectors accompanying a canonical Codex uvx launcher."""
+    hostile = {
+        key: value
+        for key, value in env.items()
+        if key in _CODEX_RUNTIME_SELECTOR_ENV_KEYS and value != "codex"
+    }
+    if hostile:
+        rendered = ", ".join(f"{key}={value!r}" for key, value in sorted(hostile.items()))
+        failures.append("Codex MCP runtime environment contains conflicting selectors: " + rendered)
+
+    if not required:
+        return
+
+    missing_or_invalid = [
+        f"{key}={expected!r}"
+        for key, expected in _CODEX_RUNTIME_ENV.items()
+        if env.get(key) != expected
+    ]
+    if missing_or_invalid:
+        failures.append(
+            "Codex MCP base uvx launcher requires runtime environment selectors: "
+            + ", ".join(missing_or_invalid)
         )
 
 
@@ -417,6 +479,7 @@ async def _list_stdio_mcp_tool_names_with_framing(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=process_env,
+        start_new_session=os.name == "posix",
     )
     stderr_buffer = bytearray()
     stderr_task = (
@@ -626,12 +689,29 @@ def _format_stdio_mcp_stderr(stderr_buffer: bytearray) -> str:
 async def _terminate_stdio_mcp_process(proc: asyncio.subprocess.Process) -> None:
     if proc.returncode is not None:
         return
-    proc.terminate()
+    if proc.stdin is not None:
+        proc.stdin.close()
+    _signal_stdio_mcp_process(proc, force=False)
     try:
         await asyncio.wait_for(proc.wait(), timeout=2.0)
     except TimeoutError:
-        proc.kill()
+        _signal_stdio_mcp_process(proc, force=True)
         await proc.wait()
+
+
+def _signal_stdio_mcp_process(proc: asyncio.subprocess.Process, *, force: bool) -> None:
+    """Stop the uvx wrapper and the MCP child that inherits its stdio pipes."""
+    if os.name != "posix":  # pragma: no cover - exercised by Windows CI/runtime
+        if force:
+            proc.kill()
+        else:
+            proc.terminate()
+        return
+
+    try:
+        os.killpg(proc.pid, signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        return
 
 
 def _read_codex_text(path: Path, label: str, failures: list[str]) -> str | None:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -206,6 +206,7 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         return failures
 
     _check_mcp_activation_surface(ouroboros_entry, failures)
+    _check_mcp_execution_surface(ouroboros_entry, failures)
 
     url = ouroboros_entry.get("url")
     if isinstance(url, str) and url.strip():
@@ -334,6 +335,31 @@ def _check_mcp_activation_surface(
             failures.append(
                 "[mcp_servers.ouroboros].disabled_tools blocks required auto tools: "
                 + ", ".join(blocked_tools)
+            )
+
+
+def _check_mcp_execution_surface(
+    ouroboros_entry: Mapping[str, object], failures: list[str]
+) -> None:
+    """Reject Codex execution controls that the doctor probe cannot reproduce.
+
+    The live probe deliberately supports only the launcher, argv, and explicit
+    environment table represented by :class:`_CodexMCPCommandEntry`.  Silently
+    ignoring any additional process or initialization controls would verify a
+    different execution contract from the one Codex actually uses.
+    """
+    unsupported_fields = {
+        "cwd": "the stdio process working directory",
+        "env_vars": "which ambient environment variables Codex forwards",
+        "environment_id": "the Codex execution environment",
+        "startup_timeout_sec": "the Codex MCP initialization deadline",
+        "startup_timeout_ms": "the legacy Codex MCP initialization deadline",
+    }
+    for field, effect in unsupported_fields.items():
+        if field in ouroboros_entry:
+            failures.append(
+                f"[mcp_servers.ouroboros].{field} is unsupported by doctor because "
+                f"it changes {effect}; remove it before verifying this MCP contract"
             )
 
 

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -205,6 +205,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append("Codex config does not contain [mcp_servers.ouroboros]")
         return failures
 
+    _check_mcp_activation_surface(ouroboros_entry, failures)
+
     url = ouroboros_entry.get("url")
     if isinstance(url, str) and url.strip():
         if live_mcp:
@@ -276,6 +278,63 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         )
 
     return failures
+
+
+def _check_mcp_activation_surface(
+    ouroboros_entry: Mapping[str, object], failures: list[str]
+) -> None:
+    """Validate the Codex fields that decide whether tools are reachable.
+
+    Codex defaults an omitted ``enabled`` field to true.  When an
+    ``enabled_tools`` allow-list is present, only its members are registered;
+    ``disabled_tools`` is then applied as a deny-list.  A direct live launch
+    bypasses all three filters, so doctor must validate their persisted types
+    and effects before it considers probing the configured transport.
+    """
+    enabled = ouroboros_entry.get("enabled", True)
+    if not isinstance(enabled, bool):
+        failures.append("[mcp_servers.ouroboros].enabled must be a boolean")
+    elif not enabled:
+        failures.append("[mcp_servers.ouroboros] is disabled (`enabled = false`)")
+
+    tool_filters: dict[str, frozenset[str]] = {}
+    for field in ("enabled_tools", "disabled_tools"):
+        if field not in ouroboros_entry:
+            continue
+        value = ouroboros_entry[field]
+        if not isinstance(value, list):
+            failures.append(f"[mcp_servers.ouroboros].{field} must be an array of strings")
+            continue
+        invalid_values = [
+            f"index {index} ({type(tool_name).__name__})"
+            for index, tool_name in enumerate(value)
+            if not isinstance(tool_name, str)
+        ]
+        if invalid_values:
+            failures.append(
+                f"[mcp_servers.ouroboros].{field} contains non-string values: "
+                + ", ".join(invalid_values)
+            )
+            continue
+        tool_filters[field] = frozenset(cast(list[str], value))
+
+    enabled_tools = tool_filters.get("enabled_tools")
+    if enabled_tools is not None:
+        missing_tools = sorted(_REQUIRED_CODEX_AUTO_TOOLS - enabled_tools)
+        if missing_tools:
+            failures.append(
+                "[mcp_servers.ouroboros].enabled_tools omits required auto tools: "
+                + ", ".join(missing_tools)
+            )
+
+    disabled_tools = tool_filters.get("disabled_tools")
+    if disabled_tools is not None:
+        blocked_tools = sorted(_REQUIRED_CODEX_AUTO_TOOLS & disabled_tools)
+        if blocked_tools:
+            failures.append(
+                "[mcp_servers.ouroboros].disabled_tools blocks required auto tools: "
+                + ", ".join(blocked_tools)
+            )
 
 
 def _check_mcp_runtime_dependency_surface(
@@ -858,6 +917,11 @@ async def _wait_for_stdio_mcp_process_group_exit(process_group_id: int) -> None:
             os.killpg(process_group_id, 0)
         except ProcessLookupError:
             return
+        except PermissionError:
+            # EPERM still proves that the group exists.  This can occur when
+            # the session-leading wrapper exits before a surviving child and
+            # the probe no longer owns permission to inspect that group.
+            pass
         await asyncio.sleep(0.02)
 
 

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -353,7 +353,8 @@ def _ensure_shell_env(*, timeout: float = 10.0) -> None:
 
 
 # Process-tree wrappers that sit between the real MCP client and this server.
-# The shipped install path (`uvx --from ouroboros-ai ... ouroboros mcp serve`)
+# The shipped install path
+# (`uvx --isolated --python >=3.12 --from ouroboros-ai[mcp] ouroboros mcp serve`)
 # interposes a uv wrapper that blocks on waitpid() and survives the client's
 # death, so the *direct* parent is not the process whose lifetime matters.
 _WRAPPER_BASENAMES = frozenset(

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -1042,7 +1042,8 @@ def serve(
         _stderr_console.print(Text(f"MCP dependencies not installed: {e}", style="red"))
         _stderr_console.print(
             "[blue]Run MCP 2 in an isolated profile:\n"
-            "  uvx --python '>=3.12' --from 'ouroboros-ai\\[mcp]' ouroboros mcp serve "
+            "  uvx --isolated --python '>=3.12' --from 'ouroboros-ai\\[mcp]' "
+            "ouroboros mcp serve "
             "--runtime claude-cli\n"
             "or:\n"
             "  pipx run --spec 'ouroboros-ai\\[mcp]' ouroboros mcp serve "

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -121,7 +121,8 @@ def check_mcp_import() -> CheckResult:
             message="mcp package not importable",
             remediation=(
                 "Run the server in its isolated profile: "
-                "uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros mcp serve"
+                "uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' "
+                "ouroboros mcp serve"
             ),
         )
 
@@ -145,7 +146,7 @@ def check_mcp_import() -> CheckResult:
             message=f"mcp {version} is not the required MCP 2 runtime",
             remediation=(
                 "Do not add MCP 2 to the Claude SDK environment. Launch the "
-                "separate server process with: uvx --python '>=3.12' --from "
+                "separate server process with: uvx --isolated --python '>=3.12' --from "
                 "'ouroboros-ai[mcp]' ouroboros mcp serve"
             ),
         )

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -106,7 +106,16 @@ class _SetupCodexCliLogger:
 
 def _build_uvx_mcp_args(package_spec: str) -> list[str]:
     """Return the canonical uvx args for the requested Ouroboros package spec."""
-    return ["--python", UVX_PYTHON_FLOOR, "--from", package_spec, "ouroboros", "mcp", "serve"]
+    return [
+        "--isolated",
+        "--python",
+        UVX_PYTHON_FLOOR,
+        "--from",
+        package_spec,
+        "ouroboros",
+        "mcp",
+        "serve",
+    ]
 
 
 def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, object] | None:
@@ -114,8 +123,10 @@ def _detect_mcp_entry(*, package_spec: str = "ouroboros-ai[mcp]") -> dict[str, o
 
     Direct ``ouroboros`` and ``python -m`` fallbacks are deliberately excluded:
     their environments may contain the Claude SDK's MCP 1.x dependency or no
-    MCP extra at all. ``uvx`` and ``pipx run`` both create a package-isolated
-    process whose ``[mcp]`` extra is known to contain MCP 2.
+    MCP extra at all. ``uvx --isolated`` and ``pipx run`` both create a
+    package-isolated process whose ``[mcp]`` extra is known to contain MCP 2.
+    ``uvx --from`` without ``--isolated`` is insufficient: uv may reuse an
+    already installed Ouroboros tool whose environment contains MCP 1.x.
     Matches the contract in install.sh and skills/setup/SKILL.md.
     """
     if shutil.which("uvx"):
@@ -435,17 +446,18 @@ _CODEX_MCP_COMMENT_LINES = (
 
 CodexMcpMode = Literal["auto", "preserve", "stdio"]
 _CODEX_APP_CLI_PATH = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
-_CODEX_UVX_MCP_ARGS = [
-    "--python",
-    UVX_PYTHON_FLOOR,
-    "--from",
-    "ouroboros-ai[mcp]",
-    "ouroboros",
-    "mcp",
-    "serve",
-]
+_CODEX_UVX_MCP_ARGS = _build_uvx_mcp_args("ouroboros-ai[mcp]")
 _CODEX_LEGACY_UVX_MCP_ARGS: tuple[tuple[str, ...], ...] = (
     tuple(_CODEX_UVX_MCP_ARGS),
+    (
+        "--python",
+        UVX_PYTHON_FLOOR,
+        "--from",
+        "ouroboros-ai[mcp]",
+        "ouroboros",
+        "mcp",
+        "serve",
+    ),
     ("--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
     ("--from", "ouroboros-ai", "ouroboros", "mcp", "serve"),
     ("ouroboros", "mcp", "serve"),
@@ -643,9 +655,9 @@ def _codex_release_mcp_launcher() -> tuple[str, list[str]] | None:
 def _render_codex_mcp_section() -> str | None:
     """Render the managed Codex MCP block for the current install source.
 
-    Release installs keep the historical ``uvx --from ouroboros-ai[mcp]``
-    command so Codex can bootstrap the MCP extra even if the invoking Python
-    environment lacks it. Dev/git installs must instead point Codex at this
+    Release installs use ``uvx --isolated --from ouroboros-ai[mcp]`` so Codex
+    can bootstrap the MCP extra without reusing a conflicting installed tool.
+    Dev/git installs must instead point Codex at this
     Python environment; otherwise setup silently downgrades the MCP server back
     to the latest PyPI release and hides main-branch fixes under test.
     """
@@ -4053,18 +4065,7 @@ def _detect_opencode_mcp_command() -> dict[str, list[str]] | None:
     stale global binary and a newer uvx install use the newer one.
     """
     if shutil.which("uvx"):
-        return {
-            "command": [
-                "uvx",
-                "--python",
-                UVX_PYTHON_FLOOR,
-                "--from",
-                "ouroboros-ai[mcp]",
-                "ouroboros",
-                "mcp",
-                "serve",
-            ]
-        }
+        return {"command": ["uvx", *_build_uvx_mcp_args("ouroboros-ai[mcp]")]}
     if shutil.which("pipx"):
         return {
             "command": [

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -194,8 +194,9 @@ Ouroboros MCP server. If it is not ready, do not assume the user knows what
 
 Offer **설정하고 시작하기 (권장)** and **나중에**. If they choose setup, run
 `ouroboros setup --runtime codex`; when Ouroboros is available only through the
-Marketplace plugin, run `uvx --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex`
-instead. Do not make them copy the command.
+Marketplace plugin, run `uvx --isolated --python '>=3.12' --from
+'ouroboros-ai[mcp]' ouroboros setup --runtime codex` instead. Do not make them
+copy the command.
 
 After it succeeds, explain that Codex's currently selected default model will
 be used and that the user can change that choice any time through `ooo config`.

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -615,6 +615,113 @@ class TestCodexDoctor:
 
         assert any("does not select the supported Python floor" in failure for failure in failures)
 
+    @pytest.mark.parametrize(
+        ("args", "expected_failure"),
+        [
+            (
+                [
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--from",
+                    "ouroboros-ai[mcp]==0.26.0",
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                ],
+                "exactly one unpinned",
+            ),
+            (
+                [
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--from",
+                    "ouroboros-ai[MCP]",
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                ],
+                "exactly one unpinned",
+            ),
+            (
+                [
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--python",
+                    "3.11",
+                    "--from",
+                    "ouroboros-ai[mcp]",
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                ],
+                "exactly one `--python >=3.12`",
+            ),
+            (
+                [
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--from",
+                    "ouroboros-ai[mcp]",
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                    "--python=3.11",
+                ],
+                "launcher flags belong before",
+            ),
+            (
+                [
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--from",
+                    "ouroboros-ai[mcp]",
+                ],
+                "launcher flags belong before",
+            ),
+            (
+                [
+                    "--isolated",
+                    "--python",
+                    ">=3.12",
+                    "--from",
+                    "ouroboros-ai[mcp]",
+                    "--isolated",
+                    "ouroboros",
+                    "mcp",
+                    "serve",
+                ],
+                "exactly one `--isolated`",
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_noncanonical_uvx_semantics(
+        self,
+        tmp_path: Path,
+        args: list[str],
+        expected_failure: str,
+    ) -> None:
+        """Equivalent-looking argv must not weaken the isolated launcher contract."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        rendered_args = ", ".join(repr(argument) for argument in args)
+        (codex_dir / "config.toml").write_text(
+            f'[mcp_servers.ouroboros]\ncommand = "uvx"\nargs = [{rendered_args}]\n',
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any(expected_failure in failure for failure in failures)
+        assert any("is not canonical" in failure for failure in failures)
+
     def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 from pathlib import Path
+import shutil
 import sys
 import textwrap
 import time
@@ -537,7 +538,7 @@ class TestCodexDoctor:
         assert any("uses `url`" in failure for failure in failures)
         assert any("verifies only stdio `command` entries" in failure for failure in failures)
 
-    def test_check_auto_dispatch_surface_accepts_custom_command_mcp_entry(
+    def test_check_auto_dispatch_surface_rejects_custom_command_mcp_entry(
         self,
         tmp_path: Path,
     ) -> None:
@@ -548,7 +549,9 @@ class TestCodexDoctor:
             encoding="utf-8",
         )
 
-        assert _check_auto_dispatch_surface(codex_dir) == []
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("not a setup-supported executable" in failure for failure in failures)
 
     def test_check_auto_dispatch_surface_reports_uvx_without_mcp_extra(
         self,
@@ -760,12 +763,14 @@ class TestCodexDoctor:
         """Setup's env-selected release launcher must remain doctor-compatible."""
         codex_dir = tmp_path / ".codex"
         self._write_healthy_codex_surface(codex_dir)
+        uvx_path = shutil.which("uvx")
+        assert uvx_path is not None
         with (
             patch.object(setup_command, "_is_dev_ouroboros_build", return_value=False),
             patch.object(
                 setup_command,
                 "_codex_release_mcp_launcher",
-                return_value=("/usr/local/bin/uvx", list(setup_command._CODEX_UVX_MCP_ARGS)),
+                return_value=(uvx_path, list(setup_command._CODEX_UVX_MCP_ARGS)),
             ),
         ):
             rendered = setup_command._render_codex_mcp_section()
@@ -1141,6 +1146,44 @@ class TestCodexDoctor:
         with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()):
             assert _check_auto_dispatch_surface(codex_dir) == []
 
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("command", "args"),
+        [
+            ("/bin/true", "[]"),
+            (
+                "/bin/echo",
+                '["-m", "ouroboros", "mcp", "serve", "--runtime", "codex", '
+                '"--llm-backend", "codex"]',
+            ),
+            (
+                sys.executable,
+                '["-I", "-m", "ouroboros", "mcp", "serve", "--runtime", "claude-cli"]',
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_unsupported_executable_arg_pairs(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        command: str,
+        args: str,
+    ) -> None:
+        """Canonical-looking argv cannot authorize an unknown or modified executable."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            f"[mcp_servers.ouroboros]\ncommand = {json.dumps(command)}\nargs = {args}\n",
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert failures
+        live_probe.assert_not_awaited()
+
     def test_list_stdio_mcp_tool_names_uses_jsonl_protocol_without_local_mcp_import(
         self,
         tmp_path: Path,
@@ -1216,15 +1259,26 @@ class TestCodexDoctor:
 
     @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group contract")
     @pytest.mark.parametrize(
-        ("ignore_sigterm", "expects_force"),
-        [(False, False), (True, True)],
-        ids=["normal-sigterm", "forced-sigkill"],
+        ("ignore_sigterm", "expects_force", "wrapper_exits"),
+        [
+            (False, False, False),
+            (True, True, False),
+            (False, False, True),
+            (True, True, True),
+        ],
+        ids=[
+            "waiting-wrapper-normal-sigterm",
+            "waiting-wrapper-forced-sigkill",
+            "exited-wrapper-normal-sigterm",
+            "exited-wrapper-forced-sigkill",
+        ],
     )
     def test_list_stdio_mcp_tool_names_cleans_up_wrapper_process_group(
         self,
         tmp_path: Path,
         ignore_sigterm: bool,
         expects_force: bool,
+        wrapper_exits: bool,
     ) -> None:
         """The live probe must reap both a launcher wrapper and its MCP child."""
         wrapper_path = tmp_path / "wrapper.py"
@@ -1292,7 +1346,7 @@ class TestCodexDoctor:
                     signal.signal(signal.SIGTERM, signal.SIG_IGN)
                 Path({str(wrapper_pid_path)!r}).write_text(str(os.getpid()), encoding="utf-8")
                 child = subprocess.Popen([sys.executable, {str(child_path)!r}])
-                child.wait()
+                {"" if wrapper_exits else "child.wait()"}
                 """
             ),
             encoding="utf-8",

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -39,6 +39,13 @@ _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST = {
     "ouroboros_generate_seed",
 }
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+_CANONICAL_CODEX_MCP_ENTRY = (
+    "[mcp_servers.ouroboros]\n"
+    'command = "uvx"\n'
+    'args = ["--isolated", "--python", ">=3.12", "--from", '
+    '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+    'env = { OUROBOROS_AGENT_RUNTIME = "codex", OUROBOROS_LLM_BACKEND = "codex" }\n'
+)
 
 
 class TestCodexRefresh:
@@ -540,6 +547,329 @@ class TestCodexDoctor:
 
     @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
     @pytest.mark.parametrize(
+        ("config_text", "expected_failure"),
+        [
+            (
+                _CANONICAL_CODEX_MCP_ENTRY.replace(
+                    "[mcp_servers.ouroboros]\n",
+                    '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n',
+                    1,
+                ),
+                "mixes stdio `command` with HTTP `url`",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nargs = []\n',
+                ".args is not supported for HTTP `url`",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nenv = {}\n',
+                ".env is not supported for HTTP `url`",
+            ),
+            *[
+                (
+                    _CANONICAL_CODEX_MCP_ENTRY.replace(
+                        "[mcp_servers.ouroboros]\n",
+                        "[mcp_servers.ouroboros]\n" + field_config,
+                        1,
+                    ),
+                    expected_failure,
+                )
+                for field_config, expected_failure in [
+                    (
+                        'bearer_token_env_var = "OUROBOROS_TOKEN"\n',
+                        ".bearer_token_env_var is not supported for stdio `command`",
+                    ),
+                    (
+                        'http_headers = { X_Test = "value" }\n',
+                        ".http_headers is not supported for stdio `command`",
+                    ),
+                    (
+                        'env_http_headers = { X_Token = "OUROBOROS_TOKEN" }\n',
+                        ".env_http_headers is not supported for stdio `command`",
+                    ),
+                    (
+                        'oauth = { client_id = "ouroboros" }\n',
+                        ".oauth is not supported for stdio `command`",
+                    ),
+                    (
+                        'oauth_resource = "https://ouroboros.example"\n',
+                        ".oauth_resource is not supported for stdio `command`",
+                    ),
+                    (
+                        'bearer_token = "plaintext-secret"\n',
+                        ".bearer_token is unsupported",
+                    ),
+                    (
+                        'environment_id = "remote"\n',
+                        "contains unsupported fields: environment_id",
+                    ),
+                ]
+            ],
+            (
+                "[mcp_servers.ouroboros]\nurl = 7\n",
+                ".url must be a string",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "bearer_token_env_var = 7\n",
+                ".bearer_token_env_var must be a string",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\noauth_resource = 7\n',
+                ".oauth_resource must be a string",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'http_headers = "invalid"\n',
+                ".http_headers must be a table of strings",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "http_headers = { X_Test = 7 }\n",
+                ".http_headers contains non-string values",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'env_http_headers = "invalid"\n',
+                ".env_http_headers must be a table of strings",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "env_http_headers = { X_Token = 7 }\n",
+                ".env_http_headers contains non-string values",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nrequired = "true"\n',
+                ".required must be a boolean",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "supports_parallel_tool_calls = 1\n",
+                ".supports_parallel_tool_calls must be a boolean",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'default_tools_approval_mode = "ask"\n',
+                ".default_tools_approval_mode must be one of:",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "default_tools_approval_mode = 1\n",
+                ".default_tools_approval_mode must be one of:",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nscopes = "openid"\n',
+                ".scopes must be an array of strings",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nscopes = [""]\n',
+                ".scopes contains empty or non-string values",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'scopes = ["openid", 7]\n',
+                ".scopes contains empty or non-string values",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\nname = 7\n',
+                ".name must be a string",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\noauth = "invalid"\n',
+                ".oauth must be a table",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "oauth = { client_id = 7 }\n",
+                ".oauth.client_id must be a string",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'oauth = { client_id = "ouroboros", redirect_uri = "https://example.com" }\n',
+                ".oauth contains unsupported fields: redirect_uri",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\ntools = "invalid"\n',
+                ".tools must be a table",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'tools = { "" = { approval_mode = "auto" } }\n',
+                ".tools contains an empty or non-string tool name",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'tools = { ouroboros_start_auto = "approve" }\n',
+                ".tools.ouroboros_start_auto must be a table",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "tools = { ouroboros_start_auto = { extra = true } }\n",
+                ".tools.ouroboros_start_auto contains unsupported fields: extra",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                'tools = { ouroboros_start_auto = { approval_mode = "ask" } }\n',
+                ".tools.ouroboros_start_auto.approval_mode must be one of:",
+            ),
+            (
+                '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+                "tools = { ouroboros_start_auto = { approval_mode = 7 } }\n",
+                ".tools.ouroboros_start_auto.approval_mode must be one of:",
+            ),
+        ],
+        ids=[
+            "mixed-transports",
+            "http-args",
+            "http-env",
+            "stdio-token-env",
+            "stdio-headers",
+            "stdio-env-headers",
+            "stdio-oauth",
+            "stdio-oauth-resource",
+            "plaintext-token",
+            "unknown-field",
+            "untyped-url",
+            "untyped-token-env",
+            "untyped-oauth-resource",
+            "scalar-http-headers",
+            "untyped-http-header",
+            "scalar-env-http-headers",
+            "untyped-env-http-header",
+            "untyped-required",
+            "untyped-parallel-tools",
+            "invalid-default-approval",
+            "untyped-default-approval",
+            "scalar-scopes",
+            "empty-scope",
+            "untyped-scope",
+            "untyped-name",
+            "scalar-oauth",
+            "untyped-oauth-client-id",
+            "unknown-oauth-field",
+            "scalar-tools",
+            "empty-tool-name",
+            "scalar-tool-config",
+            "unknown-tool-field",
+            "invalid-tool-approval",
+            "untyped-tool-approval",
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_invalid_mcp_schema_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        config_text: str,
+        expected_failure: str,
+    ) -> None:
+        """Codex transport and shared config must fail closed before live launch."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(config_text, encoding="utf-8")
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any(expected_failure in failure for failure in failures)
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    def test_check_auto_dispatch_surface_accepts_canonical_stdio_schema(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            _CANONICAL_CODEX_MCP_ENTRY,
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp) == []
+
+        if live_mcp:
+            live_probe.assert_awaited_once()
+        else:
+            live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize("approval_mode", ["auto", "prompt", "approve"])
+    def test_check_auto_dispatch_surface_accepts_shared_stdio_schema(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        approval_mode: str,
+    ) -> None:
+        shared_fields = (
+            "required = true\n"
+            "supports_parallel_tool_calls = true\n"
+            f'default_tools_approval_mode = "{approval_mode}"\n'
+            'scopes = ["openid", "profile"]\n'
+            'name = "Ouroboros"\n'
+            "tools = { ouroboros_start_auto = "
+            f'{{ approval_mode = "{approval_mode}" }} }}\n'
+        )
+        config_text = _CANONICAL_CODEX_MCP_ENTRY.replace(
+            "[mcp_servers.ouroboros]\n",
+            "[mcp_servers.ouroboros]\n" + shared_fields,
+            1,
+        )
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(config_text, encoding="utf-8")
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp) == []
+
+        if live_mcp:
+            live_probe.assert_awaited_once()
+        else:
+            live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    def test_check_auto_dispatch_surface_accepts_extended_http_schema(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'url = "https://ouroboros.example/mcp"\n'
+            'bearer_token_env_var = "OUROBOROS_TOKEN"\n'
+            'http_headers = { X_Client = "ouroboros" }\n'
+            'env_http_headers = { X_Api_Key = "OUROBOROS_API_KEY" }\n'
+            "enabled = true\n"
+            "required = true\n"
+            "supports_parallel_tool_calls = true\n"
+            'default_tools_approval_mode = "prompt"\n'
+            'scopes = ["openid", "profile"]\n'
+            'oauth = { client_id = "ouroboros" }\n'
+            'oauth_resource = "https://ouroboros.example"\n'
+            'name = "Ouroboros"\n'
+            'tools = { ouroboros_start_auto = { approval_mode = "approve" } }\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        if live_mcp:
+            assert any("uses `url`" in failure for failure in failures)
+            assert any("verifies only stdio `command` entries" in failure for failure in failures)
+        else:
+            assert failures == []
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
         ("activation_config", "expected_failure"),
         [
             ("enabled = false\n", "is disabled (`enabled = false`)"),
@@ -675,7 +1005,7 @@ class TestCodexDoctor:
         [
             ('cwd = "."\n', "cwd"),
             ('env_vars = ["PATH"]\n', "env_vars"),
-            ('environment_id = "remote"\n', "environment_id"),
+            ('experimental_environment = "remote"\n', "experimental_environment"),
             ("startup_timeout_sec = 0.25\n", "startup_timeout_sec"),
             ("startup_timeout_ms = 250\n", "startup_timeout_ms"),
             ("tool_timeout_sec = 0.001\n", "tool_timeout_sec"),
@@ -683,7 +1013,7 @@ class TestCodexDoctor:
         ids=[
             "working-directory",
             "ambient-environment",
-            "execution-environment",
+            "experimental-execution-environment",
             "startup-timeout-seconds",
             "startup-timeout-milliseconds",
             "tool-timeout-seconds",

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from pathlib import Path
 import sys
 import textwrap
+import tomllib
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands import codex as codex_command
+from ouroboros.cli.commands import setup as setup_command
 from ouroboros.cli.commands.codex import (
     _MCP_PROTOCOL_VERSION,
     _check_auto_dispatch_surface,
@@ -33,6 +36,7 @@ _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST = {
     "ouroboros_interview",
     "ouroboros_generate_seed",
 }
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class TestCodexRefresh:
@@ -485,7 +489,10 @@ class TestCodexDoctor:
             "[mcp_servers.ouroboros]\n"
             'command = "uvx"\n'
             'args = ["--isolated", "--python", ">=3.12", "--from", '
-            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
             encoding="utf-8",
         )
 
@@ -671,7 +678,7 @@ class TestCodexDoctor:
                     "serve",
                     "--python=3.11",
                 ],
-                "launcher flags belong before",
+                "arbitrary arguments are not allowed after",
             ),
             (
                 [
@@ -684,7 +691,7 @@ class TestCodexDoctor:
                     "--from",
                     "ouroboros-ai[mcp]",
                 ],
-                "launcher flags belong before",
+                "arbitrary arguments are not allowed after",
             ),
             (
                 [
@@ -721,6 +728,120 @@ class TestCodexDoctor:
 
         assert any(expected_failure in failure for failure in failures)
         assert any("is not canonical" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_accepts_shipped_codex_config(self, tmp_path: Path) -> None:
+        """The repository's host-specific Codex config is a doctor-positive contract."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            (_REPO_ROOT / ".codex" / "config.toml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    def test_shipped_mcp_codex_json_uses_doctor_accepted_launcher(self) -> None:
+        """The second shipped Codex registration must share the same static contract."""
+        document = json.loads((_REPO_ROOT / ".mcp.codex.json").read_text(encoding="utf-8"))
+        entry = document["mcpServers"]["ouroboros"]
+        failures: list[str] = []
+
+        codex_command._check_mcp_runtime_dependency_surface(
+            entry["command"], entry["args"], entry.get("env", {}), failures
+        )
+
+        assert failures == []
+
+    def test_check_auto_dispatch_surface_accepts_setup_generated_release_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Setup's env-selected release launcher must remain doctor-compatible."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        with (
+            patch.object(setup_command, "_is_dev_ouroboros_build", return_value=False),
+            patch.object(
+                setup_command,
+                "_codex_release_mcp_launcher",
+                return_value=("/usr/local/bin/uvx", list(setup_command._CODEX_UVX_MCP_ARGS)),
+            ),
+        ):
+            rendered = setup_command._render_codex_mcp_section()
+
+        assert rendered is not None
+        parsed = tomllib.loads(rendered)
+        entry = parsed["mcp_servers"]["ouroboros"]
+        assert entry["env"] == {
+            "OUROBOROS_AGENT_RUNTIME": "codex",
+            "OUROBOROS_LLM_BACKEND": "codex",
+        }
+        (codex_dir / "config.toml").write_text(rendered, encoding="utf-8")
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    @pytest.mark.parametrize(
+        "env_lines",
+        [
+            "",
+            '[mcp_servers.ouroboros.env]\nOUROBOROS_AGENT_RUNTIME = "codex"\n',
+            (
+                '[mcp_servers.ouroboros.env]\nOUROBOROS_AGENT_RUNTIME = "codex"\n'
+                'OUROBOROS_LLM_BACKEND = "claude"\n'
+            ),
+            (
+                '[mcp_servers.ouroboros.env]\nOUROBOROS_AGENT_RUNTIME = "codex"\n'
+                'OUROBOROS_LLM_BACKEND = "codex"\nOUROBOROS_RUNTIME = "claude"\n'
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_unsafe_base_launcher_runtime_env(
+        self,
+        tmp_path: Path,
+        env_lines: str,
+    ) -> None:
+        """The default server runtime must never choose a non-Codex backend implicitly."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n' + env_lines,
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any(
+            "requires runtime environment selectors" in failure
+            or "conflicting selectors" in failure
+            for failure in failures
+        )
+
+    def test_check_auto_dispatch_surface_live_rejects_hostile_runtime_env_before_probe(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Live tool exposure cannot override an unsafe static runtime selection."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "claude"\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        assert any("conflicting selectors" in failure for failure in failures)
+        live_probe.assert_not_awaited()
 
     def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
         self,
@@ -1139,7 +1260,10 @@ class TestCodexDoctor:
                 "mcp",
                 "serve",
             ),
-            {},
+            {
+                "OUROBOROS_AGENT_RUNTIME": "codex",
+                "OUROBOROS_LLM_BACKEND": "codex",
+            },
         )
 
     def test_check_auto_dispatch_surface_live_mcp_reports_missing_auto_tool(

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -843,6 +843,93 @@ class TestCodexDoctor:
         assert any("conflicting selectors" in failure for failure in failures)
         live_probe.assert_not_awaited()
 
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("replacement", "expected_failure"),
+        [
+            ("args = 7\n", ".args must be an array of strings"),
+            (
+                'args = ["--isolated", 7, "ouroboros", "mcp", "serve"]\n',
+                ".args contains non-string values",
+            ),
+            (
+                'args = ["--isolated", ["--python", ">=3.12"], "ouroboros"]\n',
+                ".args contains non-string values",
+            ),
+            (
+                'args = ["mcp", "serve"]\nenv = ["codex"]\n',
+                ".env must be a table of string values",
+            ),
+            (
+                'args = ["mcp", "serve"]\n[mcp_servers.ouroboros.env]\n'
+                "OUROBOROS_AGENT_RUNTIME = 7\n",
+                ".env contains non-string values",
+            ),
+            (
+                'args = ["mcp", "serve"]\n[mcp_servers.ouroboros.env]\n'
+                'OUROBOROS_AGENT_RUNTIME = ["codex"]\n',
+                ".env contains non-string values",
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_untyped_persisted_contract_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        replacement: str,
+        expected_failure: str,
+    ) -> None:
+        """Doctor must reject, not sanitize, non-string persisted argv and env values."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\ncommand = "uvx"\n' + replacement,
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any(expected_failure in failure for failure in failures)
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("args", "env", "expected_failure"),
+        [
+            (
+                ["--isolated", None, "ouroboros", "mcp", "serve"],
+                {
+                    "OUROBOROS_AGENT_RUNTIME": "codex",
+                    "OUROBOROS_LLM_BACKEND": "codex",
+                },
+                "args contains non-string values",
+            ),
+            (
+                list(codex_command._CANONICAL_CODEX_UVX_MCP_ARGS),
+                {"OUROBOROS_AGENT_RUNTIME": "codex", "OUROBOROS_LLM_BACKEND": None},
+                "env contains non-string values",
+            ),
+            (
+                list(codex_command._CANONICAL_CODEX_UVX_MCP_ARGS),
+                None,
+                "env must be a mapping",
+            ),
+        ],
+    )
+    def test_runtime_dependency_surface_rejects_null_without_sanitizing(
+        self,
+        args: list[object],
+        env: object,
+        expected_failure: str,
+    ) -> None:
+        """Defense-in-depth callers cannot use JSON-like null to change the argv contract."""
+        failures: list[str] = []
+
+        codex_command._check_mcp_runtime_dependency_surface("uvx", args, env, failures)
+
+        assert any(expected_failure in failure for failure in failures)
+
     def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -1363,6 +1363,44 @@ class TestCodexDoctor:
         live_probe.assert_not_awaited()
 
     @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize("nested_value", ["", "0", "false", "1"])
+    def test_check_auto_dispatch_surface_rejects_persisted_nested_guard_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        nested_value: str,
+    ) -> None:
+        """The process-internal recursion guard cannot be persisted in Codex config."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        with (codex_dir / "config.toml").open("a", encoding="utf-8") as config:
+            config.write(f'_OUROBOROS_NESTED = "{nested_value}"\n')
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any("persists `_OUROBOROS_NESTED`" in failure for failure in failures)
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "near_miss_key",
+        ["OUROBOROS_NESTED", "_ouroboros_nested", "_OUROBOROS_NESTED_EXTRA"],
+    )
+    def test_check_auto_dispatch_surface_matches_nested_guard_key_exactly(
+        self,
+        tmp_path: Path,
+        near_miss_key: str,
+    ) -> None:
+        """Unrelated environment keys must not be mistaken for the private sentinel."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        with (codex_dir / "config.toml").open("a", encoding="utf-8") as config:
+            config.write(f'{near_miss_key} = "1"\n')
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
     @pytest.mark.parametrize(
         ("replacement", "expected_failure"),
         [

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -669,6 +669,56 @@ class TestCodexDoctor:
         assert any(expected_failure in failure for failure in failures)
         live_probe.assert_not_awaited()
 
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("execution_config", "field"),
+        [
+            ('cwd = "."\n', "cwd"),
+            ('env_vars = ["PATH"]\n', "env_vars"),
+            ('environment_id = "remote"\n', "environment_id"),
+            ("startup_timeout_sec = 0.25\n", "startup_timeout_sec"),
+            ("startup_timeout_ms = 250\n", "startup_timeout_ms"),
+        ],
+        ids=[
+            "working-directory",
+            "ambient-environment",
+            "execution-environment",
+            "startup-timeout-seconds",
+            "startup-timeout-milliseconds",
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_unmodeled_execution_fields_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        execution_config: str,
+        field: str,
+    ) -> None:
+        """Doctor cannot approve a launcher after dropping Codex execution controls."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            + execution_config
+            + 'command = "uvx"\n'
+            + 'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any(
+            f"[mcp_servers.ouroboros].{field} is unsupported by doctor" in failure
+            for failure in failures
+        )
+        live_probe.assert_not_awaited()
+
     def test_check_auto_dispatch_surface_rejects_custom_command_mcp_entry(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import sys
 import textwrap
+import time
 import tomllib
 from unittest.mock import AsyncMock, patch
 
@@ -939,7 +940,8 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "/home/user/.local/bin/ouroboros"\n'
-            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            'args = ["mcp", "serve", "--runtime", "codex", '
+            '"--llm-backend", "codex"]\n',
             encoding="utf-8",
         )
 
@@ -957,7 +959,8 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "ouroboros"\n'
-            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            'args = ["mcp", "serve", "--runtime", "codex", '
+            '"--llm-backend", "codex"]\n',
             encoding="utf-8",
         )
 
@@ -973,7 +976,8 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "ouroboros"\n'
-            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            'args = ["mcp", "serve", "--runtime", "codex", '
+            '"--llm-backend", "codex"]\n',
             encoding="utf-8",
         )
         live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
@@ -986,7 +990,14 @@ class TestCodexDoctor:
 
         live_probe.assert_awaited_once_with(
             "ouroboros",
-            ("mcp", "serve", "--runtime", "codex"),
+            (
+                "mcp",
+                "serve",
+                "--runtime",
+                "codex",
+                "--llm-backend",
+                "codex",
+            ),
             {},
         )
 
@@ -999,9 +1010,10 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "ouroboros"\n'
-            'args = ["mcp", "serve", "--runtime", "codex"]\n'
+            'args = ["mcp", "serve"]\n'
             "[mcp_servers.ouroboros.env]\n"
-            'OUROBOROS_AGENT_RUNTIME = "codex"\n',
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
             encoding="utf-8",
         )
 
@@ -1024,9 +1036,110 @@ class TestCodexDoctor:
 
         live_probe.assert_awaited_once_with(
             "ouroboros",
-            ("mcp", "serve", "--runtime", "codex"),
-            {"OUROBOROS_AGENT_RUNTIME": "codex"},
+            ("mcp", "serve"),
+            {
+                "OUROBOROS_AGENT_RUNTIME": "codex",
+                "OUROBOROS_LLM_BACKEND": "codex",
+            },
         )
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("command", "args", "env_lines"),
+        [
+            (
+                "ouroboros",
+                '["mcp", "serve", "--runtime", "codex"]',
+                ('OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "claude_code"\n'),
+            ),
+            (
+                sys.executable,
+                '["-m", "ouroboros", "mcp", "serve", "--runtime", "claude-cli"]',
+                "",
+            ),
+            (
+                "uv",
+                '["run", "--with", "ouroboros-ai[mcp]", "ouroboros", "mcp", '
+                '"serve", "--runtime", "claude-cli"]',
+                "",
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_non_codex_runtime_for_every_launcher(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        command: str,
+        args: str,
+        env_lines: str,
+    ) -> None:
+        """Recognized launchers cannot route the MCP host to another backend."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        env_table = "[mcp_servers.ouroboros.env]\n" + env_lines if env_lines else ""
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            f"command = {json.dumps(command)}\n"
+            f"args = {args}\n" + env_table,
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with (
+            patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()),
+            patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe),
+        ):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert failures
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("command", "args", "env_lines"),
+        [
+            (
+                "ouroboros",
+                '["mcp", "serve", "--runtime", "codex", "--llm-backend", "codex"]',
+                "",
+            ),
+            (
+                "ouroboros",
+                '["mcp", "serve"]',
+                ('OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "codex"\n'),
+            ),
+            (
+                sys.executable,
+                '["-m", "ouroboros", "mcp", "serve", "--runtime", "codex", '
+                '"--llm-backend", "codex"]',
+                "",
+            ),
+            (
+                sys.executable,
+                '["-m", "ouroboros", "mcp", "serve"]',
+                ('OUROBOROS_AGENT_RUNTIME = "codex"\nOUROBOROS_LLM_BACKEND = "codex"\n'),
+            ),
+        ],
+    )
+    def test_check_auto_dispatch_surface_accepts_setup_generated_local_runtime_forms(
+        self,
+        tmp_path: Path,
+        command: str,
+        args: str,
+        env_lines: str,
+    ) -> None:
+        """Direct and module launchers accept only setup's two exact runtime forms."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        env_table = "[mcp_servers.ouroboros.env]\n" + env_lines if env_lines else ""
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            f"command = {json.dumps(command)}\n"
+            f"args = {args}\n" + env_table,
+            encoding="utf-8",
+        )
+
+        with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()):
+            assert _check_auto_dispatch_surface(codex_dir) == []
 
     def test_list_stdio_mcp_tool_names_uses_jsonl_protocol_without_local_mcp_import(
         self,
@@ -1100,6 +1213,133 @@ class TestCodexDoctor:
         )
 
         assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group contract")
+    @pytest.mark.parametrize(
+        ("ignore_sigterm", "expects_force"),
+        [(False, False), (True, True)],
+        ids=["normal-sigterm", "forced-sigkill"],
+    )
+    def test_list_stdio_mcp_tool_names_cleans_up_wrapper_process_group(
+        self,
+        tmp_path: Path,
+        ignore_sigterm: bool,
+        expects_force: bool,
+    ) -> None:
+        """The live probe must reap both a launcher wrapper and its MCP child."""
+        wrapper_path = tmp_path / "wrapper.py"
+        child_path = tmp_path / "child_mcp.py"
+        wrapper_pid_path = tmp_path / "wrapper.pid"
+        child_pid_path = tmp_path / "child.pid"
+        tool_names = sorted(_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+        child_path.write_text(
+            textwrap.dedent(
+                f"""
+                import json
+                import os
+                from pathlib import Path
+                import signal
+                import sys
+                import time
+
+                if {ignore_sigterm!r}:
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                Path({str(child_pid_path)!r}).write_text(str(os.getpid()), encoding="utf-8")
+
+                def read_message():
+                    return json.loads(sys.stdin.buffer.readline())
+
+                def write_message(message):
+                    sys.stdout.buffer.write(json.dumps(message).encode("utf-8") + b"\\n")
+                    sys.stdout.buffer.flush()
+
+                initialize = read_message()
+                write_message({{
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {{
+                        "protocolVersion": initialize["params"]["protocolVersion"],
+                        "capabilities": {{"tools": {{}}}},
+                        "serverInfo": {{"name": "tree-child", "version": "1"}},
+                    }},
+                }})
+                read_message()
+                tools_list = read_message()
+                write_message({{
+                    "jsonrpc": "2.0",
+                    "id": tools_list["id"],
+                    "result": {{
+                        "tools": [{{"name": name, "inputSchema": {{"type": "object"}}}}
+                                  for name in {tool_names!r}],
+                    }},
+                }})
+                while True:
+                    time.sleep(1)
+                """
+            ),
+            encoding="utf-8",
+        )
+        wrapper_path.write_text(
+            textwrap.dedent(
+                f"""
+                import os
+                from pathlib import Path
+                import signal
+                import subprocess
+                import sys
+
+                if {ignore_sigterm!r}:
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                Path({str(wrapper_pid_path)!r}).write_text(str(os.getpid()), encoding="utf-8")
+                child = subprocess.Popen([sys.executable, {str(child_path)!r}])
+                child.wait()
+                """
+            ),
+            encoding="utf-8",
+        )
+        real_create_subprocess = asyncio.create_subprocess_exec
+        real_signal_process = codex_command._signal_stdio_mcp_process
+        spawn_options: dict[str, object] = {}
+
+        async def _capturing_create_subprocess(*command: str, **kwargs: object):
+            spawn_options.update(kwargs)
+            return await real_create_subprocess(*command, **kwargs)
+
+        with (
+            patch(
+                "ouroboros.cli.commands.codex.asyncio.create_subprocess_exec",
+                side_effect=_capturing_create_subprocess,
+            ),
+            patch(
+                "ouroboros.cli.commands.codex._signal_stdio_mcp_process",
+                wraps=real_signal_process,
+            ) as signal_process,
+        ):
+            exposed_tools = asyncio.run(
+                _list_stdio_mcp_tool_names(sys.executable, (str(wrapper_path),), {})
+            )
+
+        assert exposed_tools >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+        assert spawn_options["start_new_session"] is True
+        force_calls = [call.kwargs["force"] for call in signal_process.call_args_list]
+        assert force_calls[0] is False
+        assert (True in force_calls) is expects_force
+
+        wrapper_pid = int(wrapper_pid_path.read_text(encoding="utf-8"))
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            live_pids = []
+            for pid in (wrapper_pid, child_pid):
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    continue
+                live_pids.append(pid)
+            if not live_pids:
+                break
+            time.sleep(0.02)
+        assert not live_pids
 
     def test_list_stdio_mcp_tool_names_preserves_content_length_fallback(
         self,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -678,6 +678,7 @@ class TestCodexDoctor:
             ('environment_id = "remote"\n', "environment_id"),
             ("startup_timeout_sec = 0.25\n", "startup_timeout_sec"),
             ("startup_timeout_ms = 250\n", "startup_timeout_ms"),
+            ("tool_timeout_sec = 0.001\n", "tool_timeout_sec"),
         ],
         ids=[
             "working-directory",
@@ -685,6 +686,7 @@ class TestCodexDoctor:
             "execution-environment",
             "startup-timeout-seconds",
             "startup-timeout-milliseconds",
+            "tool-timeout-seconds",
         ],
     )
     def test_check_auto_dispatch_surface_rejects_unmodeled_execution_fields_before_probe(

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -538,6 +538,137 @@ class TestCodexDoctor:
         assert any("uses `url`" in failure for failure in failures)
         assert any("verifies only stdio `command` entries" in failure for failure in failures)
 
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("activation_config", "expected_failure"),
+        [
+            ("enabled = false\n", "is disabled (`enabled = false`)"),
+            (
+                'disabled_tools = ["ouroboros_start_auto"]\n',
+                ".disabled_tools blocks required auto tools: ouroboros_start_auto",
+            ),
+            (
+                'enabled_tools = ["ouroboros_start_auto"]\n',
+                ".enabled_tools omits required auto tools:",
+            ),
+        ],
+        ids=["server-disabled", "required-tool-denied", "required-tools-not-allowed"],
+    )
+    def test_check_auto_dispatch_surface_rejects_inactive_mcp_contract_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        activation_config: str,
+        expected_failure: str,
+    ) -> None:
+        """A manually launchable server is not proof that Codex exposes its tools."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            + activation_config
+            + 'command = "uvx"\n'
+            + 'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any(expected_failure in failure for failure in failures)
+        live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    def test_check_auto_dispatch_surface_accepts_positive_mcp_tool_filters(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+    ) -> None:
+        """Allow-lists may include extras and deny-lists may block unrelated tools."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        enabled_tools = sorted({*_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST, "unrelated_extra"})
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            "enabled = true\n"
+            f"enabled_tools = {json.dumps(enabled_tools)}\n"
+            'disabled_tools = ["unrelated_disabled"]\n'
+            'command = "uvx"\n'
+            'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp) == []
+
+        if live_mcp:
+            live_probe.assert_awaited_once()
+        else:
+            live_probe.assert_not_awaited()
+
+    @pytest.mark.parametrize("live_mcp", [False, True], ids=["static", "live"])
+    @pytest.mark.parametrize(
+        ("activation_config", "expected_failure"),
+        [
+            ('enabled = "false"\n', ".enabled must be a boolean"),
+            ('enabled_tools = "ouroboros_start_auto"\n', ".enabled_tools must be an array"),
+            (
+                'enabled_tools = ["ouroboros_start_auto", 7]\n',
+                ".enabled_tools contains non-string values: index 1 (int)",
+            ),
+            ('disabled_tools = "unrelated"\n', ".disabled_tools must be an array"),
+            (
+                'disabled_tools = ["unrelated", false]\n',
+                ".disabled_tools contains non-string values: index 1 (bool)",
+            ),
+        ],
+        ids=[
+            "untyped-enabled",
+            "scalar-enabled-tools",
+            "untyped-enabled-tool",
+            "scalar-disabled-tools",
+            "untyped-disabled-tool",
+        ],
+    )
+    def test_check_auto_dispatch_surface_rejects_untyped_activation_before_probe(
+        self,
+        tmp_path: Path,
+        live_mcp: bool,
+        activation_config: str,
+        expected_failure: str,
+    ) -> None:
+        """Doctor mirrors Codex's boolean and array-of-string config types."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            + activation_config
+            + 'command = "uvx"\n'
+            + 'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n'
+            'OUROBOROS_LLM_BACKEND = "codex"\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=live_mcp)
+
+        assert any(expected_failure in failure for failure in failures)
+        live_probe.assert_not_awaited()
+
     def test_check_auto_dispatch_surface_rejects_custom_command_mcp_entry(
         self,
         tmp_path: Path,
@@ -1394,6 +1525,67 @@ class TestCodexDoctor:
                 break
             time.sleep(0.02)
         assert not live_pids
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group contract")
+    @pytest.mark.parametrize(
+        ("probe_errors", "expected_sleeps"),
+        [
+            ([ProcessLookupError()], 0),
+            ([PermissionError(), ProcessLookupError()], 1),
+        ],
+        ids=["missing-group-is-gone", "inaccessible-group-still-exists"],
+    )
+    def test_wait_for_stdio_mcp_process_group_exit_classifies_probe_errors(
+        self,
+        probe_errors: list[OSError],
+        expected_sleeps: int,
+    ) -> None:
+        """EPERM is existence evidence while ESRCH proves the group is gone."""
+        sleep = AsyncMock()
+        with (
+            patch("ouroboros.cli.commands.codex.os.killpg", side_effect=probe_errors) as probe,
+            patch("ouroboros.cli.commands.codex.asyncio.sleep", sleep),
+        ):
+            asyncio.run(codex_command._wait_for_stdio_mcp_process_group_exit(4321))
+
+        assert probe.call_count == len(probe_errors)
+        assert sleep.await_count == expected_sleeps
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX process-group contract")
+    def test_terminate_stdio_mcp_process_kills_group_when_wrapper_exits_first(self) -> None:
+        """A reaped wrapper must not prevent TERM -> wait -> KILL for its child group."""
+
+        class _WrapperProcess:
+            stdin = None
+            pid = 4321
+            returncode: int | None = None
+            wait = AsyncMock()
+
+        proc = _WrapperProcess()
+        signal_forces: list[bool] = []
+
+        def _record_signal(process: _WrapperProcess, *, force: bool) -> None:
+            assert process is proc
+            signal_forces.append(force)
+            if not force:
+                process.returncode = 0
+
+        group_wait = AsyncMock(side_effect=TimeoutError)
+        with (
+            patch(
+                "ouroboros.cli.commands.codex._signal_stdio_mcp_process",
+                side_effect=_record_signal,
+            ),
+            patch(
+                "ouroboros.cli.commands.codex._wait_for_stdio_mcp_process_group_exit",
+                group_wait,
+            ),
+        ):
+            asyncio.run(codex_command._terminate_stdio_mcp_process(proc))  # type: ignore[arg-type]
+
+        assert signal_forces == [False, True]
+        group_wait.assert_awaited_once_with(proc.pid)
+        proc.wait.assert_not_awaited()
 
     def test_list_stdio_mcp_tool_names_preserves_content_length_fallback(
         self,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -484,7 +484,7 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "uvx"\n'
-            'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            'args = ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
             encoding="utf-8",
         )
 
@@ -557,6 +557,24 @@ class TestCodexDoctor:
         failures = _check_auto_dispatch_surface(codex_dir)
 
         assert any("without the `mcp` extra" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_reports_uvx_without_tool_isolation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An installed MCP 1 tool must not satisfy an MCP 2 ``--from`` entry."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("may reuse an installed MCP 1.x tool" in failure for failure in failures)
 
     def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
         self,
@@ -965,7 +983,7 @@ class TestCodexDoctor:
 
         live_probe.assert_awaited_once_with(
             "uvx",
-            ("--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
+            ("--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
             {},
         )
 

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -484,7 +484,8 @@ class TestCodexDoctor:
         (codex_dir / "config.toml").write_text(
             "[mcp_servers.ouroboros]\n"
             'command = "uvx"\n'
-            'args = ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            'args = ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
             encoding="utf-8",
         )
 
@@ -575,6 +576,44 @@ class TestCodexDoctor:
         failures = _check_auto_dispatch_surface(codex_dir)
 
         assert any("may reuse an installed MCP 1.x tool" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_reports_uvx_without_python_floor(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Isolation still needs a supported interpreter for package resolution."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--isolated", "--from", "ouroboros-ai[mcp]", '
+            '"ouroboros", "mcp", "serve"]\n',
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("does not select the supported Python floor" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_reports_incompatible_python_selector(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A present but incompatible selector must not satisfy the floor contract."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--isolated", "--python", "3.11", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("does not select the supported Python floor" in failure for failure in failures)
 
     def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
         self,
@@ -983,7 +1022,16 @@ class TestCodexDoctor:
 
         live_probe.assert_awaited_once_with(
             "uvx",
-            ("--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
+            (
+                "--isolated",
+                "--python",
+                ">=3.12",
+                "--from",
+                "ouroboros-ai[mcp]",
+                "ouroboros",
+                "mcp",
+                "serve",
+            ),
             {},
         )
 

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -124,7 +124,8 @@ def test_serve_reports_missing_mcp_dependency(monkeypatch):
     assert "pip install" in result.output
     assert "ouroboros-ai[mcp]" in result.output
     assert (
-        "uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros mcp serve --runtime claude-cli"
+        "uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' "
+        "ouroboros mcp serve --runtime claude-cli"
     ) in normalized_output
 
 

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -308,7 +308,7 @@ class TestCodexSetup:
         assert "tool_timeout_sec" not in contents
         assert 'command = "/usr/local/bin/uvx"' in contents
         assert (
-            'args = ["--python", ">=3.12", "--from", "ouroboros-ai[mcp]", '
+            'args = ["--isolated", "--python", ">=3.12", "--from", "ouroboros-ai[mcp]", '
             '"ouroboros", "mcp", "serve"]' in contents
         )
 
@@ -7190,6 +7190,31 @@ raise SystemExit(0 if activate_claude_runtime("/second/claude") else 2)
 class TestIsolatedMCPLaunchers:
     """MCP 2 registrations must never inherit an arbitrary host environment."""
 
+    def test_uvx_launchers_explicitly_disable_installed_tool_reuse(self) -> None:
+        """``--from`` alone may reuse an installed Ouroboros MCP 1 environment."""
+        with patch(
+            "ouroboros.cli.commands.setup.shutil.which",
+            side_effect=lambda command: "/usr/local/bin/uvx" if command == "uvx" else None,
+        ):
+            common = setup_cmd._detect_mcp_entry()
+            kiro = setup_cmd._detect_mcp_entry_for_kiro()
+            opencode = setup_cmd._detect_opencode_mcp_command()
+
+        expected_args = [
+            "--isolated",
+            "--python",
+            ">=3.12",
+            "--from",
+            "ouroboros-ai[mcp]",
+            "ouroboros",
+            "mcp",
+            "serve",
+        ]
+        assert common == {"command": "uvx", "args": expected_args}
+        assert kiro == common
+        assert opencode == {"command": ["uvx", *expected_args]}
+        assert expected_args == setup_cmd._CODEX_UVX_MCP_ARGS
+
     def test_direct_binary_and_python_fallbacks_are_rejected(self) -> None:
         def direct_only(command: str) -> str | None:
             if command in {"ouroboros", "python", "python3"}:
@@ -7466,6 +7491,7 @@ class TestHermesSetup:
         config = yaml.safe_load((hermes_dir / "config.yaml").read_text(encoding="utf-8"))
         assert config["mcp_servers"]["ouroboros"]["command"] == "uvx"
         assert config["mcp_servers"]["ouroboros"]["args"] == [
+            "--isolated",
             "--python",
             ">=3.12",
             "--from",
@@ -7556,6 +7582,7 @@ class TestHermesSetup:
         result = yaml.safe_load((hermes_dir / "config.yaml").read_text(encoding="utf-8"))
         assert result["mcp_servers"]["ouroboros"]["command"] == "uvx"
         assert result["mcp_servers"]["ouroboros"]["args"] == [
+            "--isolated",
             "--python",
             ">=3.12",
             "--from",
@@ -9447,6 +9474,7 @@ class TestGjcSetup:
 
         assert entry["command"] == "uvx"
         assert entry["args"] == [
+            "--isolated",
             "--python",
             ">=3.12",
             "--from",

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -184,6 +184,8 @@ def test_codex_plugin_manifest_starts_a_codex_composed_mcp_server() -> None:
         "command": "uvx",
         "args": [
             "--isolated",
+            "--python",
+            ">=3.12",
             "--from",
             "ouroboros-ai[mcp]",
             "ouroboros",
@@ -249,7 +251,8 @@ def test_first_use_onboarding_has_host_specific_model_settings_handoffs() -> Non
         "CODEX_SETUP_REQUIRED",
         "mcp_servers\\.ouroboros",
         "ouroboros setup --runtime codex",
-        "uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' ouroboros setup --runtime codex",
+        "uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' "
+        "ouroboros setup --runtime codex",
         "설정하고 시작하기",
         "직접 모델 설정하기",
         "모델은 언제든 나중에 바꿀 수 있어요",

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -213,6 +213,9 @@ def test_shipped_mcp_launchers_use_the_isolated_mcp_profile() -> None:
     codex_entry = tomllib.loads((root / ".codex" / "config.toml").read_text(encoding="utf-8"))[
         "mcp_servers"
     ]["ouroboros"]
+    codex_plugin_entry = json.loads((root / ".mcp.codex.json").read_text(encoding="utf-8"))[
+        "mcpServers"
+    ]["ouroboros"]
 
     claude_args = [
         *expected_args,
@@ -225,14 +228,15 @@ def test_shipped_mcp_launchers_use_the_isolated_mcp_profile() -> None:
         assert entry["command"] == "uvx"
         assert entry["args"] == claude_args
 
-    assert codex_entry["command"] == "uvx"
-    assert codex_entry["args"] == [
-        *expected_args,
-        "--runtime",
-        "codex",
-        "--llm-backend",
-        "codex",
-    ]
+    for entry in (codex_entry, codex_plugin_entry):
+        assert entry["command"] == "uvx"
+        assert entry["args"] == [
+            *expected_args,
+            "--runtime",
+            "codex",
+            "--llm-backend",
+            "codex",
+        ]
 
 
 def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
@@ -246,19 +250,22 @@ def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
     exact_launcher_contracts = {
         "kiro": (
             '"command": "uvx"',
-            '"args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"args": ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
             '"command": "pipx"',
             '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
         ),
         "copilot": (
             '"command": "uvx"',
-            '"args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"args": ["--isolated", "--python", ">=3.12", "--from", '
+            '"ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
             '"command": "pipx"',
             '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
         ),
         "hermes": (
             "command: uvx",
-            'args: [--isolated, --from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
+            'args: [--isolated, --python, ">=3.12", --from, "ouroboros-ai[mcp]", '
+            "ouroboros, mcp, serve]",
             "command: pipx",
             'args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
         ),
@@ -401,6 +408,8 @@ def test_cli_reference_isolated_mcp_launchers_have_bootable_runtime_contract() -
             "command": "uvx",
             "args": [
                 "--isolated",
+                "--python",
+                ">=3.12",
                 "--from",
                 "ouroboros-ai[mcp]",
                 "ouroboros",

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -246,19 +246,19 @@ def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
     exact_launcher_contracts = {
         "kiro": (
             '"command": "uvx"',
-            '"args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
             '"command": "pipx"',
             '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
         ),
         "copilot": (
             '"command": "uvx"',
-            '"args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
+            '"args": ["--isolated", "--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
             '"command": "pipx"',
             '"args": ["run", "--spec", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]',
         ),
         "hermes": (
             "command: uvx",
-            'args: [--from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
+            'args: [--isolated, --from, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
             "command: pipx",
             'args: [run, --spec, "ouroboros-ai[mcp]", ouroboros, mcp, serve]',
         ),
@@ -400,6 +400,7 @@ def test_cli_reference_isolated_mcp_launchers_have_bootable_runtime_contract() -
         {
             "command": "uvx",
             "args": [
+                "--isolated",
                 "--from",
                 "ouroboros-ai[mcp]",
                 "ouroboros",

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -243,8 +243,15 @@ def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
     """Host guides must match setup's fail-closed uvx/pipx contract."""
     root = Path(__file__).parent.parent.parent
     guides = {
-        runtime: (root / "docs" / "runtime-guides" / f"{runtime}.md").read_text(encoding="utf-8")
-        for runtime in ("kiro", "copilot", "hermes")
+        "kiro": tuple(
+            (root / "docs" / "runtime-guides" / filename).read_text(encoding="utf-8")
+            for filename in ("kiro.md", "kiro.ko.md")
+        ),
+        "copilot": tuple(
+            (root / "docs" / "runtime-guides" / filename).read_text(encoding="utf-8")
+            for filename in ("copilot.md", "copilot.ko.md")
+        ),
+        "hermes": ((root / "docs" / "runtime-guides" / "hermes.md").read_text(encoding="utf-8"),),
     }
 
     exact_launcher_contracts = {
@@ -280,19 +287,20 @@ def test_runtime_guides_require_isolated_mcp_host_launchers() -> None:
         "command: python3",
     )
 
-    for runtime, content in guides.items():
-        assert "pipx install 'ouroboros-ai[mcp]'" in content
-        assert "uv tool install 'ouroboros-ai[mcp]'" in content
-        for snippet in exact_launcher_contracts[runtime]:
-            assert snippet in content
-        for forbidden in forbidden_host_commands:
-            assert forbidden not in content
+    for runtime, translations in guides.items():
+        for content in translations:
+            assert "pipx install 'ouroboros-ai[mcp]'" in content
+            assert "uv tool install 'ouroboros-ai[mcp]'" in content
+            for snippet in exact_launcher_contracts[runtime]:
+                assert snippet in content
+            for forbidden in forbidden_host_commands:
+                assert forbidden not in content
 
-    assert "from the venv that owns" not in guides["kiro"]
-    assert "`uv tool install` / `pip install`" not in guides["copilot"]
-    assert "plain `pip install`" in guides["copilot"]
-    assert "setup fails closed" in guides["copilot"]
-    assert "never falls back to a direct `ouroboros` binary" in guides["hermes"]
+    assert "from the venv that owns" not in guides["kiro"][0]
+    assert "`uv tool install` / `pip install`" not in guides["copilot"][0]
+    assert "plain `pip install`" in guides["copilot"][0]
+    assert "setup fails closed" in guides["copilot"][0]
+    assert "never falls back to a direct `ouroboros` binary" in guides["hermes"][0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Make Codex MCP launchers use an isolated Python 3.12+ environment so cached MCP 1.x tool environments cannot break MCP 2 initialization.
- Make `ouroboros codex doctor` validate the exact shipped launcher and runtime-selection contracts fail-closed.

## Changes

- Canonicalize Codex launchers to isolated `uvx` with the Python floor.
- Accept the two shipped Codex runtime forms: explicit runtime/backend suffixes or exact Codex selector environment variables.
- Reject pinned/case/duplicate/conflicting/misplaced launcher variants and hostile or missing runtime selectors.
- Validate shipped TOML/JSON and setup-rendered configurations directly.
- Ensure live doctor probes terminate their process group without leaving MCP children.

## Verification

- Independent verifier: PASS at `87bc02fcdb68f55a824b4dd3ae1eb2ecbb4c3c03`
- Functional/security matrix: 536 passed, 1 skipped
- Post-rebase focused doctor: 53 passed
- Actual isolated shipped TOML/JSON and setup-env probes: 35 tools, required tools complete
- Non-isolated regression probe reproduces MCP 1.29 reuse failure
- Ruff, format, MyPy, diff-check: PASS

Closes #1975