### PR TITLE
fix(claude): normalize CLI JSON output fail-closed

### DIFF
--- a/src/ouroboros/evolution/provider_usage.py
+++ b/src/ouroboros/evolution/provider_usage.py
@@ -498,19 +498,23 @@ async def tracked_complete(
         capture.resolve_model(call, getattr(response, "model", None))
         usage = getattr(response, "usage", None)
         counters = [
-            getattr(usage, field, None)
-            for field in ("prompt_tokens", "completion_tokens", "total_tokens")
+            *(
+                getattr(usage, field, None)
+                for field in ("prompt_tokens", "completion_tokens", "total_tokens")
+            ),
+            getattr(usage, "unallocated_tokens", 0),
         ]
         normalized_counters = tuple(_non_negative_counter(counter) for counter in counters)
         if all(counter is not None for counter in normalized_counters):
-            prompt_tokens, completion_tokens, total_tokens = normalized_counters
+            prompt_tokens, completion_tokens, total_tokens, unallocated_tokens = normalized_counters
             if (
                 prompt_tokens is not None
                 and completion_tokens is not None
                 and total_tokens is not None
+                and unallocated_tokens is not None
                 and total_tokens == prompt_tokens + completion_tokens
             ):
-                token_spend = _positive_finite(total_tokens)
+                token_spend = _positive_finite(total_tokens + unallocated_tokens)
     capture.finish(call, token_spend)
     return result
 

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -244,7 +244,8 @@ class ClaudeWorkerTransport:
                 ),
             )
 
