### PR TITLE
fix(mcp)!: require credentials to serve MCP beyond loopback

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1136,6 +1136,11 @@ ouroboros mcp serve [OPTIONS]
 | `-h, --host TEXT` | Host to bind to (default: localhost) |
 | `-p, --port INTEGER` | Port to bind to (default: 8080) |
 | `-t, --transport TEXT` | Transport type: `stdio`, `sse`, or `streamable-http` (default: stdio). Note: `http` is only a client config alias for outbound MCP connections and is NOT a valid serve transport. |
+| `--auth-token TEXT` | Shared secret clients present as `Authorization: Bearer <token>`. Required for a network transport on a non-loopback host. Prefer the `OUROBOROS_MCP_AUTH_TOKEN` environment variable — a token on the command line is visible to every process on the machine through `ps`. |
+| `--allow-remote` | Acknowledges that a non-loopback bind exposes seed execution beyond this machine. Required alongside `--auth-token` to serve on a routable address. |
+| `--allowed-host TEXT` | `Host` header value clients will use, e.g. `ouroboros.internal:8080`. Repeatable. Required for wildcard binds (`--host 0.0.0.0`), whose reachable name cannot be inferred. A `:*` suffix allows any port. |
+| `--allowed-origin TEXT` | `Origin` header value to permit. Repeatable. Empty by default, which rejects every browser-originated request. |
+| `--workspace-root TEXT` | Confines seed execution to directories under this path. Repeatable. Strongly recommended for network binds; unset means a caller may name any existing directory on the machine as an agent working tree. |
 | `--db TEXT` | Path to the EventStore database file |
 | `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `claude-sdk`, `claude-cli`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`). The MCP 2 server rejects SDK-backed `claude`/`claude-sdk`; use `claude-cli` for its out-of-process Claude worker. |
 | `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `copilot`, `opencode`, `gemini`, `goose`, `kiro`, `pi`, `gjc`). Affects which tool variants are instantiated |
@@ -1155,8 +1160,14 @@ ouroboros mcp serve --runtime claude-cli --transport streamable-http --port 9000
 # Start with Codex-backed orchestrator tools
 ouroboros mcp serve --runtime codex --llm-backend codex
 
-# Start on specific host
-ouroboros mcp serve --runtime claude-cli --host 0.0.0.0 --port 8080 --transport sse
+# Serve to other machines. Every flag below is required, not optional:
+# the bind is refused without them.
+export OUROBOROS_MCP_AUTH_TOKEN="$(openssl rand -hex 32)"
+ouroboros mcp serve --runtime claude-cli \
+  --transport streamable-http --host 0.0.0.0 --port 8080 \
+  --allow-remote \
+  --allowed-host ouroboros.internal:8080 \
+  --workspace-root /srv/ouroboros/projects
 ```
 
 For serving with streamable HTTP, use `streamable-http`, not `http`. `http` is accepted only in MCP client configuration as a compatibility alias for dialing another server's streamable HTTP endpoint; `mcp serve` uses the precise protocol name so users do not confuse it with a generic HTTP API. Streamable HTTP clients should connect to `http://<host>:<port>/mcp`.
@@ -1167,7 +1178,23 @@ uses MCP 2, it fails closed before startup if that effective runtime is
 SDK-backed. Pass an explicit MCP-2-compatible runtime or persist one with
 `ouroboros setup`.
 
-MCP SDK server caveats: Network serving uses the SDK v2 `MCPServer` API. The streamable HTTP path is `/mcp`. Authentication and rate limiting configured on `MCPServerAdapter` are rejected for SDK-managed transports because the handler boundary does not expose credentials or stable client identity; protect `0.0.0.0` binds with normal network controls.
+MCP SDK server caveats: Network serving uses the SDK v2 `MCPServer` API. The streamable HTTP path is `/mcp`.
+
+**Network exposure:**
+
+Reaching an Ouroboros MCP port is enough to call `ouroboros_execute_seed`, which runs caller-supplied seed YAML through a real agent runtime with that runtime's full file and shell authority. The port is therefore as privileged as a shell on the host, and `mcp serve` treats it that way.
+
+The default bind — `stdio`, or `localhost` for a network transport — needs no credentials: the client already owns the process, and the SDK enables DNS-rebinding protection for loopback binds automatically.
+
+A bind that other machines can reach is refused unless all of the following are supplied:
+
+- `--auth-token` (or `OUROBOROS_MCP_AUTH_TOKEN`), enforced by the SDK's bearer-auth middleware. Requests without a valid token get `401` before any tool dispatch.
+- `--allow-remote`, an explicit acknowledgement of the exposure.
+- `--allowed-host` for wildcard binds, which pins the `Host` allowlist that blocks DNS rebinding. A forged `Host` gets `421`.
+
+`--workspace-root` is not required but should be treated as such for any shared deployment: without it a caller may name any existing directory on the host as an agent's working tree.
+
+Rate limiting (`RateLimitConfig`) is available once an auth method is configured, because the token supplies the per-client identity it buckets by. Without authentication it is refused rather than silently sharing one bucket across all callers.
 
 **Startup behavior:**
 

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -540,6 +540,11 @@ async def _run_mcp_server(
     db_path: str | None = None,
     runtime_backend: str | None = None,
     llm_backend: str | None = None,
+    *,
+    auth_token: str = "",
+    allowed_hosts: tuple[str, ...] = (),
+    allowed_origins: tuple[str, ...] = (),
+    workspace_roots: tuple[str, ...] = (),
 ) -> None:
     """Run the MCP server.
 
@@ -550,6 +555,12 @@ async def _run_mcp_server(
         db_path: Optional path to EventStore database.
         runtime_backend: Optional orchestrator runtime backend override.
         llm_backend: Optional LLM-only backend override.
+        auth_token: Shared secret network clients must present. Empty leaves
+            the server credential-free, which serving only permits on loopback.
+        allowed_hosts: ``Host`` header allowlist for network transports.
+        allowed_origins: ``Origin`` header allowlist for network transports.
+        workspace_roots: Directories seed execution is confined to. Empty
+            leaves execution unrestricted, the historical local behaviour.
     """
     from ouroboros.mcp.server.adapter import validate_transport
 
