### PR TITLE
fix(windows): use Win32 heartbeat liveness checks

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -148,9 +148,9 @@ def _parse_pid_record(text: str) -> tuple[int, float | None] | None:
 def _record_is_stale(pid: int, start_time: float | None) -> bool:
     """True when a record's process identity is provably not running.
 
-    Windows cannot probe liveness via signal 0 (``os.kill(pid, 0)`` raises
-    ``OSError`` WinError 87) — treat as stale, preserving the degradation the
-    legacy single-slot check used.
+    The shared liveness probe uses Win32 process handles on Windows and
+    preserves a lease when the OS cannot decide. The fallback still preserves
+    the legacy behavior for unexpected errors escaping other platform probes.
     """
     try:
         return not is_process_identity_alive(pid, start_time)

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -406,25 +406,35 @@ def process_start_time(pid: int) -> float | None:
 
 
 def _is_windows_process_alive(pid: int) -> bool:
-    """Return whether Windows can confirm that ``pid`` is running."""
+    """Return whether Windows can confirm that ``pid`` is running.
+
+    This observer is deliberately fail-closed for cleanup: only an invalid PID
+    or a signaled process handle proves that an owner is dead. Win32 boundary
+    failures preserve the lease instead of letting cleanup race a live owner.
+    """
     process_query_limited_information = 0x1000
     synchronize = 0x00100000
     error_access_denied = 5
     error_invalid_parameter = 87
     wait_object_0 = 0
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    open_process = kernel32.OpenProcess
-    open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
-    open_process.restype = wintypes.HANDLE
-    wait_for_single_object = kernel32.WaitForSingleObject
-    wait_for_single_object.argtypes = (wintypes.HANDLE, wintypes.DWORD)
-    wait_for_single_object.restype = wintypes.DWORD
-    close_handle = kernel32.CloseHandle
-    close_handle.argtypes = (wintypes.HANDLE,)
-    close_handle.restype = wintypes.BOOL
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        open_process = kernel32.OpenProcess
+        open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        open_process.restype = wintypes.HANDLE
+        wait_for_single_object = kernel32.WaitForSingleObject
+        wait_for_single_object.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+        wait_for_single_object.restype = wintypes.DWORD
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = (wintypes.HANDLE,)
+        close_handle.restype = wintypes.BOOL
 
-    handle = open_process(process_query_limited_information | synchronize, False, pid)
+        handle = open_process(process_query_limited_information | synchronize, False, pid)
+    except OSError:
+        # A broken or unavailable Win32 boundary is not proof that the process
+        # is gone. Preserve its authority until a later probe can decide.
+        return True
     if not handle:
         error = ctypes.get_last_error()
         if error == error_invalid_parameter:
@@ -434,7 +444,10 @@ def _is_windows_process_alive(pid: int) -> bool:
         return True
 
     try:
-        wait_result = wait_for_single_object(handle, 0)
+        try:
+            wait_result = wait_for_single_object(handle, 0)
+        except OSError:
+            return True
         # Only a signaled process handle proves termination. Timeouts and
         # unknown/failed wait results preserve the live lease conservatively.
         return wait_result != wait_object_0

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -15,6 +15,8 @@ Any runtime can participate — just call acquire/release.
 
 from __future__ import annotations
 
+import ctypes
+from ctypes import wintypes
 from dataclasses import dataclass
 import hashlib
 import json
@@ -403,18 +405,59 @@ def process_start_time(pid: int) -> float | None:
     return _get_process_start_time(pid)
 
 