-        is_error = payload.is_error or returncode not in (0, None)
+        process_failed = returncode not in (0, None)
+        is_error = payload.is_error or process_failed
         error: str | None = None
         if is_error:
             error = (
@@ -254,7 +255,10 @@ class ClaudeWorkerTransport:
                 or f"claude exited with status {returncode}"
             )
         return WorkerTurn(
-            text=payload.result,
+            # A nonzero process status is authoritative over a stale success
+            # envelope.  Do not let its ``result`` outrank the stderr diagnostic
+            # when LeaderDrivenWorkerRuntime collects this turn.
+            text="" if process_failed else payload.result,
             session_id=payload.session_id,
             is_error=is_error,
             error=error,

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -247,7 +247,12 @@ class ClaudeWorkerTransport:
         is_error = payload.is_error or returncode not in (0, None)
         error: str | None = None
         if is_error:
-            error = stderr or payload.result or f"claude exited with status {returncode}"
+            error = (
+                stderr
+                or payload.result
+                or payload.subtype
+                or f"claude exited with status {returncode}"
+            )
         return WorkerTurn(
             text=payload.result,
             session_id=payload.session_id,

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -247,7 +247,17 @@ class ClaudeWorkerTransport:
         process_failed = returncode not in (0, None)
         is_error = payload.is_error or process_failed
         error: str | None = None
-        if is_error:
+        if process_failed:
+            # A success-looking envelope is not an error diagnostic when the
+            # outer process status says the invocation failed.  Use envelope
+            # detail only when the envelope itself also reports an error.
+            error = (
+                stderr
+                or (payload.result if payload.is_error else None)
+                or (payload.subtype if payload.is_error else None)
+                or f"claude exited with status {returncode}"
+            )
+        elif payload.is_error:
             error = (
                 stderr
                 or payload.result

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-import json
 import os
 from pathlib import Path
-from typing import Any
 
 from ouroboros.config import get_cli_path
 from ouroboros.observability.logging import get_logger
@@ -33,6 +31,10 @@ from ouroboros.orchestrator.worker_runtime import (
     ResolvedWorkerCwd,
     WorkerTurn,
     resolve_worker_cwd,
+)
+from ouroboros.providers.claude_cli_output import (
+    ClaudeCliOutputError,
+    normalize_claude_cli_output,
 )
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
@@ -230,38 +232,28 @@ class ClaudeWorkerTransport:
 
     @staticmethod
     def _parse_turn(stdout: str, stderr: str, returncode: int | None) -> WorkerTurn:
-        payload: dict[str, Any] | None = None
-        # --output-format json emits one JSON object (last non-empty line is safest).
-        for line in reversed(stdout.splitlines()):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                candidate = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(candidate, dict):
-                payload = candidate
-                break
-
-        if payload is None:
+        try:
+            payload = normalize_claude_cli_output(stdout)
+        except ClaudeCliOutputError as exc:
+            diagnostic = stderr or stdout[:200]
             return WorkerTurn(
                 text="",
                 is_error=True,
-                error=f"claude returned no JSON (rc={returncode}): {stderr or stdout[:200]}",
+                error=(
+                    f"claude returned no valid JSON result (rc={returncode}; {exc}): {diagnostic}"
+                ),
             )
 
-        session_id = payload.get("session_id")
-        result_text = payload.get("result")
-        raw_usage = payload.get("usage")
-        usage = dict(raw_usage) if isinstance(raw_usage, dict) else None
-        is_error = bool(payload.get("is_error")) or returncode not in (0, None)
+        is_error = payload.is_error or returncode not in (0, None)
+        error: str | None = None
+        if is_error:
+            error = stderr or payload.result or f"claude exited with status {returncode}"
         return WorkerTurn(
-            text=str(result_text) if result_text is not None else "",
-            session_id=session_id if isinstance(session_id, str) and session_id else None,
+            text=payload.result,
+            session_id=payload.session_id,
             is_error=is_error,
-            error=(stderr or None) if is_error else None,
-            usage=usage,
+            error=error,
+            usage=payload.usage,
         )
 
     async def spawn(

--- a/src/ouroboros/providers/base.py
+++ b/src/ouroboros/providers/base.py
@@ -94,11 +94,17 @@ class UsageInfo:
         prompt_tokens: Number of tokens in the prompt.
         completion_tokens: Number of tokens in the completion.
         total_tokens: Total tokens used (prompt + completion).
+        unallocated_tokens: Authoritative provider-reported tokens that cannot
+            be truthfully assigned to prompt or completion.  This includes a
+            total-only report and additive cache counters when the public
+            prompt/completion fields exclude them.  Accounted spend is
+            ``total_tokens + unallocated_tokens``.
     """
 
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    unallocated_tokens: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ouroboros/providers/claude_cli_output.py
+++ b/src/ouroboros/providers/claude_cli_output.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
+import math
 from typing import Any
 
 # ``communicate()`` has already materialized stdout when this parser runs, but
@@ -25,6 +26,9 @@ MAX_CLAUDE_CLI_OUTPUT_CHARS = 8 * 1024 * 1024
 MAX_CLAUDE_CLI_EVENTS = 4096
 _MAX_SESSION_ID_CHARS = 4096
 _MAX_TOKEN_COUNT = (1 << 63) - 1
+# Stay well below CPython's configurable 4,300-digit default so hostile JSON
+# cannot escape this boundary as an interpreter-level ``ValueError``.
+_MAX_JSON_INTEGER_DIGITS = 1024
 
 
 class ClaudeCliOutputError(ValueError):
@@ -69,10 +73,10 @@ def normalize_claude_cli_output(stdout: str) -> ClaudeCliResult:
     documents = _decode_documents(stripped)
     events = _flatten_events(documents)
     final = _terminal_result(events)
+    is_error = _optional_bool(final, "is_error", default=False)
     session_id = _consistent_session_id(events)
     usage = _result_usage(events, final)
-    result_text = _result_text(final)
-    is_error = _optional_bool(final, "is_error", default=False)
+    result_text = _result_text(final, is_error=is_error)
     subtype = _optional_string(final, "subtype")
     stop_reason = _optional_string(final, "stop_reason")
 
@@ -106,10 +110,13 @@ def _decode_documents(stdout: str) -> list[Any]:
     """
     decoder = json.JSONDecoder(
         parse_constant=_reject_constant,
+        parse_float=_finite_json_float,
+        parse_int=_bounded_json_int,
         object_pairs_hook=_unique_object,
     )
     documents: list[Any] = []
     position = 0
+    previous_document_end: int | None = None
     while position < len(stdout):
         while position < len(stdout) and stdout[position].isspace():
             position += 1
@@ -124,10 +131,16 @@ def _decode_documents(stdout: str) -> list[Any]:
             position = len(stdout) if newline < 0 else newline + 1
             continue
 
+        if previous_document_end is not None:
+            separator = stdout[previous_document_end:position]
+            if "\n" not in separator and "\r" not in separator:
+                raise ClaudeCliOutputError("multiple JSON documents must have a newline boundary")
+
         line_number = stdout.count("\n", 0, position) + 1
         try:
             document, position = decoder.raw_decode(stdout, position)
             documents.append(document)
+            previous_document_end = position
         except json.JSONDecodeError as exc:
             raise ClaudeCliOutputError(
                 f"malformed JSON-looking stdout line {line_number}: {exc.msg}"
@@ -141,6 +154,28 @@ def _decode_documents(stdout: str) -> list[Any]:
 
 def _reject_constant(token: str) -> None:
     raise ClaudeCliOutputError(f"non-finite JSON number is not allowed: {token}")
+
+
+def _bounded_json_int(token: str) -> int:
+    digits = token[1:] if token.startswith("-") else token
+    if len(digits) > _MAX_JSON_INTEGER_DIGITS:
+        raise ClaudeCliOutputError(
+            f"JSON integer exceeds {_MAX_JSON_INTEGER_DIGITS} digit safety limit"
+        )
+    try:
+        return int(token)
+    except ValueError as exc:  # pragma: no cover - decoder supplies JSON integer syntax
+        raise ClaudeCliOutputError("invalid JSON integer") from exc
+
+
+def _finite_json_float(token: str) -> float:
+    try:
+        value = float(token)
+    except (OverflowError, ValueError) as exc:  # pragma: no cover - decoder validates syntax
+        raise ClaudeCliOutputError("invalid JSON number") from exc
+    if not math.isfinite(value):
+        raise ClaudeCliOutputError(f"non-finite JSON number is not allowed: {token}")
+    return value
 
 
 def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -258,19 +293,21 @@ def _result_usage(
     return usage
 
 
-def _result_text(final: Mapping[str, Any]) -> str:
+def _result_text(final: Mapping[str, Any], *, is_error: bool) -> str:
     if "result" in final:
         value = final["result"]
+        if value is None and is_error:
+            return ""
     else:
         # Some stream wrappers retain the terminal text in the same nested
         # message/content shape used by assistant events.
         message = final.get("message")
         if isinstance(message, Mapping) and "content" in message:
             value = message["content"]
-        elif final.get("type") is None and "is_error" in final:
-            # Legacy untyped result envelopes used omission and ``result: null``
-            # interchangeably for an empty response.  The caller's existing
-            # empty-content policy decides whether to retry or report it.
+        elif is_error:
+            # Typed and legacy untyped error envelopes use omission and
+            # ``result: null`` interchangeably when no human-readable detail is
+            # available.  Metadata remains authoritative completion evidence.
             return ""
         else:
             raise ClaudeCliOutputError("terminal result event has no result content")

--- a/src/ouroboros/providers/claude_cli_output.py
+++ b/src/ouroboros/providers/claude_cli_output.py
@@ -26,6 +26,20 @@ MAX_CLAUDE_CLI_OUTPUT_CHARS = 8 * 1024 * 1024
 MAX_CLAUDE_CLI_EVENTS = 4096
 _MAX_SESSION_ID_CHARS = 4096
 _MAX_TOKEN_COUNT = (1 << 63) - 1
+# Keep this trust-boundary schema aligned with the worker telemetry consumers
+# in ``orchestrator.adapter`` and ``orchestrator.frugality_evidence``.  Aliases
+# ending in ``_tokens`` are validated by the same contract below even when a
+# current consumer does not attribute them.
+_TOKEN_USAGE_KEYS = frozenset(
+    {
+        "input_tokens",
+        "output_tokens",
+        "cached_input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "total_tokens",
+    }
+)
 # Stay well below CPython's configurable 4,300-digit default so hostile JSON
 # cannot escape this boundary as an interpreter-level ``ValueError``.
 _MAX_JSON_INTEGER_DIGITS = 1024
@@ -280,9 +294,8 @@ def _result_usage(
         raise ClaudeCliOutputError("usage must be a JSON object")
 
     usage = dict(raw_usage)
-    for key in ("input_tokens", "output_tokens"):
-        value = usage.get(key)
-        if value is None:
+    for key, value in usage.items():
+        if key not in _TOKEN_USAGE_KEYS and not key.endswith("_tokens"):
             continue
         if (
             isinstance(value, bool)

--- a/src/ouroboros/providers/claude_cli_output.py
+++ b/src/ouroboros/providers/claude_cli_output.py
@@ -1,0 +1,320 @@
+"""Normalize Claude CLI JSON output across supported wire shapes.
+
+Claude Code has emitted both a single ``result`` object and event streams from
+``-p`` mode.  Depending on the CLI version and wrapper, the stream can arrive
+as NDJSON or as one top-level JSON array.  Consumers must not guess which shape
+they received and then call mapping methods on a list.
+
+This module deliberately recognizes only a terminal Claude ``result``
+envelope.  Assistant text on its own is not completion evidence: accepting it
+would turn a truncated stream into a successful request.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from typing import Any
+
+# ``communicate()`` has already materialized stdout when this parser runs, but
+# the cap still prevents a hostile response from causing another large decode,
+# event list, and raw-response copy.  Legitimate Claude result envelopes are
+# several orders of magnitude smaller than this.
+MAX_CLAUDE_CLI_OUTPUT_CHARS = 8 * 1024 * 1024
+MAX_CLAUDE_CLI_EVENTS = 4096
+_MAX_SESSION_ID_CHARS = 4096
+_MAX_TOKEN_COUNT = (1 << 63) - 1
+
+
+class ClaudeCliOutputError(ValueError):
+    """The CLI output did not contain one trustworthy terminal result."""
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeCliResult:
+    """Provider-neutral view of a terminal Claude CLI result envelope."""
+
+    result: str
+    is_error: bool
+    session_id: str | None
+    usage: dict[str, Any] | None
+    subtype: str | None
+    stop_reason: str | None
+    raw_payload: dict[str, Any]
+    event_count: int
+
+
+def normalize_claude_cli_output(stdout: str) -> ClaudeCliResult:
+    """Return the single terminal result from object, array, or NDJSON output.
+
+    Non-JSON diagnostic lines may surround an NDJSON stream.  A malformed line
+    that *looks* like JSON is rejected instead of skipped, because otherwise a
+    truncated or corrupted event could silently change the meaning of the
+    terminal result.  Duplicate keys, non-finite numbers, multiple results,
+    events after a result, inconsistent session ids, and malformed field types
+    are rejected for the same fail-closed reason.
+    """
+    if not isinstance(stdout, str):
+        raise ClaudeCliOutputError("stdout must be text")
+    if len(stdout) > MAX_CLAUDE_CLI_OUTPUT_CHARS:
+        raise ClaudeCliOutputError(
+            f"stdout exceeds {MAX_CLAUDE_CLI_OUTPUT_CHARS} character safety limit"
+        )
+
+    stripped = stdout.strip()
+    if not stripped:
+        raise ClaudeCliOutputError("stdout is empty")
+
+    documents = _decode_documents(stripped)
+    events = _flatten_events(documents)
+    final = _terminal_result(events)
+    session_id = _consistent_session_id(events)
+    usage = _result_usage(events, final)
+    result_text = _result_text(final)
+    is_error = _optional_bool(final, "is_error", default=False)
+    subtype = _optional_string(final, "subtype")
+    stop_reason = _optional_string(final, "stop_reason")
+
+    raw_payload = dict(final)
+    raw_payload["result"] = result_text
+    raw_payload["is_error"] = is_error
+    if session_id is not None:
+        raw_payload["session_id"] = session_id
+    if usage is not None:
+        raw_payload["usage"] = dict(usage)
+
+    return ClaudeCliResult(
+        result=result_text,
+        is_error=is_error,
+        session_id=session_id,
+        usage=usage,
+        subtype=subtype,
+        stop_reason=stop_reason,
+        raw_payload=raw_payload,
+        event_count=len(events),
+    )
+
+
+def _decode_documents(stdout: str) -> list[Any]:
+    """Decode complete JSON documents amid line-oriented diagnostics.
+
+    ``raw_decode`` matters here: unlike splitting lines, it supports pretty
+    printed arrays/objects while still supporting multiple NDJSON documents.
+    Diagnostics are ignored only when they start their own line.  Garbage
+    appended to a JSON document on the same line is protocol corruption.
+    """
+    decoder = json.JSONDecoder(
+        parse_constant=_reject_constant,
+        object_pairs_hook=_unique_object,
+    )
+    documents: list[Any] = []
+    position = 0
+    while position < len(stdout):
+        while position < len(stdout) and stdout[position].isspace():
+            position += 1
+        if position >= len(stdout):
+            break
+
+        if stdout[position] not in "{[":
+            line_start = stdout.rfind("\n", 0, position) + 1
+            if stdout[line_start:position].strip():
+                raise ClaudeCliOutputError("unexpected trailing data after JSON document")
+            newline = stdout.find("\n", position)
+            position = len(stdout) if newline < 0 else newline + 1
+            continue
+
+        line_number = stdout.count("\n", 0, position) + 1
+        try:
+            document, position = decoder.raw_decode(stdout, position)
+            documents.append(document)
+        except json.JSONDecodeError as exc:
+            raise ClaudeCliOutputError(
+                f"malformed JSON-looking stdout line {line_number}: {exc.msg}"
+            ) from exc
+        except RecursionError as exc:
+            raise ClaudeCliOutputError("JSON nesting exceeds the parser safety limit") from exc
+    if not documents:
+        raise ClaudeCliOutputError("stdout contains no JSON document")
+    return documents
+
+
+def _reject_constant(token: str) -> None:
+    raise ClaudeCliOutputError(f"non-finite JSON number is not allowed: {token}")
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ClaudeCliOutputError(f"duplicate JSON key is not allowed: {key}")
+        result[key] = value
+    return result
+
+
+def _flatten_events(documents: Sequence[Any]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for document in documents:
+        if isinstance(document, Mapping):
+            candidates: Sequence[Any] = (document,)
+        elif isinstance(document, list):
+            candidates = document
+        else:
+            raise ClaudeCliOutputError("top-level JSON document must be an object or event array")
+
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                raise ClaudeCliOutputError("every Claude event must be a JSON object")
+            events.append(dict(candidate))
+            if len(events) > MAX_CLAUDE_CLI_EVENTS:
+                raise ClaudeCliOutputError(
+                    f"event count exceeds {MAX_CLAUDE_CLI_EVENTS} safety limit"
+                )
+    if not events:
+        raise ClaudeCliOutputError("Claude event array is empty")
+    return events
+
+
+def _terminal_result(events: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    result_indexes: list[int] = []
+    activity_seen = False
+    init_seen = False
+
+    for index, event in enumerate(events):
+        event_type = event.get("type")
+        if event_type is not None and not isinstance(event_type, str):
+            raise ClaudeCliOutputError(f"event {index} has a non-string type")
+        # Older ``--output-format json`` envelopes were untyped.  ``is_error``
+        # is the discriminator when such an envelope omits an empty ``result``
+        # key; an arbitrary object is still not completion evidence.
+        is_result = event_type == "result" or (
+            event_type is None and ("result" in event or "is_error" in event)
+        )
+        if is_result:
+            result_indexes.append(index)
+            continue
+
+        is_init = event_type == "system" and event.get("subtype") == "init"
+        if is_init:
+            if init_seen or activity_seen:
+                raise ClaudeCliOutputError("system/init event is duplicated or out of order")
+            init_seen = True
+        else:
+            activity_seen = True
+
+    if not result_indexes:
+        raise ClaudeCliOutputError("no terminal Claude result event found")
+    if len(result_indexes) != 1:
+        raise ClaudeCliOutputError("multiple Claude result events found")
+    if result_indexes[0] != len(events) - 1:
+        raise ClaudeCliOutputError("Claude result event is not terminal")
+    return events[result_indexes[0]]
+
+
+def _consistent_session_id(events: Sequence[dict[str, Any]]) -> str | None:
+    observed: set[str] = set()
+    for index, event in enumerate(events):
+        value = event.get("session_id")
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str):
+            raise ClaudeCliOutputError(f"event {index} has a non-string session_id")
+        if len(value) > _MAX_SESSION_ID_CHARS:
+            raise ClaudeCliOutputError("session_id exceeds the safety limit")
+        observed.add(value)
+    if len(observed) > 1:
+        raise ClaudeCliOutputError("Claude events contain inconsistent session_id values")
+    return next(iter(observed), None)
+
+
+def _result_usage(
+    events: Sequence[dict[str, Any]], final: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    raw_usage = final.get("usage")
+    if raw_usage is None:
+        for event in reversed(events[:-1]):
+            raw_usage = event.get("usage")
+            message = event.get("message")
+            if raw_usage is None and isinstance(message, Mapping):
+                raw_usage = message.get("usage")
+            if raw_usage is not None:
+                break
+    if raw_usage is None:
+        return None
+    if not isinstance(raw_usage, Mapping):
+        raise ClaudeCliOutputError("usage must be a JSON object")
+
+    usage = dict(raw_usage)
+    for key in ("input_tokens", "output_tokens"):
+        value = usage.get(key)
+        if value is None:
+            continue
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not 0 <= value <= _MAX_TOKEN_COUNT
+        ):
+            raise ClaudeCliOutputError(f"usage.{key} must be a bounded non-negative integer")
+    return usage
+
+
+def _result_text(final: Mapping[str, Any]) -> str:
+    if "result" in final:
+        value = final["result"]
+    else:
+        # Some stream wrappers retain the terminal text in the same nested
+        # message/content shape used by assistant events.
+        message = final.get("message")
+        if isinstance(message, Mapping) and "content" in message:
+            value = message["content"]
+        elif final.get("type") is None and "is_error" in final:
+            # Legacy untyped result envelopes used omission and ``result: null``
+            # interchangeably for an empty response.  The caller's existing
+            # empty-content policy decides whether to retry or report it.
+            return ""
+        else:
+            raise ClaudeCliOutputError("terminal result event has no result content")
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        if "content" not in value:
+            raise ClaudeCliOutputError("result object has no content field")
+        return _content_blocks_text(value["content"])
+    if isinstance(value, list):
+        return _content_blocks_text(value)
+    raise ClaudeCliOutputError("result content must be text or recognized content blocks")
+
+
+def _content_blocks_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        raise ClaudeCliOutputError("nested result content must be text or a content-block array")
+
+    text_parts: list[str] = []
+    for block in value:
+        if not isinstance(block, Mapping):
+            raise ClaudeCliOutputError("result content blocks must be JSON objects")
+        block_type = block.get("type")
+        text_value = block.get("text")
+        if block_type != "text" or not isinstance(text_value, str):
+            raise ClaudeCliOutputError("result content contains a non-text block")
+        text_parts.append(text_value)
+    return "".join(text_parts)
+
+
+def _optional_bool(payload: Mapping[str, Any], key: str, *, default: bool) -> bool:
+    value = payload.get(key, default)
+    if not isinstance(value, bool):
+        raise ClaudeCliOutputError(f"{key} must be a boolean")
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ClaudeCliOutputError(f"{key} must be a string")
+    return value

--- a/src/ouroboros/providers/claude_cli_output.py
+++ b/src/ouroboros/providers/claude_cli_output.py
@@ -12,7 +12,7 @@ would turn a truncated stream into a successful request.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 import json
 import math
@@ -40,6 +40,13 @@ _TOKEN_USAGE_KEYS = frozenset(
         "total_tokens",
     }
 )
+_TOKEN_SPEND_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+_PRIMARY_TOKEN_KEYS = frozenset({"input_tokens", "output_tokens"})
 # Stay well below CPython's configurable 4,300-digit default so hostile JSON
 # cannot escape this boundary as an interpreter-level ``ValueError``.
 _MAX_JSON_INTEGER_DIGITS = 1024
@@ -280,16 +287,37 @@ def _result_usage(
     events: Sequence[dict[str, Any]], final: Mapping[str, Any]
 ) -> dict[str, Any] | None:
     raw_usage = final.get("usage")
-    if raw_usage is None:
-        for event in reversed(events[:-1]):
-            raw_usage = event.get("usage")
-            message = event.get("message")
-            if raw_usage is None and isinstance(message, Mapping):
-                raw_usage = message.get("usage")
-            if raw_usage is not None:
-                break
-    if raw_usage is None:
+    if raw_usage is not None:
+        # Claude's terminal result usage is the request-wide total.  It is
+        # authoritative when present, so adding assistant-event usage here
+        # would count the same work twice.
+        return _validated_usage(raw_usage)
+
+    turn_usages: list[dict[str, Any]] = []
+    for index, event in enumerate(events[:-1]):
+        top_level = event.get("usage")
+        message = event.get("message")
+        nested = message.get("usage") if isinstance(message, Mapping) else None
+        if top_level is not None and nested is not None and top_level != nested:
+            raise ClaudeCliOutputError(
+                f"assistant event {index} has conflicting top-level and nested usage"
+            )
+        event_usage = top_level if top_level is not None else nested
+        if event_usage is None:
+            continue
+        if event.get("type") != "assistant":
+            raise ClaudeCliOutputError(f"non-assistant event {index} cannot supply fallback usage")
+        turn_usages.append(_validated_usage(event_usage))
+
+    if not turn_usages:
         return None
+    if len(turn_usages) == 1:
+        return turn_usages[0]
+    return _aggregate_turn_usages(turn_usages)
+
+
+def _validated_usage(raw_usage: Any) -> dict[str, Any]:
+    """Copy one usage object after validating every token-shaped counter."""
     if not isinstance(raw_usage, Mapping):
         raise ClaudeCliOutputError("usage must be a JSON object")
 
@@ -304,6 +332,109 @@ def _result_usage(
         ):
             raise ClaudeCliOutputError(f"usage.{key} must be a bounded non-negative integer")
     return usage
+
+
+def _aggregate_turn_usages(turn_usages: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate event-local assistant usage into one request-wide usage object.
+
+    Each assistant event is one billed model turn.  ``total_tokens`` is
+    authoritative for that turn when supplied; otherwise the two primary
+    counters plus Anthropic's additive cache counters determine its spend.
+    Partial event telemetry is rejected because summing only the fields that
+    happen to be present could manufacture a smaller request total.
+    """
+    spend_by_turn: list[int] = []
+    all_turns_have_components = True
+    for usage in turn_usages:
+        fallback_keys = {key for key in _TOKEN_SPEND_KEYS if key in usage}
+        has_components = _PRIMARY_TOKEN_KEYS.issubset(fallback_keys)
+        all_turns_have_components = all_turns_have_components and has_components
+        total = usage.get("total_tokens")
+
+        if total is not None:
+            if fallback_keys and not has_components:
+                raise ClaudeCliOutputError(
+                    "fallback usage with total_tokens has incomplete additive counters"
+                )
+            if has_components:
+                component_total = _bounded_usage_sum(
+                    (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
+                    key="additive token counters",
+                )
+                if total != component_total:
+                    raise ClaudeCliOutputError(
+                        "fallback usage total_tokens disagrees with additive counters"
+                    )
+            spend_by_turn.append(total)
+            continue
+
+        if not has_components:
+            raise ClaudeCliOutputError(
+                "fallback usage must include total_tokens or both input_tokens and output_tokens"
+            )
+        spend_by_turn.append(
+            _bounded_usage_sum(
+                (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
+                key="additive token counters",
+            )
+        )
+
+    token_keys = {
+        key
+        for usage in turn_usages
+        for key in usage
+        if key in _TOKEN_USAGE_KEYS or key.endswith("_tokens")
+    }
+    aggregated = {
+        key: _bounded_usage_sum(
+            (usage[key] for usage in turn_usages if key in usage),
+            key=key,
+        )
+        for key in token_keys
+    }
+
+    if all_turns_have_components:
+        # A total present on only some turns is a partial total, not a request
+        # total.  Drop it so consumers use the complete additive breakdown.
+        if not all("total_tokens" in usage for usage in turn_usages):
+            aggregated.pop("total_tokens", None)
+    else:
+        # Some turns expose only their authoritative total, so a complete
+        # per-counter breakdown cannot be reconstructed.  Preserve the exact
+        # request spend as a total and omit partial additive components.
+        for key in _TOKEN_SPEND_KEYS:
+            aggregated.pop(key, None)
+        aggregated["total_tokens"] = _bounded_usage_sum(
+            spend_by_turn,
+            key="total_tokens",
+        )
+
+    # Preserve stable non-token metadata (for example ``service_tier``) only
+    # when every turn reports the same value.  Selecting one turn's metadata
+    # would be the same last-event attribution bug as selecting one usage.
+    common_metadata = set.intersection(
+        *(
+            {key for key in usage if key not in _TOKEN_USAGE_KEYS and not key.endswith("_tokens")}
+            for usage in turn_usages
+        )
+    )
+    for key in common_metadata:
+        first = turn_usages[0][key]
+        if all(usage[key] == first for usage in turn_usages[1:]):
+            aggregated[key] = first
+    return aggregated
+
+
+def _bounded_usage_sum(values: Iterable[int], *, key: str) -> int:
+    """Add already validated token counters without crossing the wire bound."""
+    total = 0
+    for value in values:
+        if value > _MAX_TOKEN_COUNT - total:
+            raise ClaudeCliOutputError(
+                f"aggregated usage.{key} exceeds the bounded token-count limit"
+            )
+        total += value
+    return total
 
 
 def _result_text(final: Mapping[str, Any], *, is_error: bool) -> str:

--- a/src/ouroboros/providers/claude_cli_output.py
+++ b/src/ouroboros/providers/claude_cli_output.py
@@ -47,6 +47,10 @@ _TOKEN_SPEND_KEYS = (
     "cache_read_input_tokens",
 )
 _PRIMARY_TOKEN_KEYS = frozenset({"input_tokens", "output_tokens"})
+_TOKEN_KEY_ALIASES = {
+    "prompt_tokens": "input_tokens",
+    "completion_tokens": "output_tokens",
+}
 # Stay well below CPython's configurable 4,300-digit default so hostile JSON
 # cannot escape this boundary as an interpreter-level ``ValueError``.
 _MAX_JSON_INTEGER_DIGITS = 1024
@@ -317,7 +321,14 @@ def _result_usage(
 
 
 def _validated_usage(raw_usage: Any) -> dict[str, Any]:
-    """Copy one usage object after validating every token-shaped counter."""
+    """Return one canonical, internally reconciled usage authority.
+
+    Claude wrappers occasionally rename the primary counters, but every
+    consumer needs the same names and the same total.  Canonicalization happens
+    here, before the worker and provider adapter diverge.  A total-only payload
+    remains total-only: no prompt/completion allocation can be inferred from a
+    scalar total.
+    """
     if not isinstance(raw_usage, Mapping):
         raise ClaudeCliOutputError("usage must be a JSON object")
 
@@ -331,6 +342,47 @@ def _validated_usage(raw_usage: Any) -> dict[str, Any]:
             or not 0 <= value <= _MAX_TOKEN_COUNT
         ):
             raise ClaudeCliOutputError(f"usage.{key} must be a bounded non-negative integer")
+
+    for alias, canonical in _TOKEN_KEY_ALIASES.items():
+        if alias not in usage:
+            continue
+        if canonical in usage and usage[canonical] != usage[alias]:
+            raise ClaudeCliOutputError(f"usage.{alias} disagrees with canonical usage.{canonical}")
+        usage[canonical] = usage[alias]
+        del usage[alias]
+
+    unsupported_token_keys = {
+        key for key in usage if key.endswith("_tokens") and key not in _TOKEN_USAGE_KEYS
+    }
+    if unsupported_token_keys:
+        keys = ", ".join(sorted(unsupported_token_keys))
+        raise ClaudeCliOutputError(f"usage has unsupported token counters: {keys}")
+
+    fallback_keys = {key for key in _TOKEN_SPEND_KEYS if key in usage}
+    has_components = _PRIMARY_TOKEN_KEYS.issubset(fallback_keys)
+    total = usage.get("total_tokens")
+    if total is not None:
+        if fallback_keys and not has_components:
+            raise ClaudeCliOutputError("usage with total_tokens has incomplete additive counters")
+        if has_components:
+            component_total = _bounded_usage_sum(
+                (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
+                key="additive token counters",
+            )
+            if total != component_total:
+                raise ClaudeCliOutputError(
+                    "usage.total_tokens disagrees with additive token counters"
+                )
+        return usage
+
+    if not has_components:
+        raise ClaudeCliOutputError(
+            "usage must include total_tokens or both input_tokens and output_tokens"
+        )
+    usage["total_tokens"] = _bounded_usage_sum(
+        (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
+        key="total_tokens",
+    )
     return usage
 
 
@@ -343,41 +395,11 @@ def _aggregate_turn_usages(turn_usages: Sequence[dict[str, Any]]) -> dict[str, A
     Partial event telemetry is rejected because summing only the fields that
     happen to be present could manufacture a smaller request total.
     """
-    spend_by_turn: list[int] = []
     all_turns_have_components = True
     for usage in turn_usages:
         fallback_keys = {key for key in _TOKEN_SPEND_KEYS if key in usage}
         has_components = _PRIMARY_TOKEN_KEYS.issubset(fallback_keys)
         all_turns_have_components = all_turns_have_components and has_components
-        total = usage.get("total_tokens")
-
-        if total is not None:
-            if fallback_keys and not has_components:
-                raise ClaudeCliOutputError(
-                    "fallback usage with total_tokens has incomplete additive counters"
-                )
-            if has_components:
-                component_total = _bounded_usage_sum(
-                    (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
-                    key="additive token counters",
-                )
-                if total != component_total:
-                    raise ClaudeCliOutputError(
-                        "fallback usage total_tokens disagrees with additive counters"
-                    )
-            spend_by_turn.append(total)
-            continue
-
-        if not has_components:
-            raise ClaudeCliOutputError(
-                "fallback usage must include total_tokens or both input_tokens and output_tokens"
-            )
-        spend_by_turn.append(
-            _bounded_usage_sum(
-                (usage[key] for key in _TOKEN_SPEND_KEYS if key in usage),
-                key="additive token counters",
-            )
-        )
 
     token_keys = {
         key
@@ -393,21 +415,12 @@ def _aggregate_turn_usages(turn_usages: Sequence[dict[str, Any]]) -> dict[str, A
         for key in token_keys
     }
 
-    if all_turns_have_components:
-        # A total present on only some turns is a partial total, not a request
-        # total.  Drop it so consumers use the complete additive breakdown.
-        if not all("total_tokens" in usage for usage in turn_usages):
-            aggregated.pop("total_tokens", None)
-    else:
+    if not all_turns_have_components:
         # Some turns expose only their authoritative total, so a complete
         # per-counter breakdown cannot be reconstructed.  Preserve the exact
         # request spend as a total and omit partial additive components.
         for key in _TOKEN_SPEND_KEYS:
             aggregated.pop(key, None)
-        aggregated["total_tokens"] = _bounded_usage_sum(
-            spend_by_turn,
-            key="total_tokens",
-        )
 
     # Preserve stable non-token metadata (for example ``service_tier``) only
     # when every turn reports the same value.  Selecting one turn's metadata

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -367,6 +367,8 @@ class ClaudeCodeAdapter:
 
         error_type = str(error.details.get("error_type", ""))
         stderr = str(error.details.get("stderr", "") or "").strip()
+        if stderr and self._is_retryable_error(stderr):
+            return True
         if stderr:
             return False
 
@@ -792,7 +794,32 @@ class ClaudeCodeAdapter:
             )
 
         payload = normalized.raw_payload
-        if normalized.is_error or proc.returncode != 0:
+        process_failed = proc.returncode not in (0, None)
+        if process_failed:
+            # The process status is the outer authority.  A stale success
+            # envelope can remain on stdout after the CLI/service fails; using
+            # its result text would hide overload/rate-limit diagnostics and
+            # suppress the shared transient retry loop.
+            process_diagnostic = stderr_text or (normalized.result if normalized.is_error else "")
+            return Result.err(
+                ProviderError(
+                    message=(
+                        process_diagnostic
+                        or f"claude CLI command failed with exit code {proc.returncode}"
+                    ),
+                    details={
+                        "error_type": "ProcessError",
+                        "subtype": normalized.subtype,
+                        "returncode": proc.returncode,
+                        "session_id": normalized.session_id,
+                        "usage": normalized.usage,
+                        "stop_reason": normalized.stop_reason,
+                        "stderr": stderr_text[:2000],
+                        "envelope_is_error": normalized.is_error,
+                    },
+                )
+            )
+        if normalized.is_error:
             return Result.err(
                 ProviderError(
                     message=normalized.result or "claude CLI reported an error",
@@ -816,6 +843,10 @@ class ClaudeCodeAdapter:
             return Result.err(empty)
 
         usage = normalized.usage or {}
+        prompt_tokens = int(usage.get("input_tokens") or 0)
+        completion_tokens = int(usage.get("output_tokens") or 0)
+        allocated_tokens = prompt_tokens + completion_tokens
+        authoritative_tokens = int(usage.get("total_tokens") or 0)
         log.info(
             "claude_code_adapter.cli_request_completed",
             content_length=len(content),
@@ -827,13 +858,14 @@ class ClaudeCodeAdapter:
                 content=content,
                 model=config.model,
                 usage=UsageInfo(
-                    # The normalizer is the single accounting authority.  A
-                    # total-only provider payload cannot be split truthfully;
-                    # UsageInfo's legacy integer component fields stay zero
-                    # while raw_response["usage"] retains their absence.
-                    prompt_tokens=int(usage.get("input_tokens") or 0),
-                    completion_tokens=int(usage.get("output_tokens") or 0),
-                    total_tokens=int(usage.get("total_tokens") or 0),
+                    # Preserve UsageInfo's additive invariant.  The normalizer
+                    # guarantees that the authoritative total is at least the
+                    # known prompt/completion sum; cache or total-only spend is
+                    # explicit rather than silently split between components.
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=allocated_tokens,
+                    unallocated_tokens=authoritative_tokens - allocated_tokens,
                 ),
                 finish_reason=normalized.stop_reason or "stop",
                 raw_response=payload,

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -60,6 +60,10 @@ from ouroboros.providers.base import (
     MessageRole,
     UsageInfo,
 )
+from ouroboros.providers.claude_cli_output import (
+    ClaudeCliOutputError,
+    normalize_claude_cli_output,
+)
 from ouroboros.providers.profiles import resolve_completion_profile_result
 from ouroboros.providers.tool_use_diagnostics import diagnose_tool_use_turn
 from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
@@ -678,7 +682,6 @@ class ClaudeCodeAdapter:
         rather than assumed moot.
         """
         import asyncio
-        import json as _json
 
         cli_path = self._cli_path
         if cli_path is None:  # pragma: no cover - guarded by the caller
@@ -769,46 +772,53 @@ class ClaudeCodeAdapter:
 
         stderr_text = stderr.decode("utf-8", "replace").strip()
         try:
-            payload = _json.loads(stdout.decode("utf-8", "replace"))
-        except ValueError:
+            normalized = normalize_claude_cli_output(stdout.decode("utf-8", "replace"))
+        except ClaudeCliOutputError as exc:
             # A non-JSON body means the CLI failed before it produced a result
             # envelope -- an auth prompt, a usage limit, a bad flag. The stderr
             # text is the only diagnosis available, and it is what the user
             # needs to see.
             return Result.err(
                 ProviderError(
-                    message=f"claude CLI returned no JSON result (exit {proc.returncode})",
-                    details={"stderr": stderr_text[:2000], "returncode": proc.returncode},
+                    message=(
+                        f"claude CLI request failed: no valid JSON result (exit {proc.returncode})"
+                    ),
+                    details={
+                        "stderr": stderr_text[:2000],
+                        "returncode": proc.returncode,
+                        "parse_error": str(exc),
+                    },
                 )
             )
 
-        if payload.get("is_error") or proc.returncode != 0:
+        payload = normalized.raw_payload
+        if normalized.is_error or proc.returncode != 0:
             return Result.err(
                 ProviderError(
-                    message=str(payload.get("result") or "claude CLI reported an error"),
+                    message=normalized.result or "claude CLI reported an error",
                     details={
-                        "subtype": payload.get("subtype"),
+                        "subtype": normalized.subtype,
                         "returncode": proc.returncode,
-                        "session_id": payload.get("session_id"),
+                        "session_id": normalized.session_id,
                         "stderr": stderr_text[:2000],
                     },
                 )
             )
 
-        session_id = payload.get("session_id")
-        content = str(payload.get("result") or "")
+        session_id = normalized.session_id
+        content = normalized.result
         empty = self._empty_content_error(
             content, session_id=session_id, stderr_tail=stderr_text[:2000]
         )
         if empty is not None:
             return Result.err(empty)
 
-        usage = payload.get("usage") or {}
+        usage = normalized.usage or {}
         log.info(
             "claude_code_adapter.cli_request_completed",
             content_length=len(content),
             session_id=session_id,
-            stop_reason=payload.get("stop_reason"),
+            stop_reason=normalized.stop_reason,
         )
         return Result.ok(
             CompletionResponse(
@@ -820,7 +830,7 @@ class ClaudeCodeAdapter:
                     total_tokens=int(usage.get("input_tokens") or 0)
                     + int(usage.get("output_tokens") or 0),
                 ),
-                finish_reason=str(payload.get("stop_reason") or "stop"),
+                finish_reason=normalized.stop_reason or "stop",
                 raw_response=payload,
             )
         )

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -800,6 +800,8 @@ class ClaudeCodeAdapter:
                         "subtype": normalized.subtype,
                         "returncode": proc.returncode,
                         "session_id": normalized.session_id,
+                        "usage": normalized.usage,
+                        "stop_reason": normalized.stop_reason,
                         "stderr": stderr_text[:2000],
                     },
                 )

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -827,10 +827,13 @@ class ClaudeCodeAdapter:
                 content=content,
                 model=config.model,
                 usage=UsageInfo(
+                    # The normalizer is the single accounting authority.  A
+                    # total-only provider payload cannot be split truthfully;
+                    # UsageInfo's legacy integer component fields stay zero
+                    # while raw_response["usage"] retains their absence.
                     prompt_tokens=int(usage.get("input_tokens") or 0),
                     completion_tokens=int(usage.get("output_tokens") or 0),
-                    total_tokens=int(usage.get("input_tokens") or 0)
-                    + int(usage.get("output_tokens") or 0),
+                    total_tokens=int(usage.get("total_tokens") or 0),
                 ),
                 finish_reason=normalized.stop_reason or "stop",
                 raw_response=payload,

--- a/tests/unit/evolution/test_provider_usage.py
+++ b/tests/unit/evolution/test_provider_usage.py
@@ -50,6 +50,7 @@ from ouroboros.providers.profiles import (
 @dataclass
 class _Adapter:
     tokens: int | None
+    unallocated_tokens: int = 0
     response_model: str = "test-model"
     llm_backend: str | None = None
     api_base: str = "https://provider.example/v1"
@@ -115,6 +116,7 @@ class _Adapter:
                     prompt_tokens=self.tokens,
                     completion_tokens=0,
                     total_tokens=self.tokens,
+                    unallocated_tokens=self.unallocated_tokens,
                 ),
             )
         )
@@ -257,6 +259,58 @@ async def test_generation_provider_usage_sums_every_tracked_call() -> None:
     assert summary.configuration_fingerprint is not None
     assert summary.configuration_assignments
     assert summary.issues == ()
+
+
+@pytest.mark.parametrize(
+    ("allocated_tokens", "unallocated_tokens"),
+    [
+        pytest.param(0, 132, id="total-only"),
+        pytest.param(120, 12, id="cache-inclusive"),
+    ],
+)
+async def test_generation_provider_usage_accounts_explicit_unallocated_authority(
+    allocated_tokens: int,
+    unallocated_tokens: int,
+) -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(
+            _Adapter(allocated_tokens, unallocated_tokens=unallocated_tokens),
+            [],
+            config,
+        )
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is True
+    assert summary.token_spend == 132
+    assert summary.issues == ()
+
+
+@pytest.mark.parametrize(
+    "unallocated_tokens",
+    [
+        pytest.param(True, id="boolean"),
+        pytest.param(-1, id="negative"),
+        pytest.param(10**400, id="overflow"),
+    ],
+)
+async def test_generation_provider_usage_rejects_invalid_unallocated_authority(
+    unallocated_tokens: int,
+) -> None:
+    config = CompletionConfig(model="test-model", role="reflect")
+    with capture_generation_provider_usage() as capture:
+        await tracked_complete(
+            _Adapter(0, unallocated_tokens=unallocated_tokens),
+            [],
+            config,
+        )
+
+    summary = capture.summary(instrumentation_complete=True)
+
+    assert summary.complete is False
+    assert summary.token_spend is None
+    assert "missing or invalid" in "; ".join(summary.issues)
 
 
 async def test_generation_provider_usage_rejects_any_missing_runtime_usage() -> None:

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -203,6 +203,23 @@ class TestParseTurn:
         assert turn.text == ""
         assert turn.error == "process failed"
 
+    def test_nonzero_exit_without_stderr_rejects_stale_success_diagnostic(self) -> None:
+        out = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "stale success",
+                "session_id": "stale-session",
+            }
+        )
+
+        turn = ClaudeWorkerTransport._parse_turn(out, "", 7)
+
+        assert turn.is_error is True
+        assert turn.text == ""
+        assert turn.error == "claude exited with status 7"
+
 
 class TestPermissionArgs:
     def test_bypass_maps_to_skip_permissions(self) -> None:

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -46,6 +46,7 @@ class TestParseTurn:
             "input_tokens": 10,
             "output_tokens": 2,
             "cache_read_input_tokens": 40,
+            "total_tokens": 52,
         }
 
     def test_is_error_flag_propagates(self) -> None:
@@ -96,7 +97,7 @@ class TestParseTurn:
         assert turn == WorkerTurn(
             text="final",
             session_id="array-session",
-            usage={"input_tokens": 4, "output_tokens": 2},
+            usage={"input_tokens": 4, "output_tokens": 2, "total_tokens": 6},
         )
 
     def test_structured_error_uses_result_when_stderr_is_empty(self) -> None:
@@ -146,7 +147,7 @@ class TestParseTurn:
             session_id="error-session",
             is_error=True,
             error="error_max_turns",
-            usage={"input_tokens": 9, "output_tokens": 2},
+            usage={"input_tokens": 9, "output_tokens": 2, "total_tokens": 11},
         )
 
     @pytest.mark.parametrize(
@@ -168,6 +169,18 @@ class TestParseTurn:
                 '"usage":{"cache_read_input_tokens":' + "9" * 1000 + "}}",
                 "bounded non-negative integer",
                 id="thousand-digit-secondary-usage",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"prompt_tokens":' + "9" * 1000 + "}}",
+                "bounded non-negative integer",
+                id="thousand-digit-primary-alias",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"prompt_tokens":true,"completion_tokens":2}}',
+                "bounded non-negative integer",
+                id="malformed-primary-alias",
             ),
         ],
     )
