### PR TITLE
fix(verification): distinguish missing evidence from verified results

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -42,6 +42,14 @@ from ouroboros.mcp.server.project_dir import (  # noqa: F401
 )
 from ouroboros.mcp.server.protocol import PromptHandler, ResourceHandler, ToolHandler
 from ouroboros.mcp.server.security import AuthConfig, AuthMethod, RateLimitConfig, SecurityLayer
+
+# Re-exported: kept here for existing adapter-level tests and callers.
+from ouroboros.mcp.server.spec_verification_adapter import (
+    agent_results_from_execution_summary as _agent_results_from_execution_summary,
+)
+from ouroboros.mcp.server.spec_verification_adapter import (
+    evaluation_summary_from_spec_verification as _evaluation_summary_from_spec_verification,
+)
 from ouroboros.mcp.types import (
     MCPCapabilities,
     MCPPromptDefinition,
@@ -618,199 +626,6 @@ def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None
         feedback_metadata=feedback_metadata,
         execution_completion_status=execution_completion_status,
         approval_status="not_evaluated",
-    )
-
-
-def _agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
-    """Return legacy agent-reported AC outcomes for spec verification.
-
-    Formal ``ACResult`` values take precedence when present.  For legacy
-    execution-only summaries, preserve the worker task completion signal via
-    ``source_ac_index`` so skipped/unverifiable assertions do not convert a
-    worker-reported failure into formal approval.
-    """
-    agent_results = {ac.ac_index: ac.authoritative_pass for ac in mechanical.ac_results}
-    for task in mechanical.task_results:
-        source_ac_index = task.source_ac_index
-        if source_ac_index is None:
-            source_ac_index = task.task_index
-        agent_results.setdefault(source_ac_index, task.completed)
-    return agent_results
-
-
-def _evaluation_summary_from_spec_verification(
-    mechanical: Any,
-    verification_summary: Any,
-    seed: Any | None = None,
-) -> Any | None:
-    """Promote complete verifier coverage into Seed-bound formal AC verdicts."""
-    from ouroboros.core.lineage import ACResult, EvaluationSummary
-    from ouroboros.verification.models import VerificationOutcome
-
-    reports = tuple(getattr(verification_summary, "reports", ()) or ())
-    if not reports:
-        return None
-    seed_criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
-
-    def semantic_key(ac_index: int) -> str | None:
-        if 0 <= ac_index < len(seed_criteria):
-            return getattr(seed_criteria[ac_index], "semantic_ac_key", None)
-        return None
-
-    expected_ac_content: dict[int, str] = {
-        ac.ac_index: ac.ac_content for ac in mechanical.ac_results
-    }
-    expected_agent_results = _agent_results_from_execution_summary(mechanical)
-    for task in mechanical.task_results:
-        source_ac_index = task.source_ac_index
-        if source_ac_index is None:
-            source_ac_index = task.task_index
-        expected_ac_content.setdefault(source_ac_index, task.task_content)
-
-    reports_by_index = {report.ac_index: report for report in reports}
-    expected_indices = set(expected_ac_content) | set(expected_agent_results)
-    result_indices = sorted(expected_indices | set(reports_by_index))
-
-    ac_results: list[ACResult] = []
-    missing_indices: list[int] = []
-    unverifiable_indices: list[int] = []
-    skipped_indices: list[int] = []
-    for ac_index in result_indices:
-        report = reports_by_index.get(ac_index)
-        if report is None:
-            missing_indices.append(ac_index)
-            ac_results.append(
-                ACResult(
-                    ac_index=ac_index,
-                    ac_content=expected_ac_content.get(
-                        ac_index, f"Acceptance criterion {ac_index + 1}"
-                    ),
-                    semantic_ac_key=semantic_key(ac_index),
-                    passed=False,
-                    score=0.0,
-                    evidence="No spec verification report was produced for this AC.",
-                    verification_method="spec_verifier",
-                    ac_verdict_state="not_evaluated",
-                    final_verdict="fail",
-                    rendered_verdict="NOT_EVALUATED",
-                )
-            )
-            continue
-
-        details = [result.detail for result in report.results if result.detail]
-        evidence = "; ".join(details)
-        outcomes = {result.outcome for result in report.results}
-        if not report.results:
-            unverifiable_indices.append(ac_index)
-            evidence = "No independently verifiable assertions; formal AC verdict not evaluated."
-            passed = False
-            verdict_state = "not_evaluated"
-            rendered_verdict = "NOT_EVALUATED"
-        elif VerificationOutcome.DISCREPANCY in outcomes:
-            passed = False
-            verifier_overrode_pass = bool(report.agent_reported_pass)
-            verdict_state = "overridden" if verifier_overrode_pass else "evaluated"
-            rendered_verdict = "FAIL"
-            if VerificationOutcome.UNVERIFIABLE in outcomes:
-                unverifiable_indices.append(ac_index)
-            if VerificationOutcome.SKIPPED in outcomes:
-                skipped_indices.append(ac_index)
-            if not evidence:
-                evidence = "Spec verifier found a discrepancy without evidence details."
-        elif outcomes == {VerificationOutcome.VERIFIED}:
-            passed = True
-            verdict_state = "evaluated"
-            rendered_verdict = "PASS"
-            if not evidence:
-                evidence = "Spec verifier produced no evidence details."
-        else:
-            # Missing evidence is not a discrepancy, but this formal adapter is
-            # a strict gate: only an all-VERIFIED report may mint a PASS.
-            passed = False
-            verdict_state = "not_evaluated"
-            rendered_verdict = "NOT_EVALUATED"
-            if VerificationOutcome.UNVERIFIABLE in outcomes:
-                unverifiable_indices.append(ac_index)
-            if VerificationOutcome.SKIPPED in outcomes:
-                skipped_indices.append(ac_index)
-            if not evidence:
-                evidence = "Spec verification did not produce independently usable evidence."
-
-        ac_results.append(
-            ACResult(
-                ac_index=report.ac_index,
-                ac_content=report.ac_text,
-                semantic_ac_key=semantic_key(report.ac_index),
-                passed=passed,
-                score=1.0 if passed else 0.0,
-                evidence=evidence,
-                verification_method="spec_verifier",
-                ac_verdict_state=verdict_state,
-                final_verdict="pass" if passed else "fail",
-                rendered_verdict=rendered_verdict,
-            )
-        )
-
-    total = len(ac_results)
-    passed_count = sum(1 for result in ac_results if result.authoritative_pass)
-    score = passed_count / total if total > 0 else 0.0
-    complete_coverage = bool(expected_indices) and expected_indices.issubset(reports_by_index)
-    execution_completed = mechanical.execution_completion_status == "completed"
-    approved = complete_coverage and passed_count == total and total > 0 and execution_completed
-
-    failure_reason = None
-    if not approved:
-        failed_indices = [
-            result.ac_index + 1 for result in ac_results if result.rendered_verdict == "FAIL"
-        ]
-        discrepancy_count = sum(
-            1
-            for report in reports
-            if getattr(report, "has_confirmed_discrepancy", report.has_discrepancy)
-        )
-        reason_parts = []
-        if failed_indices:
-            reason_parts.append(
-                f"{len(failed_indices)}/{total} ACs failed "
-                f"(AC {', '.join(str(i) for i in failed_indices)})"
-            )
-        if discrepancy_count:
-            reason_parts.append(f"{discrepancy_count} spec verification override(s)")
-        if missing_indices:
-            reason_parts.append(
-                "missing verifier report for AC " + ", ".join(str(i + 1) for i in missing_indices)
-            )
-        if unverifiable_indices:
-            reason_parts.append(
-                "unverifiable assertion evidence for AC "
-                + ", ".join(str(i + 1) for i in unverifiable_indices)
-            )
-        if skipped_indices:
-            reason_parts.append(
-                "source verification skipped for AC "
-                + ", ".join(str(i + 1) for i in skipped_indices)
-            )
-        if not execution_completed:
-            reason_parts.append(
-                f"execution_completion_status={mechanical.execution_completion_status}"
-            )
-        if not reason_parts:
-            reason_parts.append("spec verification did not approve the run")
-        failure_reason = reason_parts[0]
-        if len(reason_parts) > 1:
-            failure_reason += f" [{'; '.join(reason_parts[1:])}]"
-
-    return EvaluationSummary(
-        final_approved=approved,
-        highest_stage_passed=3 if approved else 2,
-        score=score,
-        drift_score=None,
-        failure_reason=failure_reason,
-        ac_results=tuple(ac_results),
-        task_results=mechanical.task_results,
-        feedback_metadata=mechanical.feedback_metadata,
-        execution_completion_status=mechanical.execution_completion_status,
-        approval_status="approved" if approved else "rejected",
     )
 
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -595,12 +595,31 @@ def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None
         )
 
     total = len(task_results)
-    completed_count = sum(1 for result in task_results if result.completed)
-    score = completed_count / total if total > 0 else 0.0
+    reported_indices = [result.task_index for result in task_results]
+    reported_index_set = set(reported_indices)
+    if seed_acs:
+        expected_indices = set(range(len(seed_acs)))
+    else:
+        # Without a Seed, the report's highest one-based task number is the
+        # only available coverage boundary. Requiring the complete contiguous
+        # range keeps ``Task 2`` alone from masquerading as a complete run.
+        expected_indices = set(range(max(reported_indices, default=-1) + 1))
 
-    total_expected_tasks = len(seed_acs) if seed_acs else total
-    all_expected_tasks_reported = total >= total_expected_tasks
-    all_tasks_completed = completed_count == total and all_expected_tasks_reported
+    indices_are_unique = len(reported_indices) == len(reported_index_set)
+    exact_expected_coverage = reported_index_set == expected_indices
+    completed_expected_indices = {
+        result.task_index
+        for result in task_results
+        if result.completed and result.task_index in expected_indices
+    }
+    total_expected_tasks = len(expected_indices)
+    completed_count = len(completed_expected_indices)
+    score = completed_count / total_expected_tasks if total_expected_tasks > 0 else 0.0
+    all_tasks_completed = (
+        indices_are_unique
+        and exact_expected_coverage
+        and all(result.completed for result in task_results)
+    )
 
     failed_indices = [result.task_index + 1 for result in task_results if not result.completed]
     failure_reason = None
