### PR TITLE
fix(evaluation): name the predicate in the Stage 2 failure reason

### DIFF
--- a/src/ouroboros/evaluation/models.py
+++ b/src/ouroboros/evaluation/models.py
@@ -384,31 +384,51 @@ class EvaluationResult:
 
     @property
     def failure_reason(self) -> str | None:
-        """Return the reason for failure, if any.
+        """Return the reason for failure, if any."""
+        return build_failure_reason(
+            final_approved=self.final_approved,
+            stage1_result=self.stage1_result,
+            stage2_result=self.stage2_result,
+            stage3_result=self.stage3_result,
+        )
 
-        Stage 3 is checked before Stage 2 because when Stage 3 ran,
-        it is the authoritative verdict (Stage 2 may have been bypassed
-        via trigger_consensus).
-        """
-        if self.final_approved:
-            return None
-        if self.stage1_result and not self.stage1_result.passed:
-            failed = self.stage1_result.failed_checks
-            return f"Stage 1 failed: {', '.join(c.check_type for c in failed)}"
-        if self.stage3_result and not self.stage3_result.approved:
-            return (
-                f"Stage 3 failed: Consensus not reached ({self.stage3_result.majority_ratio:.0%})"
-            )
-        if self.stage2_result and not self.stage2_result.ac_compliance:
-            return f"Stage 2 failed: AC non-compliance (score={self.stage2_result.score:.2f})"
-        if (
-            self.stage2_result
-            and self.stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
-        ):
-            return (
-                "Stage 2 veto: reward-hacking risk "
-                f"{self.stage2_result.reward_hacking_risk:.2f} >= "
-                f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game the "
-                "evaluator rather than solve the real task"
-            )
-        return "Unknown failure"
+
+def build_failure_reason(
+    *,
+    final_approved: bool,
+    stage1_result: MechanicalResult | None,
+    stage2_result: SemanticResult | None,
+    stage3_result: ConsensusResult | None,
+) -> str | None:
+    """Return why an evaluation was rejected, or ``None`` when it passed.
+
+    Stage 3 is checked before Stage 2 because when Stage 3 ran, it is the
+    authoritative verdict (Stage 2 may have been bypassed via
+    ``trigger_consensus``).
+
+    The Stage 2 branch names ``ac_compliance`` explicitly. That boolean is the
+    gate; the semantic score is reported for context and does not decide this
+    branch, so a run can be rejected here while its score reads well above the
+    0.8 used at the approval site.
+    """
+    if final_approved:
+        return None
+    if stage1_result and not stage1_result.passed:
+        failed = stage1_result.failed_checks
+        return f"Stage 1 failed: {', '.join(c.check_type for c in failed)}"
+    if stage3_result and not stage3_result.approved:
+        return f"Stage 3 failed: Consensus not reached ({stage3_result.majority_ratio:.0%})"
+    if stage2_result and not stage2_result.ac_compliance:
+        return (
+            "Stage 2 failed: AC non-compliance "
+            f"(ac_compliance=false; semantic score {stage2_result.score:.2f} "
+            "did not gate this)"
+        )
+    if stage2_result and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD:
+        return (
+            "Stage 2 veto: reward-hacking risk "
+            f"{stage2_result.reward_hacking_risk:.2f} >= "
+            f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game the "
+            "evaluator rather than solve the real task"
+        )
+    return "Unknown failure"

--- a/src/ouroboros/evaluation/models.py
+++ b/src/ouroboros/evaluation/models.py
@@ -31,6 +31,11 @@ from ouroboros.events.base import BaseEvent
 # without a models<->pipeline import cycle.  pipeline.py imports this.
 REWARD_HACKING_VETO_THRESHOLD = 0.7
 
+# Minimum Stage 2 score for approval when no consensus ran.  Shared with
+# ``pipeline.py`` so the gate and the failure reason that has to name it
+# cannot drift apart.
+SEMANTIC_APPROVAL_SCORE = 0.8
+
 
 class VoterRole(StrEnum):
     """Roles in deliberative consensus.
@@ -402,20 +407,51 @@ def build_failure_reason(
 ) -> str | None:
     """Return why an evaluation was rejected, or ``None`` when it passed.
 
