### PR TITLE
docs(pyproject): drop the universal-quantifier claim in the summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ouroboros-ai"
 dynamic = ["version"]
-description = "Pins the acceptance spec before the run and withholds each criterion's verify command and expected output from the worker. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
+description = "Pins an acceptance spec and omits any verify command or expected output from the worker. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
 readme = "README.md"
 authors = [
     { name = "Q00", email = "jqyu.lee@gmail.com" }


### PR DESCRIPTION
## What

`pyproject.toml`'s `description` field says:

> Pins the acceptance spec before the run and withholds each criterion's verify command and expected output from the worker.

`each criterion's` claims every acceptance criterion carries a verify command and expected output. `AcceptanceCriterionSpec.verify_command` and `.output_assertion` are both `str | None = None` (`core/seed.py:462`, `:472`) -- contract-less criteria are a supported, legitimate shape. The claim is false for any criterion that doesn't define one.

## Why this one specifically

This is the same sentence that #2040 spent a day narrowing across four review rounds -- it went unconditional -> scoped to Seed-field omission -> conditional -> finally landed on wording that doesn't universally quantify. `pyproject.toml` carries an identical clause but lives outside `.claude-plugin/` and `.codex-plugin/`, so it wasn't touched by that PR and kept the pre-correction phrasing.

`wiki/ouroboros-facts.md` in the marketing repo now pins the cleared phrasings (with citations and an explicit do-not-use list) specifically so nobody composes this sentence from scratch again. This PR uses the pre-cleared short line rather than writing a new one:

> Pins an acceptance spec and omits any verify command or expected output from the worker.

## What I did not touch

The second sentence (`Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes.`) is unchanged. No other file references the old string (checked via grep across `.py`/`.md`/`.toml`).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cw86NosiBprpjac6vHGDQg

Refs #2020
Refs #2021