@@ -656,8 +667,28 @@ async def _run_mcp_server(
         # Create server with all tools pre-registered via dependency injection.
         # Do NOT re-register OUROBOROS_TOOLS here — create_ouroboros_server already
         # registers handlers with proper dependencies (event_store, llm_adapter, etc.).
+        # Install before any tool can run: the policy is what keeps a caller
+        # from naming an arbitrary directory as an agent's working tree.
+        if workspace_roots:
+            from ouroboros.mcp.server.workspace import WorkspacePolicy, set_workspace_policy
+
+            set_workspace_policy(WorkspacePolicy.from_paths(workspace_roots))
+
+        # A token turns on the SDK's bearer-auth middleware; without one the
+        # server stays credential-free, which serve() only allows on loopback.
+        auth_config = None
+        if auth_token:
+            from ouroboros.mcp.server.security import AuthConfig, AuthMethod
+
+            auth_config = AuthConfig(
+                method=AuthMethod.API_KEY,
+                api_keys=frozenset({auth_token}),
+                required=True,
+            )
+
         server = create_ouroboros_server(
             name="ouroboros-mcp",
+            auth_config=auth_config,
             event_store=event_store,
             brownfield_store=brownfield_store,
             runtime_backend=runtime_backend,
@@ -690,6 +721,21 @@ async def _run_mcp_server(
                 print_info(f"Listening on http://{host}:{port}/mcp")
             else:
                 print_info(f"Listening on {host}:{port}")
+
+            # State the posture plainly: these two lines are what an operator
+            # needs to see to know whether this port is safe where it sits.
+            if auth_token:
+                print_info("Auth: bearer token required")
+            else:
+                print_info("Auth: none — reachable only from this machine")
+            if workspace_roots:
+                print_info(f"Seed execution confined to: {', '.join(workspace_roots)}")
+            else:
+                _console_out.print(
+                    "[yellow]Seed execution is not confined: a caller may name any "
+                    "existing directory on this machine as an agent working tree. "
+                    "Pass --workspace-root to restrict it.[/yellow]"
+                )
             print_info("Press Ctrl+C to stop")
 
         if _sandbox_network_disabled:
@@ -807,7 +853,13 @@ async def _run_mcp_server(
                     await event_store.checkpoint_wal()
 
         serve_task = asyncio.create_task(
-            server.serve(transport=transport, host=host, port=port),
+            server.serve(
+                transport=transport,
+                host=host,
+                port=port,
+                allowed_hosts=allowed_hosts,
+                allowed_origins=allowed_origins,
+            ),
             name="ouroboros-mcp-serve",
         )
         stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
@@ -923,6 +975,83 @@ async def _run_mcp_server(
         raise serve_exc
 
 
+def _resolve_network_security(
+    *,
+    transport: str,
+    host: str,
+    port: int,
+    auth_token: str,
+    allow_remote: bool,
+    allowed_hosts: tuple[str, ...],
+) -> str:
+    """Validate the requested exposure and return the token to enforce.
+
+    ``MCPServerAdapter.serve`` holds the same boundary for embedders. This runs
+    first so an operator gets an actionable message rather than a traceback,
+    and so the reason a bind was refused names the flag that would allow it.
+
+    Args:
+        transport: The already-validated transport name.
+        host: The requested bind address.
+        port: The requested bind port, quoted back in the guidance.
+        auth_token: The shared secret, from the flag or the environment.
+        allow_remote: Whether the operator acknowledged remote exposure.
+        allowed_hosts: The ``Host`` header allowlist.
+
+    Returns:
+        The token to enforce, or "" when the bind requires no credential.
+
+    Raises:
+        typer.Exit: If the requested bind would expose seed execution.
+    """
+    from ouroboros.mcp.server.auth import (
+        NETWORK_TRANSPORTS,
+        is_loopback_host,
+        is_wildcard_host,
+    )
+
+    if transport not in NETWORK_TRANSPORTS:
+        if auth_token:
+            _stderr_console.print(
+                "[yellow]Ignoring --auth-token: stdio has no request headers to "
+                "carry it, and the client already owns this process.[/yellow]"
+            )
+        return ""
+
+    if is_loopback_host(host):
+        return auth_token
+
+    problems: list[str] = []
+    if not auth_token:
+        problems.append(
+            "  --auth-token <secret>   (or set OUROBOROS_MCP_AUTH_TOKEN)\n"
+            "      Without it, anyone who can reach this port can execute seeds\n"
+            "      through your local agent runtime."
+        )
+    if not allow_remote:
+        problems.append(
+            "  --allow-remote\n      Confirms you intend to expose this server beyond this machine."
+        )
+    if is_wildcard_host(host) and not allowed_hosts:
+        problems.append(
+            f"  --allowed-host <name:{port}>\n"
+            f"      A {host} bind is reached under a name this process cannot see,\n"
+            "      so the Host allowlist that blocks DNS rebinding must be given."
+        )
+
+    if not problems:
+        return auth_token
+
+    _stderr_console.print(
+        f"[red]Refusing to serve {transport} on non-loopback host {host!r}.[/red]\n"
+        "[red]Missing:[/red]\n" + "\n".join(problems)
+    )
+    _stderr_console.print(
+        "\n[blue]To serve locally instead, drop --host (it defaults to localhost).[/blue]"
+    )
+    raise typer.Exit(code=1)
+
+
 @app.command()
 def serve(
     host: Annotated[
@@ -949,6 +1078,62 @@ def serve(
             help="Transport type: stdio, sse, or streamable-http.",
         ),
     ] = "stdio",
+    auth_token: Annotated[
+        str,
+        typer.Option(
+            "--auth-token",
+            envvar="OUROBOROS_MCP_AUTH_TOKEN",
+            help=(
+                "Shared secret clients must present as 'Authorization: Bearer <token>'. "
+                "Required for network transports on a non-loopback host. Prefer the "
+                "OUROBOROS_MCP_AUTH_TOKEN environment variable: a token on the command "
+                "line is visible to every process on this machine via 'ps'."
+            ),
+        ),
+    ] = "",
+    allow_remote: Annotated[
+        bool,
+        typer.Option(
+            "--allow-remote",
+            help=(
+                "Acknowledge that a non-loopback bind exposes seed execution to "
+                "everyone who can reach the port. Required alongside --auth-token "
+                "to serve on a routable address."
+            ),
+        ),
+    ] = False,
+    allowed_host: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--allowed-host",
+            help=(
+                "Host header value clients will use, e.g. 'ouroboros.internal:8080'. "
+                "Repeatable. Required for wildcard binds (--host 0.0.0.0), whose "
+                "reachable name cannot be inferred. A ':*' suffix allows any port."
+            ),
+        ),
+    ] = None,
+    allowed_origin: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--allowed-origin",
+            help=(
+                "Origin header value to permit. Repeatable. Empty by default, which "
+                "rejects every browser-originated request."
+            ),
+        ),
+    ] = None,
+    workspace_root: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--workspace-root",
+            help=(
+                "Restrict seed execution to directories under this path. Repeatable. "
+                "Strongly recommended for network binds; unset means any existing "
+                "directory on this machine may be used as a working directory."
+            ),
+        ),
+    ] = None,
     db: Annotated[
         str,
         typer.Option(
@@ -1032,16 +1217,45 @@ def serve(
         raise typer.Exit(0)
     os.environ["_OUROBOROS_NESTED"] = "1"
 
+    # Transport is re-validated inside _run_mcp_server; normalize here first so
+    # the exposure check below classifies 'SSE' the same way serving will.
+    from ouroboros.mcp.server.adapter import validate_transport
+
+    try:
+        normalized_transport = validate_transport(transport)
+    except ValueError:
+        _stderr_console.print(
+            "[red]Invalid transport "
+            f"{transport!r}. Must be 'stdio', 'sse', or 'streamable-http'.[/red]"
+        )
+        raise typer.Exit(code=1) from None
+
+    allowed_hosts = tuple(allowed_host or ())
+    allowed_origins = tuple(allowed_origin or ())
+    workspace_roots = tuple(workspace_root or ())
+    enforced_token = _resolve_network_security(
+        transport=normalized_transport,
+        host=host,
+        port=port,
+        auth_token=auth_token,
+        allow_remote=allow_remote,
+        allowed_hosts=allowed_hosts,
+    )
+
     try:
         db_path = db if db else None
         asyncio.run(
             _run_mcp_server(
                 host,
                 port,
-                transport,
+                normalized_transport,
                 db_path,
                 selected_runtime,
                 llm_backend.value if llm_backend else None,
+                auth_token=enforced_token,
+                allowed_hosts=allowed_hosts,
+                allowed_origins=allowed_origins,
+                workspace_roots=workspace_roots,
             )
         )
     except KeyboardInterrupt:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -32,6 +32,7 @@ from ouroboros.mcp.errors import (
     MCPServerError,
     MCPToolError,
 )
+from ouroboros.mcp.server.auth import current_auth_context, resolve_network_security
 
 # Re-exported: split out in #1754, still imported from here by evaluation tests.
 from ouroboros.mcp.server.project_dir import (  # noqa: F401
@@ -41,7 +42,12 @@ from ouroboros.mcp.server.project_dir import (  # noqa: F401
     _project_dir_from_seed,
 )
 from ouroboros.mcp.server.protocol import PromptHandler, ResourceHandler, ToolHandler
-from ouroboros.mcp.server.security import AuthConfig, AuthMethod, RateLimitConfig, SecurityLayer
+from ouroboros.mcp.server.security import (
+    AuthConfig,
+    AuthContext,
+    RateLimitConfig,
+    SecurityLayer,
+)
 
 # Re-exported: kept here for existing adapter-level tests and callers.
 from ouroboros.mcp.server.spec_verification_adapter import (
@@ -837,11 +843,12 @@ class MCPServerAdapter:
         name: str,
         arguments: dict[str, Any],
         credentials: dict[str, str] | None = None,
+        auth_context: AuthContext | None = None,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Call a registered tool through the complete request observer."""
         return await observe_adapter_tool_call(
             name,
-            lambda: self._call_tool_impl(name, arguments, credentials),
+            lambda: self._call_tool_impl(name, arguments, credentials, auth_context),
             registered=name in self._tool_handlers,
         )
 
@@ -850,6 +857,7 @@ class MCPServerAdapter:
         name: str,
         arguments: dict[str, Any],
         credentials: dict[str, str] | None = None,
+        auth_context: AuthContext | None = None,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Call a registered tool.
 
@@ -857,6 +865,9 @@ class MCPServerAdapter:
             name: Name of the tool to call.
             arguments: Arguments for the tool.
             credentials: Optional credentials for authentication.
+            auth_context: Identity already established by the transport, for
+                network transports where the SDK verified the bearer token
+                before dispatch and the raw credential is no longer in reach.
 
         Returns:
             Result containing the tool result or an error.
@@ -890,7 +901,12 @@ class MCPServerAdapter:
             return Result.err(error)
 
         # Security check
-        security_result = await self._security.check_request(name, arguments, credentials)
+        security_result = await self._security.check_request(
+            name,
+            arguments,
+            credentials,
+            pre_authenticated=auth_context,
+        )
         if security_result.is_err:
             log.info(
                 "mcp.server.call_tool.return",
@@ -1051,39 +1067,50 @@ class MCPServerAdapter:
         transport: str = "stdio",
         host: str = "localhost",
         port: int = 8080,
+        *,
+        allowed_hosts: tuple[str, ...] = (),
+        allowed_origins: tuple[str, ...] = (),
     ) -> None:
         """Start serving MCP requests.
 
         This method blocks until the server is stopped.
         Uses the MCP SDK v2's public ``MCPServer`` implementation.
 
+        Network transports are gated here rather than at the CLI, because this
+        is the one place every embedder passes through. The rule: a bind that
+        other machines can reach must carry credentials. A loopback bind may
+        stay credential-free -- the client already owns this process, and the
+        SDK auto-enables DNS-rebinding protection there.
+
         Args:
             transport: Transport type - "stdio", "sse", or "streamable-http"
                 (case-insensitive).
             host: Host to bind to for network transports. Defaults to "localhost".
             port: Port to bind to for network transports. Defaults to 8080.
+            allowed_hosts: ``Host`` header allowlist for network transports.
+                Required for wildcard binds, where the name clients use cannot
+                be inferred from the bind address.
+            allowed_origins: ``Origin`` header allowlist. Empty means every
+                browser-originated request is rejected, which is the intent for
+                a server whose clients are all non-browser MCP hosts.
 
         Raises:
-            ValueError: If transport is invalid or incompatible with security config.
+            ValueError: If transport is invalid, or the requested bind would
+                expose tool execution without credentials.
         """
         transport = validate_transport(transport)
 
-        # The SDK transport cannot provide credentials or client identity.
-        if self._security.auth_config.method != AuthMethod.NONE:
-            msg = (
-                f"MCPServer transport does not support authentication. "
-                f"Configured auth method: {self._security.auth_config.method.value}. "
-                f"All tool calls will be rejected. Use AuthMethod.NONE for MCPServer transports."
-            )
-            raise ValueError(msg)
-
-        if self._security.rate_limit_config.enabled:
-            msg = (
-                "MCPServer transport does not support rate limiting "
-                "(requires client identity). Configured rate_limit_config.enabled=True "
-                "will have no effect. Disable rate limiting for MCPServer transports."
-            )
-            raise ValueError(msg)
+        # Refuses an exposing bind and builds the SDK's credential and
+        # DNS-rebinding wiring. Lives in `auth` so this method stays a
+        # transport, not a second home for security policy.
+        wiring = resolve_network_security(
+            transport=transport,
+            host=host,
+            port=port,
+            security=self._security,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
 
         if _SDKMCPServer is None:
             msg = "mcp package not installed. Install with: pip install 'ouroboros-ai[mcp]'"
@@ -1091,11 +1118,14 @@ class MCPServerAdapter:
 
         if _OuroborosSDKServer is None:  # pragma: no cover - mirrors import guard.
             raise ImportError("MCP SDK server boundary unavailable")
+
         self._mcp_server = _OuroborosSDKServer(
             self,
             name=self._name,
             instructions=self._instructions,
             version=self._version,
+            token_verifier=wiring.token_verifier,
+            auth=wiring.auth_settings,
         )
 
         # Register tools with MCPServer.
@@ -1146,12 +1176,16 @@ class MCPServerAdapter:
                         normalized_kwargs,
                     )
 
-                    # Route through call_tool() to enforce security checks.
-                    # MCPServer does not provide credentials, so:
-                    # - Input validation is enforced
-                    # - Auth/authorization will reject if any auth method configured
-                    # - Rate limiting cannot apply (requires client_id)
-                    result = await self.call_tool(h.definition.name, normalized_kwargs)
+                    # Route through call_tool() to enforce security checks. On a
+                    # token-protected network bind the SDK has already verified
+                    # the bearer token and the raw credential is gone by now, so
+                    # carry its decision across instead: that restores the client
+                    # identity authorization and rate limiting both key on.
+                    result = await self.call_tool(
+                        h.definition.name,
+                        normalized_kwargs,
+                        auth_context=current_auth_context(),
+                    )
                     if result.is_ok:
                         # Convert MCPToolResult to the SDK boundary type.
                         tool_result = result.value
@@ -1320,12 +1354,17 @@ class MCPServerAdapter:
         # Run the server with the appropriate transport
         try:
             if transport == "sse":
-                await self._mcp_server.run_sse_async(host=host, port=port)
+                await self._mcp_server.run_sse_async(
+                    host=host,
+                    port=port,
+                    transport_security=wiring.transport_security,
+                )
             elif transport == "streamable-http":
                 await self._mcp_server.run_streamable_http_async(
                     host=host,
                     port=port,
                     stateless_http=True,
+                    transport_security=wiring.transport_security,
                 )
             else:
                 await self._mcp_server.run_stdio_async()

--- a/src/ouroboros/mcp/server/auth.py
+++ b/src/ouroboros/mcp/server/auth.py
@@ -1,0 +1,390 @@
+"""Bearer-token authentication for network MCP transports.
+
+The MCP SDK owns the HTTP boundary, so credentials only ever exist inside its
+``TokenVerifier`` protocol -- an Ouroboros tool handler never sees a header.
+This module is the bridge across that boundary: it hands the SDK a verifier
+backed by Ouroboros's own :class:`~ouroboros.mcp.server.security.Authenticator`,
+so a single credential authority serves both the transport gate and the
+per-tool :class:`~ouroboros.mcp.server.security.SecurityLayer` checks.
+
+Without this bridge the two halves were disconnected: ``SecurityLayer`` could
+be configured with credentials that no network client had any way to present,
+which is why network transports used to refuse every auth method outright.
+
+Loopback binds keep the historical credential-free behaviour -- the SDK's own
+DNS-rebinding protection already fences them off from other machines. Binding a
+network transport to a routable address without credentials is refused by
+:func:`resolve_network_security`, which every serve path goes through before
+the SDK starts listening.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ipaddress
+from typing import Any
+
+import structlog
+
+from ouroboros.mcp.server.security import (
+    AuthContext,
+    Authenticator,
+    AuthMethod,
+    Permission,
+    SecurityLayer,
+)
+
+log = structlog.get_logger(__name__)
+
+#: Transports that expose an HTTP surface, and so can both carry a credential
+#: and be reached by someone other than the process that started the server.
+NETWORK_TRANSPORTS = ("sse", "streamable-http")
+
+# Bind addresses for which the SDK builds DNS-rebinding protection on its own
+# (``mcp/server/lowlevel/server.py``). It matches these three spellings
+# literally, so any other host -- including other loopback spellings -- is left
+# bare unless settings are passed explicitly.
+_SDK_AUTOPROTECTED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# Hostnames that always resolve to this machine. ``""`` is deliberately absent:
+# an empty bind host means "every interface" to uvicorn, not loopback.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
+
+#: Scope minted for every accepted credential. Ouroboros authorizes per tool
+#: through ``SecurityLayer``, so the SDK layer only needs one opaque scope to
+#: mark a request as carrying valid credentials.
+OUROBOROS_SCOPE = "ouroboros:tools"
+
+_PERMISSIONS_CLAIM = "ouroboros_permissions"
+_ROLES_CLAIM = "ouroboros_roles"
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return True when ``host`` is only reachable from this machine.
+
+    Args:
+        host: The bind address as written on the command line.
+
+    Returns:
+        True for loopback literals and loopback hostnames. A name that cannot
+        be classified without a DNS lookup (``build-box.internal``) returns
+        False: refusing to guess is the safe direction, since the caller uses
+        this to decide whether credentials are mandatory.
+    """
+    candidate = host.strip().strip("[]").lower()
+    if candidate in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
+def is_wildcard_host(host: str) -> bool:
+    """Return True when ``host`` binds every interface rather than one address.
+
+    Such a bind is reachable under names this process never sees, so anything
+    derived from the bind address itself (an advertised URL, a ``Host``
+    allowlist) has to be supplied by the operator instead of inferred.
+    """
+    return host.strip().strip("[]") in ("", "0.0.0.0", "::")
+
+
+def _credentials_for(method: AuthMethod, token: str) -> dict[str, str] | None:
+    """Map a bearer token onto the credential dict its auth method expects."""
+    if method == AuthMethod.API_KEY:
+        return {"api_key": token}
+    if method == AuthMethod.BEARER_TOKEN:
+        return {"token": token}
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class OuroborosTokenVerifier:
+    """SDK ``TokenVerifier`` that delegates to Ouroboros's authenticator.
+
+    The SDK calls this once per HTTP request, before any Ouroboros handler
+    runs. Returning ``None`` makes ``RequireAuthMiddleware`` answer 401, so an
+    unauthenticated caller never reaches tool dispatch.
+    """
+
+    authenticator: Authenticator
+    method: AuthMethod
+
+    async def verify_token(self, token: str) -> Any | None:
+        """Verify a bearer token presented over a network transport.
+
+        Args:
+            token: The raw credential from the ``Authorization`` header.
+
+        Returns:
+            An SDK ``AccessToken`` when the credential is valid, else None.
+        """
+        access_token_cls = _load_access_token_cls()
+        credentials = _credentials_for(self.method, token)
+        if credentials is None:
+            log.warning("mcp.auth.unsupported_method", auth_method=self.method.value)
+            return None
+
+        result = self.authenticator.authenticate(credentials)
+        if result.is_err:
+            log.warning(
+                "mcp.auth.token_rejected",
+                auth_method=self.method.value,
+                reason=str(result.error),
+            )
+            return None
+
+        context = result.value
+        if not context.authenticated:
+            log.warning("mcp.auth.token_unauthenticated", auth_method=self.method.value)
+            return None
+
+        # Carry the authorization decision across the SDK boundary so the
+        # per-tool check does not have to re-derive it from a token it no
+        # longer holds.
+        return access_token_cls(
+            token=token,
+            client_id=context.client_id or "unknown",
+            scopes=[OUROBOROS_SCOPE],
+            claims={
+                _PERMISSIONS_CLAIM: sorted(p.value for p in context.permissions),
+                _ROLES_CLAIM: sorted(context.roles),
+            },
+        )
+
+
+def auth_context_from_access_token(access_token: Any) -> AuthContext | None:
+    """Rebuild an Ouroboros :class:`AuthContext` from an SDK access token.
+
+    The SDK authenticated the request at the HTTP edge; this restores the
+    identity and grants that decision produced so ``SecurityLayer`` can
+    authorize the specific tool and attribute rate limiting to a client.
+
+    Args:
+        access_token: The SDK ``AccessToken`` for the in-flight request, or
+            None when the request arrived over a credential-free transport.
+
+    Returns:
+        The reconstructed context, or None when there is no access token.
+    """
+    if access_token is None:
+        return None
+
+    claims = getattr(access_token, "claims", None) or {}
+    known = {member.value for member in Permission}
+    raw_permissions = claims.get(_PERMISSIONS_CLAIM) or []
+    permissions = {Permission(value) for value in raw_permissions if value in known}
+    roles = frozenset(claims.get(_ROLES_CLAIM) or ())
+
+    return AuthContext(
+        authenticated=True,
+        client_id=getattr(access_token, "client_id", None),
+        permissions=frozenset(permissions),
+        roles=roles,
+    )
+
+
+def _load_access_token_cls() -> Any:
+    """Import the SDK ``AccessToken`` lazily.
+
+    Kept out of module scope so the core package stays importable when the
+    optional ``mcp`` extra is absent.
+    """
+    from mcp.server.auth.provider import AccessToken
+
+    return AccessToken
+
+
+def build_auth_settings(*, host: str, port: int) -> Any:
+    """Build the SDK ``AuthSettings`` for a token-protected network bind.
+
+    Ouroboros issues its own shared credentials rather than delegating to an
+    OAuth authorization server, so both URLs point back at this server. They
+    are advertised through the protected-resource metadata endpoint the SDK
+    mounts; clients presenting a static token never need to read them.
+
+    Args:
+        host: The bind address, used to build the advertised base URL.
+        port: The bind port.
+
+    Returns:
+        An SDK ``AuthSettings`` instance.
+    """
+    from mcp.server.auth.settings import AuthSettings
+
+    advertised_host = "127.0.0.1" if is_wildcard_host(host) else host
+    base_url = f"http://{advertised_host}:{port}"
+    return AuthSettings(issuer_url=base_url, resource_server_url=base_url)
+
+
+def build_transport_security(
+    *,
+    host: str,
+    port: int,
+    allowed_hosts: tuple[str, ...],
+    allowed_origins: tuple[str, ...],
+) -> Any:
+    """Build DNS-rebinding protection settings for a network bind.
+
+    The SDK only auto-enables this protection for loopback binds; a routable
+    bind is left unprotected unless settings are passed explicitly, which is
+    what this produces.
+
+    Args:
+        host: The bind address.
+        port: The bind port.
+        allowed_hosts: Operator-supplied ``Host`` header allowlist. When empty,
+            the bind address itself is allowed on any port -- which only means
+            anything for a concrete address, hence the wildcard guard below.
+        allowed_origins: Operator-supplied ``Origin`` header allowlist. Left
+            empty by default so that browser-originated requests -- the only
+            ones that carry ``Origin`` -- are rejected outright.
+
+    Returns:
+        An SDK ``TransportSecuritySettings`` instance.
+
+    Raises:
+        ValueError: If a wildcard bind is passed with no explicit allowlist.
+            Clients reach a ``0.0.0.0`` bind under some other name, so there is
+            no ``Host`` value to infer; the caller must collect one first.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    hosts = list(allowed_hosts)
+    if not hosts:
+        if is_wildcard_host(host):
+            msg = (
+                f"Cannot infer a Host allowlist for wildcard bind {host!r}. "
+                "Pass --allowed-host with the hostname clients will connect to."
+            )
+            raise ValueError(msg)
+        hosts = [f"{host}:{port}", f"{host}:*"]
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=list(allowed_origins),
+    )
+
+
+def current_auth_context() -> AuthContext | None:
+    """Return the identity the SDK established for the in-flight HTTP request.
+
+    Returns None for stdio and for credential-free loopback binds, where no
+    token was ever presented -- ``check_request`` then falls back to its own
+    authenticator, preserving the historical local behaviour.
+    """
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+    except ImportError:  # pragma: no cover - mirrors the optional-extra guard.
+        return None
+
+    return auth_context_from_access_token(get_access_token())
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkSecurityWiring:
+    """SDK security objects resolved for one bind.
+
+    All three are None for stdio and for a credential-free loopback bind, which
+    is what leaves local use exactly as it was.
+    """
+
+    token_verifier: Any | None = None
+    auth_settings: Any | None = None
+    transport_security: Any | None = None
+
+
+def resolve_network_security(
+    *,
+    transport: str,
+    host: str,
+    port: int,
+    security: SecurityLayer,
+    allowed_hosts: tuple[str, ...] = (),
+    allowed_origins: tuple[str, ...] = (),
+) -> NetworkSecurityWiring:
+    """Validate a requested bind and build the SDK wiring that protects it.
+
+    This is the trust boundary for serving: reaching a routable bind is enough
+    to execute seeds through the local agent runtime, so such a bind has to
+    demand a credential before the SDK ever starts listening.
+
+    Args:
+        transport: An already-validated transport name.
+        host: The requested bind address.
+        port: The requested bind port.
+        security: The layer whose credentials network clients must satisfy.
+        allowed_hosts: ``Host`` header allowlist. Required for wildcard binds.
+        allowed_origins: ``Origin`` header allowlist. Empty rejects every
+            browser-originated request, the intent for non-browser MCP clients.
+
+    Returns:
+        The verifier, auth settings, and transport security for this bind.
+
+    Raises:
+        ValueError: If the bind would expose tool execution without
+            credentials, if authentication is configured for a transport that
+            cannot carry it, or if a wildcard bind has no Host allowlist.
+    """
+    is_network = transport in NETWORK_TRANSPORTS
+    auth_method = security.auth_config.method
+    auth_enabled = auth_method != AuthMethod.NONE
+
+    # stdio is a pipe owned by the client that spawned this process; there is
+    # no header to carry a credential on, so an auth method configured there
+    # would reject every call instead of protecting anything.
+    if auth_enabled and not is_network:
+        msg = (
+            f"stdio transport does not support authentication "
+            f"(configured method: {auth_method.value}). The client owns this "
+            f"process directly. Use AuthMethod.NONE for stdio."
+        )
+        raise ValueError(msg)
+
+    # Rate limiting buckets by client identity, and only a credential supplies
+    # one. Without auth every caller would share a single bucket.
+    if security.rate_limit_config.enabled and not auth_enabled:
+        msg = (
+            "Rate limiting requires client identity, which only authentication "
+            "provides. Configure an auth method or disable "
+            "rate_limit_config.enabled."
+        )
+        raise ValueError(msg)
+
+    if is_network and not is_loopback_host(host) and not auth_enabled:
+        msg = (
+            f"Refusing to serve {transport} on non-loopback host {host!r} "
+            f"without authentication. Anyone who can reach this port could "
+            f"execute seeds through the local agent runtime. Either bind to "
+            f"127.0.0.1, or configure an auth token."
+        )
+        raise ValueError(msg)
+
+    if not is_network:
+        return NetworkSecurityWiring()
+
+    token_verifier = None
+    auth_settings = None
+    if auth_enabled:
+        token_verifier = OuroborosTokenVerifier(
+            authenticator=security.authenticator,
+            method=auth_method,
+        )
+        auth_settings = build_auth_settings(host=host, port=port)
+
+    transport_security = None
+    if host not in _SDK_AUTOPROTECTED_HOSTS:
+        transport_security = build_transport_security(
+            host=host,
+            port=port,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
+
+    return NetworkSecurityWiring(
+        token_verifier=token_verifier,
+        auth_settings=auth_settings,
+        transport_security=transport_security,
+    )

--- a/src/ouroboros/mcp/server/auth.py
+++ b/src/ouroboros/mcp/server/auth.py
@@ -90,6 +90,26 @@ def is_wildcard_host(host: str) -> bool:
     return host.strip().strip("[]") in ("", "0.0.0.0", "::")
 
 
+def as_url_authority(host: str) -> str:
+    """Return ``host`` spelled the way a URL or ``Host`` header needs it.
+
+    A bind address and its URL spelling differ for IPv6: the socket layer takes
+    the bare literal (``::1``) and rejects the bracketed form, while a URL or
+    ``Host`` value needs brackets or the trailing ``:port`` cannot be told apart
+    from another hextet. Callers keep the bare value for binding and pass it
+    through here for anything address-shaped that carries a port.
+    """
+    candidate = host.strip()
+    if candidate.startswith("["):
+        return candidate
+    try:
+        if ipaddress.ip_address(candidate).version == 6:
+            return f"[{candidate}]"
+    except ValueError:
+        pass
+    return candidate
+
+
 def _credentials_for(method: AuthMethod, token: str) -> dict[str, str] | None:
     """Map a bearer token onto the credential dict its auth method expects."""
     if method == AuthMethod.API_KEY:
@@ -213,7 +233,7 @@ def build_auth_settings(*, host: str, port: int) -> Any:
     """
     from mcp.server.auth.settings import AuthSettings
 
-    advertised_host = "127.0.0.1" if is_wildcard_host(host) else host
+    advertised_host = "127.0.0.1" if is_wildcard_host(host) else as_url_authority(host)
     base_url = f"http://{advertised_host}:{port}"
     return AuthSettings(issuer_url=base_url, resource_server_url=base_url)
 
@@ -259,7 +279,8 @@ def build_transport_security(
                 "Pass --allowed-host with the hostname clients will connect to."
             )
             raise ValueError(msg)
-        hosts = [f"{host}:{port}", f"{host}:*"]
+        authority = as_url_authority(host)
+        hosts = [f"{authority}:{port}", f"{authority}:*"]
 
     return TransportSecuritySettings(
         enable_dns_rebinding_protection=True,

--- a/src/ouroboros/mcp/server/security.py
+++ b/src/ouroboros/mcp/server/security.py
@@ -641,6 +641,16 @@ class SecurityLayer:
                 self.rate_limit_config.burst_size,
             )
 
+    @property
+    def authenticator(self) -> Authenticator:
+        """Return the credential authority backing this layer.
+
+        Exposed so a transport that authenticates at its own edge (the MCP
+        SDK's HTTP boundary) can verify against the same credentials this
+        layer would, instead of maintaining a second set.
+        """
+        return self._authenticator
+
     def register_tool_permission(self, permission: ToolPermission) -> None:
         """Register permission requirements for a tool."""
         self._authorizer.register_tool_permission(permission)
@@ -658,6 +668,7 @@ class SecurityLayer:
         tool_name: str,
         arguments: dict[str, Any],
         credentials: dict[str, str] | None = None,
+        pre_authenticated: AuthContext | None = None,
     ) -> Result[AuthContext, MCPServerError]:
         """Check if a request passes all security checks.
 
@@ -665,16 +676,24 @@ class SecurityLayer:
             tool_name: Name of the tool being called.
             arguments: Arguments for the tool.
             credentials: Client credentials.
+            pre_authenticated: Context established by a transport that already
+                verified the caller's credentials against this layer's own
+                authenticator. When given, step 1 is skipped -- the credential
+                itself is gone by this point, so re-running it would fail a
+                request that was in fact authenticated.
 
         Returns:
             Result containing auth context or security error.
         """
         # 1. Authenticate
-        auth_result = self._authenticator.authenticate(credentials)
-        if auth_result.is_err:
-            return Result.err(auth_result.error)
+        if pre_authenticated is not None:
+            auth_context = pre_authenticated
+        else:
+            auth_result = self._authenticator.authenticate(credentials)
+            if auth_result.is_err:
+                return Result.err(auth_result.error)
 
-        auth_context = auth_result.value
+            auth_context = auth_result.value
 
         # 2. Rate limit (if enabled)
         if (

--- a/src/ouroboros/mcp/server/workspace.py
+++ b/src/ouroboros/mcp/server/workspace.py
@@ -1,0 +1,111 @@
+"""Confinement policy for the directories seed execution may run in.
+
+``execute_seed`` takes a working directory from its caller and hands it to a
+real agent runtime with file and shell authority. Locally that is the point --
+the caller is the developer. On a shared or network-reachable server it is a
+trust boundary, and the directory needs to be one the operator chose rather
+than one the request did.
+
+The policy is process-global on purpose. It describes the deployment -- which
+directories this server was started to work in -- not any single request, and a
+server process owns exactly one bind. Threading it through every handler
+construction site would let a caller-supplied value reach the check, which is
+the thing being prevented.
+
+An empty policy permits everything, preserving the local stdio behaviour where
+confinement would only get in the developer's way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+import threading
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePolicy:
+    """The set of directory trees seed execution is confined to."""
+
+    allowed_roots: tuple[Path, ...] = ()
+
+    @classmethod
+    def from_paths(cls, raw_paths: Sequence[str | Path]) -> WorkspacePolicy:
+        """Build a policy from operator-supplied paths.
+
+        Roots are resolved here so that the comparison in :meth:`permits` is
+        between two fully resolved paths -- otherwise a symlink inside an
+        allowed root could point anywhere and still compare as contained.
+
+        Args:
+            raw_paths: Directory paths as written by the operator.
+
+        Returns:
+            The policy. An empty input yields the permit-everything policy.
+        """
+        roots = tuple(Path(path).expanduser().resolve() for path in raw_paths)
+        return cls(allowed_roots=roots)
+
+    @property
+    def restricted(self) -> bool:
+        """Return True when this policy actually confines anything."""
+        return bool(self.allowed_roots)
+
+    def permits(self, candidate: Path) -> bool:
+        """Return True when ``candidate`` lies inside an allowed root.
+
+        Args:
+            candidate: An already-resolved directory path.
+
+        Returns:
+            True when unrestricted, or when the candidate is one of the roots
+            or lives beneath one.
+        """
+        if not self.allowed_roots:
+            return True
+
+        resolved = candidate.resolve()
+        return any(resolved == root or root in resolved.parents for root in self.allowed_roots)
+
+    def describe(self) -> str:
+        """Return a human-readable summary for errors and startup output."""
+        if not self.allowed_roots:
+            return "unrestricted"
+        return ", ".join(str(root) for root in self.allowed_roots)
+
+
+_UNRESTRICTED = WorkspacePolicy()
+_lock = threading.Lock()
+_current_policy = _UNRESTRICTED
+
+
+def set_workspace_policy(policy: WorkspacePolicy) -> None:
+    """Install the policy for this server process.
+
+    Args:
+        policy: The policy to enforce for the lifetime of the process.
+    """
+    global _current_policy
+    with _lock:
+        _current_policy = policy
+    log.info("mcp.workspace.policy_set", roots=policy.describe())
+
+
+def get_workspace_policy() -> WorkspacePolicy:
+    """Return the policy currently installed for this process."""
+    with _lock:
+        return _current_policy
+
+
+def reset_workspace_policy() -> None:
+    """Restore the permit-everything default.
+
+    Exists so a test that installs a policy can undo it; production code sets
+    the policy once at startup and never clears it.
+    """
+    set_workspace_policy(_UNRESTRICTED)

--- a/src/ouroboros/mcp/telemetry_boundary.py
+++ b/src/ouroboros/mcp/telemetry_boundary.py
@@ -209,6 +209,7 @@ async def call_sdk_tool(
 
     from ouroboros.mcp.sdk_mapping import tool_result_to_sdk
     from ouroboros.mcp.server.adapter import _validate_parameter_constraints
+    from ouroboros.mcp.server.auth import current_auth_context
 
     started_at = time.monotonic()
     error_type: str | None = None
@@ -230,7 +231,15 @@ async def call_sdk_tool(
         Draft202012Validator(definition.to_input_schema()).validate(arguments)
         # The private impl skips call_tool's observer wrapper: this SDK path
         # owns the one request-outcome event itself (no double counting).
-        result = await adapter._call_tool_impl(name, arguments)
+        # On a token-protected network bind the SDK already verified the bearer
+        # token and the raw credential is gone by now, so carry its decision
+        # across instead -- that restores the client identity authorization and
+        # rate limiting key on.
+        result = await adapter._call_tool_impl(
+            name,
+            arguments,
+            auth_context=current_auth_context(),
+        )
         if result.is_err:
             error_type = _safe_error_type(result.error)
             raise RuntimeError(str(result.error))

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -2088,8 +2088,26 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         requested cwd is missing or is not a directory.  Otherwise the actual
         execution fails later inside the runtime with a less actionable
         ``FileNotFoundError``.
+
+        The same fail-closed reasoning covers the workspace policy: ``cwd``
+        arrives from the caller and becomes an agent runtime's working tree, so
+        a server started with confined roots must reject an outside directory
+        here rather than hand it to the runtime.
         """
+        from ouroboros.mcp.server.workspace import get_workspace_policy
+
         resolved_cwd = ExecuteSeedHandler._resolve_dispatch_cwd(raw_cwd)
+
+        policy = get_workspace_policy()
+        if not policy.permits(resolved_cwd):
+            return Result.err(
+                MCPToolError(
+                    f"Working directory is outside the permitted workspace: "
+                    f"{resolved_cwd} (allowed: {policy.describe()})",
+                    tool_name=tool_name,
+                )
+            )
+
         if not resolved_cwd.exists():
             return Result.err(
                 MCPToolError(

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -268,6 +268,10 @@ class TestMCPCommands:
             None,
             "pi",
             "pi",
+            auth_token="",
+            allowed_hosts=(),
+            allowed_origins=(),
+            workspace_roots=(),
         )
 
     def test_mcp_info(self) -> None:

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -152,6 +152,10 @@ def test_serve_defaults_to_port_8080_when_port_omitted(monkeypatch):
         None,
         "claude_mcp",
         None,
+        auth_token="",
+        allowed_hosts=(),
+        allowed_origins=(),
+        workspace_roots=(),
     )
 
 
@@ -174,6 +178,10 @@ def test_public_claude_cli_runtime_selects_cli_worker(monkeypatch):
         None,
         "claude_mcp",
         None,
+        auth_token="",
+        allowed_hosts=(),
+        allowed_origins=(),
+        workspace_roots=(),
     )
 
 
@@ -287,4 +295,15 @@ def test_bare_serve_allows_configured_cli_worker(monkeypatch, tmp_path) -> None:
         result = runner.invoke(app, ["serve"])
 
     assert result.exit_code == 0
-    run_mcp_server.assert_awaited_once_with("localhost", 8080, "stdio", None, "claude_mcp", None)
+    run_mcp_server.assert_awaited_once_with(
+        "localhost",
+        8080,
+        "stdio",
+        None,
+        "claude_mcp",
+        None,
+        auth_token="",
+        allowed_hosts=(),
+        allowed_origins=(),
+        workspace_roots=(),
+    )

--- a/tests/unit/cli/test_mcp_startup_cleanup.py
+++ b/tests/unit/cli/test_mcp_startup_cleanup.py
@@ -321,6 +321,8 @@ class TestMCPStartupAutoCleanup:
             transport="streamable-http",
             host="127.0.0.1",
             port=9100,
+            allowed_hosts=(),
+            allowed_origins=(),
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -2998,12 +2998,18 @@ class TestServeTransport:
             "ouroboros.mcp.server.adapter._OuroborosSDKServer",
             mock_fastmcp_cls,
         ):
-            await adapter.serve(transport="sse", host="0.0.0.0", port=9000)
+            await adapter.serve(transport="sse", host="127.0.0.1", port=9000)
 
         mock_fastmcp_cls.assert_called_once()
         assert mock_fastmcp_cls.call_args.args == (adapter,)
         assert mock_fastmcp_cls.call_args.kwargs["version"] == __version__
-        mock_instance.run_sse_async.assert_awaited_once_with(host="0.0.0.0", port=9000)
+        # The SDK builds its own DNS-rebinding settings for this bind spelling,
+        # so the adapter passes none of its own.
+        mock_instance.run_sse_async.assert_awaited_once_with(
+            host="127.0.0.1",
+            port=9000,
+            transport_security=None,
+        )
 
     @pytest.mark.asyncio
     async def test_stdio_serve_logs_exit(self) -> None:
@@ -3054,7 +3060,11 @@ class TestServeTransport:
         ):
             await adapter.serve(transport="sse", host="localhost", port=0)
 
-        mock_instance.run_sse_async.assert_awaited_once_with(host="localhost", port=0)
+        mock_instance.run_sse_async.assert_awaited_once_with(
+            host="localhost",
+            port=0,
+            transport_security=None,
+        )
 
     @pytest.mark.asyncio
     async def test_streamable_http_uses_modern_stateless_run_options(self):
@@ -3083,6 +3093,7 @@ class TestServeTransport:
             host="127.0.0.1",
             port=9100,
             stateless_http=True,
+            transport_security=None,
         )
 
     @pytest.mark.asyncio
@@ -3844,11 +3855,13 @@ class TestServeTransport:
         handler.handle_mock.assert_awaited_with("test://resource/child")
 
     @pytest.mark.asyncio
-    async def test_fastmcp_rejects_auth_config_at_startup(self):
-        """FastMCP serve() rejects auth config upfront with clear error.
+    async def test_stdio_rejects_auth_config_at_startup(self):
+        """stdio serve() rejects auth config upfront with a clear error.
 
-        This guard prevents the confusing failure mode where the server
-        starts successfully but then rejects every tool call at runtime.
+        stdio has no header to carry a credential on, so this guard prevents
+        the confusing failure mode where the server starts successfully but
+        then rejects every tool call at runtime. Network transports do support
+        authentication -- see the network security suite.
         """
         from ouroboros.mcp.server.security import AuthConfig, AuthMethod
 
@@ -3863,7 +3876,7 @@ class TestServeTransport:
         # serve() should reject the incompatible configuration immediately
         with pytest.raises(
             ValueError,
-            match="MCPServer transport does not support authentication",
+            match="stdio transport does not support authentication",
         ):
             await adapter.serve(transport="stdio")
 
@@ -3909,11 +3922,12 @@ class TestServeTransport:
             await adapter.serve(transport="stdio")
 
     @pytest.mark.asyncio
-    async def test_fastmcp_rejects_rate_limit_config(self):
-        """FastMCP serve() rejects rate limiting config upfront.
+    async def test_rejects_rate_limit_config_without_auth(self):
+        """serve() rejects rate limiting that has no client identity to bucket by.
 
-        Rate limiting requires client identity which FastMCP cannot provide,
-        so the guard prevents the false sense of security.
+        Only a credential supplies that identity, so rate limiting without an
+        auth method would put every caller in one shared bucket -- a false
+        sense of security. With auth configured it is supported.
         """
         from ouroboros.mcp.server.security import RateLimitConfig
 
@@ -3926,7 +3940,7 @@ class TestServeTransport:
 
         with pytest.raises(
             ValueError,
-            match="MCPServer transport does not support rate limiting",
+            match="Rate limiting requires client identity",
         ):
             await adapter.serve(transport="stdio")
 

--- a/tests/unit/mcp/server/test_network_security.py
+++ b/tests/unit/mcp/server/test_network_security.py
@@ -1,0 +1,592 @@
+"""Tests for the network MCP trust boundary.
+
+Reaching a network MCP bind is enough to run ``ouroboros_execute_seed``, which
+hands attacker-chosen YAML to a real agent runtime in an attacker-chosen
+directory. These tests pin the three controls that stand between a routable
+port and that capability: mandatory credentials, DNS-rebinding protection, and
+workspace confinement.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.mcp.server.adapter import MCPServerAdapter
+from ouroboros.mcp.server.auth import (
+    OuroborosTokenVerifier,
+    auth_context_from_access_token,
+    build_transport_security,
+    is_loopback_host,
+    is_wildcard_host,
+    resolve_network_security,
+)
+from ouroboros.mcp.server.security import (
+    AuthConfig,
+    Authenticator,
+    AuthMethod,
+    Permission,
+    RateLimitConfig,
+    SecurityLayer,
+)
+from ouroboros.mcp.server.workspace import (
+    WorkspacePolicy,
+    get_workspace_policy,
+    reset_workspace_policy,
+    set_workspace_policy,
+)
+
+TOKEN = "test-shared-secret"
+
+
+def _auth_config() -> AuthConfig:
+    """Return an API-key config carrying the shared test token."""
+    return AuthConfig(
+        method=AuthMethod.API_KEY,
+        api_keys=frozenset({TOKEN}),
+        required=True,
+    )
+
+
+def _mock_sdk_server() -> tuple[MagicMock, MagicMock]:
+    """Return a patched SDK server class and the instance it constructs."""
+    cls = MagicMock()
+    instance = MagicMock()
+    instance.tool = MagicMock(return_value=lambda f: f)
+    instance.resource = MagicMock(return_value=lambda f: f)
+    instance.run_sse_async = AsyncMock()
+    instance.run_streamable_http_async = AsyncMock()
+    instance.run_stdio_async = AsyncMock()
+    cls.return_value = instance
+    return cls, instance
+
+
+class TestHostClassification:
+    """Host strings decide whether credentials are mandatory."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["127.0.0.1", "localhost", "LOCALHOST", "::1", "[::1]", "127.0.0.2", " 127.0.0.1 "],
+    )
+    def test_loopback_hosts_recognized(self, host: str) -> None:
+        """Every spelling that only this machine can reach counts as loopback."""
+        assert is_loopback_host(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0.0.0.0", "::", "", "192.168.1.10", "example.com", "build-box.internal"],
+    )
+    def test_routable_hosts_are_not_loopback(self, host: str) -> None:
+        """Anything reachable from elsewhere -- including unresolvable names."""
+        assert is_loopback_host(host) is False
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "[::]", ""])
+    def test_wildcard_hosts_recognized(self, host: str) -> None:
+        assert is_wildcard_host(host) is True
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "10.0.0.4"])
+    def test_concrete_hosts_are_not_wildcard(self, host: str) -> None:
+        assert is_wildcard_host(host) is False
+
+
+class TestServeRefusesUnauthenticatedExposure:
+    """The gate that closes the reported trust-boundary hole."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+    @pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10", "example.com"])
+    async def test_non_loopback_without_auth_is_refused(self, transport: str, host: str) -> None:
+        """A routable bind with no credentials never reaches the SDK."""
+        adapter = MCPServerAdapter()
+
+        cls, _ = _mock_sdk_server()
+        with (
+            patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls),
+            pytest.raises(ValueError, match="Refusing to serve"),
+        ):
+            await adapter.serve(transport=transport, host=host, port=9000)
+
+        cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refusal_names_the_capability_at_risk(self) -> None:
+        """The error explains why, so an operator does not just add --host back."""
+        adapter = MCPServerAdapter()
+
+        with pytest.raises(ValueError, match="execute seeds through the local agent runtime"):
+            await adapter.serve(transport="streamable-http", host="0.0.0.0", port=9000)
+
+    @pytest.mark.asyncio
+    async def test_loopback_without_auth_still_serves(self) -> None:
+        """Local stdio-equivalent use is unchanged: no credential required."""
+        adapter = MCPServerAdapter()
+
+        cls, instance = _mock_sdk_server()
+        with patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls):
+            await adapter.serve(transport="streamable-http", host="127.0.0.1", port=9000)
+
+        assert cls.call_args.kwargs["token_verifier"] is None
+        assert cls.call_args.kwargs["auth"] is None
+        instance.run_streamable_http_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_with_auth_serves_with_token_verifier(self) -> None:
+        """With credentials configured the remote bind is allowed and protected."""
+        adapter = MCPServerAdapter(auth_config=_auth_config())
+
+        cls, instance = _mock_sdk_server()
+        with patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls):
+            await adapter.serve(
+                transport="streamable-http",
+                host="0.0.0.0",
+                port=9000,
+                allowed_hosts=("ouroboros.internal:9000",),
+            )
+
+        assert isinstance(cls.call_args.kwargs["token_verifier"], OuroborosTokenVerifier)
+        assert cls.call_args.kwargs["auth"] is not None
+
+        settings = instance.run_streamable_http_async.await_args.kwargs["transport_security"]
+        assert settings.enable_dns_rebinding_protection is True
+        assert settings.allowed_hosts == ["ouroboros.internal:9000"]
+        # No Origin is allowlisted, so browser-originated requests are rejected.
+        assert settings.allowed_origins == []
+
+    @pytest.mark.asyncio
+    async def test_wildcard_bind_requires_an_explicit_host_allowlist(self) -> None:
+        """A 0.0.0.0 bind has no inferable Host value to allow."""
+        adapter = MCPServerAdapter(auth_config=_auth_config())
+
+        with pytest.raises(ValueError, match="Cannot infer a Host allowlist"):
+            await adapter.serve(transport="streamable-http", host="0.0.0.0", port=9000)
+
+    @pytest.mark.asyncio
+    async def test_loopback_spelling_the_sdk_ignores_still_gets_protection(self) -> None:
+        """The SDK auto-protects three literals; other loopback names need ours."""
+        adapter = MCPServerAdapter()
+
+        cls, instance = _mock_sdk_server()
+        with patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls):
+            await adapter.serve(transport="sse", host="127.0.0.2", port=9000)
+
+        settings = instance.run_sse_async.await_args.kwargs["transport_security"]
+        assert settings is not None
+        assert settings.enable_dns_rebinding_protection is True
+        assert settings.allowed_hosts == ["127.0.0.2:9000", "127.0.0.2:*"]
+
+    @pytest.mark.asyncio
+    async def test_stdio_ignores_network_hardening(self) -> None:
+        """stdio has no HTTP edge, so none of these settings apply to it."""
+        adapter = MCPServerAdapter()
+
+        cls, instance = _mock_sdk_server()
+        with patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls):
+            await adapter.serve(transport="stdio")
+
+        instance.run_stdio_async.assert_awaited_once()
+        assert cls.call_args.kwargs["token_verifier"] is None
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting_is_allowed_once_auth_supplies_identity(self) -> None:
+        """Rate limiting was blanket-refused before; auth makes it workable."""
+        adapter = MCPServerAdapter(
+            auth_config=_auth_config(),
+            rate_limit_config=RateLimitConfig(enabled=True, requests_per_minute=10),
+        )
+
+        cls, _ = _mock_sdk_server()
+        with patch("ouroboros.mcp.server.adapter._OuroborosSDKServer", cls):
+            await adapter.serve(
+                transport="streamable-http",
+                host="10.0.0.5",
+                port=9000,
+            )
+
+        cls.assert_called_once()
+
+
+class TestResolveNetworkSecurity:
+    """The policy entry point, exercised without standing a server up."""
+
+    def test_stdio_resolves_to_no_wiring(self) -> None:
+        wiring = resolve_network_security(
+            transport="stdio",
+            host="localhost",
+            port=8080,
+            security=SecurityLayer(),
+        )
+
+        assert wiring.token_verifier is None
+        assert wiring.auth_settings is None
+        assert wiring.transport_security is None
+
+    def test_routable_bind_without_credentials_raises(self) -> None:
+        with pytest.raises(ValueError, match="Refusing to serve"):
+            resolve_network_security(
+                transport="sse",
+                host="10.0.0.5",
+                port=8080,
+                security=SecurityLayer(),
+            )
+
+    def test_routable_bind_with_credentials_returns_full_wiring(self) -> None:
+        wiring = resolve_network_security(
+            transport="streamable-http",
+            host="10.0.0.5",
+            port=8080,
+            security=SecurityLayer(auth_config=_auth_config()),
+        )
+
+        assert isinstance(wiring.token_verifier, OuroborosTokenVerifier)
+        assert wiring.auth_settings is not None
+        assert wiring.transport_security.enable_dns_rebinding_protection is True
+
+    def test_loopback_bind_needs_no_credentials(self) -> None:
+        wiring = resolve_network_security(
+            transport="streamable-http",
+            host="127.0.0.1",
+            port=8080,
+            security=SecurityLayer(),
+        )
+
+        assert wiring.token_verifier is None
+        # The SDK builds its own settings for this spelling.
+        assert wiring.transport_security is None
+
+
+class TestTransportSecurityBuilder:
+    """Direct coverage of the DNS-rebinding settings builder."""
+
+    def test_wildcard_without_allowlist_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot infer a Host allowlist"):
+            build_transport_security(
+                host="0.0.0.0",
+                port=8080,
+                allowed_hosts=(),
+                allowed_origins=(),
+            )
+
+    def test_operator_allowlists_are_passed_through(self) -> None:
+        settings = build_transport_security(
+            host="0.0.0.0",
+            port=8080,
+            allowed_hosts=("a.example:8080", "b.example:*"),
+            allowed_origins=("https://a.example",),
+        )
+
+        assert settings.allowed_hosts == ["a.example:8080", "b.example:*"]
+        assert settings.allowed_origins == ["https://a.example"]
+
+
+class TestTokenVerifier:
+    """The SDK's credential check delegates to Ouroboros's authenticator."""
+
+    @pytest.mark.asyncio
+    async def test_valid_token_is_accepted(self) -> None:
+        verifier = OuroborosTokenVerifier(
+            authenticator=Authenticator(_auth_config()),
+            method=AuthMethod.API_KEY,
+        )
+
+        access_token = await verifier.verify_token(TOKEN)
+
+        assert access_token is not None
+        assert access_token.client_id
+        # The raw secret is never used as the identity.
+        assert access_token.client_id != TOKEN
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", ["", "wrong", TOKEN + "x", TOKEN.upper()])
+    async def test_invalid_token_is_rejected(self, bad: str) -> None:
+        verifier = OuroborosTokenVerifier(
+            authenticator=Authenticator(_auth_config()),
+            method=AuthMethod.API_KEY,
+        )
+
+        assert await verifier.verify_token(bad) is None
+
+    @pytest.mark.asyncio
+    async def test_same_token_yields_a_stable_client_id(self) -> None:
+        """Rate limiting buckets by this value, so it must not drift per call."""
+        verifier = OuroborosTokenVerifier(
+            authenticator=Authenticator(_auth_config()),
+            method=AuthMethod.API_KEY,
+        )
+
+        first = await verifier.verify_token(TOKEN)
+        second = await verifier.verify_token(TOKEN)
+
+        assert first.client_id == second.client_id
+
+
+class TestAuthContextBridge:
+    """The SDK's decision survives the crossing into SecurityLayer."""
+
+    def test_none_access_token_yields_no_context(self) -> None:
+        assert auth_context_from_access_token(None) is None
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_identity_and_permissions(self) -> None:
+        verifier = OuroborosTokenVerifier(
+            authenticator=Authenticator(_auth_config()),
+            method=AuthMethod.API_KEY,
+        )
+        access_token = await verifier.verify_token(TOKEN)
+
+        context = auth_context_from_access_token(access_token)
+
+        assert context is not None
+        assert context.authenticated is True
+        assert context.client_id == access_token.client_id
+        assert Permission.EXECUTE in context.permissions
+
+    @pytest.mark.asyncio
+    async def test_pre_authenticated_context_authorizes_a_tool_call(self) -> None:
+        """call_tool must accept the transport's decision, not re-check a
+        credential that no longer exists at this layer."""
+        from ouroboros.mcp.server.security import SecurityLayer
+
+        layer = SecurityLayer(auth_config=_auth_config())
+        verifier = OuroborosTokenVerifier(
+            authenticator=layer.authenticator,
+            method=AuthMethod.API_KEY,
+        )
+        context = auth_context_from_access_token(await verifier.verify_token(TOKEN))
+
+        result = await layer.check_request(
+            "ouroboros_execute_seed",
+            {"seed_content": "goal: x"},
+            credentials=None,
+            pre_authenticated=context,
+        )
+
+        assert result.is_ok
+
+    @pytest.mark.asyncio
+    async def test_missing_context_with_auth_configured_is_rejected(self) -> None:
+        """Without the transport's decision and without credentials, no entry."""
+        from ouroboros.mcp.server.security import SecurityLayer
+
+        layer = SecurityLayer(auth_config=_auth_config())
+
+        result = await layer.check_request(
+            "ouroboros_execute_seed",
+            {"seed_content": "goal: x"},
+            credentials=None,
+        )
+
+        assert result.is_err
+
+
+class TestWorkspacePolicy:
+    """Confinement for the directory an agent runtime is pointed at."""
+
+    def teardown_method(self) -> None:
+        reset_workspace_policy()
+
+    def test_default_policy_permits_everything(self) -> None:
+        assert get_workspace_policy().permits(Path("/tmp")) is True
+        assert get_workspace_policy().restricted is False
+
+    def test_paths_inside_a_root_are_permitted(self, tmp_path: Path) -> None:
+        policy = WorkspacePolicy.from_paths([tmp_path])
+
+        assert policy.permits(tmp_path) is True
+        assert policy.permits(tmp_path / "nested" / "deeper") is True
+
+    def test_paths_outside_every_root_are_refused(self, tmp_path: Path) -> None:
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        policy = WorkspacePolicy.from_paths([allowed])
+
+        assert policy.permits(tmp_path / "elsewhere") is False
+        assert policy.permits(Path("/etc")) is False
+
+    def test_sibling_prefix_is_not_treated_as_contained(self, tmp_path: Path) -> None:
+        """``/srv/work`` must not admit ``/srv/work-evil``."""
+        allowed = tmp_path / "work"
+        allowed.mkdir()
+        sibling = tmp_path / "work-evil"
+        sibling.mkdir()
+        policy = WorkspacePolicy.from_paths([allowed])
+
+        assert policy.permits(sibling) is False
+
+    def test_symlink_out_of_the_root_is_refused(self, tmp_path: Path) -> None:
+        """Resolution happens on both sides, so a link cannot smuggle a path out."""
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = allowed / "escape"
+        link.symlink_to(outside)
+        policy = WorkspacePolicy.from_paths([allowed])
+
+        assert policy.permits(link) is False
+
+    def test_policy_is_readable_after_being_set(self, tmp_path: Path) -> None:
+        set_workspace_policy(WorkspacePolicy.from_paths([tmp_path]))
+
+        assert get_workspace_policy().restricted is True
+        assert str(tmp_path.resolve()) in get_workspace_policy().describe()
+
+
+class TestExecuteSeedCwdConfinement:
+    """The policy is enforced where cwd becomes an agent's working tree."""
+
+    def teardown_method(self) -> None:
+        reset_workspace_policy()
+
+    def test_cwd_outside_the_workspace_is_rejected(self, tmp_path: Path) -> None:
+        from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        set_workspace_policy(WorkspacePolicy.from_paths([allowed]))
+
+        result = ExecuteSeedHandler._resolve_dispatch_cwd_result(
+            str(outside),
+            tool_name="ouroboros_execute_seed",
+        )
+
+        assert result.is_err
+        assert "outside the permitted workspace" in str(result.error)
+
+    def test_cwd_inside_the_workspace_is_accepted(self, tmp_path: Path) -> None:
+        from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+        allowed = tmp_path / "allowed"
+        nested = allowed / "project"
+        nested.mkdir(parents=True)
+        set_workspace_policy(WorkspacePolicy.from_paths([allowed]))
+
+        result = ExecuteSeedHandler._resolve_dispatch_cwd_result(
+            str(nested),
+            tool_name="ouroboros_execute_seed",
+        )
+
+        assert result.is_ok
+        assert result.value == nested.resolve()
+
+    def test_confinement_is_checked_before_existence(self, tmp_path: Path) -> None:
+        """A refused path must not reveal whether it exists on this machine."""
+        from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+        set_workspace_policy(WorkspacePolicy.from_paths([allowed]))
+
+        result = ExecuteSeedHandler._resolve_dispatch_cwd_result(
+            str(tmp_path / "does-not-exist"),
+            tool_name="ouroboros_execute_seed",
+        )
+
+        assert result.is_err
+        assert "outside the permitted workspace" in str(result.error)
+        assert "does not exist" not in str(result.error)
+
+    def test_unrestricted_policy_keeps_local_behaviour(self, tmp_path: Path) -> None:
+        from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+        result = ExecuteSeedHandler._resolve_dispatch_cwd_result(
+            str(tmp_path),
+            tool_name="ouroboros_execute_seed",
+        )
+
+        assert result.is_ok
+
+
+class TestCliExposureGate:
+    """The CLI refuses the same binds, with guidance instead of a traceback."""
+
+    def test_remote_bind_without_token_exits(self) -> None:
+        import typer
+
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        with pytest.raises(typer.Exit):
+            _resolve_network_security(
+                transport="streamable-http",
+                host="0.0.0.0",
+                port=8080,
+                auth_token="",
+                allow_remote=True,
+                allowed_hosts=("a.example:8080",),
+            )
+
+    def test_remote_bind_without_acknowledgement_exits(self) -> None:
+        import typer
+
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        with pytest.raises(typer.Exit):
+            _resolve_network_security(
+                transport="streamable-http",
+                host="10.0.0.5",
+                port=8080,
+                auth_token=TOKEN,
+                allow_remote=False,
+                allowed_hosts=(),
+            )
+
+    def test_wildcard_bind_without_allowed_host_exits(self) -> None:
+        import typer
+
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        with pytest.raises(typer.Exit):
+            _resolve_network_security(
+                transport="streamable-http",
+                host="0.0.0.0",
+                port=8080,
+                auth_token=TOKEN,
+                allow_remote=True,
+                allowed_hosts=(),
+            )
+
+    def test_fully_specified_remote_bind_is_allowed(self) -> None:
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        token = _resolve_network_security(
+            transport="streamable-http",
+            host="0.0.0.0",
+            port=8080,
+            auth_token=TOKEN,
+            allow_remote=True,
+            allowed_hosts=("ouroboros.internal:8080",),
+        )
+
+        assert token == TOKEN
+
+    def test_loopback_needs_nothing(self) -> None:
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        assert (
+            _resolve_network_security(
+                transport="streamable-http",
+                host="localhost",
+                port=8080,
+                auth_token="",
+                allow_remote=False,
+                allowed_hosts=(),
+            )
+            == ""
+        )
+
+    def test_stdio_drops_an_inherited_token(self) -> None:
+        """A globally exported OUROBOROS_MCP_AUTH_TOKEN must not break stdio."""
+        from ouroboros.cli.commands.mcp import _resolve_network_security
+
+        assert (
+            _resolve_network_security(
+                transport="stdio",
+                host="localhost",
+                port=8080,
+                auth_token=TOKEN,
+                allow_remote=False,
+                allowed_hosts=(),
+            )
+            == ""
+        )

--- a/tests/unit/mcp/server/test_network_security.py
+++ b/tests/unit/mcp/server/test_network_security.py
@@ -15,7 +15,9 @@ import pytest
 from ouroboros.mcp.server.adapter import MCPServerAdapter
 from ouroboros.mcp.server.auth import (
     OuroborosTokenVerifier,
+    as_url_authority,
     auth_context_from_access_token,
+    build_auth_settings,
     build_transport_security,
     is_loopback_host,
     is_wildcard_host,
@@ -252,6 +254,91 @@ class TestResolveNetworkSecurity:
         assert wiring.token_verifier is None
         # The SDK builds its own settings for this spelling.
         assert wiring.transport_security is None
+
+
+class TestIPv6Binds:
+    """A bind address and its URL spelling differ for IPv6.
+
+    Sockets take the bare literal and reject brackets; URLs and ``Host`` values
+    require brackets or the trailing ``:port`` merges into the address. Getting
+    this backwards made authenticated IPv6 serving impossible to start.
+    """
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("::1", "[::1]"),
+            ("2001:db8::1", "[2001:db8::1]"),
+            ("[::1]", "[::1]"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("example.com", "example.com"),
+        ],
+    )
+    def test_url_authority_brackets_only_ipv6(self, host: str, expected: str) -> None:
+        assert as_url_authority(host) == expected
+
+    @pytest.mark.parametrize("host", ["::1", "2001:db8::1"])
+    def test_auth_settings_build_for_ipv6(self, host: str) -> None:
+        """Building these raised a Pydantic ValidationError before bracketing."""
+        settings = build_auth_settings(host=host, port=8080)
+
+        assert str(settings.issuer_url).startswith(f"http://[{host.strip('[]')}]:8080")
+
+    def test_inferred_host_allowlist_is_unambiguous_for_ipv6(self) -> None:
+        settings = build_transport_security(
+            host="2001:db8::1",
+            port=8080,
+            allowed_hosts=(),
+            allowed_origins=(),
+        )
+
+        assert settings.allowed_hosts == ["[2001:db8::1]:8080", "[2001:db8::1]:*"]
+
+    def test_authenticated_ipv6_loopback_bind_resolves(self) -> None:
+        """An inherited token on a valid `--host ::1` must not break startup."""
+        wiring = resolve_network_security(
+            transport="streamable-http",
+            host="::1",
+            port=8080,
+            security=SecurityLayer(auth_config=_auth_config()),
+        )
+
+        assert isinstance(wiring.token_verifier, OuroborosTokenVerifier)
+        # The SDK auto-protects this spelling, so we add nothing of our own.
+        assert wiring.transport_security is None
+
+    def test_authenticated_ipv6_routable_bind_resolves(self) -> None:
+        wiring = resolve_network_security(
+            transport="streamable-http",
+            host="2001:db8::1",
+            port=8080,
+            security=SecurityLayer(auth_config=_auth_config()),
+        )
+
+        assert isinstance(wiring.token_verifier, OuroborosTokenVerifier)
+        assert wiring.transport_security.allowed_hosts == [
+            "[2001:db8::1]:8080",
+            "[2001:db8::1]:*",
+        ]
+
+    def test_ipv6_loopback_without_auth_is_still_credential_free(self) -> None:
+        wiring = resolve_network_security(
+            transport="sse",
+            host="::1",
+            port=8080,
+            security=SecurityLayer(),
+        )
+
+        assert wiring.token_verifier is None
+
+    def test_routable_ipv6_without_auth_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="Refusing to serve"):
+            resolve_network_security(
+                transport="sse",
+                host="2001:db8::1",
+                port=8080,
+                security=SecurityLayer(),
+            )
 
 
 class TestTransportSecurityBuilder:


