### PR TITLE
fix(plugin): make agent task results race-safe

### DIFF
--- a/src/ouroboros/plugin/agents/pool.py
+++ b/src/ouroboros/plugin/agents/pool.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+_QUEUE_DRAIN_TIMEOUT_SECONDS = 1.0
+
 
 # =============================================================================
 # Agent State Enum
@@ -385,6 +387,14 @@ class AgentPool:
             else:
                 self._task_queue.task_done()
 
+        # Queue ownership must be balanced before shutdown returns. Bound the
+        # wait so a future accounting regression fails closed instead of
+        # hanging shutdown indefinitely.
+        await asyncio.wait_for(
+            self._task_queue.join(),
+            timeout=_QUEUE_DRAIN_TIMEOUT_SECONDS,
+        )
+
         # Terminate all agents
         for agent_id in list(self._agents.keys()):
             await self._terminate_agent(agent_id)
@@ -417,7 +427,18 @@ class AgentPool:
 
         Returns:
             Task ID for tracking.
+
+        Raises:
+            RuntimeError: If shutdown has started.
         """
+        # ``PriorityQueue.put`` is non-blocking for this unbounded queue, so
+        # the shutdown gate and acceptance bookkeeping form one event-loop
+        # critical section. A task is either rejected here or accepted in time
+        # for ``stop()`` to terminalize it.
+        if self._shutdown:
+            msg = "Agent pool is shutting down and cannot accept new tasks"
+            raise RuntimeError(msg)
+
         task_id = f"task-{uuid4().hex[:12]}"
 
         task = TaskRequest(
@@ -617,6 +638,8 @@ class AgentPool:
 
         while not self._shutdown:
             queue_item_acquired = False
+            queue_item_transferred = False
+            task: TaskRequest | None = None
             try:
                 # Get next task with timeout
                 priority, task = await asyncio.wait_for(
@@ -635,6 +658,7 @@ class AgentPool:
                     )
                     # Requeue
                     await self._task_queue.put((priority, task))
+                    queue_item_transferred = True
                     await asyncio.sleep(1.0)
                     continue
 
@@ -646,10 +670,23 @@ class AgentPool:
 
                 task_coro = self._execute_task(agent, task)
                 self._track_running_task(task.id, asyncio.create_task(task_coro))
+                queue_item_transferred = True
 
             except TimeoutError:
                 continue
             except Exception as e:
+                # Once acquired, the dispatcher owns settlement until it
+                # explicitly transfers the item back to the queue or to an
+                # execution task. Never acknowledge an accepted task while
+                # leaving it pending.
+                if queue_item_acquired and not queue_item_transferred and task is not None:
+                    self._publish_task_result(
+                        TaskResult(
+                            task_id=task.id,
+                            success=False,
+                            error_message=f"Task dispatch failed: {e}",
+                        )
+                    )
                 log.exception(
                     "agents.pool.dispatcher_error",
                     error=str(e),
@@ -715,6 +752,7 @@ class AgentPool:
         start_time = time.time()
         messages: list[str] = []
         result: TaskResult | None = None
+        execution_task = asyncio.current_task()
 
         try:
             log.debug(
@@ -828,8 +866,10 @@ class AgentPool:
             agent.last_activity = time.time()
             task.completed_at = time.time()
 
-            # Remove from running tasks
-            self._running_tasks.pop(task.id, None)
+            # A stale execution must not remove a replacement generation that
+            # is now authoritative for the same tracking key.
+            if execution_task is not None:
+                self._forget_running_task(task.id, execution_task)
 
             # Emit completion event
             await self._emit_event(

--- a/src/ouroboros/plugin/agents/pool.py
+++ b/src/ouroboros/plugin/agents/pool.py
@@ -290,6 +290,7 @@ class AgentPool:
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._task_results: dict[str, TaskResult] = {}
         self._task_waiters: dict[str, set[asyncio.Future[None]]] = {}
+        self._pending_task_ids: set[str] = set()
 
         # Background tasks
         self._dispatcher_task: asyncio.Task[None] | None = None
@@ -331,27 +332,58 @@ class AgentPool:
     async def stop(self) -> None:
         """Stop the agent pool gracefully.
 
