### PR TITLE
feat(cli): add installation surface doctor

### DIFF
--- a/src/ouroboros/cli/commands/doctor.py
+++ b/src/ouroboros/cli/commands/doctor.py
@@ -1,0 +1,505 @@
+"""General Ouroboros diagnostic commands."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from rich.console import Console
+from rich.markup import escape
+import typer
+
+from ouroboros import __version__
+from ouroboros.cli.commands.update import _compare_versions
+from ouroboros.codex.home import resolve_codex_home
+
+Status = Literal["pass", "warn", "fail"]
+
+app = typer.Typer(
+    name="doctor",
+    help="Run read-only diagnostics for Ouroboros installations.",
+    no_args_is_help=True,
+)
+
+_SYMBOLS: dict[Status, str] = {
+    "pass": "[green]OK[/green]",
+    "warn": "[yellow]WARN[/yellow]",
+    "fail": "[red]FAIL[/red]",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class InstallSurface:
+    """One observed installation or integration surface."""
+
+    name: str
+    status: Status
+    message: str
+    path: str | None = None
+    version: str | None = None
+    expected_version: str | None = None
+    launcher: str | None = None
+    remediation: str | None = None
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, str(exc)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc.msg} at line {exc.lineno} column {exc.colno}"
+    if not isinstance(parsed, dict):
+        return None, "expected a JSON object"
+    return parsed, None
+
+
+def _manifest_version(path: Path) -> tuple[str | None, str | None]:
+    parsed, error = _read_json(path)
+    if error is not None:
+        return None, error
+    version = parsed.get("version") if parsed else None
+    if not isinstance(version, str) or not version:
+        return None, "manifest has no string version"
+    return version, None
+
+
+def _launcher_parts(entry: object) -> tuple[str | None, list[str] | None, str | None]:
+    if not isinstance(entry, dict):
+        return None, None, "launcher entry is not an object"
+    command = entry.get("command")
+    args = entry.get("args", [])
+    if not isinstance(command, str) or not command.strip():
+        return None, None, "launcher command is missing or empty"
+    if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        return None, None, "launcher args must be a list of strings"
+    return command.strip(), args, None
+
+
+def _format_launcher(entry: object) -> str | None:
+    command, args, error = _launcher_parts(entry)
+    if error is not None or command is None or args is None:
+        return None
+    return " ".join([command, *args]).strip()
+
+
+def _read_mcp_launcher(path: Path) -> tuple[str | None, str | None, str | None, list[str] | None]:
+    parsed, error = _read_json(path)
+    if error is not None:
+        return None, error, None, None
+    servers = parsed.get("mcpServers") if parsed else None
+    if not isinstance(servers, dict):
+        return None, "missing mcpServers object", None, None
+    entry = servers.get("ouroboros")
+    if entry is None:
+        return None, "missing mcpServers.ouroboros launcher", None, None
+    launcher = _format_launcher(entry)
+    command, args, parts_error = _launcher_parts(entry)
+    if launcher is None:
+        return None, parts_error or "invalid mcpServers.ouroboros launcher", None, None
+    return launcher, None, command, args
+
+
+def _version_status(version: str, expected: str) -> tuple[Status, str | None]:
+    if expected == "0.0.0":
+        return "pass", (
+            "Running package reports editable/dev version 0.0.0, so plugin "
+            "freshness is not inferred from that version string."
+        )
+    if version == expected:
+        return "pass", None
+    return "warn", (
+        "This surface version differs from the running Ouroboros package. "
+        "Update or reinstall that client integration before trusting CLI version alone."
+    )
+
+
+def _newer_version_name(left: str, right: str) -> str:
+    comparison = _compare_versions(left, right)
+    if comparison == 0:
+        return max(left, right)
+    return left if comparison > 0 else right
+
+
+def _latest_versioned_child_with(path: Path, marker: str) -> tuple[Path | None, str | None]:
+    if not path.is_dir():
+        return None, None
+    try:
+        candidates = [child for child in path.iterdir() if (child / marker).exists()]
+    except OSError as exc:
+        return None, str(exc)
+    if not candidates:
+        return None, None
+    latest = candidates[0]
+    for candidate in candidates[1:]:
+        if _newer_version_name(candidate.name, latest.name) == candidate.name:
+            latest = candidate
+    return latest, None
+
+
+def _add_manifest_surface(
+    surfaces: list[InstallSurface],
+    *,
+    name: str,
+    path: Path,
+    expected_version: str,
+    version_label: str = "plugin",
+    stale_check: bool = True,
+) -> None:
+    if not path.exists():
+        surfaces.append(
+            InstallSurface(
+                name=name,
+                status="warn",
+                message=f"{version_label} manifest not found",
+                path=str(path),
+            )
+        )
+        return
+
+    version, error = _manifest_version(path)
+    if error is not None:
+        surfaces.append(
+            InstallSurface(
+                name=name,
+                status="fail",
+                message=f"could not read {version_label} manifest: {error}",
+                path=str(path),
+            )
+        )
+        return
+
+    if stale_check:
+        status, remediation = _version_status(version or "", expected_version)
+        if status == "pass":
+            message = f"{version_label} version {version}"
+            if expected_version == "0.0.0":
+                message += " (package is editable/dev 0.0.0; stale comparison skipped)"
+        else:
+            message = f"{version_label} version {version} differs from package {expected_version}"
+    else:
+        status = "pass"
+        remediation = None
+        message = f"{version_label} version {version}"
+
+    surfaces.append(
+        InstallSurface(
+            name=name,
+            status=status,
+            message=message,
+            path=str(path),
+            version=version,
+            expected_version=expected_version if stale_check else None,
+            remediation=remediation,
+        )
+    )
+
+
+def _add_launcher_surface(
+    surfaces: list[InstallSurface],
+    *,
+    name: str,
+    path: Path,
+    require_isolated_uvx: bool = False,
+) -> None:
+    if not path.exists():
+        surfaces.append(
+            InstallSurface(
+                name=name,
+                status="warn",
+                message="MCP launcher not found",
+                path=str(path),
+            )
+        )
+        return
+
+    launcher, error, command, args = _read_mcp_launcher(path)
+    if error is not None:
+        surfaces.append(
+            InstallSurface(
+                name=name,
+                status="fail",
+                message=f"could not read MCP launcher: {error}",
+                path=str(path),
+            )
+        )
+        return
+
+    if require_isolated_uvx and not _is_claude_isolated_uvx_launcher(command, args):
+        surfaces.append(
+            InstallSurface(
+                name=name,
+                status="warn",
+                message="launcher does not use isolated uvx",
+                path=str(path),
+                launcher=launcher,
+                remediation="Update the plugin so it uses `uvx --isolated --python >=3.12`.",
+            )
+        )
+        return
+
+    surfaces.append(
+        InstallSurface(
+            name=name,
+            status="pass",
+            message="MCP launcher present",
+            path=str(path),
+            launcher=launcher,
+        )
+    )
+
+
+def _is_claude_isolated_uvx_launcher(command: str | None, args: list[str] | None) -> bool:
+    if command != "uvx" or args is None:
+        return False
+    if len(args) != 8:
+        return False
+    if args[0] != "--isolated":
+        return False
+    if args[1] != "--python" or not args[2] or args[2].startswith("-"):
+        return False
+    return args[3:] == ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]
+
+
+def _resolve_install_codex_home(home: Path | None) -> Path:
+    if os.environ.get("CODEX_HOME"):
+        return resolve_codex_home()
+    if home is not None:
+        return home / ".codex"
+    return resolve_codex_home()
+
+
+def collect_install_surfaces(home: Path | None = None) -> list[InstallSurface]:
+    """Collect read-only installation diagnostics from known user-level locations."""
+
+    resolved_home = home or Path.home()
+    expected_version = __version__
+    surfaces: list[InstallSurface] = [
+        InstallSurface(
+            name="python_package",
+            status="pass",
+            message=f"running Ouroboros package version {expected_version}",
+            version=expected_version,
+        )
+    ]
+
+    codex_manifest = resolved_home / "plugins" / "ouroboros" / ".codex-plugin" / "plugin.json"
+    _add_manifest_surface(
+        surfaces,
+        name="codex_personal_plugin",
+        path=codex_manifest,
+        expected_version=expected_version,
+    )
+
+    codex_home = _resolve_install_codex_home(home)
+    codex_cache_root = codex_home / "plugins" / "cache" / "personal" / "ouroboros"
+    codex_cache, codex_cache_error = _latest_versioned_child_with(codex_cache_root, ".mcp.json")
+    if codex_cache_error is not None:
+        surfaces.append(
+            InstallSurface(
+                name="codex_personal_plugin_launcher",
+                status="fail",
+                message=f"could not inspect Codex personal plugin cache: {codex_cache_error}",
+                path=str(codex_cache_root),
+            )
+        )
+    elif codex_cache is None:
+        surfaces.append(
+            InstallSurface(
+                name="codex_personal_plugin_launcher",
+                status="warn",
+                message="Codex personal plugin cache launcher not found",
+                path=str(codex_cache_root),
+            )
+        )
+    else:
+        _add_launcher_surface(
+            surfaces,
+            name="codex_personal_plugin_launcher",
+            path=codex_cache / ".mcp.json",
+        )
+
+    claude_manifest = (
+        resolved_home
+        / ".claude"
+        / "plugins"
+        / "marketplaces"
+        / "ouroboros"
+        / ".claude-plugin"
+        / "plugin.json"
+    )
+    _add_manifest_surface(
+        surfaces,
+        name="claude_plugin_marketplace",
+        path=claude_manifest,
+        expected_version=expected_version,
+    )
+
+    claude_cache_root = resolved_home / ".claude" / "plugins" / "cache" / "ouroboros" / "ouroboros"
+    claude_cache, claude_cache_error = _latest_versioned_child_with(claude_cache_root, ".mcp.json")
+    if claude_cache_error is not None:
+        surfaces.append(
+            InstallSurface(
+                name="claude_plugin_launcher",
+                status="fail",
+                message=f"could not inspect Claude plugin cache: {claude_cache_error}",
+                path=str(claude_cache_root),
+            )
+        )
+    elif claude_cache is None:
+        surfaces.append(
+            InstallSurface(
+                name="claude_plugin_launcher",
+                status="warn",
+                message="Claude plugin cache launcher not found",
+                path=str(claude_cache_root),
+            )
+        )
+    else:
+        _add_launcher_surface(
+            surfaces,
+            name="claude_plugin_launcher",
+            path=claude_cache / ".mcp.json",
+            require_isolated_uvx=True,
+        )
+
+    claude_user_mcp = resolved_home / ".claude" / "mcp.json"
+    if claude_user_mcp.exists():
+        parsed, error = _read_json(claude_user_mcp)
+        if error is not None:
+            surfaces.append(
+                InstallSurface(
+                    name="claude_user_mcp_duplicate",
+                    status="fail",
+                    message=f"could not read Claude user MCP config: {error}",
+                    path=str(claude_user_mcp),
+                )
+            )
+        else:
+            servers = parsed.get("mcpServers") if parsed else None
+            has_duplicate = isinstance(servers, dict) and "ouroboros" in servers
+            if has_duplicate:
+                surfaces.append(
+                    InstallSurface(
+                        name="claude_user_mcp_duplicate",
+                        status="warn",
+                        message="user-level Claude MCP also defines `ouroboros`",
+                        path=str(claude_user_mcp),
+                        launcher=_format_launcher(servers.get("ouroboros")),
+                        remediation=(
+                            "Prefer the Claude Code plugin-managed server, or ensure this "
+                            "user-level entry uses the same current isolated launcher."
+                        ),
+                    )
+                )
+            else:
+                surfaces.append(
+                    InstallSurface(
+                        name="claude_user_mcp_duplicate",
+                        status="pass",
+                        message="no user-level Claude `ouroboros` MCP entry",
+                        path=str(claude_user_mcp),
+                    )
+                )
+    else:
+        surfaces.append(
+            InstallSurface(
+                name="claude_user_mcp_duplicate",
+                status="pass",
+                message="Claude user MCP config not present",
+                path=str(claude_user_mcp),
+            )
+        )
+
+    zcode_cache_root = (
+        resolved_home
+        / ".zcode"
+        / "cli"
+        / "plugins"
+        / "cache"
+        / "zcode-plugins-official"
+        / "ouroboros"
+    )
+    zcode_cache, zcode_cache_error = _latest_versioned_child_with(
+        zcode_cache_root,
+        ".zcode-plugin/plugin.json",
+    )
+    if zcode_cache_error is not None:
+        surfaces.append(
+            InstallSurface(
+                name="zcode_bridge_plugin",
+                status="fail",
+                message=f"could not inspect ZCode bridge plugin cache: {zcode_cache_error}",
+                path=str(zcode_cache_root),
+            )
+        )
+        surfaces.append(
+            InstallSurface(
+                name="zcode_bridge_launcher",
+                status="fail",
+                message=f"could not inspect ZCode bridge plugin cache: {zcode_cache_error}",
+                path=str(zcode_cache_root),
+            )
+        )
+        return surfaces
+    zcode_manifest = (zcode_cache or zcode_cache_root) / ".zcode-plugin" / "plugin.json"
+    _add_manifest_surface(
+        surfaces,
+        name="zcode_bridge_plugin",
+        path=zcode_manifest,
+        expected_version=expected_version,
+        version_label="bridge plugin",
+        stale_check=False,
+    )
+
+    zcode_launcher = zcode_manifest.parent.parent / ".mcp.json"
+    _add_launcher_surface(
+        surfaces,
+        name="zcode_bridge_launcher",
+        path=zcode_launcher,
+    )
+
+    return surfaces
+
+
+@app.command("install")
+def install_doctor(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON to stdout."),
+    ] = False,
+) -> None:
+    """Inspect package, plugin, and MCP install surfaces without mutating files."""
+
+    surfaces = collect_install_surfaces()
+
+    if as_json:
+        print(json.dumps([asdict(surface) for surface in surfaces], indent=2))
+    else:
+        console = Console()
+        console.print()
+        console.print("[bold]Ouroboros Installation Doctor[/bold]")
+        console.print()
+        for surface in surfaces:
+            console.print(
+                f"  {_SYMBOLS[surface.status]}  [bold]{surface.name}[/bold]: "
+                f"{escape(surface.message)}"
+            )
+            if surface.path:
+                console.print(f"      [dim]path: {escape(surface.path)}[/dim]")
+            if surface.launcher:
+                console.print(f"      [dim]launcher: {escape(surface.launcher)}[/dim]")
+            if surface.remediation:
+                console.print(f"      [dim]hint: {escape(surface.remediation)}[/dim]")
+        console.print()
+
+    if any(surface.status == "fail" for surface in surfaces):
+        raise typer.Exit(code=1)
+
+
+__all__ = ["InstallSurface", "app", "collect_install_surfaces", "install_doctor"]

--- a/src/ouroboros/cli/commands/doctor.py
+++ b/src/ouroboros/cli/commands/doctor.py
@@ -257,13 +257,23 @@ def _add_launcher_surface(
 def _is_claude_isolated_uvx_launcher(command: str | None, args: list[str] | None) -> bool:
     if command != "uvx" or args is None:
         return False
-    if len(args) != 8:
+    if len(args) != 12:
         return False
     if args[0] != "--isolated":
         return False
-    if args[1] != "--python" or not args[2] or args[2].startswith("-"):
+    if args[1:3] != ["--python", ">=3.12"]:
         return False
-    return args[3:] == ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]
+    return args[3:] == [
+        "--from",
+        "ouroboros-ai[mcp]",
+        "ouroboros",
+        "mcp",
+        "serve",
+        "--runtime",
+        "claude-cli",
+        "--llm-backend",
+        "claude_code",
+    ]
 
 
 def _resolve_install_codex_home(home: Path | None) -> Path:

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -29,6 +29,7 @@ from ouroboros.cli.commands import (
     config,
     detect,
     dispatch,
+    doctor,
     harness,
     init,
     job,
@@ -112,6 +113,7 @@ app.add_typer(status.app, name="status")
 app.add_typer(cancel.app, name="cancel")
 app.add_typer(cleanup.app, name="cleanup")
 app.add_typer(codex.app, name="codex")
+app.add_typer(doctor.app, name="doctor")
 app.add_typer(mcp.app, name="mcp")
 app.add_typer(setup.app, name="setup")
 app.add_typer(detect.app, name="detect")

--- a/src/ouroboros/telemetry.py
+++ b/src/ouroboros/telemetry.py
@@ -122,7 +122,7 @@ _CLI_FUNNEL = {"init": "interview"}
 # way the actual `ooo` entrypoint does, and `.commands.keys()` is the
 # statically-registered set -- `_PluginAwareGroup`'s dynamic fallback only
 # triggers for names NOT in that dict, so this enumeration inherently
-# excludes plugin dispatch. 27 names: every `app.command(name=...)` /
+# excludes plugin dispatch. 28 names: every `app.command(name=...)` /
 # `app.add_typer(..., name=...)` registration plus two hidden top-level
 # aliases (`monitor`, `dispatch`).
 _CANONICAL_CLI_COMMANDS = frozenset(
@@ -134,6 +134,7 @@ _CANONICAL_CLI_COMMANDS = frozenset(
         "codex",
         "config",
         "detect",
+        "doctor",
         "dispatch",
         "harness",
         "init",

--- a/tests/unit/cli/test_install_doctor.py
+++ b/tests/unit/cli/test_install_doctor.py
@@ -1,0 +1,675 @@
+"""Tests for the installation-surface doctor."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands import doctor
+from ouroboros.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_current_install(home: Path, *, version: str = "1.2.3") -> None:
+    _write_json(
+        home / "plugins" / "ouroboros" / ".codex-plugin" / "plugin.json",
+        {"name": "ouroboros", "version": version},
+    )
+    _write_json(
+        home / ".codex" / "plugins" / "cache" / "personal" / "ouroboros" / version / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "ouroboros", "args": ["mcp", "serve"]}}},
+    )
+    _write_json(
+        home
+        / ".claude"
+        / "plugins"
+        / "marketplaces"
+        / "ouroboros"
+        / ".claude-plugin"
+        / "plugin.json",
+        {"name": "ouroboros", "version": version},
+    )
+    _write_json(
+        home / ".claude" / "plugins" / "cache" / "ouroboros" / "ouroboros" / version / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--isolated",
+                        "--python",
+                        ">=3.12",
+                        "--from",
+                        "ouroboros-ai[mcp]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                    ],
+                }
+            }
+        },
+    )
+    _write_json(home / ".claude" / "mcp.json", {"mcpServers": {"telegram": {"command": "x"}}})
+    _write_json(
+        home
+        / ".zcode"
+        / "cli"
+        / "plugins"
+        / "cache"
+        / "zcode-plugins-official"
+        / "ouroboros"
+        / "0.1.0"
+        / ".zcode-plugin"
+        / "plugin.json",
+        {"name": "ouroboros", "version": "0.1.0"},
+    )
+    _write_json(
+        home
+        / ".zcode"
+        / "cli"
+        / "plugins"
+        / "cache"
+        / "zcode-plugins-official"
+        / "ouroboros"
+        / "0.1.0"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "/tmp/ouroboros/.venv/bin/ouroboros",
+                    "args": ["mcp", "serve", "--runtime", "zcode", "--llm-backend", "zcode"],
+                }
+            }
+        },
+    )
+
+
+def test_install_doctor_reports_current_surfaces(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+
+    statuses = {surface.name: surface.status for surface in surfaces}
+    assert statuses["python_package"] == "pass"
+    assert statuses["codex_personal_plugin"] == "pass"
+    assert statuses["claude_plugin_marketplace"] == "pass"
+    assert statuses["claude_plugin_launcher"] == "pass"
+    assert statuses["claude_user_mcp_duplicate"] == "pass"
+    assert statuses["zcode_bridge_plugin"] == "pass"
+
+
+def test_collect_install_surfaces_is_read_only(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    def fail_write(*args: object, **kwargs: object) -> None:
+        raise AssertionError("install doctor must not write files")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+
+    assert surfaces
+
+
+def test_install_doctor_flags_stale_codex_and_claude_plugins(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.2")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    by_name = {surface.name: surface for surface in surfaces}
+
+    assert by_name["codex_personal_plugin"].status == "warn"
+    assert "differs from package 1.2.3" in by_name["codex_personal_plugin"].message
+    assert by_name["claude_plugin_marketplace"].status == "warn"
+
+
+def test_install_doctor_warns_for_non_isolated_claude_launcher(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_rejects_flattened_argv_boundary(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--isolated --python >=3.12 --from ouroboros-ai[mcp] ouroboros mcp serve"
+                    ],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_requires_from_value_adjacency(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--isolated",
+                        "--python",
+                        ">=3.12",
+                        "--from",
+                        "different-package",
+                        "ouroboros-ai[mcp]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                    ],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_requires_python_value(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--isolated",
+                        "--python",
+                        "--from",
+                        "ouroboros-ai[mcp]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                    ],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_rejects_flags_after_command_tail(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--python",
+                        ">=3.12",
+                        "--from",
+                        "ouroboros-ai[mcp]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                        "--isolated",
+                    ],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_rejects_extra_argv_tokens(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": [
+                        "--isolated",
+                        "--python",
+                        ">=3.12",
+                        "--from",
+                        "ouroboros-ai[mcp]",
+                        "ouroboros",
+                        "mcp",
+                        "serve",
+                        "--extra",
+                    ],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_install_doctor_flags_duplicate_claude_user_mcp(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path / ".claude" / "mcp.json",
+        {
+            "mcpServers": {
+                "ouroboros": {
+                    "command": "uvx",
+                    "args": ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
+                }
+            }
+        },
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    duplicate = next(surface for surface in surfaces if surface.name == "claude_user_mcp_duplicate")
+
+    assert duplicate.status == "warn"
+    assert "user-level Claude MCP" in duplicate.message
+    assert duplicate.launcher == "uvx --from ouroboros-ai ouroboros mcp serve"
+
+
+def test_install_doctor_warns_for_missing_configs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+
+    assert any(surface.status == "warn" for surface in surfaces)
+    assert (
+        next(surface for surface in surfaces if surface.name == "python_package").status == "pass"
+    )
+    assert (
+        next(surface for surface in surfaces if surface.name == "claude_user_mcp_duplicate").status
+        == "pass"
+    )
+
+
+def test_install_doctor_fails_on_malformed_present_json(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    malformed = tmp_path / ".claude" / "mcp.json"
+    malformed.parent.mkdir(parents=True, exist_ok=True)
+    malformed.write_text("{", encoding="utf-8")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    claude_user = next(
+        surface for surface in surfaces if surface.name == "claude_user_mcp_duplicate"
+    )
+
+    assert claude_user.status == "fail"
+    assert "invalid JSON" in claude_user.message
+
+
+def test_install_doctor_fails_on_malformed_present_plugin_manifest(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    manifest = tmp_path / "plugins" / "ouroboros" / ".codex-plugin" / "plugin.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text("{", encoding="utf-8")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    codex_plugin = next(surface for surface in surfaces if surface.name == "codex_personal_plugin")
+
+    assert codex_plugin.status == "fail"
+    assert "invalid JSON" in codex_plugin.message
+
+
+def test_zcode_bridge_version_is_not_compared_to_core(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    zcode = next(surface for surface in surfaces if surface.name == "zcode_bridge_plugin")
+
+    assert zcode.status == "pass"
+    assert zcode.version == "0.1.0"
+    assert zcode.expected_version is None
+    assert "bridge plugin version 0.1.0" in zcode.message
+
+
+def test_zcode_bridge_discovers_newer_version_directory(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".zcode"
+        / "cli"
+        / "plugins"
+        / "cache"
+        / "zcode-plugins-official"
+        / "ouroboros"
+        / "0.2.0"
+        / ".zcode-plugin"
+        / "plugin.json",
+        {"name": "ouroboros", "version": "0.2.0"},
+    )
+    _write_json(
+        tmp_path
+        / ".zcode"
+        / "cli"
+        / "plugins"
+        / "cache"
+        / "zcode-plugins-official"
+        / "ouroboros"
+        / "0.2.0"
+        / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "new-zcode", "args": ["mcp", "serve"]}}},
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    zcode = next(surface for surface in surfaces if surface.name == "zcode_bridge_plugin")
+    launcher = next(surface for surface in surfaces if surface.name == "zcode_bridge_launcher")
+
+    assert zcode.status == "pass"
+    assert zcode.version == "0.2.0"
+    assert "/0.2.0/" in zcode.path
+    assert launcher.launcher == "new-zcode mcp serve"
+
+
+def test_codex_cache_uses_effective_codex_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    normal_home = tmp_path / "home"
+    codex_home = tmp_path / "custom-codex"
+    _write_current_install(normal_home, version="1.2.3")
+    _write_json(
+        codex_home / "plugins" / "cache" / "personal" / "ouroboros" / "1.2.3" / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "custom-codex", "args": ["mcp", "serve"]}}},
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    surfaces = doctor.collect_install_surfaces(home=normal_home)
+    launcher = next(
+        surface for surface in surfaces if surface.name == "codex_personal_plugin_launcher"
+    )
+
+    assert launcher.status == "pass"
+    assert launcher.path == str(
+        codex_home / "plugins" / "cache" / "personal" / "ouroboros" / "1.2.3" / ".mcp.json"
+    )
+    assert launcher.launcher == "custom-codex mcp serve"
+
+
+def test_cache_selection_uses_version_order(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.10.0")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.9.0")
+    _write_json(
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "personal"
+        / "ouroboros"
+        / "1.10.0"
+        / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "newer", "args": ["mcp", "serve"]}}},
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(
+        surface for surface in surfaces if surface.name == "codex_personal_plugin_launcher"
+    )
+
+    assert launcher.path == str(
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "personal"
+        / "ouroboros"
+        / "1.10.0"
+        / ".mcp.json"
+    )
+    assert launcher.launcher == "newer mcp serve"
+
+
+def test_empty_claude_launcher_fails(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "", "args": ["--isolated"]}}},
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "fail"
+    assert "command is missing or empty" in launcher.message
+
+
+def test_malformed_launcher_args_fail(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {"mcpServers": {"ouroboros": {"command": "uvx", "args": "--isolated"}}},
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "fail"
+    assert "args must be a list" in launcher.message
+
+
+def test_wrong_type_launcher_entry_fails(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    _write_json(
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json",
+        {"mcpServers": {"ouroboros": ["uvx", "--isolated"]}},
+    )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "fail"
+    assert "launcher entry is not an object" in launcher.message
+
+
+def test_unreadable_cache_directory_becomes_failed_surface(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    cache_root = tmp_path / ".codex" / "plugins" / "cache" / "personal" / "ouroboros"
+    original_iterdir = Path.iterdir
+
+    def fail_iterdir(path: Path):
+        if path == cache_root:
+            raise PermissionError("permission denied")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", fail_iterdir)
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(
+        surface for surface in surfaces if surface.name == "codex_personal_plugin_launcher"
+    )
+
+    assert launcher.status == "fail"
+    assert "permission denied" in launcher.message
+
+
+def test_editable_zero_version_does_not_mark_plugins_stale(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "0.0.0")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    by_name = {surface.name: surface for surface in surfaces}
+
+    assert by_name["codex_personal_plugin"].status == "pass"
+    assert "stale comparison skipped" in by_name["codex_personal_plugin"].message
+    assert by_name["claude_plugin_marketplace"].status == "pass"
+
+
+def test_cli_install_doctor_json_uses_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    result = runner.invoke(app, ["doctor", "install", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert any(surface["name"] == "claude_plugin_launcher" for surface in payload)
+
+
+def test_cli_doctor_help_registered() -> None:
+    result = runner.invoke(app, ["doctor", "--help"])
+
+    assert result.exit_code == 0
+    assert "install" in result.output
+
+
+def test_cli_install_doctor_human_output_preserves_launcher_brackets(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _write_current_install(tmp_path, version="1.2.3")
+
+    result = runner.invoke(app, ["doctor", "install"])
+
+    assert result.exit_code == 0
+    assert "ouroboros-ai[mcp]" in result.output

--- a/tests/unit/cli/test_install_doctor.py
+++ b/tests/unit/cli/test_install_doctor.py
@@ -52,6 +52,10 @@ def _write_current_install(home: Path, *, version: str = "1.2.3") -> None:
                         "ouroboros",
                         "mcp",
                         "serve",
+                        "--runtime",
+                        "claude-cli",
+                        "--llm-backend",
+                        "claude_code",
                     ],
                 }
             }
@@ -158,6 +162,31 @@ def test_install_doctor_warns_for_non_isolated_claude_launcher(monkeypatch, tmp_
             }
         },
     )
+
+    surfaces = doctor.collect_install_surfaces(home=tmp_path)
+    launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")
+
+    assert launcher.status == "warn"
+    assert "isolated uvx" in launcher.message
+
+
+def test_claude_launcher_rejects_unsupported_python_constraint(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor, "__version__", "1.2.3")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    _write_current_install(tmp_path, version="1.2.3")
+    launcher_path = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "ouroboros"
+        / "ouroboros"
+        / "1.2.3"
+        / ".mcp.json"
+    )
+    payload = json.loads(launcher_path.read_text(encoding="utf-8"))
+    payload["mcpServers"]["ouroboros"]["args"][2] = "2.7"
+    _write_json(launcher_path, payload)
 
     surfaces = doctor.collect_install_surfaces(home=tmp_path)
     launcher = next(surface for surface in surfaces if surface.name == "claude_plugin_launcher")


### PR DESCRIPTION
Refs #2035

## Summary

Adds a read-only installation-surface doctor:

```bash
ouroboros doctor install
ouroboros doctor install --json
```

This does not update, delete, or rewrite user config. It reports active package/plugin/MCP surfaces so users do not mistake `ooo --version` for proof that every client integration is current.

## Why

Ouroboros can be installed through several independent surfaces: the Python package, Codex plugin files/cache, Claude Code plugin files/cache, user-level MCP config, and bridge plugins such as ZCode. A package update can succeed while an active plugin or duplicate MCP entry remains stale.

This PR frames that as diagnostic evidence, not automatic repair: show the paths, versions, launchers, and warnings.

## What It Checks

- running Ouroboros package version
- Codex personal plugin manifest and cache launcher
- Claude Code marketplace plugin manifest and cache launcher
- duplicate `~/.claude/mcp.json` `mcpServers.ouroboros`
- Claude plugin launcher missing `uvx --isolated`
- ZCode bridge plugin and launcher, treating bridge version separately from Ouroboros core
- editable/dev package version `0.0.0`, which skips stale plugin comparison to avoid false warnings in source checkouts

## Non-Claims

- Does not fix/update installs automatically
- Does not guarantee every client is current
- Does not remove stale caches or rewrite MCP config
- Does not change execution/evaluation/verifier semantics

## Verification

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 python -m pytest tests/unit/cli/test_install_doctor.py tests/unit/cli/test_cli_telemetry.py::test_statically_registered_commands_are_subset_of_canonical_set tests/unit/cli/test_main.py::TestCommandGroups -q`
  - `19 passed`
- `uv sync --python 3.13 --dev --group mcp-test`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 python -m pytest tests/unit/cli -q`
  - `1976 passed, 7 skipped`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 ouroboros doctor install --json`
  - exit 0; reports local Codex/Claude/ZCode surfaces
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 ouroboros doctor install`
  - exit 0; preserves `ouroboros-ai[mcp]` in human launcher output
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 ruff check src/ouroboros/cli/main.py src/ouroboros/cli/commands/doctor.py src/ouroboros/telemetry.py tests/unit/cli/test_install_doctor.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run --python 3.13 ruff format --check src/ouroboros/cli/main.py src/ouroboros/cli/commands/doctor.py src/ouroboros/telemetry.py tests/unit/cli/test_install_doctor.py`
- `git diff --check`
- Ouroboros QA via Codex backend: `qa-af90ab09`, PASS 0.86