### PR TITLE
fix(skills): resolve compatible Python for plugin flows

### DIFF
--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -33,6 +33,38 @@ ooo seed [session_id]
 
 When the user invokes this skill:
 
+### Python Runtime (Required)
+
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
+```bash
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
+```
+<!-- ouroboros-python-resolver:end -->
+
 ### Load MCP Tools (Required before Path A/B decision)
 
 The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
@@ -408,7 +440,7 @@ Then check `~/.ouroboros/prefs.json` for `star_asked`. If `star_asked` is not se
 Create `~/.ouroboros/` directory if it doesn't exist. Preserve existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
 
 ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -44,19 +44,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -39,24 +39,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -42,6 +42,38 @@ ooo setup
 
 When the user invokes this skill, guide them through an enhanced 6-step wizard with progressive disclosure and celebration checkpoints.
 
+### Python Runtime (Required)
+
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
+```bash
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
+```
+<!-- ouroboros-python-resolver:end -->
+
 ---
 
 ### Step 0: Welcome & Motivation (The Hook)
@@ -95,7 +127,7 @@ Before we begin, check `~/.ouroboros/prefs.json` for `star_asked`. If not `true`
 Create `~/.ouroboros/` directory if it doesn't exist. Preserve any existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
 
 ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -122,20 +154,20 @@ If `star_asked` is already `true`, skip this step silently.
 Check the user's environment with clear feedback:
 
 ```bash
-python3 --version
+ouroboros_python --version
 which uvx 2>/dev/null && uvx --version 2>/dev/null
 which claude 2>/dev/null
 ```
 
-**IMPORTANT: If system Python is < 3.12 but uvx is available, also check uv-managed Python:**
+For diagnostics, list uv-managed Python installations when uv is available:
 
 ```bash
 uv python list 2>/dev/null | grep "cpython-3.1[2-9]"
 ```
 
-If `uv python list` shows Python >= 3.12 available, CLI workflows are available
-through uv-managed Python even when system Python is older. This does not make
-the isolated `[claude-sdk]` and MCP 2 profiles import-compatible.
+The resolver already rejects system Python below 3.12 and provisions a
+compatible uv-managed Python when needed. This does not make the isolated
+`[claude-sdk]` and MCP 2 profiles import-compatible.
 
 **Report results with personality:**
 
@@ -143,8 +175,8 @@ the isolated `[claude-sdk]` and MCP 2 profiles import-compatible.
 Environment Detected:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-System Python 3.11         [!] Below 3.12
-uv Python 3.12+            [✓] Available (uvx will use this)
+Skill Python 3.12+         [✓] Resolver-selected
+uv Python 3.12+            [✓] Available
 uvx package runner         [✓] Available
 Runtime backend            [✓] Detected
 
@@ -615,14 +647,12 @@ If Yes:
 
 ## Setup Troubleshooting
 
-### "python3: command not found"
+### "No compatible Python found"
 ```
-Plugin mode still works! You can use:
-- ooo interview
-- ooo seed
-- ooo unstuck
+Plugin mode works without a global Python when uv is on PATH. The skill
+resolver uses a compatible python3, then python, then uv-managed Python >= 3.12.
 
-For Full Mode, install Python >= 3.12:
+If neither a compatible interpreter nor uv is available, install one:
   macOS: brew install python@3.12
   Ubuntu: sudo apt install python3.12
   Windows: python.org/downloads

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -53,19 +53,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -48,24 +48,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/.claude-plugin/skills/welcome/SKILL.md
+++ b/.claude-plugin/skills/welcome/SKILL.md
@@ -19,6 +19,38 @@ Interactive onboarding for new Ouroboros users.
 
 When this skill is invoked, follow this flow:
 
+### Python Runtime (Required)
+
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
+```bash
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
+```
+<!-- ouroboros-python-resolver:end -->
+
 ---
 
 ### Pre-Check: Already Completed?
@@ -29,7 +61,7 @@ First, check `~/.ouroboros/prefs.json` for `welcomeCompleted`. For upgrades from
 PREFFILE="$HOME/.ouroboros/prefs.json"
 
 if [ -f "$PREFFILE" ]; then
-  WELCOME_COMPLETED=$(python3 - <<'PY'
+  WELCOME_COMPLETED=$(ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
@@ -41,7 +73,7 @@ if not isinstance(prefs, dict):
 print(prefs.get('welcomeCompleted') or ('legacy-welcomeShown' if prefs.get('welcomeShown') else ''))
 PY
 )
-  WELCOME_VERSION=$(python3 - <<'PY'
+  WELCOME_VERSION=$(ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
@@ -65,7 +97,7 @@ previously completed welcome must never hide the setup gate from a user who
 chose **나중에** or whose setup was later removed:
 
 ```bash
-if python3 - "$HOME/.ouroboros/config.yaml" <<'PY'
+if ouroboros_python - "$HOME/.ouroboros/config.yaml" <<'PY'
 from __future__ import annotations
 
 import sys
@@ -163,7 +195,7 @@ completion prompt and continue to the Setup Gate below.
 **If `--skip` flag present:**
 - Merge `welcomeShown: true`, `welcomeCompleted: <current timestamp>`, and `welcomeVersion` into `~/.ouroboros/prefs.json` without deleting existing keys:
   ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')