-        Waits for running tasks to complete, then terminates all agents.
+        Cancels outstanding tasks with terminal results, then terminates agents.
         """
         log.info("agents.pool.stopping")
 
         self._shutdown = True
 
-        # Cancel background tasks
-        if self._dispatcher_task:
-            self._dispatcher_task.cancel()
-        if self._scaler_task:
-            self._scaler_task.cancel()
-        if self._health_task:
-            self._health_task.cancel()
+        background_tasks = tuple(
+            task
+            for task in (self._dispatcher_task, self._scaler_task, self._health_task)
+            if task is not None
+        )
+        for task in background_tasks:
+            task.cancel()
+        if background_tasks:
+            await asyncio.gather(*background_tasks, return_exceptions=True)
+        self._dispatcher_task = None
+        self._scaler_task = None
+        self._health_task = None
 
-        # Wait for running tasks
-        if self._running_tasks:
+        # A stopped pool cannot finish outstanding work. Cancel execution tasks
+        # first so their normal terminal-result path can notify result waiters.
+        running_tasks = tuple(self._running_tasks.values())
+        if running_tasks:
             log.info(
-                "agents.pool.waiting_tasks",
-                count=len(self._running_tasks),
+                "agents.pool.cancelling_tasks",
+                count=len(running_tasks),
             )
-            await asyncio.gather(*self._running_tasks.values(), return_exceptions=True)
+            for task in running_tasks:
+                task.cancel()
+            await asyncio.gather(*running_tasks, return_exceptions=True)
+            for task_id, task in tuple(self._running_tasks.items()):
+                self._forget_running_task(task_id, task)
+
+        # Tasks still pending were queued or owned temporarily by the cancelled
+        # dispatcher. Publish a durable terminal result rather than stranding
+        # their waiters or silently forgetting them.
+        for task_id in tuple(self._pending_task_ids):
+            self._publish_task_result(
+                TaskResult(
+                    task_id=task_id,
+                    success=False,
+                    error_message="Task cancelled",
+                )
+            )
+
+        while not self._task_queue.empty():
+            try:
+                self._task_queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover - single-loop defensive guard
+                break
+            else:
+                self._task_queue.task_done()
 
         # Terminate all agents
         for agent_id in list(self._agents.keys()):
@@ -400,6 +432,7 @@ class AgentPool:
         )
 
         # Add to queue (priority queue uses negative for max-heap behavior)
+        self._pending_task_ids.add(task_id)
         await self._task_queue.put((-priority, task))
 
         log.debug(
@@ -429,34 +462,65 @@ class AgentPool:
         Raises:
             asyncio.TimeoutError: If timeout expires before task completes.
         """
-        # Check if result already available
-        if task_id in self._task_results:
-            return self._task_results[task_id]
+        # Results are non-destructive snapshots retained for the lifetime of
+        # the pool. This lets concurrent and retrying callers observe the same
+        # terminal outcome without competing for ownership.
+        result = self._task_results.get(task_id)
+        if result is not None:
+            return result
 
         # Wait for result
-        future: asyncio.Future[None] = asyncio.Future()
-
-        if task_id not in self._task_waiters:
-            self._task_waiters[task_id] = set()
-
-        self._task_waiters[task_id].add(future)
+        future = asyncio.get_running_loop().create_future()
+        self._task_waiters.setdefault(task_id, set()).add(future)
 
         try:
-            await asyncio.wait_for(future, timeout=timeout)
+            # Shield keeps caller timeouts from cancelling the pool-owned
+            # notification future while completion is being published.
+            await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
         except TimeoutError:
-            # Remove from waiters
-            self._task_waiters[task_id].discard(future)
-            if not self._task_waiters[task_id]:
-                del self._task_waiters[task_id]
+            # Terminal publication wins a boundary race with caller timeout.
+            result = self._task_results.get(task_id)
+            if result is not None:
+                return result
             raise
+        finally:
+            # Completion may already have detached the entire bucket. Cleanup
+            # must therefore be identity-safe and idempotent.
+            waiters = self._task_waiters.get(task_id)
+            if waiters is not None:
+                waiters.discard(future)
+                if not waiters:
+                    self._task_waiters.pop(task_id, None)
 
         # Return result
