### PR TITLE
docs(pyproject): lead the summary with what nothing else in the directory claims

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ouroboros-ai"
 dynamic = ["version"]
-description = "Specification-first workflow engine for AI coding agents -- works across Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Pi, Zcode, Goose, GJC, Antigravity, and Grok."
+description = "Pins the acceptance spec before the run and keeps the grading command out of the agent prompt. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
 readme = "README.md"
 authors = [
     { name = "Q00", email = "jqyu.lee@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ouroboros-ai"
 dynamic = ["version"]
-description = "Pins the acceptance spec before the run and keeps the grading command out of the agent prompt. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
+description = "Pins the acceptance spec before the run and withholds each criterion's verify command and expected output from the worker. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
 readme = "README.md"
 authors = [
     { name = "Q00", email = "jqyu.lee@gmail.com" }


### PR DESCRIPTION
Rewrites `project.description` in `pyproject.toml`, which is what PyPI shows as the package summary and what search results truncate.

## The measurement

Current summary, 183 characters:

> Specification-first workflow engine for AI coding agents -- works across Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Pi, Zcode, Goose, GJC, Antigravity, and Grok.

**67% of it is the runtime list.** Thirteen names, and by the time they finish there is no room left for what the thing does. A reader scanning search results sees a category label and a roll call.

The category label is also crowded. In the Claude Code plugin directory, 2,291 entries: 114 describe verification or acceptance gates, 83 describe evaluation or grading, 19 use "spec-driven" or "SDD". Two mention an agent gaming its grader. None describe keeping the grading contract away from the executing agent.

## The change

> Pins the acceptance spec before the run and keeps the grading command out of the agent prompt. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes.

160 characters, and the first sentence is the part nothing else claims.

The runtime list is not deleted, it is compressed. Three names stay because those are the ones people search for, and "10 more" is accurate: thirteen families, three named. The full list still lives in the README and the docs, where someone checking whether their runtime is supported will actually look. A summary is not the place to enumerate.

## On "keeps the grading command out of the agent prompt"

That is the scoped claim, not "the agent can never see it". The redaction is verbatim over five encodings and a reshaped assertion still gets through, which is open as #2020. The summary says what the system does, not what it guarantees.

## Not changed here

The README tagline is still "Stop prompting. Start specifying." which sits in the same crowded lane as the old summary. That is a bigger decision than a metadata field and belongs in its own discussion.
