### PR TITLE
fix(evolve): evaluate semantic fallback per criterion

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1565,12 +1565,7 @@ def create_ouroboros_server(
         load_config,
     )
     from ouroboros.core.errors import ConfigError
-    from ouroboros.evaluation import (
-        EvaluationContext,
-        EvaluationPipeline,
-        PipelineConfig,
-        SemanticConfig,
-    )
+    from ouroboros.evaluation import EvaluationPipeline, PipelineConfig, SemanticConfig
     from ouroboros.mcp.job_manager import JobManager
     from ouroboros.mcp.resources.handlers import (
         EventsResourceHandler,
@@ -1802,6 +1797,10 @@ def create_ouroboros_server(
     from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
     from ouroboros.evolution.reflect import ReflectEngine
     from ouroboros.evolution.wonder import WonderEngine
+    from ouroboros.mcp.server.evolve_evaluation import (
+        evaluate_seed_criteria,
+        warn_if_seed_has_no_success_contract,
+    )
     from ouroboros.verification.extractor import AssertionExtractor
     from ouroboros.verification.verifier import SpecVerifier
 
@@ -2012,6 +2011,7 @@ def create_ouroboros_server(
 
     async def _evolution_evaluator(seed: Any, execution_output: str | None) -> EvaluationSummary:
         await _ensure_evolution_store_initialized()
+        warn_if_seed_has_no_success_contract(seed)
 
         artifact = execution_output or ""
         if not artifact.strip():
@@ -2037,10 +2037,9 @@ def create_ouroboros_server(
         acs = getattr(seed, "acceptance_criteria", None)
 
         # The mechanical path needs ``### Task N: [COMPLETED]`` markers in the
-        # worker's report.  When they are absent this silently degrades to a
-        # single model verdict covering every AC at once, and on this path
-        # Stage 1 is off by default and Stage 3 is disabled, so nothing else
-        # intervenes.  Say so rather than letting every generation look the
+        # worker's report.  When they are absent this degrades to semantic
+        # evaluation, and on this path Stage 1 is off by default and Stage 3
+        # is disabled. Say so rather than letting every generation look the
         # same from the outside.
         log.warning(
             "evolution.evaluation.mechanical_skipped",
@@ -2048,48 +2047,17 @@ def create_ouroboros_server(
             seed_id=getattr(seed.metadata, "seed_id", None),
             acceptance_criteria=len(acs) if acs else 0,
             artifact_chars=len(artifact),
-            consequence=("falling back to one LLM verdict over all acceptance criteria combined"),
+            consequence="falling back to independent semantic verdicts for each criterion",
         )
-
-        if acs:
-            current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(ac_texts(acs)))
-        else:
-            current_ac = "Verify execution output meets requirements"
 
         # Collect file-based artifacts for richer evaluation
         project_dir = _extract_project_dir(artifact, seed=seed)
         artifact_bundle = ArtifactCollector().collect(artifact, project_dir)
-
-        eval_context = EvaluationContext(
-            execution_id=f"eval_{seed.metadata.seed_id}",
-            seed_id=seed.metadata.seed_id,
-            current_ac=current_ac,
+        return await evaluate_seed_criteria(
+            seed=seed,
             artifact=artifact,
-            artifact_type="code",
-            goal=seed.goal,
-            constraints=tuple(seed.constraints),
             artifact_bundle=artifact_bundle,
-        )
-
-        eval_result = await evolution_eval_pipeline.evaluate(eval_context)
-        if eval_result.is_err:
-            return EvaluationSummary(
-                final_approved=False,
-                highest_stage_passed=1,
-                score=0.0,
-                drift_score=1.0,
-                failure_reason=str(eval_result.error),
-            )
-
-        result = eval_result.value
-        stage2 = result.stage2_result
-        return EvaluationSummary(
-            final_approved=result.final_approved,
-            highest_stage_passed=max(1, result.highest_stage_completed),
-            score=stage2.score if stage2 else None,
-            drift_score=stage2.drift_score if stage2 else None,
-            reward_hacking_risk=stage2.reward_hacking_risk if stage2 else None,
-            failure_reason=result.failure_reason,
+            pipeline=evolution_eval_pipeline,
         )
 
     async def _evolution_validator(seed: Any, execution_output: str | None) -> str:

--- a/src/ouroboros/mcp/server/evolve_evaluation.py
+++ b/src/ouroboros/mcp/server/evolve_evaluation.py
@@ -1,0 +1,199 @@
+"""Semantic fallback evaluation for evolve generations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.seed import AcceptanceCriterionSpec, ac_text
+from ouroboros.evaluation.models import EvaluationContext, EvaluationResult
+
+log = structlog.get_logger(__name__)
+
+
+def warn_if_seed_has_no_success_contract(seed: Any) -> None:
+    """Expose when evolve has no fixed, structured verification anchor."""
+    criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+    if any(
+        isinstance(criterion, AcceptanceCriterionSpec) and criterion.has_success_contract
+        for criterion in criteria
+    ):
+        return
+
+    metadata = getattr(seed, "metadata", None)
+    log.warning(
+        "evolution.acceptance_contract.unstructured",
+        seed_id=getattr(metadata, "seed_id", None),
+        acceptance_criteria=len(criteria),
+        consequence=(
+            (
+                "no AC declares verify_command, expected_artifacts, or output_assertion; "
+                "evolve has no fixed structured verification anchor"
+            )
+            if criteria
+            else "the Seed declares no acceptance criteria; evolve cannot establish coverage"
+        ),
+    )
+
+
+def _rejected_summary(reason: str) -> EvaluationSummary:
+    return EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=1,
+        score=0.0,
+        drift_score=1.0,
+        failure_reason=reason,
+        approval_status="rejected",
+        execution_completion_status="completed",
+    )
+
+
+def _render_evidence(result: EvaluationResult) -> str:
+    stage2 = result.stage2_result
+    if stage2 is None:
+        return result.failure_reason or "Evaluation did not produce a semantic verdict."
+    parts = [*stage2.evidence]
+    if stage2.reasoning and stage2.reasoning not in parts:
+        parts.append(stage2.reasoning)
+    if result.failure_reason and result.failure_reason not in parts:
+        parts.append(result.failure_reason)
+    return "; ".join(parts) or "Semantic evaluation produced no evidence details."
+
+
+def _failure_reason(
+    criteria: tuple[Any, ...],
+    results: tuple[EvaluationResult, ...],
+) -> str | None:
+    failed = [
+        (
+            index,
+            ac_text(criterion),
+            (
+                result.failure_reason
+                if result.stage2_result is not None
+                else "semantic evaluation did not run"
+            ),
+        )
+        for index, (criterion, result) in enumerate(zip(criteria, results, strict=True), start=1)
+        if result.stage2_result is None or not result.final_approved
+    ]
+    if not failed:
+        return None
+    details = "; ".join(
+        f"AC {index} ({content}): {reason or 'semantic evaluation rejected this criterion'}"
+        for index, content, reason in failed
+    )
+    return f"{len(failed)}/{len(criteria)} acceptance criteria failed: {details}"
+
+
+async def evaluate_seed_criteria(
+    *,
+    seed: Any,
+    artifact: str,
+    artifact_bundle: Any,
+    pipeline: Any,
+) -> EvaluationSummary:
+    """Evaluate evolve's semantic fallback once per acceptance criterion."""
+    criteria = tuple(getattr(seed, "acceptance_criteria", ()) or ())
+    metadata = getattr(seed, "metadata", None)
+    seed_id = str(getattr(metadata, "seed_id", "unknown"))
+    goal = str(getattr(seed, "goal", ""))
+    constraints = tuple(getattr(seed, "constraints", ()) or ())
+
+    if not criteria:
+        return _rejected_summary(
+            "Seed has no acceptance criteria; semantic evaluation cannot establish coverage"
+        )
+
+    def context_for(index: int, criterion: Any) -> EvaluationContext:
+        return EvaluationContext(
+            execution_id=f"eval_{seed_id}_ac_{index + 1}",
+            seed_id=seed_id,
+            current_ac=ac_text(criterion),
+            current_ac_spec=(criterion if isinstance(criterion, AcceptanceCriterionSpec) else None),
+            artifact=artifact,
+            artifact_type="code",
+            goal=goal,
+            constraints=constraints,
+            artifact_bundle=artifact_bundle,
+        )
+
+    try:
+        first = await pipeline.evaluate(context_for(0, criteria[0]))
+    except Exception as exc:
+        return _rejected_summary(f"AC 1 evaluation raised {type(exc).__name__}: {exc}")
+    if first.is_err:
+        return _rejected_summary(f"AC 1 evaluation failed: {first.error}")
+
+    shared_stage1 = first.value.stage1_result
+
+    async def evaluate_one(index: int, criterion: Any) -> Any:
+        return await pipeline.evaluate(
+            context_for(index, criterion),
+            stage1_result=shared_stage1,
+        )
+
+    remaining = await asyncio.gather(
+        *(evaluate_one(index, criterion) for index, criterion in enumerate(criteria[1:], start=1)),
+        return_exceptions=True,
+    )
+    gathered = (first, *remaining)
+    for index, entry in enumerate(gathered, start=1):
+        if isinstance(entry, BaseException):
+            return _rejected_summary(
+                f"AC {index} evaluation raised {type(entry).__name__}: {entry}"
+            )
+        if entry.is_err:
+            return _rejected_summary(f"AC {index} evaluation failed: {entry.error}")
+
+    results = tuple(entry.value for entry in gathered)
+    stage2_results = tuple(
+        result.stage2_result for result in results if result.stage2_result is not None
+    )
+    approved = all(result.stage2_result is not None and result.final_approved for result in results)
+    scores = tuple(result.score for result in stage2_results)
+    drift_scores = tuple(result.drift_score for result in stage2_results)
+    reward_hacking_risks = tuple(result.reward_hacking_risk for result in stage2_results)
+    ac_results = tuple(
+        ACResult(
+            ac_index=index,
+            ac_content=ac_text(criterion),
+            semantic_ac_key=getattr(criterion, "semantic_ac_key", None),
+            passed=result.stage2_result is not None and result.final_approved,
+            score=result.stage2_result.score if result.stage2_result else 0.0,
+            evidence=_render_evidence(result),
+            verification_method=(
+                "semantic_evaluation" if result.stage2_result is not None else "unknown"
+            ),
+            ac_verdict_state=("evaluated" if result.stage2_result is not None else "not_evaluated"),
+            final_verdict=(
+                "pass" if result.stage2_result is not None and result.final_approved else "fail"
+            ),
+            rendered_verdict=(
+                "PASS"
+                if result.stage2_result is not None and result.final_approved
+                else "FAIL"
+                if result.stage2_result is not None
+                else "NOT_EVALUATED"
+            ),
+        )
+        for index, (criterion, result) in enumerate(zip(criteria, results, strict=True))
+    )
+
+    return EvaluationSummary(
+        final_approved=approved,
+        highest_stage_passed=min(max(1, result.highest_stage_completed) for result in results),
+        score=sum(scores) / len(scores) if scores else 0.0,
+        drift_score=max(drift_scores) if drift_scores else None,
+        reward_hacking_risk=max(reward_hacking_risks) if reward_hacking_risks else None,
+        failure_reason=_failure_reason(criteria, results),
+        ac_results=ac_results,
+        approval_status="approved" if approved else "rejected",
+        execution_completion_status="completed",
+    )
+
+
+__all__ = ["evaluate_seed_criteria", "warn_if_seed_has_no_success_contract"]

--- a/tests/unit/mcp/server/test_evolve_evaluation.py
+++ b/tests/unit/mcp/server/test_evolve_evaluation.py
@@ -1,0 +1,251 @@
+"""Regression tests for evolve's semantic fallback."""
+
+from typing import Any
+
+import pytest
+from structlog.testing import capture_logs
+
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import EvaluationResult, MechanicalResult, SemanticResult
+from ouroboros.mcp.server.evolve_evaluation import (
+    evaluate_seed_criteria,
+    warn_if_seed_has_no_success_contract,
+)
+
+
+class _Pipeline:
+    def __init__(self, verdicts: tuple[bool, ...]) -> None:
+        self.verdicts = verdicts
+        self.contexts: list[Any] = []
+
+    async def evaluate(self, context: Any, *, stage1_result: Any = None) -> Any:
+        del stage1_result
+        self.contexts.append(context)
+        index = int(context.execution_id.rsplit("_", 1)[-1]) - 1
+        passed = self.verdicts[index]
+        semantic = SemanticResult(
+            score=0.9 if passed else 0.4,
+            ac_compliance=passed,
+            goal_alignment=0.9,
+            drift_score=0.1 if passed else 0.6,
+            uncertainty=0.1,
+            reasoning=f"criterion {index + 1} {'passed' if passed else 'failed'}",
+            reward_hacking_risk=0.0,
+            evidence=(f"evidence-{index + 1}",),
+        )
+        return Result.ok(
+            EvaluationResult(
+                execution_id=context.execution_id,
+                stage2_result=semantic,
+                final_approved=passed,
+            )
+        )
+
+
+class _NoSemanticPipeline:
+    def __init__(
+        self,
+        *,
+        final_approved: bool,
+        stage1_result: MechanicalResult | None = None,
+    ) -> None:
+        self.final_approved = final_approved
+        self.stage1_result = stage1_result
+        self.contexts: list[Any] = []
+        self.injected_stage1: list[MechanicalResult | None] = []
+
+    async def evaluate(self, context: Any, *, stage1_result: Any = None) -> Any:
+        self.contexts.append(context)
+        self.injected_stage1.append(stage1_result)
+        effective_stage1 = self.stage1_result if stage1_result is None else stage1_result
+        return Result.ok(
+            EvaluationResult(
+                execution_id=context.execution_id,
+                stage1_result=effective_stage1,
+                final_approved=self.final_approved,
+            )
+        )
+
+
+def _seed(*criteria: AcceptanceCriterionSpec) -> Seed:
+    return Seed(
+        metadata=SeedMetadata(seed_id="seed_regression"),
+        acceptance_criteria=criteria,
+        goal="Ship the requested behavior",
+        constraints=("Preserve compatibility",),
+        ontology_schema=OntologySchema(
+            name="Regression",
+            description="Regression-test ontology",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fallback_evaluates_each_acceptance_criterion_independently() -> None:
+    seed = _seed(
+        AcceptanceCriterionSpec(description="first behavior"),
+        AcceptanceCriterionSpec(description="second behavior"),
+        AcceptanceCriterionSpec(description="third behavior"),
+    )
+    pipeline = _Pipeline((True, False, True))
+
+    summary = await evaluate_seed_criteria(
+        seed=seed,
+        artifact="worker report without legacy task markers",
+        artifact_bundle=None,
+        pipeline=pipeline,
+    )
+
+    assert [context.current_ac for context in pipeline.contexts] == [
+        "first behavior",
+        "second behavior",
+        "third behavior",
+    ]
+    assert [context.current_ac_spec for context in pipeline.contexts] == list(
+        seed.acceptance_criteria
+    )
+    assert [result.passed for result in summary.ac_results] == [True, False, True]
+    assert summary.final_approved is False
+    assert "1/3 acceptance criteria failed" in (summary.failure_reason or "")
+    assert "AC 2 (second behavior)" in (summary.failure_reason or "")
+    assert "first behavior" not in (summary.failure_reason or "")
+
+
+@pytest.mark.asyncio
+async def test_fallback_approves_only_when_every_criterion_passes() -> None:
+    seed = _seed(
+        AcceptanceCriterionSpec(description="first behavior"),
+        AcceptanceCriterionSpec(description="second behavior"),
+    )
+
+    summary = await evaluate_seed_criteria(
+        seed=seed,
+        artifact="worker report without legacy task markers",
+        artifact_bundle=None,
+        pipeline=_Pipeline((True, True)),
+    )
+
+    assert summary.final_approved is True
+    assert summary.approval_status == "approved"
+    assert summary.failure_reason is None
+    assert all(result.verdict_is_authoritative for result in summary.ac_results)
+
+
+def test_prose_only_acceptance_contract_emits_structural_warning() -> None:
+    seed = _seed(
+        AcceptanceCriterionSpec(description="first behavior"),
+        AcceptanceCriterionSpec(description="second behavior"),
+    )
+
+    with capture_logs() as logs:
+        warn_if_seed_has_no_success_contract(seed)
+
+    assert logs == [
+        {
+            "event": "evolution.acceptance_contract.unstructured",
+            "log_level": "warning",
+            "seed_id": "seed_regression",
+            "acceptance_criteria": 2,
+            "consequence": (
+                "no AC declares verify_command, expected_artifacts, or output_assertion; "
+                "evolve has no fixed structured verification anchor"
+            ),
+        }
+    ]
+
+
+def test_any_structured_contract_suppresses_structural_warning() -> None:
+    seed = _seed(
+        AcceptanceCriterionSpec(description="first behavior"),
+        AcceptanceCriterionSpec(description="second behavior", verify_command="pytest -q"),
+    )
+
+    with capture_logs() as logs:
+        warn_if_seed_has_no_success_contract(seed)
+
+    assert logs == []
+
+
+@pytest.mark.asyncio
+async def test_stage1_failure_never_becomes_authoritative_semantic_verdict() -> None:
+    seed = _seed(
+        AcceptanceCriterionSpec(description="first behavior"),
+        AcceptanceCriterionSpec(description="second behavior"),
+    )
+    stage1_failure = MechanicalResult(passed=False, checks=())
+    pipeline = _NoSemanticPipeline(final_approved=False, stage1_result=stage1_failure)
+
+    summary = await evaluate_seed_criteria(
+        seed=seed,
+        artifact="worker report without legacy task markers",
+        artifact_bundle=None,
+        pipeline=pipeline,
+    )
+
+    assert pipeline.injected_stage1 == [None, stage1_failure]
+    assert summary.final_approved is False
+    assert [result.ac_verdict_state for result in summary.ac_results] == [
+        "not_evaluated",
+        "not_evaluated",
+    ]
+    assert [result.rendered_verdict for result in summary.ac_results] == [
+        "NOT_EVALUATED",
+        "NOT_EVALUATED",
+    ]
+    assert not any(result.verdict_is_authoritative for result in summary.ac_results)
+    assert "AC 1 (first behavior): semantic evaluation did not run" in (
+        summary.failure_reason or ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_stage2_result_cannot_mint_authoritative_pass() -> None:
+    seed = _seed(AcceptanceCriterionSpec(description="first behavior"))
+
+    summary = await evaluate_seed_criteria(
+        seed=seed,
+        artifact="worker report without legacy task markers",
+        artifact_bundle=None,
+        pipeline=_NoSemanticPipeline(final_approved=True),
+    )
+
+    assert summary.final_approved is False
+    assert summary.approval_status == "rejected"
+    assert summary.ac_results[0].passed is False
+    assert summary.ac_results[0].ac_verdict_state == "not_evaluated"
+    assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+    assert summary.ac_results[0].verdict_is_authoritative is False
+
+
+@pytest.mark.asyncio
+async def test_zero_ac_seed_fails_closed_without_synthetic_coverage() -> None:
+    seed = _seed()
+    pipeline = _Pipeline(())
+
+    with capture_logs() as logs:
+        warn_if_seed_has_no_success_contract(seed)
+    summary = await evaluate_seed_criteria(
+        seed=seed,
+        artifact="worker report without legacy task markers",
+        artifact_bundle=None,
+        pipeline=pipeline,
+    )
+
+    assert pipeline.contexts == []
+    assert summary.final_approved is False
+    assert summary.ac_results == ()
+    assert summary.approval_status == "rejected"
+    assert summary.failure_reason == (
+        "Seed has no acceptance criteria; semantic evaluation cannot establish coverage"
+    )
+    assert logs[0]["event"] == "evolution.acceptance_contract.unstructured"
+    assert logs[0]["acceptance_criteria"] == 0
+    assert logs[0]["consequence"] == (
+        "the Seed declares no acceptance criteria; evolve cannot establish coverage"
+    )


### PR DESCRIPTION
## Summary

- Evaluate fallback semantics independently for every acceptance criterion instead of broadcasting one verdict.
- Reuse Stage 1 once while preserving criterion-specific Stage 2 context and evidence.
- Fail closed when Stage 2 did not run or when a Seed has zero acceptance criteria.

## Changes

- Add authoritative per-criterion ACResult construction and all-of approval.
- Add structural warnings for prose-only or empty acceptance-criteria contracts.
- Add adversarial regressions for Stage 1 failure, absent Stage 2, zero criteria, mixed verdicts, and exception aggregation.

## Verification

- Independent exact-head verifier: PASS, blocker count 0.
- Related verification: 372 passed.
- Ruff, format, MyPy, module-size, diff-check, clean ancestry: PASS.

Fixes #2021

Merge freeze remains until same-head CI is fully green and the official review body explicitly recommends Approve/Merge.