-        if task_id in self._task_results:
-            return self._task_results[task_id]
+        result = self._task_results.get(task_id)
+        if result is not None:
+            return result
 
         # Should not happen
         msg = f"Task {task_id} completed but result not found"
         raise RuntimeError(msg)
+
+    def _publish_task_result(self, result: TaskResult) -> None:
+        """Publish one durable terminal result and detach its waiters atomically."""
+        self._task_results[result.task_id] = result
+        self._pending_task_ids.discard(result.task_id)
+
+        for waiter in self._task_waiters.pop(result.task_id, set()):
+            if not waiter.done():
+                waiter.set_result(None)
+
+    def _track_running_task(self, task_id: str, task: asyncio.Task[None]) -> None:
+        """Track an execution task until completion, even if its body never starts."""
+        self._running_tasks[task_id] = task
+        task.add_done_callback(
+            lambda completed, task_id=task_id: self._forget_running_task(task_id, completed)
+        )
+
+    def _forget_running_task(self, task_id: str, task: asyncio.Task[None]) -> None:
+        """Forget only the tracked generation represented by ``task``."""
+        if self._running_tasks.get(task_id) is task:
+            self._running_tasks.pop(task_id, None)
 
     async def _spawn_agent(self, agent_id: str) -> AgentInstance:
         """Spawn a new agent instance.
@@ -552,12 +616,14 @@ class AgentPool:
         log.info("agents.pool.dispatcher_started")
 
         while not self._shutdown:
+            queue_item_acquired = False
             try:
                 # Get next task with timeout
                 priority, task = await asyncio.wait_for(
                     self._task_queue.get(),
                     timeout=1.0,
                 )
+                queue_item_acquired = True
 
                 # Wait for available agent
                 agent = await self._wait_for_agent(task.agent_type)
@@ -579,7 +645,7 @@ class AgentPool:
                 task.started_at = time.time()
 
                 task_coro = self._execute_task(agent, task)
-                self._running_tasks[task.id] = asyncio.create_task(task_coro)
+                self._track_running_task(task.id, asyncio.create_task(task_coro))
 
             except TimeoutError:
                 continue
@@ -588,6 +654,9 @@ class AgentPool:
                     "agents.pool.dispatcher_error",
                     error=str(e),
                 )
+            finally:
+                if queue_item_acquired:
+                    self._task_queue.task_done()
 
     async def _wait_for_agent(
         self,
@@ -697,7 +766,7 @@ class AgentPool:
                 duration_seconds=duration,
             )
 
-            self._task_results[task.id] = result
+            self._publish_task_result(result)
 
             log.info(
                 "agents.pool.task_completed",
@@ -719,7 +788,7 @@ class AgentPool:
                 messages=tuple(messages),
                 duration_seconds=duration,
             )
-            self._task_results[task.id] = result
+            self._publish_task_result(result)
 
             log.warning(
                 "agents.pool.task_cancelled",
@@ -743,7 +812,7 @@ class AgentPool:
                 duration_seconds=duration,
             )
 
-            self._task_results[task.id] = result
+            self._publish_task_result(result)
 
             log.error(
                 "agents.pool.task_failed",
@@ -761,13 +830,6 @@ class AgentPool:
 
             # Remove from running tasks
             self._running_tasks.pop(task.id, None)
-
-            # Notify waiters
-            if task.id in self._task_waiters:
-                for waiter in self._task_waiters[task.id]:
-                    if not waiter.done():
-                        waiter.set_result(None)
-                del self._task_waiters[task.id]
 
             # Emit completion event
             await self._emit_event(

--- a/src/ouroboros/plugin/agents/pool.py
+++ b/src/ouroboros/plugin/agents/pool.py
@@ -543,6 +543,22 @@ class AgentPool:
         if self._running_tasks.get(task_id) is task:
             self._running_tasks.pop(task_id, None)
 
+    def _settle_dispatch_failure(self, task: TaskRequest, error: BaseException) -> None:
+        """Publish a terminal result for an acquired task dispatch failure."""
+        if isinstance(error, asyncio.CancelledError):
+            error_message = "Task cancelled"
+        else:
+            detail = str(error) or type(error).__name__
+            error_message = f"Task dispatch failed: {detail}"
+
+        self._publish_task_result(
+            TaskResult(
+                task_id=task.id,
+                success=False,
+                error_message=error_message,
+            )
+        )
+
     async def _spawn_agent(self, agent_id: str) -> AgentInstance:
         """Spawn a new agent instance.
 
