### PR TITLE
fix(orchestrator): make lifecycle replay durable

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -42,6 +42,7 @@ from ouroboros.mcp.server.project_dir import (  # noqa: F401
     _project_dir_from_seed,
 )
 from ouroboros.mcp.server.protocol import PromptHandler, ResourceHandler, ToolHandler
+from ouroboros.mcp.server.resource_lifecycle import ServerResourceLifecycle
 from ouroboros.mcp.server.security import (
     AuthConfig,
     AuthContext,
@@ -72,7 +73,7 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
-from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
+from ouroboros.orchestrator.control_bus import ControlBus
 
 if TYPE_CHECKING:
     from ouroboros.mcp.job_manager import JobManager
@@ -725,12 +726,9 @@ class MCPServerAdapter:
         self._resource_handlers: dict[str, ResourceHandler] = {}
         self._prompt_handlers: dict[str, PromptHandler] = {}
         self._mcp_server: Any = None
-        self._owned_resources: list[Any] = []  # objects with async close()
-        self._startup_resources: list[Any] = []  # objects with async initialize()
-        self._lifecycle_lock = asyncio.Lock()
-        self._startup_complete = False
-        self._startup_error: Exception | None = None
-        self._shutdown_complete = False
+        self._resource_lifecycle = ServerResourceLifecycle(server_name=name)
+        self._owned_resources = self._resource_lifecycle.owned_resources
+        self._startup_resources = self._resource_lifecycle.startup_resources
         self._runtime_context: AgentRuntimeContext | None = None
         self._job_manager: JobManager | None = None
         self._last_tool_activity = time.monotonic()
@@ -1412,35 +1410,14 @@ class MCPServerAdapter:
         initialize_on_startup: bool = False,
     ) -> None:
         """Register a resource owned across explicit startup and shutdown."""
-        if self._startup_complete or self._startup_error is not None:
-            raise RuntimeError("Cannot register resources after server startup")
-        if self._shutdown_complete:
-            raise RuntimeError("Cannot register resources after server shutdown")
-        if initialize_on_startup and not callable(getattr(resource, "initialize", None)):
-            raise TypeError("Startup resources must provide initialize()")
-        self._owned_resources.append(resource)
-        if initialize_on_startup:
-            self._startup_resources.append(resource)
+        self._resource_lifecycle.register(
+            resource,
+            initialize_on_startup=initialize_on_startup,
+        )
 
     async def startup(self) -> None:
         """Initialize startup-owned resources exactly once before request work."""
-        async with self._lifecycle_lock:
-            if self._shutdown_complete:
-                raise RuntimeError("Cannot start a shut down MCP server")
-            if self._startup_complete:
-                return
-            if self._startup_error is not None:
-                raise self._startup_error
-            try:
-                for resource in self._startup_resources:
-                    initialize = resource.initialize
-                    initialized = initialize()
-                    if inspect.isawaitable(initialized):
-                        await initialized
-            except Exception as exc:
-                self._startup_error = exc
-                raise
-            self._startup_complete = True
+        await self._resource_lifecycle.startup()
 
     @property
     def job_manager(self) -> JobManager | None:
@@ -1507,30 +1484,7 @@ class MCPServerAdapter:
 
     async def shutdown(self) -> None:
         """Shutdown the server gracefully, closing owned resources."""
