### PR TITLE
test(opencode): write the cross-language pin the bridge comment says exists

### DIFF
--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -1075,12 +1075,10 @@ def test_the_bridge_declares_itself_with_the_grammar_the_gatekeeper_knows() -> N
     and skipped-only banners start with their own words — so a gatekeeper
     matching on that would have been wrong on arrival.
 
-    The constants live in two languages and cannot import each other, so this
-    pins them equal. That is what "written once so emitter and stripper cannot
-    drift" has to mean across a language boundary.
+    The constants live in two languages and cannot import each other. Their
+    source-level parity is pinned by ``test_bridge_literal_contract.py``; this
+    test exercises recognition of the bridge shape that parity protects.
     """
-    from pathlib import Path
-
     from ouroboros.mcp.tools.advisory_dispatch import (
         _BRIDGE_NOTICE_OPENING,
         echo_carries_dispatch,
@@ -1088,12 +1086,6 @@ def test_the_bridge_declares_itself_with_the_grammar_the_gatekeeper_knows() -> N
     from ouroboros.mcp.tools.advisory_dispatch import (
         QUESTION_ADVISORY_DISPATCH_MARKER as marker,
     )
-
-    bridge_source = (
-        Path(__file__).resolve().parents[4] / "src/ouroboros/opencode/plugin/ouroboros-bridge.ts"
-    ).read_text(encoding="utf-8")
-    assert f'export const OUROBOROS_DISPATCH_MARKER = "{marker}"' in bridge_source
-    assert f'export const BRIDGE_NOTICE_OPENING = "{_BRIDGE_NOTICE_OPENING}"' in bridge_source
 
     # The shape the bridge actually stamps, banner and identifiers and all.
     bridge_echo = (

--- a/tests/unit/opencode/test_bridge_literal_contract.py
+++ b/tests/unit/opencode/test_bridge_literal_contract.py
@@ -1,0 +1,67 @@
+"""Pin the two literals the OpenCode bridge duplicates from Python.
+
+``src/ouroboros/opencode/plugin/ouroboros-bridge.ts`` carries a comment saying
+these constants "are the Python constants in mcp/tools/advisory_dispatch.py;
+they cannot be imported across the language boundary, so a test pins them equal
+instead."
+
+The parity check previously lived inside the larger advisory-dispatch integration
+test. This focused module owns the source-level language-boundary contract while
+that integration test exercises recognition of the resulting bridge echo.
+
+It matters more than a normal duplication: the marker is how the server-side
+gatekeeper recognises a dispatch the plugin produced. If the two drift, nothing
+raises. The plugin keeps announcing itself with a string the server no longer
+looks for, and the fan-out silently stops being recognised.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+import pytest
+
+from ouroboros.mcp.tools.advisory_dispatch import (
+    _BRIDGE_NOTICE_OPENING,
+    QUESTION_ADVISORY_DISPATCH_MARKER,
+)
+
+BRIDGE_TS = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "ouroboros"
+    / "opencode"
+    / "plugin"
+    / "ouroboros-bridge.ts"
+)
+
+
+def _ts_literal(name: str) -> str:
+    """Read ``export const <name> = "..."`` out of the bridge source."""
+    source = BRIDGE_TS.read_text(encoding="utf-8")
+    match = re.search(rf'^export const {re.escape(name)} = ("(?:[^"\\]|\\.)*")$', source, re.M)
+    if match is None:
+        pytest.fail(
+            f"{name} is no longer declared as a double-quoted `export const` in "
+            f"{BRIDGE_TS.name}. If it moved or changed shape, update this reader; "
+            "do not delete the check, because the two sides still have to agree."
+        )
+    try:
+        literal = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"{name} is not a valid JSON-compatible TypeScript string: {exc.msg}")
+    assert isinstance(literal, str)
+    return literal
+
+
+@pytest.mark.parametrize(
+    ("typescript_name", "python_literal"),
+    [
+        ("OUROBOROS_DISPATCH_MARKER", QUESTION_ADVISORY_DISPATCH_MARKER),
+        ("BRIDGE_NOTICE_OPENING", _BRIDGE_NOTICE_OPENING),
+    ],
+)
+def test_bridge_literals_match_python(typescript_name: str, python_literal: str) -> None:
+    assert _ts_literal(typescript_name) == python_literal


### PR DESCRIPTION
## Summary

Equivalent cross-language assertions already existed in tests/unit/mcp/tools/test_interview_lateral_review_advisory.py. This PR extracts that source-level parity contract into a focused OpenCode test instead of adding duplicate coverage. The existing advisory test continues to exercise bridge-echo recognition.

## Why this boundary remains worth pinning

The OpenCode bridge and Python gatekeeper cannot import one shared constant across the TypeScript/Python boundary. If the marker or notice opening drifts, bridge fan-out can stop being recognised without a direct runtime exception. A small source-level contract test is therefore appropriate, but it should have one owner rather than duplicate assertions in two test modules.

## What changed

- Move ownership of the two TypeScript/Python literal comparisons to the focused OpenCode contract test.
- Keep the larger advisory test focused on recognition of the resulting bridge echo.
- Decode JSON-compatible TypeScript string literals before comparison so escape-equivalent spellings compare by runtime value.
- Remove the redundant standalone file-existence assertion; reading the source already fails if the expected file is absent.

## Validation

The focused OpenCode and advisory suites pass together, and changing either bridge literal makes its parameterized contract case fail.