### PR DESCRIPTION
## Why

`ouroboros mcp serve` accepted no credentials on its network transports. An instance bound to a routable address let anyone who could reach the port call `ouroboros_execute_seed` — caller-supplied YAML run through a local agent runtime with that runtime's full file and shell authority, in a caller-supplied directory.

Reproducible with:

```bash
ouroboros mcp serve --transport streamable-http --host 0.0.0.0 --port 8080
```

The default (`stdio` on `localhost`) and every loopback bind were never exposed — the SDK enables DNS-rebinding protection for `127.0.0.1` / `localhost` / `::1` on its own. Plugin and Claude Desktop installs are unaffected.

## Root cause

Not "auth defaulted to `AuthMethod.NONE`". Authentication was **not implemented** for network transports:

- `credentials` never reached `call_tool` — nothing extracted them from HTTP headers.
- `serve()` raised `ValueError` if any auth method was configured, so turning auth on made the server refuse to start.
- No `TransportSecuritySettings` were passed, and the SDK only synthesizes them for three literal host spellings. Every other bind, including `0.0.0.0`, ran with `Host`/`Origin` validation off.

## What changed

- `serve()` refuses a non-loopback bind without credentials, naming the capability at risk rather than failing abstractly.
- Bearer-token auth is wired through the SDK's `TokenVerifier`/`AuthSettings` to Ouroboros's existing `Authenticator`, so one credential authority covers both the HTTP edge and the per-tool `SecurityLayer`. The SDK's decision crosses back as an `AuthContext`, restoring the client identity authorization and rate limiting key on — **rate limiting is no longer blanket-refused**.
- Explicit `TransportSecuritySettings` for every bind the SDK does not auto-protect.
- `execute_seed`'s `cwd` can be confined to operator-chosen roots (`--workspace-root`). Checked *before* the existence test so a refusal cannot be used to probe paths.
- CLI: `--auth-token` (env `OUROBOROS_MCP_AUTH_TOKEN`), `--allow-remote`, `--allowed-host`, `--allowed-origin`, `--workspace-root`, and a startup banner stating the actual posture.
- `docs/cli-reference.md` no longer demonstrates a bare `--host 0.0.0.0`.

