### PR TITLE
docs: index the four Korean runtime guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,10 @@ replayable execution contract on your choice of runtime backend.
 - [Hermes](./runtime-guides/hermes.md) - Hermes Agent runtime setup and `ooo` dispatch
 - [Zcode](./runtime-guides/zcode.md) - Z.ai desktop-agent runtime and measured CLI contract
 - [Runtime Capability Matrix](./runtime-capability-matrix.md) - Feature comparison across runtime backends
+- [Claude Code (한국어)](./runtime-guides/claude-code.ko.md) - 같은 문서의 한국어판
+- [Codex CLI (한국어)](./runtime-guides/codex.ko.md) - 같은 문서의 한국어판
+- [GitHub Copilot CLI (한국어)](./runtime-guides/copilot.ko.md) - 같은 문서의 한국어판
+- [Kiro CLI (한국어)](./runtime-guides/kiro.ko.md) - 같은 문서의 한국어판
 
 ### Architecture
 


### PR DESCRIPTION
Part of #1988 (Korean runtime guides).

`docs/README.md` already indexes translated companions:

- `Evaluation Pipeline Guide (简体中文)`
- `Hidden-Checklist Convergence (简体中文)`
- `TUI Usage Guide (한국어)`

The four Korean runtime guides merged today were not among them, so they were reachable only from `README.ko.md`. Added under **Runtime Guides**, following the existing pattern and wording.

## Why

This is the second half of a gap I fixed in #2011. There, `README.ko.md` was still linking to the English version of three guides that had Korean translations. Same shape here: the translations exist, and the pages a reader actually browses do not point at them.

`docs/README.md` is the index for anyone who enters through `docs/` rather than the repository root, which is a meaningful share — `github.com` is the second-largest referrer in the measured traffic (1,217 views), and that is internal navigation.

## Verification

Checked mechanically rather than by reading, since my last pass at this class of problem missed two entries because I searched for the link text I expected instead of what was there:

- All **49** relative links in `docs/README.md` resolve.
- Every `*.ko.md` / `*.zh-CN.md` file on disk is listed in the index — nothing translated is left unreferenced.

That second check is the one worth keeping. It fails when someone adds a translation and forgets the index, which is exactly what happened here.