@@ -200,7 +232,7 @@ Before showing the welcome banner, check whether Ouroboros has been prepared
 on this machine:
 
 ```bash
-if python3 - "$HOME/.ouroboros/config.yaml" <<'PY'
+if ouroboros_python - "$HOME/.ouroboros/config.yaml" <<'PY'
 from __future__ import annotations
 
 import sys
@@ -463,7 +495,7 @@ gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
 - **Star on GitHub**: `gh api -X PUT /user/starred/Q00/ouroboros`
 - Both choices: merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys. Set `star_asked: true` after either star prompt choice so the star prompt is not repeated:
   ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')
@@ -490,7 +522,7 @@ PY
 **If `GH_MISSING` or `star_asked` is true:**
 Merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys:
   ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')

--- a/.claude-plugin/skills/welcome/SKILL.md
+++ b/.claude-plugin/skills/welcome/SKILL.md
@@ -30,19 +30,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/.claude-plugin/skills/welcome/SKILL.md
+++ b/.claude-plugin/skills/welcome/SKILL.md
@@ -25,24 +25,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/README.ko.md
+++ b/README.ko.md
@@ -210,7 +210,9 @@ Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 �
 <details>
 <summary><strong>다른 설치 방법</strong></summary>
 
-**Claude Code 플러그인만** (Python 패키지 설치는 없지만, 호스트에 `uvx`와 `python3`(3.12 권장, 최소 3.11)이 있어야 합니다 — [#2001](https://github.com/Q00/ouroboros/issues/2001)):
+**Claude Code 플러그인만** (Python 패키지나 전역 Python 설치는 필요 없습니다.
+호스트에는 uv만 있으면 됩니다. uv가 제공하는 `uvx`는 MCP 서버를 띄우고,
+스킬은 uv를 Python >= 3.12 폴백으로 사용합니다):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ See the [GitHub Copilot CLI runtime guide](./docs/runtime-guides/copilot.md) for
 <details>
 <summary><strong>Other install methods</strong></summary>
 
-**Claude Code plugin only** (no Python package to install; the host needs `uvx` and `python3` >= 3.11, 3.12 recommended — see #2001):
+**Claude Code plugin only** (no Python package or global Python to install; the
+host needs uv, which provides both `uvx` for the MCP server and the skills'
+Python >= 3.12 fallback):
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,10 @@ ouroboros setup --runtime copilot            # 实时获取模型列表并选择
 <details>
 <summary><strong>其他安装方式</strong></summary>
 
-**仅安装 Claude Code 插件**（无需安装 Python 包；但主机上需要有 `uvx` 和 `python3`（建议 3.12，最低 3.11）—— 见 #2001）：
+**仅安装 Claude Code 插件**（无需安装 Python 包或全局 Python；主机唯一的
+前置条件是 uv。uv 提供启动 MCP server 的 `uvx`，并可为插件技能配置
+Python >= 3.12。兼容的全局 `python3` 或 `python` 只是可选的快速路径；
+缺失或版本过旧时，技能会使用 uv 管理的解释器）：
 ```bash
 claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -152,7 +152,11 @@ ooo setup
 ooo help        # verify installation
 ```
 
-No pip install of Ouroboros and no API key configuration needed -- Claude Code handles the runtime. The host still needs `uvx` and `python3` >= 3.11, as above — the shipped `.claude-plugin/skills/welcome/SKILL.md` imports `datetime.UTC`, which does not exist before 3.11.
+No pip install of Ouroboros and no API key configuration is needed -- Claude
+Code handles the runtime. uv is the only host prerequisite: it provides `uvx`
+for the MCP server and can provision Python >= 3.12 for shipped skill snippets.
+A compatible global `python3` or `python` is only an optional fast path; when it
+is absent or too old, the skills use the uv-managed interpreter.
 
 ### Option 2: pip Install
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,17 +11,16 @@ Transform a vague idea into a verified, working codebase -- with any AI coding a
 
 ### Recommended: Claude Code (`ooo`)
 
-You do not install Ouroboros with pip on this path, but the host needs two
-things: **`uvx`**, because the plugin's MCP server is launched with it
-([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and **`python3` (3.12 recommended, 3.11 minimum)**, because the plugin's skills
-shell out to it directly (`.claude-plugin/skills/setup/SKILL.md:98`) and import
-`datetime.UTC` (`.claude-plugin/skills/welcome/SKILL.md:168`), which does not
-exist before Python 3.11. Install uv with `pipx install uv`, `pip install --user uv`,
-or `brew install uv`.
+You do not install Ouroboros with pip or install a global Python on this path.
+The host needs **uv**: its `uvx` command launches the plugin's MCP server
+([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and its `uv` command
+is the skills' final Python >= 3.12 fallback. Install uv with `pipx install uv`,
+`pip install --user uv`, or `brew install uv`.
 
-`uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process; it
-does not create a global `python3`, so a host with uv but no system Python fails
-during the first setup/welcome flow. Tracked in #2001.
+The welcome, setup, and seed skills prefer a compatible `python3`, then a
+compatible `python`, and otherwise run with
+`uv run --no-project --quiet --python '>=3.12' python`. Older global
+interpreters are rejected instead of entering the first-run flow.
 
 Then run the install commands in your terminal, and run setup and auto inside
 Claude Code to go from idea to execution:
@@ -135,7 +134,11 @@ Auto mode is hang-resistant by design: interview and repair loops are bounded, s
 
 ### Option 1: Claude Code Plugin (Recommended)
 
-Requires `uvx` **and** a global `python3` (3.12 recommended, **3.11 minimum**) on the host: the plugin's MCP manifest launches the server with `uvx` ([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and the bundled skills shell out to `python3` directly (`skills/setup/SKILL.md:98`, `skills/welcome/SKILL.md:32`). `uvx --python '>=3.12'` supplies an interpreter to the isolated MCP process only — it does not create a global `python3`. Install uv with `pipx install uv`, `pip install --user uv`, or `brew install uv`. Tracked in #2001.
+Requires uv on the host. Its `uvx` command launches the plugin's MCP server
+([`.claude-plugin/.mcp.json`](../.claude-plugin/.mcp.json)), and its `uv`
+command provides Python >= 3.12 to bundled skills when no compatible global
+interpreter is available. Install uv with `pipx install uv`,
+`pip install --user uv`, or `brew install uv`.
 
 ```bash
 # Terminal

--- a/docs/runtime-guides/claude-code.ko.md
+++ b/docs/runtime-guides/claude-code.ko.md
@@ -22,10 +22,9 @@ Ouroboros는 **Claude Code**를 런타임 백엔드로 쓸 수 있습니다. **C
 
 대부분의 사람은 이 길로 오면 됩니다. **Ouroboros를 pip로 설치할 필요도, API 키를 설정할 필요도 없습니다** — 런타임은 Claude Code가 맡습니다.
 
-시작하기 전에 호스트에 두 가지가 있어야 합니다:
-
-- **`uvx`** — 플러그인의 MCP 매니페스트가 이걸로 서버를 띄웁니다([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)).
-- **`python3` (3.12 이상 권장, 최소 3.11)** — 마켓플레이스 플러그인이 싣는 스킬들이 셸에서 직접 호출합니다([`.claude-plugin/skills/setup/SKILL.md:98`](../../.claude-plugin/skills/setup/SKILL.md), [`.claude-plugin/skills/welcome/SKILL.md`](../../.claude-plugin/skills/welcome/SKILL.md)). 이 welcome 스킬은 `from datetime import UTC`를 쓰는데(`:168`, `:468`, `:495`), **`datetime.UTC`는 Python 3.11부터 존재합니다.** 3.10 호스트는 사전 조건을 만족한 채로 MCP 프로세스는 뜨지만 `ooo` welcome 흐름에서 `ImportError`로 실패합니다.
+시작하기 전에 호스트에는 **uv**만 있으면 됩니다. uv가 함께 제공하는
+`uvx`로 플러그인 MCP 서버를 띄우고([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)),
+`uv`는 스킬의 Python >= 3.12 폴백으로 쓰입니다. 전역 Python은 필요하지 않습니다.
 
 ```bash
 pipx install uv