+def _is_windows_process_alive(pid: int) -> bool:
+    """Return whether Windows can confirm that ``pid`` is running."""
+    process_query_limited_information = 0x1000
+    synchronize = 0x00100000
+    error_access_denied = 5
+    error_invalid_parameter = 87
+    wait_object_0 = 0
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    open_process.restype = wintypes.HANDLE
+    wait_for_single_object = kernel32.WaitForSingleObject
+    wait_for_single_object.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    wait_for_single_object.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+
+    handle = open_process(process_query_limited_information | synchronize, False, pid)
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == error_invalid_parameter:
+            return False
+        if error == error_access_denied:
+            return True
+        return True
+
+    try:
+        wait_result = wait_for_single_object(handle, 0)
+        # Only a signaled process handle proves termination. Timeouts and
+        # unknown/failed wait results preserve the live lease conservatively.
+        return wait_result != wait_object_0
+    finally:
+        close_handle(handle)
+
+
 def is_process_identity_alive(pid: int, start_time: float | None = None) -> bool:
     """Return True when ``pid`` is alive and still has ``start_time``.
 
     ``start_time`` is optional for legacy callers, but when present it guards
     against treating a recycled PID as the original owner.
     """
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        pass
+    if os.name == "nt":
+        if not _is_windows_process_alive(pid):
+            return False
+    else:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            pass
 
     if start_time is not None:
         current_start = _get_process_start_time(pid)