@@ -637,17 +653,20 @@ class AgentPool:
         log.info("agents.pool.dispatcher_started")
 
         while not self._shutdown:
-            queue_item_acquired = False
-            queue_item_transferred = False
-            task: TaskRequest | None = None
+            # This timeout belongs only to polling an empty queue. Once get()
+            # returns, every exception is a dispatch failure for an accepted
+            # task and must pass through the ownership settlement below.
             try:
-                # Get next task with timeout
                 priority, task = await asyncio.wait_for(
                     self._task_queue.get(),
                     timeout=1.0,
                 )
-                queue_item_acquired = True
+            except TimeoutError:
+                continue
 
+            queue_item_transferred = False
+            agent: AgentInstance | None = None
+            try:
                 # Wait for available agent
                 agent = await self._wait_for_agent(task.agent_type)
                 if not agent:
@@ -672,28 +691,28 @@ class AgentPool:
                 self._track_running_task(task.id, asyncio.create_task(task_coro))
                 queue_item_transferred = True
 
-            except TimeoutError:
-                continue
-            except Exception as e:
+            except BaseException as error:
                 # Once acquired, the dispatcher owns settlement until it
                 # explicitly transfers the item back to the queue or to an
-                # execution task. Never acknowledge an accepted task while
-                # leaving it pending.
-                if queue_item_acquired and not queue_item_transferred and task is not None:
-                    self._publish_task_result(
-                        TaskResult(
-                            task_id=task.id,
-                            success=False,
-                            error_message=f"Task dispatch failed: {e}",
-                        )
-                    )
+                # execution task. Cancellation terminalizes the acquired item
+                # before propagating; process-control exceptions do likewise
+                # and retain their original propagation semantics.
+                if not queue_item_transferred:
+                    self._settle_dispatch_failure(task, error)
+                    if agent is not None and agent.current_task == task.id:
+                        agent.state = AgentState.IDLE
+                        agent.current_task = None
+                        agent.last_activity = time.time()
+
+                if isinstance(error, asyncio.CancelledError) or not isinstance(error, Exception):
+                    raise
+
                 log.exception(
                     "agents.pool.dispatcher_error",
-                    error=str(e),
+                    error=str(error),
                 )
             finally:
