### PR TITLE
fix(copilot): map Anthropic versions through exact catalog IDs

### DIFF
--- a/docs/runtime-guides/copilot.ko.md
+++ b/docs/runtime-guides/copilot.ko.md
@@ -64,20 +64,17 @@ Ouroboros가 띄우는 Copilot 자식 세션은 setup이 소유하는 `~/.copilo
 2. 그 토큰으로 `GET https://api.githubcopilot.com/models`
 3. `data[].id`와 `capabilities.family`를 타입 있는 목록으로 파싱
 4. setup 실행이 끝날 때까지 프로세스 안에 캐시
-5. 위 중 무엇이든 실패하면(`gh` 없음, 네트워크 다운, 레이트 리밋, 파싱 오류) **조용히** 잘 알려진 ID 번들 스냅숏으로 폴백해서 setup이 끝까지 진행됩니다
+5. 위 중 무엇이든 실패하면(`gh` 없음, 네트워크 다운, 레이트 리밋, 파싱 오류) 경고를 출력하고 잘 알려진 ID 번들 스냅숏으로 폴백해서 setup이 끝까지 진행됩니다
 
 setup은 고른 기본 모델을 출력하고, `~/.ouroboros/config.yaml`의 지원되는 모델 필드들에 반영합니다. 예를 들어 `clarification.default_model`, `llm.qa_model`, 평가/복원력 모델 필드, 그리고 해당 필드가 비어 있거나 아직 Ouroboros 기본값 상태일 때의 consensus 모델 기본값입니다. **설정 계약에 `llm.default_model` 키는 없습니다.** GitHub가 새 모델을 내놓은 뒤 새 기본값을 고르고 싶으면 `ouroboros setup --runtime copilot`을 언제든 다시 돌리세요.
 
 ### 하이픈 표기와 점 표기 모델 ID
 
-Ouroboros 기본값은 하이픈 붙은 Anthropic SDK 형식(`claude-opus-4-8`, `claude-sonnet-4-5`)을 씁니다. Copilot CLI는 점 표기(`claude-opus-4.6`, `claude-sonnet-4.5`)를 기대합니다. 어댑터가 **일부만** 변환하고, 그 경계가 보기보다 좁습니다. **백엔드를 바꾸기 전에 명시적으로 지정한 오버라이드를 확인하세요.**
+Ouroboros 기본값은 하이픈 붙은 Anthropic SDK 형식(`claude-opus-4-8`, `claude-sonnet-4-5`)을 씁니다. Copilot CLI는 점 표기(`claude-opus-4.8`, `claude-sonnet-4.5`)를 기대합니다. 어댑터는 임의의 모델 이름을 바꾸지 않고 발견된 Copilot catalog를 기준으로 이 형식들을 해석합니다.
 
-`map_to_copilot_model()`([`copilot/model_discovery.py:247`](../../src/ouroboros/copilot/model_discovery.py))의 해석 순서는 이렇습니다. 발견된 목록과의 그대로 일치 → 정적 이름 맵(현재 `claude-opus-4-6`, `claude-sonnet-4-5`와 그 `openrouter/anthropic/` 형태를 커버) → 하이픈-점 폴백. 결과는 둘입니다:
+`map_to_copilot_model()`([`copilot/model_discovery.py`](../../src/ouroboros/copilot/model_discovery.py))은 명시적인 점 표기 Copilot ID를 그대로 통과시키고, 알려진 `openrouter/anthropic/` 접두사 제거, 기존의 정확한 정적 별칭, 또는 마지막 숫자 버전 구분자만 점으로 바꾸는 방식으로 후보를 만듭니다. 예를 들어 `claude-opus-4-8`은 `claude-opus-4.8` 후보가 됩니다. `claude-opus` 안의 하이픈은 건드리지 않습니다. 접두사를 제거했거나 정적 매핑으로 만든 값을 포함한 모든 변환 후보는 발견된 catalog나 번들 catalog에 정확히 같은 ID가 있을 때만 반환됩니다.
 
