### PR TITLE
docs(readme): name the minimum version that starts as an MCP server

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -253,6 +253,8 @@ ouroboros uninstall
 
 </details>
 
+> **MCP 서버로 설치한다면 0.51.1 이상을 쓰세요.** 이전 버전은 기존 환경이 `[mcp]` 프로필을 가릴 때 `Failed to reconnect to plugin:ouroboros:ouroboros: -32000`로 기동에 실패할 수 있습니다([#2012](https://github.com/Q00/ouroboros/issues/2012)). PyPI가 아니라 배포판 패키지로 설치할 때 특히 해당됩니다 — 그쪽은 버전이 뒤질 수 있습니다.
+
 <details>
 <summary><strong>무슨 일이 일어났나요?</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Removes all configuration, MCP registration, and data. See [UNINSTALL.md](./UNIN
 </details>
 
 > **Python >= 3.12 required.** LiteLLM-bearing profiles support Python 3.12-3.13. See [Platform Support](./docs/platform-support.md#python-profile-matrix) and [pyproject.toml](./pyproject.toml).
+>
+> **Installing as an MCP server: use 0.51.1 or later.** Earlier versions can fail at startup with `Failed to reconnect to plugin:ouroboros:ouroboros: -32000` when an existing environment shadows the `[mcp]` profile ([#2012](https://github.com/Q00/ouroboros/issues/2012)). This matters if you install through a downstream package rather than PyPI, since those can lag.
 
 <p align="center">
   <sub>Most people find out they were unclear about three files into the review.<br/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,6 +214,8 @@ ouroboros uninstall
 </details>
 
 > **需要 Python >= 3.12**。包含 LiteLLM 的 profile 支持 Python 3.12-3.13。详见 [Platform Support](./docs/platform-support.md#python-profile-matrix) 和 [pyproject.toml](./pyproject.toml)。
+>
+> **作为 MCP 服务器安装时请用 0.51.1 或更新的版本。** 更早的版本在已有环境遮蔽 `[mcp]` profile 时会启动失败，报 `Failed to reconnect to plugin:ouroboros:ouroboros: -32000`（[#2012](https://github.com/Q00/ouroboros/issues/2012)）。如果你不是从 PyPI 而是从发行版软件包安装，尤其要注意——那边的版本可能落后。
 
 
 <p align="center">


### PR DESCRIPTION
Adds one line to the install section of all three READMEs, naming 0.51.1 as the minimum version that starts as an MCP server.

## Why

`#2012` fixed a startup failure where an existing environment shadows the `[mcp]` profile and the plugin dies with `Failed to reconnect to plugin:ouroboros:ouroboros: -32000`. Anyone on an earlier version still hits it.

That would be unremarkable except that earlier versions are still being installed. There is a downstream Arch package, `python-ouroboros-ai`, currently at 0.50.6 and four releases behind (#2044). Its users get exactly this failure, and nothing on the way in tells them which version they need.

The release notes do say it. It is the only entry under `Highlights` in v0.51.1. That did not help: I hit the failure myself earlier today, did not connect it to #2012, and filed an issue against our own packaging before finding the answer in our own changelog. Fourteen people watch this repository, so the highlight reaches fourteen people.

A line in the README reaches someone who never subscribed to anything.

## The line

> **Installing as an MCP server: use 0.51.1 or later.** Earlier versions can fail at startup with `Failed to reconnect to plugin:ouroboros:ouroboros: -32000` when an existing environment shadows the `[mcp]` profile (#2012). This matters if you install through a downstream package rather than PyPI, since those can lag.

Placed next to the existing Python version requirement, which is where a reader already looks for "what do I need".

## On the translations

The three files are not structured identically and I got this wrong once before pushing. `README.md` and `README.zh-CN.md` both carry a `> **Python >= 3.12**` requirement block, so the note appends to it. `README.ko.md` has no such block at all, so the note goes after the uninstall details block instead. My first attempt used the English anchor for all three and put the Korean note at line 538, at the very bottom of the file, nowhere near installation. Reverted and redone per file.

## Not included

Whether to notify downstream packagers at all, and whether the PyPI page should carry the same note, are open in #2044. This PR only does the part that needs no decision.