-                if queue_item_acquired:
-                    self._task_queue.task_done()
+                self._task_queue.task_done()
 
     async def _wait_for_agent(
         self,

--- a/tests/integration/plugin/test_orchestration.py
+++ b/tests/integration/plugin/test_orchestration.py
@@ -308,6 +308,68 @@ class TestAgentPoolIntegration:
         await pool.stop()
 
     @pytest.mark.asyncio
+    async def test_agent_pool_dispatcher_timeout_settles_acquired_task(self) -> None:
+        """A timeout after queue acquisition is a terminal dispatch failure."""
+        pool = AgentPool(
+            adapter=MagicMock(),
+            config=AgentPoolConfig(
+                min_instances=0,
+                max_instances=0,
+                enable_auto_scaling=False,
+            ),
+        )
+
+        with patch.object(
+            pool,
+            "_wait_for_agent",
+            side_effect=TimeoutError("agent lookup timed out"),
+        ):
+            await pool.start()
+            task_id = await pool.submit_task(agent_type="executor", prompt="settle timeout")
+            result = await pool.get_task_result(task_id, timeout=0.5)
+
+        assert result.success is False
+        assert result.error_message == "Task dispatch failed: agent lookup timed out"
+        assert task_id not in pool._pending_task_ids
+        await asyncio.wait_for(pool._task_queue.join(), timeout=0.1)
+        with pytest.raises(ValueError, match=r"task_done\(\) called too many times"):
+            pool._task_queue.task_done()
+        await pool.stop()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_queue_poll_timeout_does_not_fabricate_task(self) -> None:
+        """An empty-queue poll timeout simply starts the next poll."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        first_poll_timed_out = asyncio.Event()
+        second_poll_started = asyncio.Event()
+        never_returns = asyncio.Event()
+        poll_count = 0
+
+        async def poll_queue() -> tuple[int, TaskRequest]:
+            nonlocal poll_count
+            poll_count += 1
+            if poll_count == 1:
+                first_poll_timed_out.set()
+                raise TimeoutError
+            second_poll_started.set()
+            await never_returns.wait()
+            raise AssertionError("unreachable")
+
+        with patch.object(pool._task_queue, "get", side_effect=poll_queue):
+            await pool.start()
+            await asyncio.wait_for(first_poll_timed_out.wait(), timeout=0.5)
+            await asyncio.wait_for(second_poll_started.wait(), timeout=0.5)
+
+            assert pool._dispatcher_task is not None
+            assert not pool._dispatcher_task.done()
+            assert pool._pending_task_ids == set()
+            assert pool._task_results == {}
+
+            await pool.stop()
+
+        assert poll_count == 2
+
+    @pytest.mark.asyncio
     async def test_agent_pool_stop_acknowledges_dispatcher_owned_queue_item(self) -> None:
         """Cancelling a dispatcher-held item settles its queue ownership exactly once."""
         dispatcher_owned = asyncio.Event()

--- a/tests/integration/plugin/test_orchestration.py
+++ b/tests/integration/plugin/test_orchestration.py
@@ -8,13 +8,15 @@ Tests cover:
 import asyncio
 from pathlib import Path
 import tempfile
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from ouroboros.plugin.agents.pool import (
     AgentPool,
     AgentPoolConfig,
+    TaskRequest,
+    TaskResult,
 )
 from ouroboros.plugin.agents.registry import (
     BUILTIN_AGENTS,
@@ -118,9 +120,12 @@ class TestAgentPoolIntegration:
     async def test_agent_pool_cancels_stuck_task(self) -> None:
         """Health checker cancels timed-out tasks instead of only resetting state."""
         adapter = MagicMock()
+        task_started = asyncio.Event()
+        never_finishes = asyncio.Event()
 
         async def stalled_execute_task(*args, **kwargs):
-            await asyncio.sleep(1.0)
+            task_started.set()
+            await never_finishes.wait()
             if False:  # pragma: no cover - keep this an async generator
                 yield None
 
@@ -142,13 +147,232 @@ class TestAgentPoolIntegration:
             prompt="stuck task",
             priority=1,
         )
+        await asyncio.wait_for(task_started.wait(), timeout=0.5)
 
         result = await pool.get_task_result(task_id, timeout=0.5)
 
         assert result.success is False
         assert result.error_message == "Task cancelled"
+        assert await pool.get_task_result(task_id, timeout=0) is result
+        assert task_id not in pool._task_waiters
 
         await pool.stop()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_fans_out_terminal_result_to_concurrent_waiters(self) -> None:
+        """Completion owns waiter detachment; every registered waiter gets the result."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        task_id = "task-concurrent-waiters"
+        result = pool._task_results.get(task_id)
+        assert result is None
+
+        waiters = [
+            asyncio.create_task(pool.get_task_result(task_id, timeout=0.5)) for _ in range(16)
+        ]
+        await asyncio.sleep(0)
+
+        expected = TaskResult(task_id=task_id, success=False, error_message="Task cancelled")
+        pool._publish_task_result(expected)
+
+        assert await asyncio.gather(*waiters) == [expected] * len(waiters)
+        assert task_id not in pool._task_waiters
+        assert await pool.get_task_result(task_id, timeout=0) is expected
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_timeout_cleanup_preserves_late_result(self) -> None:
+        """A caller timeout relinquishes only its waiter, not the terminal result."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        task_id = "task-timeout-then-result"
+
+        with pytest.raises(TimeoutError):
+            await pool.get_task_result(task_id, timeout=0)
+
+        assert task_id not in pool._task_waiters
+
+        expected = TaskResult(task_id=task_id, success=True)
+        pool._publish_task_result(expected)
+        assert await pool.get_task_result(task_id, timeout=0) is expected
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_completion_wins_exact_timeout_boundary(self) -> None:
+        """Publishing during timeout cleanup returns the result instead of raising KeyError."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        task_id = "task-exact-timeout-boundary"
+        expected = TaskResult(task_id=task_id, success=False, error_message="Task cancelled")
+
+        async def publish_then_timeout(*args, **kwargs):
+            pool._publish_task_result(expected)
+            raise TimeoutError
+
+        with patch(
+            "ouroboros.plugin.agents.pool.asyncio.wait_for",
+            side_effect=publish_then_timeout,
+        ):
+            result = await pool.get_task_result(task_id, timeout=0.1)
+
+        assert result is expected
+        assert task_id not in pool._task_waiters
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_stop_cancels_running_and_queued_results(self) -> None:
+        """Shutdown terminalizes all accepted tasks and leaves no live waiter state."""
+        adapter = MagicMock()
+        first_started = asyncio.Event()
+        never_finishes = asyncio.Event()
+
+        async def stalled_execute_task(*args, **kwargs):
+            first_started.set()
+            await never_finishes.wait()
+            if False:  # pragma: no cover - keep this an async generator
+                yield None
+
+        adapter.execute_task = stalled_execute_task
+        pool = AgentPool(
+            adapter=adapter,
+            config=AgentPoolConfig(
+                min_instances=1,
+                max_instances=1,
+                enable_auto_scaling=False,
+            ),
+        )
+        await pool.start()
+        running_id = await pool.submit_task(agent_type="executor", prompt="running")
+        queued_id = await pool.submit_task(agent_type="executor", prompt="queued")
+        await asyncio.wait_for(first_started.wait(), timeout=0.5)
+
+        result_waiters = [
+            asyncio.create_task(pool.get_task_result(task_id, timeout=0.5))
+            for task_id in (running_id, queued_id)
+        ]
+        await asyncio.sleep(0)
+        await pool.stop()
+
+        results = await asyncio.gather(*result_waiters)
+        assert [result.task_id for result in results] == [running_id, queued_id]
+        assert all(result.success is False for result in results)
+        assert all(result.error_message == "Task cancelled" for result in results)
+        assert pool._running_tasks == {}
+        assert pool._pending_task_ids == set()
+        assert pool._task_waiters == {}
+        assert pool._task_queue.empty()
+        await asyncio.wait_for(pool._task_queue.join(), timeout=0.1)
+        assert pool._dispatcher_task is None
+        assert pool._scaler_task is None
+        assert pool._health_task is None
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_stop_acknowledges_dispatcher_owned_queue_item(self) -> None:
+        """Cancelling a dispatcher-held item settles its queue ownership exactly once."""
+        dispatcher_owned = asyncio.Event()
+        never_returns = asyncio.Event()
+
+        async def hold_dispatcher_ownership(*args, **kwargs):
+            dispatcher_owned.set()
+            await never_returns.wait()
+
+        pool = AgentPool(
+            adapter=MagicMock(),
+            config=AgentPoolConfig(
+                min_instances=0,
+                max_instances=0,
+                enable_auto_scaling=False,
+            ),
+        )
+        with patch.object(pool, "_wait_for_agent", side_effect=hold_dispatcher_ownership):
+            await pool.start()
+            task_id = await pool.submit_task(agent_type="executor", prompt="dispatcher-owned")
+            await asyncio.wait_for(dispatcher_owned.wait(), timeout=0.5)
+            await pool.stop()
+
+        result = await pool.get_task_result(task_id, timeout=0)
+        assert result.error_message == "Task cancelled"
+        await asyncio.wait_for(pool._task_queue.join(), timeout=0.1)
+        with pytest.raises(ValueError, match=r"task_done\(\) called too many times"):
+            pool._task_queue.task_done()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_stop_acknowledges_requeued_item_without_double_counting(
+        self,
+    ) -> None:
+        """Requeue transfers ownership before shutdown drains the replacement item."""
+        no_agent_checked = asyncio.Event()
+
+        async def return_no_agent(*args, **kwargs):
+            no_agent_checked.set()
+            return None
+
+        pool = AgentPool(
+            adapter=MagicMock(),
+            config=AgentPoolConfig(
+                min_instances=0,
+                max_instances=0,
+                enable_auto_scaling=False,
+            ),
+        )
+        with patch.object(pool, "_wait_for_agent", side_effect=return_no_agent):
+            await pool.start()
+            task_id = await pool.submit_task(agent_type="executor", prompt="requeued")
+            await asyncio.wait_for(no_agent_checked.wait(), timeout=0.5)
+            for _ in range(100):
+                if not pool._task_queue.empty():
+                    break
+                await asyncio.sleep(0)
+            assert pool._task_queue.qsize() == 1
+            await pool.stop()
+
+        result = await pool.get_task_result(task_id, timeout=0)
+        assert result.error_message == "Task cancelled"
+        await asyncio.wait_for(pool._task_queue.join(), timeout=0.1)
+        with pytest.raises(ValueError, match=r"task_done\(\) called too many times"):
+            pool._task_queue.task_done()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_stop_forgets_execution_cancelled_before_first_instruction(
+        self,
+    ) -> None:
+        """Shutdown cleanup does not depend on the execution coroutine entering its body."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        agent = await pool._spawn_agent("agent-prestart-cancel")
+        task = TaskRequest(
+            id="task-prestart-cancel",
+            agent_type="executor",
+            prompt="never starts",
+            context={},
+        )
+        pool._pending_task_ids.add(task.id)
+        execution = asyncio.create_task(pool._execute_task(agent, task))
+        pool._track_running_task(task.id, execution)
+        execution.cancel()
+
+        await pool.stop()
+
+        result = await pool.get_task_result(task.id, timeout=0)
+        assert result.error_message == "Task cancelled"
+        assert execution.cancelled()
+        assert pool._running_tasks == {}
+        assert pool._pending_task_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_running_task_cleanup_is_generation_safe(self) -> None:
+        """An older done callback cannot discard a replacement tracked generation."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        first_gate = asyncio.Event()
+        replacement_gate = asyncio.Event()
+        first = asyncio.create_task(first_gate.wait())
+        replacement = asyncio.create_task(replacement_gate.wait())
+        task_id = "task-reused-tracking-key"
+        pool._track_running_task(task_id, first)
+        pool._track_running_task(task_id, replacement)
+
+        first.cancel()
+        await asyncio.gather(first, return_exceptions=True)
+        await asyncio.sleep(0)
+        assert pool._running_tasks[task_id] is replacement
+
+        replacement.cancel()
+        await asyncio.gather(replacement, return_exceptions=True)
+        await asyncio.sleep(0)
+        assert task_id not in pool._running_tasks
 
 
 class TestAgentRegistryIntegration:

--- a/tests/integration/plugin/test_orchestration.py
+++ b/tests/integration/plugin/test_orchestration.py
@@ -8,7 +8,7 @@ Tests cover:
 import asyncio
 from pathlib import Path
 import tempfile
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -245,7 +245,9 @@ class TestAgentPoolIntegration:
             for task_id in (running_id, queued_id)
         ]
         await asyncio.sleep(0)