@@ -609,6 +628,26 @@ def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None
             failure_reason = (
                 f"{len(failed_indices)}/{total} tasks failed "
                 f"(Task {', '.join(str(i) for i in failed_indices)})"
+            )
+        elif not indices_are_unique:
+            failure_reason = (
+                "duplicate task indices in execution report; formal AC evaluation not run"
+            )
+        elif not exact_expected_coverage:
+            missing_indices = sorted(expected_indices - reported_index_set)
+            unexpected_indices = sorted(reported_index_set - expected_indices)
+            coverage_parts = []
+            if missing_indices:
+                coverage_parts.append(
+                    "missing Task " + ", ".join(str(index + 1) for index in missing_indices)
+                )
+            if unexpected_indices:
+                coverage_parts.append(
+                    "unexpected Task " + ", ".join(str(index + 1) for index in unexpected_indices)
+                )
+            failure_reason = (
+                "incomplete task coverage (" + "; ".join(coverage_parts) + "); "
+                "formal AC evaluation not run"
             )
         else:
             failure_reason = (

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -48,6 +48,9 @@ from ouroboros.mcp.server.spec_verification_adapter import (
     agent_results_from_execution_summary as _agent_results_from_execution_summary,
 )
 from ouroboros.mcp.server.spec_verification_adapter import (
+    evaluation_summary_for_unavailable_spec_verification as _evaluation_summary_for_unavailable_spec_verification,
+)
+from ouroboros.mcp.server.spec_verification_adapter import (
     evaluation_summary_from_spec_verification as _evaluation_summary_from_spec_verification,
 )
 from ouroboros.mcp.types import (
@@ -1849,12 +1852,18 @@ def create_ouroboros_server(
     ) -> EvaluationSummary | None:
         """Run spec verification and override mechanical results if discrepancies found.
 
-        Returns a corrected EvaluationSummary if discrepancies are detected,
-        or None if no override is needed (verification passed or unavailable).
+        Returns a formal EvaluationSummary whenever Seed AC verification can
+        be evaluated. Missing project context, extraction failure, and empty
+        extraction are explicit rejected summaries rather than mechanical-pass
+        fallbacks.
         """
         project_dir = _extract_project_dir(artifact, seed=seed)
         if not project_dir:
-            return None
+            return _evaluation_summary_for_unavailable_spec_verification(
+                mechanical,
+                seed,
+                "Spec verification unavailable: project directory could not be resolved.",
+            )
 
         seed_acs = getattr(seed, "acceptance_criteria", None) or ()
         if not seed_acs:
@@ -1862,16 +1871,28 @@ def create_ouroboros_server(
 
         seed_id = getattr(getattr(seed, "metadata", None), "seed_id", None)
         if not seed_id:
-            return None
+            return _evaluation_summary_for_unavailable_spec_verification(
+                mechanical,
+                seed,
+                "Spec verification unavailable: Seed identifier is missing.",
+            )
 
         extract_result = await spec_extractor.extract(seed_id, ac_texts(seed_acs))
         if extract_result.is_err:
             log.warning("spec_verification.extraction_failed", error=str(extract_result.error))
-            return None
+            return _evaluation_summary_for_unavailable_spec_verification(
+                mechanical,
+                seed,
+                f"Spec assertion extraction failed: {extract_result.error}",
+            )
 
         assertions = extract_result.value
         if not assertions:
-            return None
+            return _evaluation_summary_for_unavailable_spec_verification(
+                mechanical,
+                seed,
+                "Spec assertion extraction produced no independently usable assertions.",
+            )
 
         agent_results = _agent_results_from_execution_summary(mechanical)
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -645,6 +645,7 @@ def _evaluation_summary_from_spec_verification(
 ) -> Any | None:
     """Promote complete verifier coverage into Seed-bound formal AC verdicts."""
     from ouroboros.core.lineage import ACResult, EvaluationSummary
+    from ouroboros.verification.models import VerificationOutcome
 
     reports = tuple(getattr(verification_summary, "reports", ()) or ())
     if not reports:
@@ -673,6 +674,7 @@ def _evaluation_summary_from_spec_verification(
     ac_results: list[ACResult] = []
     missing_indices: list[int] = []
     unverifiable_indices: list[int] = []
+    skipped_indices: list[int] = []
     for ac_index in result_indices:
         report = reports_by_index.get(ac_index)
         if report is None:
@@ -697,19 +699,42 @@ def _evaluation_summary_from_spec_verification(
 
         details = [result.detail for result in report.results if result.detail]
         evidence = "; ".join(details)
+        outcomes = {result.outcome for result in report.results}
         if not report.results:
             unverifiable_indices.append(ac_index)
             evidence = "No independently verifiable assertions; formal AC verdict not evaluated."
             passed = False
             verdict_state = "not_evaluated"
             rendered_verdict = "NOT_EVALUATED"
-        else:
-            passed = bool(report.verified_pass)
-            verifier_overrode_pass = bool(report.agent_reported_pass) and not passed
+        elif VerificationOutcome.DISCREPANCY in outcomes:
+            passed = False
+            verifier_overrode_pass = bool(report.agent_reported_pass)
             verdict_state = "overridden" if verifier_overrode_pass else "evaluated"
-            rendered_verdict = "PASS" if passed else "FAIL"
+            rendered_verdict = "FAIL"
+            if VerificationOutcome.UNVERIFIABLE in outcomes:
+                unverifiable_indices.append(ac_index)
+            if VerificationOutcome.SKIPPED in outcomes:
+                skipped_indices.append(ac_index)
+            if not evidence:
+                evidence = "Spec verifier found a discrepancy without evidence details."
+        elif outcomes == {VerificationOutcome.VERIFIED}:
+            passed = True
+            verdict_state = "evaluated"
+            rendered_verdict = "PASS"
             if not evidence:
                 evidence = "Spec verifier produced no evidence details."
+        else:
+            # Missing evidence is not a discrepancy, but this formal adapter is
+            # a strict gate: only an all-VERIFIED report may mint a PASS.
+            passed = False
+            verdict_state = "not_evaluated"
+            rendered_verdict = "NOT_EVALUATED"
+            if VerificationOutcome.UNVERIFIABLE in outcomes:
+                unverifiable_indices.append(ac_index)
+            if VerificationOutcome.SKIPPED in outcomes:
+                skipped_indices.append(ac_index)
+            if not evidence:
+                evidence = "Spec verification did not produce independently usable evidence."
 
         ac_results.append(
             ACResult(
@@ -735,8 +760,14 @@ def _evaluation_summary_from_spec_verification(
 
     failure_reason = None
     if not approved:
-        failed_indices = [result.ac_index + 1 for result in ac_results if result.unresolved]
-        discrepancy_count = getattr(verification_summary, "discrepancy_count", 0)
+        failed_indices = [
+            result.ac_index + 1 for result in ac_results if result.rendered_verdict == "FAIL"
+        ]
+        discrepancy_count = sum(
+            1
+            for report in reports
+            if getattr(report, "has_confirmed_discrepancy", report.has_discrepancy)
+        )
         reason_parts = []
         if failed_indices:
             reason_parts.append(
@@ -751,8 +782,13 @@ def _evaluation_summary_from_spec_verification(
             )
         if unverifiable_indices:
             reason_parts.append(
-                "no independently verifiable assertions for AC "
+                "unverifiable assertion evidence for AC "
                 + ", ".join(str(i + 1) for i in unverifiable_indices)
+            )
+        if skipped_indices:
+            reason_parts.append(
+                "source verification skipped for AC "
+                + ", ".join(str(i + 1) for i in skipped_indices)
             )
         if not execution_completed:
             reason_parts.append(
@@ -2024,13 +2060,18 @@ def create_ouroboros_server(
 
         agent_results = _agent_results_from_execution_summary(mechanical)
 
-        verifier = SpecVerifier(project_dir=project_dir)
+        # The evolutionary self-improvement loop is an evidence gate, not an
+        # exploratory report: unavailable/skipped outcomes must block approval.
+        verifier = SpecVerifier(project_dir=project_dir, strict=True)
         summary = verifier.verify_all(assertions, agent_results)
 
-        if summary.has_discrepancies:
+        if summary.has_confirmed_discrepancies:
+            override_count = sum(
+                1 for report in summary.reports if report.has_confirmed_discrepancy
+            )
             log.warning(
                 "spec_verification.discrepancies_found",
-                count=summary.discrepancy_count,
+                count=override_count,
                 project_dir=project_dir,
             )
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -567,17 +567,36 @@ def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None
     from ouroboros.core.lineage import EvaluationSummary, TaskResult
 
     task_line_matches = re.findall(
-        r"### (?:Task|AC) (\d+): \[(COMPLETED|FAILED|PASS|FAIL)\]\s*(.*)", artifact
+        r"### (?:Task|AC) (-?\d+): \[(COMPLETED|FAILED|PASS|FAIL)\]\s*(.*)", artifact
     )
     if not task_line_matches:
         return None
 
     seed_acs = getattr(seed, "acceptance_criteria", None) or ()
     feedback_metadata = _extract_feedback_metadata_from_artifact(artifact)
+    task_numbers = [int(task_number) for task_number, _, _ in task_line_matches]
+    invalid_task_numbers = sorted({number for number in task_numbers if number < 1})
+    if invalid_task_numbers:
+        rendered_numbers = ", ".join(str(number) for number in invalid_task_numbers)
+        return EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            score=0.0,
+            drift_score=None,
+            failure_reason=(
+                f"invalid one-based task number(s): {rendered_numbers}; "
+                "formal AC evaluation not run"
+            ),
+            ac_results=(),
+            task_results=(),
+            feedback_metadata=feedback_metadata,
+            execution_completion_status="failed",
+            approval_status="not_evaluated",
+        )
 
     task_results: list[TaskResult] = []
-    for ac_num_str, status, description in task_line_matches:
-        task_idx = int(ac_num_str) - 1
+    for task_number, (_, status, description) in zip(task_numbers, task_line_matches, strict=True):
+        task_idx = task_number - 1
         task_content = (
             ac_text(seed_acs[task_idx]) if task_idx < len(seed_acs) else description.strip()
         )

--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -1,0 +1,198 @@
+"""Project spec-verification results into formal evaluation summaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
+    """Return legacy agent-reported AC outcomes for spec verification.
+
+    Formal ``ACResult`` values take precedence when present. For legacy
+    execution-only summaries, preserve the worker task completion signal via
+    ``source_ac_index`` so skipped or unverifiable assertions cannot convert a
+    worker-reported failure into formal approval.
+    """
+    agent_results = {ac.ac_index: ac.authoritative_pass for ac in mechanical.ac_results}
+    for task in mechanical.task_results:
+        source_ac_index = task.source_ac_index
+        if source_ac_index is None:
+            source_ac_index = task.task_index
+        agent_results.setdefault(source_ac_index, task.completed)
+    return agent_results
+
+
+def evaluation_summary_from_spec_verification(
+    mechanical: Any,
+    verification_summary: Any,
+    seed: Any | None = None,
+) -> Any | None:
+    """Promote complete verifier coverage into Seed-bound formal AC verdicts."""
+    from ouroboros.core.lineage import ACResult, EvaluationSummary
+    from ouroboros.verification.models import VerificationOutcome
+
+    reports = tuple(getattr(verification_summary, "reports", ()) or ())
+    if not reports:
+        return None
+    seed_criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+
+    def semantic_key(ac_index: int) -> str | None:
+        if 0 <= ac_index < len(seed_criteria):
+            return getattr(seed_criteria[ac_index], "semantic_ac_key", None)
+        return None
+
+    expected_ac_content: dict[int, str] = {
+        ac.ac_index: ac.ac_content for ac in mechanical.ac_results
+    }
+    expected_agent_results = agent_results_from_execution_summary(mechanical)
+    for task in mechanical.task_results:
+        source_ac_index = task.source_ac_index
+        if source_ac_index is None:
+            source_ac_index = task.task_index
+        expected_ac_content.setdefault(source_ac_index, task.task_content)
+
+    reports_by_index = {report.ac_index: report for report in reports}
+    expected_indices = set(expected_ac_content) | set(expected_agent_results)
+    result_indices = sorted(expected_indices | set(reports_by_index))
+
+    ac_results: list[ACResult] = []
+    missing_indices: list[int] = []
+    unverifiable_indices: list[int] = []
+    skipped_indices: list[int] = []
+    for ac_index in result_indices:
+        report = reports_by_index.get(ac_index)
+        if report is None:
+            missing_indices.append(ac_index)
+            ac_results.append(
+                ACResult(
+                    ac_index=ac_index,
+                    ac_content=expected_ac_content.get(
+                        ac_index, f"Acceptance criterion {ac_index + 1}"
+                    ),
+                    semantic_ac_key=semantic_key(ac_index),
+                    passed=False,
+                    score=0.0,
+                    evidence="No spec verification report was produced for this AC.",
+                    verification_method="spec_verifier",
+                    ac_verdict_state="not_evaluated",
+                    final_verdict="fail",
+                    rendered_verdict="NOT_EVALUATED",
+                )
+            )
+            continue
+
+        details = [result.detail for result in report.results if result.detail]
+        evidence = "; ".join(details)
+        outcomes = {result.outcome for result in report.results}
+        if not report.results:
+            unverifiable_indices.append(ac_index)
+            evidence = "No independently verifiable assertions; formal AC verdict not evaluated."
+            passed = False
+            verdict_state = "not_evaluated"
+            rendered_verdict = "NOT_EVALUATED"
+        elif VerificationOutcome.DISCREPANCY in outcomes:
+            passed = False
+            verifier_overrode_pass = bool(report.agent_reported_pass)
+            verdict_state = "overridden" if verifier_overrode_pass else "evaluated"
+            rendered_verdict = "FAIL"
+            if VerificationOutcome.UNVERIFIABLE in outcomes:
+                unverifiable_indices.append(ac_index)
+            if VerificationOutcome.SKIPPED in outcomes:
+                skipped_indices.append(ac_index)
+            if not evidence:
+                evidence = "Spec verifier found a discrepancy without evidence details."
+        elif outcomes == {VerificationOutcome.VERIFIED}:
+            passed = True
+            verdict_state = "evaluated"
+            rendered_verdict = "PASS"
+            if not evidence:
+                evidence = "Spec verifier produced no evidence details."
+        else:
+            # Missing evidence is not a discrepancy, but this formal adapter is
+            # a strict gate: only an all-VERIFIED report may mint a PASS.
+            passed = False
+            verdict_state = "not_evaluated"
+            rendered_verdict = "NOT_EVALUATED"
+            if VerificationOutcome.UNVERIFIABLE in outcomes:
+                unverifiable_indices.append(ac_index)
+            if VerificationOutcome.SKIPPED in outcomes:
+                skipped_indices.append(ac_index)
+            if not evidence:
+                evidence = "Spec verification did not produce independently usable evidence."
+
+        ac_results.append(
+            ACResult(
+                ac_index=report.ac_index,
+                ac_content=report.ac_text,
+                semantic_ac_key=semantic_key(report.ac_index),
+                passed=passed,
+                score=1.0 if passed else 0.0,
+                evidence=evidence,
+                verification_method="spec_verifier",
+                ac_verdict_state=verdict_state,
+                final_verdict="pass" if passed else "fail",
+                rendered_verdict=rendered_verdict,
+            )
+        )
+
+    total = len(ac_results)
+    passed_count = sum(1 for result in ac_results if result.authoritative_pass)
+    score = passed_count / total if total > 0 else 0.0
+    complete_coverage = bool(expected_indices) and expected_indices.issubset(reports_by_index)
+    execution_completed = mechanical.execution_completion_status == "completed"
+    approved = complete_coverage and passed_count == total and total > 0 and execution_completed
+
+    failure_reason = None
+    if not approved:
+        failed_indices = [
+            result.ac_index + 1 for result in ac_results if result.rendered_verdict == "FAIL"
+        ]
+        discrepancy_count = sum(
+            1
+            for report in reports
+            if getattr(report, "has_confirmed_discrepancy", report.has_discrepancy)
+        )
+        reason_parts = []
+        if failed_indices:
+            reason_parts.append(
+                f"{len(failed_indices)}/{total} ACs failed "
+                f"(AC {', '.join(str(i) for i in failed_indices)})"
+            )
+        if discrepancy_count:
+            reason_parts.append(f"{discrepancy_count} spec verification override(s)")
+        if missing_indices:
+            reason_parts.append(
+                "missing verifier report for AC " + ", ".join(str(i + 1) for i in missing_indices)
+            )
+        if unverifiable_indices:
+            reason_parts.append(
+                "unverifiable assertion evidence for AC "
+                + ", ".join(str(i + 1) for i in unverifiable_indices)
+            )
+        if skipped_indices:
+            reason_parts.append(
+                "source verification skipped for AC "
+                + ", ".join(str(i + 1) for i in skipped_indices)
+            )
+        if not execution_completed:
+            reason_parts.append(
+                f"execution_completion_status={mechanical.execution_completion_status}"
+            )
+        if not reason_parts:
+            reason_parts.append("spec verification did not approve the run")
+        failure_reason = reason_parts[0]
+        if len(reason_parts) > 1:
+            failure_reason += f" [{'; '.join(reason_parts[1:])}]"
+
+    return EvaluationSummary(
+        final_approved=approved,
+        highest_stage_passed=3 if approved else 2,
+        score=score,
+        drift_score=None,
+        failure_reason=failure_reason,
+        ac_results=tuple(ac_results),
+        task_results=mechanical.task_results,
+        feedback_metadata=mechanical.feedback_metadata,
+        execution_completion_status=mechanical.execution_completion_status,
+        approval_status="approved" if approved else "rejected",
+    )

--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -2,7 +2,79 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeGuard
+
+
+def _valid_ac_index(value: Any) -> TypeGuard[int]:
+    """Whether an untrusted identity is a raw non-negative integer.
+
+    ``bool`` is an ``int`` subclass and equality-coincides with indices 0/1;
+    using exact type identity prevents model-construction bypasses from
+    laundering booleans or coercible strings/floats into AC authority.
+    """
+    return type(value) is int and value >= 0
+
+
+def _report_identity_error(
+    reports: tuple[Any, ...],
+    seed_criteria: tuple[Any, ...],
+) -> str | None:
+    """Return why verifier reports cannot carry Seed-bound authority.
+
+    Pydantic models validate ordinary construction and replay, but this adapter
+    is a public authority boundary and also receives compatibility objects in
+    tests and integrations. Revalidate identity here before any report is
+    indexed: a dictionary projection must never turn ordering into authority.
+    """
+    from ouroboros.core.seed import AcceptanceCriterionSpec
+
+    seen_indices: set[int] = set()
+    for position, report in enumerate(reports):
+        ac_index = getattr(report, "ac_index", None)
+        if not _valid_ac_index(ac_index):
+            return f"report {position + 1} has invalid ac_index={ac_index!r}"
+        if ac_index in seen_indices:
+            return f"duplicate report ac_index={ac_index}"
+        seen_indices.add(ac_index)
+
+        report_text = getattr(report, "ac_text", None)
+        if not isinstance(report_text, str):
+            return f"report AC {ac_index + 1} has invalid ac_text"
+        if seed_criteria:
+            if ac_index >= len(seed_criteria):
+                return f"report ac_index={ac_index} is outside Seed AC coverage"
+            criterion = seed_criteria[ac_index]
+            expected_text: str | None = None
+            if isinstance(criterion, str):
+                expected_text = criterion
+            elif isinstance(criterion, AcceptanceCriterionSpec):
+                expected_text = criterion.description
+            if expected_text is not None and report_text != expected_text:
+                return f"report AC {ac_index + 1} text does not match the authoritative Seed AC"
+
+        results = getattr(report, "results", ())
+        if not isinstance(results, tuple | list):
+            return f"report AC {ac_index + 1} has invalid results"
+        for result_position, result in enumerate(results):
+            assertion = getattr(result, "assertion", None)
+            assertion_index = getattr(assertion, "ac_index", None)
+            assertion_text = getattr(assertion, "ac_text", None)
+            if not _valid_ac_index(assertion_index):
+                return (
+                    f"report AC {ac_index + 1} result {result_position + 1} "
+                    f"has invalid assertion ac_index={assertion_index!r}"
+                )
+            if assertion_index != ac_index:
+                return (
+                    f"report AC {ac_index + 1} result {result_position + 1} "
+                    f"has assertion ac_index={assertion_index!r}"
+                )
+            if assertion_text != report_text:
+                return (
+                    f"report AC {ac_index + 1} result {result_position + 1} "
+                    "assertion text does not match its parent report"
+                )
+    return None
 
 
 def agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
@@ -36,6 +108,13 @@ def evaluation_summary_from_spec_verification(
     if not reports:
         return None
     seed_criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+    identity_error = _report_identity_error(reports, seed_criteria)
+    if identity_error is not None:
+        return evaluation_summary_for_unavailable_spec_verification(
+            mechanical,
+            seed,
+            f"Spec verification report identity invalid: {identity_error}",
+        )
 
     def semantic_key(ac_index: int) -> str | None:
         if 0 <= ac_index < len(seed_criteria):

--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -196,3 +196,58 @@ def evaluation_summary_from_spec_verification(
         execution_completion_status=mechanical.execution_completion_status,
         approval_status="approved" if approved else "rejected",
     )
+
+
+def evaluation_summary_for_unavailable_spec_verification(
+    mechanical: Any,
+    seed: Any,
+    reason: str,
+) -> Any:
+    """Reject a mechanically completed run when formal evidence is unavailable."""
+    from ouroboros.core.lineage import ACResult, EvaluationSummary
+    from ouroboros.core.seed import ac_texts
+
+    seed_criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+    seed_texts = ac_texts(seed_criteria)
+    expected_content = dict(enumerate(seed_texts))
+    for ac in mechanical.ac_results:
+        expected_content.setdefault(ac.ac_index, ac.ac_content)
+    for task in mechanical.task_results:
+        source_ac_index = task.source_ac_index
+        if source_ac_index is None:
+            source_ac_index = task.task_index
+        expected_content.setdefault(source_ac_index, task.task_content)
+
+    def semantic_key(ac_index: int) -> str | None:
+        if 0 <= ac_index < len(seed_criteria):
+            return getattr(seed_criteria[ac_index], "semantic_ac_key", None)
+        return None
+
+    ac_results = tuple(
+        ACResult(
+            ac_index=ac_index,
+            ac_content=ac_content,
+            semantic_ac_key=semantic_key(ac_index),
+            passed=False,
+            score=0.0,
+            evidence=reason,
+            verification_method="spec_verifier",
+            ac_verdict_state="not_evaluated",
+            final_verdict="fail",
+            rendered_verdict="NOT_EVALUATED",
+        )
+        for ac_index, ac_content in sorted(expected_content.items())
+    )
+
+    return EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=2 if mechanical.execution_completion_status == "completed" else 1,
+        score=0.0,
+        drift_score=None,
+        failure_reason=reason,
+        ac_results=ac_results,
+        task_results=mechanical.task_results,
+        feedback_metadata=mechanical.feedback_metadata,
+        execution_completion_status=mechanical.execution_completion_status,
+        approval_status="rejected",
+    )

--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -29,6 +29,7 @@ def evaluation_summary_from_spec_verification(
 ) -> Any | None:
     """Promote complete verifier coverage into Seed-bound formal AC verdicts."""
     from ouroboros.core.lineage import ACResult, EvaluationSummary
+    from ouroboros.core.seed import ac_texts
     from ouroboros.verification.models import VerificationOutcome
 
     reports = tuple(getattr(verification_summary, "reports", ()) or ())
@@ -41,9 +42,12 @@ def evaluation_summary_from_spec_verification(
             return getattr(seed_criteria[ac_index], "semantic_ac_key", None)
         return None
 
-    expected_ac_content: dict[int, str] = {
-        ac.ac_index: ac.ac_content for ac in mechanical.ac_results
-    }
+    # Seed criteria are the authority boundary. Mechanical execution records
+    # and verifier reports may add diagnostic indices, but they cannot narrow
+    # the set of ACs that must be independently verified before PASS.
+    expected_ac_content: dict[int, str] = dict(enumerate(ac_texts(seed_criteria)))
+    for ac in mechanical.ac_results:
+        expected_ac_content.setdefault(ac.ac_index, ac.ac_content)
     expected_agent_results = agent_results_from_execution_summary(mechanical)
     for task in mechanical.task_results:
         source_ac_index = task.source_ac_index

--- a/src/ouroboros/verification/__init__.py
+++ b/src/ouroboros/verification/__init__.py
@@ -5,6 +5,7 @@ from ouroboros.verification.models import (
     SpecAssertion,
     SpecVerificationResult,
     SpecVerificationSummary,
+    VerificationOutcome,
     VerificationTier,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "SpecAssertion",
     "SpecVerificationResult",
     "SpecVerificationSummary",
+    "VerificationOutcome",
     "VerificationTier",
 ]

--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -145,7 +145,9 @@ class AssertionExtractor:
             # of the seed. The transport-failure path above already retries;
             # this one now does too.
             logger.warning("AssertionExtractor response unreadable, not caching: %s", seed_id)
-            return Result.err("Extraction response was unreadable or all assertions were rejected")
+            return Result.err(
+                "Extraction response was unreadable or contained a rejected assertion"
+            )
 
         self._cache[seed_id] = assertions
         # LRU eviction: remove oldest entry if cache exceeds max size
@@ -162,9 +164,9 @@ class AssertionExtractor:
 
         Returns ``None`` when the response could not be read as an extraction:
         no JSON payload, malformed JSON, a payload that is not the expected
-        array, or an array that offered assertions and had every one of them
-        rejected. In none of those cases did the model answer in the schema
-        this asks for.
+        array, or an array containing any rejected assertion. Extraction is
+        atomic: accepting only the valid subset would erase offered evidence
+        and could let the surviving subset manufacture a formal PASS.
 
         An empty tuple means the opposite — the array was read and was empty,
         the model saying there is nothing here to verify. That is an answer,
@@ -182,12 +184,15 @@ class AssertionExtractor:
                 return None
 
             assertions: list[SpecAssertion] = []
+            response_rejected = False
             for item in data:
                 if not isinstance(item, dict):
                     logger.warning("Expected assertion object, got: %s", type(item))
+                    response_rejected = True
                     continue
                 if "ac_index" not in item:
                     logger.warning("Ignoring assertion without explicit ac_index: %r", item)
+                    response_rejected = True
                     continue
                 ac_idx = item["ac_index"]
                 if (
@@ -197,16 +202,19 @@ class AssertionExtractor:
                     or ac_idx >= len(acceptance_criteria)
                 ):
                     logger.warning("Ignoring assertion with invalid ac_index: %r", ac_idx)
+                    response_rejected = True
                     continue
                 ac_text = acceptance_criteria[ac_idx]
                 if "tier" not in item:
                     logger.warning("Ignoring assertion without explicit tier: %r", item)
+                    response_rejected = True
                     continue
                 raw_tier = item["tier"]
                 try:
                     tier = VerificationTier(raw_tier)
                 except (TypeError, ValueError):
                     logger.warning("Ignoring assertion with invalid tier: %r", raw_tier)
+                    response_rejected = True
                     continue
                 text_fields = {
                     name: item.get(name, "")
@@ -214,6 +222,7 @@ class AssertionExtractor:
                 }
                 if not all(isinstance(value, str) for value in text_fields.values()):
                     logger.warning("Ignoring assertion with invalid text fields: %r", item)
+                    response_rejected = True
                     continue
                 if (
                     tier
@@ -228,6 +237,7 @@ class AssertionExtractor:
                         tier.value,
                         item,
                     )
+                    response_rejected = True
                     continue
                 if tier in (
                     VerificationTier.T1_CONSTANT,
@@ -238,6 +248,7 @@ class AssertionExtractor:
                         tier.value,
                         item,
                     )
+                    response_rejected = True
                     continue
                 if (
                     tier is VerificationTier.T1_CONSTANT
@@ -247,6 +258,7 @@ class AssertionExtractor:
                         "Ignoring t1_constant assertion without expected_value: %r",
                         item,
                     )
+                    response_rejected = True
                     continue
 
                 try:
@@ -263,14 +275,15 @@ class AssertionExtractor:
                     )
                 except ValidationError as e:
                     logger.warning("Ignoring invalid assertion object: %s", e)
+                    response_rejected = True
                     continue
 
-            if data and not assertions:
-                # The model offered assertions and every one was thrown out, so
-                # nothing it said arrived in the schema this asks for. Read as
-                # "nothing to verify" that would be indistinguishable from a
-                # criterion set with nothing mechanical in it.
-                logger.warning("Every assertion in the extraction response was rejected")
+            if response_rejected:
+                # The model offered evidence that did not survive validation.
+                # Returning the surviving subset would make that loss invisible
+                # to coverage checks, especially when both entries belong to
+                # the same AC. Keep the whole response retryable instead.
+                logger.warning("Extraction response contained a rejected assertion")
                 return None
 
             return tuple(assertions)

--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -145,7 +145,7 @@ class AssertionExtractor:
             # of the seed. The transport-failure path above already retries;
             # this one now does too.
             logger.warning("AssertionExtractor response unreadable, not caching: %s", seed_id)
-            return Result.ok(())
+            return Result.err("Extraction response was unreadable or all assertions were rejected")
 
         self._cache[seed_id] = assertions
         # LRU eviction: remove oldest entry if cache exceeds max size

--- a/src/ouroboros/verification/models.py
+++ b/src/ouroboros/verification/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class VerificationTier(StrEnum):
@@ -21,6 +21,21 @@ class VerificationTier(StrEnum):
     T2_STRUCTURAL = "t2_structural"
     T3_BEHAVIORAL = "t3_behavioral"
     T4_UNVERIFIABLE = "t4_unverifiable"
+
+
+class VerificationOutcome(StrEnum):
+    """What independent verification actually established.
+
+    ``UNVERIFIABLE`` means the verifier had no usable evidence surface (for
+    example, no candidate files or no usable pattern). ``SKIPPED`` means the
+    assertion belongs to a tier this source scanner deliberately does not run.
+    Neither outcome is a successful verification.
+    """
+
+    VERIFIED = "verified"
+    DISCREPANCY = "discrepancy"
+    UNVERIFIABLE = "unverifiable"
+    SKIPPED = "skipped"
 
 
 class SpecAssertion(BaseModel, frozen=True):
@@ -40,14 +55,44 @@ class SpecAssertion(BaseModel, frozen=True):
 
 
 class SpecVerificationResult(BaseModel, frozen=True):
-    """Result of verifying a single assertion against source code."""
+    """Result of verifying a single assertion against source code.
+
+    ``verified`` and ``discrepancy`` remain serialized fields so existing
+    callers and persisted payloads keep working. New code should use
+    ``outcome``; when loading a legacy payload without it, the outcome is
+    inferred from the old booleans. When an outcome is supplied explicitly it
+    is authoritative and contradictory legacy booleans are rejected.
+    """
 
     assertion: SpecAssertion
-    verified: bool
+    outcome: VerificationOutcome = VerificationOutcome.DISCREPANCY
+    verified: bool = False
     actual_value: str = ""
     file_path: str = ""
     discrepancy: bool = False
     detail: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_legacy_booleans(self) -> SpecVerificationResult:
+        fields_set = self.model_fields_set
+        if "outcome" not in fields_set:
+            # Every legacy ``verified=False`` result represented a failed
+            # comparison; unavailable/skipped were not expressible at all.
+            inferred = (
+                VerificationOutcome.VERIFIED if self.verified else VerificationOutcome.DISCREPANCY
+            )
+            object.__setattr__(self, "outcome", inferred)
+            return self
+
+        expected_verified = self.outcome is VerificationOutcome.VERIFIED
+        expected_discrepancy = self.outcome is VerificationOutcome.DISCREPANCY
+        if "verified" in fields_set and self.verified is not expected_verified:
+            raise ValueError("verified contradicts verification outcome")
+        if "discrepancy" in fields_set and self.discrepancy is not expected_discrepancy:
+            raise ValueError("discrepancy contradicts verification outcome")
+        object.__setattr__(self, "verified", expected_verified)
+        object.__setattr__(self, "discrepancy", expected_discrepancy)
+        return self
 
 
 class ACVerificationReport(BaseModel, frozen=True):
@@ -67,12 +112,34 @@ class ACVerificationReport(BaseModel, frozen=True):
         """True if all assertions verified successfully."""
         if not self.results:
             return self.agent_reported_pass
-        return all(r.verified for r in self.results)
+        return all(r.outcome is VerificationOutcome.VERIFIED for r in self.results)
 
     @property
     def has_discrepancy(self) -> bool:
-        """True if agent reported PASS but verification found FAIL."""
+        """Legacy signal that an agent PASS was not independently verified.
+
+        This intentionally retains the pre-outcome API semantics. Use
+        ``has_confirmed_discrepancy`` when missing evidence must stay distinct
+        from evidence that contradicts the assertion.
+        """
         return self.agent_reported_pass and not self.verified_pass
+
+    @property
+    def has_confirmed_discrepancy(self) -> bool:
+        """True if usable evidence contradicted an agent-reported PASS."""
+        return self.agent_reported_pass and any(
+            result.outcome is VerificationOutcome.DISCREPANCY for result in self.results
+        )
+
+    @property
+    def has_unverifiable(self) -> bool:
+        """True if any assertion lacked a usable independent evidence surface."""
+        return any(result.outcome is VerificationOutcome.UNVERIFIABLE for result in self.results)
+
+    @property
+    def has_skipped(self) -> bool:
+        """True if any assertion was deliberately outside this verifier's tiers."""
+        return any(result.outcome is VerificationOutcome.SKIPPED for result in self.results)
 
 
 class SpecVerificationSummary(BaseModel, frozen=True):
@@ -83,13 +150,49 @@ class SpecVerificationSummary(BaseModel, frozen=True):
     total_assertions: int = 0
     verified_count: int = 0
     failed_count: int = 0
+    unverifiable_count: int = 0
     skipped_count: int = 0
     discrepancy_count: int = 0
+    confirmed_discrepancy_count: int = 0
+    strict: bool = True
+
+    @model_validator(mode="after")
+    def _preserve_legacy_discrepancy_override(self) -> SpecVerificationSummary:
+        if "confirmed_discrepancy_count" not in self.model_fields_set and self.discrepancy_count:
+            # Old serialized summaries could not distinguish a confirmed
+            # mismatch from unavailable evidence. Preserve their fail-closed
+            # override rather than silently weakening a replayed gate.
+            object.__setattr__(
+                self,
+                "confirmed_discrepancy_count",
+                self.discrepancy_count,
+            )
+        return self
 
     @property
     def has_discrepancies(self) -> bool:
-        """True if any AC has a discrepancy (agent lied)."""
+        """Legacy signal that one or more claimed passes were not verified."""
         return self.discrepancy_count > 0
+
+    @property
+    def has_confirmed_discrepancies(self) -> bool:
+        """True if usable evidence contradicted one or more claimed passes."""
+        return self.confirmed_discrepancy_count > 0
+
+    @property
+    def has_unverifiable(self) -> bool:
+        """True if verification could not run for one or more assertions."""
+        return self.unverifiable_count > 0
+
+    @property
+    def has_skipped(self) -> bool:
+        """True if one or more assertions were outside the scanner's tiers."""
+        return self.skipped_count > 0
+
+    @property
+    def has_incomplete_verification(self) -> bool:
+        """True if any assertion lacks a genuine VERIFIED outcome."""
+        return self.has_unverifiable or self.has_skipped
 
     @property
     def override_approval(self) -> bool | None:
@@ -97,7 +200,7 @@ class SpecVerificationSummary(BaseModel, frozen=True):
 
         Returns False if discrepancies found, None if no override needed.
         """
-        if self.has_discrepancies:
+        if self.has_confirmed_discrepancies or (self.strict and self.has_incomplete_verification):
             return False
         return None
 
@@ -105,20 +208,45 @@ class SpecVerificationSummary(BaseModel, frozen=True):
     def from_reports(
         reports: tuple[ACVerificationReport, ...],
         project_dir: str = "",
+        *,
+        strict: bool = True,
     ) -> SpecVerificationSummary:
         """Build summary from individual AC reports."""
         total = sum(len(r.results) for r in reports)
-        verified = sum(sum(1 for v in r.results if v.verified) for r in reports)
-        failed = sum(sum(1 for v in r.results if not v.verified) for r in reports)
-        skipped = sum(1 for r in reports if not r.results)
+        verified = sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.VERIFIED)
+            for report in reports
+        )
+        confirmed_discrepancies = sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.DISCREPANCY)
+            for report in reports
+        )
+        unverifiable = sum(
+            sum(
+                1 for result in report.results if result.outcome is VerificationOutcome.UNVERIFIABLE
+            )
+            for report in reports
+        )
+        # ``failed_count`` historically counted every explicit non-pass. Keep
+        # that contract for readers of persisted summaries while the outcome
+        # counters above expose why verification did not pass.
+        failed = confirmed_discrepancies + unverifiable
+        # Preserve the legacy meaning for manually built empty reports while
+        # also counting the now-visible T3/T4 assertion results.
+        skipped = sum(1 for report in reports if not report.results) + sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.SKIPPED)
+            for report in reports
+        )
         discrepancies = sum(1 for r in reports if r.has_discrepancy)
-
         return SpecVerificationSummary(
             reports=reports,
             project_dir=project_dir,
             total_assertions=total,
             verified_count=verified,
             failed_count=failed,
+            unverifiable_count=unverifiable,
             skipped_count=skipped,
             discrepancy_count=discrepancies,
+            confirmed_discrepancy_count=confirmed_discrepancies,
+            strict=strict,
         )

--- a/src/ouroboros/verification/models.py
+++ b/src/ouroboros/verification/models.py
@@ -171,33 +171,59 @@ class SpecVerificationSummary(BaseModel, frozen=True):
     strict: bool = True
 
     @model_validator(mode="after")
-    def _preserve_legacy_discrepancy_override(self) -> SpecVerificationSummary:
-        if "confirmed_discrepancy_count" not in self.model_fields_set and self.discrepancy_count:
-            has_outcome_aware_result = any(
-                "outcome" in result.model_fields_set
-                for report in self.reports
-                for result in report.results
-            )
-            # Old serialized summaries could not distinguish a confirmed
-            # mismatch from unavailable evidence. Preserve their fail-closed
-            # override, but do not reinterpret a compact outcome-aware payload
-            # whose explicit UNVERIFIABLE/SKIPPED result proves the zero was
-            # omitted only because it equals the Pydantic default.
+    def _canonicalize_derived_counts(self) -> SpecVerificationSummary:
+        if self.reports:
+            # Reports contain canonicalized result outcomes, including when
+            # their source payload used only legacy booleans. Every persisted
+            # count is derived compatibility data once reports exist, so never
+            # let contradictory counters suppress or manufacture authority.
+            counts = self._counts_from_reports(self.reports)
+            for field_name, value in counts.items():
+                object.__setattr__(self, field_name, value)
+        elif "confirmed_discrepancy_count" not in self.model_fields_set and self.discrepancy_count:
+            # Report-less legacy summaries have no stronger evidence surface.
+            # Preserve their historical fail-closed discrepancy override.
             object.__setattr__(
                 self,
                 "confirmed_discrepancy_count",
-                (
-                    sum(
-                        1
-                        for report in self.reports
-                        for result in report.results
-                        if result.outcome is VerificationOutcome.DISCREPANCY
-                    )
-                    if has_outcome_aware_result
-                    else self.discrepancy_count
-                ),
+                self.discrepancy_count,
             )
         return self
+
+    @staticmethod
+    def _counts_from_reports(
+        reports: tuple[ACVerificationReport, ...],
+    ) -> dict[str, int]:
+        total = sum(len(report.results) for report in reports)
+        verified = sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.VERIFIED)
+            for report in reports
+        )
+        confirmed_discrepancies = sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.DISCREPANCY)
+            for report in reports
+        )
+        unverifiable = sum(
+            sum(
+                1 for result in report.results if result.outcome is VerificationOutcome.UNVERIFIABLE
+            )
+            for report in reports
+        )
+        failed = confirmed_discrepancies + unverifiable
+        skipped = sum(1 for report in reports if not report.results) + sum(
+            sum(1 for result in report.results if result.outcome is VerificationOutcome.SKIPPED)
+            for report in reports
+        )
+        discrepancies = sum(1 for report in reports if report.has_discrepancy)
+        return {
+            "total_assertions": total,
+            "verified_count": verified,
+            "failed_count": failed,
+            "unverifiable_count": unverifiable,
+            "skipped_count": skipped,
+            "discrepancy_count": discrepancies,
+            "confirmed_discrepancy_count": confirmed_discrepancies,
+        }
 
     @property
     def has_discrepancies(self) -> bool:
@@ -242,41 +268,10 @@ class SpecVerificationSummary(BaseModel, frozen=True):
         strict: bool = True,
     ) -> SpecVerificationSummary:
         """Build summary from individual AC reports."""
-        total = sum(len(r.results) for r in reports)
-        verified = sum(
-            sum(1 for result in report.results if result.outcome is VerificationOutcome.VERIFIED)
-            for report in reports
-        )
-        confirmed_discrepancies = sum(
-            sum(1 for result in report.results if result.outcome is VerificationOutcome.DISCREPANCY)
-            for report in reports
-        )
-        unverifiable = sum(
-            sum(
-                1 for result in report.results if result.outcome is VerificationOutcome.UNVERIFIABLE
-            )
-            for report in reports
-        )
-        # ``failed_count`` historically counted every explicit non-pass. Keep
-        # that contract for readers of persisted summaries while the outcome
-        # counters above expose why verification did not pass.
-        failed = confirmed_discrepancies + unverifiable
-        # Preserve the legacy meaning for manually built empty reports while
-        # also counting the now-visible T3/T4 assertion results.
-        skipped = sum(1 for report in reports if not report.results) + sum(
-            sum(1 for result in report.results if result.outcome is VerificationOutcome.SKIPPED)
-            for report in reports
-        )
-        discrepancies = sum(1 for r in reports if r.has_discrepancy)
+        counts = SpecVerificationSummary._counts_from_reports(reports)
         return SpecVerificationSummary(
             reports=reports,
             project_dir=project_dir,
-            total_assertions=total,
-            verified_count=verified,
-            failed_count=failed,
-            unverifiable_count=unverifiable,
-            skipped_count=skipped,
-            discrepancy_count=discrepancies,
-            confirmed_discrepancy_count=confirmed_discrepancies,
             strict=strict,
+            **counts,
         )

--- a/src/ouroboros/verification/models.py
+++ b/src/ouroboros/verification/models.py
@@ -57,11 +57,11 @@ class SpecAssertion(BaseModel, frozen=True):
 class SpecVerificationResult(BaseModel, frozen=True):
     """Result of verifying a single assertion against source code.
 
-    ``verified`` and ``discrepancy`` remain serialized fields so existing
-    callers and persisted payloads keep working. New code should use
-    ``outcome``; when loading a legacy payload without it, the outcome is
-    inferred from the old booleans. When an outcome is supplied explicitly it
-    is authoritative and contradictory legacy booleans are rejected.
+    The boolean fields remain serialized so existing callers and persisted
+    payloads keep working. New code should use ``outcome``. Legacy payloads
+    without it are inferred fail-closed, then every boolean is normalized from
+    the canonical outcome. When an outcome is supplied explicitly it is always
+    authoritative, even if legacy booleans contradict it.
     """
 
     assertion: SpecAssertion
@@ -70,28 +70,37 @@ class SpecVerificationResult(BaseModel, frozen=True):
     actual_value: str = ""
     file_path: str = ""
     discrepancy: bool = False
+    unverifiable: bool = False
+    skipped: bool = False
     detail: str = ""
 
     @model_validator(mode="after")
     def _normalize_legacy_booleans(self) -> SpecVerificationResult:
         fields_set = self.model_fields_set
         if "outcome" not in fields_set:
-            # Every legacy ``verified=False`` result represented a failed
-            # comparison; unavailable/skipped were not expressible at all.
-            inferred = (
-                VerificationOutcome.VERIFIED if self.verified else VerificationOutcome.DISCREPANCY
-            )
+            # ``verified`` / ``discrepancy`` were the only historical flags.
+            # A false legacy result remains a discrepancy even when its old
+            # ``discrepancy`` bit was omitted or contradictory. The two newer
+            # flags let transitional callers construct the richer outcomes
+            # without supplying the enum yet.
+            if self.verified:
+                inferred = VerificationOutcome.VERIFIED
+            elif self.skipped:
+                inferred = VerificationOutcome.SKIPPED
+            elif self.unverifiable:
+                inferred = VerificationOutcome.UNVERIFIABLE
+            else:
+                inferred = VerificationOutcome.DISCREPANCY
             object.__setattr__(self, "outcome", inferred)
-            return self
 
         expected_verified = self.outcome is VerificationOutcome.VERIFIED
         expected_discrepancy = self.outcome is VerificationOutcome.DISCREPANCY
-        if "verified" in fields_set and self.verified is not expected_verified:
-            raise ValueError("verified contradicts verification outcome")
-        if "discrepancy" in fields_set and self.discrepancy is not expected_discrepancy:
-            raise ValueError("discrepancy contradicts verification outcome")
+        expected_unverifiable = self.outcome is VerificationOutcome.UNVERIFIABLE
+        expected_skipped = self.outcome is VerificationOutcome.SKIPPED
         object.__setattr__(self, "verified", expected_verified)
         object.__setattr__(self, "discrepancy", expected_discrepancy)
+        object.__setattr__(self, "unverifiable", expected_unverifiable)
+        object.__setattr__(self, "skipped", expected_skipped)
         return self
 
 

--- a/src/ouroboros/verification/models.py
+++ b/src/ouroboros/verification/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, StrictInt, model_validator
 
 
 class VerificationTier(StrEnum):
@@ -45,7 +45,7 @@ class SpecAssertion(BaseModel, frozen=True):
     that the verifier can check against actual source code.
     """
 
-    ac_index: int
+    ac_index: StrictInt = Field(ge=0)
     ac_text: str
     tier: VerificationTier
     pattern: str = ""
@@ -116,10 +116,22 @@ class ACVerificationReport(BaseModel, frozen=True):
     yields two T1 assertions). The AC passes only if ALL assertions pass.
     """
 
-    ac_index: int
+    ac_index: StrictInt = Field(ge=0)
     ac_text: str
     results: tuple[SpecVerificationResult, ...] = ()
     agent_reported_pass: bool = True
+
+    @model_validator(mode="after")
+    def _validate_assertion_identity(self) -> ACVerificationReport:
+        for position, result in enumerate(self.results):
+            assertion = result.assertion
+            if assertion.ac_index != self.ac_index:
+                raise ValueError(
+                    f"result {position + 1} assertion ac_index must match parent report"
+                )
+            if assertion.ac_text != self.ac_text:
+                raise ValueError(f"result {position + 1} assertion text must match parent report")
+        return self
 
     @property
     def verified_pass(self) -> bool:
@@ -173,6 +185,9 @@ class SpecVerificationSummary(BaseModel, frozen=True):
     @model_validator(mode="after")
     def _canonicalize_derived_counts(self) -> SpecVerificationSummary:
         if self.reports:
+            report_indices = [report.ac_index for report in self.reports]
+            if len(report_indices) != len(set(report_indices)):
+                raise ValueError("duplicate report ac_index values are not authoritative")
             # Reports contain canonicalized result outcomes, including when
             # their source payload used only legacy booleans. Every persisted
             # count is derived compatibility data once reports exist, so never

--- a/src/ouroboros/verification/models.py
+++ b/src/ouroboros/verification/models.py
@@ -83,12 +83,17 @@ class SpecVerificationResult(BaseModel, frozen=True):
             # ``discrepancy`` bit was omitted or contradictory. The two newer
             # flags let transitional callers construct the richer outcomes
             # without supplying the enum yet.
-            if self.verified:
-                inferred = VerificationOutcome.VERIFIED
-            elif self.skipped:
-                inferred = VerificationOutcome.SKIPPED
+            # Contradictory legacy flags are untrusted persisted input. Prefer
+            # the strongest non-success evidence instead of allowing a stale
+            # ``verified=True`` bit to launder it into a PASS.
+            if self.discrepancy:
+                inferred = VerificationOutcome.DISCREPANCY
             elif self.unverifiable:
                 inferred = VerificationOutcome.UNVERIFIABLE
+            elif self.skipped:
+                inferred = VerificationOutcome.SKIPPED
+            elif self.verified:
+                inferred = VerificationOutcome.VERIFIED
             else:
                 inferred = VerificationOutcome.DISCREPANCY
             object.__setattr__(self, "outcome", inferred)
@@ -168,13 +173,29 @@ class SpecVerificationSummary(BaseModel, frozen=True):
     @model_validator(mode="after")
     def _preserve_legacy_discrepancy_override(self) -> SpecVerificationSummary:
         if "confirmed_discrepancy_count" not in self.model_fields_set and self.discrepancy_count:
+            has_outcome_aware_result = any(
+                "outcome" in result.model_fields_set
+                for report in self.reports
+                for result in report.results
+            )
             # Old serialized summaries could not distinguish a confirmed
             # mismatch from unavailable evidence. Preserve their fail-closed
-            # override rather than silently weakening a replayed gate.
+            # override, but do not reinterpret a compact outcome-aware payload
+            # whose explicit UNVERIFIABLE/SKIPPED result proves the zero was
+            # omitted only because it equals the Pydantic default.
             object.__setattr__(
                 self,
                 "confirmed_discrepancy_count",
-                self.discrepancy_count,
+                (
+                    sum(
+                        1
+                        for report in self.reports
+                        for result in report.results
+                        if result.outcome is VerificationOutcome.DISCREPANCY
+                    )
+                    if has_outcome_aware_result
+                    else self.discrepancy_count
+                ),
             )
         return self
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -24,6 +24,7 @@ from ouroboros.verification.models import (
     SpecAssertion,
     SpecVerificationResult,
     SpecVerificationSummary,
+    VerificationOutcome,
     VerificationTier,
 )
 
@@ -722,10 +723,14 @@ class SpecVerifier:
     """Verifies spec assertions against actual project files.
 
     Reads source files and applies regex patterns to check whether
-    the expected values/structures actually exist in the codebase.
+    the expected values/structures actually exist in the codebase. Strict mode
+    is the safe default: unavailable and skipped evidence block an approval
+    override. Exploratory callers may set ``strict=False`` to observe those
+    outcomes without requesting an override; they still never become VERIFIED.
     """
 
     project_dir: str
+    strict: bool = True
 
     def verify_all(
         self,
@@ -742,7 +747,7 @@ class SpecVerifier:
             SpecVerificationSummary with all results.
         """
         if not assertions:
-            return SpecVerificationSummary(project_dir=self.project_dir)
+            return SpecVerificationSummary(project_dir=self.project_dir, strict=self.strict)
 
         agent_results = agent_results or {}
 
@@ -759,9 +764,7 @@ class SpecVerifier:
 
             results: list[SpecVerificationResult] = []
             for assertion in ac_assertions:
-                result = self._verify_one(assertion)
-                if result is not None:
-                    results.append(result)
+                results.append(self._verify_one(assertion))
 
             reports.append(
                 ACVerificationReport(
@@ -775,6 +778,7 @@ class SpecVerifier:
         return SpecVerificationSummary.from_reports(
             tuple(reports),
             project_dir=self.project_dir,
+            strict=self.strict,
         )
 
     def _compile_or_none(self, pattern: str, flags: int = 0) -> re.Pattern | None:
@@ -830,23 +834,28 @@ class SpecVerifier:
             return None
         return compiled
 
-    def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult | None:
-        """Verify a single assertion. Returns None for skipped tiers."""
+    def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult:
+        """Verify one assertion, including tiers this scanner deliberately skips."""
         if assertion.tier == VerificationTier.T1_CONSTANT:
             return self._verify_constant(assertion)
-        elif assertion.tier == VerificationTier.T2_STRUCTURAL:
+        if assertion.tier == VerificationTier.T2_STRUCTURAL:
             return self._verify_structural(assertion)
+        if assertion.tier == VerificationTier.T3_BEHAVIORAL:
+            detail = "Behavioral assertion requires test execution or semantic analysis"
         else:
-            # T3/T4: skip verification
-            return None
+            detail = "Subjective assertion is not independently verifiable by source scanning"
+        return SpecVerificationResult(
+            assertion=assertion,
+            outcome=VerificationOutcome.SKIPPED,
+            detail=detail,
+        )
 
     def _verify_constant(self, assertion: SpecAssertion) -> SpecVerificationResult:
         """Verify a T1 constant/config assertion by searching source files."""
         if not assertion.pattern:
             return SpecVerificationResult(
                 assertion=assertion,
-                verified=False,
-                discrepancy=True,
+                outcome=VerificationOutcome.UNVERIFIABLE,
                 detail="No pattern to verify",
             )
 
@@ -854,8 +863,7 @@ class SpecVerifier:
         if not files:
             return SpecVerificationResult(
                 assertion=assertion,
-                verified=False,
-                discrepancy=True,
+                outcome=VerificationOutcome.UNVERIFIABLE,
                 detail=f"No files matched hint: {assertion.file_hint}",
             )
 
@@ -865,15 +873,16 @@ class SpecVerifier:
         if pattern is None:
             return SpecVerificationResult(
                 assertion=assertion,
-                verified=False,
-                discrepancy=True,
+                outcome=VerificationOutcome.UNVERIFIABLE,
                 detail="Unusable regex pattern: invalid, too long, or able to match a file with no content",
             )
 
+        readable_files = 0
         for file_path in files:
             content = self._read_file(file_path)
             if content is None:
                 continue
+            readable_files += 1
 
             match = pattern.search(content)
             if match:
@@ -883,10 +892,13 @@ class SpecVerifier:
                     verified = assertion.expected_value.strip() == actual.strip()
                     return SpecVerificationResult(
                         assertion=assertion,
-                        verified=verified,
+                        outcome=(
+                            VerificationOutcome.VERIFIED
+                            if verified
+                            else VerificationOutcome.DISCREPANCY
+                        ),
                         actual_value=actual,
                         file_path=file_path,
-                        discrepancy=not verified,
                         detail=(
                             f"Expected '{assertion.expected_value}', "
                             f"found '{actual}' in {os.path.basename(file_path)}"
@@ -896,17 +908,23 @@ class SpecVerifier:
                     # Pattern found, no expected value to check
                     return SpecVerificationResult(
                         assertion=assertion,
-                        verified=True,
+                        outcome=VerificationOutcome.VERIFIED,
                         actual_value=actual,
                         file_path=file_path,
                         detail=f"Pattern found in {os.path.basename(file_path)}",
                     )
 
-        # Pattern not found in any file
+        if readable_files == 0:
+            return SpecVerificationResult(
+                assertion=assertion,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=f"Could not read any of {len(files)} matched files",
+            )
+
+        # A usable pattern did not match any readable candidate: a real discrepancy.
         return SpecVerificationResult(
             assertion=assertion,
-            verified=False,
-            discrepancy=True,
+            outcome=VerificationOutcome.DISCREPANCY,
             detail=f"Pattern '{assertion.pattern}' not found in {len(files)} files",
         )
 
@@ -915,8 +933,7 @@ class SpecVerifier:
         if not assertion.pattern:
             return SpecVerificationResult(
                 assertion=assertion,
-                verified=False,
-                discrepancy=True,
+                outcome=VerificationOutcome.UNVERIFIABLE,
                 detail="No pattern to verify",
             )
 
@@ -931,7 +948,7 @@ class SpecVerifier:
                 if name_pattern.search(basename):
                     return SpecVerificationResult(
                         assertion=assertion,
-                        verified=True,
+                        outcome=VerificationOutcome.VERIFIED,
                         file_path=file_path,
                         detail=f"Found file: {basename}",
                     )
@@ -943,27 +960,34 @@ class SpecVerifier:
         if content_pattern is None:
             return SpecVerificationResult(
                 assertion=assertion,
-                verified=False,
-                discrepancy=True,
+                outcome=VerificationOutcome.UNVERIFIABLE,
                 detail="Unusable regex pattern: invalid, too long, or able to match a file with no content",
             )
 
+        readable_files = 0
         for file_path in files:
             content = self._read_file(file_path)
             if content is None:
                 continue
+            readable_files += 1
             if content_pattern.search(content):
                 return SpecVerificationResult(
                     assertion=assertion,
-                    verified=True,
+                    outcome=VerificationOutcome.VERIFIED,
                     file_path=file_path,
                     detail=f"Pattern found in {os.path.basename(file_path)}",
                 )
 
+        if files and readable_files == 0:
+            return SpecVerificationResult(
+                assertion=assertion,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=f"Could not read any of {len(files)} matched files",
+            )
+
         return SpecVerificationResult(
             assertion=assertion,
-            verified=False,
-            discrepancy=True,
+            outcome=VerificationOutcome.DISCREPANCY,
             detail=f"Structure '{assertion.pattern}' not found in {len(files)} files",
         )
 

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -938,6 +938,12 @@ class SpecVerifier:
             )
 
         files = self._find_files(assertion.file_hint)
+        if not files:
+            return SpecVerificationResult(
+                assertion=assertion,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                detail=f"No files matched hint: {assertion.file_hint}",
+            )
 
         # First check: does the pattern match any filename?
         name_pattern = self._safe_compile(assertion.pattern, re.IGNORECASE)

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -55,6 +55,7 @@ from ouroboros.verification.models import (
     SpecAssertion,
     SpecVerificationResult,
     SpecVerificationSummary,
+    VerificationOutcome,
     VerificationTier,
 )
 from ouroboros.verification.verifier import SpecVerifier
@@ -477,8 +478,7 @@ Parallel Execution Verification Report
                     results=(
                         SpecVerificationResult(
                             assertion=assertion,
-                            verified=False,
-                            discrepancy=True,
+                            outcome=VerificationOutcome.UNVERIFIABLE,
                             detail="No files matched hint: *.rs",
                         ),
                     ),
@@ -493,9 +493,61 @@ Parallel Execution Verification Report
         assert summary is not None
         assert summary.final_approved is False
         assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].ac_verdict_state == "not_evaluated"
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
         assert summary.ac_results[0].evidence == "No files matched hint: *.rs"
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
+
+    def test_skipped_spec_verification_result_does_not_approve_run(self) -> None:
+        """A visible T3/T4 skip remains NOT_EVALUATED at the formal gate."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Interaction feels natural",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Interaction feels natural",
+            tier=VerificationTier.T4_UNVERIFIABLE,
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Interaction feels natural",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.SKIPPED,
+                            detail="Subjective assertion is not independently verifiable",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].ac_verdict_state == "not_evaluated"
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert "source verification skipped for AC 1" in (summary.failure_reason or "")
 
     def test_spec_verification_promotes_checked_reports_to_formal_ac_results(self) -> None:
         """Verifier-checked reports become formal AC verdicts without synthetic drift."""
@@ -1164,7 +1216,7 @@ Parallel Execution Verification Report
         assert summary.ac_results[0].ac_verdict_state == "not_evaluated"
         assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
         assert summary.approval_status == "rejected"
-        assert "no independently verifiable assertions for AC 1" in (summary.failure_reason or "")
+        assert "unverifiable assertion evidence for AC 1" in (summary.failure_reason or "")
         assert summary.run_verdict == "FAIL"
 
     def test_extract_feedback_metadata_from_artifact_parses_structured_warning(self) -> None:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -52,6 +52,7 @@ from ouroboros.mcp.types import (
 from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
 from ouroboros.persistence.event_store import EventStore
+from ouroboros.verification.extractor import AssertionExtractor
 from ouroboros.verification.models import (
     ACVerificationReport,
     SpecAssertion,
@@ -292,6 +293,24 @@ Parallel Execution Verification Report
         assert summary.drift_score is None
         assert summary.run_verdict == "FAIL"
 
+    def test_duplicate_task_indices_do_not_satisfy_seed_coverage(self) -> None:
+        """Repeated Task 1 records cannot stand in for a missing Seed AC."""
+        seed = SimpleNamespace(acceptance_criteria=("Create config", "Add docs"))
+        artifact = """
+### Task 1: [COMPLETED] Create config
+### Task 1: [COMPLETED] Duplicate worker record
+""".strip()
+
+        summary = _parse_legacy_execution_task_summary(artifact, seed)
+
+        assert summary is not None
+        assert [task.source_ac_index for task in summary.task_results] == [0, 0]
+        assert summary.score == 0.5
+        assert summary.execution_completion_status == "failed"
+        assert summary.approval_status == "not_evaluated"
+        assert summary.run_verdict == "FAIL"
+        assert "duplicate task indices" in (summary.failure_reason or "")
+
     def test_agent_results_preserve_failed_legacy_task_for_spec_verification(self) -> None:
         """Legacy task failures must remain visible to the verifier input map."""
         mechanical = EvaluationSummary(
@@ -494,6 +513,101 @@ Parallel Execution Verification Report
         assert "No spec verification report" in summary.ac_results[1].evidence
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
+
+    def test_seed_coverage_survives_partial_production_extraction(self, tmp_path: Any) -> None:
+        """Parser, extractor, verifier, and formal adapter fail closed together."""
+        seed = SimpleNamespace(
+            seed_id="seed-partial-coverage",
+            acceptance_criteria=("Create marker.txt", "Add docs.md"),
+        )
+        mechanical = _parse_legacy_execution_task_summary(
+            "### Task 1: [COMPLETED] first\n### Task 1: [COMPLETED] duplicate",
+            seed,
+        )
+        assert mechanical is not None
+
+        extractor = AssertionExtractor(llm_adapter=AsyncMock(), model="test-model")
+        assertions = extractor._parse_response(
+            json.dumps(
+                [
+                    {
+                        "ac_index": 0,
+                        "tier": "t2_structural",
+                        "pattern": "marker",
+                        "expected_value": "marker.txt",
+                        "file_hint": "marker.txt",
+                    }
+                ]
+            ),
+            seed.acceptance_criteria,
+        )
+        assert assertions is not None
+        (tmp_path / "marker.txt").write_text("marker\n")
+        verification = SpecVerifier(project_dir=str(tmp_path)).verify_all(
+            assertions,
+            agent_results=_agent_results_from_execution_summary(mechanical),
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert [result.ac_index for result in summary.ac_results] == [0, 1]
+        assert summary.ac_results[0].rendered_verdict == "PASS"
+        assert summary.ac_results[1].rendered_verdict == "NOT_EVALUATED"
+        assert summary.execution_completion_status == "failed"
+        assert summary.final_approved is False
+        assert summary.run_verdict == "FAIL"
+        assert "missing verifier report for AC 2" in (summary.failure_reason or "")
+
+    def test_seed_indices_are_required_even_when_mechanical_records_omit_them(self) -> None:
+        """A mechanically reported subset cannot narrow formal Seed authority."""
+        seed = SimpleNamespace(acceptance_criteria=("Create config", "Add docs"))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.VERIFIED,
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert [result.rendered_verdict for result in summary.ac_results] == [
+            "PASS",
+            "NOT_EVALUATED",
+        ]
+        assert summary.final_approved is False
+        assert summary.run_verdict == "FAIL"
+        assert "missing verifier report for AC 2" in (summary.failure_reason or "")
 
     def test_unavailable_spec_verification_result_does_not_approve_run(self) -> None:
         """Unavailable verifier evidence is a failed formal AC, not approval."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -311,6 +311,74 @@ Parallel Execution Verification Report
         assert summary.run_verdict == "FAIL"
         assert "duplicate task indices" in (summary.failure_reason or "")
 
+    def test_task_zero_is_rejected_before_formal_spec_projection(self) -> None:
+        """A zero task number cannot become a negative Seed or AC identity."""
+        seed = SimpleNamespace(acceptance_criteria=("Create marker.txt",))
+        mechanical = _parse_legacy_execution_task_summary(
+            "### Task 0: [COMPLETED] bogus",
+            seed,
+        )
+        assert mechanical is not None
+        assert mechanical.task_results == ()
+        assert mechanical.execution_completion_status == "failed"
+        assert "invalid one-based task number(s): 0" in (mechanical.failure_reason or "")
+
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create marker.txt",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="marker",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create marker.txt",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=True,
+                            detail="Found marker.txt",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.execution_completion_status == "failed"
+        assert summary.run_verdict == "FAIL"
+
+    @pytest.mark.parametrize(
+        "artifact, invalid_number",
+        [
+            ("### AC 0: [PASS] bogus", "0"),
+            ("### Task -1: [COMPLETED] bogus", "-1"),
+        ],
+    )
+    def test_all_non_positive_legacy_task_numbers_are_rejected(
+        self,
+        artifact: str,
+        invalid_number: str,
+    ) -> None:
+        """Both legacy syntaxes enforce a positive one-based identity."""
+        summary = _parse_legacy_execution_task_summary(
+            artifact,
+            SimpleNamespace(acceptance_criteria=("Create marker.txt",)),
+        )
+
+        assert summary is not None
+        assert summary.task_results == ()
+        assert summary.execution_completion_status == "failed"
+        assert f"invalid one-based task number(s): {invalid_number}" in (
+            summary.failure_reason or ""
+        )
+
     def test_agent_results_preserve_failed_legacy_task_for_spec_verification(self) -> None:
         """Legacy task failures must remain visible to the verifier input map."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -12,7 +12,8 @@ import pytest
 from structlog.testing import capture_logs
 
 from ouroboros import __version__
-from ouroboros.core.lineage import EvaluationSummary, TaskResult
+from ouroboros.core.lineage import ACResult, EvaluationSummary, TaskResult
+from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.io_recorder import get_current_io_journal_recorder
@@ -24,6 +25,7 @@ from ouroboros.mcp.server.adapter import (
     _agent_results_from_execution_summary,
     _build_prompt_signature_with_aliases,
     _build_tool_signature_with_aliases,
+    _evaluation_summary_for_unavailable_spec_verification,
     _evaluation_summary_from_spec_verification,
     _extract_feedback_metadata_from_artifact,
     _parse_legacy_execution_task_summary,
@@ -310,6 +312,55 @@ Parallel Execution Verification Report
         )
 
         assert _agent_results_from_execution_summary(mechanical) == {0: False}
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "Spec assertion extraction failed: unreadable response",
+            "Spec assertion extraction produced no independently usable assertions.",
+        ],
+    )
+    def test_unavailable_assertion_extraction_cannot_fall_back_to_mechanical_pass(
+        self,
+        reason: str,
+    ) -> None:
+        """Unreadable, rejected, and empty extraction all fail the formal gate."""
+        mechanical = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=3,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Set MAX_RETRIES to 5",
+                    passed=True,
+                    score=1.0,
+                    evidence="Agent reported PASS",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="approved",
+        )
+        seed = SimpleNamespace(
+            acceptance_criteria=(
+                AcceptanceCriterionSpec(
+                    description="Set MAX_RETRIES to 5",
+                    semantic_ac_key="ac_0123456789abcdef",
+                ),
+            )
+        )
+
+        summary = _evaluation_summary_for_unavailable_spec_verification(
+            mechanical,
+            seed,
+            reason,
+        )
+
+        assert summary.final_approved is False
+        assert summary.approval_status == "rejected"
+        assert summary.run_verdict == "FAIL"
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert summary.ac_results[0].semantic_ac_key == "ac_0123456789abcdef"
+        assert summary.failure_reason == reason
 
     def test_unverifiable_report_preserves_legacy_task_failure_as_ac_failure(self) -> None:
         """Skipped verifier assertions must not upgrade a failed task to approval."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -609,6 +609,398 @@ Parallel Execution Verification Report
         assert summary.run_verdict == "FAIL"
         assert "missing verifier report for AC 2" in (summary.failure_reason or "")
 
+    @pytest.mark.parametrize(
+        "ordered_outcomes",
+        [
+            (VerificationOutcome.DISCREPANCY, VerificationOutcome.VERIFIED),
+            (VerificationOutcome.VERIFIED, VerificationOutcome.DISCREPANCY),
+        ],
+    )
+    def test_duplicate_report_order_cannot_mint_formal_authority(
+        self,
+        ordered_outcomes: tuple[VerificationOutcome, VerificationOutcome],
+    ) -> None:
+        """The adapter revalidates duplicate identity even for compatibility objects."""
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        reports = tuple(
+            ACVerificationReport(
+                ac_index=0,
+                ac_text="Create config",
+                results=(SpecVerificationResult(assertion=assertion, outcome=outcome),),
+            )
+            for outcome in ordered_outcomes
+        )
+
+        summary = _evaluation_summary_from_spec_verification(
+            mechanical,
+            SimpleNamespace(reports=reports),
+            seed,
+        )
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert "duplicate report ac_index=0" in (summary.failure_reason or "")
+
+    @pytest.mark.parametrize("surface", ["report", "assertion"])
+    @pytest.mark.parametrize("invalid_index", [True, False, "0", "1", 0.0, 1.0, 1.5, -1])
+    def test_adapter_rejects_non_strict_raw_indices_after_model_bypass(
+        self,
+        surface: str,
+        invalid_index: object,
+    ) -> None:
+        """Raw compatibility objects cannot exploit bool/int equality or coercion."""
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        raw_assertion = SimpleNamespace(
+            ac_index=invalid_index if surface == "assertion" else 0,
+            ac_text="Create config",
+        )
+        raw_report = SimpleNamespace(
+            ac_index=invalid_index if surface == "report" else 0,
+            ac_text="Create config",
+            results=(SimpleNamespace(assertion=raw_assertion),),
+        )
+
+        summary = _evaluation_summary_from_spec_verification(
+            mechanical,
+            SimpleNamespace(reports=(raw_report,)),
+            seed,
+        )
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert "invalid" in (summary.failure_reason or "")
+
+    @pytest.mark.parametrize(
+        ("assertion_index", "assertion_text", "reason"),
+        [
+            (7, "Create config", "assertion ac_index=7"),
+            (0, "Unrelated criterion", "assertion text"),
+        ],
+    )
+    def test_adapter_rejects_unvalidated_nested_report_identity(
+        self,
+        assertion_index: int,
+        assertion_text: str,
+        reason: str,
+    ) -> None:
+        """Model validation bypasses cannot introduce misbound evidence authority."""
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=assertion_index,
+            ac_text=assertion_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        result = SpecVerificationResult(
+            assertion=assertion,
+            outcome=VerificationOutcome.VERIFIED,
+        )
+        unvalidated_report = ACVerificationReport.model_construct(
+            ac_index=0,
+            ac_text="Create config",
+            results=(result,),
+            agent_reported_pass=True,
+        )
+
+        summary = _evaluation_summary_from_spec_verification(
+            mechanical,
+            SimpleNamespace(reports=(unvalidated_report,)),
+            seed,
+        )
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert reason in (summary.failure_reason or "")
+
+    def test_serialized_out_of_range_report_is_rejected_against_seed(self) -> None:
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=1,
+            ac_text="Unexpected AC",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        verification = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 1,
+                        "ac_text": "Unexpected AC",
+                        "results": [
+                            {
+                                "assertion": assertion.model_dump(mode="json"),
+                                "outcome": "verified",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert "outside Seed AC coverage" in (summary.failure_reason or "")
+
+    def test_serialized_seed_text_mismatch_is_rejected(self) -> None:
+        seed = SimpleNamespace(
+            acceptance_criteria=(
+                AcceptanceCriterionSpec(
+                    description="Create config",
+                    semantic_ac_key="ac_0123456789abcdef",
+                ),
+            )
+        )
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Unrelated criterion",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Unrelated criterion",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.VERIFIED,
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].semantic_ac_key == "ac_0123456789abcdef"
+        assert "does not match the authoritative Seed AC" in (summary.failure_reason or "")
+
+    def test_serialized_missing_report_remains_not_evaluated(self) -> None:
+        seed = SimpleNamespace(acceptance_criteria=("Create config", "Add docs"))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=tuple(
+                TaskResult(
+                    task_index=index,
+                    task_content=text,
+                    status="completed",
+                    completed=True,
+                    source_ac_index=index,
+                )
+                for index, text in enumerate(seed.acceptance_criteria)
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        verification = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "Create config",
+                        "results": [
+                            {
+                                "assertion": assertion.model_dump(mode="json"),
+                                "outcome": "verified",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert [result.rendered_verdict for result in summary.ac_results] == [
+            "PASS",
+            "NOT_EVALUATED",
+        ]
+        assert summary.final_approved is False
+
+    def test_identity_consistent_legacy_payload_can_still_approve(self) -> None:
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        verification = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "Create config",
+                        "results": [
+                            {
+                                "assertion": assertion.model_dump(mode="json"),
+                                "verified": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is True
+        assert summary.run_verdict == "PASS"
+
+    def test_serialized_mixed_outcomes_cannot_mint_formal_pass(self) -> None:
+        seed = SimpleNamespace(acceptance_criteria=("Create config",))
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        )
+        serialized_assertion = assertion.model_dump(mode="json")
+        verification = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "Create config",
+                        "results": [
+                            {"assertion": serialized_assertion, "outcome": "verified"},
+                            {"assertion": serialized_assertion, "outcome": "discrepancy"},
+                        ],
+                    }
+                ],
+                "confirmed_discrepancy_count": 0,
+            }
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert verification.confirmed_discrepancy_count == 1
+        assert summary.final_approved is False
+        assert summary.ac_results[0].rendered_verdict == "FAIL"
+        assert summary.run_verdict == "FAIL"
+
     def test_unavailable_spec_verification_result_does_not_approve_run(self) -> None:
         """Unavailable verifier evidence is a failed formal AC, not approval."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -499,6 +499,56 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
+    def test_contradictory_legacy_verification_flags_cannot_mint_formal_pass(self) -> None:
+        """A stale legacy PASS bit cannot override an explicit discrepancy bit."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Set MAX_RETRIES to 5",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Set MAX_RETRIES to 5",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        contradictory = SpecVerificationResult.model_validate(
+            {
+                "assertion": assertion.model_dump(mode="json"),
+                "verified": True,
+                "discrepancy": True,
+                "detail": "Observed MAX_RETRIES=3",
+            }
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Set MAX_RETRIES to 5",
+                    results=(contradictory,),
+                    agent_reported_pass=True,
+                ),
+            )
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert contradictory.outcome is VerificationOutcome.DISCREPANCY
+        assert summary.ac_results[0].rendered_verdict == "FAIL"
+        assert summary.final_approved is False
+        assert summary.run_verdict == "FAIL"
+
     def test_skipped_spec_verification_result_does_not_approve_run(self) -> None:
         """A visible T3/T4 skip remains NOT_EVALUATED at the formal gate."""
         mechanical = EvaluationSummary(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -2296,36 +2296,43 @@ class TestAssertionExtractor:
         assert extractor.llm_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_an_array_only_partly_rejected_is_remembered_as_what_survived(self) -> None:
-        """One good entry among bad ones is still an extraction that was read.
-
-        The rule is about a reply in which *nothing* arrived, not about every
-        entry being perfect. If one assertion survives, the model answered in
-        this schema and the seed should not pay for a second extraction.
-        """
+    async def test_same_ac_mixed_valid_and_invalid_assertions_are_retried_atomically(
+        self,
+    ) -> None:
+        """A rejected assertion cannot disappear behind a valid sibling in one AC."""
         extractor = self._make_extractor_sequence(
             json.dumps(
                 [
-                    {"ac_index": 0},
                     {
                         "ac_index": 0,
                         "tier": "t2_structural",
-                        "pattern": "class Foo",
-                        "expected_value": "",
-                        "file_hint": "*.py",
+                        "pattern": "marker",
+                        "expected_value": "marker.txt",
+                        "file_hint": "marker.txt",
                         "description": "",
                     },
-                    {"ac_index": 99, "tier": "t2_structural", "pattern": "class Bar"},
+                    {
+                        "ac_index": 0,
+                        "tier": "t2_structural",
+                        "pattern": "(",
+                        "expected_value": "docs.md",
+                        "file_hint": "docs.md",
+                        "description": "",
+                    },
                 ]
-            )
+            ),
+            _GOOD_EXTRACTION,
+            _GOOD_EXTRACTION,
         )
 
-        first = await extractor.extract("seed_partly_rejected", ("Has class Foo",))
-        second = await extractor.extract("seed_partly_rejected", ("Has class Foo",))
+        first = await extractor.extract("seed_partly_rejected", ("Create marker.txt and docs.md",))
+        second = await extractor.extract("seed_partly_rejected", ("Create marker.txt and docs.md",))
+        third = await extractor.extract("seed_partly_rejected", ("Create marker.txt and docs.md",))
 
-        assert first.is_ok and len(first.value) == 1
-        assert second.value is first.value
-        extractor.llm_adapter.complete.assert_called_once()
+        assert first.is_err
+        assert second.is_ok and len(second.value) == 1
+        assert third.value is second.value
+        assert extractor.llm_adapter.complete.await_count == 2
 
     @pytest.mark.asyncio
     async def test_a_readable_empty_extraction_is_still_remembered(self) -> None:

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -11,6 +11,7 @@ import tempfile
 import textwrap
 from unittest.mock import AsyncMock
 
+from pydantic import ValidationError
 import pytest
 
 from ouroboros.core.types import Result
@@ -44,6 +45,58 @@ class TestVerificationModels:
         assert a.tier == VerificationTier.T1_CONSTANT
         with pytest.raises(Exception):
             a.ac_index = 1  # type: ignore[misc]
+
+    @pytest.mark.parametrize("invalid_index", [True, False, "0", "1", 0.0, 1.0, 1.5, -1])
+    def test_spec_assertion_requires_raw_non_negative_integer_index(
+        self,
+        invalid_index: object,
+    ) -> None:
+        with pytest.raises(ValidationError):
+            SpecAssertion.model_validate(
+                {
+                    "ac_index": invalid_index,
+                    "ac_text": "Create config",
+                    "tier": "t2_structural",
+                }
+            )
+
+    @pytest.mark.parametrize("invalid_index", [True, False, "0", "1", 0.0, 1.0, 1.5, -1])
+    def test_ac_report_requires_raw_non_negative_integer_index(
+        self,
+        invalid_index: object,
+    ) -> None:
+        with pytest.raises(ValidationError):
+            ACVerificationReport.model_validate(
+                {
+                    "ac_index": invalid_index,
+                    "ac_text": "Create config",
+                    "results": [],
+                }
+            )
+
+    def test_zero_index_remains_valid_for_assertion_and_report(self) -> None:
+        assertion = SpecAssertion.model_validate(
+            {
+                "ac_index": 0,
+                "ac_text": "Create config",
+                "tier": "t2_structural",
+            }
+        )
+        report = ACVerificationReport.model_validate(
+            {
+                "ac_index": 0,
+                "ac_text": "Create config",
+                "results": [
+                    {
+                        "assertion": assertion.model_dump(mode="json"),
+                        "outcome": "verified",
+                    }
+                ],
+            }
+        )
+
+        assert report.ac_index == 0
+        assert report.verified_pass is True
 
     def test_verification_result_discrepancy(self) -> None:
         assertion = SpecAssertion(
@@ -278,19 +331,32 @@ class TestVerificationModels:
         assert not report.has_discrepancy
 
     def test_summary_from_reports(self) -> None:
-        assertion = SpecAssertion(ac_index=0, ac_text="test", tier=VerificationTier.T1_CONSTANT)
+        first_assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test1",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        second_assertion = SpecAssertion(
+            ac_index=1,
+            ac_text="test2",
+            tier=VerificationTier.T1_CONSTANT,
+        )
         reports = (
             ACVerificationReport(
                 ac_index=0,
                 ac_text="test1",
-                results=(SpecVerificationResult(assertion=assertion, verified=True),),
+                results=(SpecVerificationResult(assertion=first_assertion, verified=True),),
                 agent_reported_pass=True,
             ),
             ACVerificationReport(
                 ac_index=1,
                 ac_text="test2",
                 results=(
-                    SpecVerificationResult(assertion=assertion, verified=False, discrepancy=True),
+                    SpecVerificationResult(
+                        assertion=second_assertion,
+                        verified=False,
+                        discrepancy=True,
+                    ),
                 ),
                 agent_reported_pass=True,
             ),
@@ -309,6 +375,120 @@ class TestVerificationModels:
         assert summary.discrepancy_count == 1
         assert summary.has_discrepancies
         assert summary.override_approval is False
+
+    @pytest.mark.parametrize(
+        "ordered_outcomes",
+        [
+            ("discrepancy", "verified"),
+            ("verified", "discrepancy"),
+        ],
+    )
+    def test_serialized_duplicate_report_order_is_rejected(
+        self,
+        ordered_outcomes: tuple[str, str],
+    ) -> None:
+        """Replay ordering cannot select authority for a duplicate AC report."""
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        ).model_dump(mode="json")
+        reports = [
+            {
+                "ac_index": 0,
+                "ac_text": "Create config",
+                "results": [{"assertion": assertion, "outcome": outcome}],
+            }
+            for outcome in ordered_outcomes
+        ]
+
+        with pytest.raises(ValidationError, match="duplicate report ac_index"):
+            SpecVerificationSummary.model_validate({"reports": reports})
+
+    @pytest.mark.parametrize(
+        ("assertion_index", "assertion_text", "error"),
+        [
+            (7, "Create config", "assertion ac_index"),
+            (0, "Unrelated criterion", "assertion text"),
+        ],
+    )
+    def test_serialized_report_rejects_mismatched_nested_identity(
+        self,
+        assertion_index: int,
+        assertion_text: str,
+        error: str,
+    ) -> None:
+        """Nested evidence must identify the same AC as its parent report."""
+        payload = {
+            "ac_index": 0,
+            "ac_text": "Create config",
+            "results": [
+                {
+                    "assertion": {
+                        "ac_index": assertion_index,
+                        "ac_text": assertion_text,
+                        "tier": "t2_structural",
+                    },
+                    "outcome": "verified",
+                }
+            ],
+        }
+
+        with pytest.raises(ValidationError, match=error):
+            ACVerificationReport.model_validate(payload)
+
+    def test_serialized_mixed_outcomes_retain_conservative_authority(self) -> None:
+        """A VERIFIED result cannot erase a sibling discrepancy on replay."""
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        ).model_dump(mode="json")
+        summary = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "Create config",
+                        "results": [
+                            {"assertion": assertion, "outcome": "verified"},
+                            {"assertion": assertion, "outcome": "discrepancy"},
+                        ],
+                    }
+                ],
+                "confirmed_discrepancy_count": 0,
+            }
+        )
+
+        assert summary.verified_count == 1
+        assert summary.confirmed_discrepancy_count == 1
+        assert summary.reports[0].verified_pass is False
+        assert summary.override_approval is False
+
+    def test_identity_consistent_legacy_report_payload_remains_readable(self) -> None:
+        """Legacy boolean results remain compatible when their identity is sound."""
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+        ).model_dump(mode="json")
+        summary = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "Create config",
+                        "results": [{"assertion": assertion, "verified": True}],
+                    }
+                ],
+                "verified_count": 0,
+            }
+        )
+
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.VERIFIED
+        assert summary.verified_count == 1
+        assert SpecVerificationSummary.model_validate(summary.model_dump(mode="json")) == summary
 
     def test_summary_no_discrepancies(self) -> None:
         assertion = SpecAssertion(ac_index=0, ac_text="test", tier=VerificationTier.T1_CONSTANT)

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -158,6 +158,50 @@ class TestVerificationModels:
         assert replayed.confirmed_discrepancy_count == 0
         assert replayed.override_approval is None
 
+    def test_outcome_reports_canonicalize_contradictory_persisted_counts(self) -> None:
+        """Public summary authority is derived from reports, never stale counters."""
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        summary = SpecVerificationSummary.model_validate(
+            {
+                "reports": [
+                    {
+                        "ac_index": 0,
+                        "ac_text": "test",
+                        "agent_reported_pass": True,
+                        "results": [
+                            {
+                                "assertion": assertion.model_dump(mode="json"),
+                                "outcome": "discrepancy",
+                            }
+                        ],
+                    }
+                ],
+                "total_assertions": 0,
+                "verified_count": 99,
+                "failed_count": 0,
+                "unverifiable_count": 99,
+                "skipped_count": 99,
+                "discrepancy_count": 0,
+                "confirmed_discrepancy_count": 0,
+                "strict": False,
+            }
+        )
+
+        assert summary.total_assertions == 1
+        assert summary.verified_count == 0
+        assert summary.failed_count == 1
+        assert summary.unverifiable_count == 0
+        assert summary.skipped_count == 0
+        assert summary.discrepancy_count == 1
+        assert summary.confirmed_discrepancy_count == 1
+        assert summary.has_confirmed_discrepancies is True
+        assert summary.override_approval is False
+        assert summary.model_dump(mode="json")["confirmed_discrepancy_count"] == 1
+
     @pytest.mark.parametrize(
         ("outcome", "flags"),
         [

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -21,6 +21,7 @@ from ouroboros.verification.models import (
     SpecAssertion,
     SpecVerificationResult,
     SpecVerificationSummary,
+    VerificationOutcome,
     VerificationTier,
 )
 from ouroboros.verification.verifier import SpecVerifier
@@ -58,6 +59,43 @@ class TestVerificationModels:
         )
         assert r.discrepancy
         assert not r.verified
+        assert r.outcome is VerificationOutcome.DISCREPANCY
+
+    def test_verification_result_preserves_legacy_json_and_round_trips_outcome(self) -> None:
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        legacy = SpecVerificationResult.model_validate(
+            {"assertion": assertion.model_dump(mode="json"), "verified": True}
+        )
+        assert legacy.outcome is VerificationOutcome.VERIFIED
+        assert legacy.verified is True
+
+        result = SpecVerificationResult(
+            assertion=assertion,
+            outcome=VerificationOutcome.UNVERIFIABLE,
+            detail="No files matched hint: *.rs",
+        )
+        payload = result.model_dump(mode="json")
+        assert payload["outcome"] == "unverifiable"
+        assert payload["verified"] is False
+        assert payload["discrepancy"] is False
+        assert SpecVerificationResult.model_validate(payload) == result
+
+    def test_explicit_outcome_rejects_contradictory_legacy_boolean(self) -> None:
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        with pytest.raises(ValueError, match="verified contradicts"):
+            SpecVerificationResult(
+                assertion=assertion,
+                outcome=VerificationOutcome.UNVERIFIABLE,
+                verified=True,
+            )
 
     def test_ac_report_verified_pass_all_pass(self) -> None:
         assertion = SpecAssertion(ac_index=0, ac_text="test", tier=VerificationTier.T1_CONSTANT)
@@ -143,6 +181,45 @@ class TestVerificationModels:
         summary = SpecVerificationSummary.from_reports(reports)
         assert not summary.has_discrepancies
         assert summary.override_approval is None
+
+    def test_strict_policy_blocks_incomplete_evidence_without_minting_discrepancy(self) -> None:
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        report = ACVerificationReport(
+            ac_index=0,
+            ac_text="test",
+            results=(
+                SpecVerificationResult(
+                    assertion=assertion,
+                    outcome=VerificationOutcome.UNVERIFIABLE,
+                    detail="No pattern to verify",
+                ),
+            ),
+            agent_reported_pass=True,
+        )
+
+        strict = SpecVerificationSummary.from_reports((report,), strict=True)
+        exploratory = SpecVerificationSummary.from_reports((report,), strict=False)
+
+        assert strict.unverifiable_count == 1
+        assert strict.confirmed_discrepancy_count == 0
+        assert strict.override_approval is False
+        assert exploratory.override_approval is None
+        assert exploratory.reports[0].verified_pass is False
+
+    def test_legacy_summary_payload_keeps_fail_closed_override(self) -> None:
+        summary = SpecVerificationSummary.model_validate(
+            {
+                "project_dir": "/tmp/project",
+                "discrepancy_count": 1,
+            }
+        )
+
+        assert summary.confirmed_discrepancy_count == 1
+        assert summary.override_approval is False
 
 
 # -- Verifier Tests --
@@ -383,7 +460,7 @@ class TestSpecVerifier:
         assert summary.discrepancy_count == 1
 
     def test_t3_t4_skipped(self) -> None:
-        """T3 and T4 assertions are skipped (no results)."""
+        """T3 and T4 assertions stay visible as explicit skipped outcomes."""
         project = self._create_project({"main.py": ""})
         verifier = SpecVerifier(project_dir=project)
         assertions = (
@@ -391,8 +468,14 @@ class TestSpecVerifier:
             SpecAssertion(ac_index=1, ac_text="subjective", tier=VerificationTier.T4_UNVERIFIABLE),
         )
         summary = verifier.verify_all(assertions)
-        assert summary.total_assertions == 0
+        assert summary.total_assertions == 2
         assert summary.skipped_count == 2
+        assert all(report.results for report in summary.reports)
+        assert {result.outcome for report in summary.reports for result in report.results} == {
+            VerificationOutcome.SKIPPED
+        }
+        assert summary.verified_count == 0
+        assert summary.override_approval is False
 
     def test_no_files_match_hint(self) -> None:
         """File hint matches nothing → verification fails closed."""
@@ -409,7 +492,46 @@ class TestSpecVerifier:
         summary = verifier.verify_all((assertion,), agent_results={0: True})
         assert summary.verified_count == 0
         assert summary.failed_count == 1
+        assert summary.unverifiable_count == 1
         assert summary.discrepancy_count == 1
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.reports[0].results[0].outcome is VerificationOutcome.UNVERIFIABLE
+
+    @pytest.mark.parametrize("tier", [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL])
+    @pytest.mark.parametrize(
+        ("pattern", "detail"),
+        [("", "No pattern to verify"), ("(", "Unusable regex pattern")],
+        ids=["empty", "invalid"],
+    )
+    def test_unusable_pattern_is_unverifiable_not_a_false_pass_or_discrepancy(
+        self,
+        tier: VerificationTier,
+        pattern: str,
+        detail: str,
+    ) -> None:
+        project = self._create_project({"main.py": "VALUE = 1\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=tier,
+            pattern=pattern,
+            expected_value="1" if tier is VerificationTier.T1_CONSTANT else "",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: True}
+        )
+        result = summary.reports[0].results[0]
+
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert result.verified is False
+        assert result.discrepancy is False
+        assert detail in result.detail
+        assert summary.verified_count == 0
+        assert summary.unverifiable_count == 1
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.override_approval is False
 
     def test_multiple_assertions_per_ac(self) -> None:
         """Multiple assertions for one AC — all must pass."""

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -1874,15 +1874,7 @@ class TestAssertionExtractor:
             ]
         )
         result = await extractor.extract("seed_empty_expected", ("WARMUP_FRAMES should be 10",))