@@ -378,11 +391,27 @@ class TestRuntimeWiring:
         }
 
     @pytest.mark.asyncio
-    async def test_hostile_secondary_usage_never_reaches_frugality_consumer(self) -> None:
-        stdout = (
-            '{"type":"result","is_error":false,"result":"done",'
-            '"usage":{"cache_read_input_tokens":' + "9" * 1000 + "}}"
-        )
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"cache_read_input_tokens":' + "9" * 1000 + "}}",
+                id="huge-secondary",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"prompt_tokens":' + "9" * 1000 + "}}",
+                id="huge-alias",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"prompt_tokens":true,"completion_tokens":2}}',
+                id="malformed-alias",
+            ),
+        ],
+    )
+    async def test_hostile_usage_never_reaches_frugality_consumer(self, stdout: str) -> None:
         turn = ClaudeWorkerTransport._parse_turn(stdout, "", 0)
         assert turn.is_error is True
         assert turn.usage is None
@@ -424,7 +453,11 @@ class TestRuntimeWiring:
             0,
         )
         assert turn.is_error is False
-        assert turn.usage == {"input_tokens": 110, "output_tokens": 22}
+        assert turn.usage == {
+            "input_tokens": 110,
+            "output_tokens": 22,
+            "total_tokens": 132,
+        }
 
         rt = build_claude_worker_runtime(cwd="/tmp")
         transport = rt._transport
