### PR TITLE
docs(zh): scope the hidden-assertion claim at the point it is made

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -390,7 +390,7 @@ src/ouroboros/
 完整设计文档见 [Architecture](./docs/architecture.md)（英文）。中文文档：
 
 - [评估流水线指南（Evaluation Pipeline）](./docs/guides/evaluation-pipeline.zh-CN.md) —— 三阶段关卡的完整参考：每个阶段验什么、阈值和配置项、失败模式与排查、以及事件审计轨迹
-- [隐藏清单收敛（Hidden-Checklist Convergence）](./docs/hidden-checklist-convergence/README.zh-CN.md) —— run → 评估 → 有预算的 Ralph 链，以及为什么判分用的断言对 worker 无条件隐藏
+- [隐藏清单收敛（Hidden-Checklist Convergence）](./docs/hidden-checklist-convergence/README.zh-CN.md) —— run → 评估 → 有预算的 Ralph 链，以及为什么判分用的断言对 worker 隐藏、且没有配置项能把它打开
 
 </details>
 


### PR DESCRIPTION
Relates to https://github.com/Q00/ouroboros/issues/2020.

`README.zh-CN.md` described the hidden-checklist doc as covering 为什么判分用的断言对 worker **无条件**隐藏.

The design doc is careful about that word. `docs/hidden-checklist-convergence/README.zh-CN.md:23` defines it explicitly:

> 这里的「无条件」指的是**没有配置项可以把它打开**，而不是说存在一个文件系统沙箱

That is accurate, and the distinction matters. But the qualifier lives at the destination, and the index line is what most readers see. Read alone, 无条件隐藏 says the assertion cannot reach the worker at all, which is a stronger claim than the code makes: redaction enumerates five encodings and replaces them literally (`orchestrator/contract_redaction.py:10`, `:42`), so a copy transformed by line wrapping, a diff prefix, or an ANSI code inside the string survives into the retry hint. That gap is #2020.

This moves the scope inline: 隐藏、且没有配置项能把它打开. Same meaning as the design doc, stated where the claim is made.

One line changed. No other content touched.

## Noticed while here, not fixed in this PR

`README.md` and `README.ko.md` do not link the hidden-checklist doc at all. `docs/README.md:52-53` lists both the English and Chinese versions, so only the top-level English and Korean READMEs are missing it. The Chinese README is ahead of the English one here, which is the reverse of the usual direction and worth a separate PR rather than widening this one.