-        assert result.is_ok
-        assert result.value == ()
-
-        project = TestSpecVerifier()._create_project({"config.py": "WARMUP_FRAMES = 999\n"})
-        summary = SpecVerifier(project_dir=project).verify_all(
-            result.value, agent_results={0: True}
-        )
-        assert summary.total_assertions == 0
-        assert summary.verified_count == 0
+        assert result.is_err
 
     @pytest.mark.asyncio
     async def test_wrapped_invalid_regex_assertion_rejected_before_verifier(self) -> None:
@@ -1903,8 +1895,7 @@ class TestAssertionExtractor:
 
         result = await extractor.extract("seed_invalid_regex", ("MAX_RETRIES should be 5",))
 
-        assert result.is_ok
-        assert result.value == ()
+        assert result.is_err
 
     @pytest.mark.asyncio
     async def test_overflowing_regex_assertion_rejected_before_verifier(self) -> None:
@@ -1925,8 +1916,7 @@ class TestAssertionExtractor:
 
         result = await extractor.extract("seed_overflow_regex", ("constant is five",))
 
-        assert result.is_ok
-        assert result.value == ()
+        assert result.is_err
 
     def test_overflowing_regex_fails_closed_in_verifier(self) -> None:
         """Direct verifier callers cannot crash it with a regex overflow."""
