### PR TITLE
docs(readme): surface the star count on the first screen

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -22,6 +22,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -269,8 +269,8 @@ ooo evaluate   →  3단계 검증: Mechanical → Semantic → Consensus
 
 
 <p align="center">
-  <sub>인터뷰가 물었는데 답 못 한 질문이 있었다면, 그게 남한테 말할 만한 부분입니다.<br/>
-  <a href="https://github.com/Q00/ouroboros"><strong>저장소에 star</strong></a>를 눌러두면, 자기가 시키지도 않은 코드를 리뷰하느라 지친 다음 사람에게 닿습니다.</sub>
+  <sub>대개는 리뷰 세 번째 파일쯤에서 자기가 명확하지 않았다는 걸 알게 됩니다.<br/>
+  익숙한 기분이라면, 이 페이지 위쪽의 <strong>Star</strong> 버튼이 같은 일을 겪을 다음 사람에게 이걸 보내줍니다.</sub>
 </p>
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -267,6 +267,12 @@ ooo evaluate   →  3단계 검증: Mechanical → Semantic → Consensus
 
 </details>
 
+
+<p align="center">
+  <sub>인터뷰가 물었는데 답 못 한 질문이 있었다면, 그게 남한테 말할 만한 부분입니다.<br/>
+  <a href="https://github.com/Q00/ouroboros"><strong>저장소에 star</strong></a>를 눌러두면, 자기가 시키지도 않은 코드를 리뷰하느라 지친 다음 사람에게 닿습니다.</sub>
+</p>
+
 ---
 
 ## 순환 구조

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/Q00/ouroboros"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
@@ -270,7 +270,7 @@ ooo evaluate   →  3단계 검증: Mechanical → Semantic → Consensus
 
 <p align="center">
   <sub>대개는 리뷰 세 번째 파일쯤에서 자기가 명확하지 않았다는 걸 알게 됩니다.<br/>