@@ -435,10 +468,46 @@ class TestRuntimeWiring:
         transport.spawn = _fake_spawn  # type: ignore[method-assign]
         messages = [message async for message in rt.execute_task("hi")]
 
-        assert messages[-1].data["usage"] == {"input_tokens": 110, "output_tokens": 22}
+        assert messages[-1].data["usage"] == {
+            "input_tokens": 110,
+            "output_tokens": 22,
+            "total_tokens": 132,
+        }
         assert harvest_token_spend(messages) == (
             132.0,
-            {"input_tokens": 110.0, "output_tokens": 22.0},
+            {"input_tokens": 110.0, "output_tokens": 22.0, "total_tokens": 132.0},
+        )
+
+    @pytest.mark.asyncio
+    async def test_total_only_cli_usage_reaches_final_receipt_without_allocation(self) -> None:
+        turn = ClaudeWorkerTransport._parse_turn(
+            json.dumps(
+                {
+                    "type": "result",
+                    "is_error": False,
+                    "result": "ok",
+                    "usage": {"total_tokens": 132},
+                }
+            ),
+            "",
+            0,
+        )
+        assert turn.is_error is False
+        assert turn.usage == {"total_tokens": 132}
+
+        rt = build_claude_worker_runtime(cwd="/tmp")
+        transport = rt._transport
+
+        async def _fake_spawn(**_kwargs) -> WorkerTurn:
+            return turn
+
+        transport.spawn = _fake_spawn  # type: ignore[method-assign]
+        messages = [message async for message in rt.execute_task("hi")]
+
+        assert messages[-1].data["usage"] == {"total_tokens": 132}
+        assert harvest_token_spend(messages) == (
+            132.0,
+            {"total_tokens": 132.0},
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -199,6 +200,7 @@ class TestParseTurn:
         turn = ClaudeWorkerTransport._parse_turn(out, "process failed", 7)
 
         assert turn.is_error is True
+        assert turn.text == ""
         assert turn.error == "process failed"
 
 
@@ -231,6 +233,32 @@ class TestRuntimeWiring:
     def test_persisted_runtime_declares_targeted_resume(self) -> None:
         rt = build_claude_worker_runtime(cwd="/tmp", persist_sessions=True)
         assert rt.capabilities.targeted_resume is True
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_stderr_is_public_provider_error_message(
+        self, tmp_path: Path
+    ) -> None:
+        runtime = build_claude_worker_runtime(cli_path="claude", cwd=tmp_path)
+        process = AsyncMock()
+        process.returncode = 7
+        process.communicate.return_value = (
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "stale success",
+                    "session_id": "stale-session",
+                }
+            ).encode(),
+            b"error: authentication required",
+        )
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await runtime.execute_task_to_result("do the work")
+
+        assert result.is_err
+        assert result.error.message == "error: authentication required"
 
     def test_normalizes_path_cwd(self, tmp_path: Path) -> None:
         rt = build_claude_worker_runtime(cwd=tmp_path, persist_sessions=True)

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -401,6 +401,47 @@ class TestRuntimeWiring:
         assert harvest_token_spend(messages) is None
 
     @pytest.mark.asyncio