-        await pool.stop()
+        queue_join = AsyncMock(wraps=pool._task_queue.join)
+        with patch.object(pool._task_queue, "join", queue_join):
+            await pool.stop()
 
         results = await asyncio.gather(*result_waiters)
         assert [result.task_id for result in results] == [running_id, queued_id]
@@ -259,6 +261,51 @@ class TestAgentPoolIntegration:
         assert pool._dispatcher_task is None
         assert pool._scaler_task is None
         assert pool._health_task is None
+        queue_join.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_rejects_submissions_during_and_after_shutdown(self) -> None:
+        """The shutdown boundary permanently closes task acceptance."""
+        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        await pool.start()
+
+        stopping = asyncio.create_task(pool.stop())
+        while not pool._shutdown:
+            await asyncio.sleep(0)
+
+        with pytest.raises(RuntimeError, match="cannot accept new tasks"):
+            await pool.submit_task(agent_type="executor", prompt="during shutdown")
+
+        await stopping
+
+        with pytest.raises(RuntimeError, match="cannot accept new tasks"):
+            await pool.submit_task(agent_type="executor", prompt="after shutdown")
+
+        assert pool._pending_task_ids == set()
+        assert pool._task_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_agent_pool_dispatcher_exception_settles_acquired_task(self) -> None:
+        """An acquired item becomes a terminal failure if dispatch raises."""
+        pool = AgentPool(
+            adapter=MagicMock(),
+            config=AgentPoolConfig(
+                min_instances=0,
+                max_instances=0,
+                enable_auto_scaling=False,
+            ),
+        )
+
+        with patch.object(pool, "_wait_for_agent", side_effect=RuntimeError("dispatch broke")):
+            await pool.start()
+            task_id = await pool.submit_task(agent_type="executor", prompt="settle me")
+            result = await pool.get_task_result(task_id, timeout=0.5)
+
+        assert result.success is False
+        assert result.error_message == "Task dispatch failed: dispatch broke"
+        assert task_id not in pool._pending_task_ids
+        await asyncio.wait_for(pool._task_queue.join(), timeout=0.1)
+        await pool.stop()
 
     @pytest.mark.asyncio
     async def test_agent_pool_stop_acknowledges_dispatcher_owned_queue_item(self) -> None:
