### PR TITLE
fix(mcp): launch shipped MCP servers with uvx --isolated

### DIFF
--- a/.claude-plugin/.mcp.json
+++ b/.claude-plugin/.mcp.json
@@ -3,6 +3,7 @@
     "ouroboros": {
       "command": "uvx",
       "args": [
+        "--isolated",
         "--python",
         ">=3.12",
         "--from",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,7 @@
 [mcp_servers.ouroboros]
 command = "uvx"
 args = [
+    "--isolated",
     "--python",
     ">=3.12",
     "--from",

--- a/.mcp.codex.json
+++ b/.mcp.codex.json
@@ -3,6 +3,7 @@
     "ouroboros": {
       "command": "uvx",
       "args": [
+        "--isolated",
         "--from",
         "ouroboros-ai[mcp]",
         "ouroboros",

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,7 @@
     "ouroboros": {
       "command": "uvx",
       "args": [
+        "--isolated",
         "--python",
         ">=3.12",
         "--from",

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -183,6 +183,7 @@ def test_codex_plugin_manifest_starts_a_codex_composed_mcp_server() -> None:
     assert codex_mcp["mcpServers"]["ouroboros"] == {
         "command": "uvx",
         "args": [
+            "--isolated",
             "--from",
             "ouroboros-ai[mcp]",
             "ouroboros",

--- a/tests/unit/test_dependencies_configured.py
+++ b/tests/unit/test_dependencies_configured.py
@@ -194,6 +194,7 @@ def test_shipped_mcp_launchers_use_the_isolated_mcp_profile() -> None:
     """Repository and plugin launchers must never combine MCP 2 with Claude."""
     root = Path(__file__).parent.parent.parent
     expected_args = [
+        "--isolated",
         "--python",
         ">=3.12",
         "--from",


### PR DESCRIPTION
## Problem

`/mcp` in Claude Code fails with:

```
Failed to reconnect to plugin:ouroboros:ouroboros: -32000
```

Root cause: without `--isolated`, **uvx reuses an existing `uv tool install ouroboros-ai` environment even when the request names the `[mcp]` extra**. When that tool env was installed with `claude-agent-sdk` (MCP SDK 1.x), the shipped launcher resolves `mcp==1.29.0` instead of the `[mcp]` extra's `mcp==2.0.0`. The server builds the full composition root, registers all 35 tools, then dies at stdio startup:

```
MCP Server starting on stdio...
Registered 35 tools
...
MCP dependencies not installed: mcp package not installed.
```

Ironically, `adapter.py`'s own error message already says *"Run MCP 2 in an isolated profile: uvx --from 'ouroboros-ai[mcp]' ..."* — but the shipped launchers don't actually guarantee isolation.

## Why `--python >=3.12` is not enough

Verified empirically on a machine with `uv tool install ouroboros-ai --with claude-agent-sdk==0.2.123`:

```
$ uvx --python '>=3.12' --from 'ouroboros-ai[mcp]' python -c "import importlib.metadata as im; print(im.version('mcp'))"
1.29.0    # tool env reused — its Python 3.14 satisfies the constraint

$ uvx --isolated --python '>=3.12' --from 'ouroboros-ai[mcp]' python -c "import importlib.metadata as im; print(im.version('mcp'))"
2.0.0     # fresh resolution — [mcp]'s pin wins
```

With `--isolated`, the stdio `initialize` handshake succeeds (exit 0, valid JSON-RPC response); without it, exit 1 → `-32000`.

## Change

Prepend `--isolated` to the uvx args of all four shipped launchers:

- `.mcp.json`
- `.claude-plugin/.mcp.json`
- `.mcp.codex.json`
- `.codex/config.toml`

and update the two launcher-contract tests (`test_shipped_mcp_launchers_use_the_isolated_mcp_profile`, `test_skill_artifacts`).

6 insertions, no behavior change for users without a conflicting tool env (the isolated env is cached by uv after first run).

## Not in scope (follow-up)

`ooo setup`-generated user entries still emit non-isolated args and should get the same treatment plus legacy-form recognition:

- `_uvx_mcp_args()` / `_detect_mcp_entry()` (Claude path)
- `_CODEX_UVX_MCP_ARGS` + `_CODEX_LEGACY_UVX_MCP_ARGS` (Codex path — new form must be added to the managed-entry allowlist so setup can keep upgrading it)
- `_detect_opencode_mcp_command()` (OpenCode path)
- `mcp_doctor` suggested commands and the kiro/copilot/hermes runtime guides

Note: existing setup-managed detection is not regressed by this PR — `_is_setup_managed_codex_mcp_entry` treats the new arg shape as user-customized and preserves it.

## Test

```
uv run pytest tests/unit/test_dependencies_configured.py tests/unit/skills/test_skill_artifacts.py -q
66 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gRidMo4DhRu3CqmAYwgys