+    Branches are ordered by which gate actually decided, not by stage number.
+
+    The reward-hacking veto is applied last in the pipeline and only ever
+    flips approve to reject, so it is the deciding gate exactly when the
+    result would otherwise have been approved.  That has to be reconstructed
+    here because this function sees ``final_approved`` after the veto has
+    already been applied.  Without it, a run that Stage 3 approved and the
+    veto then rejected reports Stage 2 non-compliance, naming a gate that
+    did not decide anything.
+
     Stage 3 is checked before Stage 2 because when Stage 3 ran, it is the
     authoritative verdict (Stage 2 may have been bypassed via
     ``trigger_consensus``).
 
-    The Stage 2 branch names ``ac_compliance`` explicitly. That boolean is the
-    gate; the semantic score is reported for context and does not decide this
-    branch, so a run can be rejected here while its score reads well above the
-    0.8 used at the approval site.
+    The Stage 2 branches name their predicate.  ``ac_compliance`` is a
+    boolean and the semantic score is a separate gate, so a run can be
+    rejected by either while the other reads fine.
     """
     if final_approved:
         return None
     if stage1_result and not stage1_result.passed:
         failed = stage1_result.failed_checks
         return f"Stage 1 failed: {', '.join(c.check_type for c in failed)}"
+
+    # What approval would have been, had the veto not run.
+    if stage3_result is not None:
+        approved_before_veto = stage3_result.approved
+    elif stage2_result is not None:
+        approved_before_veto = (
+            stage2_result.ac_compliance and stage2_result.score >= SEMANTIC_APPROVAL_SCORE
+        )
+    else:
+        approved_before_veto = True
+
+    if (
+        stage2_result
+        and approved_before_veto
+        and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
+    ):
+        return (
+            "Stage 2 veto: reward-hacking risk "
+            f"{stage2_result.reward_hacking_risk:.2f} >= "
+            f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game the "
+            "evaluator rather than solve the real task"
+        )
     if stage3_result and not stage3_result.approved:
         return f"Stage 3 failed: Consensus not reached ({stage3_result.majority_ratio:.0%})"
     if stage2_result and not stage2_result.ac_compliance:
@@ -424,11 +460,10 @@ def build_failure_reason(
             f"(ac_compliance=false; semantic score {stage2_result.score:.2f} "
             "did not gate this)"
         )
-    if stage2_result and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD:
+    if stage2_result and stage2_result.score < SEMANTIC_APPROVAL_SCORE:
         return (
-            "Stage 2 veto: reward-hacking risk "
-            f"{stage2_result.reward_hacking_risk:.2f} >= "
-            f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game the "
-            "evaluator rather than solve the real task"
+            "Stage 2 failed: semantic score "
+            f"{stage2_result.score:.2f} < {SEMANTIC_APPROVAL_SCORE:.2f} "
+            "(ac_compliance=true; the score gate decided this)"
         )
     return "Unknown failure"

--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -23,6 +23,7 @@ from ouroboros.evaluation.models import (
     EvaluationContext,
     EvaluationResult,
     MechanicalResult,
+    build_failure_reason,
 )
 from ouroboros.evaluation.semantic import SemanticConfig, SemanticEvaluator
 from ouroboros.evaluation.trigger import (
@@ -299,34 +300,15 @@ class EvaluationPipeline:
         if stage3_result is not None:
             highest_stage = 3
 
-        # Calculate failure reason before creating immutable result.
-        # Stage 3 is checked before Stage 2 because when Stage 3 ran,
-        # it is the authoritative verdict (Stage 2 may have been bypassed
-        # via trigger_consensus).
-        failure_reason: str | None = None
-        if not final_approved:
-            if stage1_result and not stage1_result.passed:
-                failed = stage1_result.failed_checks
-                failure_reason = f"Stage 1 failed: {', '.join(c.check_type for c in failed)}"
-            elif stage3_result and not stage3_result.approved:
-                failure_reason = (
-                    f"Stage 3 failed: Consensus not reached ({stage3_result.majority_ratio:.0%})"
-                )
-            elif stage2_result and not stage2_result.ac_compliance:
-                failure_reason = (
-                    f"Stage 2 failed: AC non-compliance (score={stage2_result.score:.2f})"
-                )
-            elif (
-                stage2_result and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
-            ):
-                failure_reason = (
-                    "Stage 2 veto: reward-hacking risk "
-                    f"{stage2_result.reward_hacking_risk:.2f} >= "
-                    f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game "
-                    "the evaluator rather than solve the real task"
-                )
-            else:
-                failure_reason = "Unknown failure"
+        # Calculate failure reason before creating immutable result.  Shared
+        # with ``EvaluationResult.failure_reason`` so the two surfaces cannot
+        # drift: this one is built before the result exists, that one after.
+        failure_reason = build_failure_reason(
+            final_approved=final_approved,
+            stage1_result=stage1_result,
+            stage2_result=stage2_result,
+            stage3_result=stage3_result,
+        )
 
         # Create completion event
         completion_event = create_pipeline_completed_event(

--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -19,6 +19,7 @@ from ouroboros.evaluation.mechanical import (
 )
 from ouroboros.evaluation.models import (
     REWARD_HACKING_VETO_THRESHOLD,
+    SEMANTIC_APPROVAL_SCORE,
     CheckType,
     EvaluationContext,
     EvaluationResult,
@@ -246,7 +247,9 @@ class EvaluationPipeline:
         # here — this branch only decides the Stage 2 pass conditions.
         final_approved = True
         if stage2_result:
-            final_approved = stage2_result.ac_compliance and stage2_result.score >= 0.8
+            final_approved = (
+                stage2_result.ac_compliance and stage2_result.score >= SEMANTIC_APPROVAL_SCORE
+            )
 
         return self._build_result(
             context.execution_id,

--- a/tests/unit/evaluation/test_failure_reason_gates.py
+++ b/tests/unit/evaluation/test_failure_reason_gates.py
@@ -1,0 +1,118 @@
+"""The failure reason must name the gate that actually decided.
+
+Three gates can reject a run and two of them can be true at once, so the
+branch order carries meaning. These cases pin the ones where naming the
+wrong gate sends an operator to the wrong place.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.evaluation.models import (
+    REWARD_HACKING_VETO_THRESHOLD,
+    SEMANTIC_APPROVAL_SCORE,
+    ConsensusResult,
+    SemanticResult,
+    Vote,
+    build_failure_reason,
+)
+
+
+def semantic(score: float, ac_compliance: bool, risk: float = 0.0) -> SemanticResult:
+    """Build a Stage 2 result varying only the fields the gates read."""
+    return SemanticResult(
+        score=score,
+        ac_compliance=ac_compliance,
+        goal_alignment=0.9,
+        drift_score=0.1,
+        uncertainty=0.1,
+        reasoning="fixture",
+        reward_hacking_risk=risk,
+    )
+
+
+def consensus(approved: bool, ratio: float = 1.0) -> ConsensusResult:
+    """Build a Stage 3 result with one vote matching the verdict."""
+    return ConsensusResult(
+        approved=approved,
+        votes=(Vote(model="m", approved=approved, confidence=0.9, reasoning="fixture"),),
+        majority_ratio=ratio,
+    )
+
+
+def rejected(**kwargs: object) -> str:
+    """Call the builder for a rejected run and assert it produced a reason."""
+    reason = build_failure_reason(final_approved=False, stage1_result=None, **kwargs)  # type: ignore[arg-type]
+    assert reason is not None
+    return reason
+
+
+def test_veto_overriding_an_approving_consensus_names_the_veto() -> None:
+    """The veto decided, so non-compliance must not take the credit.
+
+    Stage 3 approved, the veto flipped it, and Stage 2 also happens to be
+    non-compliant. Reporting non-compliance here names a gate that did not
+    decide, because the pipeline had already moved past Stage 2.
+    """
+    reason = rejected(
+        stage2_result=semantic(0.92, ac_compliance=False, risk=0.95),
+        stage3_result=consensus(True),
+    )
+
+    assert reason.startswith("Stage 2 veto:")
+    assert "AC non-compliance" not in reason
+
+
+def test_score_gate_rejection_is_named_rather_than_unknown() -> None:
+    """``ac_compliance`` passes and the score gate rejects, with no consensus."""
+    reason = rejected(
+        stage2_result=semantic(SEMANTIC_APPROVAL_SCORE - 0.01, ac_compliance=True),
+        stage3_result=None,
+    )
+
+    assert "semantic score" in reason
+    assert f"{SEMANTIC_APPROVAL_SCORE:.2f}" in reason
+    assert reason != "Unknown failure"
+
+
+def test_consensus_rejection_wins_over_a_high_risk_score() -> None:
+    """A rejected consensus was never approved, so the veto did not decide it."""
+    reason = rejected(
+        stage2_result=semantic(0.9, ac_compliance=True, risk=0.95),
+        stage3_result=consensus(False, ratio=0.33),
+    )
+
+    assert reason.startswith("Stage 3 failed:")
+
+
+def test_non_compliance_still_wins_when_the_veto_could_not_have_decided() -> None:
+    """Without consensus, a non-compliant Stage 2 was never approved.
+
+    The veto only flips approve to reject, so it cannot be the deciding gate
+    on a run that Stage 2 had already rejected.
+    """
+    reason = rejected(
+        stage2_result=semantic(0.92, ac_compliance=False, risk=REWARD_HACKING_VETO_THRESHOLD + 0.1),
+        stage3_result=None,
+    )
+
+    assert "AC non-compliance" in reason
+    assert not reason.startswith("Stage 2 veto:")
+
+
+@pytest.mark.parametrize(
+    ("score", "ac_compliance"),
+    [(0.92, False), (0.79, True)],
+)
+def test_approved_runs_have_no_reason(score: float, ac_compliance: bool) -> None:
+    """``final_approved`` short-circuits before any gate is inspected."""
+    assert (
+        build_failure_reason(
+            final_approved=True,
+            stage1_result=None,
+            stage2_result=semantic(score, ac_compliance=ac_compliance),
+            stage3_result=None,
+        )
+        is None
+    )