@@ -2029,8 +2019,7 @@ class TestAssertionExtractor:
         extractor = self._make_extractor_sequence(unreadable, _GOOD_EXTRACTION, _GOOD_EXTRACTION)
 
         first = await extractor.extract("seed_unreadable", ("Has class Foo",))
-        assert first.is_ok
-        assert first.value == ()
+        assert first.is_err
 
         second = await extractor.extract("seed_unreadable", ("Has class Foo",))
         assert second.is_ok
@@ -2072,8 +2061,7 @@ class TestAssertionExtractor:
         extractor = self._make_extractor_sequence(wrong_schema, _GOOD_EXTRACTION, _GOOD_EXTRACTION)
 
         first = await extractor.extract("seed_wrong_schema", ("Has class Foo",))
-        assert first.is_ok
-        assert first.value == ()
+        assert first.is_err
 
         second = await extractor.extract("seed_wrong_schema", ("Has class Foo",))
         assert second.is_ok
@@ -2151,8 +2139,8 @@ class TestAssertionExtractor:
         assert result.value == ()
 
     @pytest.mark.asyncio
-    async def test_invalid_json_returns_empty(self) -> None:
-        """Malformed LLM response → empty assertions, no crash."""
+    async def test_invalid_json_returns_error(self) -> None:
+        """Malformed LLM response remains retryable and cannot bypass the gate."""
         mock_adapter = AsyncMock()
         mock_adapter.complete = AsyncMock(
             return_value=Result.ok(
@@ -2165,8 +2153,7 @@ class TestAssertionExtractor:
         )
         extractor = AssertionExtractor(llm_adapter=mock_adapter)
         result = await extractor.extract("seed_bad", ("test",))
-        assert result.is_ok
-        assert result.value == ()
+        assert result.is_err
 
     @pytest.mark.asyncio
     async def test_invalid_tier_is_rejected(self) -> None:
@@ -2184,5 +2171,4 @@ class TestAssertionExtractor:
             ]
         )
         result = await extractor.extract("seed_tier", ("test",))