@@ -354,25 +401,42 @@ class TestAgentPoolIntegration:
 
     @pytest.mark.asyncio
     async def test_agent_pool_running_task_cleanup_is_generation_safe(self) -> None:
-        """An older done callback cannot discard a replacement tracked generation."""
-        pool = AgentPool(adapter=MagicMock(), config=AgentPoolConfig(min_instances=0))
+        """An older execution finalizer cannot discard a replacement generation."""
+        adapter = MagicMock()
+        first_started = asyncio.Event()
         first_gate = asyncio.Event()
-        replacement_gate = asyncio.Event()
-        first = asyncio.create_task(first_gate.wait())
-        replacement = asyncio.create_task(replacement_gate.wait())
-        task_id = "task-reused-tracking-key"
-        pool._track_running_task(task_id, first)
-        pool._track_running_task(task_id, replacement)
 
-        first.cancel()
-        await asyncio.gather(first, return_exceptions=True)
+        async def execute_first(*args, **kwargs):
+            first_started.set()
+            await first_gate.wait()
+            if False:  # pragma: no cover - keep this an async generator
+                yield None
+
+        adapter.execute_task = execute_first
+        pool = AgentPool(adapter=adapter, config=AgentPoolConfig(min_instances=0))
+        agent = await pool._spawn_agent("agent-generation-safe")
+        request = TaskRequest(
+            id="task-reused-tracking-key",
+            agent_type="executor",
+            prompt="old generation",
+            context={},
+        )
+        replacement_gate = asyncio.Event()
+        first = asyncio.create_task(pool._execute_task(agent, request))
+        await asyncio.wait_for(first_started.wait(), timeout=0.5)
+        replacement = asyncio.create_task(replacement_gate.wait())
+        pool._track_running_task(request.id, first)
+        pool._track_running_task(request.id, replacement)
+
+        first_gate.set()
+        await first
         await asyncio.sleep(0)