--- a/tests/unit/orchestrator/test_heartbeat.py
+++ b/tests/unit/orchestrator/test_heartbeat.py
@@ -1,0 +1,116 @@
+"""Windows process-liveness regressions for heartbeat leases."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from ouroboros.orchestrator import heartbeat
+
+
+def _install_windows_api(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    handle: int,
+    last_error: int,
+    wait_result: int = 258,
+) -> SimpleNamespace:
+    """Replace the Win32 boundary with a deterministic fake."""
+    kernel32 = SimpleNamespace(
+        OpenProcess=Mock(return_value=handle),
+        WaitForSingleObject=Mock(return_value=wait_result),
+        CloseHandle=Mock(return_value=True),
+    )
+    api = SimpleNamespace(
+        WinDLL=Mock(return_value=kernel32),
+        get_last_error=Mock(return_value=last_error),
+    )
+    monkeypatch.setattr(heartbeat, "ctypes", api)
+    return kernel32
+
+
+@pytest.mark.parametrize(
+    ("wait_result", "expected"),
+    [
+        (258, True),
+        (0, False),
+        (0xFFFFFFFF, True),
+        (1, True),
+    ],
+    ids=["running", "terminated", "wait-failed", "unknown-wait-result"],
+)
+def test_windows_process_liveness_uses_wait_result_and_closes_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    wait_result: int,
+    expected: bool,
+) -> None:
+    kernel32 = _install_windows_api(
+        monkeypatch,
+        handle=1234,
+        last_error=0,
+        wait_result=wait_result,
+    )
+
+    assert heartbeat._is_windows_process_alive(42) is expected
+    kernel32.OpenProcess.assert_called_once_with(0x101000, False, 42)
+    kernel32.WaitForSingleObject.assert_called_once_with(1234, 0)
+    kernel32.CloseHandle.assert_called_once_with(1234)
+
+
+@pytest.mark.parametrize(
+    ("last_error", "expected"),
+    [
+        (87, False),
+        (5, True),
+        (123, True),
+    ],
+    ids=["invalid-pid", "access-denied", "unexpected-open-process-error"],
+)
+def test_windows_process_liveness_handles_open_process_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    last_error: int,
+    expected: bool,
+) -> None:
+    kernel32 = _install_windows_api(monkeypatch, handle=0, last_error=last_error)
+
+    assert heartbeat._is_windows_process_alive(42) is expected
+    kernel32.OpenProcess.assert_called_once_with(0x101000, False, 42)
+    kernel32.WaitForSingleObject.assert_not_called()
+    kernel32.CloseHandle.assert_not_called()
+
+
+def test_process_identity_alive_uses_windows_api_instead_of_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(heartbeat.os, "name", "nt")
+    alive = Mock(return_value=True)
+    kill = Mock(side_effect=AssertionError("os.kill must not run on Windows"))
+    monkeypatch.setattr(heartbeat, "_is_windows_process_alive", alive)
+    monkeypatch.setattr(heartbeat.os, "kill", kill)
+
+    assert heartbeat.is_process_identity_alive(42) is True
+    alive.assert_called_once_with(42)
+    kill.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        (None, True),
+        (ProcessLookupError(), False),
+        (PermissionError(), True),
+    ],
+)
+def test_process_identity_alive_preserves_posix_kill_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: BaseException | None,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(heartbeat.os, "name", "posix")
+    kill = Mock(side_effect=outcome)
+    monkeypatch.setattr(heartbeat.os, "kill", kill)
+
+    assert heartbeat.is_process_identity_alive(42) is expected
+    kill.assert_called_once_with(42, 0)

--- a/tests/unit/orchestrator/test_heartbeat.py
+++ b/tests/unit/orchestrator/test_heartbeat.py
@@ -81,6 +81,28 @@ def test_windows_process_liveness_handles_open_process_failures(
     kernel32.CloseHandle.assert_not_called()
 
 
+def test_windows_process_liveness_preserves_lease_when_open_process_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel32 = _install_windows_api(monkeypatch, handle=0, last_error=0)
+    kernel32.OpenProcess.side_effect = OSError("Win32 boundary unavailable")
+
+    assert heartbeat._is_windows_process_alive(42) is True
+    kernel32.WaitForSingleObject.assert_not_called()
+    kernel32.CloseHandle.assert_not_called()
+
+
+def test_windows_process_liveness_closes_handle_when_wait_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel32 = _install_windows_api(monkeypatch, handle=1234, last_error=0)
+    kernel32.WaitForSingleObject.side_effect = OSError("wait failed")
+
+    assert heartbeat._is_windows_process_alive(42) is True
+
+    kernel32.CloseHandle.assert_called_once_with(1234)
+
+
 def test_process_identity_alive_uses_windows_api_instead_of_kill(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -113,4 +135,18 @@ def test_process_identity_alive_preserves_posix_kill_behavior(
     monkeypatch.setattr(heartbeat.os, "kill", kill)
 
     assert heartbeat.is_process_identity_alive(42) is expected
+    kill.assert_called_once_with(42, 0)
+
+
+def test_process_identity_alive_preserves_unexpected_posix_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(heartbeat.os, "name", "posix")
+    error = OSError("unexpected signal-zero failure")
+    kill = Mock(side_effect=error)
+    monkeypatch.setattr(heartbeat.os, "kill", kill)
+
+    with pytest.raises(OSError, match="unexpected signal-zero failure"):
+        heartbeat.is_process_identity_alive(42)
+
     kill.assert_called_once_with(42, 0)


### PR DESCRIPTION
## Summary

Fix the remaining Windows heartbeat liveness path that calls `os.kill(pid, 0)` and raises `OSError: [WinError 87]` during MCP startup cleanup.

The Windows implementation now opens the process with `PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE`, checks the process object's zero-timeout wait state, and closes every opened handle. Only affirmative evidence (`WAIT_OBJECT_0` or `ERROR_INVALID_PARAMETER`) marks the owner dead; access-denied, failed waits, and unknown Win32 failures preserve the lease conservatively.

The shared MCP cleanup documentation now reflects that fail-closed contract. POSIX signal-zero behavior is unchanged.

This is the same failure class previously addressed in #121 / #123, but in the separate `orchestrator/heartbeat.py` call site.

## Exact candidate

- HEAD: `03bba45513d77427e5b21d561fc5a53d14aab64e`
- Base: `cbedda5e5a5b79e97a2d4dc0a9222a2c21fd19c9`
- Independent exact-head verifier: **PASS**, with no blocking finding reported

## Test plan

- [x] Heartbeat, MCP PID registry, persisted process identity, and job drain regression suites — 58 passed
- [x] Windows-faithful mocks cover running, terminated, invalid-PID, access-denied, failed-wait, and unknown outcomes
- [x] Handle closure is verified for normal and exceptional wait paths
- [x] POSIX signal-zero behavior, including unexpected `OSError`, remains unchanged
- [x] Ruff check and format — passed
- [x] MyPy for both changed source modules — passed
- [x] Module-size policy and diff-check — passed
- [x] Latest-main ancestry and clean worktree — passed

## Related issues

Closes #2023
Refs #121
Refs #123
