### PR TITLE
READMEs promise a Copilot model mapping that does not happen for the current default

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -197,7 +197,7 @@ ouroboros setup --runtime copilot            # 모델 실시간 검색 및 기�
                                              # ~/.copilot/mcp-config.json에 MCP 서버 등록
 ```
 
-Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 사용합니다. 다른 설정에서 사용하는 하이픈 형식의 Anthropic 모델 ID(`claude-opus-4-6`)는 런타임에서 Copilot의 점 표기 형식(`claude-opus-4.6`)으로 자동 변환되므로, 백엔드를 전환해도 기존 설정을 그대로 사용할 수 있습니다.
+Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 사용합니다. **모델 ID 변환 범위는 생각보다 좁습니다.** 정적 맵은 `claude-opus-4-6`과 `claude-sonnet-4-5`까지 커버하고, `.`이 이미 들어간 ID는 그대로 통과하며, 하이픈-점 폴백은 **하이픈을 전부** 바꾸기 때문에 현재 기본값 `claude-opus-4-8`은 `claude.opus.4.8`이 되어 매칭에 실패합니다. 역할별 모델을 비워 두어 setup이 발견한 ID를 쓰게 하거나, 점 표기 Copilot ID를 명시하세요. [#1995](https://github.com/Q00/ouroboros/issues/1995)와 [Copilot 런타임 가이드](./docs/runtime-guides/copilot.ko.md) 참고.
 
 자세한 내용은 [GitHub Copilot CLI 런타임 가이드](./docs/runtime-guides/copilot.md)를 참고하세요.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ ouroboros setup --runtime copilot            # discovers models live, picks a de
                                              # registers MCP server in ~/.copilot/mcp-config.json
 ```
 
-Restart your Copilot CLI session, then use `ooo` commands inside it. Hyphenated Anthropic model IDs (`claude-opus-4-6`) used elsewhere in your config are auto-mapped to the dotted Copilot form (`claude-opus-4.6`) at runtime, so existing configs keep working when you switch backends.
+Restart your Copilot CLI session, then use `ooo` commands inside it. Model-ID mapping is narrower than it looks: the static map covers `claude-opus-4-6` and `claude-sonnet-4-5`, any ID already containing a `.` passes through unchanged, and the hyphen-to-dot fallback rewrites *every* hyphen, so the current default `claude-opus-4-8` becomes `claude.opus.4.8` and misses. Leave role models unset so setup writes a discovered ID, or set a Copilot-valid dotted ID explicitly. See [#1995](https://github.com/Q00/ouroboros/issues/1995) and the [Copilot runtime guide](./docs/runtime-guides/copilot.md).
 
 See the [GitHub Copilot CLI runtime guide](./docs/runtime-guides/copilot.md) for full details.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,7 +158,7 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
                                              # 在 ~/.copilot/mcp-config.json 中注册 MCP server
 ```
 
-重新启动 Copilot CLI 会话后，即可在会话中使用 `ooo` 命令。配置中其他地方使用的连字符格式 Anthropic 模型 ID（如 `claude-opus-4-6`）会在运行时自动映射为 Copilot 的点号格式（`claude-opus-4.6`），因此切换后端时现有配置仍然可用。
+重新启动 Copilot CLI 会话后，即可在会话中使用 `ooo` 命令。**模型 ID 映射的覆盖范围比看上去要窄**：静态映射表只覆盖 `claude-opus-4-6` 和 `claude-sonnet-4-5`；已经包含 `.` 的 ID 会原样通过；连字符转点号的兜底逻辑会替换**每一个**连字符，因此当前默认值 `claude-opus-4-8` 会变成 `claude.opus.4.8` 而匹配失败。请让各角色模型保持未设置，由 setup 写入发现到的 ID；或显式设置一个 Copilot 可用的点号格式 ID。参见 [#1995](https://github.com/Q00/ouroboros/issues/1995) 与 [Copilot 运行时指南](./docs/runtime-guides/copilot.md)。
 
 完整说明见 [GitHub Copilot CLI 运行时指南](./docs/runtime-guides/copilot.md)。
 


### PR DESCRIPTION
All three READMEs promise a model mapping that does not happen for the current default.

> Hyphenated Anthropic model IDs (`claude-opus-4-6`) used elsewhere in your config are auto-mapped to the dotted Copilot form (`claude-opus-4.6`) at runtime, so existing configs keep working when you switch backends.

`README.md:197`, `README.ko.md:200`, `README.zh-CN.md:161`.

## Why it is false

`map_to_copilot_model()` (`copilot/model_discovery.py:247`):

- The static map covers `claude-opus-4-6`, `claude-sonnet-4-5`, and their `openrouter/anthropic/` forms (`:96`). The **current** default is not in it.
- Any ID already containing a `.` short-circuits at `:276` and passes through unchanged.
- The hyphen-to-dot fallback at `:295` runs `replace("-", ".")` over the whole string, so `claude-opus-4-8` becomes `claude.opus.4.8` — not a Copilot ID — and misses.

`DEFAULT_OPUS_MODEL` is `claude-opus-4-8` (`config/_model_defaults.py:31`) and backs `clarification.default_model`, `resilience.wonder_model`, `resilience.reflect_model`, and `evaluation.semantic_model`. So a user with shipped defaults who switches to Copilot gets those passed through unmapped — the opposite of what the README told them. Runtime issue: #1995.

Replaced with the actual boundary in all three languages, plus what to do instead.

## How this was found

I corrected this same claim in `copilot.md` in #1997 and did not check whether it appeared elsewhere. Over this session I have now made that mistake — fix where the review points, leave the same claim standing in a sibling file — four times, on #1972, #1987 (twice), and #1989.

So instead of waiting for the fifth, I swept the repository for every claim I had corrected in a single file this session:

| Claim | Result |
|---|---|
| `llm.default_model` presented as real | clean — remaining hits are the corrections themselves |
| `OUROBOROS_DEFAULT_MODEL` | clean — both hits state it does not exist |
| MCP `overrides` allowlist bypass | clean — zero hits |
| Copilot hyphen-to-dot auto-mapping | **3 stale sites, this PR** |
| stale `claude-opus-4-6` references | remaining hits are correct — they describe the static map contents |

Four of five swept clean, which is why the sweep was worth running: it separates "I fixed it everywhere" from "I fixed it where I was looking," and I could not tell those apart by memory.

The generalisation belongs in #1998 — nothing mechanically relates a claim in the README to the code that would falsify it, so the detector is a person happening to grep.