-        async with self._lifecycle_lock:
-            if self._shutdown_complete:
-                return
-            log.info("mcp.server.shutdown", name=self._name)
-            for resource in self._owned_resources:
-                close_fn = getattr(resource, "close", None)
-                if callable(close_fn):
-                    try:
-                        await close_fn()
-                    except ControlBusDrainError:
-                        log.error(
-                            "mcp.server.control_bus_close_failed",
-                            resource=type(resource).__name__,
-                        )
-                        raise
-                    except Exception as exc:
-                        log.warning(
-                            "mcp.server.resource_close_failed",
-                            resource=type(resource).__name__,
-                            error=str(exc),
-                        )
-            self._owned_resources.clear()
-            self._startup_resources.clear()
-            self._shutdown_complete = True
+        await self._resource_lifecycle.shutdown()
 
 
 def create_ouroboros_server(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -726,6 +726,11 @@ class MCPServerAdapter:
         self._prompt_handlers: dict[str, PromptHandler] = {}
         self._mcp_server: Any = None
         self._owned_resources: list[Any] = []  # objects with async close()
+        self._startup_resources: list[Any] = []  # objects with async initialize()
+        self._lifecycle_lock = asyncio.Lock()
+        self._startup_complete = False
+        self._startup_error: Exception | None = None
+        self._shutdown_complete = False
         self._runtime_context: AgentRuntimeContext | None = None
         self._job_manager: JobManager | None = None
         self._last_tool_activity = time.monotonic()
@@ -920,6 +925,7 @@ class MCPServerAdapter:
             return Result.err(security_result.error)
 
         try:
+            await self.startup()
             timeout = getattr(handler, "TIMEOUT_SECONDS", None)
 
             async def invoke_handler() -> Result[MCPToolResult, MCPServerError]:
@@ -1119,6 +1125,7 @@ class MCPServerAdapter:
         if _OuroborosSDKServer is None:  # pragma: no cover - mirrors import guard.
             raise ImportError("MCP SDK server boundary unavailable")
 
+        await self.startup()
         self._mcp_server = _OuroborosSDKServer(
             self,
             name=self._name,
@@ -1398,9 +1405,42 @@ class MCPServerAdapter:
         """Attach the session-scoped runtime context to the server object graph."""
         self._runtime_context = context
 
-    def register_owned_resource(self, resource: Any) -> None:
-        """Register a resource whose ``close()`` will be called on shutdown."""
+    def register_owned_resource(
+        self,
+        resource: Any,
+        *,
+        initialize_on_startup: bool = False,
+    ) -> None:
+        """Register a resource owned across explicit startup and shutdown."""
+        if self._startup_complete or self._startup_error is not None:
+            raise RuntimeError("Cannot register resources after server startup")
+        if self._shutdown_complete:
+            raise RuntimeError("Cannot register resources after server shutdown")
+        if initialize_on_startup and not callable(getattr(resource, "initialize", None)):
+            raise TypeError("Startup resources must provide initialize()")
         self._owned_resources.append(resource)
+        if initialize_on_startup:
+            self._startup_resources.append(resource)
+
+    async def startup(self) -> None:
+        """Initialize startup-owned resources exactly once before request work."""
+        async with self._lifecycle_lock:
+            if self._shutdown_complete:
+                raise RuntimeError("Cannot start a shut down MCP server")
+            if self._startup_complete:
+                return
+            if self._startup_error is not None:
+                raise self._startup_error
+            try:
+                for resource in self._startup_resources:
+                    initialize = resource.initialize
+                    initialized = initialize()
+                    if inspect.isawaitable(initialized):
+                        await initialized
+            except Exception as exc:
+                self._startup_error = exc
+                raise
+            self._startup_complete = True
 
     @property
     def job_manager(self) -> JobManager | None:
@@ -1467,25 +1507,30 @@ class MCPServerAdapter:
 
     async def shutdown(self) -> None:
         """Shutdown the server gracefully, closing owned resources."""
-        log.info("mcp.server.shutdown", name=self._name)
-        for resource in self._owned_resources:
-            close_fn = getattr(resource, "close", None)
-            if callable(close_fn):
-                try:
-                    await close_fn()
-                except ControlBusDrainError:
-                    log.error(
-                        "mcp.server.control_bus_close_failed",
-                        resource=type(resource).__name__,
-                    )
-                    raise
-                except Exception as exc:
-                    log.warning(
-                        "mcp.server.resource_close_failed",
-                        resource=type(resource).__name__,
-                        error=str(exc),
-                    )
-        self._owned_resources.clear()
+        async with self._lifecycle_lock:
+            if self._shutdown_complete:
+                return
+            log.info("mcp.server.shutdown", name=self._name)
+            for resource in self._owned_resources:
+                close_fn = getattr(resource, "close", None)
+                if callable(close_fn):
+                    try:
+                        await close_fn()
+                    except ControlBusDrainError:
+                        log.error(
+                            "mcp.server.control_bus_close_failed",
+                            resource=type(resource).__name__,
+                        )
+                        raise
+                    except Exception as exc:
+                        log.warning(
+                            "mcp.server.resource_close_failed",
+                            resource=type(resource).__name__,
+                            error=str(exc),
+                        )
+            self._owned_resources.clear()
+            self._startup_resources.clear()
+            self._shutdown_complete = True
 
 
 def create_ouroboros_server(
@@ -1772,9 +1817,9 @@ def create_ouroboros_server(
     )
 
     # Create or use provided EventStore
-    if event_store is None:
-        from ouroboros.persistence.event_store import EventStore
+    from ouroboros.persistence.event_store import EventStore
 
+    if event_store is None:
         event_store = EventStore()
 
     # Create state directory for interviews
@@ -2365,6 +2410,19 @@ def create_ouroboros_server(
     # issued fan-out id, whose valid submission then returns
     # ``unknown_fanout_id``.
     fanout_registry = FanoutRegistry(state_dir_path / "fanout")
+    # Create the lifecycle owner before its production handlers. Raw builtin
+    # runtime interception calls handlers directly rather than through
+    # ``call_tool()``, so durable fan-out publication receives this same
+    # explicit readiness boundary as server transport requests.
+    from ouroboros.backends import render_mcp_server_instructions
+
+    server = MCPServerAdapter(
+        name=name,
+        version=version,
+        instructions=instructions if instructions is not None else render_mcp_server_instructions(),
+        auth_config=auth_config,
+        rate_limit_config=rate_limit_config,
+    )
     # No shared-adapter injection for interview handlers: the injected stage
     # adapter has no strict MCP isolation, and ``self.llm_adapter or ...``
     # would bypass the handler's own strict factory (#765, #1768). Injection
@@ -2484,7 +2542,12 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             fanout_registry=fanout_registry,
         ),
-        *create_fanout_handlers(fanout_registry, effective_cwd, event_store),
+        *create_fanout_handlers(
+            fanout_registry,
+            effective_cwd,
+            event_store,
+            ensure_ready=server.startup,
+        ),
         evolve_step,
         StartEvolveStepHandler(
             evolve_handler=evolve_step,
@@ -2525,19 +2588,6 @@ def create_ouroboros_server(
         EventsResourceHandler(event_store=event_store),
     ]
 
-    # Create server adapter. The MCP ``instructions`` field is the cross-provider
-    # "ubiquitous language" channel — default to the registry-rendered guidance so
-    # every MCP client (Claude included) receives it at session start.
-    from ouroboros.backends import render_mcp_server_instructions
-
-    server = MCPServerAdapter(
-        name=name,
-        version=version,
-        instructions=instructions if instructions is not None else render_mcp_server_instructions(),
-        auth_config=auth_config,
-        rate_limit_config=rate_limit_config,
-    )
-
     # Build the AgentRuntimeContext that #474 funnels through every
     # handler. For now the context only exposes the EventStore, the
     # backend labels, the optional MCP bridge, and a fresh ControlBus
@@ -2558,7 +2608,10 @@ def create_ouroboros_server(
     # Close the reactive control surface before stores/bridges it may
     # reference from subscriber tasks.
     server.register_owned_resource(control_bus)
-    server.register_owned_resource(event_store)
+    server.register_owned_resource(
+        event_store,
+        initialize_on_startup=type(event_store) is EventStore,
+    )
     if brownfield_store is not None:
         server.register_owned_resource(brownfield_store)
 

--- a/src/ouroboros/mcp/server/resource_lifecycle.py
+++ b/src/ouroboros/mcp/server/resource_lifecycle.py
@@ -1,0 +1,95 @@
+"""Explicit startup and shutdown ownership for MCP server resources."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import structlog
+
+from ouroboros.orchestrator.control_bus import ControlBusDrainError
+
+log = structlog.get_logger(__name__)
+
+
+class ServerResourceLifecycle:
+    """Initialize and close server-owned resources exactly once."""
+
+    def __init__(self, *, server_name: str) -> None:
+        self._server_name = server_name
+        self._owned: list[Any] = []
+        self._startup_owned: list[Any] = []
+        self._lock = asyncio.Lock()
+        self._startup_complete = False
+        self._startup_error: Exception | None = None
+        self._shutdown_complete = False
+
+    def register(self, resource: Any, *, initialize_on_startup: bool = False) -> None:
+        """Register a resource before startup begins."""
+        if self._startup_complete or self._startup_error is not None:
+            raise RuntimeError("Cannot register resources after server startup")
+        if self._shutdown_complete:
+            raise RuntimeError("Cannot register resources after server shutdown")
+        if initialize_on_startup and not callable(getattr(resource, "initialize", None)):
+            raise TypeError("Startup resources must provide initialize()")
+        self._owned.append(resource)
+        if initialize_on_startup:
+            self._startup_owned.append(resource)
+
+    @property
+    def owned_resources(self) -> list[Any]:
+        """Return the live owned-resource list for adapter compatibility."""
+        return self._owned
+
+    @property
+    def startup_resources(self) -> list[Any]:
+        """Return the live startup-resource list for adapter compatibility."""
+        return self._startup_owned
+
+    async def startup(self) -> None:
+        """Initialize startup-owned resources before request work."""
+        async with self._lock:
+            if self._shutdown_complete:
+                raise RuntimeError("Cannot start a shut down MCP server")
+            if self._startup_complete:
+                return
+            if self._startup_error is not None:
+                raise self._startup_error
+            try:
+                for resource in self._startup_owned:
+                    initialized = resource.initialize()
+                    if inspect.isawaitable(initialized):
+                        await initialized
+            except Exception as exc:
+                self._startup_error = exc
+                raise
+            self._startup_complete = True
+
+    async def shutdown(self) -> None:
+        """Close owned resources once, preserving control-bus drain failures."""
+        async with self._lock:
+            if self._shutdown_complete:
+                return
+            log.info("mcp.server.shutdown", name=self._server_name)
+            for resource in self._owned:
+                close_fn = getattr(resource, "close", None)
+                if not callable(close_fn):
+                    continue
+                try:
+                    await close_fn()
+                except ControlBusDrainError:
+                    log.error(
+                        "mcp.server.control_bus_close_failed",
+                        resource=type(resource).__name__,
+                    )
+                    raise
+                except Exception as exc:
+                    log.warning(
+                        "mcp.server.resource_close_failed",
+                        resource=type(resource).__name__,
+                        error=str(exc),
+                    )
+            self._owned.clear()
+            self._startup_owned.clear()
+            self._shutdown_complete = True

--- a/src/ouroboros/mcp/tools/fanout_handler.py
+++ b/src/ouroboros/mcp/tools/fanout_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import hashlib
 import json
@@ -286,6 +287,8 @@ def create_fanout_handler(
     fanout_registry: FanoutRegistry,
     project_dir: Any,
     event_store: Any,
+    *,
+    ensure_ready: Callable[[], Awaitable[None]] | None = None,
 ) -> SubmitFanoutResultsHandler:
     """Build the production fan-out boundary for a resolved workspace."""
     from ouroboros.persistence.artifact_store import ContentAddressedArtifactStore
@@ -295,6 +298,7 @@ def create_fanout_handler(
         disposable_memory=DisposableMemory(
             artifact_store=ContentAddressedArtifactStore.for_project(project_dir),
             event_store=event_store,
+            ensure_ready=ensure_ready,
         ),
     )
 
@@ -314,9 +318,16 @@ def create_fanout_handlers(
     fanout_registry: FanoutRegistry,
     project_dir: Any,
     event_store: Any,
+    *,
+    ensure_ready: Callable[[], Awaitable[None]] | None = None,
 ) -> tuple[SubmitFanoutResultsHandler, FetchArtifactHandler]:
     """Build the paired submit/fetch production boundary for one workspace."""
-    submit = create_fanout_handler(fanout_registry, project_dir, event_store)
+    submit = create_fanout_handler(
+        fanout_registry,
+        project_dir,
+        event_store,
+        ensure_ready=ensure_ready,
+    )
     return submit, FetchArtifactHandler(disposable_memory=submit.disposable_memory)
 
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -70,6 +70,43 @@ _CANCEL_CONTROL_SEED_PREFIX: Final[str] = "__ouroboros_agent_process_cancel__:"
 _CANCELLED_WORK_DRAIN_GRACE_SECONDS: Final[float] = 10.0
 
 
+async def _run_cancellation_atomic_handoff[T](awaitable: Awaitable[T]) -> T:
+    """Settle one bounded lifecycle handoff before surfacing cancellation.
+
+    A durable resume has two inseparable halves: commit ``CONTINUE`` and
+    release the live waiter.  EventStore already settles the SQLite half
+    before re-raising caller cancellation, but that re-raise used to strand
+    the live handle in ``PAUSED`` after the journal had committed ``RUNNING``.
+    Shield the complete handoff and, if its caller is cancelled, wait until
+    it either fails before commit or finishes the post-commit release.  The
+    original cancellation is then re-raised so cancellation semantics are
+    preserved without allowing a persisted/live split.
+
+    The durable append keeps its persistence-owned timeout, so a wedged write
+    still rolls back and settles within that deadline rather than making this
+    wrapper an unbounded database wait.
+    """
+    inner = asyncio.ensure_future(awaitable)
+    try:
+        return await asyncio.shield(inner)
+    except asyncio.CancelledError as caller_cancellation:
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                # Repeated cancellation cannot abandon a half-applied handoff.
+                continue
+            except Exception:
+                # The pre-commit failure has settled; preserve cancellation below.
+                break
+        handoff_error: BaseException | None = None
+        if not inner.cancelled():
+            handoff_error = inner.exception()
+        if handoff_error is not None:
+            raise caller_cancellation from handoff_error
+        raise
+
+
 class AgentProcessStatus(StrEnum):
     """Lifecycle state of an :class:`AgentProcessHandle`.
 
@@ -371,21 +408,31 @@ class AgentProcessHandle:
                 return
 
             if self._journal_mode is AgentProcessJournalMode.DURABLE:
-                # Commit replay authority before changing any checkpoint or
-                # releasing the waiter.  The waiter never retries this write.
-                await self._emit_lifecycle_transition(
-                    Directive.CONTINUE,
-                    "resume requested",
-                    AgentProcessStatus.RUNNING,
-                )
-                self._save_lifecycle_checkpoint(
-                    phase="agent_process_running",
-                    status="running",
-                    event_key="resumed_at",
-                    log_key="resume_projection",
-                    store=self._pause_checkpoint_store,
-                    strict=False,
-                )
+
+                async def commit_and_release() -> None:
+                    # Commit replay authority before changing any checkpoint
+                    # or releasing the waiter.  Cancellation settles this
+                    # complete handoff before it reaches the caller.
+                    await self._emit_lifecycle_transition(
+                        Directive.CONTINUE,
+                        "resume requested",
+                        AgentProcessStatus.RUNNING,
+                    )
+                    self._save_lifecycle_checkpoint(
+                        phase="agent_process_running",
+                        status="running",
+                        event_key="resumed_at",
+                        log_key="resume_projection",
+                        store=self._pause_checkpoint_store,
+                        strict=False,
+                    )
+                    self._status = AgentProcessStatus.RUNNING
+                    self._pause_checkpoint_reason = None
+                    self._pause_checkpoint_requested = False
+                    self._paused_event.set()
+
+                await _run_cancellation_atomic_handoff(commit_and_release())
+                return
             else:
                 # Preserve the direct-AgentProcess compatibility contract:
                 # checkpoint persistence is strict while journal emission is
@@ -408,11 +455,6 @@ class AgentProcessHandle:
                     AgentProcessStatus.RUNNING,
                 )
                 return
-
-            self._status = AgentProcessStatus.RUNNING
-            self._pause_checkpoint_reason = None
-            self._pause_checkpoint_requested = False
-            self._paused_event.set()
 
     async def cancel(
         self,

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -73,14 +73,13 @@ _CANCELLED_WORK_DRAIN_GRACE_SECONDS: Final[float] = 10.0
 async def _run_cancellation_atomic_handoff[T](awaitable: Awaitable[T]) -> T:
     """Settle one bounded lifecycle handoff before surfacing cancellation.
 
-    A durable resume has two inseparable halves: commit ``CONTINUE`` and
-    release the live waiter.  EventStore already settles the SQLite half
-    before re-raising caller cancellation, but that re-raise used to strand
-    the live handle in ``PAUSED`` after the journal had committed ``RUNNING``.
-    Shield the complete handoff and, if its caller is cancelled, wait until
-    it either fails before commit or finishes the post-commit release.  The
-    original cancellation is then re-raised so cancellation semantics are
-    preserved without allowing a persisted/live split.
+    Durable lifecycle transitions can have an inseparable live half after
+    their journal write: resume releases a waiter, while cancelled startup
+    terminalizes a possibly committed initial RUNNING row.  EventStore settles
+    the SQLite half before re-raising caller cancellation. Shield the complete
+    handoff and wait until it either fails before commit or finishes its live
+    release/reconciliation. The original cancellation is then re-raised, so
+    cancellation semantics survive without allowing a persisted/live split.
 
     The durable append keeps its persistence-owned timeout, so a wedged write
     still rolls back and settles within that deadline rather than making this
@@ -1080,7 +1079,24 @@ class AgentProcess:
         # cooperative checkpoint.
         if emit is not None:
             handle._expected_directive_count += 1
-            await emit(Directive.CONTINUE, "spawned", AgentProcessStatus.RUNNING)
+            try:
+                await emit(Directive.CONTINUE, "spawned", AgentProcessStatus.RUNNING)
+            except asyncio.CancelledError as caller_cancellation:
+                if self.journal_mode is AgentProcessJournalMode.DURABLE:
+                    # EventStore settles a transaction before it re-raises
+                    # cancellation, so the initial RUNNING row may already be
+                    # committed even though no runner exists yet.  Reconcile
+                    # that possible row to one durable terminal state before
+                    # cancellation escapes.  Work is never created or started.
+                    handle._request_cancel("cancelled during initial durable handoff")
+                    try:
+                        await _run_cancellation_atomic_handoff(handle._mark_cancelled())
+                    except asyncio.CancelledError as settlement_cancellation:
+                        if settlement_cancellation.__cause__ is not None:
+                            raise caller_cancellation from settlement_cancellation.__cause__
+                    except BaseException as exc:
+                        raise caller_cancellation from exc
+                raise caller_cancellation
 
         async def _runner() -> None:
             try:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -239,6 +239,15 @@ class _AppendableEventStore(Protocol):
     def append(self, event: Any) -> Awaitable[None]:  # pragma: no cover — Protocol-style
         ...
 
+    def append_durable(
+        self,
+        event: Any,
+        *,
+        timeout: float,
+    ) -> Awaitable[None]:  # pragma: no cover — Protocol-style
+        """Append with a persistence-owned, cancellation-atomic deadline."""
+        ...
+
 
 class _ReplayableEventStore(Protocol):
     """Structural type for the replay-capable event store."""
@@ -277,6 +286,7 @@ class AgentProcessHandle:
     _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
     _cancel_reason: str = "cancel requested"
     _failure: BaseException | None = None
+    _journal_failure: BaseException | None = None
     _complete_on_return_after_cancel: bool = False
     _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
     _journal_mode: AgentProcessJournalMode = AgentProcessJournalMode.BEST_EFFORT
@@ -345,34 +355,64 @@ class AgentProcessHandle:
         No-op when the process is not currently paused. Returns it to
         :attr:`AgentProcessStatus.RUNNING`.
 
-        Slice 2 (#518): overwrites the persisted pause checkpoint with a
-        ``running`` row so ``load_persisted_pause`` returns False after
-        resume. Persistence failures are raised before the loop is released
-        so durable state cannot remain paused while in-memory work resumes.
-        If *store* differs from the store captured by the acknowledged
-        pause, the captured store remains authoritative and *store* is
-        ignored.
+        In durable journal mode the committed ``CONTINUE`` row is the sole
+        resume authority.  The pause checkpoint is updated only after that
+        commit and is a restart cache/projection, never a competing release
+        boundary.  A failed append therefore leaves both the checkpoint and
+        work loop paused, and only a later explicit ``resume()`` call may
+        retry.  Direct ``AgentProcess`` users retain the legacy checkpoint-
+        first, best-effort journal behavior.
         """
-        if self._status in _TERMINAL_STATUSES or not self.should_pause():
-            return
+        del store  # the store captured by the acknowledged pause is authoritative
+        async with self._status_lock:
+            if self._status in _TERMINAL_STATUSES or not self.should_pause():
+                return
+            if self._status is not AgentProcessStatus.PAUSED:
+                return
 
-        # Overwrite any acknowledged paused checkpoint before releasing the
-        # work loop; otherwise a failed save could leave durable state paused
-        # while in-memory work has resumed.
-        self._save_lifecycle_checkpoint(
-            phase="agent_process_running",
-            status="running",
-            event_key="resumed_at",
-            log_key="resume",
-            store=self._pause_checkpoint_store,
-            strict=True,
-        )
-        self._pause_checkpoint_reason = None
-        self._pause_checkpoint_requested = False
+            if self._journal_mode is AgentProcessJournalMode.DURABLE:
+                # Commit replay authority before changing any checkpoint or
+                # releasing the waiter.  The waiter never retries this write.
+                await self._emit_lifecycle_transition(
+                    Directive.CONTINUE,
+                    "resume requested",
+                    AgentProcessStatus.RUNNING,
+                )
+                self._save_lifecycle_checkpoint(
+                    phase="agent_process_running",
+                    status="running",
+                    event_key="resumed_at",
+                    log_key="resume_projection",
+                    store=self._pause_checkpoint_store,
+                    strict=False,
+                )
+            else:
+                # Preserve the direct-AgentProcess compatibility contract:
+                # checkpoint persistence is strict while journal emission is
+                # observational and happens after the waiter is released.
+                self._save_lifecycle_checkpoint(
+                    phase="agent_process_running",
+                    status="running",
+                    event_key="resumed_at",
+                    log_key="resume",
+                    store=self._pause_checkpoint_store,
+                    strict=True,
+                )
+                self._status = AgentProcessStatus.RUNNING
+                self._pause_checkpoint_reason = None
+                self._pause_checkpoint_requested = False
+                self._paused_event.set()
+                await self._emit_lifecycle_transition(
+                    Directive.CONTINUE,
+                    "resume requested",
+                    AgentProcessStatus.RUNNING,
+                )
+                return
 
-        self._paused_event.set()
-        if self._status is AgentProcessStatus.PAUSED:
-            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
+            self._status = AgentProcessStatus.RUNNING
+            self._pause_checkpoint_reason = None
+            self._pause_checkpoint_requested = False
+            self._paused_event.set()
 
     async def cancel(
         self,
@@ -466,12 +506,13 @@ class AgentProcessHandle:
         *,
         store: CheckpointStore | None = None,
     ) -> bool:
-        """Return True iff the latest persisted checkpoint marks this process as paused.
+        """Return whether a legacy checkpoint-authoritative process was paused.
 
-        This is the restart-recovery primitive for slice 2 (#518). A caller
-        restarting the process calls this to ask "was I paused before the
-        restart?" and, if True, calls :meth:`pause` again to restore the
-        in-memory flag.
+        This is the restart-recovery primitive for direct, best-effort
+        ``AgentProcess`` consumers.  Durable journal mode writes checkpoints
+        only as projections and must recover through :meth:`replay`; this
+        helper raises instead of letting a stale cache compete with committed
+        lifecycle history.
 
         Args:
             process_id: The process identifier to look up. UUID4 hex is
@@ -499,7 +540,14 @@ class AgentProcessHandle:
             )
             if result.is_err:
                 return False
+            if result.value.state.get("authority") == "journal":
+                raise RuntimeError(
+                    "Durable AgentProcess pause recovery requires lifecycle replay; "
+                    "the checkpoint is a non-authoritative journal projection."
+                )
             return result.value.phase == "agent_process_paused"
+        except RuntimeError:
+            raise
         except Exception:  # noqa: BLE001 — fault-tolerant; absence of checkpoint == not paused
             logger.warning(
                 "agent_process.load_persisted_pause_failed",
@@ -683,8 +731,9 @@ class AgentProcessHandle:
                     strict=True,
                 )
         await self._paused_event.wait()
-        if self._status is AgentProcessStatus.PAUSED and not self.should_cancel():
-            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
+        # ``resume()`` owns the CONTINUE commit and status change.  A waiter
+        # must never turn a surfaced publication failure into an implicit
+        # retry and successful release.
 
     async def wait_until_complete(self, *, timeout: float | None = None) -> AgentProcessStatus:
         """Wait for a terminal status transition.
@@ -714,7 +763,13 @@ class AgentProcessHandle:
         try:
             async with self._emit_lock:
                 await self._emit_directive(directive, reason, status)
-        except Exception:
+        except Exception as exc:
+            if self._journal_mode is AgentProcessJournalMode.DURABLE:
+                self._journal_failure = exc
+                # Failed durable attempts are not replay facts and cannot be
+                # counted as committed history.  A later explicit retry earns
+                # its own expected count after it actually appends.
+                self._expected_directive_count -= 1
             logger.warning(
                 "agent_process.directive_emit_failed",
                 extra={
@@ -725,6 +780,8 @@ class AgentProcessHandle:
             )
             if self._journal_mode is AgentProcessJournalMode.DURABLE:
                 raise
+        else:
+            self._journal_failure = None
         finally:
             self._pending_emit_count -= 1
             self._pending_emit_statuses.discard(status)
@@ -795,6 +852,18 @@ class AgentProcessHandle:
         """Mark the underlying work task as exited without changing lifecycle status."""
         self._completed_event.set()
 
+    def _fail_closed_after_journal_failure(self, exc: BaseException) -> None:
+        """Stop locally after a required write fails, without another append.
+
+        A terminal compensation event would consume a second deadline and
+        could itself commit after the caller has already observed failure.
+        The original persistence error is therefore the only failure
+        authority for this live process.
+        """
+        self._failure = exc
+        self._status = AgentProcessStatus.FAILED
+        self._completed_event.set()
+
     async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
         async with self._status_lock:
             if new_status == self._status:
@@ -835,6 +904,11 @@ class AgentProcessHandle:
             state: dict[str, str | None] = {
                 "status": status,
                 event_key: datetime.now(UTC).isoformat(),
+                "authority": (
+                    "journal"
+                    if self._journal_mode is AgentProcessJournalMode.DURABLE
+                    else "checkpoint"
+                ),
             }
             if reason is not None:
                 state["reason"] = reason
@@ -975,13 +1049,16 @@ class AgentProcess:
                 try:
                     await handle._mark_cancelled()
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
-                    handle._failure = exc
-                    try:
-                        await handle._mark_failed(
-                            reason=f"cancel finalization failed {type(exc).__name__}: {exc!s}"
-                        )
-                    except BaseException:  # noqa: BLE001 — failure is stored on the handle
-                        pass
+                    if exc is handle._journal_failure:
+                        handle._fail_closed_after_journal_failure(exc)
+                    else:
+                        handle._failure = exc
+                        try:
+                            await handle._mark_failed(
+                                reason=f"cancel finalization failed {type(exc).__name__}: {exc!s}"
+                            )
+                        except BaseException:  # noqa: BLE001 — failure is stored on the handle
+                            pass
                     logger.exception(
                         "agent_process.cancel_finalization_failed",
                         extra={"process_id": pid},
@@ -989,17 +1066,20 @@ class AgentProcess:
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 handle._failure = exc
-                try:
-                    if handle.status() in _TERMINAL_STATUSES:
-                        await handle._mark_failed(
-                            reason=f"work raised {type(exc).__name__}: {exc!s}", force=True
-                        )
-                    else:
-                        await handle._mark_failed(
-                            reason=f"work raised {type(exc).__name__}: {exc!s}"
-                        )
-                except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
-                    pass
+                if exc is handle._journal_failure:
+                    handle._fail_closed_after_journal_failure(exc)
+                else:
+                    try:
+                        if handle.status() in _TERMINAL_STATUSES:
+                            await handle._mark_failed(
+                                reason=f"work raised {type(exc).__name__}: {exc!s}", force=True
+                            )
+                        else:
+                            await handle._mark_failed(
+                                reason=f"work raised {type(exc).__name__}: {exc!s}"
+                            )
+                    except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
+                        pass
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
@@ -1022,13 +1102,16 @@ class AgentProcess:
                     else:
                         await handle._mark_completed(reason="work returned")
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
-                    handle._failure = exc
-                    try:
-                        await handle._mark_failed(
-                            reason=f"terminal transition failed {type(exc).__name__}: {exc!s}"
-                        )
-                    except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
-                        pass
+                    if exc is handle._journal_failure:
+                        handle._fail_closed_after_journal_failure(exc)
+                    else:
+                        handle._failure = exc
+                        try:
+                            await handle._mark_failed(
+                                reason=f"terminal transition failed {type(exc).__name__}: {exc!s}"
+                            )
+                        except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
+                            pass
                     logger.exception(
                         "agent_process.terminal_transition_failed",
                         extra={"process_id": pid},
@@ -1050,24 +1133,32 @@ class AgentProcess:
         async def emit(
             directive: Directive, reason: str, lifecycle_status: AgentProcessStatus
         ) -> None:
-            async def append_event() -> None:
-                await _ensure_event_store_initialized(store)
-                event = create_control_directive_emitted_event(
-                    target_type=_TARGET_TYPE,
-                    target_id=process_id,
-                    emitted_by=_EMITTED_BY,
-                    directive=directive,
-                    reason=f"{intent}: {reason}" if reason else intent,
-                    extra={"intent": intent, "lifecycle_status": lifecycle_status.value},
-                )
-                await store.append(event)
+            event = create_control_directive_emitted_event(
+                target_type=_TARGET_TYPE,
+                target_id=process_id,
+                emitted_by=_EMITTED_BY,
+                directive=directive,
+                reason=f"{intent}: {reason}" if reason else intent,
+                extra={"intent": intent, "lifecycle_status": lifecycle_status.value},
+            )
 
             if self.journal_mode is AgentProcessJournalMode.DURABLE:
-                await asyncio.wait_for(
-                    append_event(),
+                append_durable = getattr(store, "append_durable", None)
+                if not callable(append_durable):
+                    raise TypeError(
+                        "Durable AgentProcess journaling requires event_store.append_durable() "
+                        "so the persistence layer, not caller cancellation, owns the deadline."
+                    )
+                await append_durable(
+                    event,
                     timeout=_DURABLE_DIRECTIVE_EMIT_TIMEOUT_SECONDS,
                 )
                 return
+
+            async def append_event() -> None:
+                await _ensure_event_store_initialized(store)
+                await store.append(event)
+
             try:
                 await asyncio.wait_for(append_event(), timeout=_DIRECTIVE_EMIT_TIMEOUT_SECONDS)
             except Exception:  # noqa: BLE001 — observational-first

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -920,7 +920,21 @@ class AgentProcessHandle:
                 )
             directive = _TRANSITION_DIRECTIVE.get(new_status)
             if directive is not None and self._journal_mode is AgentProcessJournalMode.DURABLE:
-                await self._emit_lifecycle_transition(directive, reason, new_status)
+
+                async def commit_and_apply_live_status() -> None:
+                    await self._emit_lifecycle_transition(directive, reason, new_status)
+                    self._status = new_status
+                    if new_status in _TERMINAL_STATUSES:
+                        self._completed_event.set()
+
+                # Every durable transition has one indivisible journal/live
+                # handoff. EventStore may finish a commit before surfacing
+                # caller cancellation; keep the corresponding live status
+                # (and terminal completion signal) in the same shielded task
+                # so replay can never advance past the live state. The helper
+                # re-raises cancellation only after both halves have settled.
+                await _run_cancellation_atomic_handoff(commit_and_apply_live_status())
+                return
             self._status = new_status
             if new_status in _TERMINAL_STATUSES:
                 self._completed_event.set()
@@ -1107,6 +1121,14 @@ class AgentProcess:
                 try:
                     await handle._mark_cancelled()
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
+                    if (
+                        isinstance(exc, asyncio.CancelledError)
+                        and handle.status() is AgentProcessStatus.CANCELLED
+                    ):
+                        # The durable terminal handoff committed and applied
+                        # its live state before preserving task cancellation.
+                        # It is authoritative, not a new terminal failure.
+                        raise
                     if exc is handle._journal_failure:
                         handle._fail_closed_after_journal_failure(exc)
                     else:
@@ -1160,6 +1182,14 @@ class AgentProcess:
                     else:
                         await handle._mark_completed(reason="work returned")
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
+                    if isinstance(exc, asyncio.CancelledError) and handle.status() in {
+                        AgentProcessStatus.CANCELLED,
+                        AgentProcessStatus.COMPLETED,
+                    }:
+                        # Cancellation after a terminal commit remains caller
+                        # cancellation; the committed terminal state must not
+                        # be reclassified through a synthetic FAILED append.
+                        raise
                     if exc is handle._journal_failure:
                         handle._fail_closed_after_journal_failure(exc)
                     else:
@@ -1245,13 +1275,16 @@ def _new_process_id() -> str:
 async def _wait_for_lifecycle_emit_drain(
     handle: AgentProcessHandle, *, timeout: float = 1.0
 ) -> None:
-    """Best-effort wait for AgentProcess lifecycle journal writes to drain."""
-    if handle._pending_emit_count <= 0:
+    """Best-effort wait for terminal publication and owned runner cleanup."""
+    work_task = handle._work_task
+    if handle._pending_emit_count <= 0 and (work_task is None or work_task.done()):
         return
 
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
-    while handle._pending_emit_count > 0 and loop.time() < deadline:
+    while (
+        handle._pending_emit_count > 0 or (work_task is not None and not work_task.done())
+    ) and loop.time() < deadline:
         await asyncio.sleep(0.01)
 
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -63,6 +63,7 @@ logger = logging.getLogger(__name__)
 _TARGET_TYPE: Final[str] = "agent_process"
 _EMITTED_BY: Final[str] = "agent_process"
 _DIRECTIVE_EMIT_TIMEOUT_SECONDS: Final[float] = 1.0
+_DURABLE_DIRECTIVE_EMIT_TIMEOUT_SECONDS: Final[float] = 30.0
 _CANCELLED_PHASE: Final[str] = "agent_process_cancelled"
 _CANCEL_CONSUMED_PHASE: Final[str] = "agent_process_cancel_consumed"
 _CANCEL_CONTROL_SEED_PREFIX: Final[str] = "__ouroboros_agent_process_cancel__:"
@@ -82,6 +83,19 @@ class AgentProcessStatus(StrEnum):
     CANCELLED = "cancelled"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+class AgentProcessJournalMode(StrEnum):
+    """Durability contract for lifecycle directive publication.
+
+    ``BEST_EFFORT`` preserves the legacy liveness-first behavior for direct
+    ``AgentProcess`` users. ``DURABLE`` makes every lifecycle transition a
+    required write and is used by the production ``run_with_agent_process``
+    boundary, whose replay contract cannot tolerate missing history.
+    """
+
+    BEST_EFFORT = "best_effort"
+    DURABLE = "durable"
 
 
 @dataclass(frozen=True, slots=True)
@@ -265,12 +279,14 @@ class AgentProcessHandle:
     _failure: BaseException | None = None
     _complete_on_return_after_cancel: bool = False
     _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
+    _journal_mode: AgentProcessJournalMode = AgentProcessJournalMode.BEST_EFFORT
     _replay_store: _ReplayableEventStore | None = None
     _validate_replay_against_live_status: bool = False
     _pending_emit_statuses: set[AgentProcessStatus] = field(default_factory=set)
     _pending_emit_count: int = 0
     _expected_directive_count: int = 0
     _emit_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _status_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _work_task: asyncio.Task[None] | None = None
     _checkpoint_store: CheckpointStore | None = field(default=None, repr=False)
     _cancel_key: str | None = field(default=None, repr=False)
@@ -683,6 +699,36 @@ class AgentProcessHandle:
     # Status transition machinery
     # ------------------------------------------------------------------
 
+    async def _emit_lifecycle_transition(
+        self,
+        directive: Directive,
+        reason: str,
+        status: AgentProcessStatus,
+    ) -> None:
+        """Publish one transition according to the configured journal contract."""
+        if self._emit_directive is None:
+            return
+        self._expected_directive_count += 1
+        self._pending_emit_count += 1
+        self._pending_emit_statuses.add(status)
+        try:
+            async with self._emit_lock:
+                await self._emit_directive(directive, reason, status)
+        except Exception:
+            logger.warning(
+                "agent_process.directive_emit_failed",
+                extra={
+                    "process_id": self.process_id,
+                    "directive": directive.value,
+                },
+                exc_info=True,
+            )
+            if self._journal_mode is AgentProcessJournalMode.DURABLE:
+                raise
+        finally:
+            self._pending_emit_count -= 1
+            self._pending_emit_statuses.discard(status)
+
     async def _mark_completed(self, *, reason: str = "work loop returned") -> None:
         """Mark the process as completed and emit the lifecycle directive."""
         if self._status in _TERMINAL_STATUSES:
@@ -716,27 +762,27 @@ class AgentProcessHandle:
                     extra={"process_id": self.process_id},
                 )
                 self._delete_lifecycle_checkpoint(store=self._pause_checkpoint_store)
+        if self._journal_mode is AgentProcessJournalMode.DURABLE:
+            try:
+                await self._emit_lifecycle_transition(
+                    Directive.CANCEL,
+                    reason,
+                    AgentProcessStatus.FAILED,
+                )
+            except BaseException as exc:
+                if self._failure is None:
+                    self._failure = exc
+                self._status = AgentProcessStatus.FAILED
+                self._completed_event.set()
+                raise
         self._status = AgentProcessStatus.FAILED
         self._completed_event.set()
-        if self._emit_directive is not None:
-            self._expected_directive_count += 1
-            self._pending_emit_count += 1
-            self._pending_emit_statuses.add(AgentProcessStatus.FAILED)
-            try:
-                async with self._emit_lock:
-                    await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
-            except Exception:  # noqa: BLE001 — failed work must still unblock waiters
-                logger.warning(
-                    "agent_process.directive_emit_failed",
-                    extra={
-                        "process_id": self.process_id,
-                        "directive": Directive.CANCEL.value,
-                    },
-                    exc_info=True,
-                )
-            finally:
-                self._pending_emit_count -= 1
-                self._pending_emit_statuses.discard(AgentProcessStatus.FAILED)
+        if self._journal_mode is AgentProcessJournalMode.BEST_EFFORT:
+            await self._emit_lifecycle_transition(
+                Directive.CANCEL,
+                reason,
+                AgentProcessStatus.FAILED,
+            )
 
     async def _mark_cancelled(self) -> None:
         """Mark the process as cancelled after the work task has exited."""
@@ -750,40 +796,26 @@ class AgentProcessHandle:
         self._completed_event.set()
 
     async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
-        if new_status == self._status:
-            return
-        if new_status in _TERMINAL_STATUSES and self._pause_checkpoint_requested:
-            self._save_lifecycle_checkpoint(
-                phase=f"agent_process_{new_status.value}",
-                status=new_status.value,
-                event_key=f"{new_status.value}_at",
-                log_key="terminal",
-                store=self._pause_checkpoint_store,
-                strict=True,
-            )
-        self._status = new_status
-        if new_status in _TERMINAL_STATUSES:
-            self._completed_event.set()
-        directive = _TRANSITION_DIRECTIVE.get(new_status)
-        if directive is not None and self._emit_directive is not None:
-            self._expected_directive_count += 1
-            self._pending_emit_count += 1
-            self._pending_emit_statuses.add(new_status)
-            try:
-                async with self._emit_lock:
-                    await self._emit_directive(directive, reason, new_status)
-            except Exception:  # noqa: BLE001 — lifecycle completion must not hang on emit failure
-                logger.warning(
-                    "agent_process.directive_emit_failed",
-                    extra={
-                        "process_id": self.process_id,
-                        "directive": directive.value,
-                    },
-                    exc_info=True,
+        async with self._status_lock:
+            if new_status == self._status:
+                return
+            if new_status in _TERMINAL_STATUSES and self._pause_checkpoint_requested:
+                self._save_lifecycle_checkpoint(
+                    phase=f"agent_process_{new_status.value}",
+                    status=new_status.value,
+                    event_key=f"{new_status.value}_at",
+                    log_key="terminal",
+                    store=self._pause_checkpoint_store,
+                    strict=True,
                 )
-            finally:
-                self._pending_emit_count -= 1
-                self._pending_emit_statuses.discard(new_status)
+            directive = _TRANSITION_DIRECTIVE.get(new_status)
+            if directive is not None and self._journal_mode is AgentProcessJournalMode.DURABLE:
+                await self._emit_lifecycle_transition(directive, reason, new_status)
+            self._status = new_status
+            if new_status in _TERMINAL_STATUSES:
+                self._completed_event.set()
+            if directive is not None and self._journal_mode is AgentProcessJournalMode.BEST_EFFORT:
+                await self._emit_lifecycle_transition(directive, reason, new_status)
 
     def _save_lifecycle_checkpoint(
         self,
@@ -868,6 +900,7 @@ class AgentProcess:
     event_store: _AppendableEventStore | None = None
     checkpoint_store: CheckpointStore | None = None
     cancel_key: str | None = None
+    journal_mode: AgentProcessJournalMode = AgentProcessJournalMode.BEST_EFFORT
 
     async def spawn(
         self,
@@ -908,6 +941,7 @@ class AgentProcess:
         handle = AgentProcessHandle(
             process_id=pid,
             _emit_directive=emit,
+            _journal_mode=self.journal_mode,
             _replay_store=replay_store,
             _validate_replay_against_live_status=True,
             _checkpoint_store=self.checkpoint_store,
@@ -941,9 +975,13 @@ class AgentProcess:
                 try:
                     await handle._mark_cancelled()
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
-                    await handle._mark_failed(
-                        reason=f"cancel finalization failed {type(exc).__name__}: {exc!s}"
-                    )
+                    handle._failure = exc
+                    try:
+                        await handle._mark_failed(
+                            reason=f"cancel finalization failed {type(exc).__name__}: {exc!s}"
+                        )
+                    except BaseException:  # noqa: BLE001 — failure is stored on the handle
+                        pass
                     logger.exception(
                         "agent_process.cancel_finalization_failed",
                         extra={"process_id": pid},
@@ -951,12 +989,17 @@ class AgentProcess:
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 handle._failure = exc
-                if handle.status() in _TERMINAL_STATUSES:
-                    await handle._mark_failed(
-                        reason=f"work raised {type(exc).__name__}: {exc!s}", force=True
-                    )
-                else:
-                    await handle._mark_failed(reason=f"work raised {type(exc).__name__}: {exc!s}")
+                try:
+                    if handle.status() in _TERMINAL_STATUSES:
+                        await handle._mark_failed(
+                            reason=f"work raised {type(exc).__name__}: {exc!s}", force=True
+                        )
+                    else:
+                        await handle._mark_failed(
+                            reason=f"work raised {type(exc).__name__}: {exc!s}"
+                        )
+                except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
+                    pass
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
@@ -979,9 +1022,13 @@ class AgentProcess:
                     else:
                         await handle._mark_completed(reason="work returned")
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
-                    await handle._mark_failed(
-                        reason=f"terminal transition failed {type(exc).__name__}: {exc!s}"
-                    )
+                    handle._failure = exc
+                    try:
+                        await handle._mark_failed(
+                            reason=f"terminal transition failed {type(exc).__name__}: {exc!s}"
+                        )
+                    except BaseException:  # noqa: BLE001 — failure is stored and completion signalled
+                        pass
                     logger.exception(
                         "agent_process.terminal_transition_failed",
                         extra={"process_id": pid},
@@ -1015,6 +1062,12 @@ class AgentProcess:
                 )
                 await store.append(event)
 
+            if self.journal_mode is AgentProcessJournalMode.DURABLE:
+                await asyncio.wait_for(
+                    append_event(),
+                    timeout=_DURABLE_DIRECTIVE_EMIT_TIMEOUT_SECONDS,
+                )
+                return
             try:
                 await asyncio.wait_for(append_event(), timeout=_DIRECTIVE_EMIT_TIMEOUT_SECONDS)
             except Exception:  # noqa: BLE001 — observational-first
@@ -1111,7 +1164,14 @@ async def run_with_agent_process[T](
             durable_store = None
 
     process = AgentProcess(
-        event_store=event_store, checkpoint_store=durable_store, cancel_key=durable_cancel_key
+        event_store=event_store,
+        checkpoint_store=durable_store,
+        cancel_key=durable_cancel_key,
+        journal_mode=(
+            AgentProcessJournalMode.DURABLE
+            if event_store is not None
+            else AgentProcessJournalMode.BEST_EFFORT
+        ),
     )
     handle = await process.spawn(intent=intent, work_fn=_work, process_id=process_id)
 
@@ -1182,6 +1242,11 @@ async def run_with_agent_process[T](
             return result_box[0]
         raise asyncio.CancelledError(f"{intent} cancelled")
     if final_status is AgentProcessStatus.FAILED:
+        failure = handle.failure()
+        if failure is not None:
+            if isinstance(failure, Exception):
+                raise failure
+            raise RuntimeError(f"{intent} failed") from failure
         if result_box:
             return result_box[0]
         if error_box:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -905,6 +905,18 @@ class AgentProcessHandle:
         self._status = AgentProcessStatus.FAILED
         self._completed_event.set()
 
+    def _is_or_caused_by_journal_failure(self, exc: BaseException) -> bool:
+        """Return whether *exc* preserves the current journal failure as its cause."""
+        journal_failure = self._journal_failure
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        while journal_failure is not None and current is not None and id(current) not in seen:
+            if current is journal_failure:
+                return True
+            seen.add(id(current))
+            current = current.__cause__
+        return False
+
     async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
         async with self._status_lock:
             if new_status == self._status:
@@ -1129,8 +1141,8 @@ class AgentProcess:
                         # its live state before preserving task cancellation.
                         # It is authoritative, not a new terminal failure.
                         raise
-                    if exc is handle._journal_failure:
-                        handle._fail_closed_after_journal_failure(exc)
+                    if handle._is_or_caused_by_journal_failure(exc):
+                        handle._fail_closed_after_journal_failure(handle._journal_failure or exc)
                     else:
                         handle._failure = exc
                         try:
@@ -1146,8 +1158,8 @@ class AgentProcess:
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 handle._failure = exc
-                if exc is handle._journal_failure:
-                    handle._fail_closed_after_journal_failure(exc)
+                if handle._is_or_caused_by_journal_failure(exc):
+                    handle._fail_closed_after_journal_failure(handle._journal_failure or exc)
                 else:
                     try:
                         if handle.status() in _TERMINAL_STATUSES:
@@ -1190,8 +1202,8 @@ class AgentProcess:
                         # cancellation; the committed terminal state must not
                         # be reclassified through a synthetic FAILED append.
                         raise
-                    if exc is handle._journal_failure:
-                        handle._fail_closed_after_journal_failure(exc)
+                    if handle._is_or_caused_by_journal_failure(exc):
+                        handle._fail_closed_after_journal_failure(handle._journal_failure or exc)
                     else:
                         handle._failure = exc
                         try:

--- a/src/ouroboros/orchestrator/disposable_memory.py
+++ b/src/ouroboros/orchestrator/disposable_memory.py
@@ -28,6 +28,7 @@ class DisposableMemory:
     artifact_store: ContentAddressedArtifactStore
     event_store: Any | None = None
     checkpoint_store: CheckpointStore | None = None
+    ensure_ready: Callable[[], Awaitable[None]] | None = None
 
     async def run(
         self,
@@ -40,6 +41,8 @@ class DisposableMemory:
         timeout: float | None = None,
     ) -> DisposableResultEnvelope:
         """Execute child work and return only a bounded result envelope."""
+        if self.ensure_ready is not None:
+            await self.ensure_ready()
         resolved_contract_id = contract_id or new_call_id()
         async with asyncio.timeout(timeout):
             return await self._run_within_timeout(

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -15,7 +15,6 @@ import json
 import logging
 from pathlib import Path
 import sqlite3
-import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, unquote
 
@@ -56,6 +55,12 @@ from ouroboros.persistence.sqlite_memory import (
     validate_standard_shared_memory_sqlite_url,
 )
 from ouroboros.persistence.write_lifecycle import run_with_write_lifecycle
+from ouroboros.persistence.write_settlement import (
+    append_with_sqlite_deadline,
+)
+from ouroboros.persistence.write_settlement import (
+    run_to_settlement as _run_to_settlement,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,77 +130,6 @@ _AC_ACCEPTANCE_DISPOSITIONS = frozenset(
         "invalid",
     }
 )
-
-
-async def _run_to_settlement[T](
-    coro: Coroutine[Any, Any, T],
-    *,
-    registry: set[asyncio.Future[Any]] | None = None,
-    refuse_when: Callable[[], bool] | None = None,
-    operation: str = "append",
-) -> T:
-    """Run a transactional coroutine, settling it before cancellation surfaces.
-
-    A write, once begun, must commit or roll back inside the caller's
-    lifetime: shield-only semantics let a cancelled caller (and even
-    ``EventStore.close()``) return while the transaction was still pending,
-    so durable history could change after shutdown. Cancellation is re-raised
-    only after the inner task completes, which both preserves the
-    cancellation-atomicity contract and keeps every write within the store
-    lifecycle (#1794 review rounds one and two).
-    """
-    if refuse_when is not None and refuse_when():
-        # Admission is synchronized with close(): this check and the registry
-        # add below run in one synchronous block on the event loop, so a
-        # write either registers before close() snapshots the registry or is
-        # refused outright — it can never slip past the drain (round five).
-        coro.close()
-        raise PersistenceError(
-            "EventStore is closing; write refused.",
-            operation=operation,
-        )
-    inner: asyncio.Task[T] = asyncio.ensure_future(coro)
-    if registry is not None:
-        # close() drains this registry so no settling write can escape the
-        # store lifecycle (review round four).
-        registry.add(inner)
-        inner.add_done_callback(registry.discard)
-    try:
-        return await asyncio.shield(inner)
-    except asyncio.CancelledError as caller_cancellation:
-        while not inner.done():
-            try:
-                await asyncio.shield(inner)
-            except asyncio.CancelledError:
-                # A further caller cancellation — keep settling.
-                continue
-            except Exception:
-                # The transaction settled by failing; the loop exits below.
-                break
-        settlement_error: BaseException | None = None
-        if not inner.cancelled():
-            settlement_error = inner.exception()
-        if settlement_error is not None:
-            # Cancellation outranks the write's own failure: lifecycle code
-            # awaiting a cancelled task must still observe CancelledError
-            # (e.g. the watchdog's decision batch depends on it). The
-            # transaction failure is preserved as the cause.
-            logger.debug(
-                "event_store.append.settled_with_error",
-                exc_info=settlement_error,
-            )
-            raise caller_cancellation from settlement_error
-        raise
-
-
-async def _await_sqlite_write_atomically[T](awaitable: Coroutine[Any, Any, T]) -> T:
-    """Compatibility wrapper for cancellation-atomic SQLite writes.
-
-    The lifecycle-aware settlement primitive now also supports write
-    registration and close admission fencing. Keep the narrower helper for
-    callers and regressions that only need transaction settlement.
-    """
-    return await _run_to_settlement(awaitable)
 
 
 def acceptance_generation_id_for_session(session_id: str, execution_id: str) -> str:
@@ -925,7 +859,8 @@ class EventStore:
         # contract and cannot honestly be folded into a hard append deadline.
         # Production EventStores initialize during service startup; refusing
         # lazy initialization here is the bounded, ambiguity-free contract.
-        if not self._initialized or self._engine is None:
+        engine = self._engine
+        if not self._initialized or engine is None:
             raise PersistenceError(
                 "Durable append requires an initialized EventStore; initialize it "
                 "during startup before beginning the bounded lifecycle write.",
@@ -933,89 +868,17 @@ class EventStore:
             )
 
         await _run_to_settlement(
-            self._append_durable_registered(event, overall_deadline=overall_deadline),
+            append_with_sqlite_deadline(
+                engine,
+                event,
+                overall_deadline=overall_deadline,
+                picker_projection_ready=self._picker_projection_ready,
+                insert_event=_insert_event,
+            ),
             registry=self._settling_writes,
             refuse_when=lambda: self._closing,
             operation="append_durable",
         )
-
-    async def _append_durable_registered(
-        self,
-        event: BaseEvent,
-        *,
-        overall_deadline: float,
-    ) -> None:
-        """Run one deadline-aware SQLite transaction to final settlement."""
-        engine = self._engine
-        if engine is None:
-            raise PersistenceError(
-                "EventStore not initialized. Call initialize() first.",
-                operation="append_durable",
-            )
-
-        loop = asyncio.get_running_loop()
-        remaining = overall_deadline - loop.time()
-        if remaining <= 0:
-            raise TimeoutError("durable append deadline expired before transaction admission")
-
-        # Reserve up to 250ms (half of very small test budgets) for rollback,
-        # handler removal, and pool return.  The SQL interrupt fires at the
-        # earlier operation deadline; the public deadline includes cleanup.
-        settlement_reserve = min(0.25, remaining / 2)
-        operation_deadline = time.monotonic() + (remaining - settlement_reserve)
-        deadline_reached = False
-
-        def _interrupt_long_sql() -> int:
-            nonlocal deadline_reached
-            if time.monotonic() < operation_deadline:
-                return 0
-            deadline_reached = True
-            return 1
-
-        try:
-            async with asyncio.timeout_at(overall_deadline):
-                async with engine.connect() as conn:
-                    raw = await conn.get_raw_connection()
-                    driver = raw.driver_connection
-                    await driver.set_progress_handler(_interrupt_long_sql, 1_000)
-                    busy_ms = max(1, int((operation_deadline - time.monotonic()) * 1_000))
-                    busy_cursor = await driver.execute(f"PRAGMA busy_timeout={busy_ms}")
-                    await busy_cursor.close()
-
-                    interrupt_handle = loop.call_later(
-                        max(0.0, operation_deadline - time.monotonic()),
-                        lambda: asyncio.create_task(driver.interrupt()),
-                    )
-                    try:
-                        async with conn.begin():
-                            await _insert_event(conn, event, self._picker_projection_ready)
-                    finally:
-                        interrupt_handle.cancel()
-                        await driver.set_progress_handler(None, 0)
-                        restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
-                        await restore_cursor.close()
-        except TimeoutError:
-            raise
-        except OperationalError as exc:
-            if deadline_reached or loop.time() >= overall_deadline - settlement_reserve:
-                raise TimeoutError("durable append exceeded its persistence deadline") from exc
-            raise PersistenceError(
-                f"Failed to append event: {exc}",
-                operation="append_durable",
-                table="events",
-                details={"event_id": event.id, "event_type": event.type},
-            ) from exc
-        except Exception as exc:
-            if deadline_reached:
-                raise TimeoutError("durable append exceeded its persistence deadline") from exc
-            if isinstance(exc, PersistenceError):
-                raise
-            raise PersistenceError(
-                f"Failed to append event: {exc}",
-                operation="append_durable",
-                table="events",
-                details={"event_id": event.id, "event_type": event.type},
-            ) from exc
 
     async def append_session_start_if_absent(self, event: BaseEvent) -> None:
         """Fenced wrapper: admission + settlement for the CAS below.

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -15,6 +15,7 @@ import json
 import logging
 from pathlib import Path
 import sqlite3
+import time
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, unquote
 
@@ -623,6 +624,7 @@ class EventStore:
         self._picker_projection_ready = False
         self._settling_writes = set()
         self._closing = False
+        self._initialized = False
         self._lifecycle_lock = asyncio.Lock()
         validate_standard_shared_memory_sqlite_url(database_url)
         validate_canonical_named_memdb_sqlite_url(database_url)
@@ -773,6 +775,7 @@ class EventStore:
                 self._initialize_locked(create_schema=create_schema),
                 operation="initialize",
             )
+            self._initialized = True
 
     async def _initialize_locked(self, *, create_schema: bool | None = None) -> None:
         if self._configuration_error is not None:
@@ -881,6 +884,138 @@ class EventStore:
             )
         await self.append_with_rowid(event, _skip_workflow_ir_guard=_skip_workflow_ir_guard)
         return None
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        """Append one ordinary event within a cancellation-atomic deadline.
+
+        Caller-side ``wait_for()`` cannot bound :func:`_run_to_settlement`:
+        cancellation intentionally waits for the transaction's final commit
+        or rollback.  This entry point moves the deadline into persistence.
+        SQLite receives both a deadline-sized ``busy_timeout`` and a progress
+        handler/interrupt, while a small part of the advertised budget is
+        reserved for rollback and connection cleanup.  ``TimeoutError`` is
+        raised only after that settlement, so returning never leaves an
+        ambiguous transaction running in the background.
+
+        Agent-process lifecycle events are ordinary append-only events.  The
+        guarded session/workflow event families keep their specialized APIs
+        and are deliberately rejected here rather than silently weakening
+        their conditional transition contracts.
+        """
+        if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
+            raise ValueError("append_durable timeout must be a positive number")
+        if not isinstance(event, BaseEvent):
+            self._raise_invalid_append_input(event, operation="append_durable")
+        if (
+            _is_session_start_event(event)
+            or _is_session_terminal_event(event)
+            or _is_ac_acceptance_finalized_type(event)
+            or event.aggregate_type == "workflow_ir"
+        ):
+            raise PersistenceError(
+                "append_durable only accepts ordinary append-only events.",
+                operation="append_durable",
+                details={"event_type": event.type, "aggregate_type": event.aggregate_type},
+            )
+
+        loop = asyncio.get_running_loop()
+        overall_deadline = loop.time() + float(timeout)
+
+        # Schema initialization has its own cancellation-atomic settlement
+        # contract and cannot honestly be folded into a hard append deadline.
+        # Production EventStores initialize during service startup; refusing
+        # lazy initialization here is the bounded, ambiguity-free contract.
+        if not self._initialized or self._engine is None:
+            raise PersistenceError(
+                "Durable append requires an initialized EventStore; initialize it "
+                "during startup before beginning the bounded lifecycle write.",
+                operation="append_durable",
+            )
+
+        await _run_to_settlement(
+            self._append_durable_registered(event, overall_deadline=overall_deadline),
+            registry=self._settling_writes,
+            refuse_when=lambda: self._closing,
+            operation="append_durable",
+        )
+
+    async def _append_durable_registered(
+        self,
+        event: BaseEvent,
+        *,
+        overall_deadline: float,
+    ) -> None:
+        """Run one deadline-aware SQLite transaction to final settlement."""
+        engine = self._engine
+        if engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="append_durable",
+            )
+
+        loop = asyncio.get_running_loop()
+        remaining = overall_deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError("durable append deadline expired before transaction admission")
+
+        # Reserve up to 250ms (half of very small test budgets) for rollback,
+        # handler removal, and pool return.  The SQL interrupt fires at the
+        # earlier operation deadline; the public deadline includes cleanup.
+        settlement_reserve = min(0.25, remaining / 2)
+        operation_deadline = time.monotonic() + (remaining - settlement_reserve)
+        deadline_reached = False
+
+        def _interrupt_long_sql() -> int:
+            nonlocal deadline_reached
+            if time.monotonic() < operation_deadline:
+                return 0
+            deadline_reached = True
+            return 1
+
+        try:
+            async with asyncio.timeout_at(overall_deadline):
+                async with engine.connect() as conn:
+                    raw = await conn.get_raw_connection()
+                    driver = raw.driver_connection
+                    await driver.set_progress_handler(_interrupt_long_sql, 1_000)
+                    busy_ms = max(1, int((operation_deadline - time.monotonic()) * 1_000))
+                    busy_cursor = await driver.execute(f"PRAGMA busy_timeout={busy_ms}")
+                    await busy_cursor.close()
+
+                    interrupt_handle = loop.call_later(
+                        max(0.0, operation_deadline - time.monotonic()),
+                        lambda: asyncio.create_task(driver.interrupt()),
+                    )
+                    try:
+                        async with conn.begin():
+                            await _insert_event(conn, event, self._picker_projection_ready)
+                    finally:
+                        interrupt_handle.cancel()
+                        await driver.set_progress_handler(None, 0)
+                        restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
+                        await restore_cursor.close()
+        except TimeoutError:
+            raise
+        except OperationalError as exc:
+            if deadline_reached or loop.time() >= overall_deadline - settlement_reserve:
+                raise TimeoutError("durable append exceeded its persistence deadline") from exc
+            raise PersistenceError(
+                f"Failed to append event: {exc}",
+                operation="append_durable",
+                table="events",
+                details={"event_id": event.id, "event_type": event.type},
+            ) from exc
+        except Exception as exc:
+            if deadline_reached:
+                raise TimeoutError("durable append exceeded its persistence deadline") from exc
+            if isinstance(exc, PersistenceError):
+                raise
+            raise PersistenceError(
+                f"Failed to append event: {exc}",
+                operation="append_durable",
+                table="events",
+                details={"event_id": event.id, "event_type": event.type},
+            ) from exc
 
     async def append_session_start_if_absent(self, event: BaseEvent) -> None:
         """Fenced wrapper: admission + settlement for the CAS below.
@@ -3066,6 +3201,7 @@ class EventStore:
                     await self.checkpoint_wal()
                     await self._engine.dispose()
                     self._engine = None
+                    self._initialized = False
                 if self._memory_keepalive is not None:
                     # Release the shared in-memory database anchor last so
                     # pooled connections never observe the database

--- a/src/ouroboros/persistence/write_settlement.py
+++ b/src/ouroboros/persistence/write_settlement.py
@@ -1,0 +1,173 @@
+"""Cancellation-settled persistence writes and bounded SQLite appends.
+
+Transactions that survive caller cancellation must finish before the caller
+or EventStore lifecycle can move on.  This module owns that settlement
+primitive and the SQLite-specific deadline/interrupt transaction used by
+durable lifecycle publication.  EventStore retains admission, validation,
+write-registry, and engine lifecycle ownership and passes the live engine into
+the bounded operation only after those gates succeed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
+import logging
+import time
+from typing import Any
+
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ouroboros.core.errors import PersistenceError
+from ouroboros.events.base import BaseEvent
+
+logger = logging.getLogger(__name__)
+
+InsertEvent = Callable[[Any, BaseEvent, bool], Awaitable[None]]
+
+
+async def run_to_settlement[T](
+    coro: Coroutine[Any, Any, T],
+    *,
+    registry: set[asyncio.Future[Any]] | None = None,
+    refuse_when: Callable[[], bool] | None = None,
+    operation: str = "append",
+) -> T:
+    """Run a transactional coroutine, settling it before cancellation surfaces.
+
+    A write, once begun, must commit or roll back inside the caller's
+    lifetime: shield-only semantics let a cancelled caller (and even
+    ``EventStore.close()``) return while the transaction was still pending,
+    so durable history could change after shutdown. Cancellation is re-raised
+    only after the inner task completes, which both preserves the
+    cancellation-atomicity contract and keeps every write within the store
+    lifecycle (#1794 review rounds one and two).
+    """
+    if refuse_when is not None and refuse_when():
+        # Admission is synchronized with close(): this check and the registry
+        # add below run in one synchronous block on the event loop, so a
+        # write either registers before close() snapshots the registry or is
+        # refused outright — it can never slip past the drain (round five).
+        coro.close()
+        raise PersistenceError(
+            "EventStore is closing; write refused.",
+            operation=operation,
+        )
+    inner: asyncio.Task[T] = asyncio.ensure_future(coro)
+    if registry is not None:
+        # close() drains this registry so no settling write can escape the
+        # store lifecycle (review round four).
+        registry.add(inner)
+        inner.add_done_callback(registry.discard)
+    try:
+        return await asyncio.shield(inner)
+    except asyncio.CancelledError as caller_cancellation:
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                # A further caller cancellation — keep settling.
+                continue
+            except Exception:
+                # The transaction settled by failing; the loop exits below.
+                break
+        settlement_error: BaseException | None = None
+        if not inner.cancelled():
+            settlement_error = inner.exception()
+        if settlement_error is not None:
+            # Cancellation outranks the write's own failure: lifecycle code
+            # awaiting a cancelled task must still observe CancelledError
+            # (e.g. the watchdog's decision batch depends on it). The
+            # transaction failure is preserved as the cause.
+            logger.debug(
+                "event_store.append.settled_with_error",
+                exc_info=settlement_error,
+            )
+            raise caller_cancellation from settlement_error
+        raise
+
+
+async def await_sqlite_write_atomically[T](awaitable: Coroutine[Any, Any, T]) -> T:
+    """Compatibility entry point for callers needing transaction settlement."""
+    return await run_to_settlement(awaitable)
+
+
+async def append_with_sqlite_deadline(
+    engine: AsyncEngine,
+    event: BaseEvent,
+    *,
+    overall_deadline: float,
+    picker_projection_ready: bool,
+    insert_event: InsertEvent,
+) -> None:
+    """Run one deadline-aware SQLite insert transaction to final settlement.
+
+    The connection, progress handler, interrupt, transaction, and cleanup all
+    stay in one task so aiosqlite thread ownership cannot cross cancellation
+    boundaries.  EventStore supplies its initialized engine and canonical
+    event insertion callback after registering this task with its lifecycle.
+    """
+    loop = asyncio.get_running_loop()
+    remaining = overall_deadline - loop.time()
+    if remaining <= 0:
+        raise TimeoutError("durable append deadline expired before transaction admission")
+
+    # Reserve up to 250ms (half of very small test budgets) for rollback,
+    # handler removal, and pool return. The SQL interrupt fires at the earlier
+    # operation deadline; the public deadline includes cleanup.
+    settlement_reserve = min(0.25, remaining / 2)
+    operation_deadline = time.monotonic() + (remaining - settlement_reserve)
+    deadline_reached = False
+
+    def interrupt_long_sql() -> int:
+        nonlocal deadline_reached
+        if time.monotonic() < operation_deadline:
+            return 0
+        deadline_reached = True
+        return 1
+
+    try:
+        async with asyncio.timeout_at(overall_deadline):
+            async with engine.connect() as conn:
+                raw = await conn.get_raw_connection()
+                driver = raw.driver_connection
+                await driver.set_progress_handler(interrupt_long_sql, 1_000)
+                busy_ms = max(1, int((operation_deadline - time.monotonic()) * 1_000))
+                busy_cursor = await driver.execute(f"PRAGMA busy_timeout={busy_ms}")
+                await busy_cursor.close()
+
+                interrupt_handle = loop.call_later(
+                    max(0.0, operation_deadline - time.monotonic()),
+                    lambda: asyncio.create_task(driver.interrupt()),
+                )
+                try:
+                    async with conn.begin():
+                        await insert_event(conn, event, picker_projection_ready)
+                finally:
+                    interrupt_handle.cancel()
+                    await driver.set_progress_handler(None, 0)
+                    restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
+                    await restore_cursor.close()
+    except TimeoutError:
+        raise
+    except OperationalError as exc:
+        if deadline_reached or loop.time() >= overall_deadline - settlement_reserve:
+            raise TimeoutError("durable append exceeded its persistence deadline") from exc
+        raise PersistenceError(
+            f"Failed to append event: {exc}",
+            operation="append_durable",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        ) from exc
+    except Exception as exc:
+        if deadline_reached:
+            raise TimeoutError("durable append exceeded its persistence deadline") from exc
+        if isinstance(exc, PersistenceError):
+            raise
+        raise PersistenceError(
+            f"Failed to append event: {exc}",
+            operation="append_durable",
+            table="events",
+            details={"event_id": event.id, "event_type": event.type},
+        ) from exc

--- a/src/ouroboros/persistence/write_settlement.py
+++ b/src/ouroboros/persistence/write_settlement.py
@@ -119,6 +119,8 @@ async def append_with_sqlite_deadline(
     settlement_reserve = min(0.25, remaining / 2)
     operation_deadline = time.monotonic() + (remaining - settlement_reserve)
     deadline_reached = False
+    committed = False
+    post_commit_cleanup_error: BaseException | None = None
 
     def interrupt_long_sql() -> int:
         nonlocal deadline_reached
@@ -141,17 +143,66 @@ async def append_with_sqlite_deadline(
                     max(0.0, operation_deadline - time.monotonic()),
                     lambda: asyncio.create_task(driver.interrupt()),
                 )
+                operation_error: BaseException | None = None
                 try:
                     async with conn.begin():
                         await insert_event(conn, event, picker_projection_ready)
+                    committed = True
+                except BaseException as exc:
+                    operation_error = exc
+                    raise
                 finally:
                     interrupt_handle.cancel()
-                    await driver.set_progress_handler(None, 0)
-                    restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
-                    await restore_cursor.close()
+                    cleanup_error: BaseException | None = None
+                    try:
+                        await driver.set_progress_handler(None, 0)
+                    except Exception as exc:
+                        cleanup_error = exc
+                    try:
+                        restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
+                        await restore_cursor.close()
+                    except Exception as exc:
+                        if cleanup_error is None:
+                            cleanup_error = exc
+                        else:
+                            logger.warning(
+                                "event_store.append.secondary_cleanup_failed",
+                                exc_info=exc,
+                            )
+                    if cleanup_error is not None:
+                        try:
+                            await conn.invalidate(cleanup_error)
+                        except Exception as exc:
+                            logger.warning(
+                                "event_store.append.connection_invalidation_failed",
+                                exc_info=exc,
+                            )
+                        if committed:
+                            post_commit_cleanup_error = cleanup_error
+                        elif operation_error is None:
+                            raise cleanup_error
+                        else:
+                            logger.warning(
+                                "event_store.append.rollback_cleanup_failed",
+                                exc_info=cleanup_error,
+                            )
+        if post_commit_cleanup_error is not None:
+            logger.warning(
+                "event_store.append.post_commit_cleanup_failed",
+                exc_info=post_commit_cleanup_error,
+            )
     except TimeoutError:
+        if committed:
+            logger.warning("event_store.append.post_commit_cleanup_timed_out")
+            return
         raise
     except OperationalError as exc:
+        if committed:
+            logger.warning(
+                "event_store.append.post_commit_cleanup_failed",
+                exc_info=exc,
+            )
+            return
         if deadline_reached or loop.time() >= overall_deadline - settlement_reserve:
             raise TimeoutError("durable append exceeded its persistence deadline") from exc
         raise PersistenceError(
@@ -161,6 +212,12 @@ async def append_with_sqlite_deadline(
             details={"event_id": event.id, "event_type": event.type},
         ) from exc
     except Exception as exc:
+        if committed:
+            logger.warning(
+                "event_store.append.post_commit_cleanup_failed",
+                exc_info=exc,
+            )
+            return
         if deadline_reached:
             raise TimeoutError("durable append exceeded its persistence deadline") from exc
         if isinstance(exc, PersistenceError):

--- a/src/ouroboros/persistence/write_settlement.py
+++ b/src/ouroboros/persistence/write_settlement.py
@@ -156,11 +156,25 @@ async def append_with_sqlite_deadline(
                     cleanup_error: BaseException | None = None
                     try:
                         await driver.set_progress_handler(None, 0)
+                    except asyncio.CancelledError as exc:
+                        # The overall deadline can expire after COMMIT while
+                        # driver cleanup is in flight.  Keep that cancellation
+                        # as a cleanup failure so the still-configured progress
+                        # handler can never return to the pool.
+                        cleanup_error = exc
                     except Exception as exc:
                         cleanup_error = exc
                     try:
                         restore_cursor = await driver.execute("PRAGMA busy_timeout=30000")
                         await restore_cursor.close()
+                    except asyncio.CancelledError as exc:
+                        if cleanup_error is None:
+                            cleanup_error = exc
+                        else:
+                            logger.warning(
+                                "event_store.append.secondary_cleanup_cancelled",
+                                exc_info=exc,
+                            )
                     except Exception as exc:
                         if cleanup_error is None:
                             cleanup_error = exc
@@ -172,6 +186,11 @@ async def append_with_sqlite_deadline(
                     if cleanup_error is not None:
                         try:
                             await conn.invalidate(cleanup_error)
+                        except asyncio.CancelledError as exc:
+                            logger.warning(
+                                "event_store.append.connection_invalidation_cancelled",
+                                exc_info=exc,
+                            )
                         except Exception as exc:
                             logger.warning(
                                 "event_store.append.connection_invalidation_failed",

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -51,6 +51,11 @@ class _FakeEventStore:
     async def append(self, event: Any) -> None:
         self.appended.append(event)
 
+    async def append_durable(self, event: Any, *, timeout: float) -> None:
+        async with asyncio.timeout(timeout):
+            await self.initialize()
+            await self.append(event)
+
 
 def _directives(store: _FakeEventStore) -> list[str]:
     return [
@@ -392,6 +397,10 @@ async def test_ralph_agent_process_pause_inspect_resume_preserves_event_tail(
 ) -> None:
     """Closeout audit: Ralph-scoped AgentProcess pause/resume keeps continuity."""
     event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    # Durable lifecycle deadlines begin at append admission.  Real
+    # EventStores initialize during service startup so cancellation-atomic
+    # schema creation is never misrepresented as a bounded transaction.
+    await event_store.initialize()
     checkpoint_store = CheckpointStore(base_path=tmp_path / "checkpoints")
     process_id = "ralph:lin_closeout:job_1448"
     captured_handle: asyncio.Future[AgentProcessHandle] = asyncio.get_running_loop().create_future()
@@ -436,7 +445,8 @@ async def test_ralph_agent_process_pause_inspect_resume_preserves_event_tail(
         paused_events = await event_store.replay("agent_process", process_id)
         assert _event_directives(paused_events) == ["continue", "wait"]
         assert _event_statuses(paused_events) == ["running", "paused"]
-        assert AgentProcessHandle.load_persisted_pause(process_id, store=checkpoint_store) is True
+        with pytest.raises(RuntimeError, match="requires lifecycle replay"):
+            AgentProcessHandle.load_persisted_pause(process_id, store=checkpoint_store)
         pause_checkpoint_key = f"agent_process_{hashlib.sha256(process_id.encode()).hexdigest()}"
         paused_checkpoint = checkpoint_store.load(pause_checkpoint_key)
         assert paused_checkpoint.is_ok
@@ -456,7 +466,10 @@ async def test_ralph_agent_process_pause_inspect_resume_preserves_event_tail(
         assert _event_statuses(post_resume_tail) == ["running", "completed"]
         assert result.meta["generations"] == ["generation-1", "generation-2"]
         assert observed_generations == ["generation-1", "generation-2"]
-        assert AgentProcessHandle.load_persisted_pause(process_id, store=checkpoint_store) is False
+        resumed_checkpoint = checkpoint_store.load(pause_checkpoint_key)
+        assert resumed_checkpoint.is_ok
+        assert resumed_checkpoint.value.phase == "agent_process_running"
+        assert resumed_checkpoint.value.state["authority"] == "journal"
     finally:
         if not task.done():
             task.cancel()

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2087,6 +2087,84 @@ class TestMCPServerAdapterTools:
         assert result.value.text_content == "Success"
         handler.handle_mock.assert_called_once_with({"input": "test"})
 
+    async def test_concurrent_calls_share_startup_before_handler_dispatch(self) -> None:
+        """Owned startup runs once and gates every concurrent request."""
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("my_tool")
+        adapter.register_tool(handler)
+        initialize_started = asyncio.Event()
+        release_initialize = asyncio.Event()
+
+        class _StartupResource:
+            initialize_calls = 0
+            close_calls = 0
+
+            async def initialize(self) -> None:
+                self.initialize_calls += 1
+                initialize_started.set()
+                await release_initialize.wait()
+
+            async def close(self) -> None:
+                self.close_calls += 1
+
+        resource = _StartupResource()
+        adapter.register_owned_resource(resource, initialize_on_startup=True)
+
+        calls = [
+            asyncio.create_task(adapter.call_tool("my_tool", {"input": str(index)}))
+            for index in range(2)
+        ]
+        await asyncio.wait_for(initialize_started.wait(), timeout=0.5)
+        assert handler.handle_mock.await_count == 0
+        release_initialize.set()
+
+        results = await asyncio.gather(*calls)
+        assert all(result.is_ok for result in results)
+        assert resource.initialize_calls == 1
+        assert handler.handle_mock.await_count == 2
+
+        await asyncio.gather(adapter.shutdown(), adapter.shutdown())
+        assert resource.close_calls == 1
+
+    async def test_startup_failure_prevents_handler_work_and_remains_owned(self) -> None:
+        """A failed initializer blocks dispatch but shutdown still releases resources."""
+        adapter = MCPServerAdapter()
+        handler = MockToolHandler("my_tool")
+        adapter.register_tool(handler)
+        close_order: list[str] = []
+
+        class _Resource:
+            def __init__(self, name: str, *, fail: bool = False) -> None:
+                self.name = name
+                self.fail = fail
+                self.initialize_calls = 0
+
+            async def initialize(self) -> None:
+                self.initialize_calls += 1
+                if self.fail:
+                    raise RuntimeError("startup exploded")
+
+            async def close(self) -> None:
+                close_order.append(self.name)
+
+        first = _Resource("first")
+        failing = _Resource("failing", fail=True)
+        adapter.register_owned_resource(first, initialize_on_startup=True)
+        adapter.register_owned_resource(failing, initialize_on_startup=True)
+
+        first_result = await adapter.call_tool("my_tool", {"input": "one"})
+        second_result = await adapter.call_tool("my_tool", {"input": "two"})
+
+        assert first_result.is_err and second_result.is_err
+        assert "startup exploded" in str(first_result.error)
+        assert "startup exploded" in str(second_result.error)
+        assert first.initialize_calls == 1
+        assert failing.initialize_calls == 1
+        handler.handle_mock.assert_not_awaited()
+
+        await adapter.shutdown()
+        assert close_order == ["first", "failing"]
+
     async def test_call_tool_logs_lifecycle_without_argument_values(self) -> None:
         """call_tool emits boundary logs without leaking argument payloads."""
         adapter = MCPServerAdapter(name="test-server")
@@ -3039,6 +3117,41 @@ class TestServeTransport:
         assert exit_event["transport"] == "stdio"
         assert isinstance(exit_event["duration_ms"], int)
         assert exit_event["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_serve_initializes_owned_resources_before_transport(self) -> None:
+        """No transport accepts work before the explicit startup boundary."""
+        from unittest.mock import MagicMock, patch
+
+        lifecycle: list[str] = []
+
+        class _StartupResource:
+            async def initialize(self) -> None:
+                lifecycle.append("initialize")
+
+            async def close(self) -> None:
+                lifecycle.append("close")
+
+        async def run_stdio() -> None:
+            lifecycle.append("serve")
+
+        mock_fastmcp_cls = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.tool = MagicMock(return_value=lambda f: f)
+        mock_instance.resource = MagicMock(return_value=lambda f: f)
+        mock_instance.run_stdio_async = AsyncMock(side_effect=run_stdio)
+        mock_fastmcp_cls.return_value = mock_instance
+        adapter = MCPServerAdapter()
+        adapter.register_owned_resource(_StartupResource(), initialize_on_startup=True)
+
+        with patch(
+            "ouroboros.mcp.server.adapter._OuroborosSDKServer",
+            mock_fastmcp_cls,
+        ):
+            await adapter.serve(transport="stdio")
+        await adapter.shutdown()
+
+        assert lifecycle == ["initialize", "serve", "close"]
 
     @pytest.mark.asyncio
     async def test_sse_ephemeral_port_zero(self):
@@ -4649,4 +4762,120 @@ async def test_production_fanout_returns_only_disposable_envelope(
         assert len(changed_events) == 1
         assert changed_marker not in json.dumps(changed_events[0].data)
     finally:
-        await event_store.close()
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_production_fanout_surfaces_owned_store_startup_failure_before_work(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production readiness boundary fails before synthesis or publication."""
+    from ouroboros.mcp.server import adapter as adapter_module
+    from ouroboros.mcp.tools import fanout_handler
+    from ouroboros.mcp.tools.fanout import FANOUT_KIND_QUESTION_ADVISORY
+
+    event_store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    server = adapter_module.create_ouroboros_server(
+        name="fanout-startup-failure-probe",
+        event_store=event_store,
+        state_dir=tmp_path / "state",
+        project_dir=tmp_path,
+    )
+    handler = server._tool_handlers["ouroboros_submit_fanout_results"]
+    registry = handler.fanout_registry
+    assert registry is not None
+    fanout_id = registry.register(
+        kind=FANOUT_KIND_QUESTION_ADVISORY,
+        session_id="session-startup-failure",
+        correlation_key="context.lane_id",
+        expected_keys=["code_context"],
+        synthesizer_input={"lane_ids": ["code_context"]},
+        required_keys=["code_context"],
+    )
+    assert fanout_id is not None
+    synthesize = AsyncMock()
+    monkeypatch.setattr(fanout_handler, "synthesize_fanout_results", synthesize)
+    initialize = AsyncMock(side_effect=RuntimeError("event store startup failed"))
+    monkeypatch.setattr(event_store, "initialize", initialize)
+
+    try:
+        result = await handler.handle(
+            {
+                "session_id": "session-startup-failure",
+                "fanout_id": fanout_id,
+                "correlation_key": "context.lane_id",
+                "results": [{"key": "code_context", "content": "child output"}],
+            }
+        )
+
+        assert result.is_err
+        assert "event store startup failed" in str(result.error)
+        initialize.assert_awaited_once()
+        synthesize.assert_not_awaited()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_production_fanout_does_not_initialize_custom_store(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Production ownership must not weaken custom-store durable fail-fast."""
+    from ouroboros.mcp.server import adapter as adapter_module
+    from ouroboros.mcp.tools import fanout_handler
+    from ouroboros.mcp.tools.fanout import FANOUT_KIND_QUESTION_ADVISORY
+
+    class _CustomStore:
+        initialize_calls = 0
+        close_calls = 0
+
+        async def initialize(self) -> None:
+            self.initialize_calls += 1
+
+        async def append_durable(self, _event: BaseEvent, *, timeout: float) -> None:
+            del timeout
+            raise RuntimeError("custom store remains uninitialized")
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    custom_store = _CustomStore()
+    server = adapter_module.create_ouroboros_server(
+        name="fanout-custom-store-probe",
+        event_store=custom_store,
+        state_dir=tmp_path / "state",
+        project_dir=tmp_path,
+    )
+    handler = server._tool_handlers["ouroboros_submit_fanout_results"]
+    registry = handler.fanout_registry
+    assert registry is not None
+    fanout_id = registry.register(
+        kind=FANOUT_KIND_QUESTION_ADVISORY,
+        session_id="session-custom-store",
+        correlation_key="context.lane_id",
+        expected_keys=["code_context"],
+        synthesizer_input={"lane_ids": ["code_context"]},
+        required_keys=["code_context"],
+    )
+    assert fanout_id is not None
+    synthesize = AsyncMock()
+    monkeypatch.setattr(fanout_handler, "synthesize_fanout_results", synthesize)
+
+    try:
+        result = await handler.handle(
+            {
+                "session_id": "session-custom-store",
+                "fanout_id": fanout_id,
+                "correlation_key": "context.lane_id",
+                "results": [{"key": "code_context", "content": "child output"}],
+            }
+        )
+
+        assert result.is_err
+        assert "custom store remains uninitialized" in str(result.error)
+        assert custom_store.initialize_calls == 0
+        synthesize.assert_not_awaited()
+    finally:
+        await server.shutdown()
+
+    assert custom_store.close_calls == 1

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -146,6 +146,43 @@ class _FailOnceAttemptReplayStore(_FakeEventStore):
         await super().append(event)
 
 
+class _CommittedResumeHandoffStore(_FakeEventStore):
+    """Hold the third append after commit to expose the resume handoff race."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.append_attempts = 0
+        self.resume_committed = asyncio.Event()
+        self.release_append = asyncio.Event()
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        self.append_attempts += 1
+        await self.append(event)
+        if self.append_attempts == 3:
+            self.resume_committed.set()
+            async with asyncio.timeout(timeout):
+                await self.release_append.wait()
+
+
+class _PreCommitResumeFailureStore(_FakeEventStore):
+    """Hold then fail the third append before it reaches durable history."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.append_attempts = 0
+        self.resume_append_started = asyncio.Event()
+        self.release_failure = asyncio.Event()
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        self.append_attempts += 1
+        if self.append_attempts == 3:
+            self.resume_append_started.set()
+            async with asyncio.timeout(timeout):
+                await self.release_failure.wait()
+            raise RuntimeError("resume failed before commit")
+        await self.append(event)
+
+
 class _CancellationResistantDeadlineStore(_FakeEventStore):
     """Model a persistence operation that settles only after interruption."""
 
@@ -2390,6 +2427,200 @@ async def test_durable_transient_resume_failure_stays_paused_until_explicit_retr
     assert committed_resume_checkpoint.value.phase == "agent_process_running"
     with pytest.raises(RuntimeError, match="requires lifecycle replay"):
         AgentProcessHandle.load_persisted_pause(process_id, store=checkpoint_store)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_durable_resume_preserves_pause_when_append_fails_pre_commit() -> None:
+    """Cancellation still surfaces after a pre-commit failure settles PAUSED."""
+    store = _PreCommitResumeFailureStore()
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+    work_released = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        reached_pause.set()
+        await handle.wait_unpaused()
+        work_released.set()
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+    handle = handle_box[0]
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    resume_task = asyncio.create_task(handle.resume())
+    await asyncio.wait_for(store.resume_append_started.wait(), timeout=1.0)
+    resume_task.cancel()
+    store.release_failure.set()
+    with pytest.raises(asyncio.CancelledError) as cancelled:
+        await resume_task
+
+    assert isinstance(cancelled.value.__cause__, RuntimeError)
+    assert handle.status() is AgentProcessStatus.PAUSED
+    assert work_released.is_set() is False
+    assert _directives(store.appended) == ["continue", "wait"]
+    assert (await handle.replay()).status is AgentProcessStatus.PAUSED
+
+    await handle.resume()
+    assert await asyncio.wait_for(run_task, timeout=1.0) == "done"
+    assert work_released.is_set()
+    assert _directives(store.appended) == ["continue", "wait", "continue", "converge"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_durable_resume_settles_release_after_committed_continue() -> None:
+    """Repeated cancellation cannot strand a committed resume in live PAUSED."""
+    store = _CommittedResumeHandoffStore()
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+    work_released = asyncio.Event()
+    finish_work = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        reached_pause.set()
+        await handle.wait_unpaused()
+        work_released.set()
+        await finish_work.wait()
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+    handle = handle_box[0]
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    resume_task = asyncio.create_task(handle.resume())
+    await asyncio.wait_for(store.resume_committed.wait(), timeout=1.0)
+    resume_task.cancel()
+    await asyncio.sleep(0)
+    resume_task.cancel()
+    competing_resume = asyncio.create_task(handle.resume())
+    await asyncio.sleep(0)
+
+    assert resume_task.done() is False
+    assert competing_resume.done() is False
+    assert _directives(store.appended) == ["continue", "wait", "continue"]
+    committed_snapshot = project_agent_process_snapshot(
+        store.appended,
+        process_id=handle.process_id,
+    )
+    assert committed_snapshot is not None
+    assert committed_snapshot.status is AgentProcessStatus.RUNNING
+    assert handle.status() is AgentProcessStatus.PAUSED
+    assert work_released.is_set() is False
+
+    store.release_append.set()
+    with pytest.raises(asyncio.CancelledError):
+        await resume_task
+    await competing_resume
+    await asyncio.wait_for(work_released.wait(), timeout=1.0)
+
+    assert handle.status() is AgentProcessStatus.RUNNING
+    assert (await handle.replay()).status is AgentProcessStatus.RUNNING
+    assert store.append_attempts == 3
+    assert _directives(store.appended) == ["continue", "wait", "continue"]
+
+    finish_work.set()
+    assert await asyncio.wait_for(run_task, timeout=1.0) == "done"
+    assert _directives(store.appended) == ["continue", "wait", "continue", "converge"]
+
+
+@pytest.mark.asyncio
+async def test_real_event_store_cancel_after_resume_commit_releases_live_waiter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real SQLite commit and live release settle before cancellation surfaces."""
+    process_id = "durable-real-store-cancelled-resume"
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    original_append = store._append_durable_registered
+    resume_committed = asyncio.Event()
+    release_append = asyncio.Event()
+
+    async def append_then_hold_after_resume_commit(
+        event: BaseEvent,
+        *,
+        overall_deadline: float,
+    ) -> None:
+        await original_append(event, overall_deadline=overall_deadline)
+        if event.data.get("directive") == "continue" and "resume requested" in str(
+            event.data.get("reason")
+        ):
+            resume_committed.set()
+            await release_append.wait()
+
+    monkeypatch.setattr(store, "_append_durable_registered", append_then_hold_after_resume_commit)
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+    work_released = asyncio.Event()
+    finish_work = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        reached_pause.set()
+        await handle.wait_unpaused()
+        work_released.set()
+        await finish_work.wait()
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+            process_id=process_id,
+        )
+    )
+    try:
+        await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+        handle = handle_box[0]
+        await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+        resume_task = asyncio.create_task(handle.resume())
+        await asyncio.wait_for(resume_committed.wait(), timeout=1.0)
+        resume_task.cancel()
+        await asyncio.sleep(0)
+
+        assert resume_task.done() is False
+        assert handle.status() is AgentProcessStatus.PAUSED
+        assert work_released.is_set() is False
+
+        release_append.set()
+        with pytest.raises(asyncio.CancelledError):
+            await resume_task
+        await asyncio.wait_for(work_released.wait(), timeout=1.0)
+
+        events = await store.replay("agent_process", process_id)
+        assert _directives(events) == ["continue", "wait", "continue"]
+        snapshot = project_agent_process_snapshot(events, process_id=process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.RUNNING
+        assert handle.status() is AgentProcessStatus.RUNNING
+
+        finish_work.set()
+        assert await asyncio.wait_for(run_task, timeout=1.0) == "done"
+        assert _directives(await store.replay("agent_process", process_id)) == [
+            "continue",
+            "wait",
+            "continue",
+            "converge",
+        ]
+    finally:
+        release_append.set()
+        finish_work.set()
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+        await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -2349,6 +2349,92 @@ async def test_run_with_agent_process_surfaces_initial_journal_failure_before_wo
 
 
 @pytest.mark.asyncio
+async def test_real_event_store_cancel_after_initial_commit_terminalizes_without_starting_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A committed RUNNING row is terminalized before caller cancellation escapes."""
+    from ouroboros.persistence import event_store as event_store_module
+
+    process_id = "durable-real-store-cancelled-initial-handoff"
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    original_append = event_store_module.append_with_sqlite_deadline
+    initial_committed = asyncio.Event()
+    release_initial_append = asyncio.Event()
+    work_started = asyncio.Event()
+
+    async def append_then_hold_after_initial_commit(
+        engine: Any,
+        event: BaseEvent,
+        *,
+        overall_deadline: float,
+        picker_projection_ready: bool,
+        insert_event: Any,
+    ) -> None:
+        await original_append(
+            engine,
+            event,
+            overall_deadline=overall_deadline,
+            picker_projection_ready=picker_projection_ready,
+            insert_event=insert_event,
+        )
+        if event.data.get("directive") == "continue" and "spawned" in str(event.data.get("reason")):
+            initial_committed.set()
+            await release_initial_append.wait()
+
+    monkeypatch.setattr(
+        event_store_module,
+        "append_with_sqlite_deadline",
+        append_then_hold_after_initial_commit,
+    )
+
+    async def work(_handle: AgentProcessHandle) -> str:
+        work_started.set()
+        return "must not run"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+            process_id=process_id,
+        )
+    )
+    try:
+        await asyncio.wait_for(initial_committed.wait(), timeout=1.0)
+        run_task.cancel()
+        await asyncio.sleep(0)
+        run_task.cancel()
+
+        assert run_task.done() is False
+        assert work_started.is_set() is False
+
+        release_initial_append.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(run_task, timeout=1.0)
+
+        events = await store.replay("agent_process", process_id)
+        assert _directives(events) == ["continue", "cancel"]
+        snapshot = project_agent_process_snapshot(events, process_id=process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.CANCELLED
+        assert snapshot.directive_count == 2
+        assert work_started.is_set() is False
+        assert not any(
+            task.get_name() == f"agent_process:{process_id}" and not task.done()
+            for task in asyncio.all_tasks()
+        )
+    finally:
+        release_initial_append.set()
+        if not run_task.done():
+            run_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await run_task
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_run_with_agent_process_surfaces_terminal_journal_failure() -> None:
     """Durable mode cannot return success with a missing terminal row."""
     store = _DropAfterFirstAppendReplayStore()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -2538,26 +2538,41 @@ async def test_real_event_store_cancel_after_resume_commit_releases_live_waiter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real SQLite commit and live release settle before cancellation surfaces."""
+    from ouroboros.persistence import event_store as event_store_module
+
     process_id = "durable-real-store-cancelled-resume"
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
     await store.initialize()
-    original_append = store._append_durable_registered
+    original_append = event_store_module.append_with_sqlite_deadline
     resume_committed = asyncio.Event()
     release_append = asyncio.Event()
 
     async def append_then_hold_after_resume_commit(
+        engine: Any,
         event: BaseEvent,
         *,
         overall_deadline: float,
+        picker_projection_ready: bool,
+        insert_event: Any,
     ) -> None:
-        await original_append(event, overall_deadline=overall_deadline)
+        await original_append(
+            engine,
+            event,
+            overall_deadline=overall_deadline,
+            picker_projection_ready=picker_projection_ready,
+            insert_event=insert_event,
+        )
         if event.data.get("directive") == "continue" and "resume requested" in str(
             event.data.get("reason")
         ):
             resume_committed.set()
             await release_append.wait()
 
-    monkeypatch.setattr(store, "_append_durable_registered", append_then_hold_after_resume_commit)
+    monkeypatch.setattr(
+        event_store_module,
+        "append_with_sqlite_deadline",
+        append_then_hold_after_resume_commit,
+    )
     handle_box: list[AgentProcessHandle] = []
     reached_pause = asyncio.Event()
     work_released = asyncio.Event()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -2435,6 +2435,183 @@ async def test_real_event_store_cancel_after_initial_commit_terminalizes_without
 
 
 @pytest.mark.asyncio
+async def test_real_event_store_cancel_after_committed_converge_keeps_completed_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A committed CONVERGE cannot be reclassified as a synthetic FAILED state."""
+    from ouroboros.persistence import event_store as event_store_module
+
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    original_append = event_store_module.append_with_sqlite_deadline
+    terminal_committed = asyncio.Event()
+    release_terminal_append = asyncio.Event()
+    handle_box: list[AgentProcessHandle] = []
+
+    async def append_then_hold_after_converge_commit(
+        engine: Any,
+        event: BaseEvent,
+        *,
+        overall_deadline: float,
+        picker_projection_ready: bool,
+        insert_event: Any,
+    ) -> None:
+        await original_append(
+            engine,
+            event,
+            overall_deadline=overall_deadline,
+            picker_projection_ready=picker_projection_ready,
+            insert_event=insert_event,
+        )
+        if event.data.get("directive") == "converge":
+            terminal_committed.set()
+            await release_terminal_append.wait()
+
+    monkeypatch.setattr(
+        event_store_module,
+        "append_with_sqlite_deadline",
+        append_then_hold_after_converge_commit,
+    )
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    try:
+        await asyncio.wait_for(terminal_committed.wait(), timeout=1.0)
+        run_task.cancel()
+        await asyncio.sleep(0)
+        run_task.cancel()
+
+        assert run_task.done() is False
+        release_terminal_append.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(run_task, timeout=1.0)
+
+        handle = handle_box[0]
+        events = await store.replay("agent_process", handle.process_id)
+        assert _directives(events) == ["continue", "converge"]
+        snapshot = project_agent_process_snapshot(events, process_id=handle.process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.COMPLETED
+        assert handle.status() is AgentProcessStatus.COMPLETED
+        assert handle.failure() is None
+        await asyncio.sleep(0)
+        assert _directives(await store.replay("agent_process", handle.process_id)) == [
+            "continue",
+            "converge",
+        ]
+        assert not any(
+            task.get_name() == f"agent_process:{handle.process_id}" and not task.done()
+            for task in asyncio.all_tasks()
+        )
+    finally:
+        release_terminal_append.set()
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_real_event_store_cancel_after_committed_terminal_cancel_stays_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated cancellation after terminal CANCEL cannot append a later FAILED row."""
+    from ouroboros.persistence import event_store as event_store_module
+
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    original_append = event_store_module.append_with_sqlite_deadline
+    terminal_committed = asyncio.Event()
+    release_terminal_append = asyncio.Event()
+    work_started = asyncio.Event()
+    handle_box: list[AgentProcessHandle] = []
+
+    async def append_then_hold_after_cancel_commit(
+        engine: Any,
+        event: BaseEvent,
+        *,
+        overall_deadline: float,
+        picker_projection_ready: bool,
+        insert_event: Any,
+    ) -> None:
+        await original_append(
+            engine,
+            event,
+            overall_deadline=overall_deadline,
+            picker_projection_ready=picker_projection_ready,
+            insert_event=insert_event,
+        )
+        if (
+            event.data.get("directive") == "cancel"
+            and event.data.get("extra", {}).get("lifecycle_status") == "cancelled"
+        ):
+            terminal_committed.set()
+            await release_terminal_append.wait()
+
+    monkeypatch.setattr(
+        event_store_module,
+        "append_with_sqlite_deadline",
+        append_then_hold_after_cancel_commit,
+    )
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        work_started.set()
+        await asyncio.Event().wait()
+        return "unreachable"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    try:
+        await asyncio.wait_for(work_started.wait(), timeout=1.0)
+        run_task.cancel()
+        await asyncio.wait_for(terminal_committed.wait(), timeout=1.0)
+
+        handle = handle_box[0]
+        runner_task = handle._work_task
+        assert runner_task is not None
+        runner_task.cancel()
+        await asyncio.sleep(0)
+        runner_task.cancel()
+
+        assert run_task.done() is False
+        release_terminal_append.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(run_task, timeout=1.0)
+
+        events = await store.replay("agent_process", handle.process_id)
+        assert _directives(events) == ["continue", "cancel"]
+        snapshot = project_agent_process_snapshot(events, process_id=handle.process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.CANCELLED
+        assert handle.status() is AgentProcessStatus.CANCELLED
+        assert handle.failure() is None
+        await asyncio.sleep(0)
+        assert _directives(await store.replay("agent_process", handle.process_id)) == [
+            "continue",
+            "cancel",
+        ]
+        assert not any(
+            task.get_name() == f"agent_process:{handle.process_id}" and not task.done()
+            for task in asyncio.all_tasks()
+        )
+    finally:
+        release_terminal_append.set()
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_run_with_agent_process_surfaces_terminal_journal_failure() -> None:
     """Durable mode cannot return success with a missing terminal row."""
     store = _DropAfterFirstAppendReplayStore()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -225,6 +225,28 @@ def _directives(events: list[BaseEvent]) -> list[str]:
     return [e.data["directive"] for e in events if e.type == "control.directive.emitted"]
 
 
+def _fail_sqlite_progress_handler_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every real durable append fail only after its transaction commits."""
+    from aiosqlite import Connection
+
+    original_set_progress_handler = Connection.set_progress_handler
+
+    async def fail_when_removing_progress_handler(
+        connection: Connection,
+        handler: Any,
+        steps: int,
+    ) -> None:
+        if handler is None:
+            raise RuntimeError("simulated post-commit cleanup failure")
+        await original_set_progress_handler(connection, handler, steps)
+
+    monkeypatch.setattr(
+        Connection,
+        "set_progress_handler",
+        fail_when_removing_progress_handler,
+    )
+
+
 async def _wait_for_status(handle, status: AgentProcessStatus) -> None:
     for _ in range(100):
         if handle.status() is status:
@@ -2894,6 +2916,108 @@ async def test_real_event_store_cancel_after_resume_commit_releases_live_waiter(
         ]
     finally:
         release_append.set()
+        finish_work.set()
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_real_event_store_post_commit_cleanup_failure_preserves_initial_and_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Committed initial and terminal rows keep journal and live authority aligned."""
+    _fail_sqlite_progress_handler_cleanup(monkeypatch)
+    process_id = "durable-post-commit-cleanup-initial-terminal"
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    handle_box: list[AgentProcessHandle] = []
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        return "done"
+
+    try:
+        assert (
+            await run_with_agent_process(
+                event_store=store,
+                intent="durable",
+                work_fn=work,
+                process_id=process_id,
+            )
+            == "done"
+        )
+
+        events = await store.replay("agent_process", process_id)
+        assert _directives(events) == ["continue", "converge"]
+        snapshot = project_agent_process_snapshot(events, process_id=process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.COMPLETED
+        assert handle_box[0].status() is AgentProcessStatus.COMPLETED
+        assert handle_box[0].failure() is None
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_real_event_store_post_commit_cleanup_failure_preserves_resume_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A committed resume releases the waiter without a duplicate CONTINUE."""
+    _fail_sqlite_progress_handler_cleanup(monkeypatch)
+    process_id = "durable-post-commit-cleanup-resume"
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+    work_released = asyncio.Event()
+    finish_work = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        reached_pause.set()
+        await handle.wait_unpaused()
+        work_released.set()
+        await finish_work.wait()
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+            process_id=process_id,
+        )
+    )
+    try:
+        await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+        handle = handle_box[0]
+        await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+        await handle.resume()
+        await asyncio.wait_for(work_released.wait(), timeout=1.0)
+        events = await store.replay("agent_process", process_id)
+        assert _directives(events) == ["continue", "wait", "continue"]
+        snapshot = project_agent_process_snapshot(events, process_id=process_id)
+        assert snapshot is not None
+        assert snapshot.status is AgentProcessStatus.RUNNING
+        assert handle.status() is AgentProcessStatus.RUNNING
+
+        finish_work.set()
+        assert await asyncio.wait_for(run_task, timeout=1.0) == "done"
+        assert _directives(await store.replay("agent_process", process_id)) == [
+            "continue",
+            "wait",
+            "continue",
+            "converge",
+        ]
+        assert handle.status() is AgentProcessStatus.COMPLETED
+        assert handle.failure() is None
+    finally:
         finish_work.set()
         if not run_task.done():
             run_task.cancel()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -29,7 +29,18 @@ from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 
 
-class _FakeEventStore:
+class _DurableAppendTestStore:
+    """Test-double implementation of the persistence-owned deadline API."""
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        async with asyncio.timeout(timeout):
+            initialize = getattr(self, "initialize", None)
+            if callable(initialize):
+                await initialize()
+            await self.append(event)  # type: ignore[attr-defined]
+
+
+class _FakeEventStore(_DurableAppendTestStore):
     def __init__(self) -> None:
         self.appended: list[BaseEvent] = []
 
@@ -40,7 +51,7 @@ class _FakeEventStore:
         return list(self.appended)
 
 
-class _FailingAppendReplayStore:
+class _FailingAppendReplayStore(_DurableAppendTestStore):
     async def append(self, event: BaseEvent) -> None:  # noqa: ARG002
         raise RuntimeError("simulated append failure")
 
@@ -48,7 +59,7 @@ class _FailingAppendReplayStore:
         return []
 
 
-class _DropAfterFirstAppendReplayStore:
+class _DropAfterFirstAppendReplayStore(_DurableAppendTestStore):
     def __init__(self) -> None:
         self.appended: list[BaseEvent] = []
 
@@ -61,7 +72,7 @@ class _DropAfterFirstAppendReplayStore:
         return list(self.appended)
 
 
-class _BlockingSecondAppendStore:
+class _BlockingSecondAppendStore(_DurableAppendTestStore):
     def __init__(self) -> None:
         self.appended: list[BaseEvent] = []
         self.second_append_started = asyncio.Event()
@@ -77,7 +88,7 @@ class _BlockingSecondAppendStore:
         return list(self.appended)
 
 
-class _DropSecondAppendReplayStore:
+class _DropSecondAppendReplayStore(_DurableAppendTestStore):
     def __init__(self) -> None:
         self.appended: list[BaseEvent] = []
         self.append_attempts = 0
@@ -118,6 +129,55 @@ class _BlockingInitializeReplayStore(_FakeEventStore):
     async def initialize(self) -> None:
         self.initialize_started.set()
         await self.release_initialize.wait()
+
+
+class _FailOnceAttemptReplayStore(_FakeEventStore):
+    """Store that fails one selected durable lifecycle append exactly once."""
+
+    def __init__(self, fail_attempt: int) -> None:
+        super().__init__()
+        self.fail_attempt = fail_attempt
+        self.append_attempts = 0
+
+    async def append(self, event: BaseEvent) -> None:
+        self.append_attempts += 1
+        if self.append_attempts == self.fail_attempt:
+            raise RuntimeError(f"transient append failure at attempt {self.fail_attempt}")
+        await super().append(event)
+
+
+class _CancellationResistantDeadlineStore(_FakeEventStore):
+    """Model a persistence operation that settles only after interruption."""
+
+    def __init__(self, fail_attempt: int) -> None:
+        super().__init__()
+        self.fail_attempt = fail_attempt
+        self.append_attempts = 0
+        self.cancellation_seen = asyncio.Event()
+        self.transaction_settled = asyncio.Event()
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        self.append_attempts += 1
+        if self.append_attempts != self.fail_attempt:
+            self.appended.append(event)
+            return
+
+        interrupt = asyncio.Event()
+
+        async def cancellation_atomic_transaction() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancellation_seen.set()
+                await interrupt.wait()
+                self.transaction_settled.set()
+
+        transaction = asyncio.create_task(cancellation_atomic_transaction())
+        await asyncio.sleep(0)
+        transaction.cancel()
+        asyncio.get_running_loop().call_later(timeout / 2, interrupt.set)
+        await transaction
+        raise TimeoutError("persistence deadline interrupted and rolled back transaction")
 
 
 def _types(events: list[BaseEvent]) -> list[str]:
@@ -2267,6 +2327,173 @@ async def test_run_with_agent_process_surfaces_terminal_journal_failure() -> Non
         )
 
     assert _directives(store.appended) == ["continue"]
+
+
+@pytest.mark.asyncio
+async def test_durable_transient_resume_failure_stays_paused_until_explicit_retry(
+    tmp_path: Path,
+) -> None:
+    """A surfaced resume error cannot release work or be retried by its waiter."""
+    store = _FailOnceAttemptReplayStore(fail_attempt=3)
+    checkpoint_store = CheckpointStore(tmp_path / "checkpoints")
+    checkpoint_store.initialize()
+    process_id = "durable-transient-resume"
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+    resumed_work = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause(reason="operator pause", store=checkpoint_store)
+        reached_pause.set()
+        await handle.wait_unpaused()
+        resumed_work.set()
+        return "done"
+
+    task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+            process_id=process_id,
+            checkpoint_store=checkpoint_store,
+        )
+    )
+    await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+    handle = handle_box[0]
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    with pytest.raises(RuntimeError, match="transient append failure"):
+        await handle.resume()
+
+    await asyncio.sleep(0.05)
+    assert task.done() is False
+    assert resumed_work.is_set() is False
+    assert handle.status() is AgentProcessStatus.PAUSED
+    assert store.append_attempts == 3
+    assert _directives(store.appended) == ["continue", "wait"]
+    assert (await handle.replay()).status is AgentProcessStatus.PAUSED
+    checkpoint_key = f"agent_process_{hashlib.sha256(process_id.encode()).hexdigest()}"
+    failed_resume_checkpoint = checkpoint_store.load(checkpoint_key)
+    assert failed_resume_checkpoint.is_ok
+    assert failed_resume_checkpoint.value.phase == "agent_process_paused"
+    assert failed_resume_checkpoint.value.state["authority"] == "journal"
+
+    # Recovery is an explicit operator decision; exactly one new CONTINUE is
+    # committed before the checkpoint projection and work-loop release.
+    await handle.resume()
+    assert await asyncio.wait_for(task, timeout=1.0) == "done"
+    assert resumed_work.is_set()
+    assert _directives(store.appended) == ["continue", "wait", "continue", "converge"]
+    committed_resume_checkpoint = checkpoint_store.load(checkpoint_key)
+    assert committed_resume_checkpoint.is_ok
+    assert committed_resume_checkpoint.value.phase == "agent_process_running"
+    with pytest.raises(RuntimeError, match="requires lifecycle replay"):
+        AgentProcessHandle.load_persisted_pause(process_id, store=checkpoint_store)
+
+
+@pytest.mark.asyncio
+async def test_durable_pause_journal_failure_fails_without_compensating_append() -> None:
+    """A failed WAIT is surfaced once and cannot consume another deadline."""
+    store = _FailOnceAttemptReplayStore(fail_attempt=2)
+    handle_box: list[AgentProcessHandle] = []
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        await handle.wait_unpaused()
+        return "unreachable"
+
+    with pytest.raises(RuntimeError, match="transient append failure"):
+        await run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+
+    assert handle_box[0].status() is AgentProcessStatus.FAILED
+    assert store.append_attempts == 2
+    assert _directives(store.appended) == ["continue"]
+
+
+@pytest.mark.asyncio
+async def test_durable_concurrent_resume_commits_one_release_transition() -> None:
+    """Two overlapping resume calls serialize around one journal commit."""
+
+    class _BlockingResumeStore(_FakeEventStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.append_attempts = 0
+            self.resume_append_started = asyncio.Event()
+            self.release_resume_append = asyncio.Event()
+
+        async def append(self, event: BaseEvent) -> None:
+            self.append_attempts += 1
+            if self.append_attempts == 3:
+                self.resume_append_started.set()
+                await self.release_resume_append.wait()
+            await super().append(event)
+
+    store = _BlockingResumeStore()
+    handle_box: list[AgentProcessHandle] = []
+    reached_pause = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        await handle.pause()
+        reached_pause.set()
+        await handle.wait_unpaused()
+        return "done"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    await asyncio.wait_for(reached_pause.wait(), timeout=1.0)
+    handle = handle_box[0]
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    first = asyncio.create_task(handle.resume())
+    await asyncio.wait_for(store.resume_append_started.wait(), timeout=1.0)
+    second = asyncio.create_task(handle.resume())
+    await asyncio.sleep(0)
+    assert first.done() is False
+    assert second.done() is False
+
+    store.release_resume_append.set()
+    await asyncio.gather(first, second)
+    assert await asyncio.wait_for(run_task, timeout=1.0) == "done"
+    assert _directives(store.appended) == ["continue", "wait", "continue", "converge"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fail_attempt", "work_must_start", "expected_attempts"),
+    [(1, False, 1), (2, True, 2)],
+)
+async def test_durable_initial_and_later_append_deadlines_settle_once(
+    monkeypatch: pytest.MonkeyPatch,
+    fail_attempt: int,
+    work_must_start: bool,
+    expected_attempts: int,
+) -> None:
+    """Persistence interruption bounds cancellation-resistant settlement."""
+    from ouroboros.orchestrator import agent_process as agent_process_module
+
+    monkeypatch.setattr(agent_process_module, "_DURABLE_DIRECTIVE_EMIT_TIMEOUT_SECONDS", 0.04)
+    store = _CancellationResistantDeadlineStore(fail_attempt)
+    work_started = asyncio.Event()
+
+    async def work(handle: AgentProcessHandle) -> str:  # noqa: ARG001
+        work_started.set()
+        return "done"
+
+    started_at = asyncio.get_running_loop().time()
+    with pytest.raises(TimeoutError, match="interrupted and rolled back"):
+        await run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert elapsed < 0.1
+    assert store.cancellation_seen.is_set()
+    assert store.transaction_settled.is_set()
+    assert store.append_attempts == expected_attempts
+    assert work_started.is_set() is work_must_start
+    assert len(store.appended) == (1 if work_must_start else 0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -183,6 +183,25 @@ class _PreCommitResumeFailureStore(_FakeEventStore):
         await self.append(event)
 
 
+class _PreCommitTerminalFailureStore(_FakeEventStore):
+    """Hold then fail the terminal append before it reaches durable history."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.append_attempts = 0
+        self.terminal_append_started = asyncio.Event()
+        self.release_failure = asyncio.Event()
+
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        self.append_attempts += 1
+        if self.append_attempts == 2:
+            self.terminal_append_started.set()
+            async with asyncio.timeout(timeout):
+                await self.release_failure.wait()
+            raise RuntimeError("terminal failed before commit")
+        await self.append(event)
+
+
 class _CancellationResistantDeadlineStore(_FakeEventStore):
     """Model a persistence operation that settles only after interruption."""
 
@@ -2649,6 +2668,45 @@ async def test_run_with_agent_process_surfaces_terminal_journal_failure() -> Non
         )
 
     assert _directives(store.appended) == ["continue"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_terminal_journal_failure_does_not_append_compensation() -> None:
+    """A journal failure wrapped by caller cancellation remains fail-closed."""
+    store = _PreCommitTerminalFailureStore()
+    handle_box: list[AgentProcessHandle] = []
+
+    async def work(handle: AgentProcessHandle) -> str:
+        handle_box.append(handle)
+        return "result"
+
+    run_task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+        )
+    )
+    try:
+        await asyncio.wait_for(store.terminal_append_started.wait(), timeout=1.0)
+        handle = handle_box[0]
+        runner_task = handle._work_task
+        assert runner_task is not None
+        runner_task.cancel()
+        store.release_failure.set()
+
+        with pytest.raises(RuntimeError, match="terminal failed before commit"):
+            await asyncio.wait_for(run_task, timeout=1.0)
+
+        assert store.append_attempts == 2
+        assert _directives(store.appended) == ["continue"]
+        assert handle.status() is AgentProcessStatus.FAILED
+        assert isinstance(handle.failure(), RuntimeError)
+    finally:
+        store.release_failure.set()
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -107,6 +107,19 @@ class _BlockingWaitEventStore(_FakeEventStore):
             await self.release_wait_append.wait()
 
 
+class _BlockingInitializeReplayStore(_FakeEventStore):
+    """Store whose first-use readiness is controlled by the test."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.initialize_started = asyncio.Event()
+        self.release_initialize = asyncio.Event()
+
+    async def initialize(self) -> None:
+        self.initialize_started.set()
+        await self.release_initialize.wait()
+
+
 def _types(events: list[BaseEvent]) -> list[str]:
     return [e.type for e in events]
 
@@ -2155,6 +2168,105 @@ async def test_run_with_agent_process_separates_lifecycle_id_from_cancel_key(tmp
 
     assert fresh_result == "fresh"
     assert fresh_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_waits_for_durable_journal_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Work must not start before the initial lifecycle row is durable."""
+    from ouroboros.orchestrator import agent_process as agent_process_module
+
+    monkeypatch.setattr(agent_process_module, "_DIRECTIVE_EMIT_TIMEOUT_SECONDS", 0.01)
+    store = _BlockingInitializeReplayStore()
+    work_started = asyncio.Event()
+
+    async def work(handle):  # noqa: ARG001
+        work_started.set()
+        return "done"
+
+    task = asyncio.create_task(
+        run_with_agent_process(event_store=store, intent="durable", work_fn=work)
+    )
+    await asyncio.wait_for(store.initialize_started.wait(), timeout=1.0)
+    await asyncio.sleep(0.05)
+
+    assert work_started.is_set() is False
+    assert task.done() is False
+
+    store.release_initialize.set()
+    assert await asyncio.wait_for(task, timeout=1.0) == "done"
+    assert _directives(store.appended) == ["continue", "converge"]
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_bounds_durable_journal_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wedged required journal fails closed without starting work."""
+    from ouroboros.orchestrator import agent_process as agent_process_module
+
+    monkeypatch.setattr(
+        agent_process_module,
+        "_DURABLE_DIRECTIVE_EMIT_TIMEOUT_SECONDS",
+        0.01,
+    )
+    store = _BlockingInitializeReplayStore()
+    work_called = False
+
+    async def work(handle):  # noqa: ARG001
+        nonlocal work_called
+        work_called = True
+        return "must not run"
+
+    with pytest.raises(TimeoutError):
+        await run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+        )
+
+    assert store.initialize_started.is_set()
+    assert work_called is False
+    assert store.appended == []
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_surfaces_initial_journal_failure_before_work() -> None:
+    """A required RUNNING row must fail spawn instead of being dropped."""
+    work_called = False
+
+    async def work(handle):  # noqa: ARG001
+        nonlocal work_called
+        work_called = True
+        return "must not run"
+
+    with pytest.raises(RuntimeError, match="simulated append failure"):
+        await run_with_agent_process(
+            event_store=_FailingAppendReplayStore(),
+            intent="durable",
+            work_fn=work,
+        )
+
+    assert work_called is False
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_surfaces_terminal_journal_failure() -> None:
+    """Durable mode cannot return success with a missing terminal row."""
+    store = _DropAfterFirstAppendReplayStore()
+
+    async def work(handle):  # noqa: ARG001
+        return "result"
+
+    with pytest.raises(RuntimeError, match="simulated later append failure"):
+        await run_with_agent_process(
+            event_store=store,
+            intent="durable",
+            work_fn=work,
+        )
+
+    assert _directives(store.appended) == ["continue"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_disposable_memory.py
+++ b/tests/unit/orchestrator/test_disposable_memory.py
@@ -39,6 +39,10 @@ class _EventStore:
     async def append(self, event: BaseEvent) -> None:
         self.appended.append(event)
 
+    async def append_durable(self, event: BaseEvent, *, timeout: float) -> None:
+        async with asyncio.timeout(timeout):
+            await self.append(event)
+
     async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:
         return [
             event
@@ -815,6 +819,7 @@ async def test_cancel_requested_by_child_prevents_completed_publication(tmp_path
 @pytest.mark.asyncio
 async def test_bounded_reference_round_trips_through_real_event_store(tmp_path: Path) -> None:
     event_store = EventStore("sqlite+aiosqlite:///:memory:")
+    await event_store.initialize()
     service = DisposableMemory(
         artifact_store=ContentAddressedArtifactStore(tmp_path / "artifacts"),
         event_store=event_store,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -161,6 +161,60 @@ class TestEventStoreInitialization:
         assert "event_store.append.post_commit_cleanup_failed" in caplog.text
         await store.close()
 
+    async def test_durable_append_invalidates_connection_when_cleanup_is_cancelled(
+        self,
+        tmp_path: Path,
+        sample_event: BaseEvent,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cleanup deadline after commit cannot return a poisoned driver to the pool."""
+        from aiosqlite import Connection
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'cleanup-timeout.db'}")
+        await store.initialize()
+        original_set_progress_handler = Connection.set_progress_handler
+        configured_drivers: list[Connection] = []
+        cleanup_started = asyncio.Event()
+
+        async def delay_progress_handler_removal(
+            connection: Connection,
+            handler,
+            steps: int,
+        ) -> None:
+            if handler is None:
+                cleanup_started.set()
+                await asyncio.sleep(1.0)
+            else:
+                configured_drivers.append(connection)
+            await original_set_progress_handler(connection, handler, steps)
+
+        monkeypatch.setattr(
+            Connection,
+            "set_progress_handler",
+            delay_progress_handler_removal,
+        )
+
+        await store.append_durable(sample_event, timeout=0.2)
+        assert cleanup_started.is_set()
+        assert len(configured_drivers) == 1
+
+        monkeypatch.setattr(Connection, "set_progress_handler", original_set_progress_handler)
+        events = await store.replay(sample_event.aggregate_type, sample_event.aggregate_id)
+        assert [event.id for event in events] == [sample_event.id]
+
+        engine = store._engine
+        assert engine is not None
+        async with engine.connect() as conn:
+            raw = await conn.get_raw_connection()
+            assert raw.driver_connection is not configured_drivers[0]
+            result = await conn.exec_driver_sql(
+                "WITH RECURSIVE count(x) AS ("
+                "SELECT 1 UNION ALL SELECT x + 1 FROM count WHERE x < 2000"
+                ") SELECT sum(x) FROM count"
+            )
+            assert result.scalar_one() == 2_001_000
+        await store.close()
+
     async def test_repeated_initialize_settles_schema_transaction_before_cancellation(
         self,
         monkeypatch,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 import logging
 from pathlib import Path
 import shutil
+import sqlite3
 
 import pytest
 
@@ -84,6 +85,42 @@ class TestEventStoreInitialization:
         await store.initialize()
         await store.initialize()  # Should not raise
         await store.close()
+
+    async def test_durable_append_interrupts_lock_and_returns_after_rollback(
+        self,
+        tmp_path: Path,
+        sample_event: BaseEvent,
+    ) -> None:
+        """The real SQLite path owns its deadline and cannot commit afterward."""
+        db_path = tmp_path / "durable-deadline.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        blocker = sqlite3.connect(db_path, isolation_level=None)
+        blocker.execute("BEGIN IMMEDIATE")
+        started_at = asyncio.get_running_loop().time()
+        try:
+            with pytest.raises(TimeoutError):
+                await store.append_durable(sample_event, timeout=0.08)
+        finally:
+            blocker.execute("ROLLBACK")
+            blocker.close()
+
+        assert asyncio.get_running_loop().time() - started_at < 0.2
+        await asyncio.sleep(0.05)
+        assert await store.replay(sample_event.aggregate_type, sample_event.aggregate_id) == []
+        await store.close()
+
+    async def test_durable_append_refuses_unbounded_lazy_initialization(
+        self,
+        tmp_path: Path,
+        sample_event: BaseEvent,
+    ) -> None:
+        """The hard append deadline never wraps cancellation-atomic schema setup."""
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'not-initialized.db'}")
+        started_at = asyncio.get_running_loop().time()
+        with pytest.raises(PersistenceError, match="requires an initialized EventStore"):
+            await store.append_durable(sample_event, timeout=0.01)
+        assert asyncio.get_running_loop().time() - started_at < 0.05
 
     async def test_repeated_initialize_settles_schema_transaction_before_cancellation(
         self,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -15,8 +15,10 @@ from ouroboros.orchestrator.execution_runtime_scope import normalize_execution_s
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import (
     EventStore,
-    _await_sqlite_write_atomically,
     acceptance_generation_id_for_session,
+)
+from ouroboros.persistence.write_settlement import (
+    await_sqlite_write_atomically as _await_sqlite_write_atomically,
 )
 
 

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -124,6 +124,43 @@ class TestEventStoreInitialization:
             await store.append_durable(sample_event, timeout=0.01)
         assert asyncio.get_running_loop().time() - started_at < 0.05
 
+    async def test_durable_append_keeps_committed_authority_when_cleanup_fails(
+        self,
+        tmp_path: Path,
+        sample_event: BaseEvent,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A post-commit driver cleanup error cannot report the append as absent."""
+        from aiosqlite import Connection
+
+        store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'post-commit-cleanup.db'}")
+        await store.initialize()
+        original_set_progress_handler = Connection.set_progress_handler
+
+        async def fail_when_removing_progress_handler(
+            connection: Connection,
+            handler,
+            steps: int,
+        ) -> None:
+            if handler is None:
+                raise RuntimeError("simulated post-commit cleanup failure")
+            await original_set_progress_handler(connection, handler, steps)
+
+        monkeypatch.setattr(
+            Connection,
+            "set_progress_handler",
+            fail_when_removing_progress_handler,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await store.append_durable(sample_event, timeout=1.0)
+
+        events = await store.replay(sample_event.aggregate_type, sample_event.aggregate_id)
+        assert [event.id for event in events] == [sample_event.id]
+        assert "event_store.append.post_commit_cleanup_failed" in caplog.text
+        await store.close()
+
     async def test_repeated_initialize_settles_schema_transaction_before_cancellation(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary

- Make production AgentProcess lifecycle journaling durable so projected state cannot become visible before replay authority.
- Fail closed when initial or later lifecycle persistence cannot complete within a bounded 30-second deadline.
- Preserve legacy best-effort behavior for direct AgentProcess consumers while production run_with_agent_process opts into durability.

## Changes

- Add explicit best-effort and durable journal modes.
- Persist the initial running and continue state before work starts.
- Serialize status transitions to prevent duplicate concurrent resume events.
- Surface initial, terminal, pause, and resume persistence failures through the process state.
- Add replay, failure-state, wedge, and concurrency regressions.

## Verification

- Focused unit: 80 passed.
- Three-surface integration: 19 passed.
- New durable cases repeated 20 times: 80 passed.
- Broad orchestrator suite: 5,186 passed, 1 skipped.
- Real 30-second wedge: fail-closed at 30.002s, work not started, zero journal appends.
- Ruff, format, MyPy, diff-check, clean-tree: PASS.
- Independent exact-head verifier: STRICT PASS at f034ee78367248757f7da75f31d57361ef87af9f on main 9d23b21c4ad4cf4495d58d4d4815ae038aa76605.

Part of #2010