-- `.`이 이미 들어 있는 ID는 맨 앞에서 단락되어 **그대로 통과합니다**(`:276`).
-- 폴백은 `replace("-", ".")`를 호출해 **하이픈을 전부** 바꿉니다. `claude-opus-4-8`은 `claude.opus.4.8`이 되고, 이건 Copilot ID가 아니므로 **역시 그대로 통과합니다.**
-
-즉 현재 `DEFAULT_OPUS_MODEL`인 `claude-opus-4-8`은 이전 기본값과 달리 **Copilot 매핑이 없습니다.** [#1995](https://github.com/Q00/ouroboros/issues/1995)에서 추적 중입니다. 역할별 모델을 비워 두어 setup이 발견한 ID를 쓰게 하거나, 점 표기 Copilot ID를 명시적으로 지정하세요.
+따라서 현재 `DEFAULT_OPUS_MODEL`인 `claude-opus-4-8`과 `openrouter/anthropic/claude-opus-4-8`은 모두 catalog에 공개된 `claude-opus-4.8`로 해석됩니다. 앞으로 나올 Anthropic 버전도 정적 맵을 더하지 않고 같은 catalog 확인 규칙을 씁니다. 알 수 없는 모델이나 현재 catalog에 없는 변환 후보는 OpenRouter 접두사를 포함한 원래 ID를 보존합니다. 다른 모델을 조용히 고르는 대신 기존 Copilot unavailable-model 오류가 명확히 드러나게 하기 위해서입니다.
 
 Copilot이 모르는 모델을 지정하면 서브프로세스가 `Model "<id>" from --model flag is not available.`로 실패합니다. 발견된 목록에 있는 모델을 넘기거나 setup을 다시 돌려 갱신하세요.
 

--- a/docs/runtime-guides/copilot.ko.md
+++ b/docs/runtime-guides/copilot.ko.md
@@ -70,7 +70,7 @@ setup은 고른 기본 모델을 출력하고, `~/.ouroboros/config.yaml`의 지
 
 ### 하이픈 표기와 점 표기 모델 ID
 
-Ouroboros 기본값은 하이픈 붙은 Anthropic SDK 형식(`claude-opus-4-8`, `claude-sonnet-4-5`)을 씁니다. Copilot CLI는 점 표기(`claude-opus-4.8`, `claude-sonnet-4.5`)를 기대합니다. 어댑터는 임의의 모델 이름을 바꾸지 않고 발견된 Copilot catalog를 기준으로 이 형식들을 해석합니다.
+Ouroboros 기본값은 하이픈 붙은 Anthropic SDK 형식(`claude-opus-4-8`, `claude-sonnet-4-6`)을 씁니다. Copilot CLI는 점 표기(`claude-opus-4.8`, `claude-sonnet-4.6`)를 기대합니다. 어댑터는 임의의 모델 이름을 바꾸지 않고 발견된 Copilot catalog를 기준으로 이 형식들을 해석합니다.
 
 `map_to_copilot_model()`([`copilot/model_discovery.py`](../../src/ouroboros/copilot/model_discovery.py))은 명시적인 점 표기 Copilot ID를 그대로 통과시키고, 알려진 `openrouter/anthropic/` 접두사 제거, 기존의 정확한 정적 별칭, 또는 마지막 숫자 버전 구분자만 점으로 바꾸는 방식으로 후보를 만듭니다. 예를 들어 `claude-opus-4-8`은 `claude-opus-4.8` 후보가 됩니다. `claude-opus` 안의 하이픈은 건드리지 않습니다. 접두사를 제거했거나 정적 매핑으로 만든 값을 포함한 모든 변환 후보는 발견된 catalog나 번들 catalog에 정확히 같은 ID가 있을 때만 반환됩니다.
 

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -86,8 +86,8 @@ at the start of the wizard. The flow:
 3. Parse `data[].id` and `capabilities.family` into a typed list.
 4. Cache the result in process for the rest of the setup run.
 5. If any of the above fails (no `gh`, network down, rate limited, parse
-   error), fall back silently to a bundled snapshot of well-known IDs so
-   setup still completes.
+   error), print a warning and fall back to a bundled snapshot of well-known
+   IDs so setup still completes.
 
 Setup prints the chosen default model and persists it through supported
 model fields in `~/.ouroboros/config.yaml` — for example