+    async def test_multi_turn_cli_usage_reaches_frugality_as_request_total(self) -> None:
+        turn = ClaudeWorkerTransport._parse_turn(
+            json.dumps(
+                [
+                    {
+                        "type": "assistant",
+                        "message": {"usage": {"input_tokens": 100, "output_tokens": 20}},
+                    },
+                    {
+                        "type": "assistant",
+                        "message": {"usage": {"input_tokens": 10, "output_tokens": 2}},
+                    },
+                    {
+                        "type": "result",
+                        "is_error": False,
+                        "result": "ok",
+                    },
+                ]
+            ),
+            "",
+            0,
+        )
+        assert turn.is_error is False
+        assert turn.usage == {"input_tokens": 110, "output_tokens": 22}
+
+        rt = build_claude_worker_runtime(cwd="/tmp")
+        transport = rt._transport
+
+        async def _fake_spawn(**_kwargs) -> WorkerTurn:
+            return turn
+
+        transport.spawn = _fake_spawn  # type: ignore[method-assign]
+        messages = [message async for message in rt.execute_task("hi")]
+
+        assert messages[-1].data["usage"] == {"input_tokens": 110, "output_tokens": 22}
+        assert harvest_token_spend(messages) == (
+            132.0,
+            {"input_tokens": 110.0, "output_tokens": 22.0},
+        )
+
+    @pytest.mark.asyncio
     async def test_bounded_all_counter_usage_preserves_spend_semantics(self) -> None:
         usage = {
             "input_tokens": 5,

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -112,6 +112,67 @@ class TestParseTurn:
         assert turn.is_error is True
         assert turn.error == "maximum turns reached"
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(
+                {
+                    "type": "result",
+                    "is_error": True,
+                    "result": None,
+                    "subtype": "error_max_turns",
+                    "session_id": "error-session",
+                    "usage": {"input_tokens": 9, "output_tokens": 2},
+                },
+                id="typed-null",
+            ),
+            pytest.param(
+                {
+                    "is_error": True,
+                    "subtype": "error_max_turns",
+                    "session_id": "error-session",
+                    "usage": {"input_tokens": 9, "output_tokens": 2},
+                },
+                id="untyped-omitted",
+            ),
+        ],
+    )
+    def test_empty_structured_error_preserves_metadata(self, payload: dict[str, object]) -> None:
+        turn = ClaudeWorkerTransport._parse_turn(json.dumps(payload), "", 0)
+
+        assert turn == WorkerTurn(
+            text="",
+            session_id="error-session",
+            is_error=True,
+            error="error_max_turns",
+            usage={"input_tokens": 9, "output_tokens": 2},
+        )
+
+    @pytest.mark.parametrize(
+        ("stdout", "message"),
+        [
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done","trace":' + "9" * 4301 + "}",
+                "integer exceeds",
+                id="oversized-integer",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"cache_read_input_tokens":1e9999}}',
+                "non-finite JSON number",
+                id="non-finite-secondary-usage",
+            ),
+        ],
+    )
+    def test_hostile_number_becomes_structured_worker_error(
+        self, stdout: str, message: str
+    ) -> None:
+        turn = ClaudeWorkerTransport._parse_turn(stdout, "", 0)
+
+        assert turn.is_error is True
+        assert turn.session_id is None
+        assert message in (turn.error or "")
+
     def test_nonzero_exit_cannot_be_overridden_by_success_payload(self) -> None:
         out = json.dumps({"type": "result", "is_error": False, "result": "looks okay"})
 

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -18,6 +18,7 @@ from ouroboros.orchestrator.claude_worker_runtime import (
     ClaudeWorkerTransport,
     build_claude_worker_runtime,
 )
+from ouroboros.orchestrator.frugality_evidence import harvest_token_spend
 from ouroboros.orchestrator.worker_runtime import WorkerTurn
 
 
@@ -161,6 +162,12 @@ class TestParseTurn:
                 '"usage":{"cache_read_input_tokens":1e9999}}',
                 "non-finite JSON number",
                 id="non-finite-secondary-usage",
+            ),
+            pytest.param(
+                '{"type":"result","is_error":false,"result":"done",'
+                '"usage":{"cache_read_input_tokens":' + "9" * 1000 + "}}",
+                "bounded non-negative integer",
+                id="thousand-digit-secondary-usage",
             ),
         ],
     )
@@ -369,6 +376,76 @@ class TestRuntimeWiring:
             "output_tokens": 1,
             "cache_creation_input_tokens": 20,
         }
+
+    @pytest.mark.asyncio
+    async def test_hostile_secondary_usage_never_reaches_frugality_consumer(self) -> None:
+        stdout = (
+            '{"type":"result","is_error":false,"result":"done",'
+            '"usage":{"cache_read_input_tokens":' + "9" * 1000 + "}}"
+        )
+        turn = ClaudeWorkerTransport._parse_turn(stdout, "", 0)
+        assert turn.is_error is True
+        assert turn.usage is None
+
+        rt = build_claude_worker_runtime(cwd="/tmp")
+        transport = rt._transport
+
+        async def _fake_spawn(**_kwargs) -> WorkerTurn:
+            return turn
+
+        transport.spawn = _fake_spawn  # type: ignore[method-assign]
+        messages = [message async for message in rt.execute_task("hi")]
+
+        assert messages[-1].is_error is True
+        assert "usage" not in messages[-1].data
+        assert harvest_token_spend(messages) is None
+
+    @pytest.mark.asyncio
+    async def test_bounded_all_counter_usage_preserves_spend_semantics(self) -> None:
+        usage = {
+            "input_tokens": 5,
+            "output_tokens": 1,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 40,
+            "cached_input_tokens": 7,
+            "total_tokens": 66,
+        }
+        turn = ClaudeWorkerTransport._parse_turn(
+            json.dumps(
+                {
+                    "type": "result",
+                    "is_error": False,
+                    "result": "ok",
+                    "usage": usage,
+                }
+            ),
+            "",
+            0,
+        )
+        assert turn.is_error is False
+        assert turn.usage == usage
+
+        rt = build_claude_worker_runtime(cwd="/tmp")
+        transport = rt._transport
+
+        async def _fake_spawn(**_kwargs) -> WorkerTurn:
+            return turn
+
+        transport.spawn = _fake_spawn  # type: ignore[method-assign]
+        messages = [message async for message in rt.execute_task("hi")]
+
+        assert messages[-1].data["usage"] == usage
+        assert harvest_token_spend(messages) == (
+            66.0,
+            {
+                "input_tokens": 5.0,
+                "output_tokens": 1.0,
+                "cache_creation_input_tokens": 20.0,
+                "cache_read_input_tokens": 40.0,
+                "cached_input_tokens": 7.0,
+                "total_tokens": 66.0,
+            },
+        )
 
     def test_resume_is_cwd_pinned(self) -> None:
         # The transport must pin cwd so --resume targets the session's store.

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -70,6 +70,56 @@ class TestParseTurn:
         assert turn.text == "ok"
         assert turn.session_id == "z"
 
+    def test_parses_top_level_stream_event_array(self) -> None:
+        out = json.dumps(
+            [
+                {"type": "system", "subtype": "init", "session_id": "array-session"},
+                {
+                    "type": "assistant",
+                    "session_id": "array-session",
+                    "message": {"content": [{"type": "text", "text": "draft"}]},
+                },
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "final",
+                    "session_id": "array-session",
+                    "usage": {"input_tokens": 4, "output_tokens": 2},
+                },
+            ]
+        )
+
+        turn = ClaudeWorkerTransport._parse_turn(out, "", 0)
+
+        assert turn == WorkerTurn(
+            text="final",
+            session_id="array-session",
+            usage={"input_tokens": 4, "output_tokens": 2},
+        )
+
+    def test_structured_error_uses_result_when_stderr_is_empty(self) -> None:
+        out = json.dumps(
+            {
+                "type": "result",
+                "is_error": True,
+                "result": "maximum turns reached",
+            }
+        )
+
+        turn = ClaudeWorkerTransport._parse_turn(out, "", 0)
+
+        assert turn.is_error is True
+        assert turn.error == "maximum turns reached"
+
+    def test_nonzero_exit_cannot_be_overridden_by_success_payload(self) -> None:
+        out = json.dumps({"type": "result", "is_error": False, "result": "looks okay"})
+
+        turn = ClaudeWorkerTransport._parse_turn(out, "process failed", 7)
+
+        assert turn.is_error is True
+        assert turn.error == "process failed"
+
 
 class TestPermissionArgs:
     def test_bypass_maps_to_skip_permissions(self) -> None:

--- a/tests/unit/providers/test_base.py
+++ b/tests/unit/providers/test_base.py
@@ -160,6 +160,19 @@ class TestUsageInfo:
         assert usage.prompt_tokens == 100
         assert usage.completion_tokens == 50
         assert usage.total_tokens == 150
+        assert usage.unallocated_tokens == 0
+
+    def test_usage_info_explicitly_preserves_unallocated_authority(self) -> None:
+        usage = UsageInfo(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            unallocated_tokens=12,
+        )
+
+        assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+        assert usage.unallocated_tokens == 12
+        assert usage.total_tokens + usage.unallocated_tokens == 132
 
     def test_usage_info_is_frozen(self) -> None:
         """UsageInfo is immutable."""

--- a/tests/unit/providers/test_claude_cli_output.py
+++ b/tests/unit/providers/test_claude_cli_output.py
@@ -335,6 +335,54 @@ def test_rejects_unbounded_or_non_finite_numbers(stdout: str, message: str) -> N
         normalize_claude_cli_output(stdout)
 
 
+@pytest.mark.parametrize(
+    "token_key",
+    [
+        "input_tokens",
+        "output_tokens",
+        "cached_input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+    ],
+)
+def test_rejects_thousand_digit_token_counters_and_aliases(token_key: str) -> None:
+    stdout = (
+        '{"type":"result","is_error":false,"result":"done","usage":{"'
+        + token_key
+        + '":'
+        + "9" * 1000
+        + "}}"
+    )
+
+    with pytest.raises(
+        ClaudeCliOutputError,
+        match=rf"usage\.{token_key} must be a bounded non-negative integer",
+    ):
+        normalize_claude_cli_output(stdout)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="null"),
+        pytest.param(True, id="boolean"),
+        pytest.param(-1, id="negative"),
+        pytest.param(1.5, id="fractional"),
+    ],
+)
+def test_rejects_invalid_secondary_token_counter_types(value: object) -> None:
+    payload = _result(usage={"input_tokens": 1, "cache_read_input_tokens": value})
+
+    with pytest.raises(
+        ClaudeCliOutputError,
+        match="usage.cache_read_input_tokens must be a bounded non-negative integer",
+    ):
+        normalize_claude_cli_output(json.dumps(payload))
+
+
 def test_rejects_oversized_stdout_before_decoding() -> None:
     with pytest.raises(ClaudeCliOutputError, match="character safety limit"):
         normalize_claude_cli_output("x" * (MAX_CLAUDE_CLI_OUTPUT_CHARS + 1))

--- a/tests/unit/providers/test_claude_cli_output.py
+++ b/tests/unit/providers/test_claude_cli_output.py
@@ -54,7 +54,11 @@ def test_normalizes_single_result_object() -> None:
     assert normalized.result == "done"
     assert normalized.session_id == "session-1"
     assert normalized.is_error is False
-    assert normalized.usage == {"input_tokens": 11, "output_tokens": 7}
+    assert normalized.usage == {
+        "input_tokens": 11,
+        "output_tokens": 7,
+        "total_tokens": 18,
+    }
     assert normalized.stop_reason == "end_turn"
     assert normalized.event_count == 1
 
@@ -214,7 +218,11 @@ def test_error_envelope_allows_empty_result_and_preserves_metadata(
     assert normalized.is_error is True
     assert normalized.subtype == "error_max_turns"
     assert normalized.session_id == "error-session"
-    assert normalized.usage == {"input_tokens": 9, "output_tokens": 2}
+    assert normalized.usage == {
+        "input_tokens": 9,
+        "output_tokens": 2,
+        "total_tokens": 11,
+    }
     assert normalized.raw_payload["result"] == ""
 
 
@@ -237,7 +245,11 @@ def test_usage_falls_back_to_nested_assistant_usage() -> None:
 
     normalized = normalize_claude_cli_output(json.dumps(_events(final)))
 
-    assert normalized.usage == {"input_tokens": 3, "output_tokens": 1}
+    assert normalized.usage == {
+        "input_tokens": 3,
+        "output_tokens": 1,
+        "total_tokens": 4,
+    }
 
 
 def test_missing_terminal_usage_aggregates_every_assistant_turn() -> None:
@@ -253,7 +265,7 @@ def test_missing_terminal_usage_aggregates_every_assistant_turn() -> None:
                 "input_tokens": 100,
                 "output_tokens": 20,
                 "cache_read_input_tokens": 7,
-                "reasoning_tokens": 4,
+                "cached_input_tokens": 4,
             },
         },
     )
@@ -264,7 +276,8 @@ def test_missing_terminal_usage_aggregates_every_assistant_turn() -> None:
         "input_tokens": 103,
         "output_tokens": 21,
         "cache_read_input_tokens": 7,
-        "reasoning_tokens": 4,
+        "cached_input_tokens": 4,
+        "total_tokens": 131,
     }
 
 
@@ -281,7 +294,94 @@ def test_terminal_usage_is_authoritative_and_never_double_counted() -> None:
 
     normalized = normalize_claude_cli_output(json.dumps(events))
 