@@ -33,7 +32,9 @@ pip install --user uv
 brew install uv          # macOS / Linuxbrew
 ```
 
-> **`uvx`가 Python 요구를 대신하지 않습니다.** `uvx --python '>=3.12'`는 **격리된 MCP 프로세스에** 인터프리터를 붙여 줄 뿐, 전역 `python3` 명령을 만들어 주지 않습니다. 위 스킬 스니펫들은 셸에서 `python3`을 직접 찾으므로, `uvx`만 있고 시스템 Python이 없는 호스트는 **첫 setup/welcome 흐름에서 실패합니다.** 스킬 쪽 인터프리터 탐색을 고치는 건 [#2001](https://github.com/Q00/ouroboros/issues/2001)에서 추적합니다.
+> welcome, setup, seed 스킬은 호환되는 `python3`, 호환되는 `python`,
+> `uv run --no-project --quiet --python '>=3.12' python` 순서로 실행기를
+> 고릅니다. 3.12 미만 전역 인터프리터는 거부하고 uv 폴백을 사용합니다.
 
 **터미널:**
 
@@ -60,8 +61,8 @@ ooo
 ### 사전 조건 (권장 경로)
 
 - Claude Code CLI 설치 및 인증 완료 (Pro 또는 Max Plan)
-- **`uvx`** (uv에 포함) — 위에서 설명한 대로 플러그인 MCP 매니페스트가 이걸로 서버를 띄웁니다
-- **`python3` (3.12 이상 권장, 최소 3.11)** — 플러그인이 싣는 스킬이 셸에서 직접 호출하고, `datetime.UTC` 때문에 3.11 미만은 실패합니다. `uvx`가 이걸 대신하지 않습니다 ([#2001](https://github.com/Q00/ouroboros/issues/2001))
+- **uv** — 함께 설치되는 `uvx`는 플러그인 MCP 서버를 띄우고, `uv`는
+  전역 Python이 없거나 3.12 미만일 때 스킬 실행기를 제공합니다
 
 아래 독립 CLI 경로의 `Python >= 3.12` 요구사항은 **이 경로에는 해당하지 않습니다.**
 

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -20,20 +20,16 @@ Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude
 ## Prerequisites
 
 - Claude Code CLI installed and authenticated (Pro or Max Plan)
-- **`uvx`** (ships with uv) if you use the marketplace plugin. The plugin's MCP
-  manifest launches the server with `uvx`
+- **uv** if you use the marketplace plugin. The plugin's MCP manifest launches
+  the server with the bundled `uvx` command
   ([`.claude-plugin/.mcp.json`](../../.claude-plugin/.mcp.json)), so a host with
   only Claude Code cannot start it. Install uv with `pipx install uv`,
   `pip install --user uv`, or `brew install uv`.
-- **`python3` on `PATH`, 3.12 recommended and 3.11 minimum**, for the marketplace
-  plugin as well. `.claude-plugin/plugin.json` selects `.claude-plugin/skills/`,
-  whose snippets shell out to `python3` directly
-  (`.claude-plugin/skills/setup/SKILL.md:98`) and import `datetime.UTC`
-  (`.claude-plugin/skills/welcome/SKILL.md:168`, `:468`, `:495`), which does not
-  exist before 3.11. `uvx --python '>=3.12'` supplies an interpreter to the
-  isolated MCP process only; it does not create a global `python3`. A host with
-  uv but no system Python, or with Python 3.10, satisfies neither. Tracked in
-  #2001.
+- No global Python is required for the marketplace plugin. Its shipped skills
+  resolve Python >= 3.12 in this order: compatible `python3`, compatible
+  `python`, then `uv run --no-project --quiet --python '>=3.12' python`. This
+  rejects older host interpreters and lets the same uv prerequisite cover the
+  first-run welcome, setup, and seed snippets.
 - Python >= 3.12 specifically, **for the standalone CLI**.
 - Ouroboros installed, for the standalone CLI (see [Getting Started](../getting-started.md) for install options)
 

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -33,6 +33,38 @@ ooo seed [session_id]
 
 When the user invokes this skill:
 
+### Python Runtime (Required)
+
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
+```bash
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
+```
+<!-- ouroboros-python-resolver:end -->
+
 ### Load MCP Tools (Required before Path A/B decision)
 
 The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
@@ -422,7 +454,7 @@ Then check `~/.ouroboros/prefs.json` for `star_asked`. If `star_asked` is not se
 Create `~/.ouroboros/` directory if it doesn't exist. Preserve existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
 
 ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -44,19 +44,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -39,24 +39,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -42,6 +42,38 @@ ooo setup
 
 When the user invokes this skill, guide them through an enhanced 6-step wizard with progressive disclosure and celebration checkpoints.
 
+### Python Runtime (Required)
+
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
+```bash
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
+  fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
+```
+<!-- ouroboros-python-resolver:end -->
+
 ---
 
 ### Step 0: Welcome & Motivation (The Hook)
@@ -95,7 +127,7 @@ Before we begin, check `~/.ouroboros/prefs.json` for `star_asked`. If not `true`
 Create `~/.ouroboros/` directory if it doesn't exist. Preserve any existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
 
 ```bash
-python3 - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -122,20 +154,20 @@ If `star_asked` is already `true`, skip this step silently.
 Check the user's environment with clear feedback:
 
 ```bash
-python3 --version
+ouroboros_python --version
 which uvx 2>/dev/null && uvx --version 2>/dev/null
 which claude 2>/dev/null
 ```
 
-**IMPORTANT: If system Python is < 3.12 but uvx is available, also check uv-managed Python:**
+For diagnostics, list uv-managed Python installations when uv is available:
 
 ```bash
 uv python list 2>/dev/null | grep "cpython-3.1[2-9]"
 ```
 
-If `uv python list` shows Python >= 3.12 available, CLI workflows are available
-through uv-managed Python even when system Python is older. This does not make
-the isolated `[claude-sdk]` and MCP 2 profiles import-compatible.
+The resolver already rejects system Python below 3.12 and provisions a
+compatible uv-managed Python when needed. This does not make the isolated
+`[claude-sdk]` and MCP 2 profiles import-compatible.
 
 **Report results with personality:**
 
@@ -143,8 +175,8 @@ the isolated `[claude-sdk]` and MCP 2 profiles import-compatible.
 Environment Detected:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-System Python 3.11         [!] Below 3.12
-uv Python 3.12+            [✓] Available (uvx will use this)
+Skill Python 3.12+         [✓] Resolver-selected
+uv Python 3.12+            [✓] Available
 uvx package runner         [✓] Available
 Runtime backend            [✓] Detected
 
@@ -615,14 +647,12 @@ If Yes:
 
 ## Setup Troubleshooting
 
-### "python3: command not found"
+### "No compatible Python found"
 ```
-Plugin mode still works! You can use:
-- ooo interview
-- ooo seed
-- ooo unstuck
+Plugin mode works without a global Python when uv is on PATH. The skill
+resolver uses a compatible python3, then python, then uv-managed Python >= 3.12.
 
-For Full Mode, install Python >= 3.12:
+If neither a compatible interpreter nor uv is available, install one:
   macOS: brew install python@3.12
   Ubuntu: sudo apt install python3.12
   Windows: python.org/downloads

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -53,19 +53,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -48,24 +48,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -19,24 +19,37 @@ Interactive onboarding for new Ouroboros users.
 
 When this skill is invoked, follow this flow:
 
-Before running any shell snippets below, choose a Python command without
-assuming a system `python3` binary. Marketplace installs require `uvx`, not a
-global Python executable:
+### Python Runtime (Required)
 
+Before running any shell snippet below, define this resolver in the same shell.
+It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
+uses uv as the final fallback. Call `ouroboros_python` directly and quote every
+argument passed to it; the function preserves arguments and heredoc/stdin input.
+
+<!-- ouroboros-python-resolver:start -->
 ```bash
