### PR TITLE
Korean Codex guide, part 2 (Command Surface through Seed reference)

### DIFF
--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -329,7 +329,10 @@ uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros
 
 > **`ambiguity_score`의 0.2 임계값이 실제로 걸리는 지점:** 이 필드 자체는 `0.0`~`1.0`을 허용합니다([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). 0.2 게이트는 **seed 생성 시점**에 걸립니다. 인터뷰가 0.2 아래로 못 내려가면 seed를 안 만들어 주는 것이고, 여기에는 명시적 우회 선택지가 있습니다. CLI의 "Generate Seed anyway", MCP의 `force` 파라미터입니다. 우회해도 **실제 점수는 그대로 메타데이터에 기록되고 감사 로그에 남습니다.**
 >
-> `ouroboros auto`는 실행 중에 readiness를 다시 보긴 하지만 **조건부입니다.** 인터뷰가 ledger 근거로 닫혔거나(`closure_mode`가 `ledger_only`·`safe_default`), Seed가 `degraded`로 표시돼 있으면 `high_ambiguity_score` 블로커가 억제됩니다([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)). 그런 닫힘에서는 **ledger의 구조적 완결성이 수용 신호이고 LLM이 매긴 점수는 설계상 낡은 값**이라서, 0.2를 크게 웃도는 Seed도 A 등급을 받고 실행될 수 있습니다. 나머지 채점 축은 그대로 적용됩니다.
+> `ouroboros auto`는 실행 중에 readiness를 다시 보긴 하지만 **조건부이고, 억제되는 두 경우의 결과가 정반대입니다** ([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)):
+>
+> - **ledger 닫힘**(`closure_mode`가 `ledger_only`·`safe_default`이고 degraded가 아닐 때): **ledger의 구조적 완결성이 수용 신호이고 LLM이 매긴 점수는 설계상 낡은 값**이라, 0.2를 크게 웃도는 Seed도 A 등급을 받고 **실행됩니다.** 나머지 채점 축은 그대로 적용됩니다.
+> - **degraded Seed**: 블로커가 억제되는 건 **부분 산출물을 내보내기 위해서일 뿐입니다.** 블로커가 없는 degraded Seed는 **등급이나 `may_run`과 무관하게** 곧바로 partial-product 종단(`AutoPhase.COMPLETE`)으로 갑니다([`auto/pipeline.py:1286`](../../src/ouroboros/auto/pipeline.py)). **RUN에는 절대 도달하지 않습니다.** 남아 있는 블로커는 하드 안전 블로커라 그대로 실행을 종료시킵니다.
 >
 > 실무적으로: 손으로 쓴 seed에 높은 `ambiguity_score`를 박아도 `ouroboros run workflow`가 막지는 않습니다. 이 값은 **강제 차단 장치가 아니라 출처 기록(provenance)**입니다.
 

--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -7,7 +7,7 @@ doc_metadata:
 
 > English: [codex.md](./codex.md)
 >
-> **번역 진행 상황**: 이 문서는 설치까지(시작하기 · 독립 설치 · Codex CLI 설치 · 플랫폼 · 설정 · 빠른 시작)를 옮긴 1부입니다. 그 뒤 절(Command Surface, How It Works, CLI 옵션, 문제 해결, 비용, Active Conductor)은 아직 영문입니다 — [codex.md](./codex.md)를 보세요. 진행은 [#1988](https://github.com/Q00/ouroboros/issues/1988)에서 추적합니다.
+> **번역 진행 상황**: 명령 표면 · 동작 방식 · 런타임 차이 · CLI 옵션 · Seed 레퍼런스까지 옮겼습니다. 문제 해결 · 비용 · Active Conductor는 아직 영문입니다 — [codex.md](./codex.md)를 보세요. 진행은 [#1988](https://github.com/Q00/ouroboros/issues/1988)에서 추적합니다.
 
 > 설치와 첫 실행 흐름 전체는 [Getting Started](../getting-started.md)(영문)를 보세요.
 
@@ -163,6 +163,8 @@ ouroboros --help
 - 손대지 않은 레거시 자동생성 `ouroboros-*.config.toml` 태스크 프로파일 앵커만 정리합니다. 사용자가 만든 Codex 프로파일은 보존됩니다
 - 관리되는 `ouroboros-worker.config.toml`을 등록해서, Agent OS 워커 서브프로세스가 MCP/env 연결을 잃지 않고도 대화형 Codex 기본값에서 빠질 수 있게 합니다
 
+`~/.codex/` 밖의 전역 산출물도 함께 생깁니다. `ensure_config_dir()`가 `~/.ouroboros/data/`와 `~/.ouroboros/logs/`를 만들고([`setup.py:2632`](../../src/ouroboros/cli/commands/setup.py)), 설정이 처음이면 `~/.ouroboros/credentials.yaml`을 `0600` 권한으로 새로 씁니다([`setup.py:2771`](../../src/ouroboros/cli/commands/setup.py)).
+
 `~/.codex/config.toml`은 **Ouroboros 스테이지 모델 핀을 둘 자리가 아닙니다.** 설정 UI나 그에 대응하는 `~/.ouroboros/config.yaml` 값을 쓰고, 명시적인 `--profile`이 필요할 때만 사용자가 관리하는 네이티브 Codex 프로파일을 유지하세요. 장기 실행 URL 기반 Ouroboros MCP 서버를 직접 운영한다면 그 URL 항목을 `~/.codex/config.toml`에 그대로 두면 됩니다. `ouroboros setup --runtime codex`가 기본적으로 보존합니다. setup이 그 항목을 관리형 command-spawn 서버로 **바꾸길 원할 때만** `--mcp-mode stdio`를 쓰세요.
 
 ### 워커 서브프로세스 격리 (Agent OS `runtime_profile`)
@@ -197,10 +199,16 @@ sandbox = "workspace-write"
 
 `ouroboros setup --runtime codex`를 돌리고 나면 번들 `ooo` 스킬이 `~/.codex/skills/ouroboros-*`에, 라우팅 규칙이 `~/.codex/rules/`에 설치됩니다. Ouroboros를 올린 뒤 **그 산출물만** 갱신하려면 `ouroboros codex refresh`를 쓰세요. `~/.codex/config.toml`도 `~/.ouroboros/config.yaml`도 건드리지 않습니다.
 
-아래 표는 각 스킬과, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
+현재 스냅숏 기준 setup은 `skills/*/SKILL.md` 디렉터리 **21개**를 패키징합니다. 아래 표는 그 전부와, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
 
 | `ooo` 스킬 | Codex 세션 | CLI 대응 (터미널) |
 |-------------|---------------|--------------------------|
+| `ooo` (인자 없이) | O | *(디스패처가 라우팅. 세션에서 시작점으로 씀)* |
+| `ooo auto` | O | `ouroboros auto "goal"` (관리 규칙이 `ouroboros_start_auto`로 라우팅) |
+| `ooo brownfield` | O | *(MCP 전용)* |
+| `ooo config` | O | `ouroboros config show` |
+| `ooo pm` | O | *(MCP 전용)* |
+| `ooo resume-session` | O | `ouroboros run workflow --resume <session_id> ...` |
 | `ooo interview` | O | `ouroboros init start --llm-backend codex "your idea"` |
 | `ooo seed` | O | *(`ouroboros init start`에 포함됨)* |
 | `ooo run` | O | `ouroboros run workflow --runtime codex seed.yaml` |
@@ -275,7 +283,7 @@ Codex CLI와 Claude Code는 **서로 독립적인 런타임 백엔드**이고, �
 | 항목 | Codex CLI | Claude Code |
 |--------|-----------|-------------|
 | 정체 | Codex CLI 전송을 쓰는 Ouroboros 세션 런타임 | Anthropic의 에이전틱 코딩 도구 |
-| 인증 | OpenAI API 키 | Max Plan 구독 |
+| 인증 | Codex 계정 로그인 또는 OpenAI API 키 | Max Plan 구독 |
 | 모델 | Codex의 현재 기본 모델 (권장) | Claude (claude-agent-sdk 경유) |
 | 샌드박스 | Codex CLI 자체 샌드박스 모델 | Claude Code의 권한 시스템 |
 | 도구 표면 | Codex 네이티브 도구 (파일 I/O, 셸) | Read, Write, Edit, Bash, Glob, Grep |
@@ -319,7 +327,9 @@ uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros
 | `metadata` | O | 생성 메타데이터 |
 | `metadata.ambiguity_score` | X | 생성 시점 모호도. 기본 `0.15`, 허용 범위 `0.0`~`1.0` |
 
-> **`ambiguity_score`의 0.2 임계값이 실제로 걸리는 지점:** 이 필드 자체는 `0.0`~`1.0`을 허용합니다([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). 0.2 게이트는 **seed 생성 시점**에 걸립니다. 인터뷰가 0.2 아래로 못 내려가면 seed를 안 만들어 주는 것이고, 여기에는 명시적 우회 선택지가 있습니다. CLI의 "Generate Seed anyway", MCP의 `force` 파라미터입니다. 우회해도 **실제 점수는 그대로 메타데이터에 기록되고 감사 로그에 남습니다.** 그리고 `ouroboros auto`는 실행 중에 이 readiness를 다시 확인합니다([`auto/grading.py:226`](../../src/ouroboros/auto/grading.py)).
+> **`ambiguity_score`의 0.2 임계값이 실제로 걸리는 지점:** 이 필드 자체는 `0.0`~`1.0`을 허용합니다([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). 0.2 게이트는 **seed 생성 시점**에 걸립니다. 인터뷰가 0.2 아래로 못 내려가면 seed를 안 만들어 주는 것이고, 여기에는 명시적 우회 선택지가 있습니다. CLI의 "Generate Seed anyway", MCP의 `force` 파라미터입니다. 우회해도 **실제 점수는 그대로 메타데이터에 기록되고 감사 로그에 남습니다.**
+>
+> `ouroboros auto`는 실행 중에 readiness를 다시 보긴 하지만 **조건부입니다.** 인터뷰가 ledger 근거로 닫혔거나(`closure_mode`가 `ledger_only`·`safe_default`), Seed가 `degraded`로 표시돼 있으면 `high_ambiguity_score` 블로커가 억제됩니다([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)). 그런 닫힘에서는 **ledger의 구조적 완결성이 수용 신호이고 LLM이 매긴 점수는 설계상 낡은 값**이라서, 0.2를 크게 웃도는 Seed도 A 등급을 받고 실행될 수 있습니다. 나머지 채점 축은 그대로 적용됩니다.
 >
 > 실무적으로: 손으로 쓴 seed에 높은 `ambiguity_score`를 박아도 `ouroboros run workflow`가 막지는 않습니다. 이 값은 **강제 차단 장치가 아니라 출처 기록(provenance)**입니다.
 

--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -145,14 +145,190 @@ ouroboros --help
 
 ---
 
+## 명령 표면 (Command Surface)
+
+사용자 눈에 Codex 연동은 **세션 지향 Ouroboros 런타임**으로 보입니다. Claude 런타임을 굴리는 것과 같은, 명세 우선(specification-first) 워크플로 하네스입니다.
+
+내부적으로 `CodexCliRuntime`은 여전히 로컬 `codex` 실행 파일과 대화하지만, Codex 고유의 세션 ID와 resume 핸들을 보존하고, Codex 명령 디스패처가 `ooo` 스타일 스킬 명령을 인프로세스 Ouroboros MCP 서버로 넘길 수 있습니다.
+
+`ouroboros setup --runtime codex`가 현재 하는 일:
+
+- `PATH`에서 `codex` 바이너리를 찾습니다
+- `~/.ouroboros/config.yaml`에 `orchestrator.runtime_backend: codex`와 `llm.backend: codex`를 씁니다
+- Codex LLM 호출과 에이전트 런타임 세션용으로, 빠져 있는 공급자 중립 `llm_profiles`·`llm_role_profiles` 기본값을 채웁니다. 호출마다 reasoning effort가 적용되고 모델 핀은 걸지 않습니다
+- 가능하면 `orchestrator.codex_cli_path`를 기록합니다
+- 관리되는 Ouroboros 규칙을 `~/.codex/rules/`에 설치합니다
+- 관리되는 Ouroboros 스킬을 `~/.codex/skills/`에 설치합니다
+- `~/.codex/config.toml`에 Ouroboros MCP/env 연결이 없으면 등록하고, setup이 관리하는 stdio 블록은 갱신하되, 사용자가 관리하는 URL·커스텀 항목은 기본적으로 보존합니다
+- 손대지 않은 레거시 자동생성 `ouroboros-*.config.toml` 태스크 프로파일 앵커만 정리합니다. 사용자가 만든 Codex 프로파일은 보존됩니다
+- 관리되는 `ouroboros-worker.config.toml`을 등록해서, Agent OS 워커 서브프로세스가 MCP/env 연결을 잃지 않고도 대화형 Codex 기본값에서 빠질 수 있게 합니다
+
+`~/.codex/config.toml`은 **Ouroboros 스테이지 모델 핀을 둘 자리가 아닙니다.** 설정 UI나 그에 대응하는 `~/.ouroboros/config.yaml` 값을 쓰고, 명시적인 `--profile`이 필요할 때만 사용자가 관리하는 네이티브 Codex 프로파일을 유지하세요. 장기 실행 URL 기반 Ouroboros MCP 서버를 직접 운영한다면 그 URL 항목을 `~/.codex/config.toml`에 그대로 두면 됩니다. `ouroboros setup --runtime codex`가 기본적으로 보존합니다. setup이 그 항목을 관리형 command-spawn 서버로 **바꾸길 원할 때만** `--mcp-mode stdio`를 쓰세요.
+
+### 워커 서브프로세스 격리 (Agent OS `runtime_profile`)
+
+대화형 `codex` 세션과 Ouroboros가 띄우는 워커 서브프로세스는 서로 다른 기본값을 원할 때가 있습니다. 모델, 샌드박스, notify 훅 같은 것들이요. 오케스트레이터 수준의 런타임 프로파일을 `worker`로 두면, Ouroboros가 띄우는 모든 `codex exec` 호출이 관리형 `~/.codex/ouroboros-worker.config.toml` 프로파일을 쓰게 됩니다.
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: codex
+  runtime_profile:
+    backend_profile: worker   # 선택. 기본값(미설정)은 지금 동작을 그대로 유지
+```
+
+한 번만 다르게 돌리고 싶으면 환경변수로:
+
+```bash
+OUROBOROS_RUNTIME_PROFILE=worker ouroboros run workflow --runtime codex seed.yaml
+```
+
+워커 오버라이드는 `~/.codex/ouroboros-worker.config.toml`에서 직접 고칩니다:
+
+```toml
+model = "o3-mini"
+notify = []
+sandbox = "workspace-write"
+```
+
+`runtime_profile`이 미설정이면(기본) Ouroboros는 예전과 똑같이 `codex exec`를 내보냅니다. 프로파일 플래그 없이, 사용자 설정을 전부 상속합니다. 이건 런타임 공통 Agent OS 프로파일 계약의 Codex 쪽 매핑이고, OpenCode·Hermes·Claude Code·LiteLLM은 각자의 백엔드 로컬 매핑을 따로 추가할 수 있습니다.
+
+### Codex에서 쓸 수 있는 `ooo` 스킬
+
+`ouroboros setup --runtime codex`를 돌리고 나면 번들 `ooo` 스킬이 `~/.codex/skills/ouroboros-*`에, 라우팅 규칙이 `~/.codex/rules/`에 설치됩니다. Ouroboros를 올린 뒤 **그 산출물만** 갱신하려면 `ouroboros codex refresh`를 쓰세요. `~/.codex/config.toml`도 `~/.ouroboros/config.yaml`도 건드리지 않습니다.
+
+아래 표는 각 스킬과, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
+
+| `ooo` 스킬 | Codex 세션 | CLI 대응 (터미널) |
+|-------------|---------------|--------------------------|
+| `ooo interview` | O | `ouroboros init start --llm-backend codex "your idea"` |
+| `ooo seed` | O | *(`ouroboros init start`에 포함됨)* |
+| `ooo run` | O | `ouroboros run workflow --runtime codex seed.yaml` |
+| `ooo status` | O | `ouroboros status execution <execution_id>` |
+| `ooo evaluate` | O | *(MCP 전용)* |
+| `ooo evolve` | O | *(MCP 전용)* |
+| `ooo ralph` | O | MCP가 소유하는 `ouroboros_ralph` 백그라운드 작업. job 도구로 모니터링 |
+| `ooo cancel` | O | `ouroboros cancel execution <execution_id>` |
+| `ooo unstuck` | O | *(MCP 전용)* |
+| `ooo tutorial` | O | *(MCP 전용)* |
+| `ooo welcome` | O | *(MCP 전용)* |
+| `ooo update` | O | `ouroboros update` |
+| `ooo help` | O | `ouroboros --help` |
+| `ooo qa` | O | *(MCP 전용)* |
+| `ooo setup` | O | `ouroboros setup --runtime codex` |
+| `ooo publish` | O | *(`ouroboros publish` 서브커맨드는 없음. 스킬/런타임 흐름이 `gh` CLI를 씀)* |
+
+> **Ralph 주의 (#528):** `ooo ralph`는 이제 MCP가 소유하는 `ouroboros_ralph` 백그라운드 작업 하나를 시작하고, 표준 job 도구로 감시합니다. 스킬이 클라이언트 쪽 `evolve_step` 폴링으로 다세대 루프를 다시 구현하지 않습니다. 돌고 있는 Ralph를 멈추려면 MCP 작업 취소 도구 `ouroboros_cancel_job(job_id)`를 쓰세요. **`ouroboros cancel execution <execution_id>`는 실행 세션 전용이라 Ralph의 job ID를 취소하지 못합니다.**
+
+> **`ooo seed`와 `ooo interview`의 차이:** 별개의 스킬이고 역할이 다릅니다. `ooo interview`는 소크라테스식 문답 세션을 돌리고 `session_id`를 돌려줍니다. `ooo seed`는 그 `session_id`를 받아 구조화된 Seed YAML을 만듭니다(모호도 채점 포함). 터미널에서는 두 단계가 `ouroboros init start` 한 번에 함께 수행됩니다.
+
+> **`ooo publish` 주의:** Codex 세션에서 `ooo publish`는 setup이 관리형 규칙과 스킬을 설치한 뒤 스킬/런타임 표면으로 제공됩니다. 지금은 전용 `ouroboros publish` 셸 서브커맨드가 아니라, 외부 `gh` CLI와 GitHub 인증에 의존합니다.
+
+Codex는 정확한 `ooo` 및 `/ouroboros:` 스킬 디스패치에 공통 무상태 `ouroboros.router` 리졸버를 씁니다. 명령을 추가하거나 바꾸려면 해당 `SKILL.md`의 frontmatter만 고치면 되고, 런타임은 로깅·메시지 조립·MCP 호출을 로컬에 유지합니다. [Shared `ooo` Skill Dispatch Router](../guides/ooo-skill-dispatch-router.md)(영문)를 보세요.
+
+## 동작 방식
+
+```
++-----------------+     +------------------+     +-----------------+
+|   Seed YAML     | --> |   Orchestrator   | --> |   Codex CLI     |
+|  (your task)    |     | (runtime_factory)|     |   (runtime)     |
++-----------------+     +------------------+     +-----------------+
+                                |
+                                v
+                        +------------------+
+                        |  Codex executes  |
+                        |  with its own    |
+                        |  tool set and    |
+                        |  sandbox model   |
+                        +------------------+
+```
+
+`CodexCliRuntime` 어댑터는 `codex`(또는 `codex-cli`)를 전송 계층으로 띄우되, 세션 핸들·resume 지원·결정적 스킬/MCP 디스패치로 감싸서 런타임이 지속적인 Ouroboros 세션처럼 동작하게 합니다.
+
+### 실행 파일 버전 증명 (attestation)
+
+어댑터는 런타임을 만들 때 성공한 `codex --version` 증거를 선택된 경로, 실제 대상의 device/inode 쌍, 콘텐츠 다이제스트, 심링크 동일성과 함께 기록해 두고, 실행할 때마다 그 증거를 검증합니다. 정책은 fail-closed지만, **증거를 못 얻은 것과 변조가 확인된 것을 혼동하지 않습니다.**
+
+- 초기화 중 타임아웃이나 실행 실패가 나면 긍정적 기준선이 남지 않으므로 실행이 차단되고, 새 런타임 세션이 필요합니다.
+- 이후 검사에서 타임아웃이나 실행 실패가 나면 그 시도는 차단되지만 **증명 증거 없음**으로 보고됩니다. 같은 런타임을 다시 시도할 수 있습니다.
+- 선택된 실행 파일을 `--version`으로 돌리기 **전에**, 어댑터는 실행하지 않는 방식으로 경로·콘텐츠·device/inode·완전한 의미론적 심링크 증거를 검증된 초기화 기준선과 비교합니다. 알려진 변조는 바뀐 후보를 실행하지 않고 거부합니다.
+- 시작된 프로브는 타임아웃이나 실패로 끝나도 전부 사후 샘플링됩니다. 그 증거가 프로브 구간 중 변조를 입증하면, 변조가 일시적 프로브 결과보다 우선합니다.
+- 상위 디렉터리의 generation 변화만으로는 실행 파일 동일성보다 범위가 넓습니다. 무관한 형제 항목이나 항목 교체 후 복원에서도 생길 수 있습니다. 그래서 이 경우는 실행 파일 변조가 확인됐다고 주장하지 않고, **재시도 가능한 불확정 권위**로 fail-closed 처리합니다.
+- 버전 변조는 **성공한 버전 증명 두 개가 서로 다를 때만** 보고됩니다. 경로·콘텐츠·심링크·device/inode·프로브 구간 generation 변조는 두 번째 성공 프로브 전에 fail-closed될 수 있습니다. 증명이 두 번 없었다는 사실은 실행 파일이 안 바뀌었다는 증거가 되지 않습니다.
+
+Copilot·Gemini·Goose·Grok 런타임도 같은 증명·비교 정책을 상속합니다.
+
+> 전체 런타임 백엔드 비교는 [runtime capability matrix](../runtime-capability-matrix.md)(영문)를 보세요.
+
+## Codex CLI의 강점
+
+- **세션을 아는 Codex 런타임** — Ouroboros가 워크플로 단계 전반에서 Codex 세션 핸들과 resume 상태를 보존합니다
+- **강한 코딩·추론** — Codex가 현재 선택한 모델을 쓰고, Ouroboros는 작업에 맞는 reasoning effort를 적용합니다
+- **에이전틱 작업 실행** — 복잡한 작업을 순차 단계로 쪼개고 자율적으로 반복하는 데 강합니다
+- **오픈소스** — Codex CLI는 오픈소스(Apache 2.0)라 열어보고 기여할 수 있습니다
+- **Ouroboros 하네스** — 명세 우선 워크플로 엔진이 Codex CLI 위에 구조화된 검수 기준, 평가 원칙, 결정적 종료 조건을 얹습니다
+
+## 런타임 차이
+
+Codex CLI와 Claude Code는 **서로 독립적인 런타임 백엔드**이고, 도구 집합·권한 모델·샌드박싱 동작이 다릅니다. 같은 Seed 파일이 양쪽에서 동작하지만, 실행 경로는 달라질 수 있습니다.
+
+| 항목 | Codex CLI | Claude Code |
+|--------|-----------|-------------|
+| 정체 | Codex CLI 전송을 쓰는 Ouroboros 세션 런타임 | Anthropic의 에이전틱 코딩 도구 |
+| 인증 | OpenAI API 키 | Max Plan 구독 |
+| 모델 | Codex의 현재 기본 모델 (권장) | Claude (claude-agent-sdk 경유) |
+| 샌드박스 | Codex CLI 자체 샌드박스 모델 | Claude Code의 권한 시스템 |
+| 도구 표면 | Codex 네이티브 도구 (파일 I/O, 셸) | Read, Write, Edit, Bash, Glob, Grep |
+| 세션 모델 | 런타임 핸들·resume ID·스킬 디스패치로 세션 인지 | 네이티브 Claude 세션 컨텍스트 |
+| 비용 모델 | OpenAI API 사용 요금 | Max Plan 구독에 포함 |
+| Windows (네이티브) | 미지원 | 실험적 |
+
+> **참고:** Ouroboros의 워크플로 모델(Seed 파일, 검수 기준, 평가 원칙)은 런타임과 무관하게 동일합니다. 다만 Codex CLI와 Claude Code는 바탕이 되는 에이전트 능력·도구 접근·샌드박싱이 다르기 때문에, **같은 Seed 파일에서도 실행 경로와 결과가 달라질 수 있습니다.**
+
+## CLI 옵션
+
+### 워크플로 명령
+
+```bash
+# 워크플로 실행 (Codex 런타임)
+# ouroboros init이 만든 seed는 ~/.ouroboros/seeds/seed_{id}.yaml에 저장됩니다
+uv run ouroboros run workflow --runtime codex ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# 드라이런 (실행하지 않고 seed만 검증)
+uv run ouroboros run workflow --dry-run ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# 디버그 출력 (로그와 에이전트 출력 표시)
+uv run ouroboros run workflow --runtime codex --debug ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# 이전 세션 이어서 실행
+uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+## Seed 파일 레퍼런스
+
+| 필드 | 필수 | 설명 |
+|-------|----------|-------------|
+| `goal` | O | 주 목표. 빈 문자열 불가 |
+| `task_type` | X | 실행 전략. `code`(기본), `research`, `analysis`, `artifact`, `document`, `documentation`, `presentation` |
+| `brownfield_context` | X | 기존 코드베이스 컨텍스트. 비어 있으면 greenfield로 취급 |
+| `constraints` | X | 반드시 만족해야 하는 제약 |
+| `acceptance_criteria` | X | 성공 판정 기준 |
+| `ontology_schema` | O | 출력 구조 정의 |
+| `evaluation_principles` | X | 평가 원칙 |
+| `exit_conditions` | X | 종료 조건 |
+| `metadata` | O | 생성 메타데이터 |
+| `metadata.ambiguity_score` | X | 생성 시점 모호도. 기본 `0.15`, 허용 범위 `0.0`~`1.0` |
+
+> **`ambiguity_score`의 0.2 임계값이 실제로 걸리는 지점:** 이 필드 자체는 `0.0`~`1.0`을 허용합니다([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). 0.2 게이트는 **seed 생성 시점**에 걸립니다. 인터뷰가 0.2 아래로 못 내려가면 seed를 안 만들어 주는 것이고, 여기에는 명시적 우회 선택지가 있습니다. CLI의 "Generate Seed anyway", MCP의 `force` 파라미터입니다. 우회해도 **실제 점수는 그대로 메타데이터에 기록되고 감사 로그에 남습니다.** 그리고 `ouroboros auto`는 실행 중에 이 readiness를 다시 확인합니다([`auto/grading.py:226`](../../src/ouroboros/auto/grading.py)).
+>
+> 실무적으로: 손으로 쓴 seed에 높은 `ambiguity_score`를 박아도 `ouroboros run workflow`가 막지는 않습니다. 이 값은 **강제 차단 장치가 아니라 출처 기록(provenance)**입니다.
+
+---
+
 ## 이후 절
 
 아래 내용은 아직 영문입니다. [codex.md](./codex.md)에서 이어 보세요.
 
-- Command Surface (`ouroboros setup --runtime codex`가 실제로 건드리는 것 11가지, 워커 서브프로세스 격리, `ooo` 스킬 가용성)
-- How It Works (실행 파일 버전 증명 포함)
-- Codex CLI의 강점 / 런타임 차이
-- CLI 옵션 / Seed 파일 레퍼런스
 - 문제 해결 (Codex CLI를 못 찾을 때, 인증 오류, 헬스체크 경고, EventStore 미초기화)
 - 비용
 - Active Conductor와 Synapse

--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -199,16 +199,16 @@ sandbox = "workspace-write"
 
 `ouroboros setup --runtime codex`를 돌리고 나면 번들 `ooo` 스킬이 `~/.codex/skills/ouroboros-*`에, 라우팅 규칙이 `~/.codex/rules/`에 설치됩니다. Ouroboros를 올린 뒤 **그 산출물만** 갱신하려면 `ouroboros codex refresh`를 쓰세요. `~/.codex/config.toml`도 `~/.ouroboros/config.yaml`도 건드리지 않습니다.
 
-현재 스냅숏 기준 setup은 `skills/*/SKILL.md` 디렉터리 **21개**를 패키징합니다. 아래 표는 그 전부와, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
+현재 스냅숏 기준 `resolve_packaged_codex_assets()`는 `skills/*/SKILL.md` 번들 **22개**를 해석해 설치합니다(맨 `ooo`와 `welcome` 포함). 아래 표는 그 전부와, 터미널만 쓰는 사람을 위한 CLI 대응입니다.
 
 | `ooo` 스킬 | Codex 세션 | CLI 대응 (터미널) |
 |-------------|---------------|--------------------------|
 | `ooo` (인자 없이) | O | *(디스패처가 라우팅. 세션에서 시작점으로 씀)* |
 | `ooo auto` | O | `ouroboros auto "goal"` (관리 규칙이 `ouroboros_start_auto`로 라우팅) |
-| `ooo brownfield` | O | *(MCP 전용)* |
-| `ooo config` | O | `ouroboros config show` |
-| `ooo pm` | O | *(MCP 전용)* |
-| `ooo resume-session` | O | `ouroboros run workflow --resume <session_id> ...` |
+| `ooo brownfield` | O | `ouroboros setup scan` / `setup list` / `setup default` |
+| `ooo config` | O | `ouroboros config` (설정 화면. `config show`는 읽기 전용 출력이라 다릅니다) |
+| `ooo pm` | O | `ouroboros pm` |
+| `ooo resume-session` | O | `ouroboros resume` (진행 중 세션을 나열합니다. `run workflow --resume`는 그 탐색 단계를 건너뜁니다) |
 | `ooo interview` | O | `ouroboros init start --llm-backend codex "your idea"` |
 | `ooo seed` | O | *(`ouroboros init start`에 포함됨)* |
 | `ooo run` | O | `ouroboros run workflow --runtime codex seed.yaml` |
@@ -222,7 +222,7 @@ sandbox = "workspace-write"
 | `ooo welcome` | O | *(MCP 전용)* |
 | `ooo update` | O | `ouroboros update` |
 | `ooo help` | O | `ouroboros --help` |
-| `ooo qa` | O | *(MCP 전용)* |
+| `ooo qa` | O | `ouroboros qa` |
 | `ooo setup` | O | `ouroboros setup --runtime codex` |
 | `ooo publish` | O | *(`ouroboros publish` 서브커맨드는 없음. 스킬/런타임 흐름이 `gh` CLI를 씀)* |
 
@@ -288,7 +288,7 @@ Codex CLI와 Claude Code는 **서로 독립적인 런타임 백엔드**이고, �
 | 샌드박스 | Codex CLI 자체 샌드박스 모델 | Claude Code의 권한 시스템 |
 | 도구 표면 | Codex 네이티브 도구 (파일 I/O, 셸) | Read, Write, Edit, Bash, Glob, Grep |
 | 세션 모델 | 런타임 핸들·resume ID·스킬 디스패치로 세션 인지 | 네이티브 Claude 세션 컨텍스트 |
-| 비용 모델 | OpenAI API 사용 요금 | Max Plan 구독에 포함 |
+| 비용 모델 | Codex CLI에 설정된 경로를 따름 — Codex OAuth 또는 OpenAI API 키 | Max Plan 구독에 포함 |
 | Windows (네이티브) | 미지원 | 실험적 |
 
 > **참고:** Ouroboros의 워크플로 모델(Seed 파일, 검수 기준, 평가 원칙)은 런타임과 무관하게 동일합니다. 다만 Codex CLI와 Claude Code는 바탕이 되는 에이전트 능력·도구 접근·샌드박싱이 다르기 때문에, **같은 Seed 파일에서도 실행 경로와 결과가 달라질 수 있습니다.**

--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -1,0 +1,133 @@
+<!--
+doc_metadata:
+  runtime_scope: [codex]
+-->
+
+# Codex CLI로 Ouroboros 실행하기
+
+> English: [codex.md](./codex.md)
+>
+> **번역 진행 상황**: 이 문서는 설치까지(사전 조건 · Codex CLI 설치 · Ouroboros 설치 · 플랫폼 · 설정 · 빠른 시작)를 옮긴 1부입니다. 그 뒤 절(Command Surface, How It Works, CLI 옵션, 문제 해결, 비용, Active Conductor)은 아직 영문입니다 — [codex.md](./codex.md)를 보세요. 진행은 [#1988](https://github.com/Q00/ouroboros/issues/1988)에서 추적합니다.
+
+> 설치와 첫 실행 흐름 전체는 [Getting Started](../getting-started.md)(영문)를 보세요.
+
+Ouroboros는 **OpenAI Codex**를 런타임 백엔드로 쓸 수 있습니다. [Codex CLI](https://github.com/openai/codex)가 어댑터와 실제로 대화하는 로컬 실행 표면입니다. macOS에서는 `PATH`에 없을 때 ChatGPT 앱에 딸려 오는 실행 파일도 setup이 찾아냅니다. Ouroboros 안에서 이 백엔드는 **세션 지향 런타임**으로 다뤄지며, 규약 우선 워크플로우 하네스(검수 기준, 평가 원칙, 결정적 종료 조건)는 동일하게 적용됩니다. 어댑터 자체는 로컬 `codex` 실행 파일과 통신할 뿐입니다. 기본값으로 Ouroboros는 **Codex가 지금 선택하고 있는 모델**을 그대로 쓰고, 역할별 추론 강도(reasoning effort)만 넘깁니다.
+
+기본 `ouroboros-ai` 패키지 외에 추가 Python SDK는 필요 없습니다.
+
+> **모델 권장**: Codex의 현재 기본 모델로 시작하세요. Ouroboros는 호출마다 역할별 추론 강도를 적용합니다. 특정 단계에 모델을 의도적으로 고정해야 할 때만 Ouroboros 설정에서 모델을 지정하세요.
+
+## 사전 조건
+
+- **Codex CLI**가 설치돼 있고 `PATH`에 있을 것. 또는 macOS ChatGPT 앱에 딸린 실행 파일([설치 절차](#codex-cli-설치) 참고)
+- 로그인된 **Codex CLI** 계정. API 키 인증도 됩니다: `printenv OPENAI_API_KEY | codex login --with-api-key`. 파일 기반 키 관리는 [`credentials.yaml`](../config-reference.md#credentialsyaml) 참고
+- **Python >= 3.12**
+
+## Codex CLI 설치
+
+Codex CLI는 npm 패키지로 배포됩니다. 전역으로 설치하세요.
+
+```bash
+npm install -g @openai/codex
+```
+
+설치를 확인합니다.
+
+```bash
+codex --version
+```
+
+다른 설치 방법과 셸 자동완성은 [Codex CLI README](https://github.com/openai/codex#readme)를 보세요.
+
+## Ouroboros 설치
+
+> 설치 방법 전체(pip, 한 줄 설치, 소스에서 빌드)와 첫 실행 안내는 **[Getting Started](../getting-started.md)**(영문)를 보세요.
+> 기본 `ouroboros-ai` 패키지에 Codex CLI 런타임 어댑터가 들어 있습니다. extras는 필요 없습니다.
+
+## 플랫폼
+
+| 플랫폼 | 상태 | 비고 |
+|----------|--------|-------|
+| macOS (ARM/Intel) | 지원 | 주 개발 플랫폼 |
+| Linux (x86_64/ARM64) | 지원 | Ubuntu 22.04+, Debian 12+, Fedora 38+ 에서 검증 |
+| Windows (WSL 2) | 지원 | Windows 사용자에게 권장하는 경로 |
+| Windows (네이티브) | 실험적 | WSL 2를 강력히 권장합니다. 네이티브 Windows에서는 경로 처리와 프로세스 관리에 문제가 있을 수 있습니다. **Codex CLI 자체가 네이티브 Windows를 지원하지 않습니다.** |
+
+## 설정
+
+런타임 백엔드로 Codex CLI를 고르려면 설정에 이렇게 씁니다.
+
+```yaml
+orchestrator:
+  runtime_backend: codex
+```
+
+명령줄에서 넘길 수도 있습니다.
+
+```bash
+uv run ouroboros run workflow --runtime codex ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+### Codex 사용자는 무엇을 어디에 설정하나
+
+**Ouroboros 런타임 설정은 `~/.ouroboros/config.yaml`입니다.** 평소 모델 선택은 `ouroboros config` 또는 `ouroboros config --web`으로 여세요. 둘 다 같은 설정 화면입니다.
+
+**Use Codex default model**을 고르면 Codex의 현재 기본 모델을 그대로 씁니다. 이게 권장 설정입니다 — Ouroboros가 Codex 호출마다 역할별 추론 강도만 넘기므로, Codex App이나 CLI에서 새 모델로 바꾸면 자동으로 그게 쓰입니다. 목록에서 모델을 고르거나 **Enter another model ID…**를 쓰는 건, 특정 단계(Execute 포함)에 모델을 의도적으로 고정하고 싶을 때만 하세요.
+
+**Codex의 MCP/env 연결과 사용자가 직접 관리하는 네이티브 Codex 프로필은 `$CODEX_HOME/config.toml`입니다.** `CODEX_HOME`이 설정돼 있지 않으면 Codex는 `~/.codex/config.toml`을 씁니다.
+
+Codex 기반 Ouroboros 역할들이 Codex CLI의 활성 기본값/프로필을 물려받는 대신 명시적 모델을 쓰게 하려면, `config.yaml` 키를 직접 지정하세요.
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: codex
+  codex_cli_path: /usr/local/bin/codex   # codex가 이미 PATH에 있으면 생략
+
+llm:
+  backend: codex
+  qa_model: gpt-5.4
+
+clarification:
+  default_model: gpt-5.4
+
+evaluation:
+  semantic_model: gpt-5.4
+
+consensus:
+  advocate_model: gpt-5.4
+  devil_model: gpt-5.4
+  judge_model: gpt-5.4
+  # 선택: 단순 투표 로스터도 여기에 `consensus.models`로 둡니다
+```
+
+이 키들을 기본값 그대로 두면, Codex setup이 프로바이더 중립적인 `llm_profiles`와 `llm_role_profiles` 매핑을 추가합니다. 그 Codex 매핑은 **모델이나 생성된 Codex 프로필을 고르지 않고** 호출별 추론 강도만 정합니다(fast: low, standard: medium, deep: high, frontier: xhigh). `config.yaml`에 명시한 모델 값이 있으면 그쪽이 이깁니다.
+
+> **주의**: `~/.codex/config.toml`은 Ouroboros 단계별 모델을 고정하는 자리가 **아닙니다.** 설정 화면이나 `~/.ouroboros/config.yaml`의 해당 값을 쓰세요. 명시적 `--profile`이 필요하면 사용자가 관리하는 네이티브 Codex 프로필을 그대로 두면 됩니다.
+>
+> 오래 떠 있는 URL 기반 Ouroboros MCP 서버를 운영한다면 그 URL 항목을 `~/.codex/config.toml`에 두세요. `ouroboros setup --runtime codex`는 **기본적으로 그 항목을 보존합니다.** setup이 그 항목을 관리형 command-spawned 서버로 **교체하기를 의도적으로 원할 때만** `--mcp-mode stdio`를 쓰세요.
+
+## 빠른 시작
+
+> 첫 실행 흐름 전체(인터뷰 → seed → 실행)는 **[Getting Started](../getting-started.md)**(영문)를 보세요.
+
+### 설치 확인
+
+```bash
+codex --version
+ouroboros --help
+```
+
+---
+
+## 이후 절
+
+아래 내용은 아직 영문입니다. [codex.md](./codex.md)에서 이어 보세요.
+
+- Command Surface (`ouroboros setup --runtime codex`가 실제로 건드리는 것 11가지, 워커 서브프로세스 격리, `ooo` 스킬 가용성)
+- How It Works (실행 파일 버전 증명 포함)
+- Codex CLI의 강점 / 런타임 차이
+- CLI 옵션 / Seed 파일 레퍼런스
+- 문제 해결 (Codex CLI를 못 찾을 때, 인증 오류, 헬스체크 경고, EventStore 미초기화)
+- 비용
+- Active Conductor와 Synapse

--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -7,7 +7,7 @@ doc_metadata:
 
 > English: [codex.md](./codex.md)
 >
-> **번역 진행 상황**: 이 문서는 설치까지(사전 조건 · Codex CLI 설치 · Ouroboros 설치 · 플랫폼 · 설정 · 빠른 시작)를 옮긴 1부입니다. 그 뒤 절(Command Surface, How It Works, CLI 옵션, 문제 해결, 비용, Active Conductor)은 아직 영문입니다 — [codex.md](./codex.md)를 보세요. 진행은 [#1988](https://github.com/Q00/ouroboros/issues/1988)에서 추적합니다.
+> **번역 진행 상황**: 이 문서는 설치까지(시작하기 · 독립 설치 · Codex CLI 설치 · 플랫폼 · 설정 · 빠른 시작)를 옮긴 1부입니다. 그 뒤 절(Command Surface, How It Works, CLI 옵션, 문제 해결, 비용, Active Conductor)은 아직 영문입니다 — [codex.md](./codex.md)를 보세요. 진행은 [#1988](https://github.com/Q00/ouroboros/issues/1988)에서 추적합니다.
 
 > 설치와 첫 실행 흐름 전체는 [Getting Started](../getting-started.md)(영문)를 보세요.
 
@@ -17,15 +17,45 @@ Ouroboros는 **OpenAI Codex**를 런타임 백엔드로 쓸 수 있습니다. [C
 
 > **모델 권장**: Codex의 현재 기본 모델로 시작하세요. Ouroboros는 호출마다 역할별 추론 강도를 적용합니다. 특정 단계에 모델을 의도적으로 고정해야 할 때만 Ouroboros 설정에서 모델을 지정하세요.
 
-## 사전 조건
+## 시작하기 (권장 경로)
+
+Codex 플러그인으로 시작하는 게 가장 짧습니다.
+
+**터미널:**
+
+```bash
+codex plugin marketplace add Q00/ouroboros
+codex plugin add ouroboros@ouroboros
+```
+
+새 Codex 세션을 열고 `ooo`를 입력하세요. setup이 아직 안 돌았다면, Ouroboros가 **무언가를 바꾸기 전에 먼저 런타임을 준비할지 물어봅니다.** 준비가 끝나면 Codex의 현재 기본 모델을 자동으로 씁니다. **Directly configure models**는 특정 파이프라인 단계의 모델을 고르거나 고정하고 싶을 때만 선택하세요 — Codex에서는 임시 `localhost` 주소로 브라우저에 로컬 설정 화면이 열립니다.
+
+### 사전 조건 (권장 경로)
 
 - **Codex CLI**가 설치돼 있고 `PATH`에 있을 것. 또는 macOS ChatGPT 앱에 딸린 실행 파일([설치 절차](#codex-cli-설치) 참고)
 - 로그인된 **Codex CLI** 계정. API 키 인증도 됩니다: `printenv OPENAI_API_KEY | codex login --with-api-key`. 파일 기반 키 관리는 [`credentials.yaml`](../config-reference.md#credentialsyaml) 참고
+
+**Python 요구사항은 아래 독립 설치 경로에만 해당합니다.**
+
+## 독립 설치 (플러그인 없이)
+
+플러그인 없이 Codex CLI를 직접 붙이려면 한 번만 준비하면 됩니다.
+
+**터미널:**
+
+```bash
+ouroboros setup --runtime codex
+```
+
+### 사전 조건 (독립 설치 경로)
+
+- 위 권장 경로의 사전 조건 두 가지
 - **Python >= 3.12**
+- Ouroboros 설치 — 기본 `ouroboros-ai` 패키지에 Codex CLI 런타임 어댑터가 들어 있습니다. extras는 필요 없습니다. 설치 방법 전체(pip, 한 줄 설치, 소스)는 [Getting Started](../getting-started.md)(영문) 참고
 
 ## Codex CLI 설치
 
-Codex CLI는 npm 패키지로 배포됩니다. 전역으로 설치하세요.
+Codex CLI 자체는 npm 패키지로 배포됩니다. 전역으로 설치하세요.
 
 ```bash
 npm install -g @openai/codex
@@ -38,11 +68,6 @@ codex --version
 ```
 
 다른 설치 방법과 셸 자동완성은 [Codex CLI README](https://github.com/openai/codex#readme)를 보세요.
-
-## Ouroboros 설치
-
-> 설치 방법 전체(pip, 한 줄 설치, 소스에서 빌드)와 첫 실행 안내는 **[Getting Started](../getting-started.md)**(영문)를 보세요.
-> 기본 `ouroboros-ai` 패키지에 Codex CLI 런타임 어댑터가 들어 있습니다. extras는 필요 없습니다.
 
 ## 플랫폼
 

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -267,7 +267,7 @@ Codex CLI and Claude Code are independent runtime backends with different tool s
 | Aspect | Codex CLI | Claude Code |
 |--------|-----------|-------------|
 | What it is | Ouroboros session runtime backed by Codex CLI transport | Anthropic's agentic coding tool |
-| Authentication | OpenAI API key | Max Plan subscription |
+| Authentication | Codex account sign-in or OpenAI API key | Max Plan subscription |
 | Model | Codex's current default model (recommended) | Claude (via claude-agent-sdk) |
 | Sandbox | Codex CLI's own sandbox model | Claude Code's permission system |
 | Tool surface | Codex-native tools (file I/O, shell) | Read, Write, Edit, Bash, Glob, Grep |
@@ -315,8 +315,15 @@ uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros
 > ([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). The 0.2 gate is enforced at **seed
 > generation**: if the interview cannot get below it, no seed is produced. That gate has an explicit
 > opt-out — the CLI's "Generate Seed anyway" and the MCP `force` parameter. Bypassing it still records
-> the real score in seed metadata and emits the bypass to the audit log. `ouroboros auto` re-checks the
-> same readiness during a run ([`auto/grading.py:226`](../../src/ouroboros/auto/grading.py)).
+> the real score in seed metadata and emits the bypass to the audit log.
+>
+> `ouroboros auto` re-checks readiness during a run, but **conditionally**. The
+> `high_ambiguity_score` blocker is suppressed when the interview closed on ledger
+> evidence (`closure_mode` of `ledger_only` or `safe_default`) or when the Seed is
+> marked `degraded` ([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)).
+> Under those closures the ledger's structural completeness is the acceptance
+> signal and the LLM-derived score is stale by design, so a Seed scoring well above
+> 0.2 can grade A and run. Other grading axes still apply.
 >
 > In practice: a hand-written seed carrying a high `ambiguity_score` is not blocked by
 > `ouroboros run workflow`. The field is provenance, not an enforcement gate.

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -300,14 +300,26 @@ uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `goal` | Yes | Primary objective |
-| `task_type` | No | Execution strategy: `code` (default), `research`, or `analysis` |
+| `goal` | Yes | Primary objective. Cannot be empty |
+| `task_type` | No | Execution strategy: `code` (default), `research`, `analysis`, `artifact`, `document`, `documentation`, or `presentation` |
+| `brownfield_context` | No | Existing-codebase context. Empty means greenfield |
 | `constraints` | No | Hard constraints to satisfy |
 | `acceptance_criteria` | No | Specific success criteria |
 | `ontology_schema` | Yes | Output structure definition |
 | `evaluation_principles` | No | Principles for evaluation |
 | `exit_conditions` | No | Termination conditions |
-| `metadata.ambiguity_score` | Yes | Must be <= 0.2 |
+| `metadata` | Yes | Generation metadata |
+| `metadata.ambiguity_score` | No | Ambiguity at generation time. Defaults to `0.15`, accepts `0.0`-`1.0` |
+
+> **Where the 0.2 threshold actually applies.** The field itself accepts `0.0`-`1.0`
+> ([`core/seed.py:409`](../../src/ouroboros/core/seed.py)). The 0.2 gate is enforced at **seed
+> generation**: if the interview cannot get below it, no seed is produced. That gate has an explicit
+> opt-out — the CLI's "Generate Seed anyway" and the MCP `force` parameter. Bypassing it still records
+> the real score in seed metadata and emits the bypass to the audit log. `ouroboros auto` re-checks the
+> same readiness during a run ([`auto/grading.py:226`](../../src/ouroboros/auto/grading.py)).
+>
+> In practice: a hand-written seed carrying a high `ambiguity_score` is not blocked by
+> `ouroboros run workflow`. The field is provenance, not an enforcement gate.
 
 ## Troubleshooting
 

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -5,6 +5,8 @@ doc_metadata:
 
 # Running Ouroboros with Codex CLI
 
+> 한국어: [codex.ko.md](./codex.ko.md) (설치까지 번역됨, 이후 절은 이 문서를 보세요)
+
 > For installation and first-run onboarding, see [Getting Started](../getting-started.md).
 
 Ouroboros can use **OpenAI Codex** as a runtime backend. [Codex CLI](https://github.com/openai/codex) is the local execution surface that the adapter talks to; on macOS, setup also detects the executable bundled with the ChatGPT app when it is not on your `PATH`. In Ouroboros, that backend is presented as a **session-oriented runtime** with the same specification-first workflow harness (acceptance criteria, evaluation principles, deterministic exit conditions), even though the adapter itself communicates with the local `codex` executable. By default, Ouroboros uses the model currently selected by Codex and supplies only the role's reasoning effort.

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -155,7 +155,7 @@ When `runtime_profile` is unset (the default), Ouroboros emits `codex exec` exac
 
 ### `ooo` Skill Availability on Codex
 
-After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are installed into `~/.codex/skills/ouroboros-*` and the routing rules into `~/.codex/rules/`. To refresh only those artifacts after upgrading Ouroboros, run `ouroboros codex refresh`; it does not modify `~/.codex/config.toml` or `~/.ouroboros/config.yaml`. The table below shows each skill and its CLI equivalent for terminal-only workflows.
+After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are installed into `~/.codex/skills/ouroboros-*` and the routing rules into `~/.codex/rules/`. To refresh only those artifacts after upgrading Ouroboros, run `ouroboros codex refresh`; it does not modify `~/.codex/config.toml` or `~/.ouroboros/config.yaml`. `resolve_packaged_codex_assets()` currently resolves and installs 22 `skills/*/SKILL.md` bundles. The table below is a **subset** — the ones most often driven from a terminal — with their CLI equivalents. See the Korean guide for the complete 22-row table.
 
 | `ooo` Skill | Codex session | CLI equivalent (Terminal) |
 |-------------|---------------|--------------------------|
@@ -272,7 +272,7 @@ Codex CLI and Claude Code are independent runtime backends with different tool s
 | Sandbox | Codex CLI's own sandbox model | Claude Code's permission system |
 | Tool surface | Codex-native tools (file I/O, shell) | Read, Write, Edit, Bash, Glob, Grep |
 | Session model | Session-aware via runtime handles, resume IDs, and skill dispatch | Native Claude session context |
-| Cost model | OpenAI API usage charges | Included in Max Plan subscription |
+| Cost model | Follows whatever your Codex CLI is configured for — Codex OAuth or OpenAI API key | Included in Max Plan subscription |
 | Windows (native) | Not supported | Experimental |
 
 > **Note:** The Ouroboros workflow model (Seed files, acceptance criteria, evaluation principles) is identical across runtimes. However, because Codex CLI and Claude Code have different underlying agent capabilities, tool access, and sandboxing, they may produce different execution paths and results for the same Seed file.

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -172,7 +172,7 @@ After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are in
 | `ooo welcome` | Yes | *(MCP only)* |
 | `ooo update` | Yes | `ouroboros update` |
 | `ooo help` | Yes | `ouroboros --help` |
-| `ooo qa` | Yes | *(MCP only)* |
+| `ooo qa` | Yes | `ouroboros qa` |
 | `ooo setup` | Yes | `ouroboros setup --runtime codex` |
 | `ooo publish` | Yes | *(no direct `ouroboros publish` subcommand; skill/runtime flow uses `gh` CLI)* |
 
@@ -317,13 +317,20 @@ uv run ouroboros run workflow --runtime codex --resume <session_id> ~/.ouroboros
 > opt-out — the CLI's "Generate Seed anyway" and the MCP `force` parameter. Bypassing it still records
 > the real score in seed metadata and emits the bypass to the audit log.
 >
-> `ouroboros auto` re-checks readiness during a run, but **conditionally**. The
-> `high_ambiguity_score` blocker is suppressed when the interview closed on ledger
-> evidence (`closure_mode` of `ledger_only` or `safe_default`) or when the Seed is
-> marked `degraded` ([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)).
-> Under those closures the ledger's structural completeness is the acceptance
-> signal and the LLM-derived score is stale by design, so a Seed scoring well above
-> 0.2 can grade A and run. Other grading axes still apply.
+> `ouroboros auto` re-checks readiness during a run, but **conditionally**, and the
+> two suppression cases have opposite consequences
+> ([`auto/grading.py:225-226`](../../src/ouroboros/auto/grading.py)):
+>
+> - **Ledger closure** (`closure_mode` of `ledger_only` or `safe_default`, not
+>   degraded): the ledger's structural completeness is the acceptance signal and
+>   the LLM-derived score is stale by design, so a Seed scoring well above 0.2 can
+>   grade A and **run**. Other grading axes still apply.
+> - **Degraded Seed**: the blocker is suppressed only so the run can emit a typed
+>   partial product. A blocker-free degraded Seed goes straight to the
+>   partial-product terminal as `AutoPhase.COMPLETE` **regardless of grade or
+>   `may_run`** ([`auto/pipeline.py:1286`](../../src/ouroboros/auto/pipeline.py)).
+>   It never reaches RUN. Remaining blockers are hard safety blockers and still
+>   terminate.
 >
 > In practice: a hand-written seed carrying a high `ambiguity_score` is not blocked by
 > `ouroboros run workflow`. The field is provenance, not an enforcement gate.


### PR DESCRIPTION
Stacked on #1989. Continues the Korean Codex runtime guide from where part 1 stopped.

## Translated

Command Surface (the 11 things `ouroboros setup --runtime codex` touches, the `~/.codex/config.toml` boundary), worker subprocess isolation, the full `ooo` skill table with CLI equivalents, executable version attestation, Codex CLI strengths, runtime differences vs Claude Code, CLI options, and the seed file reference.

Kept the Ralph note prominent, since `ouroboros cancel execution` silently does not cancel a Ralph job ID.

## Corrections to the English source

Verifying each claim before translating turned up three real drifts in the seed reference table:

1. `task_type` listed `code`/`research`/`analysis`. The model accepts seven values — `artifact`, `document`, `documentation`, and `presentation` were missing (`core/seed.py:711`).
2. `metadata.ambiguity_score` was marked **Required: Yes** and **"Must be <= 0.2"**. Neither is true: `SeedMetadata.ambiguity_score` is `Field(default=0.15, ge=0.0, le=1.0)` (`core/seed.py:409`). The 0.2 threshold is enforced at **generation**, and that gate has an explicit opt-out — the CLI's "Generate Seed anyway" and the MCP `force` parameter (`mcp/tools/authoring_handlers.py:1295`). `ouroboros run workflow` does not re-enforce it; `ouroboros auto` re-checks readiness at `auto/grading.py:226`.

   This one misleads in a specific way: a reader who hand-writes a seed and sets a high score expects to be stopped, and is not. The field is provenance, not a gate. Documented that in both languages.
3. `brownfield_context` and `metadata` were absent from the table entirely.

## Remaining

Part 3 covers Troubleshooting through Synapse. Tracked in #1988.