-    assert normalized.usage == {"input_tokens": 110, "output_tokens": 22}
+    assert normalized.usage == {
+        "input_tokens": 110,
+        "output_tokens": 22,
+        "total_tokens": 132,
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_usage", "expected"),
+    [
+        pytest.param(
+            {"total_tokens": 132},
+            {"total_tokens": 132},
+            id="total-only-stays-unallocated",
+        ),
+        pytest.param(
+            {"input_tokens": 110, "output_tokens": 22},
+            {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+            id="components-derive-total",
+        ),
+        pytest.param(
+            {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+            {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+            id="consistent-total-and-components",
+        ),
+        pytest.param(
+            {"prompt_tokens": 110, "completion_tokens": 22},
+            {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+            id="primary-aliases-canonicalized",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 8,
+                "cache_read_input_tokens": 4,
+                "cached_input_tokens": 90,
+            },
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 8,
+                "cache_read_input_tokens": 4,
+                "cached_input_tokens": 90,
+                "total_tokens": 132,
+            },
+            id="secondary-additive-and-diagnostic-counters",
+        ),
+    ],
+)
+def test_usage_is_one_canonical_accounting_authority(
+    raw_usage: dict[str, int], expected: dict[str, int]
+) -> None:
+    normalized = normalize_claude_cli_output(json.dumps(_result(usage=raw_usage)))
+
+    assert normalized.usage == expected
+    assert normalized.raw_payload["usage"] == expected
+
+
+@pytest.mark.parametrize(
+    "raw_usage",
+    [
+        pytest.param(
+            {"input_tokens": 110, "output_tokens": 22, "total_tokens": 12},
+            id="inconsistent-total",
+        ),
+        pytest.param(
+            {"input_tokens": 110, "total_tokens": 132},
+            id="partial-components-with-total",
+        ),
+        pytest.param(
+            {"input_tokens": 110, "prompt_tokens": 109, "output_tokens": 22},
+            id="conflicting-alias",
+        ),
+        pytest.param(
+            {"input_tokens": 110, "output_tokens": 22, "reasoning_tokens": 1},
+            id="unsupported-token-counter",
+        ),
+        pytest.param({}, id="empty-usage"),
+    ],
+)
+def test_invalid_terminal_usage_never_falls_back_to_assistant_totals(
+    raw_usage: dict[str, int],
+) -> None:
+    events = _events(_result(usage=raw_usage))
+
+    with pytest.raises(ClaudeCliOutputError, match="usage|token"):
+        normalize_claude_cli_output(json.dumps(events))
 
 
 def test_fallback_aggregates_reconciled_per_turn_totals_and_metadata() -> None:
@@ -407,7 +507,7 @@ def test_rejects_multi_turn_counter_sum_overflow() -> None:
             "usage": {
                 "input_tokens": 1,
                 "output_tokens": 1,
-                "reasoning_tokens": (1 << 63) - 1,
+                "cached_input_tokens": (1 << 63) - 1,
             },
         },
         {
@@ -415,13 +515,13 @@ def test_rejects_multi_turn_counter_sum_overflow() -> None:
             "usage": {
                 "input_tokens": 1,
                 "output_tokens": 1,
-                "reasoning_tokens": 1,
+                "cached_input_tokens": 1,
             },
         },
         final,
     ]
 
-    with pytest.raises(ClaudeCliOutputError, match="aggregated usage.reasoning_tokens"):
+    with pytest.raises(ClaudeCliOutputError, match="aggregated usage.cached_input_tokens"):
         normalize_claude_cli_output(json.dumps(events))
 
 
@@ -564,6 +664,26 @@ def test_rejects_invalid_secondary_token_counter_types(value: object) -> None:
     with pytest.raises(
         ClaudeCliOutputError,
         match="usage.cache_read_input_tokens must be a bounded non-negative integer",
+    ):
+        normalize_claude_cli_output(json.dumps(payload))
+
+
+@pytest.mark.parametrize(
+    ("alias", "value"),
+    [
+        pytest.param("prompt_tokens", True, id="boolean-prompt-alias"),
+        pytest.param("completion_tokens", 1.5, id="fractional-completion-alias"),
+        pytest.param("prompt_tokens", -1, id="negative-prompt-alias"),
+    ],
+)
+def test_rejects_malformed_primary_aliases(alias: str, value: object) -> None:
+    usage: dict[str, object] = {"prompt_tokens": 1, "completion_tokens": 2}
+    usage[alias] = value
+    payload = _result(usage=usage)
+
+    with pytest.raises(
+        ClaudeCliOutputError,
+        match=rf"usage\.{alias} must be a bounded non-negative integer",
     ):
         normalize_claude_cli_output(json.dumps(payload))
 

--- a/tests/unit/providers/test_claude_cli_output.py
+++ b/tests/unit/providers/test_claude_cli_output.py
@@ -112,6 +112,14 @@ def test_flattens_array_documents_inside_ndjson() -> None:
     assert normalized.event_count == 3
 
 
+@pytest.mark.parametrize("separator", ["", " ", "\t"])
+def test_rejects_concatenated_json_documents_without_newline(separator: str) -> None:
+    stdout = json.dumps({"type": "assistant"}) + separator + json.dumps(_result())
+
+    with pytest.raises(ClaudeCliOutputError, match="newline boundary"):
+        normalize_claude_cli_output(stdout)
+
+
 @pytest.mark.parametrize(
     ("result_value", "expected"),
     [
@@ -150,6 +158,77 @@ def test_error_result_preserves_diagnostics_and_metadata() -> None:
     assert normalized.is_error is True
     assert normalized.result == "reached maximum number of turns"
     assert normalized.subtype == "error_max_turns"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {
+                "type": "result",
+                "is_error": True,
+                "result": None,
+                "subtype": "error_max_turns",
+                "session_id": "error-session",
+                "usage": {"input_tokens": 9, "output_tokens": 2},
+            },
+            id="typed-null",
+        ),
+        pytest.param(
+            {
+                "type": "result",
+                "is_error": True,
+                "subtype": "error_max_turns",
+                "session_id": "error-session",
+                "usage": {"input_tokens": 9, "output_tokens": 2},
+            },
+            id="typed-omitted",
+        ),
+        pytest.param(
+            {
+                "is_error": True,
+                "result": None,
+                "subtype": "error_max_turns",
+                "session_id": "error-session",
+                "usage": {"input_tokens": 9, "output_tokens": 2},
+            },
+            id="untyped-null",
+        ),
+        pytest.param(
+            {
+                "is_error": True,
+                "subtype": "error_max_turns",
+                "session_id": "error-session",
+                "usage": {"input_tokens": 9, "output_tokens": 2},
+            },
+            id="untyped-omitted",
+        ),
+    ],
+)
+def test_error_envelope_allows_empty_result_and_preserves_metadata(
+    payload: dict[str, object],
+) -> None:
+    normalized = normalize_claude_cli_output(json.dumps(payload))
+
+    assert normalized.result == ""
+    assert normalized.is_error is True
+    assert normalized.subtype == "error_max_turns"
+    assert normalized.session_id == "error-session"
+    assert normalized.usage == {"input_tokens": 9, "output_tokens": 2}
+    assert normalized.raw_payload["result"] == ""
+
+
+@pytest.mark.parametrize("typed", [False, True], ids=["untyped", "typed"])
+@pytest.mark.parametrize("include_null", [False, True], ids=["omitted", "null"])
+def test_success_envelope_rejects_empty_result(typed: bool, include_null: bool) -> None:
+    payload: dict[str, object] = {"is_error": False}
+    if typed:
+        payload["type"] = "result"
+    if include_null:
+        payload["result"] = None
+
+    with pytest.raises(ClaudeCliOutputError, match="result"):
+        normalize_claude_cli_output(json.dumps(payload))
 
 
 def test_usage_falls_back_to_nested_assistant_usage() -> None:
@@ -227,6 +306,32 @@ def test_rejects_garbage_appended_to_json_on_the_same_line() -> None:
 )
 def test_rejects_ambiguous_json(stdout: str) -> None:
     with pytest.raises(ClaudeCliOutputError):
+        normalize_claude_cli_output(stdout)
+
+
+@pytest.mark.parametrize(
+    ("stdout", "message"),
+    [
+        pytest.param(
+            '{"type":"result","is_error":false,"result":"done","trace":' + "9" * 4301 + "}",
+            "integer exceeds",
+            id="oversized-integer",
+        ),
+        pytest.param(
+            '{"type":"result","is_error":false,"result":"done","score":1e9999}',
+            "non-finite JSON number",
+            id="raw-overflowing-float",
+        ),
+        pytest.param(
+            '{"type":"result","is_error":false,"result":"done",'
+            '"usage":{"input_tokens":1,"cache_read_input_tokens":1e9999}}',
+            "non-finite JSON number",
+            id="secondary-usage-overflowing-float",
+        ),
+    ],
+)
+def test_rejects_unbounded_or_non_finite_numbers(stdout: str, message: str) -> None:
+    with pytest.raises(ClaudeCliOutputError, match=message):
         normalize_claude_cli_output(stdout)
 
 

--- a/tests/unit/providers/test_claude_cli_output.py
+++ b/tests/unit/providers/test_claude_cli_output.py
@@ -240,6 +240,191 @@ def test_usage_falls_back_to_nested_assistant_usage() -> None:
     assert normalized.usage == {"input_tokens": 3, "output_tokens": 1}
 
 