@@ -101,25 +101,26 @@ a new default after GitHub ships new models.
 
 Ouroboros' defaults use the hyphenated Anthropic SDK form
 (`claude-opus-4-8`, `claude-sonnet-4-5`). Copilot CLI expects the dotted form
-(`claude-opus-4.6`, `claude-sonnet-4.5`). The adapter maps *some* of these, and
-the boundary is narrower than it looks — check your explicit overrides before
-switching.
+(`claude-opus-4.8`, `claude-sonnet-4.5`). The adapter resolves these forms
+against the discovered Copilot catalog rather than rewriting arbitrary model
+names.
 
-`map_to_copilot_model()` ([`copilot/model_discovery.py:247`](../../src/ouroboros/copilot/model_discovery.py))
-resolves in order: a verbatim match against the discovered catalog; a static
-name map that currently covers `claude-opus-4-6`, `claude-sonnet-4-5`, and their
-`openrouter/anthropic/` forms; then a hyphen-to-dot fallback. Two consequences:
+`map_to_copilot_model()` ([`copilot/model_discovery.py`](../../src/ouroboros/copilot/model_discovery.py))
+passes through an explicit dotted Copilot ID, then derives candidates by
+removing the known `openrouter/anthropic/` prefix, preserving exact legacy
+aliases, or changing only the trailing numeric version separator. For example,
+`claude-opus-4-8` becomes the candidate `claude-opus-4.8`; the hyphens in
+`claude-opus` are never touched. Every transformed candidate, including a
+prefix-stripped or statically mapped one, is returned only when that exact ID
+is in the discovered or bundled catalog.
 