-        assert result.is_ok
-        assert result.value == ()
+        assert result.is_err

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -72,6 +72,43 @@ class TestVerificationModels:
         )
         assert legacy.outcome is VerificationOutcome.VERIFIED
         assert legacy.verified is True
+        assert legacy.discrepancy is False
+        assert legacy.unverifiable is False
+        assert legacy.skipped is False
+
+        legacy_false = SpecVerificationResult.model_validate(
+            {
+                "assertion": assertion.model_dump(mode="json"),
+                "verified": False,
+                "discrepancy": False,
+            }
+        )
+        assert legacy_false.outcome is VerificationOutcome.DISCREPANCY
+        assert legacy_false.verified is False
+        assert legacy_false.discrepancy is True
+        assert legacy_false.unverifiable is False
+        assert legacy_false.skipped is False
+        assert (
+            SpecVerificationResult.model_validate(legacy_false.model_dump(mode="json"))
+            == legacy_false
+        )
+
+        contradictory = SpecVerificationResult.model_validate(
+            {
+                "assertion": assertion.model_dump(mode="json"),
+                "verified": True,
+                "discrepancy": True,
+                "unverifiable": True,
+                "skipped": True,
+            }
+        )
+        assert contradictory.outcome is VerificationOutcome.VERIFIED
+        assert (
+            contradictory.verified,
+            contradictory.discrepancy,
+            contradictory.unverifiable,
+            contradictory.skipped,
+        ) == (True, False, False, False)
 
         result = SpecVerificationResult(
             assertion=assertion,
@@ -82,20 +119,46 @@ class TestVerificationModels:
         assert payload["outcome"] == "unverifiable"
         assert payload["verified"] is False
         assert payload["discrepancy"] is False
+        assert payload["unverifiable"] is True
+        assert payload["skipped"] is False
         assert SpecVerificationResult.model_validate(payload) == result
 
-    def test_explicit_outcome_rejects_contradictory_legacy_boolean(self) -> None:
+    @pytest.mark.parametrize(
+        ("outcome", "flags"),
+        [
+            (VerificationOutcome.VERIFIED, (True, False, False, False)),
+            (VerificationOutcome.DISCREPANCY, (False, True, False, False)),
+            (VerificationOutcome.UNVERIFIABLE, (False, False, True, False)),
+            (VerificationOutcome.SKIPPED, (False, False, False, True)),
+        ],
+    )
+    def test_explicit_outcome_normalizes_contradictory_legacy_booleans(
+        self,
+        outcome: VerificationOutcome,
+        flags: tuple[bool, bool, bool, bool],
+    ) -> None:
         assertion = SpecAssertion(
             ac_index=0,
             ac_text="test",
             tier=VerificationTier.T1_CONSTANT,
         )
-        with pytest.raises(ValueError, match="verified contradicts"):
-            SpecVerificationResult(
-                assertion=assertion,
-                outcome=VerificationOutcome.UNVERIFIABLE,
-                verified=True,
-            )
+        result = SpecVerificationResult(
+            assertion=assertion,
+            outcome=outcome,
+            verified=not flags[0],
+            discrepancy=not flags[1],
+            unverifiable=not flags[2],
+            skipped=not flags[3],
+        )
+
+        assert (result.verified, result.discrepancy, result.unverifiable, result.skipped) == flags
+        payload = result.model_dump(mode="json")
+        assert (
+            payload["verified"],
+            payload["discrepancy"],
+            payload["unverifiable"],
+            payload["skipped"],
+        ) == flags
 
     def test_ac_report_verified_pass_all_pass(self) -> None:
         assertion = SpecAssertion(ac_index=0, ac_text="test", tier=VerificationTier.T1_CONSTANT)
@@ -477,16 +540,19 @@ class TestSpecVerifier:
         assert summary.verified_count == 0
         assert summary.override_approval is False
 
-    def test_no_files_match_hint(self) -> None:
-        """File hint matches nothing → verification fails closed."""
+    @pytest.mark.parametrize("tier", [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL])
+    def test_no_files_match_hint_is_unverifiable_for_every_scanned_tier(
+        self, tier: VerificationTier
+    ) -> None:
+        """No candidate source is missing evidence, not a contradicted assertion."""
         project = self._create_project({"main.py": ""})
         verifier = SpecVerifier(project_dir=project)
         assertion = SpecAssertion(
             ac_index=0,
             ac_text="test",
-            tier=VerificationTier.T1_CONSTANT,
+            tier=tier,
             pattern=r"FOO",
-            expected_value="bar",
+            expected_value="bar" if tier is VerificationTier.T1_CONSTANT else "",
             file_hint="*.rs",
         )
         summary = verifier.verify_all((assertion,), agent_results={0: True})
@@ -495,7 +561,11 @@ class TestSpecVerifier:
         assert summary.unverifiable_count == 1
         assert summary.discrepancy_count == 1
         assert summary.confirmed_discrepancy_count == 0
-        assert summary.reports[0].results[0].outcome is VerificationOutcome.UNVERIFIABLE
+        result = summary.reports[0].results[0]
+        assert result.outcome is VerificationOutcome.UNVERIFIABLE
+        assert result.unverifiable is True
+        assert result.discrepancy is False
+        assert result.detail == "No files matched hint: *.rs"
 
     @pytest.mark.parametrize("tier", [VerificationTier.T1_CONSTANT, VerificationTier.T2_STRUCTURAL])
     @pytest.mark.parametrize(

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -102,13 +102,13 @@ class TestVerificationModels:
                 "skipped": True,
             }
         )