+def test_missing_terminal_usage_aggregates_every_assistant_turn() -> None:
+    final = _result()
+    final.pop("usage")
+    events = _events(final)
+    events.insert(
+        -1,
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 7,
+                "reasoning_tokens": 4,
+            },
+        },
+    )
+
+    normalized = normalize_claude_cli_output(json.dumps(events))
+
+    assert normalized.usage == {
+        "input_tokens": 103,
+        "output_tokens": 21,
+        "cache_read_input_tokens": 7,
+        "reasoning_tokens": 4,
+    }
+
+
+def test_terminal_usage_is_authoritative_and_never_double_counted() -> None:
+    events = _events(_result(usage={"input_tokens": 110, "output_tokens": 22}))
+    events.insert(
+        -1,
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "message": {"usage": {"input_tokens": 100, "output_tokens": 20}},
+        },
+    )
+
+    normalized = normalize_claude_cli_output(json.dumps(events))
+
+    assert normalized.usage == {"input_tokens": 110, "output_tokens": 22}
+
+
+def test_fallback_aggregates_reconciled_per_turn_totals_and_metadata() -> None:
+    final = _result()
+    final.pop("usage")
+    events = [
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "message": {
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 3,
+                    "total_tokens": 123,
+                    "service_tier": "standard",
+                }
+            },
+        },
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "message": {
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 2,
+                    "cache_read_input_tokens": 4,
+                    "total_tokens": 16,
+                    "service_tier": "standard",
+                }
+            },
+        },
+        final,
+    ]
+
+    normalized = normalize_claude_cli_output(json.dumps(events))
+
+    assert normalized.usage == {
+        "input_tokens": 110,
+        "output_tokens": 22,
+        "cache_creation_input_tokens": 3,
+        "cache_read_input_tokens": 4,
+        "total_tokens": 139,
+        "service_tier": "standard",
+    }
+
+
+def test_fallback_synthesizes_only_total_when_a_turn_has_no_breakdown() -> None:
+    final = _result()
+    final.pop("usage")
+    events = [
+        {"type": "assistant", "usage": {"total_tokens": 120}},
+        {
+            "type": "assistant",
+            "message": {"usage": {"input_tokens": 10, "output_tokens": 2}},
+        },
+        final,
+    ]
+
+    normalized = normalize_claude_cli_output(json.dumps(events))
+
+    assert normalized.usage == {"total_tokens": 132}
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        pytest.param(
+            [
+                {
+                    "type": "assistant",
+                    "usage": {"input_tokens": 100, "output_tokens": 20},
+                    "message": {"usage": {"input_tokens": 10, "output_tokens": 2}},
+                }
+            ],
+            id="conflicting-sources",
+        ),
+        pytest.param(
+            [
+                {"type": "assistant", "usage": {"input_tokens": 100}},
+                {
+                    "type": "assistant",
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                },
+            ],
+            id="partial-turn",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "assistant",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 2,
+                        "total_tokens": 1,
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                },
+            ],
+            id="inconsistent-total",
+        ),
+    ],
+)
+def test_rejects_ambiguous_or_incomplete_multi_turn_fallback_usage(
+    events: list[dict[str, object]],
+) -> None:
+    final = _result()
+    final.pop("usage")
+
+    with pytest.raises(ClaudeCliOutputError, match="usage|token"):
+        normalize_claude_cli_output(json.dumps([*events, final]))
+
+
+def test_rejects_multi_turn_counter_sum_overflow() -> None:
+    final = _result()
+    final.pop("usage")
+    events = [
+        {
+            "type": "assistant",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "reasoning_tokens": (1 << 63) - 1,
+            },
+        },
+        {
+            "type": "assistant",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "reasoning_tokens": 1,
+            },
+        },
+        final,
+    ]
+
+    with pytest.raises(ClaudeCliOutputError, match="aggregated usage.reasoning_tokens"):
+        normalize_claude_cli_output(json.dumps(events))
+
+
 @pytest.mark.parametrize(
     "events",
     [

--- a/tests/unit/providers/test_claude_cli_output.py
+++ b/tests/unit/providers/test_claude_cli_output.py
@@ -1,0 +1,242 @@
+"""Regression coverage for Claude CLI result-shape normalization (#2037)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.providers.claude_cli_output import (
+    MAX_CLAUDE_CLI_EVENTS,
+    MAX_CLAUDE_CLI_OUTPUT_CHARS,
+    ClaudeCliOutputError,
+    normalize_claude_cli_output,
+)
+
+
+def _result(**overrides: object) -> dict[str, object]:
+    result: dict[str, object] = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "done",
+        "session_id": "session-1",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 11, "output_tokens": 7},
+    }
+    result.update(overrides)
+    return result
+
+
+def _events(final: dict[str, object] | None = None) -> list[dict[str, object]]:
+    return [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "session-1",
+            "cwd": "/workspace",
+        },
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "message": {
+                "content": [{"type": "text", "text": "intermediate"}],
+                "usage": {"input_tokens": 3, "output_tokens": 1},
+            },
+        },
+        final or _result(),
+    ]
+
+
+def test_normalizes_single_result_object() -> None:
+    normalized = normalize_claude_cli_output(json.dumps(_result()))
+
+    assert normalized.result == "done"
+    assert normalized.session_id == "session-1"
+    assert normalized.is_error is False
+    assert normalized.usage == {"input_tokens": 11, "output_tokens": 7}
+    assert normalized.stop_reason == "end_turn"
+    assert normalized.event_count == 1
+
+
+def test_normalizes_top_level_event_array_and_uses_terminal_result() -> None:
+    normalized = normalize_claude_cli_output(json.dumps(_events()))
+
+    assert normalized.result == "done"
+    assert normalized.session_id == "session-1"
+    assert normalized.event_count == 3
+    assert normalized.raw_payload["type"] == "result"
+
+
+def test_normalizes_ndjson_with_plain_diagnostic_lines() -> None:
+    stdout = "\n".join(
+        [
+            "warning: optional plugin unavailable",
+            *(json.dumps(event) for event in _events()),
+            "diagnostic: request complete",
+        ]
+    )
+
+    normalized = normalize_claude_cli_output(stdout)
+
+    assert normalized.result == "done"
+    assert normalized.event_count == 3
+
+
+def test_normalizes_pretty_event_array_between_diagnostic_lines() -> None:
+    stdout = "\n".join(
+        [
+            "warning: optional plugin unavailable",
+            json.dumps(_events(), indent=2),
+            "diagnostic: request complete",
+        ]
+    )
+
+    normalized = normalize_claude_cli_output(stdout)
+
+    assert normalized.result == "done"
+    assert normalized.event_count == 3
+
+
+def test_flattens_array_documents_inside_ndjson() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps(_events()[:2]),
+            json.dumps(_events()[-1]),
+        ]
+    )
+
+    normalized = normalize_claude_cli_output(stdout)
+
+    assert normalized.result == "done"
+    assert normalized.event_count == 3
+
+
+@pytest.mark.parametrize(
+    ("result_value", "expected"),
+    [
+        ([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}], "ab"),
+        ({"content": [{"type": "text", "text": "nested"}]}, "nested"),
+    ],
+)
+def test_normalizes_recognized_nested_result_content(result_value: object, expected: str) -> None:
+    normalized = normalize_claude_cli_output(json.dumps(_result(result=result_value)))
+
+    assert normalized.result == expected
+    assert normalized.raw_payload["result"] == expected
+
+
+def test_accepts_terminal_message_content_wrapper() -> None:
+    final = _result()
+    final.pop("result")
+    final["message"] = {"content": [{"type": "text", "text": "wrapped"}]}
+
+    normalized = normalize_claude_cli_output(json.dumps(_events(final)))
+
+    assert normalized.result == "wrapped"
+
+
+def test_error_result_preserves_diagnostics_and_metadata() -> None:
+    normalized = normalize_claude_cli_output(
+        json.dumps(
+            _result(
+                is_error=True,
+                subtype="error_max_turns",
+                result="reached maximum number of turns",
+            )
+        )
+    )
+
+    assert normalized.is_error is True
+    assert normalized.result == "reached maximum number of turns"
+    assert normalized.subtype == "error_max_turns"
+
+
+def test_usage_falls_back_to_nested_assistant_usage() -> None:
+    final = _result()
+    final.pop("usage")
+
+    normalized = normalize_claude_cli_output(json.dumps(_events(final)))
+
+    assert normalized.usage == {"input_tokens": 3, "output_tokens": 1}
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        pytest.param(_events()[:-1], id="no-result"),
+        pytest.param([_result(), {"type": "assistant"}], id="result-not-terminal"),
+        pytest.param([_result(), _result()], id="multiple-results"),
+        pytest.param(
+            [{"type": "assistant"}, {"type": "system", "subtype": "init"}, _result()],
+            id="late-init",
+        ),
+        pytest.param([], id="empty-array"),
+    ],
+)
+def test_rejects_missing_or_ambiguous_terminal_result(events: list[dict[str, object]]) -> None:
+    with pytest.raises(ClaudeCliOutputError):
+        normalize_claude_cli_output(json.dumps(events))
+
+
+def test_rejects_session_id_disagreement_between_init_and_result() -> None:
+    with pytest.raises(ClaudeCliOutputError, match="inconsistent session_id"):
+        normalize_claude_cli_output(json.dumps(_events(_result(session_id="session-2"))))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(_result(is_error="false"), id="string-error-flag"),
+        pytest.param(_result(session_id=7), id="numeric-session"),
+        pytest.param(_result(usage=[]), id="list-usage"),
+        pytest.param(_result(usage={"input_tokens": -1}), id="negative-usage"),
+        pytest.param(_result(result={"unexpected": "object"}), id="unknown-result-object"),
+        pytest.param(
+            _result(result=[{"type": "tool_use", "name": "Read"}]),
+            id="non-text-result-block",
+        ),
+    ],
+)
+def test_rejects_hostile_or_schema_invalid_result_fields(payload: dict[str, object]) -> None:
+    with pytest.raises(ClaudeCliOutputError):
+        normalize_claude_cli_output(json.dumps(payload))
+
+
+def test_rejects_malformed_json_looking_line_even_if_later_result_is_valid() -> None:
+    stdout = '{"type":"assistant"\n' + json.dumps(_result())
+
+    with pytest.raises(ClaudeCliOutputError, match="malformed JSON-looking"):
+        normalize_claude_cli_output(stdout)
+
+
+def test_rejects_garbage_appended_to_json_on_the_same_line() -> None:
+    stdout = json.dumps(_result()) + " forged diagnostic"
+
+    with pytest.raises(ClaudeCliOutputError, match="unexpected trailing data"):
+        normalize_claude_cli_output(stdout)
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        '{"type":"result","result":"first","result":"forged"}',
+        '{"type":"result","result":"x","usage":{"input_tokens":NaN}}',
+        json.dumps([_result(), "not-an-event"]),
+    ],
+)
+def test_rejects_ambiguous_json(stdout: str) -> None:
+    with pytest.raises(ClaudeCliOutputError):
+        normalize_claude_cli_output(stdout)
+
+
+def test_rejects_oversized_stdout_before_decoding() -> None:
+    with pytest.raises(ClaudeCliOutputError, match="character safety limit"):
+        normalize_claude_cli_output("x" * (MAX_CLAUDE_CLI_OUTPUT_CHARS + 1))
+
+
+def test_rejects_excessive_event_count() -> None:
+    events = [{"type": "assistant"}] * MAX_CLAUDE_CLI_EVENTS + [_result()]
+
+    with pytest.raises(ClaudeCliOutputError, match="event count"):
+        normalize_claude_cli_output(json.dumps(events))

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2653,6 +2653,12 @@ class TestCLIFallbackWhenSDKAbsent:
                 "non-finite JSON number",
                 id="non-finite-secondary-usage",
             ),
+            pytest.param(
+                b'{"type":"result","is_error":false,"result":"done",'
+                b'"usage":{"cache_read_input_tokens":' + b"9" * 1000 + b"}}",
+                "bounded non-negative integer",
+                id="thousand-digit-secondary-usage",
+            ),
         ],
     )
     def test_hostile_number_becomes_structured_provider_error(

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -16,6 +16,11 @@ import pytest
 
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
+from ouroboros.evolution import provider_usage as provider_usage_module
+from ouroboros.evolution.provider_usage import (
+    capture_generation_provider_usage,
+    tracked_complete,
+)
 from ouroboros.providers.base import (
     CompletionConfig,
     CompletionResponse,
@@ -2587,7 +2592,7 @@ class TestCLIFallbackWhenSDKAbsent:
         [
             pytest.param(
                 {"total_tokens": 132},
-                (0, 0, 132),
+                (0, 0, 0, 132),
                 {"total_tokens": 132},
                 id="total-only-is-not-allocated",
             ),
@@ -2597,7 +2602,7 @@ class TestCLIFallbackWhenSDKAbsent:
                     "output_tokens": 20,
                     "cache_read_input_tokens": 12,
                 },
-                (100, 20, 132),
+                (100, 20, 120, 12),
                 {
                     "input_tokens": 100,
                     "output_tokens": 20,
@@ -2608,13 +2613,13 @@ class TestCLIFallbackWhenSDKAbsent:
             ),
             pytest.param(
                 {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
-                (110, 22, 132),
+                (110, 22, 132, 0),
                 {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
                 id="consistent-components-and-total",
             ),
             pytest.param(
                 {"prompt_tokens": 110, "completion_tokens": 22},
-                (110, 22, 132),
+                (110, 22, 132, 0),
                 {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
                 id="aliases-become-canonical-components",
             ),
@@ -2623,7 +2628,7 @@ class TestCLIFallbackWhenSDKAbsent:
     def test_cli_fallback_uses_normalized_canonical_usage_authority(
         self,
         wire_usage: dict[str, int],
-        expected_components: tuple[int, int, int],
+        expected_components: tuple[int, int, int, int],
         expected_raw: dict[str, int],
     ) -> None:
         adapter = self._adapter()
@@ -2655,7 +2660,15 @@ class TestCLIFallbackWhenSDKAbsent:
             result.value.usage.prompt_tokens,
             result.value.usage.completion_tokens,
             result.value.usage.total_tokens,
+            result.value.usage.unallocated_tokens,
         ) == expected_components
+        assert result.value.usage.total_tokens == (
+            result.value.usage.prompt_tokens + result.value.usage.completion_tokens
+        )
+        assert (
+            result.value.usage.total_tokens + result.value.usage.unallocated_tokens
+            == expected_raw["total_tokens"]
+        )
         assert result.value.raw_response["usage"] == expected_raw
 
     def test_invalid_terminal_total_cannot_fall_back_or_split_authority(self) -> None:
@@ -2695,6 +2708,71 @@ class TestCLIFallbackWhenSDKAbsent:
 
         assert result.is_err
         assert "usage.total_tokens disagrees" in result.error.details["parse_error"]
+
+    @pytest.mark.parametrize(
+        "wire_usage",
+        [
+            pytest.param({"total_tokens": 132}, id="total-only"),
+            pytest.param(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 12,
+                },
+                id="cache-inclusive",
+            ),
+        ],
+    )
+    def test_cli_usage_survives_tracked_completion_frugality_capture(
+        self,
+        wire_usage: dict[str, int],
+    ) -> None:
+        adapter = self._adapter()
+        config = CompletionConfig(model="claude-haiku-4-5", role="reflect")
+        payload = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "answer",
+                "usage": wire_usage,
+            }
+        ).encode()
+
+        # This regression isolates the completion-usage boundary from the
+        # separate execution-configuration attestation gate.  The real Claude
+        # CLI adapter response passes directly through tracked_complete().
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+            patch.object(
+                provider_usage_module,
+                "_prepare_completion_configuration",
+                return_value=(config, {}, None, True, None),
+            ),
+            patch.object(
+                provider_usage_module,
+                "_completion_configuration",
+                return_value={"surface": "completion", "backend": "claude-cli"},
+            ),
+        ):
+            with capture_generation_provider_usage() as capture:
+                result = asyncio.run(
+                    tracked_complete(
+                        adapter,
+                        [Message(role=MessageRole.USER, content="ping")],
+                        config,
+                    )
+                )
+
+        summary = capture.summary(instrumentation_complete=True)
+        assert result.is_ok, result
+        assert summary.complete is True
+        assert summary.token_spend == 132
+        assert summary.issues == ()
 
     def test_the_adapters_own_permission_vocabulary_is_not_forwarded_blindly(self) -> None:
         """`default` is a mode this adapter has and the CLI does not.
@@ -3113,6 +3191,69 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.is_ok, result
         assert result.value.content == "recovered"
         assert spawn.await_count == 2
+
+    def test_nonzero_exit_stale_success_uses_transient_stderr_and_retries(self) -> None:
+        adapter = self._adapter()
+        stale_success = b'{"is_error":false,"result":"completed"}'
+        good = b'{"is_error":false,"result":"recovered","stop_reason":"end_turn"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(
+                    side_effect=[
+                        self._proc(
+                            stale_success,
+                            stderr=b"API error: 529 overloaded_error",
+                            returncode=1,
+                        ),
+                        self._proc(good),
+                    ]
+                ),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == "recovered"
+        assert spawn.await_count == 2
+
+    def test_nonzero_exit_stale_success_surfaces_nontransient_stderr(self) -> None:
+        adapter = self._adapter()
+        stale_success = b'{"is_error":false,"result":"completed"}'
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(
+                    return_value=self._proc(
+                        stale_success,
+                        stderr=b"error: authentication required",
+                        returncode=1,
+                    )
+                ),
+            ) as spawn,
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert result.error.message == "error: authentication required"
+        assert result.error.details["error_type"] == "ProcessError"
+        assert result.error.details["envelope_is_error"] is False
+        assert result.error.details["stderr"] == "error: authentication required"
+        assert spawn.await_count == 1
 
     def test_a_permanent_cli_failure_is_not_retried(self) -> None:
         """The other half: a non-transient error still fails on the first try."""

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -8,6 +8,7 @@ being embedded as XML in the user prompt.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2490,6 +2491,51 @@ class TestCLIFallbackWhenSDKAbsent:
         # the prompt, matching what the SDK path does with it.
         assert "--append-system-prompt" in argv
         assert argv[argv.index("--append-system-prompt") + 1] == "be terse"