## Breaking change

A remote bind now needs `--auth-token`, `--allow-remote`, and `--allowed-host` for wildcard binds. An existing `--host 0.0.0.0` command refuses to start until those are supplied. **`stdio` and loopback binds are unchanged** — no credential, no new flags.

## Verification

End to end against a real `0.0.0.0` bind (not mocks), re-run after rebasing onto current `main`:

| request | result |
|---|---|
| anonymous | `401` |
| wrong token | `401` |
| correct token | `200` + full `initialize` handshake |
| forged `Host: attacker.example.com` | `421` |

Tests: 61 new in `tests/unit/mcp/server/test_network_security.py`; `tests/unit/mcp/server` + `tests/unit/cli` green (2287 passed); `ruff` and `mypy` clean.

## Note for reviewers

The rebase onto `main` interacts with #1908 — telemetry split `call_tool` into an observer wrapper plus `_call_tool_impl`, and moved the SDK dispatch body into `telemetry_boundary.call_sdk_tool`. The auth-context bridge had to follow into both. Git's auto-merge produced a version where `call_tool` accepted `auth_context` and silently dropped it while `_call_tool_impl` referenced an undefined name; that is resolved here, and the e2e run above is the proof the live path still carries the identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzysvKLDuJW9bkKQFBnP5B