### PR TITLE
fix(mcp): tell the default-runtime user to pass --runtime, not to reinstall

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -33,6 +33,7 @@ from ouroboros.orchestrator.heartbeat import (
     process_start_time,
 )
 from ouroboros.package_profiles import (
+    SDK_RUNTIME_IN_MCP_SERVER_MESSAGE,
     UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE,
     has_unsupported_claude_sdk_mcp_mix,
     public_runtime_backend,
@@ -1203,8 +1204,16 @@ def serve(
     # missing option inherits config and ultimately defaults to the SDK-backed
     # ``claude`` runtime, which is not executable inside this MCP 2 process.
     selected_runtime = _effective_mcp_server_runtime(runtime)
-    if has_unsupported_claude_sdk_mcp_mix() or selected_runtime == "claude":
+    # Two different failures used to share one string. An environment that mixes
+    # MCP 2 with the Claude SDK really is a package-profile problem and the user
+    # must reinstall. Inheriting the ``claude`` default is a runtime-selection
+    # failure, and the fix is ``--runtime``. Telling that user to reinstall sent
+    # them to change extras that were never relevant to the selected backend.
+    if has_unsupported_claude_sdk_mcp_mix():
         _stderr_console.print(Text(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE, style="red"))
+        raise typer.Exit(1)
+    if selected_runtime == "claude":
+        _stderr_console.print(Text(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE, style="red"))
         raise typer.Exit(1)
 
     # Guard: prevent recursive MCP server spawning.

--- a/src/ouroboros/package_profiles.py
+++ b/src/ouroboros/package_profiles.py
@@ -26,6 +26,14 @@ UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE = (
 )
 
 
+SDK_RUNTIME_IN_MCP_SERVER_MESSAGE = (
+    "The MCP server cannot host the 'claude' SDK runtime in this process. "
+    "Pass an executable runtime, for example "
+    "'ouroboros mcp serve --runtime claude-cli', or set the runtime in config "
+    "so this command stops inheriting the 'claude' default."
+)
+
+
 class PublicAgentRuntimeBackend(str, Enum):  # noqa: UP042
     """Public runtime spellings shared by every workflow CLI front door.
 
@@ -93,6 +101,7 @@ __all__ = [
     "CLAUDE_SDK_PROFILE",
     "CLAUDE_SDK_RUNTIME_BACKEND",
     "MCP_PROFILE",
+    "SDK_RUNTIME_IN_MCP_SERVER_MESSAGE",
     "PublicAgentRuntimeBackend",
     "UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE",
     "has_unsupported_claude_sdk_mcp_mix",

--- a/tests/integration/plugin/test_wheel_packaging.py
+++ b/tests/integration/plugin/test_wheel_packaging.py
@@ -11,6 +11,7 @@ shipped archive.
 from __future__ import annotations
 
 from email.parser import Parser
+import json
 import os
 from pathlib import Path
 import shutil
@@ -21,7 +22,7 @@ import zipfile
 
 import pytest
 
-from ouroboros.package_profiles import UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE
+from ouroboros.package_profiles import SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
 from ouroboros.plugin.manifest import SUPPORTED_SCHEMA_VERSIONS
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -249,11 +250,55 @@ def test_built_wheel_preserves_packaging_contracts(tmp_path: Path) -> None:
     )
     assert bare_probe.returncode == 1
     rendered_probe = " ".join((bare_probe.stdout + bare_probe.stderr).split())
-    assert " ".join(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE.split()) in rendered_probe
+    assert " ".join(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.split()) in rendered_probe
+    assert "--runtime claude-cli" in rendered_probe
+    assert "ouroboros-ai[mcp]" not in rendered_probe
     state_dir = probe_home / ".ouroboros"
     assert not (state_dir / "ouroboros.db").exists()
     assert not (state_dir / "config.yaml").exists()
     assert not (state_dir / "sessions").exists()
+
+    # The actionable replacements named by the diagnostic must both cross the
+    # real wheel/console-script/MCP-v2 boundary, not only a mocked unit dispatch.
+    initialize_request = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2026-07-28",
+                "capabilities": {},
+                "clientInfo": {"name": "wheel-probe", "version": "1.0"},
+            },
+        }
+    )
+    for executable_runtime in ("claude-cli", "codex"):
+        runtime_home = tmp_path / f"{executable_runtime}-probe-home"
+        runtime_home.mkdir()
+        runtime_env = probe_env.copy()
+        runtime_env["HOME"] = str(runtime_home)
+        runtime_env["USERPROFILE"] = str(runtime_home)
+        runtime_probe = subprocess.run(
+            [str(probe_cli), "mcp", "serve", "--runtime", executable_runtime],
+            input=f"{initialize_request}\n",
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=runtime_env,
+        )
+        assert runtime_probe.returncode == 0, (
+            f"wheel runtime {executable_runtime!r} failed its MCP initialize handshake: "
+            f"stdout={runtime_probe.stdout!r} stderr={runtime_probe.stderr!r}"
+        )
+        responses = [
+            json.loads(line)
+            for line in runtime_probe.stdout.splitlines()
+            if line.lstrip().startswith("{")
+        ]
+        assert any(response.get("id") == 1 and "result" in response for response in responses), (
+            responses
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/unit/cli/test_mcp_nested_guard.py
+++ b/tests/unit/cli/test_mcp_nested_guard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from importlib import metadata as importlib_metadata
 import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
@@ -18,9 +19,27 @@ import pytest
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.mcp import _require_mcp_dependency, _run_mcp_server, app
-from ouroboros.package_profiles import UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE
+from ouroboros.package_profiles import (
+    SDK_RUNTIME_IN_MCP_SERVER_MESSAGE,
+    UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE,
+)
 
 runner = CliRunner()
+
+
+def _set_installed_versions(monkeypatch, versions: dict[str, str]) -> None:
+    """Make package-profile detection deterministic for a CLI scenario."""
+
+    def fake_version(distribution: str) -> str:
+        try:
+            return versions[distribution]
+        except KeyError as exc:
+            raise importlib_metadata.PackageNotFoundError(distribution) from exc
+
+    monkeypatch.setattr(
+        "ouroboros.package_profiles.importlib_metadata.version",
+        fake_version,
+    )
 
 
 def test_nested_guard_exits_cleanly(monkeypatch):
@@ -162,6 +181,7 @@ def test_serve_defaults_to_port_8080_when_port_omitted(monkeypatch):
 def test_public_claude_cli_runtime_selects_cli_worker(monkeypatch):
     """The explicit `claude-cli` name selects the worker inside MCP 2."""
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(monkeypatch, {"mcp": "2.0.0"})
 
     mock_run_mcp_server = AsyncMock()
     with patch(
@@ -185,43 +205,105 @@ def test_public_claude_cli_runtime_selects_cli_worker(monkeypatch):
     )
 
 
+def test_public_codex_runtime_remains_executable(monkeypatch):
+    """Separating the Claude SDK diagnostic must not gate other workers."""
+    monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(monkeypatch, {"mcp": "2.0.0"})
+
+    mock_run_mcp_server = AsyncMock()
+    with patch(
+        "ouroboros.cli.commands.mcp._run_mcp_server",
+        new=mock_run_mcp_server,
+    ):
+        result = runner.invoke(app, ["serve", "--runtime", "codex"])
+
+    assert result.exit_code == 0
+    mock_run_mcp_server.assert_awaited_once_with(
+        "localhost",
+        8080,
+        "stdio",
+        None,
+        "codex",
+        None,
+        auth_token="",
+        allowed_hosts=(),
+        allowed_origins=(),
+        workspace_roots=(),
+    )
+
+
 def test_public_claude_sdk_runtime_fails_before_process_state(monkeypatch):
     """The MCP 2 server cannot select the in-process SDK runtime."""
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(monkeypatch, {"mcp": "2.0.0"})
 
     result = runner.invoke(app, ["serve", "--runtime", "claude"])
 
     assert result.exit_code == 1
-    for profile in ("ouroboros-ai[mcp]", "ouroboros-ai[claude]", "[claude-sdk]", "[claude-cli]"):
-        assert profile in result.output
-    assert " ".join(result.output.split()) == " ".join(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE.split())
+    # This is a runtime-selection failure, not a packaging one (#2038). The
+    # message must name the flag that fixes it and must not send a user with a
+    # correct install back to change extras.
+    assert " ".join(result.output.split()) == " ".join(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.split())
+    assert "--runtime" in result.output
+    assert "claude-cli" in result.output
+    assert "ouroboros-ai[mcp]" not in result.output
     assert "_OUROBOROS_NESTED" not in os.environ
 
 
 def test_public_claude_sdk_alias_reaches_canonical_mcp2_guard(monkeypatch):
     """The shipped SDK alias parses before the MCP 2 boundary rejects it."""
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(monkeypatch, {"mcp": "2.0.0"})
 
     result = runner.invoke(app, ["serve", "--runtime", "claude-sdk"])
 
     assert result.exit_code == 1
     assert "Invalid value" not in result.output
-    assert " ".join(result.output.split()) == " ".join(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE.split())
+    assert " ".join(result.output.split()) == " ".join(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.split())
     assert "_OUROBOROS_NESTED" not in os.environ
 
 
-def test_forced_sdk_mcp_mix_fails_before_process_state(monkeypatch):
+@pytest.mark.parametrize(
+    "versions",
+    [
+        pytest.param({}, id="no-mcp"),
+        pytest.param(
+            {"mcp": "1.29.0", "claude-agent-sdk": "0.2.123"},
+            id="mcp1-claude-sdk-profile",
+        ),
+    ],
+)
+def test_sdk_runtime_diagnostic_does_not_claim_install_health(
+    monkeypatch, tmp_path, versions: dict[str, str]
+) -> None:
+    """The early runtime diagnosis must stay true before MCP v2 preflight."""
     monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(monkeypatch, versions)
 
-    with patch(
-        "ouroboros.cli.commands.mcp.has_unsupported_claude_sdk_mcp_mix",
-        return_value=True,
-    ):
-        result = runner.invoke(app, ["serve", "--runtime", "claude-cli"])
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        result = runner.invoke(app, ["serve", "--runtime", "claude"])
+
+    assert result.exit_code == 1
+    assert " ".join(result.output.split()) == " ".join(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.split())
+    assert "install" not in result.output.lower()
+    assert "--runtime claude-cli" in " ".join(result.output.split())
+    assert "_OUROBOROS_NESTED" not in os.environ
+    assert not (tmp_path / ".ouroboros").exists()
+
+
+def test_mixed_sdk_mcp2_profile_uses_canonical_diagnostic(monkeypatch):
+    monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
+    _set_installed_versions(
+        monkeypatch,
+        {"mcp": "2.0.0", "claude-agent-sdk": "0.2.123"},
+    )
+
+    result = runner.invoke(app, ["serve", "--runtime", "claude-cli"])
 
     assert result.exit_code == 1
     for profile in ("ouroboros-ai[mcp]", "ouroboros-ai[claude]", "[claude-sdk]", "[claude-cli]"):
         assert profile in result.output
+    assert " ".join(result.output.split()) == " ".join(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE.split())
     assert "_OUROBOROS_NESTED" not in os.environ
 
 
@@ -232,8 +314,13 @@ def _clear_runtime_selection(monkeypatch) -> None:
 
 
 def _assert_rejected_before_start(result, run_mcp_server: AsyncMock, home) -> None:
+    """A bare ``serve`` inherits the ``claude`` default and must say so.
+
+    Before #2038 this asserted the package-profile message, which told a user
+    with a clean install to change extras that were never wrong.
+    """
     assert result.exit_code == 1
-    assert " ".join(result.output.split()) == " ".join(UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE.split())
+    assert " ".join(result.output.split()) == " ".join(SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.split())
     run_mcp_server.assert_not_awaited()
     assert "_OUROBOROS_NESTED" not in os.environ
     assert not (home / ".ouroboros" / "ouroboros.db").exists()
@@ -242,8 +329,9 @@ def _assert_rejected_before_start(result, run_mcp_server: AsyncMock, home) -> No
 def test_bare_serve_rejects_missing_config_sdk_default_before_mutation(
     monkeypatch, tmp_path
 ) -> None:
-    """Missing config falls back to SDK Claude and must fail before startup."""
+    """A valid MCP 2 install still rejects the inherited SDK default safely."""
     _clear_runtime_selection(monkeypatch)
+    _set_installed_versions(monkeypatch, {"mcp": "2.0.0"})
     run_mcp_server = AsyncMock()
 
     with (

--- a/tests/unit/test_package_profiles.py
+++ b/tests/unit/test_package_profiles.py
@@ -54,3 +54,19 @@ def test_platform_matrix_uses_canonical_unsupported_message() -> None:
     content = (root / "docs" / "platform-support.md").read_text(encoding="utf-8")
 
     assert UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE in content
+
+
+def test_sdk_runtime_message_names_the_fix_not_a_reinstall() -> None:
+    """The default-runtime failure must not read as a packaging problem.
+
+    Regression for the report in #2038: `ouroboros mcp serve` with no
+    `--runtime` inherits the `claude` default and printed the package-profile
+    message, so a user with a perfectly good install was told to change extras.
+    """
+    from ouroboros.package_profiles import SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
+
+    assert "--runtime" in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
+    assert "claude-cli" in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
+    # It must not send the reader back to the package extras.
+    assert "[mcp]" not in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
+    assert SDK_RUNTIME_IN_MCP_SERVER_MESSAGE != UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE

--- a/tests/unit/test_package_profiles.py
+++ b/tests/unit/test_package_profiles.py
@@ -69,4 +69,7 @@ def test_sdk_runtime_message_names_the_fix_not_a_reinstall() -> None:
     assert "claude-cli" in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
     # It must not send the reader back to the package extras.
     assert "[mcp]" not in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE
+    # Dependency validation happens later, so this early runtime diagnostic
+    # must not make an unconditional claim about installation health.
+    assert "install" not in SDK_RUNTIME_IN_MCP_SERVER_MESSAGE.lower()
     assert SDK_RUNTIME_IN_MCP_SERVER_MESSAGE != UNSUPPORTED_CLAUDE_SDK_MCP_MESSAGE


### PR DESCRIPTION
Closes #2038

`ouroboros mcp serve` without an explicit runtime inherits the SDK-backed `claude` default. That runtime cannot execute inside the MCP 2 server process, but the command used to report the separate mixed-package-profile diagnostic and sent users toward reinstalling extras that were not the cause.

## Change

The two failure modes now have separate diagnostics:

- An actual MCP 2 + Claude SDK package mix keeps the canonical package-profile message.
- An inherited or explicit SDK runtime receives a runtime-selection message that names `--runtime claude-cli` and configuration as actionable alternatives.

The runtime-selection diagnostic intentionally makes no claim that the installation is healthy. Dependency validation happens later, so the early message stays true in no-MCP, MCP 1 + SDK, clean MCP 2, and mixed-profile environments.

## Why this remains after #2012

#2012 fixed the isolated `uvx` launcher/profile path. This PR addresses the remaining direct or bare `mcp serve` diagnosis when the selected runtime itself is not executable in the MCP server process.

## Verified

- Built-wheel console script: bare `mcp serve` returns the runtime-selection diagnostic without creating Ouroboros database, config, or session state.
- Built-wheel `--runtime claude-cli` and `--runtime codex`: real JSON-RPC `initialize` handshakes return a result and exit successfully.
- Actual no-MCP, MCP 1 + Claude SDK, clean MCP 2, and MCP 2 + Claude SDK environments exercise the intended diagnostic branches.
- Focused MCP tests: 163 passed, 6 skipped.
- Python 3.12, 3.13, and 3.14 focused regressions: 27 passed each.
- Ruff, format, MyPy, module-size, dependency checks, and `git diff --check` pass.

## Scope

This changes only the diagnosis and its regression coverage. It does not change runtime selection, dependency resolution, or the executable MCP worker implementations.
