### PR TITLE
OUROBOROS_SUB_RETRIES is documented but does not exist

### DIFF
--- a/docs/guides/opencode-subagent-bridge.md
+++ b/docs/guides/opencode-subagent-bridge.md
@@ -172,7 +172,15 @@ does **not** abort the rest of a fan-out batch.
 | Variable                         | Default   | Purpose |
 |----------------------------------|-----------|---------|
 | `OUROBOROS_CHILD_TIMEOUT_MS`     | 1 200 000 | Per-child overall timeout (ms) |
-| `OUROBOROS_SUB_RETRIES`          | 2         | Extra retries after first child attempt |
+
+`OUROBOROS_CHILD_TIMEOUT_MS` is the only variable the bridge reads
+(`process.env` appears once, at `opencode/plugin/ouroboros-bridge.ts:38`).
+
+Retries are **not** configurable. The bridge holds two compile-time constants
+at `:40-41`: `PATCH_RETRIES = 3`, applied when a PATCH hits a network or server
+blip (`:598`), and `RESOLVE_RETRIES = 5`, applied when resolving the assistant
+message that hosts a `callID` (`:613`, fails closed and returns `null` if no
+exact match is found). Neither responds to an environment variable.
 
 ## Installation
 

--- a/docs/runtime-guides/opencode.md
+++ b/docs/runtime-guides/opencode.md
@@ -131,7 +131,11 @@ ouroboros_lateral_think persona="all"
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `OUROBOROS_CHILD_TIMEOUT_MS` | `1200000` (20 min) | Per-child wall clock |
-| `OUROBOROS_SUB_RETRIES` | `2` | Retry count on spawn failure |
+
+> `OUROBOROS_CHILD_TIMEOUT_MS` is the only environment knob the bridge reads
+> (`opencode/plugin/ouroboros-bridge.ts:38`). Retry counts are compile-time
+> constants there — `PATCH_RETRIES = 3` and `RESOLVE_RETRIES = 5` (`:40-41`) —
+> and neither is overridable.
 
 See the full plugin guide: **[OpenCode Subagent Bridge](../guides/opencode-subagent-bridge.md)**.
 


### PR DESCRIPTION
`OUROBOROS_SUB_RETRIES` is documented in two places with a default of `2`. It does not exist.

## Verification

The OpenCode bridge reads exactly one environment variable. `process.env` appears once in `src/ouroboros/opencode/plugin/ouroboros-bridge.ts`, at line 38:

```ts
export const CHILD_TIMEOUT_MS = num(process.env.OUROBOROS_CHILD_TIMEOUT_MS, 20 * 60 * 1000)
```

Retries are compile-time constants at `:40-41`:

```ts
const PATCH_RETRIES = 3
const RESOLVE_RETRIES = 5
```

`PATCH_RETRIES` applies to PATCH calls on a network or server blip (`:598`). `RESOLVE_RETRIES` applies when resolving the assistant message hosting a `callID` (`:613`), which fails closed and returns `null` if no exact match is found. Neither reads an environment variable, and `OUROBOROS_SUB_RETRIES` appears nowhere in the repository outside these two documentation tables.

## Why this shape of error is worth fixing rather than deleting quietly

Both tables sit under an "Environment knobs" heading next to `OUROBOROS_CHILD_TIMEOUT_MS`, which **is** real. That adjacency is what makes it convincing: a reader debugging flaky child spawns finds a table of two knobs, sets the one named for retries, restarts, sees no change, and has no signal that the variable was ignored.

So I replaced the row with what is actually true in each document, rather than removing it. Someone who came looking for a retry knob should learn that retries are fixed at 3 and 5 and where those live, not just fail to find the row.

The same defect shape appears in `copilot.md`, where troubleshooting recommends setting `OUROBOROS_DEFAULT_MODEL` — also nonexistent — as the fix for a real error message. That one is corrected in #1997.

## How these were found

A scan of every `OUROBOROS_*` token in `docs/` against every occurrence in the rest of the repository. Twelve names appeared only in documentation; ten were false positives worth naming, since they show what the check must not flag:

- **Five** are in `docs/contributing/findings-registry.md`, a `status: legacy-frozen` archive whose entry `CLM-003` *records* that `OUROBOROS_TUI_THEME`, `OUROBOROS_MAX_AGENTS`, and `OUROBOROS_EVENT_CACHE_SIZE` are unread. That file documents the defect rather than committing it.
- **Two** (`OUROBOROS_CODEX_RPM`, `OUROBOROS_OPENCODE_RPM`) are illustrative expansions of the documented `OUROBOROS_<BACKEND>_RPM` pattern, constructed at runtime rather than matched as literals.
- **Three** more resolve in test files or the TypeScript bridge rather than `src/**/*.py`.

That leaves two genuine defects: this one and the `copilot.md` one.

That the frozen registry already recorded this exact class in March, and it recurred twice since, is the argument in #1998: documentation and source have no mechanical relationship, so the only detector is a person reading both. A lint over `OUROBOROS_*` tokens would be cheap and would have caught both, provided it tolerates the three false-positive shapes above.
