### PR TITLE
docs(pypi): add loop-engineering keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ keywords = [
     "cli",
     "developer-tools",
     "llm-orchestration",
+    "loop-engineering",
     "mcp",
     "prompt-engineering",
     "socratic-method",


### PR DESCRIPTION
## Summary
- Adds `loop-engineering` to `pyproject.toml`'s PyPI `keywords` list -- one word, structurally accurate for this project's RUN/GATE/JUDGE + evolve stop-rule mechanism, but currently missing from discovery metadata.

## Why
Counted directly against `anthropics/claude-plugins-community`'s `marketplace.json` (2,291 entries, exact-match only): `loop engineering` appears in 0 listings, `agentic loop` in 2. The term is trending (Boris Cherny, Peter Steinberger, Andrew Ng mentions in July 2026) but not yet established -- some pushback exists that it's a rebrand of existing practice. Full evidence and the term's current-state caveat are in the linked issue.

Scoped to PyPI metadata only. Does not touch `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json`, which are under active edit in #2040.

Disclosure: researched and drafted with AI assistance (Claude).

Closes #2052

## Test plan
- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` -- valid TOML
- [x] Searched for duplicate issues/PRs before opening (none found)