### PR TITLE
test: harden setup and stage synchronization deadlines

### DIFF
--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -5782,15 +5782,27 @@ raise SystemExit(0 if activate_claude_runtime("/second/claude") else 2)
             text=True,
         )
         try:
-            for _ in range(500):
+            import time
+
+            startup_timeout = 30.0
+            startup_deadline = time.monotonic() + startup_timeout
+            while time.monotonic() < startup_deadline:
                 if marker.exists():
                     break
                 if first.poll() is not None:
                     break
-                import time
-
                 time.sleep(0.01)
-            assert marker.exists(), first.communicate(timeout=1)
+            if not marker.exists():
+                if first.poll() is None:
+                    first.kill()
+                first_stdout, first_stderr = first.communicate()
+                pytest.fail(
+                    "first setup subprocess did not reach the credentials publication "
+                    f"checkpoint within {startup_timeout:.0f} seconds "
+                    f"(returncode={first.returncode})\n"
+                    f"stdout:\n{first_stdout}\n"
+                    f"stderr:\n{first_stderr}"
+                )
             second = subprocess.Popen(
                 [sys.executable, "-c", second_script],
                 cwd=root,
@@ -5800,8 +5812,6 @@ raise SystemExit(0 if activate_claude_runtime("/second/claude") else 2)
                 text=True,
             )
             # The second process must still be waiting on the activation lock.
-            import time
-
             time.sleep(0.1)
             assert second.poll() is None
             release.write_text("go", encoding="utf-8")

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -5781,10 +5781,12 @@ raise SystemExit(0 if activate_claude_runtime("/second/claude") else 2)
             stderr=subprocess.PIPE,
             text=True,
         )
+        second: subprocess.Popen[str] | None = None
         try:
             import time
 
             startup_timeout = 30.0
+            deadlock_timeout = 30.0
             startup_deadline = time.monotonic() + startup_timeout
             while time.monotonic() < startup_deadline:
                 if marker.exists():
@@ -5815,12 +5817,28 @@ raise SystemExit(0 if activate_claude_runtime("/second/claude") else 2)
             time.sleep(0.1)
             assert second.poll() is None
             release.write_text("go", encoding="utf-8")
-            first_stdout, first_stderr = first.communicate(timeout=10)
-            second_stdout, second_stderr = second.communicate(timeout=10)
+            first_stdout, first_stderr = first.communicate(timeout=deadlock_timeout)
+            second_stdout, second_stderr = second.communicate(timeout=deadlock_timeout)
         finally:
-            if first.poll() is None:
-                first.kill()
-                first.wait()
+            primary_error = sys.exception()
+            cleanup_errors: list[tuple[str, Exception]] = []
+            for name, process in (("first", first), ("second", second)):
+                if process is None:
+                    continue
+                try:
+                    if process.poll() is None:
+                        process.kill()
+                    process.communicate()
+                except Exception as error:  # pragma: no cover - OS-level cleanup failure
+                    cleanup_errors.append((name, error))
+            if cleanup_errors:
+                details = "; ".join(
+                    f"{name} subprocess cleanup failed: {error!r}" for name, error in cleanup_errors
+                )
+                if primary_error is not None:
+                    primary_error.add_note(details)
+                else:
+                    raise AssertionError(details) from cleanup_errors[0][1]
 
         assert first.returncode == 0, first_stdout + first_stderr
         assert second.returncode == 0, second_stdout + second_stderr

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -16065,11 +16065,11 @@ class TestParallelACExecutor:
                 )
             )
 
-            await asyncio.wait_for(all_stage_one_started.wait(), timeout=1)
+            await asyncio.wait_for(all_stage_one_started.wait(), timeout=30)
             assert stage_two_started.is_set() is False
 
             release_stage_one.set()
-            result = await asyncio.wait_for(execution_task, timeout=1)
+            result = await asyncio.wait_for(execution_task, timeout=30)
 
         assert result.all_succeeded is True
         assert result.success_count == 3
@@ -16147,12 +16147,12 @@ class TestParallelACExecutor:
                 )
             )
 
-            await asyncio.wait_for(all_first_batch_started.wait(), timeout=1)
+            await asyncio.wait_for(all_first_batch_started.wait(), timeout=30)
             assert second_batch_started.is_set() is False
             assert stage_two_started.is_set() is False
 
             release_first_batch.set()
-            result = await asyncio.wait_for(execution_task, timeout=1)
+            result = await asyncio.wait_for(execution_task, timeout=30)
 
         assert result.all_succeeded is True
         assert result.success_count == 4


### PR DESCRIPTION
## Summary

- replace a fragile five-second interpreter-start budget with an explicit 30-second monotonic startup guard
- preserve the original setup failure by killing and reaping the child before reporting checkpoint, return code, stdout, and stderr
- normalize four one-second stage synchronization waits to the existing 30-second deadlock margin

## Changes

- harden `test_setup_claude_serializes_competing_operator_generations` diagnostics so `TimeoutExpired` cannot mask the missing-marker cause
- retain bounded waits and all stage-ordering assertions in the parallel executor tests
- add no product behavior changes; this isolates the test-hardening portion of #2010

## Notes

Independent exact-head verification passed forced deadline diagnostics, real-child cleanup, 8-way startup contention, the full changed-file suite (`933 passed, 1 skipped`), Ruff, formatting, and diff checks.

Refs #2010