-        assert contradictory.outcome is VerificationOutcome.VERIFIED
+        assert contradictory.outcome is VerificationOutcome.DISCREPANCY
         assert (
             contradictory.verified,
             contradictory.discrepancy,
             contradictory.unverifiable,
             contradictory.skipped,
-        ) == (True, False, False, False)
+        ) == (False, True, False, False)
 
         result = SpecVerificationResult(
             assertion=assertion,
@@ -122,6 +122,41 @@ class TestVerificationModels:
         assert payload["unverifiable"] is True
         assert payload["skipped"] is False
         assert SpecVerificationResult.model_validate(payload) == result
+
+    def test_compact_outcome_summary_replay_preserves_zero_confirmed_discrepancies(
+        self,
+    ) -> None:
+        """Outcome-aware compact JSON cannot revive a legacy discrepancy override."""
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="test",
+            tier=VerificationTier.T1_CONSTANT,
+        )
+        result = SpecVerificationResult(
+            assertion=assertion,
+            outcome=VerificationOutcome.UNVERIFIABLE,
+        )
+        summary = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="test",
+                    results=(result,),
+                    agent_reported_pass=True,
+                ),
+            ),
+            strict=False,
+        )
+
+        assert summary.discrepancy_count == 1
+        assert summary.confirmed_discrepancy_count == 0
+        assert summary.override_approval is None
+        payload = summary.model_dump(mode="json", exclude_defaults=True)
+        assert "confirmed_discrepancy_count" not in payload
+
+        replayed = SpecVerificationSummary.model_validate(payload)
+        assert replayed.confirmed_discrepancy_count == 0
+        assert replayed.override_approval is None
 
     @pytest.mark.parametrize(
         ("outcome", "flags"),


### PR DESCRIPTION
## Summary

`SpecVerifier` currently encodes several “verification did not run” conditions as `verified=True`, making missing evidence indistinguishable from a genuine mechanical pass.

This change introduces first-class verification outcomes and carries them through the public result, aggregation, serialization, and MCP adapter surfaces:

- `VERIFIED` — positive evidence was found
- `DISCREPANCY` — verification ran and contradictory/missing-required evidence was established
- `UNVERIFIABLE` — no candidate files or no usable pattern made verification possible
- `SKIPPED` — T3/T4 assertions are outside this verifier rather than silently omitted

Legacy boolean payloads remain readable, but all boolean views and serialized flags are canonicalized from the authoritative outcome. Contradictory legacy fields cannot manufacture a pass.

The adapter now publishes PASS only when every result is `VERIFIED`; unverifiable or skipped evidence produces `NOT_EVALUATED`, while an actual discrepancy produces FAIL.

Closes #1991

## Verification

Exact candidate: `6e8482d5cfc01a4f4f91d597d390d205387b4143`

- independent exact verifier: PASS
- current main ancestry: PASS (`0b95a9789043f05e33e2671874b0c08f623e8c1b`)
- impacted verification and adapter suites: 456 passed
- adversarial T1/T2 no-file, empty, invalid, and too-long patterns: `UNVERIFIABLE`
- T3/T4: explicit `SKIPPED`
- all four outcomes plus legacy/contradictory JSON round trips: canonical
- aggregate and adapter all-verified-only gate: verified
- #1835 degenerate-regex behavior remains a separate concern and is not conflated with this missing-evidence fix
- Ruff check and format: PASS
- MyPy: PASS
- `git diff --check`: PASS

## Merge gate

Do not merge from badge state alone. Require required CI 6/6, no human `CHANGES_REQUESTED`, and a fresh official review whose API `commit_id`, body `HEAD checked`, and `Review-Metadata head_sha` all bind to the exact PR HEAD and whose final recommendation explicitly authorizes merge.