-  익숙한 기분이라면, 이 페이지 위쪽의 <strong>Star</strong> 버튼이 같은 일을 겪을 다음 사람에게 이걸 보내줍니다.</sub>
+  익숙한 기분이라면, 같은 일을 겪을 다음 사람이 이 프로젝트를 찾도록 <a href="https://github.com/Q00/ouroboros"><strong>GitHub의 Q00/ouroboros</strong></a>에 Star를 남겨 주세요.</sub>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ Removes all configuration, MCP registration, and data. See [UNINSTALL.md](./UNIN
 > **Python >= 3.12 required.** LiteLLM-bearing profiles support Python 3.12-3.13. See [Platform Support](./docs/platform-support.md#python-profile-matrix) and [pyproject.toml](./pyproject.toml).
 
 <p align="center">
-  <sub>If the interview asked you something you could not answer, that is the part worth telling people about.<br/>
-  <a href="https://github.com/Q00/ouroboros"><strong>Star the repo</strong></a> so it finds the next person who is tired of reviewing code they did not ask for.</sub>
+  <sub>Most people find out they were unclear about three files into the review.<br/>
+  If that is a familiar feeling, the <strong>Star</strong> button at the top of this page is what puts this in front of the next person it would have saved.</sub>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>

--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ Removes all configuration, MCP registration, and data. See [UNINSTALL.md](./UNIN
 
 > **Python >= 3.12 required.** LiteLLM-bearing profiles support Python 3.12-3.13. See [Platform Support](./docs/platform-support.md#python-profile-matrix) and [pyproject.toml](./pyproject.toml).
 
+<p align="center">
+  <sub>If the interview asked you something you could not answer, that is the part worth telling people about.<br/>
+  <a href="https://github.com/Q00/ouroboros"><strong>Star the repo</strong></a> so it finds the next person who is tired of reviewing code they did not ask for.</sub>
+</p>
+
 ---
 
 ## What You Get

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/Q00/ouroboros"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
@@ -260,7 +260,7 @@ Removes all configuration, MCP registration, and data. See [UNINSTALL.md](./UNIN
 
 <p align="center">
   <sub>Most people find out they were unclear about three files into the review.<br/>
-  If that is a familiar feeling, the <strong>Star</strong> button at the top of this page is what puts this in front of the next person it would have saved.</sub>
+  If that feels familiar, star <a href="https://github.com/Q00/ouroboros"><strong>Q00/ouroboros on GitHub</strong></a> so the next person it could save can find it.</sub>
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,12 @@ ouroboros uninstall
 
 > **需要 Python >= 3.12**。包含 LiteLLM 的 profile 支持 Python 3.12-3.13。详见 [Platform Support](./docs/platform-support.md#python-profile-matrix) 和 [pyproject.toml](./pyproject.toml)。
 
+
+<p align="center">
+  <sub>如果访谈问到了你答不上来的地方，那一条才是值得说给别人听的。<br/>
+  给仓库<a href="https://github.com/Q00/ouroboros"><strong>点个 star</strong></a>，它就能找到下一个正在审自己没要过的代码的人。</sub>
+</p>
+
 ---
 
 ## 你能得到什么

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
+  <a href="https://github.com/Q00/ouroboros"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
@@ -218,7 +218,7 @@ ouroboros uninstall
 
 <p align="center">
   <sub>大多数人是在审到第三个文件的时候，才发现自己当初没说清楚。<br/>
-  如果这感觉很熟，页面顶部那个 <strong>Star</strong> 按钮，能把它送到下一个会栽在同一处的人面前。</sub>
+  如果这种感觉很熟悉，请给 <a href="https://github.com/Q00/ouroboros"><strong>GitHub 上的 Q00/ouroboros</strong></a> 点个 Star，让下一个遇到同样问题的人更容易找到它。</sub>
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Q00/ouroboros/stargazers"><img src="https://img.shields.io/github/stars/Q00/ouroboros?color=yellow&logo=github&label=stars" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/ouroboros-ai/"><img src="https://img.shields.io/pypi/v/ouroboros-ai?color=blue" alt="PyPI"></a>
   <a href="https://github.com/Q00/ouroboros/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/Q00/ouroboros/test.yml?branch=main" alt="Tests"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,8 +217,8 @@ ouroboros uninstall
 
 
 <p align="center">
-  <sub>如果访谈问到了你答不上来的地方，那一条才是值得说给别人听的。<br/>
-  给仓库<a href="https://github.com/Q00/ouroboros"><strong>点个 star</strong></a>，它就能找到下一个正在审自己没要过的代码的人。</sub>
+  <sub>大多数人是在审到第三个文件的时候，才发现自己当初没说清楚。<br/>
+  如果这感觉很熟，页面顶部那个 <strong>Star</strong> 按钮，能把它送到下一个会栽在同一处的人面前。</sub>
 </p>
 
 ---


### PR DESCRIPTION
Adds two coordinated star prompts to all three public READMEs:

- a GitHub star-count badge, placed first in each five-badge row; and
- a localized star CTA after Quick Start, where readers have enough context to decide whether the project is useful.

## Why

The existing badge row surfaced releases, CI, licensing, and sponsorship, but not the repository's adoption signal. The new CTA makes the next action explicit without pretending that GitHub exposes a direct-star URL.

## Renderer-safe behavior

`README.md` is also the PyPI long description. The CTA therefore names **Q00/ouroboros on GitHub** instead of referring to a button “at the top of this page,” so it remains true on both GitHub and PyPI.

The badge links to the verified repository root, `https://github.com/Q00/ouroboros`, because the `/stargazers` destination currently returns 404.

## Localization

The English, Korean, and Simplified Chinese CTAs preserve the same intent while using natural phrasing in each language.

## Verified

- All three READMEs contain five badges with the star badge first.
- The repository link and Shields SVG endpoint return HTTP 200.
- The three CTA fragments render with PyPI's `readme_renderer[md]` path.
- Built wheel and sdist pass `twine check`.
- Pre-commit file hooks and `git diff --check` pass.

## Scope

- Only `README.md`, `README.ko.md`, and `README.zh-CN.md` change: 20 insertions and no deletions.
- This documentation-only growth improvement intentionally has no linked issue; the `no-issue` label records that scope.
- Moving the demo or adding a star-history chart remains outside this PR.