-- Any ID already containing a `.` short-circuits at the top and passes through
-  unchanged (`:276`).
-- The fallback calls `replace("-", ".")`, which rewrites *every* hyphen, so
-  `claude-opus-4-8` becomes `claude.opus.4.8` — not a Copilot ID — and also
-  passes through unchanged.
-
-So the current `DEFAULT_OPUS_MODEL` (`claude-opus-4-8`) has **no** Copilot
-mapping, unlike the previous default. Tracked in
-[#1995](https://github.com/Q00/ouroboros/issues/1995). Leave role models unset so
-setup writes a discovered ID, or set a dotted Copilot ID explicitly.
+The current `DEFAULT_OPUS_MODEL` therefore resolves to the published
+`claude-opus-4.8`, as does `openrouter/anthropic/claude-opus-4-8`. Future
+Anthropic versions use the same catalog-gated trailing-version rule without
+another static-map entry. An unknown model, or any derived candidate that the
+active catalog does not publish, remains unchanged—including its OpenRouter
+prefix—so the existing Copilot unavailable-model error stays explicit rather
+than silently selecting a different model.
 
 If you set a model that Copilot does not recognise, the subprocess will
 fail with `Model "<id>" from --model flag is not available.` Pass a model

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -100,8 +100,8 @@ a new default after GitHub ships new models.
 ### Hyphen versus dotted model IDs
 
 Ouroboros' defaults use the hyphenated Anthropic SDK form
-(`claude-opus-4-8`, `claude-sonnet-4-5`). Copilot CLI expects the dotted form
-(`claude-opus-4.8`, `claude-sonnet-4.5`). The adapter resolves these forms
+(`claude-opus-4-8`, `claude-sonnet-4-6`). Copilot CLI expects the dotted form
+(`claude-opus-4.8`, `claude-sonnet-4.6`). The adapter resolves these forms
 against the discovered Copilot catalog rather than rewriting arbitrary model
 names.
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3384,8 +3384,9 @@ def _setup_copilot(copilot_path: str, *, non_interactive: bool = False) -> bool:
         print_error("~/.ouroboros/config.yaml top-level is not a mapping — aborting Copilot setup.")
         return False
 
-    # Live-discover available Copilot models. Falls back silently to a
-    # bundled snapshot when the GitHub API is unreachable or unauthenticated.
+    # Live-discover available Copilot models. When the GitHub API is
+    # unreachable or unauthenticated, use a bundled snapshot and warn that it
+    # may be stale.
     models = list_copilot_models(refresh=True)
     if used_fallback():
         print_warning(

--- a/src/ouroboros/copilot/model_discovery.py
+++ b/src/ouroboros/copilot/model_discovery.py
@@ -13,11 +13,12 @@ This module:
 * Caches the result in process so setup wizards and adapters don't re-hit the
   API on every call.
 * Falls back to a hardcoded snapshot when the API or auth fails so offline
-  setup still produces a usable list.
+  setup still produces a usable list, with setup warning that the snapshot
+  may be stale.
 * Exposes :func:`map_to_copilot_model` which translates an internal Ouroboros
   model name (typically the Anthropic hyphen form) to a Copilot-valid ID by
-  consulting the discovered list, falling back to a static map of well-known
-  Anthropic IDs.
+  consulting the discovered list, preserving legacy aliases, and converting
+  only a catalog-backed trailing Anthropic version separator.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 import json
 import os
+import re
 import shutil
 import subprocess
 from typing import Any
@@ -40,6 +42,8 @@ _MODELS_URL = "https://api.githubcopilot.com/models"
 _REQUEST_TIMEOUT_SECONDS = 5.0
 _INTEGRATION_ID = "copilot-cli"
 _EDITOR_VERSION = "ouroboros-discovery/1.0"
+_OPENROUTER_ANTHROPIC_PREFIX = "openrouter/anthropic/"
+_ANTHROPIC_HYPHEN_VERSION = re.compile(r"^(?P<stem>claude-[a-z0-9]+-\d+)-(?P<minor>\d+)$")
 
 
 @dataclass(frozen=True)
@@ -54,6 +58,9 @@ class CopilotModel:
 
 
 _FALLBACK_MODELS: tuple[CopilotModel, ...] = (
+    CopilotModel(
+        id="claude-opus-4.8", family="claude-opus-4.8", vendor="Anthropic", name="Claude Opus 4.8"
+    ),
     CopilotModel(
         id="claude-opus-4.7", family="claude-opus-4.7", vendor="Anthropic", name="Claude Opus 4.7"
     ),
@@ -244,6 +251,26 @@ def used_fallback() -> bool:
     return _cached_used_fallback
 
 
+def _unqualified_anthropic_model(model: str) -> str:
+    """Return the Copilot candidate behind a known provider prefix."""
+    if model.startswith(_OPENROUTER_ANTHROPIC_PREFIX):
+        return model[len(_OPENROUTER_ANTHROPIC_PREFIX) :]
+    return model
+
+
+def _anthropic_dotted_candidate(model: str) -> str | None:
+    """Convert only an Anthropic model's trailing numeric version separator.
+
+    ``claude-opus-4-8`` becomes ``claude-opus-4.8``. Other hyphens remain
+    untouched, and non-Anthropic identifiers do not produce a candidate.
+    Availability is checked separately against the discovered catalog.
+    """
+    match = _ANTHROPIC_HYPHEN_VERSION.fullmatch(model)
+    if match is None:
+        return None
+    return f"{match.group('stem')}.{match.group('minor')}"
+
+
 def map_to_copilot_model(
     model: str,
     *,
@@ -253,12 +280,12 @@ def map_to_copilot_model(
 
     Resolution order:
 
-    1. If ``model`` already matches one of ``available`` model IDs verbatim,
-       return it unchanged.
-    2. If ``model`` is in the static name map (well-known Anthropic IDs),
-       return the mapped form.
-    3. If ``model`` strips to a known dotted family present in ``available``,
-       return that ID.
+    1. Trust the ``default`` marker and direct dotted Copilot IDs.
+    2. Derive candidates by removing a known ``openrouter/anthropic/`` prefix,
+       applying a legacy alias, or changing only the trailing Anthropic version
+       separator from a hyphen to a dot.
+    3. Return a derived candidate only when its exact ID is in the discovered
+       Copilot catalog.
     4. Otherwise return ``model`` unchanged so the caller can decide whether
        to fail or pass it through.
     """
@@ -268,34 +295,30 @@ def map_to_copilot_model(
     model_clean = model.strip()
     if not model_clean:
         return model
+    has_openrouter_prefix = model_clean.startswith(_OPENROUTER_ANTHROPIC_PREFIX)
+    unqualified_model = _unqualified_anthropic_model(model_clean)
 
-    # Fast path: dotted forms (the Copilot canonical shape) and explicit
-    # passthrough markers skip discovery entirely. This keeps the adapter
-    # zero-cost in unit tests and avoids spawning ``gh auth token`` for
-    # callers that already supply a Copilot-valid ID.
-    if model_clean == "default" or "." in model_clean:
+    # Direct dotted forms are already in Copilot's canonical shape. A dotted
+    # OpenRouter value is different: removing its provider prefix is a
+    # transformation, so it must still be checked against the catalog below.
+    if model_clean == "default" or (not has_openrouter_prefix and "." in model_clean):
         return model_clean
 
     mapped_static = _STATIC_NAME_MAP.get(model_clean)
-    if mapped_static is not None and available is None:
-        return mapped_static
 
     pool = list(available) if available is not None else list_copilot_models()
     available_ids = {entry.id for entry in pool}
-    families = {entry.family for entry in pool if entry.family}
 
-    if model_clean in available_ids:
-        return model_clean
+    if unqualified_model in available_ids:
+        return unqualified_model
 
-    if mapped_static and (
-        not available_ids or mapped_static in available_ids or mapped_static in families
-    ):
+    if mapped_static and mapped_static in available_ids:
         return mapped_static
 
-    # Last attempt: hyphen-to-dot conversion when the dotted variant exists.
-    if "-" in model_clean:
-        dotted_candidate = model_clean.replace("-", ".")
-        if dotted_candidate in available_ids:
-            return dotted_candidate
+    # Last attempt: convert only the trailing numeric version separator, and
+    # only accept the result when Copilot's catalog publishes that exact ID.
+    dotted_candidate = _anthropic_dotted_candidate(unqualified_model)
+    if dotted_candidate is not None and dotted_candidate in available_ids:
+        return dotted_candidate
 
     return model_clean

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -9973,9 +9973,7 @@ class TestCopilotSetup:
         assert config_path.read_text(encoding="utf-8") == original
         mock_register.assert_not_called()
 
-    def test_setup_copilot_warns_when_discovery_used_fallback(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_setup_copilot_warns_when_discovery_used_fallback(self, tmp_path: Path) -> None:
         """Setup must visibly warn when it could not reach the live API."""
         config_dir = tmp_path / ".ouroboros"
         config_dir.mkdir()
@@ -9995,11 +9993,14 @@ class TestCopilotSetup:
                 return_value=True,
             ),
             patch("ouroboros.cli.commands.setup._register_copilot_mcp_server"),
+            patch("ouroboros.cli.commands.setup.print_warning") as mock_warning,
         ):
             setup_cmd._setup_copilot("/opt/bin/copilot", non_interactive=True)
 
-        out = capsys.readouterr().out
-        assert "fallback" in out.lower() or "gh auth" in out.lower()
+        mock_warning.assert_called_once_with(
+            "Could not reach the GitHub Copilot models API — using a bundled "
+            "fallback list. Run `gh auth login` and re-run setup to refresh."
+        )
 
     def test_setup_copilot_aborts_when_no_models_discovered(self, tmp_path: Path) -> None:
         """If discovery returns an empty list, setup must abort cleanly

--- a/tests/unit/copilot/test_model_discovery.py
+++ b/tests/unit/copilot/test_model_discovery.py
@@ -8,10 +8,17 @@ import subprocess
 from typing import Any
 from unittest.mock import patch
 
+from ouroboros.config._model_defaults import DEFAULT_CONSENSUS_OPUS_MODEL, DEFAULT_OPUS_MODEL
 from ouroboros.copilot import model_discovery as md
 
 _FAKE_API_PAYLOAD: dict[str, Any] = {
     "data": [
+        {
+            "id": "claude-opus-4.8",
+            "name": "Claude Opus 4.8",
+            "vendor": "Anthropic",
+            "capabilities": {"family": "claude-opus-4.8"},
+        },
         {
             "id": "claude-opus-4.6",
             "name": "Claude Opus 4.6",
@@ -66,6 +73,7 @@ class TestListCopilotModels:
             models = md.list_copilot_models(refresh=True)
 
         assert [m.id for m in models] == [
+            "claude-opus-4.8",
             "claude-opus-4.6",
             "claude-sonnet-4.5",
             "gpt-5.2",
@@ -77,6 +85,7 @@ class TestListCopilotModels:
             models = md.list_copilot_models(refresh=True)
 
         assert models, "fallback list should be non-empty"
+        assert any(m.id == "claude-opus-4.8" for m in models)
         assert any(m.id == "claude-opus-4.6" for m in models)
         assert md.used_fallback() is True
 
@@ -133,13 +142,90 @@ class TestMapToCopilotModel:
         with patch.object(md, "_resolve_token", side_effect=AssertionError("called")):
             assert md.map_to_copilot_model("default") == "default"
 
-    def test_static_map_handles_anthropic_hyphen_form(self) -> None:
+    def test_static_map_handles_anthropic_hyphen_form_when_available(self) -> None:
+        pool = [
+            md.CopilotModel(id="claude-opus-4.6", family="claude-opus-4.6"),
+            md.CopilotModel(id="claude-sonnet-4.6", family="claude-sonnet-4.6"),
+        ]
         with patch.object(md, "_resolve_token", side_effect=AssertionError("called")):
-            assert md.map_to_copilot_model("claude-opus-4-6") == "claude-opus-4.6"
-            assert md.map_to_copilot_model("claude-sonnet-4-6") == "claude-sonnet-4.6"
+            assert md.map_to_copilot_model("claude-opus-4-6", available=pool) == "claude-opus-4.6"
             assert (
-                md.map_to_copilot_model("openrouter/anthropic/claude-opus-4-6") == "claude-opus-4.6"
+                md.map_to_copilot_model("claude-sonnet-4-6", available=pool) == "claude-sonnet-4.6"
             )
+            assert (
+                md.map_to_copilot_model(
+                    "openrouter/anthropic/claude-opus-4-6",
+                    available=pool,
+                )
+                == "claude-opus-4.6"
+            )
+
+    def test_current_default_maps_to_exact_catalog_id(self) -> None:
+        pool = [md.CopilotModel(id="claude-opus-4.8", family="claude-opus-4.8")]
+
+        assert md.map_to_copilot_model(DEFAULT_OPUS_MODEL, available=pool) == "claude-opus-4.8"
+        assert (
+            md.map_to_copilot_model(DEFAULT_CONSENSUS_OPUS_MODEL, available=pool)
+            == "claude-opus-4.8"
+        )
+
+    def test_current_default_maps_from_bundled_catalog_when_discovery_fails(self) -> None:
+        with patch.object(md, "_resolve_token", return_value=None):
+            assert md.map_to_copilot_model(DEFAULT_OPUS_MODEL) == "claude-opus-4.8"
+            assert md.used_fallback() is True
+
+    def test_future_anthropic_version_uses_catalog_driven_candidate(self) -> None:
+        pool = [md.CopilotModel(id="claude-sonnet-5.1", family="claude-sonnet-5.1")]
+
+        assert md.map_to_copilot_model("claude-sonnet-5-1", available=pool) == "claude-sonnet-5.1"
+        assert (
+            md.map_to_copilot_model(
+                "openrouter/anthropic/claude-sonnet-5-1",
+                available=pool,
+            )
+            == "claude-sonnet-5.1"
+        )
+
+    def test_candidate_must_be_available_in_catalog(self) -> None:
+        pool = [md.CopilotModel(id="claude-opus-4.7", family="claude-opus-4.7")]
+
+        assert md.map_to_copilot_model(DEFAULT_OPUS_MODEL, available=pool) == DEFAULT_OPUS_MODEL
+        assert (
+            md.map_to_copilot_model(DEFAULT_CONSENSUS_OPUS_MODEL, available=pool)
+            == DEFAULT_CONSENSUS_OPUS_MODEL
+        )
+
+    def test_openrouter_prefix_is_removed_only_for_an_exact_catalog_id(self) -> None:
+        model = "openrouter/anthropic/claude-fable-5"
+        exact_pool = [md.CopilotModel(id="claude-fable-5", family="claude-fable-5")]
+        family_only_pool = [md.CopilotModel(id="claude-fable-5-fast", family="claude-fable-5")]
+
+        assert md.map_to_copilot_model(model, available=exact_pool) == "claude-fable-5"
+        assert md.map_to_copilot_model(model, available=family_only_pool) == model
+
+    def test_static_alias_is_catalog_gated_by_exact_id(self) -> None:
+        alias = "legacy-opus"
+        target = "claude-opus-4.6"
+        exact_pool = [md.CopilotModel(id=target, family=target)]
+        family_only_pool = [md.CopilotModel(id="claude-opus-fast", family=target)]
+
+        with patch.dict(md._STATIC_NAME_MAP, {alias: target}):
+            assert md.map_to_copilot_model(alias, available=exact_pool) == target
+            assert md.map_to_copilot_model(alias, available=family_only_pool) == alias
+
+    def test_fallback_never_replaces_every_hyphen(self) -> None:
+        malformed_old_candidate = "claude.opus.beta.4.8"
+        pool = [md.CopilotModel(id=malformed_old_candidate, family=malformed_old_candidate)]
+
+        assert (
+            md.map_to_copilot_model("claude-opus-beta-4-8", available=pool)
+            == "claude-opus-beta-4-8"
+        )
+
+    def test_non_anthropic_unknown_id_is_preserved_even_if_dotted_shape_exists(self) -> None:
+        pool = [md.CopilotModel(id="acme-future-9.0", family="acme-future-9.0")]
+
+        assert md.map_to_copilot_model("acme-future-9-0", available=pool) == "acme-future-9-0"
 
     def test_unknown_hyphen_id_returns_unchanged(self) -> None:
         with patch.object(md, "_resolve_token", return_value=None):

--- a/tests/unit/copilot/test_model_discovery.py
+++ b/tests/unit/copilot/test_model_discovery.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import subprocess
 from typing import Any
 from unittest.mock import patch
 
-from ouroboros.config._model_defaults import DEFAULT_CONSENSUS_OPUS_MODEL, DEFAULT_OPUS_MODEL
+import pytest
+
+from ouroboros.config._model_defaults import (
+    DEFAULT_CONSENSUS_OPUS_MODEL,
+    DEFAULT_OPUS_MODEL,
+    DEFAULT_SONNET_MODEL,
+)
 from ouroboros.copilot import model_discovery as md
 
 _FAKE_API_PAYLOAD: dict[str, Any] = {
@@ -39,6 +46,26 @@ _FAKE_API_PAYLOAD: dict[str, Any] = {
         },
     ]
 }
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "guide_path",
+    (
+        "docs/runtime-guides/copilot.md",
+        "docs/runtime-guides/copilot.ko.md",
+    ),
+)
+def test_runtime_guide_documents_current_anthropic_default_mappings(guide_path: str) -> None:
+    guide = (_REPO_ROOT / guide_path).read_text(encoding="utf-8")
+
+    assert f"`{DEFAULT_OPUS_MODEL}`" in guide
+    assert "`claude-opus-4.8`" in guide
+    assert f"`{DEFAULT_SONNET_MODEL}`" in guide
+    assert "`claude-sonnet-4.6`" in guide
+    assert "`claude-sonnet-4-5`" not in guide
+    assert "`claude-sonnet-4.5`" not in guide
 
 
 class _FakeUrlResponse:

--- a/tests/unit/orchestrator/test_copilot_cli_runtime.py
+++ b/tests/unit/orchestrator/test_copilot_cli_runtime.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 from dataclasses import replace
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL
+from ouroboros.copilot.model_discovery import CopilotModel
 from ouroboros.orchestrator.adapter import ParamSupport
 from ouroboros.orchestrator.copilot_cli_runtime import (
     _MAX_OUROBOROS_DEPTH,
@@ -99,6 +102,23 @@ def test_build_command_maps_anthropic_hyphen_id_to_dotted_form() -> None:
     )
     idx = command.index("--model")
     assert command[idx + 1] == "claude-opus-4.6"
+
+
+def test_build_command_maps_current_default_from_catalog() -> None:
+    runtime = _make_runtime(model=DEFAULT_OPUS_MODEL)
+    catalog = [CopilotModel(id="claude-opus-4.8", family="claude-opus-4.8")]
+
+    with patch(
+        "ouroboros.copilot.model_discovery.list_copilot_models",
+        return_value=catalog,
+    ):
+        command = runtime._build_command(
+            output_last_message_path="/tmp/ignored",
+            prompt="task",
+        )
+
+    idx = command.index("--model")
+    assert command[idx + 1] == "claude-opus-4.8"
 
 
 def test_build_command_passes_dotted_model_through_unchanged() -> None:

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 
 import pytest
 
+from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL
+from ouroboros.copilot.model_discovery import CopilotModel
 from ouroboros.core.errors import ProviderError
 from ouroboros.providers.base import CompletionConfig, Message, MessageRole
 from ouroboros.providers.copilot_cli_adapter import CopilotCliLLMAdapter
@@ -248,6 +250,19 @@ class TestCommandBuilding:
         command = adapter._build_command(model="claude-opus-4-6")
         idx = command.index("--model")
         assert command[idx + 1] == "claude-opus-4.6"
+
+    def test_command_maps_current_default_from_catalog(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot")
+        catalog = [CopilotModel(id="claude-opus-4.8", family="claude-opus-4.8")]
+
+        with patch(
+            "ouroboros.copilot.model_discovery.list_copilot_models",
+            return_value=catalog,
+        ):
+            command = adapter._build_command(model=DEFAULT_OPUS_MODEL)
+
+        idx = command.index("--model")
+        assert command[idx + 1] == "claude-opus-4.8"
 
     def test_command_uses_agent_over_model_when_runtime_profile_set(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", runtime_profile="worker")


### PR DESCRIPTION
Closes #1995

Follow-up to #2004: this fixes the runtime mapping boundary instead of only narrowing README wording.

## Summary

- map only the trailing Anthropic numeric separator, preserving family-name hyphens
- require the exact derived direct/static/OpenRouter model ID to exist in the discovered catalog
- preserve unavailable, malformed, blank, and non-Anthropic IDs unchanged
- map shipped Opus and Sonnet defaults to current Copilot catalog forms
- correct English/Korean runtime guidance and add bilingual documentation-contract coverage

## Verification

Independent PASS at exact HEAD `94c6531b91ca39c63939a58fdd7b809825b4085b`, based on GitHub main `5ba0af5c4a1824695fb7848db01171a41624dcba`.

- focused mapper/docs/runtime/provider/setup: 120 passed after rebase
- broader prior independent run: 6,489 passed, 8 skipped
- exact catalog, unavailable-candidate, OpenRouter, setup-warning, and malformed-ID adversarial probes: PASS
- Ruff, format, MyPy, diff check, and EN/KO links: PASS