### PR TITLE
chore(pyproject): add agentic-loop and loop-engineering keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,14 @@ authors = [
 requires-python = ">=3.12"
 keywords = [
     "agent-os",
+    "agentic-loop",
     "ai-agent",
     "ai-coding-agent",
     "claude-code",
     "cli",
     "developer-tools",
     "llm-orchestration",
+    "loop-engineering",
     "mcp",
     "prompt-engineering",
     "socratic-method",


### PR DESCRIPTION
Adds two discovery keywords to `[project].keywords`: `agentic-loop` and `loop-engineering`.

### Why these two

I counted term usage across the full Claude Code community marketplace manifest (`.claude-plugin/marketplace.json`, 2,291 plugins) rather than relying on web search, since that list is what this audience actually browses. Matching on name + description + keywords + category, case-insensitive, exact substring:

| term | plugins |
|---|---:|
| `loop engineering` | 0 |
| `agentic loop` | 3 |
| `spec-driven` | 17 |
| `rubric` | 10 |
| `evaluation` | 22 |
| `memory` | 137 |
| `security` | 177 |
| `test` | 260 |

The last four rows are controls. A zero is only informative if the same query returns large numbers for terms that obviously exist, and it does.

### What the zero does and does not mean

It means nobody in that list *describes* their plugin with those words. It does not mean nobody builds this. Descriptions are marketing copy, not feature inventories.

It is also worth stating that "loop engineering" is a recent coinage, roughly six weeks old at the time of writing, and there is active disagreement about whether it names anything new. I am adding it as a search term, not asserting it is established terminology, which is why this PR touches `keywords` and leaves the summary alone.

### What I deliberately did not change

- **`spec-driven-development` stays.** We have been moving the *lead* wording away from that lane because it is crowded, but keywords are a discovery surface, not a positioning statement. Dropping a term people actually search for would cost traffic for no gain.
- **The `description` field.** #2051 is open against that same line; this PR stays out of its way.

Keywords remain sorted; `agentic-loop` sorts after `agent-os` because `-` precedes `i`.


Refs #2052