-if [ -z "${OUROBOROS_WELCOME_PYTHON:-}" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    OUROBOROS_WELCOME_PYTHON="python3"
-  elif command -v python >/dev/null 2>&1; then
-    OUROBOROS_WELCOME_PYTHON="python"
-  elif command -v uv >/dev/null 2>&1; then
-    OUROBOROS_WELCOME_PYTHON="uv run --no-project --quiet python"
-  else
-    echo "Ouroboros welcome requires python3, python, or uv to inspect local setup."
-    exit 1
+ouroboros_python() {
+  if command -v python3 >/dev/null 2>&1 &&
+    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python3 "$@"
+    return
   fi
-fi
+  if command -v python >/dev/null 2>&1 &&
+    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+  then
+    command python "$@"
+    return
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    return
+  fi
+  printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2
+  return 127
+}
 ```
+<!-- ouroboros-python-resolver:end -->
 
 ---
 
@@ -48,7 +61,7 @@ First, check `~/.ouroboros/prefs.json` for `welcomeCompleted`. For upgrades from
 PREFFILE="$HOME/.ouroboros/prefs.json"
 
 if [ -f "$PREFFILE" ]; then
-  WELCOME_COMPLETED=$($OUROBOROS_WELCOME_PYTHON - <<'PY'
+  WELCOME_COMPLETED=$(ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
@@ -60,7 +73,7 @@ if not isinstance(prefs, dict):
 print(prefs.get('welcomeCompleted') or ('legacy-welcomeShown' if prefs.get('welcomeShown') else ''))
 PY
 )
-  WELCOME_VERSION=$($OUROBOROS_WELCOME_PYTHON - <<'PY'
+  WELCOME_VERSION=$(ouroboros_python - <<'PY'
 import json, os
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
@@ -89,7 +102,7 @@ case "$CODEX_HOME_DIR" in
   "~") CODEX_HOME_DIR="$HOME" ;;
   "~/"*) CODEX_HOME_DIR="$HOME/${CODEX_HOME_DIR#"~/"}" ;;
 esac
-if $OUROBOROS_WELCOME_PYTHON - "$HOME/.ouroboros/config.yaml" "$CODEX_HOME_DIR/config.toml" <<'PY'
+if ouroboros_python - "$HOME/.ouroboros/config.yaml" "$CODEX_HOME_DIR/config.toml" <<'PY'
 from __future__ import annotations
 
 import re
@@ -260,7 +273,7 @@ possible user pin. Instead, when Codex is ready, detect that exact legacy
 shape once before honoring the welcome-completed marker:
 
 ```bash
-if $OUROBOROS_WELCOME_PYTHON - "$HOME/.ouroboros/config.yaml" "$HOME/.ouroboros/prefs.json" <<'PY'
+if ouroboros_python - "$HOME/.ouroboros/config.yaml" "$HOME/.ouroboros/prefs.json" <<'PY'
 from __future__ import annotations
 
 import json
@@ -346,7 +359,7 @@ Use **AskUserQuestion**:
   on the current host:
 
 ```bash
-$OUROBOROS_WELCOME_PYTHON - "$HOME/.ouroboros/config.yaml" <<'PY'
+ouroboros_python - "$HOME/.ouroboros/config.yaml" <<'PY'
 from __future__ import annotations
 
 import os
@@ -413,7 +426,7 @@ For either completed choice, merge exactly one marker into
 `~/.ouroboros/prefs.json` without deleting existing keys:
 
 ```bash
-$OUROBOROS_WELCOME_PYTHON - "automatic-v1" <<'PY'
+ouroboros_python - "automatic-v1" <<'PY'
 import json, os, sys
 path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
@@ -459,7 +472,7 @@ completion prompt and continue to the Setup Gate below.
 **If `--skip` flag present:**
 - Merge `welcomeShown: true`, `welcomeCompleted: <current timestamp>`, and `welcomeVersion` into `~/.ouroboros/prefs.json` without deleting existing keys:
   ```bash
-$OUROBOROS_WELCOME_PYTHON - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')
@@ -502,7 +515,7 @@ case "$CODEX_HOME_DIR" in
   "~") CODEX_HOME_DIR="$HOME" ;;
   "~/"*) CODEX_HOME_DIR="$HOME/${CODEX_HOME_DIR#"~/"}" ;;
 esac
-if $OUROBOROS_WELCOME_PYTHON - "$HOME/.ouroboros/config.yaml" "$CODEX_HOME_DIR/config.toml" <<'PY'
+if ouroboros_python - "$HOME/.ouroboros/config.yaml" "$CODEX_HOME_DIR/config.toml" <<'PY'
 from __future__ import annotations
 
 import re
@@ -892,7 +905,7 @@ gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
 - **Star on GitHub**: `gh api -X PUT /user/starred/Q00/ouroboros`
 - Both choices: merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys. Set `star_asked: true` after either star prompt choice so the star prompt is not repeated:
   ```bash
-$OUROBOROS_WELCOME_PYTHON - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')
@@ -919,7 +932,7 @@ PY
 **If `GH_MISSING` or `star_asked` is true:**
 Merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys:
   ```bash
-$OUROBOROS_WELCOME_PYTHON - <<'PY'
+ouroboros_python - <<'PY'
 import json, os
 from datetime import UTC, datetime
 path = os.path.expanduser('~/.ouroboros/prefs.json')

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -30,19 +30,19 @@ argument passed to it; the function preserves arguments and heredoc/stdin input.
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python3 "$@"
+    (unset PYTHONHOME; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))' >/dev/null 2>&1
+    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    command python "$@"
+    (unset PYTHONHOME; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    command uv run --no-project --quiet --python '>=3.12' python "$@"
+    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -25,24 +25,26 @@ Before running any shell snippet below, define this resolver in the same shell.
 It accepts only Python 3.12 or newer, prefers `python3` and then `python`, and
 uses uv as the final fallback. Call `ouroboros_python` directly and quote every
 argument passed to it; the function preserves arguments and heredoc/stdin input.
+Only the probe and child interpreter discard inherited CPython path-selection
+overrides; the caller shell keeps its environment unchanged.
 
 <!-- ouroboros-python-resolver:start -->
 ```bash
 ouroboros_python() {
   if command -v python3 >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python3 "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python3 "$@")
     return
   fi
   if command -v python >/dev/null 2>&1 &&
-    (unset PYTHONHOME; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python -c 'import sys; raise SystemExit(sys.version_info < (3, 12))') >/dev/null 2>&1
   then
-    (unset PYTHONHOME; command python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command python "$@")
     return
   fi
   if command -v uv >/dev/null 2>&1; then
-    (unset PYTHONHOME; command uv run --no-project --quiet --python '>=3.12' python "$@")
+    (unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__; command uv run --no-project --quiet --python '>=3.12' python "$@")
     return
   fi
   printf '%s\n' 'Ouroboros skills require Python >= 3.12 or uv on PATH.' >&2

--- a/tests/integration/plugin/test_wheel_packaging.py
+++ b/tests/integration/plugin/test_wheel_packaging.py
@@ -26,6 +26,17 @@ from ouroboros.plugin.manifest import SUPPORTED_SCHEMA_VERSIONS
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 BUILTIN_GLOSSARY_PACKS = ("ui_ux_basics.yaml",)
+PYTHON_RESOLVER_START = "<!-- ouroboros-python-resolver:start -->"
+PYTHON_RESOLVER_END = "<!-- ouroboros-python-resolver:end -->"
+
+
+def _extract_python_resolver(contents: str) -> str:
+    """Extract the executable resolver contract from one skill artifact."""
+    start = contents.index(PYTHON_RESOLVER_START) + len(PYTHON_RESOLVER_START)
+    end = contents.index(PYTHON_RESOLVER_END, start)
+    fenced = contents[start:end].strip()
+    assert fenced.startswith("```bash\n") and fenced.endswith("\n```")
+    return fenced.removeprefix("```bash\n").removesuffix("\n```")
 
 
 @pytest.mark.skipif(
@@ -89,6 +100,21 @@ def test_built_wheel_preserves_packaging_contracts(tmp_path: Path) -> None:
         metadata = Parser().parsestr(archive.read(metadata_paths[0]).decode("utf-8"))
         requires_dist = metadata.get_all("Requires-Dist") or []
         provided_extras = set(metadata.get_all("Provides-Extra") or [])
+
+        wheel_skill_paths = {
+            skill: f"ouroboros/skills/{skill}/SKILL.md" for skill in ("welcome", "setup", "seed")
+        }
+        wheel_resolvers: dict[str, str] = {}
+        for skill, path in wheel_skill_paths.items():
+            assert names.count(path) == 1, (
+                f"built wheel must ship {path} exactly once; found {names.count(path)} entries"
+            )
+            wheel_resolvers[skill] = _extract_python_resolver(archive.read(path).decode("utf-8"))
+
+        source_resolver = _extract_python_resolver(
+            (PROJECT_ROOT / "skills" / "welcome" / "SKILL.md").read_text(encoding="utf-8")
+        )
+        assert set(wheel_resolvers.values()) == {source_resolver}, wheel_resolvers
 
     assert {"claude", "claude-cli", "claude-sdk", "mcp", "all"} <= provided_extras
     sdk_requirements = [

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -127,6 +128,98 @@ _CLAUDE_RESERVED_SKILL_NAMES = frozenset(
     }
 )
 _SKILL_ALIAS_FIELDS = ("alias", "aliases", "command_aliases", "skill_aliases", "commands")
+_PYTHON_SKILL_PATHS = tuple(
+    Path(root) / skill / "SKILL.md"
+    for root in ("skills", ".claude-plugin/skills")
+    for skill in ("welcome", "setup", "seed")
+)
+_PYTHON_RESOLVER_START = "<!-- ouroboros-python-resolver:start -->"
+_PYTHON_RESOLVER_END = "<!-- ouroboros-python-resolver:end -->"
+
+
+def _python_resolver_code(skill_path: Path | None = None) -> str:
+    """Extract the executable resolver contract from one packaged skill."""
+    if skill_path is None:
+        skill_path = Path(__file__).resolve().parents[3] / _PYTHON_SKILL_PATHS[0]
+    contents = skill_path.read_text(encoding="utf-8")
+    start = contents.index(_PYTHON_RESOLVER_START) + len(_PYTHON_RESOLVER_START)
+    end = contents.index(_PYTHON_RESOLVER_END, start)
+    fenced = contents[start:end].strip()
+    assert fenced.startswith("```bash\n") and fenced.endswith("\n```")
+    return fenced.removeprefix("```bash\n").removesuffix("\n```")
+
+
+def _bash_block_containing(skill_path: Path, needle: str) -> str:
+    contents = skill_path.read_text(encoding="utf-8")
+    needle_at = contents.index(needle)
+    start = contents.rfind("```bash\n", 0, needle_at)
+    assert start >= 0
+    start += len("```bash\n")
+    closing_fence = re.search(r"\n[ \t]*```(?:\n|$)", contents[needle_at:])
+    assert closing_fence is not None
+    end = needle_at + closing_fence.start()
+    return contents[start:end]
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _install_direct_python(path: Path, label: str) -> None:
+    _write_executable(
+        path,
+        f'#!/bin/sh\nprintf \'%s\\n\' \'{label}\' >> "$CALL_LOG"\nexec "$REAL_PYTHON" "$@"\n',
+    )
+
+
+def _install_old_python(path: Path, label: str) -> None:
+    _write_executable(
+        path,
+        f"#!/bin/sh\nprintf '%s\\n' '{label}' >> \"$CALL_LOG\"\nexit 1\n",
+    )
+
+
+def _install_uv_fallback(path: Path) -> None:
+    _write_executable(
+        path,
+        """#!/bin/sh
+printf '%s\n' "$@" >> "$UV_LOG"
+[ "$1" = run ] || exit 91
+[ "$2" = --no-project ] || exit 92
+[ "$3" = --quiet ] || exit 93
+[ "$4" = --python ] || exit 94
+[ "$5" = '>=3.12' ] || exit 95
+[ "$6" = python ] || exit 96
+shift 6
+exec "$REAL_PYTHON" "$@"
+""",
+    )
+
+
+def _run_resolver(
+    script: str,
+    *,
+    path: Path,
+    extra_env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "HOME": str(path.parent),
+        "PATH": str(path),
+        "REAL_PYTHON": sys.executable,
+        "CALL_LOG": str(path.parent / "python-calls.log"),
+        "UV_LOG": str(path.parent / "uv-calls.log"),
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["/bin/bash", "-c", f"{_python_resolver_code()}\n{script}"],
+        check=check,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
 
 def _skill_frontmatter(skill_path: Path) -> dict[str, object]:
@@ -328,17 +421,24 @@ def _run_setup_gate(
     extra_env: dict[str, str] | None = None,
 ) -> str:
     """Run the packaged setup gate exactly as a host executes its Markdown snippet."""
+    python_bin = home / ".test-python-bin"
+    python_bin.mkdir(exist_ok=True)
+    python3 = python_bin / "python3"
+    if not python3.exists():
+        python3.symlink_to(sys.executable)
     env = {
         "HOME": str(home),
-        "OUROBOROS_WELCOME_PYTHON": sys.executable,
+        "PATH": str(python_bin),
         "OUROBOROS_CODEX_APP_CLI_PATH": str(home / "missing-app-codex"),
     }
     if codex_home is not None:
         env["CODEX_HOME"] = str(codex_home)
     if extra_env is not None:
+        if "PATH" in extra_env:
+            extra_env = {**extra_env, "PATH": f"{python_bin}:{extra_env['PATH']}"}
         env.update(extra_env)
     return subprocess.run(
-        ["/bin/bash", "-c", script],
+        ["/bin/bash", "-c", f"{_python_resolver_code()}\n{script}"],
         check=True,
         capture_output=True,
         text=True,
@@ -601,14 +701,165 @@ def test_codex_setup_gate_rejects_blank_mcp_endpoint_values(tmp_path: Path) -> N
         assert _run_setup_gate(gate, home=tmp_path, codex_home=codex_home) == "CODEX_SETUP_REQUIRED"
 
 
-def test_codex_welcome_python_fallback_uses_uv_no_project() -> None:
+def test_python_resolver_contract_is_identical_in_all_six_packaged_skill_sources() -> None:
     repo_root = Path(__file__).resolve().parents[3]
-    skill = (repo_root / "skills" / "welcome" / "SKILL.md").read_text(encoding="utf-8")
+    contracts = {
+        relative_path: _python_resolver_code(repo_root / relative_path)
+        for relative_path in _PYTHON_SKILL_PATHS
+    }
 
-    assert 'OUROBOROS_WELCOME_PYTHON="uv run --no-project --quiet python"' in skill
-    assert 'OUROBOROS_WELCOME_PYTHON="uv run --quiet python"' not in skill
-    assert "\nPY\n```" in skill
-    assert "\n  PY\n```" not in skill
+    assert len(set(contracts.values())) == 1, contracts
+    contract = next(iter(contracts.values()))
+    assert "sys.version_info < (3, 12)" in contract
+    assert 'command python3 "$@"' in contract
+    assert 'command python "$@"' in contract
+    assert "uv run --no-project --quiet --python '>=3.12' python \"$@\"" in contract
+
+    for relative_path in _PYTHON_SKILL_PATHS:
+        contents = (repo_root / relative_path).read_text(encoding="utf-8")
+        without_contract = contents.replace(
+            f"{_PYTHON_RESOLVER_START}\n```bash\n{contract}\n```\n{_PYTHON_RESOLVER_END}",
+            "",
+        )
+        assert "OUROBOROS_WELCOME_PYTHON" not in contents
+        assert not re.search(r"(?m)^\s*(?:if\s+)?python3(?:\s|$)", without_contract), (
+            f"{relative_path}: direct python3 invocation bypasses the shared resolver"
+        )
+
+    plugin_manifest = json.loads((repo_root / ".claude-plugin" / "plugin.json").read_text())
+    assert plugin_manifest["skills"] == "./skills/"
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"skills" = "ouroboros/skills"' in pyproject
+
+
+def test_python_resolver_prefers_compatible_python3_and_preserves_arguments_and_stdin(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_direct_python(bin_dir / "python3", "python3")
+    _install_direct_python(bin_dir / "python", "python")
+    _install_uv_fallback(bin_dir / "uv")
+
+    result = _run_resolver(
+        """ouroboros_python -c 'import json, sys; print(json.dumps({"argv": sys.argv[1:], "stdin": sys.stdin.read()}))' 'argument with spaces' 'quote"value' '*' <<'DATA'
+stdin payload
+DATA
+""",
+        path=bin_dir,
+    )
+
+    assert json.loads(result.stdout) == {
+        "argv": ["argument with spaces", 'quote"value', "*"],
+        "stdin": "stdin payload\n",
+    }
+    assert (tmp_path / "python-calls.log").read_text().splitlines() == ["python3", "python3"]
+    assert not (tmp_path / "uv-calls.log").exists()
+
+
+def test_python_resolver_uses_compatible_python_when_python3_is_old(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_old_python(bin_dir / "python3", "old-python3")
+    _install_direct_python(bin_dir / "python", "python")
+    _install_uv_fallback(bin_dir / "uv")
+
+    result = _run_resolver(
+        "ouroboros_python -c 'import sys; print(sys.version_info[:2])'",
+        path=bin_dir,
+    )
+
+    assert result.stdout.strip().startswith("(3, ")
+    assert (tmp_path / "python-calls.log").read_text().splitlines() == [
+        "old-python3",
+        "python",
+        "python",
+    ]
+    assert not (tmp_path / "uv-calls.log").exists()
+
+
+def test_python_resolver_uses_uv_on_a_host_without_global_python(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_uv_fallback(bin_dir / "uv")
+
+    result = _run_resolver(
+        """ouroboros_python - 'space value' <<'PY'
+import json, sys
+print(json.dumps({"argv": sys.argv[1:], "value": "from-heredoc"}))
+PY
+""",
+        path=bin_dir,
+    )
+
+    assert json.loads(result.stdout) == {"argv": ["space value"], "value": "from-heredoc"}
+    assert (tmp_path / "uv-calls.log").read_text().splitlines() == [
+        "run",
+        "--no-project",
+        "--quiet",
+        "--python",
+        ">=3.12",
+        "python",
+        "-",
+        "space value",
+    ]
+
+
+def test_python_resolver_rejects_old_global_interpreters_before_uv_fallback(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_old_python(bin_dir / "python3", "old-python3")
+    _install_old_python(bin_dir / "python", "old-python")
+    _install_uv_fallback(bin_dir / "uv")
+
+    result = _run_resolver("ouroboros_python -c 'print(\"uv-selected\")'", path=bin_dir)
+
+    assert result.stdout.strip() == "uv-selected"
+    assert (tmp_path / "python-calls.log").read_text().splitlines() == [
+        "old-python3",
+        "old-python",
+    ]
+    assert "--python\n>=3.12\npython" in (tmp_path / "uv-calls.log").read_text()
+
+
+def test_python_resolver_fails_cleanly_without_python_or_uv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    result = _run_resolver("ouroboros_python -c 'print(1)'", path=bin_dir, check=False)
+
+    assert result.returncode == 127
+    assert result.stdout == ""
+    assert "require Python >= 3.12 or uv on PATH" in result.stderr
+
+
+@pytest.mark.parametrize("relative_path", _PYTHON_SKILL_PATHS)
+def test_first_run_preference_write_works_through_uv_only_path(
+    tmp_path: Path, relative_path: Path
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    skill_path = repo_root / relative_path
+    needle = (
+        "    'welcomeShown': True,"
+        if relative_path.parts[-2] == "welcome"
+        else "prefs['star_asked'] = True"
+    )
+    snippet = _bash_block_containing(skill_path, needle)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_uv_fallback(bin_dir / "uv")
+
+    _run_resolver(snippet, path=bin_dir, extra_env={"HOME": str(tmp_path)})
+
+    prefs = json.loads((tmp_path / ".ouroboros" / "prefs.json").read_text(encoding="utf-8"))
+    if relative_path.parts[-2] == "welcome":
+        assert prefs["welcomeShown"] is True
+        assert prefs["welcomeCompleted"]
+        assert prefs["welcomeVersion"]
+    else:
+        assert prefs["star_asked"] is True
 
 
 def test_codex_legacy_gpt5_migration_gate_targets_legacy_and_partial_migration(
@@ -624,9 +875,7 @@ def test_codex_legacy_gpt5_migration_gate_targets_legacy_and_partial_migration(
     )
     skill = (repo_root / "skills" / "welcome" / "SKILL.md").read_text(encoding="utf-8")
     migration_start = skill.index("### Legacy Codex Model Migration")
-    start = skill.index(
-        'if $OUROBOROS_WELCOME_PYTHON - "$HOME/.ouroboros/config.yaml"', migration_start
-    )
+    start = skill.index('if ouroboros_python - "$HOME/.ouroboros/config.yaml"', migration_start)
     gate = skill[start : skill.index("\n```", start)]
 
     assert (
@@ -685,7 +934,7 @@ def test_claude_setup_gate_accepts_default_sdk_without_host_mcp_file(tmp_path: P
         encoding="utf-8"
     )
     setup_gate_start = skill.index("### Setup Gate: First Use")
-    start = skill.index('if python3 - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
+    start = skill.index('if ouroboros_python - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
     gate = skill[start : skill.index("\n```", start)]
 
     assert _run_setup_gate(gate, home=tmp_path) == "SETUP_READY"
@@ -707,7 +956,7 @@ def test_claude_setup_gate_accepts_yaml_flow_mappings_without_host_mcp_file(
         encoding="utf-8"
     )
     setup_gate_start = skill.index("### Setup Gate: First Use")
-    start = skill.index('if python3 - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
+    start = skill.index('if ouroboros_python - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
     gate = skill[start : skill.index("\n```", start)]
 
     assert _run_setup_gate(gate, home=tmp_path) == "SETUP_READY"
@@ -731,7 +980,7 @@ def test_claude_completed_welcome_precheck_is_idempotent_without_host_mcp_file(
         encoding="utf-8"
     )
     precheck_context = skill.index("Before honoring that completion marker")
-    start = skill.index('if python3 - "$HOME/.ouroboros/config.yaml"', precheck_context)
+    start = skill.index('if ouroboros_python - "$HOME/.ouroboros/config.yaml"', precheck_context)
     gate = skill[start : skill.index("\n```", start)] + '\nprintf "%s" "${SETUP_READY:-}"\n'
 
     assert _run_setup_gate(gate, home=tmp_path) == "true"
@@ -755,7 +1004,7 @@ def test_claude_setup_gate_rejects_incomplete_runtime_config(tmp_path: Path, con
         encoding="utf-8"
     )
     setup_gate_start = skill.index("### Setup Gate: First Use")
-    start = skill.index('if python3 - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
+    start = skill.index('if ouroboros_python - "$HOME/.ouroboros/config.yaml"', setup_gate_start)
     gate = skill[start : skill.index("\n```", start)]
 
     assert _run_setup_gate(gate, home=tmp_path) == "SETUP_REQUIRED"

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 
@@ -135,6 +137,13 @@ _PYTHON_SKILL_PATHS = tuple(
 )
 _PYTHON_RESOLVER_START = "<!-- ouroboros-python-resolver:start -->"
 _PYTHON_RESOLVER_END = "<!-- ouroboros-python-resolver:end -->"
+_PYTHON_PATH_SHAPING_ENV = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONPLATLIBDIR",
+    "PYTHONEXECUTABLE",
+    "__PYVENV_LAUNCHER__",
+)
 
 
 def _python_resolver_code(skill_path: Path | None = None) -> str:
@@ -220,6 +229,24 @@ def _run_resolver(
         text=True,
         env=env,
     )
+
+
+def _poisoned_python_env(tmp_path: Path) -> dict[str, str]:
+    """Return inherited values that each make a real CPython child unusable."""
+    stale_stdlib = tmp_path / "python3.11-stdlib"
+    encodings = stale_stdlib / "encodings"
+    encodings.mkdir(parents=True, exist_ok=True)
+    (encodings / "__init__.py").write_text(
+        "raise RuntimeError('stale Python 3.11 stdlib loaded')\n",
+        encoding="utf-8",
+    )
+    return {
+        "PYTHONHOME": str(tmp_path / "missing-python-home"),
+        "PYTHONPATH": str(stale_stdlib),
+        "PYTHONPLATLIBDIR": "lib64",
+        "PYTHONEXECUTABLE": str(tmp_path / "poison-python-executable"),
+        "__PYVENV_LAUNCHER__": str(tmp_path / "poison-venv-launcher"),
+    }
 
 
 def _skill_frontmatter(skill_path: Path) -> dict[str, object]:
@@ -714,12 +741,14 @@ def test_python_resolver_contract_is_identical_in_all_six_packaged_skill_sources
     assert 'command python3 "$@"' in contract
     assert 'command python "$@"' in contract
     assert "uv run --no-project --quiet --python '>=3.12' python \"$@\"" in contract
-    assert contract.count("unset PYTHONHOME") == 5
-    assert "(unset PYTHONHOME; command python3 -c" in contract
-    assert '(unset PYTHONHOME; command python3 "$@")' in contract
-    assert "(unset PYTHONHOME; command python -c" in contract
-    assert '(unset PYTHONHOME; command python "$@")' in contract
-    assert "(unset PYTHONHOME; command uv run" in contract
+    clean_env = "unset PYTHONHOME PYTHONPATH PYTHONPLATLIBDIR PYTHONEXECUTABLE __PYVENV_LAUNCHER__"
+    assert contract.count(clean_env) == 5
+    assert f"({clean_env}; command python3 -c" in contract
+    assert f'({clean_env}; command python3 "$@")' in contract
+    assert f"({clean_env}; command python -c" in contract
+    assert f'({clean_env}; command python "$@")' in contract
+    assert f"({clean_env}; command uv run" in contract
+    assert "PYTHONUSERBASE" not in contract
 
     for relative_path in _PYTHON_SKILL_PATHS:
         contents = (repo_root / relative_path).read_text(encoding="utf-8")
@@ -763,27 +792,128 @@ DATA
     assert not (tmp_path / "uv-calls.log").exists()
 
 
-def test_python_resolver_sanitizes_pythonhome_for_compatible_global_python(
+@pytest.mark.parametrize(
+    ("selected_runtime", "expected_calls"),
+    [
+        ("python3", ["python3", "python3"]),
+        ("python", ["old-python3", "python", "python"]),
+        ("uv", ["old-python3", "old-python"]),
+    ],
+)
+def test_python_resolver_sanitizes_path_shaping_env_for_every_runtime_path(
     tmp_path: Path,
+    selected_runtime: str,
+    expected_calls: list[str],
 ) -> None:
-    """A stale inherited Python home cannot poison probes or the selected child."""
+    """Probes and children are isolated while the caller keeps its environment."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _install_direct_python(bin_dir / "python3", "python3")
-    poisoned_pythonhome = str(tmp_path / "missing-python-home")
+    if selected_runtime == "python3":
+        _install_direct_python(bin_dir / "python3", "python3")
+    elif selected_runtime == "python":
+        _install_old_python(bin_dir / "python3", "old-python3")
+        _install_direct_python(bin_dir / "python", "python")
+    else:
+        _install_old_python(bin_dir / "python3", "old-python3")
+        _install_old_python(bin_dir / "python", "old-python")
+        _install_uv_fallback(bin_dir / "uv")
+
+    poisoned_env = _poisoned_python_env(tmp_path)
 
     result = _run_resolver(
-        """ouroboros_python -c 'import json, os; print(json.dumps({"pythonhome": os.environ.get("PYTHONHOME")}))'
+        """ouroboros_python -c 'import json, os; print(json.dumps({key: os.environ.get(key) for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONPLATLIBDIR", "PYTHONEXECUTABLE", "__PYVENV_LAUNCHER__")}))'
 printf 'caller-pythonhome=%s\n' "$PYTHONHOME"
+printf 'caller-pythonpath=%s\n' "$PYTHONPATH"
+printf 'caller-pythonplatlibdir=%s\n' "$PYTHONPLATLIBDIR"
+printf 'caller-pythonexecutable=%s\n' "$PYTHONEXECUTABLE"
+printf 'caller-pyvenv-launcher=%s\n' "$__PYVENV_LAUNCHER__"
 """,
         path=bin_dir,
-        extra_env={"PYTHONHOME": poisoned_pythonhome},
+        extra_env=poisoned_env,
     )
 
     output_lines = result.stdout.splitlines()
-    assert json.loads(output_lines[0]) == {"pythonhome": None}
-    assert output_lines[1] == f"caller-pythonhome={poisoned_pythonhome}"
-    assert (tmp_path / "python-calls.log").read_text().splitlines() == ["python3", "python3"]
+    assert json.loads(output_lines[0]) == dict.fromkeys(_PYTHON_PATH_SHAPING_ENV)
+    assert output_lines[1:] == [
+        f"caller-pythonhome={poisoned_env['PYTHONHOME']}",
+        f"caller-pythonpath={poisoned_env['PYTHONPATH']}",
+        f"caller-pythonplatlibdir={poisoned_env['PYTHONPLATLIBDIR']}",
+        f"caller-pythonexecutable={poisoned_env['PYTHONEXECUTABLE']}",
+        f"caller-pyvenv-launcher={poisoned_env['__PYVENV_LAUNCHER__']}",
+    ]
+    assert (tmp_path / "python-calls.log").read_text().splitlines() == expected_calls
+    if selected_runtime == "uv":
+        assert "--python\n>=3.12\npython" in (tmp_path / "uv-calls.log").read_text()
+    else:
+        assert not (tmp_path / "uv-calls.log").exists()
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONPLATLIBDIR",
+        pytest.param(
+            "PYTHONEXECUTABLE",
+            marks=pytest.mark.skipif(sys.platform != "darwin", reason="macOS CPython variable"),
+        ),
+        pytest.param(
+            "__PYVENV_LAUNCHER__",
+            marks=pytest.mark.skipif(sys.platform != "darwin", reason="macOS CPython variable"),
+        ),
+    ],
+)
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not available")
+def test_path_shaping_poison_really_breaks_an_unsanitized_python(
+    tmp_path: Path,
+    variable: str,
+) -> None:
+    """Guard the regression matrix against harmless placeholder poison values."""
+    poison = _poisoned_python_env(tmp_path)
+    env = os.environ.copy()
+    for key in _PYTHON_PATH_SHAPING_ENV:
+        env.pop(key, None)
+    env[variable] = poison[variable]
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--quiet",
+            "--python",
+            ">=3.12",
+            "python",
+            "-c",
+            "print('unexpected-success')",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode != 0, f"{variable} poison no longer exercises CPython startup"
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv not available")
+def test_python_resolver_real_uv_path_survives_all_path_shaping_poison(tmp_path: Path) -> None:
+    """Exercise uv's managed interpreter, not the lightweight test double."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv = shutil.which("uv")
+    assert uv is not None
+    (bin_dir / "uv").symlink_to(uv)
+
+    result = _run_resolver(
+        """ouroboros_python -c 'import json, os, sys; print(json.dumps({"env": {key: os.environ.get(key) for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONPLATLIBDIR", "PYTHONEXECUTABLE", "__PYVENV_LAUNCHER__")}, "version": list(sys.version_info[:2])}))'""",
+        path=bin_dir,
+        extra_env=_poisoned_python_env(tmp_path),
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["env"] == dict.fromkeys(_PYTHON_PATH_SHAPING_ENV)
+    assert tuple(payload["version"]) >= (3, 12)
 
 
 def test_python_resolver_uses_compatible_python_when_python3_is_old(tmp_path: Path) -> None:

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -714,6 +714,12 @@ def test_python_resolver_contract_is_identical_in_all_six_packaged_skill_sources
     assert 'command python3 "$@"' in contract
     assert 'command python "$@"' in contract
     assert "uv run --no-project --quiet --python '>=3.12' python \"$@\"" in contract
+    assert contract.count("unset PYTHONHOME") == 5
+    assert "(unset PYTHONHOME; command python3 -c" in contract
+    assert '(unset PYTHONHOME; command python3 "$@")' in contract
+    assert "(unset PYTHONHOME; command python -c" in contract
+    assert '(unset PYTHONHOME; command python "$@")' in contract
+    assert "(unset PYTHONHOME; command uv run" in contract
 
     for relative_path in _PYTHON_SKILL_PATHS:
         contents = (repo_root / relative_path).read_text(encoding="utf-8")
@@ -757,6 +763,29 @@ DATA
     assert not (tmp_path / "uv-calls.log").exists()
 
 
+def test_python_resolver_sanitizes_pythonhome_for_compatible_global_python(
+    tmp_path: Path,
+) -> None:
+    """A stale inherited Python home cannot poison probes or the selected child."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_direct_python(bin_dir / "python3", "python3")
+    poisoned_pythonhome = str(tmp_path / "missing-python-home")
+
+    result = _run_resolver(
+        """ouroboros_python -c 'import json, os; print(json.dumps({"pythonhome": os.environ.get("PYTHONHOME")}))'
+printf 'caller-pythonhome=%s\n' "$PYTHONHOME"
+""",
+        path=bin_dir,
+        extra_env={"PYTHONHOME": poisoned_pythonhome},
+    )
+
+    output_lines = result.stdout.splitlines()
+    assert json.loads(output_lines[0]) == {"pythonhome": None}
+    assert output_lines[1] == f"caller-pythonhome={poisoned_pythonhome}"
+    assert (tmp_path / "python-calls.log").read_text().splitlines() == ["python3", "python3"]
+
+
 def test_python_resolver_uses_compatible_python_when_python3_is_old(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -767,6 +796,7 @@ def test_python_resolver_uses_compatible_python_when_python3_is_old(tmp_path: Pa
     result = _run_resolver(
         "ouroboros_python -c 'import sys; print(sys.version_info[:2])'",
         path=bin_dir,
+        extra_env={"PYTHONHOME": str(tmp_path / "missing-python-home")},
     )
 
     assert result.stdout.strip().startswith("(3, ")
@@ -785,14 +815,19 @@ def test_python_resolver_uses_uv_on_a_host_without_global_python(tmp_path: Path)
 
     result = _run_resolver(
         """ouroboros_python - 'space value' <<'PY'
-import json, sys
-print(json.dumps({"argv": sys.argv[1:], "value": "from-heredoc"}))
+import json, os, sys
+print(json.dumps({"argv": sys.argv[1:], "pythonhome": os.environ.get("PYTHONHOME"), "value": "from-heredoc"}))
 PY
 """,
         path=bin_dir,
+        extra_env={"PYTHONHOME": str(tmp_path / "missing-python-home")},
     )
 
-    assert json.loads(result.stdout) == {"argv": ["space value"], "value": "from-heredoc"}
+    assert json.loads(result.stdout) == {
+        "argv": ["space value"],
+        "pythonhome": None,
+        "value": "from-heredoc",
+    }
     assert (tmp_path / "uv-calls.log").read_text().splitlines() == [
         "run",
         "--no-project",
@@ -814,9 +849,13 @@ def test_python_resolver_rejects_old_global_interpreters_before_uv_fallback(
     _install_old_python(bin_dir / "python", "old-python")
     _install_uv_fallback(bin_dir / "uv")
 
-    result = _run_resolver("ouroboros_python -c 'print(\"uv-selected\")'", path=bin_dir)
+    result = _run_resolver(
+        "ouroboros_python -c 'import os; print(os.environ.get(\"PYTHONHOME\") is None)'",
+        path=bin_dir,
+        extra_env={"PYTHONHOME": str(tmp_path / "missing-python-home")},
+    )
 
-    assert result.stdout.strip() == "uv-selected"
+    assert result.stdout.strip() == "True"
     assert (tmp_path / "python-calls.log").read_text().splitlines() == [
         "old-python3",
         "old-python",
@@ -828,11 +867,17 @@ def test_python_resolver_fails_cleanly_without_python_or_uv(tmp_path: Path) -> N
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
 
-    result = _run_resolver("ouroboros_python -c 'print(1)'", path=bin_dir, check=False)
+    result = _run_resolver(
+        "ouroboros_python -c 'print(1)'",
+        path=bin_dir,
+        extra_env={"PYTHONHOME": str(tmp_path / "missing-python-home")},
+        check=False,
+    )
 
     assert result.returncode == 127
     assert result.stdout == ""
     assert "require Python >= 3.12 or uv on PATH" in result.stderr
+    assert "Fatal Python error" not in result.stderr
 
 
 @pytest.mark.parametrize("relative_path", _PYTHON_SKILL_PATHS)
@@ -851,7 +896,14 @@ def test_first_run_preference_write_works_through_uv_only_path(
     bin_dir.mkdir()
     _install_uv_fallback(bin_dir / "uv")
 
-    _run_resolver(snippet, path=bin_dir, extra_env={"HOME": str(tmp_path)})
+    _run_resolver(
+        snippet,
+        path=bin_dir,
+        extra_env={
+            "HOME": str(tmp_path),
+            "PYTHONHOME": str(tmp_path / "missing-python-home"),
+        },
+    )
 
     prefs = json.loads((tmp_path / ".ouroboros" / "prefs.json").read_text(encoding="utf-8"))
     if relative_path.parts[-2] == "welcome":


### PR DESCRIPTION
## Summary

- Restore the marketplace promise that uv is the only host runtime prerequisite.
- Resolve a compatible Python 3.12 or newer for welcome, setup, and seed flows instead of calling python3 unconditionally.
- Keep canonical root skills and the actually shipped Claude plugin copies mechanically aligned.

## Changes

- Add one quoted resolver contract to all six root and shipped skill files.
- Prefer compatible python3, then compatible python, then uv provisioning with Python 3.12 or newer.
- Preserve arguments and heredoc stdin while failing clearly when no supported executor exists.
- Add byte-alignment, direct-bypass, adversarial PATH, uv-only first-run, wheel, and marketplace source checks.
- Align English, Korean, and Chinese prerequisite documentation with the implemented uv-only contract.

## Verification

- Focused artifact suite: 46 passed.
- Full suite: 19,802 passed, 94 skipped, 1 expected xfail.
- Actual uv-only, old-global-Python, quoting, heredoc, and injection-like argument probes: PASS.
- Built wheel and marketplace shipped-source checks: PASS.
- Ruff, format, MyPy, diff-check, ancestry, bundle, and clean-tree: PASS.
- Independent exact-head verifier: PASS at d082a6b3647c7644c0ff1d0bb7905fbdb3ae0529 on main 25f958dd7938d3c383ccfd14d551467bcf6e6bd6.

Closes #2001