### PR DESCRIPTION
Fixes defects 3 and 4 from https://github.com/Q00/ouroboros/issues/2021.

## The message named the wrong thing

```python
elif stage2_result and not stage2_result.ac_compliance:
    failure_reason = f"Stage 2 failed: AC non-compliance (score={stage2_result.score:.2f})"
```

The gate is `ac_compliance`, a boolean the semantic evaluator returns (`evaluation/semantic.py:39`). The message printed `score`, a float that does not decide this branch. A run can therefore fail with `score=0.92` on screen, which sends the reader looking at thresholds. The score threshold is real but lives at the approval site (`pipeline.py:248`, `>= 0.8`), a different branch entirely.

Before and after, same inputs:

```
Stage 2 failed: AC non-compliance (score=0.92)
Stage 2 failed: AC non-compliance (ac_compliance=false; semantic score 0.92 did not gate this)
```

This matters most on the evolve path, where Stage 1 is off by default and Stage 3 is hardcoded off (`mcp/server/adapter.py:1890`, `:1897`), so this line is the only explanation an operator gets for a generation.

## The ladder existed twice

The identical branch order appeared in `pipeline.py` (built before the result object exists) and in `EvaluationResult.failure_reason` (built after). Same strings, same ordering, same Stage-3-before-Stage-2 rationale in both docstrings. Fixing the message in one would have left the other, which is the shape of drift this repo keeps finding.

Both now call `build_failure_reason` in `evaluation/models.py`. It lives there because `REWARD_HACKING_VETO_THRESHOLD` already does, for the same stated reason: no `models` to `pipeline` import cycle.

Net: `pipeline.py` loses 22 lines of duplicated branching.

## Not changed

- Branch order and semantics are identical. Stage 1, then Stage 3, then Stage 2 compliance, then the reward-hacking veto.
- The `"AC non-compliance"` substring is preserved, so the two existing assertions still hold (`tests/unit/evaluation/test_checklist.py:230`, `tests/unit/evaluation/test_models.py:311`).
- The root cause in #2021 (the exact-match regex at `adapter.py:558` silently downgrading every generation to the LLM fallback) is untouched. This PR only stops the resulting message from misdirecting whoever reads it.

## Verification

- `tests/unit/evaluation/` — 611 passed.
- `ruff check`, `ruff format --check`, `mypy` clean on both files.
- Confirmed by construction that a `SemanticResult(score=0.92, ac_compliance=False)` produces the new text and still contains the asserted substring, and that an approved result still returns `None`.