+
+    def test_cli_fallback_accepts_top_level_event_array(self) -> None:
+        """Newer/wrapped Claude CLIs may batch stream-json events as one array."""
+        adapter = self._adapter()
+        payload = json.dumps(
+            [
+                {"type": "system", "subtype": "init", "session_id": "array-session"},
+                {
+                    "type": "assistant",
+                    "session_id": "array-session",
+                    "message": {
+                        "content": [{"type": "text", "text": "draft"}],
+                        "usage": {"input_tokens": 2, "output_tokens": 1},
+                    },
+                },
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "array answer",
+                    "session_id": "array-session",
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 13, "output_tokens": 5},
+                },
+            ]
+        ).encode()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.content == "array answer"
+        assert result.value.usage.total_tokens == 18
+        assert result.value.raw_response["type"] == "result"
+        assert result.value.raw_response["session_id"] == "array-session"
 
     def test_the_adapters_own_permission_vocabulary_is_not_forwarded_blindly(self) -> None:
         """`default` is a mode this adapter has and the CLI does not.

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2587,6 +2587,95 @@ class TestCLIFallbackWhenSDKAbsent:
         assert "maximum number of turns" in result.error.message
         assert result.error.details["subtype"] == "error_max_turns"
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(
+                {
+                    "type": "result",
+                    "is_error": True,
+                    "result": None,
+                    "subtype": "error_max_turns",
+                    "session_id": "error-session",
+                    "stop_reason": "max_turns",
+                    "usage": {"input_tokens": 9, "output_tokens": 2},
+                },
+                id="typed-null",
+            ),
+            pytest.param(
+                {
+                    "is_error": True,
+                    "subtype": "error_max_turns",
+                    "session_id": "error-session",
+                    "stop_reason": "max_turns",
+                    "usage": {"input_tokens": 9, "output_tokens": 2},
+                },
+                id="untyped-omitted",
+            ),
+        ],
+    )
+    def test_empty_cli_error_preserves_structured_metadata(
+        self, payload: dict[str, object]
+    ) -> None:
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(json.dumps(payload).encode())),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert result.error.message == "claude CLI reported an error"
+        assert result.error.details["subtype"] == "error_max_turns"
+        assert result.error.details["session_id"] == "error-session"
+        assert result.error.details["stop_reason"] == "max_turns"
+        assert result.error.details["usage"] == {"input_tokens": 9, "output_tokens": 2}
+
+    @pytest.mark.parametrize(
+        ("payload", "message"),
+        [
+            pytest.param(
+                b'{"type":"result","is_error":false,"result":"done","trace":' + b"9" * 4301 + b"}",
+                "integer exceeds",
+                id="oversized-integer",
+            ),
+            pytest.param(
+                b'{"type":"result","is_error":false,"result":"done",'
+                b'"usage":{"cache_read_input_tokens":1e9999}}',
+                "non-finite JSON number",
+                id="non-finite-secondary-usage",
+            ),
+        ],
+    )
+    def test_hostile_number_becomes_structured_provider_error(
+        self, payload: bytes, message: str
+    ) -> None:
+        adapter = self._adapter()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert message in result.error.details["parse_error"]
+
     def test_a_non_json_body_surfaces_stderr(self) -> None:
         """An auth prompt or a bad flag never reaches the result envelope.
 
@@ -2919,8 +3008,8 @@ class TestCLIFallbackWhenSDKAbsent:
         assert "Empty response" in result.error.message
         assert result.error.details["content_length"] == 0
 
-    def test_a_missing_result_key_is_treated_the_same_as_an_empty_one(self) -> None:
-        """No `result` key at all is the same absence, not a different one."""
+    def test_a_success_envelope_with_missing_result_fails_closed(self) -> None:
+        """Only an explicit error envelope may omit its result content."""
         adapter = self._adapter()
         with (
             patch.dict("sys.modules", {"claude_agent_sdk": None}),
@@ -2942,7 +3031,8 @@ class TestCLIFallbackWhenSDKAbsent:
             )
 
         assert result.is_err
-        assert "Empty response" in result.error.message
+        assert "no valid JSON result" in result.error.message
+        assert "no result content" in result.error.details["parse_error"]
 
     def test_unencodable_caller_text_never_reaches_a_spawn(self) -> None:
         """A lone surrogate must fail before there is a child to orphan.

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2579,7 +2579,122 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.value.raw_response["usage"] == {
             "input_tokens": 110,
             "output_tokens": 22,
+            "total_tokens": 132,
         }
+
+    @pytest.mark.parametrize(
+        ("wire_usage", "expected_components", "expected_raw"),
+        [
+            pytest.param(
+                {"total_tokens": 132},
+                (0, 0, 132),
+                {"total_tokens": 132},
+                id="total-only-is-not-allocated",
+            ),
+            pytest.param(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 12,
+                },
+                (100, 20, 132),
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 12,
+                    "total_tokens": 132,
+                },
+                id="components-derive-cache-inclusive-total",
+            ),
+            pytest.param(
+                {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+                (110, 22, 132),
+                {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+                id="consistent-components-and-total",
+            ),
+            pytest.param(
+                {"prompt_tokens": 110, "completion_tokens": 22},
+                (110, 22, 132),
+                {"input_tokens": 110, "output_tokens": 22, "total_tokens": 132},
+                id="aliases-become-canonical-components",
+            ),
+        ],
+    )
+    def test_cli_fallback_uses_normalized_canonical_usage_authority(
+        self,
+        wire_usage: dict[str, int],
+        expected_components: tuple[int, int, int],
+        expected_raw: dict[str, int],
+    ) -> None:
+        adapter = self._adapter()
+        payload = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "answer",
+                "usage": wire_usage,
+            }
+        ).encode()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert (
+            result.value.usage.prompt_tokens,
+            result.value.usage.completion_tokens,
+            result.value.usage.total_tokens,
+        ) == expected_components
+        assert result.value.raw_response["usage"] == expected_raw
+
+    def test_invalid_terminal_total_cannot_fall_back_or_split_authority(self) -> None:
+        adapter = self._adapter()
+        payload = json.dumps(
+            [
+                {
+                    "type": "assistant",
+                    "message": {"usage": {"input_tokens": 100, "output_tokens": 20}},
+                },
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "answer",
+                    "usage": {
+                        "input_tokens": 110,
+                        "output_tokens": 22,
+                        "total_tokens": 12,
+                    },
+                },
+            ]
+        ).encode()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_err
+        assert "usage.total_tokens disagrees" in result.error.details["parse_error"]
 
     def test_the_adapters_own_permission_vocabulary_is_not_forwarded_blindly(self) -> None:
         """`default` is a mode this adapter has and the CLI does not.
@@ -2681,7 +2796,11 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.error.details["subtype"] == "error_max_turns"
         assert result.error.details["session_id"] == "error-session"
         assert result.error.details["stop_reason"] == "max_turns"
-        assert result.error.details["usage"] == {"input_tokens": 9, "output_tokens": 2}
+        assert result.error.details["usage"] == {
+            "input_tokens": 9,
+            "output_tokens": 2,
+            "total_tokens": 11,
+        }
 
     @pytest.mark.parametrize(
         ("payload", "message"),
@@ -2702,6 +2821,18 @@ class TestCLIFallbackWhenSDKAbsent:
                 b'"usage":{"cache_read_input_tokens":' + b"9" * 1000 + b"}}",
                 "bounded non-negative integer",
                 id="thousand-digit-secondary-usage",
+            ),
+            pytest.param(
+                b'{"type":"result","is_error":false,"result":"done",'
+                b'"usage":{"prompt_tokens":' + b"9" * 1000 + b"}}",
+                "bounded non-negative integer",
+                id="thousand-digit-primary-alias",
+            ),
+            pytest.param(
+                b'{"type":"result","is_error":false,"result":"done",'
+                b'"usage":{"prompt_tokens":true,"completion_tokens":2}}',
+                "bounded non-negative integer",
+                id="malformed-primary-alias",
             ),
         ],
     )

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -2537,6 +2537,50 @@ class TestCLIFallbackWhenSDKAbsent:
         assert result.value.raw_response["type"] == "result"
         assert result.value.raw_response["session_id"] == "array-session"
 
+    def test_cli_fallback_aggregates_multi_turn_usage_without_terminal_total(self) -> None:
+        adapter = self._adapter()
+        payload = json.dumps(
+            [
+                {
+                    "type": "assistant",
+                    "message": {"usage": {"input_tokens": 100, "output_tokens": 20}},
+                },
+                {
+                    "type": "assistant",
+                    "message": {"usage": {"input_tokens": 10, "output_tokens": 2}},
+                },
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "array answer",
+                    "stop_reason": "end_turn",
+                },
+            ]
+        ).encode()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": None}),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=self._proc(payload)),
+            ),
+        ):
+            result = asyncio.run(
+                adapter.complete(
+                    [Message(role=MessageRole.USER, content="ping")],
+                    CompletionConfig(model="claude-haiku-4-5"),
+                )
+            )
+
+        assert result.is_ok, result
+        assert result.value.usage.prompt_tokens == 110
+        assert result.value.usage.completion_tokens == 22
+        assert result.value.usage.total_tokens == 132
+        assert result.value.raw_response["usage"] == {
+            "input_tokens": 110,
+            "output_tokens": 22,
+        }
+
     def test_the_adapters_own_permission_vocabulary_is_not_forwarded_blindly(self) -> None:
         """`default` is a mode this adapter has and the CLI does not.
 


### PR DESCRIPTION
Closes #2037

## Problem

Claude CLI output is not always one JSON object. Depending on the CLI path it can be a top-level event array, NDJSON, or diagnostic text followed by pretty-printed JSON. The worker and adapter parsed those shapes differently, so a valid event array could fail before AC dispatch with `claude returned no JSON` or `AttributeError: 'list' object has no attribute 'get'`.

## Change

- Add one shared fail-closed normalizer for a single object, event arrays, pretty JSON, and newline-delimited documents.
- Use the same normalized envelope in both the Claude worker transport and adapter.
- Bound JSON integer parsing and reject non-finite floats so hostile numeric input becomes `ClaudeCliOutputError` rather than escaping as an untyped crash or entering usage/raw metadata as infinity.
- Preserve structured error-envelope fields when `result` is null or omitted, while continuing to reject null or omitted successful results.
- Require an LF/CR document boundary between multiple JSON documents; same-line concatenation with empty, space, or tab separators is protocol corruption.

## Compatibility

The original single-object response remains supported. Typed and untyped Claude error envelopes retain subtype, session, usage, stop reason, and diagnostic detail. The change is limited to provider-output normalization and its two consumers.

## Verification

- Python 3.12, 3.13, and 3.14 focused suites: `200 passed, 1 skipped` each
- Provider + relevant orchestrator suites: `6066 passed, 2 skipped`
- Independent hostile probes cover oversized integers, non-finite numbers in raw/nested/secondary usage, null/omitted error and success results, same-line concatenation, LF/CR/CRLF boundaries, single/pretty/array/NDJSON inputs, and the issue's actual event-array shape
- Ruff, format, MyPy, module-size, bundle/fsck, ancestry, and diff checks pass

This PR is opened as a draft while same-head CI and the official detailed review run.


## Review-loop repairs

- Preserve authoritative total-only and cache-inclusive Claude usage without violating the public additive `UsageInfo` contract by carrying unattributed authority explicitly in `unallocated_tokens`; evolution frugality capture accounts for `total_tokens + unallocated_tokens`.
- Make non-zero Claude process status authoritative over stale success-looking envelopes in both the provider adapter and worker runtime. Provider retries classify stderr diagnostics, and public worker `execute_task()` / `execute_task_to_result()` return the authoritative error rather than stale result text.
- Reject stale success diagnostics even when stderr is empty, falling back to the non-zero exit-status message; genuine structured error envelopes retain their own detail.

## Updated verification

- Focused Python 3.12/3.13/3.14 normalization/accounting suites before the final worker repair: `338 passed, 72 skipped` each
- Broad provider/orchestrator/evolution suites: `6117 passed, 79 skipped`
- Final exact-head changed suites: `340 passed, 72 skipped`
- Shared Claude worker/runtime: `84 passed`; adjacent Codex worker/model routing: `36 passed`
- Fresh independent exact-head verifier: PASS
- Full Ruff, format, MyPy, module-size/diff checks: PASS