### PR TITLE
fix(evolve): warn when the mechanical evaluation path is skipped

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1996,6 +1996,22 @@ def create_ouroboros_server(
 
         # Fallback: LLM-based evaluation when no structured AC results
         acs = getattr(seed, "acceptance_criteria", None)
+
+        # The mechanical path needs ``### Task N: [COMPLETED]`` markers in the
+        # worker's report.  When they are absent this silently degrades to a
+        # single model verdict covering every AC at once, and on this path
+        # Stage 1 is off by default and Stage 3 is disabled, so nothing else
+        # intervenes.  Say so rather than letting every generation look the
+        # same from the outside.
+        log.warning(
+            "evolution.evaluation.mechanical_skipped",
+            reason="no '### Task N: [COMPLETED|FAILED]' markers in execution output",
+            seed_id=getattr(seed.metadata, "seed_id", None),
+            acceptance_criteria=len(acs) if acs else 0,
+            artifact_chars=len(artifact),
+            consequence=("falling back to one LLM verdict over all acceptance criteria combined"),
+        )
+
         if acs:
             current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(ac_texts(acs)))
         else:


### PR DESCRIPTION
Fixes defect 1 from https://github.com/Q00/ouroboros/issues/2021, which is the one I flagged there as highest value: the failure is silent, so nobody can see it happening.

## What is silent

`_evaluate_mechanically` is `_parse_legacy_execution_task_summary` (`mcp/server/adapter.py:547`), which matches one regex against the worker's report:

```python
r"### (?:Task|AC) (\d+): \[(COMPLETED|FAILED|PASS|FAIL)\]\s*(.*)"
```

No match returns `None`, and `_evolution_evaluator` moves on to the LLM fallback. Nothing logs it. The regex requires exact casing, brackets, and spacing from model-written prose, so ordinary drift in the report format takes every generation down this path.

Checked by running the pattern rather than reading it:

| Execution output | Mechanical path |
|---|---|
| `### Task 1: [COMPLETED] did the thing` | engages |
| `### AC 2: [PASS] ok` | engages |
| `I finished the task. All acceptance criteria are met.` | skipped |
| `## Task 1: COMPLETED` | skipped |

## Why it matters more here than it looks

The fallback folds every acceptance criterion into one string (`adapter.py:2000`) and asks for a single `ac_compliance` boolean (`evaluation/semantic.py:39`). On this path Stage 1 is off by default (`adapter.py:1890`, env `OUROBOROS_EVOLVE_STAGE1`) and Stage 3 is hardcoded off (`:1897`), so that one boolean is the entire acceptance surface for the generation. Losing the mechanical check is not a small downgrade here, and from the outside a degraded run looks exactly like a normal one.

## The change

One `log.warning` at the point of the downgrade, following the existing shape of `evolution.validation.skipped` a few functions up (`adapter.py:2059`):

```python
log.warning(
    "evolution.evaluation.mechanical_skipped",
    reason="no '### Task N: [COMPLETED|FAILED]' markers in execution output",
    seed_id=...,
    acceptance_criteria=len(acs) if acs else 0,
    artifact_chars=len(artifact),
    consequence="falling back to one LLM verdict over all acceptance criteria combined",
)
```

`acceptance_criteria` is included because the count is what makes the fallback fragile: one boolean has to cover all of them, so a run with twelve criteria is far likelier to come back false than a run with two. `artifact_chars` separates "the worker wrote nothing useful" from "the worker wrote plenty in the wrong format".

16 lines added, nothing removed, no behavior change. This does not fix the fragile coupling, it makes it visible. Deciding whether to relax the parser, emit the markers reliably, or grade per criterion is the larger call in #2021.

## Verification

- `ruff check`, `ruff format --check`, `mypy` clean on the file.
- `tests/unit/mcp` cannot collect in my environment (`ModuleNotFoundError: No module named 'mcp'`, the `[mcp]` extra is not installed locally). I confirmed this is pre-existing by stashing the change and re-running on clean `main`: identical 3 collection errors. CI installs the extra, so this will exercise there.