-        assert pool._running_tasks[task_id] is replacement
+        assert pool._running_tasks[request.id] is replacement
 
         replacement.cancel()
         await asyncio.gather(replacement, return_exceptions=True)
         await asyncio.sleep(0)
-        assert task_id not in pool._running_tasks
+        assert request.id not in pool._running_tasks
 
 
 class TestAgentRegistryIntegration:


### PR DESCRIPTION
## Summary

- make terminal AgentPool results non-destructive snapshots retained for the pool lifetime
- atomically publish one result to concurrent waiters so health cancellation cannot race result retrieval into `KeyError`
- complete shutdown ownership for queued, dispatcher-owned, running, and pre-start-cancelled tasks

## Changes

- centralize terminal publication and waiter fan-out with idempotent timeout cleanup
- retain late-reader result identity across exact timeout boundaries
- acknowledge every PriorityQueue acquisition exactly once and make bounded `queue.join()` a shutdown invariant
- reconcile execution-task cleanup even when cancellation happens before the coroutine first instruction
- add generation-safe callbacks so stale completion cannot remove a replacement task

## Notes

Independent verification reproduced the former exact-boundary `KeyError`, then passed the repaired boundary, 64 concurrent waiters, health cancellation, queue accounting, shutdown, pre-start cancellation, and stale-callback probes. Rebased verification passed 15 focused tests, 55 repeated cases, 81 broad plugin tests, Ruff, full MyPy, module-size, and boundary gates.

Refs #2010