### PR TITLE
docs(ko): point the Korean README at the Korean runtime guides

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -203,7 +203,7 @@ ouroboros setup --runtime copilot            # 모델 실시간 검색 및 기�
 
 Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 사용합니다. **모델 ID 변환 범위는 생각보다 좁습니다.** 정적 맵은 `claude-opus-4-6`과 `claude-sonnet-4-5`까지 커버하고, `.`이 이미 들어간 ID는 그대로 통과하며, 하이픈-점 폴백은 **하이픈을 전부** 바꾸기 때문에 현재 기본값 `claude-opus-4-8`은 `claude.opus.4.8`이 되어 매칭에 실패합니다. 역할별 모델을 비워 두어 setup이 발견한 ID를 쓰게 하거나, 점 표기 Copilot ID를 명시하세요. [#1995](https://github.com/Q00/ouroboros/issues/1995)와 [Copilot 런타임 가이드](./docs/runtime-guides/copilot.ko.md) 참고.
 
-자세한 내용은 [GitHub Copilot CLI 런타임 가이드](./docs/runtime-guides/copilot.md)를 참고하세요.
+자세한 내용은 [GitHub Copilot CLI 런타임 가이드](./docs/runtime-guides/copilot.ko.md)를 참고하세요.
 
 </details>
 
@@ -235,7 +235,7 @@ ouroboros setup                         # 런타임 설정
 
 호환성 참고: extras 전환 기간 동안 `ouroboros-ai[dashboard]`도 no-op alias로 계속 허용됩니다.
 
-런타임별 가이드: [Claude Code](./docs/runtime-guides/claude-code.ko.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
+런타임별 가이드: [Claude Code](./docs/runtime-guides/claude-code.ko.md) · [Codex CLI](./docs/runtime-guides/codex.ko.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.ko.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.ko.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
 
 </details>
 


### PR DESCRIPTION
Part of #1988 (Korean runtime guides).

Four Korean runtime guides are now on `main` — `claude-code.ko.md`, `codex.ko.md`, `copilot.ko.md`, `kiro.ko.md`. `README.ko.md` still linked to the English version of three of them.

| Link | Was | Now |
|---|---|---|
| GitHub Copilot CLI 런타임 가이드 | `copilot.md` | `copilot.ko.md` |
| GitHub Copilot CLI | `copilot.md` | `copilot.ko.md` |
| Codex CLI | `codex.md` | `codex.ko.md` |
| Kiro CLI | `kiro.md` | `kiro.ko.md` |

## Why this is worth a PR on its own

`README.ko.md` is the **second most-read path in the repository** — 1,855 views and 1,202 unique visitors over the measured 14-day window, six times the third-place path. It is where Korean readers arrive, and it was routing them past translations that already exist a few directories away.

Translating a guide and not linking to it from the page its readers actually land on gets most of the benefit lost.

## Verification

I checked mechanically rather than by re-reading, because my first pass at this used the link text I *expected* and missed two of the four — `[Kiro CLI]` and `[GitHub Copilot CLI]` rather than the `[Kiro]` and `[GitHub Copilot CLI 런타임 가이드]` I had guessed. The check caught them.

After the change: every `docs/runtime-guides/*.md` link in `README.ko.md` resolves, and there is no remaining English link for which a `.ko.md` sibling exists.

Ran the same check on `README.zh-CN.md` (against `.zh-CN.md` siblings) and `README.md` — both already clean, so this is Korean-only.
