### PR TITLE
fix(codex app): avoid native Windows crashes with HTTP MCP

### DIFF
--- a/docs/runtime-guides/codex.ko.md
+++ b/docs/runtime-guides/codex.ko.md
@@ -105,7 +105,20 @@ codex --version
 | macOS (ARM/Intel) | 지원 | 주 개발 플랫폼 |
 | Linux (x86_64/ARM64) | 지원 | Ubuntu 22.04+, Debian 12+, Fedora 38+ 에서 검증 |
 | Windows (WSL 2) | 지원 | Windows 사용자에게 권장하는 경로 |
-| Windows (네이티브) | 실험적 | WSL 2를 강력히 권장합니다. 네이티브 Windows에서는 경로 처리와 프로세스 관리에 문제가 있을 수 있습니다. **Codex CLI 자체가 네이티브 Windows를 지원하지 않습니다.** |
+| Windows (네이티브) | 실험적 | 로컬 HTTP 엔드포인트를 통한 Codex Desktop MCP를 실험적으로 지원합니다. 네이티브 Codex CLI 워커/런타임 실행은 지원하지 않으므로 전체 워크플로에는 WSL 2를 사용하세요. |
+### 네이티브 Windows Codex Desktop MCP (실험적)
+네이티브 Windows에서 `ouroboros setup --runtime codex`는 로그인할 때 HTTP MCP를 시작하는, setup이 관리하는 정확히 하나의 사용자별 `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` 시작 값을 씁니다. setup은 HTTP MCP를 즉시 시작하고 MCP `initialize` 프로브로 검증한 뒤에만 Codex Desktop에 `http://127.0.0.1:8765/mcp`를 등록합니다. setup이 성공하면 Codex Desktop이 이 엔드포인트를 사용하므로, 사용자는 세션마다 MCP 명령을 실행하지 않습니다.
+
+`--mcp-mode`는 MCP 등록만 제어합니다.
+
+- `auto`(기본값): 네이티브 Windows에서는 시작 값이 없거나 이미 setup 관리 값과 일치할 때만 관리형 HTTP 엔드포인트를 사용합니다. 그 밖의 플랫폼에서는 관리형 stdio를 사용하며, 사용자가 관리하는 항목은 보존합니다.
+- `http`: 관리형 HTTP 엔드포인트를 사용합니다.
+- `stdio`: 관리형 항목을 명령으로 실행하는 stdio 서버로 교체합니다.
+- `preserve`: 기존에 사용 가능한 명령 또는 URL 항목만 검증합니다.
+
+setup과 uninstall은 현재 Windows 로그인 세션 범위의 시간 제한 명명된 뮤텍스를 통해 협력하므로, 같은 로그인 세션에서 협력하는 Ouroboros setup 및 uninstall 작업이 직렬화되며, 시작 값의 정확한 형식과 값을 즉시 다시 확인합니다. 이 재확인에서 불일치가 관찰되면 setup은 그 값을 보존하고, 수정하거나 제거한 뒤 다시 실행하는 방법을 알리며, 그 전에는 HTTP 설정을 쓰지 않습니다. 같은 계정의 여러 Windows 세션에서 동시에 실행하는 lifecycle 명령은 이 실험적 setup 계약의 범위 밖이므로 실행하지 않아야 합니다. setup이 활성화된 동안 수동 또는 비-Ouroboros 레지스트리 편집은 동기화되지 않으므로 피해야 합니다. 이 실험적 경로는 로그인 시 MCP를 시작하지만, 충돌 후 재시작, 세대 관리, 자동 롤백, 무중단 업그레이드, 서비스 관리자 의미론을 제공하지 않습니다.
+
+> **Windows 사용자:** 네이티브 Codex CLI 워커/런타임 워크플로에는 WSL 2를 사용하세요. 위 네이티브 Windows setup은 실험적인 Codex Desktop MCP로만 한정됩니다.
 
 ## 설정
 
@@ -198,13 +211,13 @@ codex --version
 - 가능하면 `orchestrator.codex_cli_path`를 기록합니다
 - 관리되는 Ouroboros 규칙을 `~/.codex/rules/`에 설치합니다
 - 관리되는 Ouroboros 스킬을 `~/.codex/skills/`에 설치합니다
-- `~/.codex/config.toml`에 Ouroboros MCP/env 연결이 없으면 등록하고, setup이 관리하는 stdio 블록은 갱신하되, 사용자가 관리하는 URL·커스텀 항목은 기본적으로 보존합니다
+- `~/.codex/config.toml`에 Ouroboros MCP/env 연결을 등록합니다. 네이티브 Windows의 `auto`는 조건이 맞을 때 고정 관리형 HTTP 엔드포인트를 사용하고, 그 밖의 플랫폼에서는 관리형 stdio를 사용하며 사용자가 관리하는 항목은 보존합니다
 - 손대지 않은 레거시 자동생성 `ouroboros-*.config.toml` 태스크 프로파일 앵커만 정리합니다. 사용자가 만든 Codex 프로파일은 보존됩니다
 - 관리되는 `ouroboros-worker.config.toml`을 등록해서, Agent OS 워커 서브프로세스가 MCP/env 연결을 잃지 않고도 대화형 Codex 기본값에서 빠질 수 있게 합니다
 
 `~/.codex/` 밖의 전역 산출물도 함께 생깁니다. `ensure_config_dir()`가 `~/.ouroboros/data/`와 `~/.ouroboros/logs/`를 만들고([`setup.py:2632`](../../src/ouroboros/cli/commands/setup.py)), 설정이 처음이면 `~/.ouroboros/credentials.yaml`을 `0600` 권한으로 새로 씁니다([`setup.py:2771`](../../src/ouroboros/cli/commands/setup.py)).
 
-`~/.codex/config.toml`은 **Ouroboros 스테이지 모델 핀을 둘 자리가 아닙니다.** 설정 UI나 그에 대응하는 `~/.ouroboros/config.yaml` 값을 쓰고, 명시적인 `--profile`이 필요할 때만 사용자가 관리하는 네이티브 Codex 프로파일을 유지하세요. 장기 실행 URL 기반 Ouroboros MCP 서버를 직접 운영한다면 그 URL 항목을 `~/.codex/config.toml`에 그대로 두면 됩니다. `ouroboros setup --runtime codex`가 기본적으로 보존합니다. setup이 그 항목을 관리형 command-spawn 서버로 **바꾸길 원할 때만** `--mcp-mode stdio`를 쓰세요.
+`~/.codex/config.toml`은 **Ouroboros 스테이지 모델 핀을 둘 자리가 아닙니다.** 설정 UI나 그에 대응하는 `~/.ouroboros/config.yaml` 값을 쓰고, 명시적인 `--profile`이 필요할 때만 사용자가 관리하는 네이티브 Codex 프로필을 유지하세요. `auto`는 사용자가 관리하는 MCP 명령과 URL 항목을 보존합니다. 관리형 등록을 의도적으로 고를 때만 `--mcp-mode stdio` 또는 `http`를 사용하세요.
 
 ### 워커 서브프로세스 격리 (Agent OS `runtime_profile`)
 

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -50,9 +50,22 @@ For alternative install methods and shell completions, see the [Codex CLI README
 | macOS (ARM/Intel) | Supported | Primary development platform |
 | Linux (x86_64/ARM64) | Supported | Tested on Ubuntu 22.04+, Debian 12+, Fedora 38+ |
 | Windows (WSL 2) | Supported | Recommended path for Windows users |
-| Windows (native) | Experimental | WSL 2 strongly recommended; native Windows may have path-handling and process-management issues. Codex CLI itself does not support native Windows. |
+| Windows (native) | Experimental | Codex Desktop MCP is supported experimentally through a local HTTP endpoint. Native Codex CLI worker/runtime execution is unsupported; use WSL 2 for full workflows. |
 
 > **Windows users:** Install and run both Codex CLI and Ouroboros inside a WSL 2 environment for full compatibility. See [Platform Support](../platform-support.md) for details.
+### Native Windows Codex Desktop MCP (experimental)
+On native Windows, `ouroboros setup --runtime codex` writes one exact setup-managed per-user `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` startup value that launches the HTTP MCP at login. Setup launches the HTTP MCP immediately, verifies it with an MCP `initialize` probe, and only then registers `http://127.0.0.1:8765/mcp` with Codex Desktop. After successful setup, Codex Desktop uses that endpoint; users do not run an MCP command each session.
+
+`--mcp-mode` controls only the MCP registration:
+
+- `auto` (default): on native Windows, use the managed HTTP endpoint only when the startup value is absent or already matches the setup-managed value; elsewhere, use managed stdio. User-managed entries are preserved.
+- `http`: use the managed HTTP endpoint.
+- `stdio`: replace the managed entry with the command-spawned stdio server.
+- `preserve`: only validate an existing usable command or URL entry.
+
+Setup and uninstall cooperate through a bounded named mutex scoped to the current Windows login session, serializing cooperating Ouroboros setup and uninstall operations in that session, and immediately recheck the startup value's exact type and value. If that recheck observes a mismatch, setup preserves it, reports how to correct or remove it, and does not write the HTTP configuration first. Concurrent lifecycle commands from multiple Windows sessions for the same account are outside this experimental setup contract and should not be run. Manual or non-Ouroboros registry edits while setup is active are not synchronized and should be avoided. This experimental path starts the MCP at login, but has no crash restart, generation management, automatic rollback, zero-downtime upgrades, or service-manager semantics.
+
+> **Windows users:** Use WSL 2 for native Codex CLI worker/runtime workflows. The native Windows setup above is limited to experimental Codex Desktop MCP.
 
 ## Configuration
 
@@ -120,13 +133,13 @@ Under the hood, `CodexCliRuntime` still talks to the local `codex` executable, b
 - Records `orchestrator.codex_cli_path` when available
 - Installs managed Ouroboros rules into `~/.codex/rules/`
 - Installs managed Ouroboros skills into `~/.codex/skills/`
-- Registers the Ouroboros MCP/env hookup in `~/.codex/config.toml` when absent, refreshes setup-managed stdio blocks, and preserves user-managed URL/custom entries by default
+- Registers the Ouroboros MCP/env hookup in `~/.codex/config.toml`; native Windows `auto` uses the fixed managed HTTP endpoint when eligible, while non-Windows uses managed stdio and user-managed entries are preserved
 - Retires only untouched legacy generated `ouroboros-*.config.toml` task-profile anchors; user-created Codex profiles are preserved
 - Registers a managed `ouroboros-worker.config.toml` file so Agent OS worker subprocesses can opt out of interactive Codex defaults without losing the MCP/env hookup
 
 Setup also creates artifacts outside `~/.codex/`: `ensure_config_dir()` creates `~/.ouroboros/data/` and `~/.ouroboros/logs/` (`cli/commands/setup.py:2632`), and a fresh configuration gets a new `~/.ouroboros/credentials.yaml` written at mode `0600` (`:2771`).
 
-`~/.codex/config.toml` is not where Ouroboros stage model pins belong. Use the settings UI or the equivalent `~/.ouroboros/config.yaml` values; keep user-managed native Codex profiles when you need an explicit `--profile`. If you manage a long-running URL-based Ouroboros MCP server, keep that URL entry in `~/.codex/config.toml`; `ouroboros setup --runtime codex` preserves it by default. Use `--mcp-mode stdio` only when you intentionally want setup to replace the entry with the managed command-spawned server.
+`~/.codex/config.toml` is not where Ouroboros stage model pins belong. Use the settings UI or the equivalent `~/.ouroboros/config.yaml` values; keep user-managed native Codex profiles when you need an explicit `--profile`. User-managed MCP command and URL entries are preserved by `auto`; use `--mcp-mode stdio` or `http` only when you intentionally select a managed registration.
 
 ### Worker subprocess isolation (Agent OS `runtime_profile`)
 

--- a/src/ouroboros/cli/codex_http_mcp.py
+++ b/src/ouroboros/cli/codex_http_mcp.py
@@ -1,0 +1,686 @@
+"""Provision the per-user Windows startup entry for Codex Desktop's HTTP MCP."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+import ctypes
+from dataclasses import dataclass, field
+import json
+import os
+import re
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+from ouroboros.package_profiles import UVX_PYTHON_FLOOR
+
+HTTP_ENDPOINT = "http://127.0.0.1:8765/mcp"
+MANAGED_CODEX_MCP_COMMENT_LINES = (
+    "# Ouroboros MCP hookup for Codex CLI.",
+    "# Keep Ouroboros runtime settings and per-role model overrides in",
+    "# ~/.ouroboros/config.yaml (for example: clarification.default_model,",
+    "# llm.qa_model, evaluation.semantic_model, consensus.*).",
+    "# This file is only for the Codex MCP/env registration block.",
+)
+_STARTUP_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+_STARTUP_VALUE_NAME = "Ouroboros MCP HTTP"
+_FIXED_OPTIONS = (
+    "--runtime",
+    "codex",
+    "--llm-backend",
+    "codex",
+    "--transport",
+    "streamable-http",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    "8765",
+)
+_STARTUP_COMMAND_MAX_LENGTH = 260
+_PROBE_ATTEMPTS = 10
+_PROBE_TIMEOUT_SECONDS = 2
+_PROBE_RETRY_SECONDS = 0.5
+_ENDPOINT_UNREACHABLE = "unreachable"
+_ENDPOINT_OCCUPIED_INVALID = "occupied-invalid"
+_ENDPOINT_READY = "ready-ouroboros"
+_MCP_PROTOCOL_VERSION = "2025-03-26"
+_STARTUP_MUTEX_NAME = r"Local\OuroborosCodexMcpHttpStartup"
+_STARTUP_MUTEX_WAIT_MILLISECONDS = 5_000
+_WAIT_OBJECT_0 = 0x00000000
+_WAIT_ABANDONED = 0x00000080
+_WAIT_TIMEOUT = 0x00000102
+
+
+@dataclass
+class WindowsHttpProvision:
+    command: str
+    created_value: bool
+    process: subprocess.Popen[bytes] | None
+    lease: _StartupMutexLease | None = field(default=None, compare=False, repr=False)
+
+
+def provision_windows_codex_mcp_http(
+    launcher: tuple[str, list[str]],
+) -> tuple[WindowsHttpProvision | None, str | None]:
+    """Create or reuse the fixed per-user startup entry and verify its endpoint."""
+    if not _is_valid_launcher(launcher):
+        return None, (
+            "Codex HTTP MCP launcher must contain a non-empty command and string arguments."
+        )
+    if not _is_windows():
+        return None, "Codex HTTP MCP startup setup is only supported on Windows."
+
+    try:
+        command = _startup_command(launcher)
+    except ValueError as exc:
+        return None, str(exc)
+    if len(command) > _STARTUP_COMMAND_MAX_LENGTH:
+        return None, (
+            f"Windows startup command is {len(command)} characters, exceeding the "
+            f"{_STARTUP_COMMAND_MAX_LENGTH}-character HKCU Run limit. Shorten the Ouroboros "
+            "launcher path or arguments, then run setup again."
+        )
+
+    lease, mutex_error = _acquire_startup_mutex()
+    if mutex_error is not None:
+        return None, mutex_error
+    assert lease is not None
+    provision: WindowsHttpProvision | None = None
+    try:
+        existing, error = _read_startup_value()
+        if error is not None:
+            return None, error
+        if existing is not None:
+            if existing != command:
+                return None, _mismatch_error()
+            endpoint_state = _probe_endpoint()
+            if endpoint_state == _ENDPOINT_READY:
+                provision = WindowsHttpProvision(command, False, None, lease)
+                return provision, None
+            if endpoint_state == _ENDPOINT_OCCUPIED_INVALID:
+                return None, _endpoint_occupied_error()
+            provision, error = _launch_and_verify(command, False)
+        else:
+            endpoint_state = _probe_endpoint()
+            if endpoint_state == _ENDPOINT_READY:
+                return None, _endpoint_conflict_error()
+            if endpoint_state == _ENDPOINT_OCCUPIED_INVALID:
+                return None, _endpoint_occupied_error()
+            created_value, error = _write_startup_value(command)
+            if error is not None:
+                return None, error
+            provision, error = _launch_and_verify(command, created_value)
+        if error is not None:
+            return None, error
+        assert provision is not None
+        provision.lease = lease
+        return provision, None
+    finally:
+        if provision is None:
+            lease.release()
+
+
+def commit_windows_codex_mcp_http(provision: WindowsHttpProvision) -> None:
+    """Release a successfully transferred in-memory startup ownership record."""
+    if provision.lease is not None:
+        provision.lease.release()
+        provision.lease = None
+
+
+def commit_windows_codex_mcp_http_batch(provisions: list[WindowsHttpProvision]) -> None:
+    """Commit all startup ownership records after the encompassing setup succeeds."""
+    for provision in provisions:
+        commit_windows_codex_mcp_http(provision)
+
+
+def retain_windows_codex_mcp_http(
+    provision: WindowsHttpProvision, pending: list[WindowsHttpProvision] | None
+) -> None:
+    """Commit now or retain ownership until the encompassing setup succeeds."""
+    if pending is None:
+        commit_windows_codex_mcp_http(provision)
+    else:
+        pending.append(provision)
+
+
+def rollback_windows_codex_mcp_http_batch(
+    provisions: list[WindowsHttpProvision],
+) -> list[str]:
+    """Undo startup ownership records in reverse order and collect cleanup errors."""
+    return [
+        error
+        for provision in reversed(provisions)
+        if (error := rollback_windows_codex_mcp_http(provision)) is not None
+    ]
+
+
+def render_windows_codex_http_mcp_section() -> str:
+    """Render the managed Codex URL entry for the Windows HTTP server."""
+    return (
+        "\n".join(MANAGED_CODEX_MCP_COMMENT_LINES)
+        + f"\n\n[mcp_servers.ouroboros]\nurl = {json.dumps(HTTP_ENDPOINT, ensure_ascii=False)}\n"
+    )
+
+
+def has_managed_codex_mcp_comment(
+    raw: str,
+    line_starts_structure: Callable[[list[str], int], bool],
+    is_ouroboros_table_header: Callable[[str], bool],
+) -> bool:
+    """Return whether the Ouroboros MCP table carries the managed comment."""
+    lines = raw.splitlines()
+    for index, line in enumerate(lines):
+        if not line_starts_structure(lines, index) or not is_ouroboros_table_header(line.strip()):
+            continue
+        comment_end = index
+        while comment_end > 0 and not lines[comment_end - 1].strip():
+            comment_end -= 1
+        comment_start = comment_end - len(MANAGED_CODEX_MCP_COMMENT_LINES)
+        if comment_start >= 0 and lines[comment_start:comment_end] == list(
+            MANAGED_CODEX_MCP_COMMENT_LINES
+        ):
+            return True
+    return False
+
+
+def rollback_windows_codex_mcp_http(provision: WindowsHttpProvision) -> str | None:
+    """Undo only startup state and process launched by this invocation."""
+    errors: list[str] = []
+    try:
+        if provision.process is not None:
+            termination_error = _terminate_process_tree(provision.process)
+            if termination_error is not None:
+                errors.append(termination_error)
+        if provision.created_value:
+            _removed, cleanup_error = _delete_startup_value_if_matches(provision.command)
+            if cleanup_error is not None:
+                errors.append(cleanup_error)
+    finally:
+        commit_windows_codex_mcp_http(provision)
+    return "; ".join(errors) or None
+
+
+def remove_windows_codex_mcp_startup(
+    launcher: tuple[str, list[str]], *, dry_run: bool = False
+) -> tuple[bool, str | None]:
+    """Remove the exact managed Run value without affecting prior-session processes."""
+    if not _is_valid_launcher(launcher):
+        return False, (
+            "Codex HTTP MCP launcher must contain a non-empty command and string arguments."
+        )
+    if not _is_windows():
+        return False, "Codex HTTP MCP startup setup is only supported on Windows."
+    try:
+        command = _startup_command(launcher)
+    except ValueError as exc:
+        return False, str(exc)
+    if len(command) > _STARTUP_COMMAND_MAX_LENGTH:
+        return False, (
+            f"Windows startup command is {len(command)} characters, exceeding the "
+            f"{_STARTUP_COMMAND_MAX_LENGTH}-character HKCU Run limit. Shorten the Ouroboros "
+            "launcher path or arguments, then run setup again."
+        )
+
+    with _startup_mutex() as mutex_error:
+        if mutex_error is not None:
+            return False, mutex_error
+        existing, error = _read_startup_value()
+        if error is not None:
+            return False, error
+        if existing is None:
+            return False, None
+        if existing != command and not _is_managed_startup_variant(existing):
+            return False, None
+        if dry_run:
+            return True, None
+        return _delete_startup_value_if_matches(existing)
+
+
+def _launch_and_verify(
+    command: str, created_value: bool
+) -> tuple[WindowsHttpProvision | None, str | None]:
+    process, error = _launch(command)
+    if error is not None:
+        provision = WindowsHttpProvision(command, created_value, process)
+        return None, _with_rollback_error(provision, error)
+    provision = WindowsHttpProvision(command, created_value, process)
+    readiness_error = _wait_for_ouroboros_initialize()
+    if readiness_error is not None:
+        return None, _with_rollback_error(provision, readiness_error)
+    return provision, None
+
+
+def _with_rollback_error(provision: WindowsHttpProvision, error: str) -> str:
+    rollback_error = rollback_windows_codex_mcp_http(provision)
+    if rollback_error is not None:
+        return f"{error}; {rollback_error}"
+    return error
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _is_valid_launcher(launcher: object) -> bool:
+    return (
+        isinstance(launcher, tuple)
+        and len(launcher) == 2
+        and isinstance(launcher[0], str)
+        and bool(launcher[0])
+        and isinstance(launcher[1], list)
+        and all(isinstance(argument, str) for argument in launcher[1])
+    )
+
+
+def _startup_command(launcher: tuple[str, list[str]]) -> str:
+    return subprocess.list2cmdline([launcher[0], *_managed_arguments(launcher[1])])
+
+
+def _managed_arguments(arguments: list[str]) -> list[str]:
+    managed = list(arguments)
+    for option, required_value in zip(_FIXED_OPTIONS[::2], _FIXED_OPTIONS[1::2], strict=True):
+        values = _option_values(managed, option)
+        if not values:
+            managed.extend((option, required_value))
+            continue
+        if len(values) != 1:
+            raise ValueError(
+                f"Codex HTTP MCP launcher specifies {option} more than once. Keep exactly "
+                f"{option} {required_value}, then run setup again."
+            )
+        if values[0] != required_value:
+            raise ValueError(
+                f"Codex HTTP MCP launcher specifies {option} {values[0]!r}, but requires "
+                f"{option} {required_value!r}. Correct the launcher, then run setup again."
+            )
+    return managed
+
+
+def _option_values(arguments: list[str], option: str) -> list[str]:
+    values: list[str] = []
+    for index, argument in enumerate(arguments):
+        if argument == option:
+            if index + 1 >= len(arguments) or arguments[index + 1].startswith("--"):
+                raise ValueError(
+                    f"Codex HTTP MCP launcher is missing a value for {option}. Use "
+                    f"{option} <value>, then run setup again."
+                )
+            values.append(arguments[index + 1])
+        elif argument.startswith(f"{option}="):
+            values.append(argument.removeprefix(f"{option}="))
+    return values
+
+
+def _is_managed_startup_variant(command: str) -> bool:
+    arguments = _parse_windows_command_line(command)
+    if arguments is None or len(arguments) < 1 + len(_FIXED_OPTIONS):
+        return False
+    executable = os.path.basename(arguments[0]).lower()
+    if (
+        executable not in {"uvx", "uvx.exe", "ouroboros", "ouroboros.exe"}
+        and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?\.exe", executable) is None
+    ):
+        return False
+    prefix, suffix = arguments[1 : -len(_FIXED_OPTIONS)], arguments[-len(_FIXED_OPTIONS) :]
+    if tuple(suffix) != _FIXED_OPTIONS:
+        return False
+    if executable.startswith("uvx"):
+        return prefix in (
+            ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+            ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
+            ["ouroboros", "mcp", "serve"],
+            [
+                "--isolated",
+                "--python",
+                UVX_PYTHON_FLOOR,
+                "--from",
+                "ouroboros-ai[mcp]",
+                "ouroboros",
+                "mcp",
+                "serve",
+            ],
+        )
+    if executable.startswith("python"):
+        return prefix == ["-m", "ouroboros", "mcp", "serve"]
+    return prefix == ["mcp", "serve"]
+
+
+def _parse_windows_command_line(command: str) -> list[str] | None:
+    try:
+        argc = ctypes.c_int()
+        shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+        command_line_to_argv = shell32.CommandLineToArgvW
+        command_line_to_argv.argtypes = (ctypes.c_wchar_p, ctypes.POINTER(ctypes.c_int))
+        command_line_to_argv.restype = ctypes.POINTER(ctypes.c_wchar_p)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        local_free = kernel32.LocalFree
+        local_free.argtypes = (ctypes.c_void_p,)
+        local_free.restype = ctypes.c_void_p
+        argv = command_line_to_argv(command, ctypes.byref(argc))
+        if not argv:
+            return None
+        try:
+            return [argv[index] for index in range(argc.value)]
+        finally:
+            local_free(argv)
+    except OSError:
+        return None
+
+
+class _StartupMutexLease:
+    def __init__(
+        self,
+        handle: object,
+        release_mutex: Callable[[object], object],
+        close_handle: Callable[[object], object],
+    ) -> None:
+        self._handle = handle
+        self._release_mutex = release_mutex
+        self._close_handle = close_handle
+        self._released = False
+
+    def release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._release_mutex(self._handle)
+            self._close_handle(self._handle)
+
+
+def _acquire_startup_mutex() -> tuple[_StartupMutexLease | None, str | None]:
+    """Acquire the Ouroboros startup mutex scoped to the current Windows login session."""
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        create_mutex = kernel32.CreateMutexW
+        wait_for_single_object = kernel32.WaitForSingleObject
+        release_mutex = kernel32.ReleaseMutex
+        close_handle = kernel32.CloseHandle
+        create_mutex.argtypes = (ctypes.c_void_p, ctypes.c_bool, ctypes.c_wchar_p)
+        create_mutex.restype = ctypes.c_void_p
+        wait_for_single_object.argtypes = (ctypes.c_void_p, ctypes.c_ulong)
+        wait_for_single_object.restype = ctypes.c_ulong
+        release_mutex.argtypes = (ctypes.c_void_p,)
+        release_mutex.restype = ctypes.c_bool
+        close_handle.argtypes = (ctypes.c_void_p,)
+        close_handle.restype = ctypes.c_bool
+        handle = create_mutex(None, False, _STARTUP_MUTEX_NAME)
+    except OSError as exc:
+        return None, f"Could not create Windows startup mutex: {exc}"
+    if not handle:
+        return (
+            None,
+            f"Could not create Windows startup mutex (Win32 error {ctypes.get_last_error()}).",
+        )
+    wait_result = wait_for_single_object(handle, _STARTUP_MUTEX_WAIT_MILLISECONDS)
+    if wait_result in {_WAIT_OBJECT_0, _WAIT_ABANDONED}:
+        return _StartupMutexLease(handle, release_mutex, close_handle), None
+    close_handle(handle)
+    if wait_result == _WAIT_TIMEOUT:
+        return (
+            None,
+            f"Could not acquire Windows startup mutex: timed out after "
+            f"{_STARTUP_MUTEX_WAIT_MILLISECONDS} ms.",
+        )
+    return (
+        None,
+        "Could not acquire Windows startup mutex: WaitForSingleObject failed "
+        f"(Win32 error {ctypes.get_last_error()}).",
+    )
+
+
+@contextmanager
+def _startup_mutex() -> Iterator[str | None]:
+    lease, error = _acquire_startup_mutex()
+    try:
+        yield error
+    finally:
+        if lease is not None:
+            lease.release()
+
+
+def _winreg() -> object:
+    import winreg
+
+    return winreg
+
+
+def _read_startup_value() -> tuple[str | None, str | None]:
+    with _startup_mutex() as mutex_error:
+        if mutex_error is not None:
+            return None, mutex_error
+        registry = _winreg()
+        try:
+            with registry.OpenKey(
+                registry.HKEY_CURRENT_USER, _STARTUP_KEY, 0, registry.KEY_READ
+            ) as key:
+                value, value_type = registry.QueryValueEx(key, _STARTUP_VALUE_NAME)
+        except FileNotFoundError:
+            return None, None
+        except OSError as exc:
+            return None, f"Could not read Windows startup entry {_STARTUP_VALUE_NAME!r}: {exc}"
+        if value_type != registry.REG_SZ or not isinstance(value, str):
+            return "", None
+        return value, None
+
+
+def _write_startup_value(value: str) -> tuple[bool, str | None]:
+    """Set an absent Run value without overwriting a concurrent owner."""
+    with _startup_mutex() as mutex_error:
+        if mutex_error is not None:
+            return False, mutex_error
+        registry = _winreg()
+        try:
+            with registry.CreateKeyEx(
+                registry.HKEY_CURRENT_USER,
+                _STARTUP_KEY,
+                0,
+                registry.KEY_QUERY_VALUE | registry.KEY_SET_VALUE,
+            ) as key:
+                try:
+                    existing, value_type = registry.QueryValueEx(key, _STARTUP_VALUE_NAME)
+                except FileNotFoundError:
+                    registry.SetValueEx(key, _STARTUP_VALUE_NAME, 0, registry.REG_SZ, value)
+                    return True, None
+                if (
+                    value_type == registry.REG_SZ
+                    and isinstance(existing, str)
+                    and existing == value
+                ):
+                    return False, None
+                return False, _mismatch_error()
+        except OSError as exc:
+            return False, f"Could not write Windows startup entry {_STARTUP_VALUE_NAME!r}: {exc}"
+
+
+def _delete_startup_value_if_matches(expected: str) -> tuple[bool, str | None]:
+    with _startup_mutex() as mutex_error:
+        if mutex_error is not None:
+            return False, mutex_error
+        registry = _winreg()
+        try:
+            with registry.OpenKey(
+                registry.HKEY_CURRENT_USER,
+                _STARTUP_KEY,
+                0,
+                registry.KEY_QUERY_VALUE | registry.KEY_SET_VALUE,
+            ) as key:
+                value, value_type = registry.QueryValueEx(key, _STARTUP_VALUE_NAME)
+                if value_type != registry.REG_SZ or value != expected:
+                    return False, None
+                registry.DeleteValue(key, _STARTUP_VALUE_NAME)
+        except FileNotFoundError:
+            return False, None
+        except OSError as exc:
+            return False, f"Could not remove Windows startup entry {_STARTUP_VALUE_NAME!r}: {exc}"
+        return True, None
+
+
+def _launch(command: str) -> tuple[subprocess.Popen[bytes] | None, str | None]:
+    try:
+        process = subprocess.Popen(
+            command,
+            creationflags=(
+                getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+            ),
+            close_fds=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        return None, f"Could not launch {_STARTUP_VALUE_NAME!r}: {exc}"
+    return process, None
+
+
+def _terminate_process_tree(process: subprocess.Popen[bytes]) -> str | None:
+    try:
+        import ctypes
+
+        buffer_size = 32768
+        system_directory = ctypes.create_unicode_buffer(buffer_size)
+        length = ctypes.windll.kernel32.GetSystemDirectoryW(system_directory, buffer_size)
+        if not length or length >= buffer_size:
+            raise OSError("GetSystemDirectoryW failed")
+        subprocess.run(
+            [
+                os.path.join(system_directory.value, "taskkill.exe"),
+                "/PID",
+                str(process.pid),
+                "/T",
+                "/F",
+            ],
+            check=True,
+            close_fds=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"Could not terminate {_STARTUP_VALUE_NAME!r} process tree: {exc}"
+    return None
+
+
+def _mismatch_error() -> str:
+    return (
+        f"Existing Windows startup entry {_STARTUP_VALUE_NAME!r} does not match the required "
+        "Ouroboros Codex HTTP command. Remove or correct that value manually, then run setup "
+        "again."
+    )
+
+
+def _endpoint_conflict_error() -> str:
+    return (
+        f"{HTTP_ENDPOINT} already responds as an Ouroboros MCP endpoint, but Windows startup "
+        f"entry {_STARTUP_VALUE_NAME!r} is absent. Stop or reconfigure the existing server, "
+        "then run setup again."
+    )
+
+
+def _endpoint_occupied_error() -> str:
+    return (
+        f"{HTTP_ENDPOINT} is occupied by a process that did not return a valid Ouroboros MCP "
+        "initialize response. Stop or reconfigure that process, then run setup again."
+    )
+
+
+def _wait_for_ouroboros_initialize() -> str | None:
+    for attempt in range(_PROBE_ATTEMPTS):
+        if _probe_endpoint() == _ENDPOINT_READY:
+            return None
+        if attempt + 1 < _PROBE_ATTEMPTS:
+            time.sleep(_PROBE_RETRY_SECONDS)
+    return (
+        f"Startup entry {_STARTUP_VALUE_NAME!r} launched, but {HTTP_ENDPOINT} did not return "
+        "a valid Ouroboros MCP initialize response."
+    )
+
+
+def _probe_endpoint() -> str:
+    if not _endpoint_is_reachable():
+        return _ENDPOINT_UNREACHABLE
+    return _ENDPOINT_READY if _initialize_reports_ouroboros() else _ENDPOINT_OCCUPIED_INVALID
+
+
+def _endpoint_is_reachable() -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", 8765), timeout=_PROBE_TIMEOUT_SECONDS):
+            return True
+    except OSError:
+        return False
+
+
+def _initialize_reports_ouroboros() -> bool:
+    request = urllib.request.Request(
+        HTTP_ENDPOINT,
+        data=json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": _MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "ouroboros-setup", "version": "1"},
+                },
+            }
+        ).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_PROBE_TIMEOUT_SECONDS) as response:
+            payload = response.read().decode("utf-8")
+    except (OSError, urllib.error.URLError, TimeoutError, UnicodeDecodeError):
+        return False
+    return _response_is_ouroboros(payload)
+
+
+def _response_is_ouroboros(payload: str) -> bool:
+    for candidate in _json_payloads(payload):
+        try:
+            response = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(response, Mapping):
+            continue
+        if (
+            response.get("jsonrpc") != "2.0"
+            or type(response.get("id")) is not int
+            or response["id"] != 1
+        ):
+            continue
+        result = response.get("result")
+        if not isinstance(result, Mapping):
+            continue
+        protocol_version = result.get("protocolVersion")
+        capabilities = result.get("capabilities")
+        server_info = result.get("serverInfo")
+        if (
+            protocol_version != _MCP_PROTOCOL_VERSION
+            or not isinstance(capabilities, Mapping)
+            or not isinstance(server_info, Mapping)
+        ):
+            continue
+        if (
+            server_info.get("name") == "ouroboros-mcp"
+            and isinstance(server_info.get("version"), str)
+            and server_info["version"]
+        ):
+            return True
+    return False
+
+
+def _json_payloads(payload: str) -> list[str]:
+    candidates = [payload]
+    candidates.extend(
+        line.removeprefix("data:").strip()
+        for line in payload.splitlines()
+        if line.startswith("data:")
+    )
+    return candidates

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -37,6 +37,20 @@ import typer
 import yaml
 
 from ouroboros.bigbang.brownfield import scan_and_register, set_default_repo
+from ouroboros.cli.codex_http_mcp import (
+    HTTP_ENDPOINT,
+    WindowsHttpProvision,
+    commit_windows_codex_mcp_http_batch,
+    has_managed_codex_mcp_comment,
+    provision_windows_codex_mcp_http,
+    remove_windows_codex_mcp_startup,
+    render_windows_codex_http_mcp_section,
+    retain_windows_codex_mcp_http,
+    rollback_windows_codex_mcp_http_batch,
+)
+from ouroboros.cli.codex_http_mcp import (
+    MANAGED_CODEX_MCP_COMMENT_LINES as _CODEX_MCP_COMMENT_LINES,
+)
 from ouroboros.cli.commands.claude_setup import (
     setup_claude as _setup_claude,
 )
@@ -436,15 +450,8 @@ OUROBOROS_AGENT_RUNTIME = "codex"
 OUROBOROS_LLM_BACKEND = "codex"
 """
 
-_CODEX_MCP_COMMENT_LINES = (
-    "# Ouroboros MCP hookup for Codex CLI.",
-    "# Keep Ouroboros runtime settings and per-role model overrides in",
-    "# ~/.ouroboros/config.yaml (for example: clarification.default_model,",
-    "# llm.qa_model, evaluation.semantic_model, consensus.*).",
-    "# This file is only for the Codex MCP/env registration block.",
-)
 
-CodexMcpMode = Literal["auto", "preserve", "stdio"]
+CodexMcpMode = Literal["auto", "preserve", "stdio", "http"]
 _CODEX_APP_CLI_PATH = Path("/Applications/ChatGPT.app/Contents/Resources/codex")
 _CODEX_UVX_MCP_ARGS = _build_uvx_mcp_args("ouroboros-ai[mcp]")
 _CODEX_LEGACY_UVX_MCP_ARGS: tuple[tuple[str, ...], ...] = (
@@ -545,8 +552,8 @@ _CODEX_DEFAULT_LLM_ROLE_PROFILES: dict[str, str] = {
 def _normalize_codex_mcp_mode(value: str) -> CodexMcpMode:
     """Validate and normalize the Codex MCP setup mode."""
     normalized = value.lower()
-    if normalized not in {"auto", "preserve", "stdio"}:
-        print_error("Unsupported Codex MCP mode. Use one of: auto, preserve, stdio.")
+    if normalized not in {"auto", "preserve", "stdio", "http"}:
+        print_error("Unsupported Codex MCP mode. Use one of: auto, preserve, stdio, http.")
         raise typer.Exit(1)
     return normalized  # type: ignore[return-value]
 
@@ -652,15 +659,8 @@ def _codex_release_mcp_launcher() -> tuple[str, list[str]] | None:
     return None
 
 
-def _render_codex_mcp_section() -> str | None:
-    """Render the managed Codex MCP block for the current install source.
-
-    Release installs use ``uvx --isolated --from ouroboros-ai[mcp]`` so Codex
-    can bootstrap the MCP extra without reusing a conflicting installed tool.
-    Dev/git installs must instead point Codex at this
-    Python environment; otherwise setup silently downgrades the MCP server back
-    to the latest PyPI release and hides main-branch fixes under test.
-    """
+def _resolve_codex_mcp_launcher() -> tuple[str, list[str]] | None:
+    """Resolve the launcher shared by stdio config and Windows HTTP provisioning."""
     if _is_dev_ouroboros_build():
         if (
             not Path(sys.executable).is_file()
@@ -668,13 +668,17 @@ def _render_codex_mcp_section() -> str | None:
             or importlib_util.find_spec("mcp") is None
         ):
             return None
-        command = sys.executable
-        args = list(_CODEX_MODULE_MCP_ARGS)
-    else:
-        launcher = _codex_release_mcp_launcher()
-        if launcher is None:
-            return None
-        command, args = launcher
+        return sys.executable, list(_CODEX_MODULE_MCP_ARGS)
+    return _codex_release_mcp_launcher()
+
+
+def _render_codex_mcp_section(launcher: tuple[str, list[str]] | None = None) -> str | None:
+    """Render the managed Codex stdio MCP block for the resolved launcher."""
+    if launcher is None:
+        launcher = _resolve_codex_mcp_launcher()
+    if launcher is None:
+        return None
+    command, args = launcher
     command_lines = "\n".join(
         (
             f"command = {_toml_string(command)}",
@@ -684,42 +688,22 @@ def _render_codex_mcp_section() -> str | None:
     return _CODEX_MCP_SECTION_TEMPLATE.format(command_lines=command_lines)
 
 
-def _has_managed_codex_mcp_comment(raw: str) -> bool:
-    """Return whether the Ouroboros MCP table carries setup's managed comment."""
-    lines = raw.splitlines()
-    expected = list(_CODEX_MCP_COMMENT_LINES)
-    for index, line in enumerate(lines):
-        if not _toml_line_starts_structure(lines, index):
-            continue
-        if not _is_codex_ouroboros_table_header(line.strip()):
-            continue
-        comment_end = index
-        while comment_end > 0 and not lines[comment_end - 1].strip():
-            comment_end -= 1
-        comment_start = comment_end - len(expected)
-        if comment_start >= 0 and lines[comment_start:comment_end] == expected:
-            return True
-    return False
-
-
 def _is_setup_managed_codex_mcp_entry(
     entry: dict[str, object], *, has_managed_comment: bool = False
 ) -> bool:
     """Return whether setup may safely replace this Codex MCP entry."""
-    if "url" in entry:
-        return False
+    if entry.get("url") == HTTP_ENDPOINT:
+        return has_managed_comment and set(entry) == {"url"}
 
     command = entry.get("command")
     args = entry.get("args")
     if not isinstance(command, str) or not isinstance(args, list):
         return False
-
     env = entry.get("env")
     if env is not None and env != _CODEX_MANAGED_MCP_ENV:
         return False
     if set(entry) - {"command", "args", "env"}:
         return False
-
     if Path(command).name == "uvx":
         return tuple(str(arg) for arg in args) in _CODEX_LEGACY_UVX_MCP_ARGS
     if not has_managed_comment:
@@ -1180,6 +1164,7 @@ def _register_codex_mcp_server(
     *,
     mode: CodexMcpMode = "auto",
     expected_snapshots: dict[Path, _PathSnapshot] | None = None,
+    http_provisions: list[WindowsHttpProvision] | None = None,
 ) -> bool:
     """Register the Ouroboros MCP/env hookup in ~/.codex/config.toml."""
     import tomllib
@@ -1204,18 +1189,10 @@ def _register_codex_mcp_server(
         print_info("Preserved Codex MCP config.")
         return True
 
-    rendered_section = _render_codex_mcp_section()
-    if rendered_section is None:
-        print_error(
-            "Could not find a launchable Ouroboros MCP command. Install uv, or install "
-            "Ouroboros with the [mcp] extra, then rerun setup."
-        )
-        return False
-
     codex_config = resolve_codex_home() / "config.toml"
-    codex_config.parent.mkdir(parents=True, exist_ok=True)
-    codex_config_snapshot = _snapshot_path(codex_config)
-
+    raw = ""
+    entry: dict[str, object] | None = None
+    has_managed_comment = False
     if codex_config.exists():
         raw = codex_config.read_text(encoding="utf-8")
         try:
@@ -1223,61 +1200,103 @@ def _register_codex_mcp_server(
         except tomllib.TOMLDecodeError:
             print_error(f"Could not parse {codex_config} — Codex setup not saved.")
             return False
-
         entry = _codex_mcp_entry_from_toml(parsed)
-        has_managed_comment = _has_managed_codex_mcp_comment(raw)
-        if entry is not None and not _codex_mcp_entry_has_endpoint(entry) and mode != "stdio":
-            print_error(
-                "Existing Codex Ouroboros MCP config has no usable command or URL; "
-                "Codex setup not saved. Use --mcp-mode stdio to replace it."
-            )
-            return False
-        if (
-            mode == "auto"
-            and entry is not None
-            and not _is_setup_managed_codex_mcp_entry(
-                entry, has_managed_comment=has_managed_comment
-            )
-        ):
-            print_info(
-                "Preserved existing user-managed Ouroboros MCP config in "
-                f"{codex_config}. Use --mcp-mode stdio to replace it."
-            )
-            return True
-
-        updated_raw, existed_before = _upsert_codex_mcp_section(raw, rendered_section)
-        if updated_raw == raw:
-            print_info("Codex MCP server already up to date.")
-            return True
-        try:
-            tomllib.loads(updated_raw)
-        except tomllib.TOMLDecodeError as exc:
-            print_error(
-                f"Could not update {codex_config} — MCP registration would create invalid TOML."
-            )
-            print_info(str(exc))
-            return False
-
-        written_snapshot = _atomic_write_text_if_current_matches(
-            codex_config,
-            updated_raw,
-            codex_config_snapshot,
+        has_managed_comment = has_managed_codex_mcp_comment(
+            raw, _toml_line_starts_structure, _is_codex_ouroboros_table_header
         )
-        if expected_snapshots is not None:
-            expected_snapshots[codex_config] = written_snapshot
-        if existed_before:
-            print_success(f"Updated Ouroboros MCP server in {codex_config}")
-        else:
-            print_success(f"Registered Ouroboros MCP server in {codex_config}")
+
+    managed_entry = entry is not None and _is_setup_managed_codex_mcp_entry(
+        entry, has_managed_comment=has_managed_comment
+    )
+    use_http = mode == "http" or (
+        mode == "auto" and sys.platform == "win32" and (entry is None or managed_entry)
+    )
+    if (
+        entry is not None
+        and not _codex_mcp_entry_has_endpoint(entry)
+        and mode not in {"stdio", "http"}
+    ):
+        print_error(
+            "Existing Codex Ouroboros MCP config has no usable command or URL; "
+            "Codex setup not saved. Use --mcp-mode stdio or http to replace it."
+        )
+        return False
+    if mode == "auto" and entry is not None and not managed_entry:
+        print_info(
+            "Preserved existing user-managed Ouroboros MCP config in "
+            f"{codex_config}. Use --mcp-mode stdio or http to replace it."
+        )
+        return True
+
+    launcher = _resolve_codex_mcp_launcher()
+    if launcher is None:
+        print_error(
+            "Could not find a launchable Ouroboros MCP command. Install uv, or install "
+            "Ouroboros with the [mcp] extra, then rerun setup."
+        )
+        return False
+
+    provision: WindowsHttpProvision | None = None
+    if use_http:
+        provision, provisioning_error = provision_windows_codex_mcp_http(launcher)
+        if provisioning_error is not None:
+            print_error(provisioning_error)
+            return False
+        if provision is None:
+            print_error("Codex HTTP MCP setup did not return an ownership record.")
+            return False
+        rendered_section = render_windows_codex_http_mcp_section()
     else:
-        written_snapshot = _atomic_write_text_if_current_matches(
-            codex_config,
-            rendered_section.lstrip("\n"),
-            codex_config_snapshot,
-        )
-        if expected_snapshots is not None:
-            expected_snapshots[codex_config] = written_snapshot
-        print_success(f"Registered Ouroboros MCP server in {codex_config}")
+        rendered_section = _render_codex_mcp_section(launcher)
+        if rendered_section is None:
+            return False
+    rollback_provisions = [] if provision is None else [provision]
+
+    try:
+        codex_config.parent.mkdir(parents=True, exist_ok=True)
+        codex_config_snapshot = _snapshot_path(codex_config)
+        if codex_config.exists():
+            updated_raw, existed_before = _upsert_codex_mcp_section(raw, rendered_section)
+            if updated_raw == raw:
+                print_info("Codex MCP server already up to date.")
+            else:
+                try:
+                    tomllib.loads(updated_raw)
+                except tomllib.TOMLDecodeError as exc:
+                    for error in rollback_windows_codex_mcp_http_batch(rollback_provisions):
+                        print_error(error)
+                    print_error(
+                        f"Could not update {codex_config} — MCP registration would create invalid TOML."
+                    )
+                    print_info(str(exc))
+                    return False
+                written_snapshot = _atomic_write_text_if_current_matches(
+                    codex_config,
+                    updated_raw,
+                    codex_config_snapshot,
+                )
+                if expected_snapshots is not None:
+                    expected_snapshots[codex_config] = written_snapshot
+                if existed_before:
+                    print_success(f"Updated Ouroboros MCP server in {codex_config}")
+                else:
+                    print_success(f"Registered Ouroboros MCP server in {codex_config}")
+        else:
+            written_snapshot = _atomic_write_text_if_current_matches(
+                codex_config,
+                rendered_section.lstrip("\n"),
+                codex_config_snapshot,
+            )
+            if expected_snapshots is not None:
+                expected_snapshots[codex_config] = written_snapshot
+            print_success(f"Registered Ouroboros MCP server in {codex_config}")
+    except OSError:
+        for error in rollback_windows_codex_mcp_http_batch(rollback_provisions):
+            print_error(error)
+        raise
+
+    if provision is not None:
+        retain_windows_codex_mcp_http(provision, http_provisions)
     return True
 
 
@@ -2739,29 +2758,42 @@ def _setup_codex(
         print_info("Replace the symlink with a regular Codex config path, then rerun setup.")
         return False
     managed_codex_snapshot = _snapshot_managed_codex_setup_paths(codex_home)
+    http_provisions: list[WindowsHttpProvision] = []
     managed_codex_expected_snapshot: dict[Path, _PathSnapshot] | None = None
     config_expected_snapshot: _PathSnapshot | None = config_snapshot
     credentials_expected_snapshot: _PathSnapshot | None = credentials_snapshot
+
+    mcp_expected_snapshot: dict[Path, _PathSnapshot] = {}
     try:
-        mcp_expected_snapshot: dict[Path, _PathSnapshot] = {}
         mcp_registered = _register_codex_mcp_server(
             mode=mcp_mode,
             expected_snapshots=mcp_expected_snapshot,
+            http_provisions=http_provisions,
         )
     except OSError as exc:
+        if mcp_expected_snapshot:
+            managed_codex_expected_snapshot = dict(managed_codex_snapshot)
+            managed_codex_expected_snapshot.update(mcp_expected_snapshot)
         _restore_managed_codex_setup_paths(
             managed_codex_snapshot,
-            expected_current=managed_codex_snapshot,
+            expected_current=managed_codex_expected_snapshot or managed_codex_snapshot,
         )
+        for error in rollback_windows_codex_mcp_http_batch(http_provisions):
+            print_error(error)
         _restore_created_directory_topology(setup_directory_topology_snapshot)
         print_error(f"Could not save Codex MCP config: {exc}")
         print_info("Restored unchanged Codex MCP config paths; setup incomplete.")
         return False
     if not mcp_registered:
+        if mcp_expected_snapshot:
+            managed_codex_expected_snapshot = dict(managed_codex_snapshot)
+            managed_codex_expected_snapshot.update(mcp_expected_snapshot)
         _restore_managed_codex_setup_paths(
             managed_codex_snapshot,
-            expected_current=managed_codex_snapshot,
+            expected_current=managed_codex_expected_snapshot or managed_codex_snapshot,
         )
+        for error in rollback_windows_codex_mcp_http_batch(http_provisions):
+            print_error(error)
         _restore_created_directory_topology(setup_directory_topology_snapshot)
         print_info("Aborting Codex setup without rewriting config.yaml.")
         return False
@@ -2805,10 +2837,13 @@ def _setup_codex(
             credentials_snapshot,
             credentials_expected_snapshot,
         )
+        for error in rollback_windows_codex_mcp_http_batch(http_provisions):
+            print_error(error)
         _restore_created_directory_topology(setup_directory_topology_snapshot)
         print_error(f"Could not save Codex runtime config: {exc}")
         print_info("Restored Codex MCP config; setup incomplete.")
         return False
+    removed_startup = False
 
     try:
         # Install Codex-native rules and skills into the active Codex home.
@@ -2831,6 +2866,13 @@ def _setup_codex(
             expected_snapshots=managed_codex_expected_snapshot,
         ):
             raise OSError("Codex worker profile registration failed")
+        if mcp_mode == "stdio" and sys.platform == "win32":
+            launcher = _resolve_codex_mcp_launcher()
+            if launcher is None:
+                raise OSError("Could not find a launchable Ouroboros MCP command")
+            removed_startup, cleanup_error = remove_windows_codex_mcp_startup(launcher)
+            if cleanup_error is not None:
+                raise OSError(cleanup_error)
     except (OSError, TypeError, ValueError) as exc:
         _restore_managed_codex_setup_paths(
             managed_codex_snapshot,
@@ -2846,10 +2888,15 @@ def _setup_codex(
             credentials_snapshot,
             credentials_expected_snapshot,
         )
+        for error in rollback_windows_codex_mcp_http_batch(http_provisions):
+            print_error(error)
         _restore_created_directory_topology(setup_directory_topology_snapshot)
         print_error(f"Could not finish Codex setup: {exc}")
         print_info("Restored Codex and Ouroboros config; setup incomplete.")
         return False
+    commit_windows_codex_mcp_http_batch(http_provisions)
+    if removed_startup:
+        print_warning("Removed the managed Windows HTTP MCP startup entry.")
     print_success(f"Configured Codex runtime (CLI: {codex_path})")
     print_info(f"Config saved to: {config_path}")
     if added_profiles:
@@ -4658,7 +4705,12 @@ def setup(
         str,
         typer.Option(
             "--mcp-mode",
-            help="Codex MCP config mode: auto preserves user-managed entries, preserve skips MCP changes, stdio replaces with the managed stdio entry.",
+            help=(
+                "Codex MCP config mode (auto | preserve | stdio | http): auto uses managed "
+                "HTTP on Windows when safe and otherwise preserves user-managed entries or "
+                "uses stdio; preserve skips MCP changes; stdio and http replace with the "
+                "selected managed entry."
+            ),
         ),
     ] = "auto",
     preserve_existing_llm: Annotated[

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -23,6 +23,11 @@ from typing import Annotated
 
 import typer
 
+from ouroboros.cli.codex_http_mcp import (
+    _is_windows,
+    has_managed_codex_mcp_comment,
+    remove_windows_codex_mcp_startup,
+)
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
     print_info,
@@ -81,10 +86,11 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
     from ouroboros.cli.commands.setup import (
         _atomic_write_text_if_current_matches,
         _codex_mcp_entry_from_toml,
-        _has_managed_codex_mcp_comment,
+        _is_codex_ouroboros_table_header,
         _is_setup_managed_codex_mcp_entry,
         _remove_codex_mcp_section,
         _snapshot_path,
+        _toml_line_starts_structure,
     )
 
     codex_config = resolve_codex_home() / "config.toml"
@@ -107,7 +113,11 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
         return False
     if not _is_setup_managed_codex_mcp_entry(
         entry,
-        has_managed_comment=_has_managed_codex_mcp_comment(raw),
+        has_managed_comment=has_managed_codex_mcp_comment(
+            raw,
+            _toml_line_starts_structure,
+            _is_codex_ouroboros_table_header,
+        ),
     ):
         print_info("Preserved user-managed Ouroboros MCP config in ~/.codex/config.toml")
         return False
@@ -135,6 +145,44 @@ def _remove_codex_mcp(dry_run: bool) -> bool:
         print_warning("Could not write ~/.codex/config.toml — skipping.")
         return False
     print_success("Removed ouroboros from ~/.codex/config.toml")
+    return True
+
+
+def _remove_windows_codex_mcp_startup(dry_run: bool, *, report: bool = True) -> bool:
+    """Remove this installation's Windows login startup entry for Codex HTTP MCP."""
+    if not _is_windows():
+        return False
+
+    from ouroboros.cli.commands.setup import _resolve_codex_mcp_launcher
+
+    launcher = _resolve_codex_mcp_launcher()
+    if launcher is None:
+        print_warning(
+            "Could not resolve the Codex MCP launcher; preserving the Windows login startup entry."
+        )
+        return False
+
+    removed, error = remove_windows_codex_mcp_startup(launcher, dry_run=dry_run)
+    if error is not None:
+        print_warning(error)
+        return False
+    if not removed:
+        if report:
+            print_info("No matching managed Windows login startup entry was removed.")
+        return False
+
+    if dry_run:
+        if report:
+            print_info(
+                "[dry-run] Would remove the Ouroboros Codex HTTP MCP Windows login startup entry"
+            )
+        return True
+
+    print_success(
+        "Removed the Ouroboros Codex HTTP MCP Windows login startup entry. "
+        "Future logins will no longer launch it. An instance already running in this "
+        "login session may remain until logoff."
+    )
     return True
 
 
@@ -445,14 +493,19 @@ def uninstall(
             else:
                 from ouroboros.cli.commands.setup import (
                     _codex_mcp_entry_from_toml,
-                    _has_managed_codex_mcp_comment,
+                    _is_codex_ouroboros_table_header,
                     _is_setup_managed_codex_mcp_entry,
+                    _toml_line_starts_structure,
                 )
 
                 entry = _codex_mcp_entry_from_toml(parsed_codex_config)
                 if isinstance(entry, dict) and _is_setup_managed_codex_mcp_entry(
                     entry,
-                    has_managed_comment=_has_managed_codex_mcp_comment(raw_codex_config),
+                    has_managed_comment=has_managed_codex_mcp_comment(
+                        raw_codex_config,
+                        _toml_line_starts_structure,
+                        _is_codex_ouroboros_table_header,
+                    ),
                 ):
                     targets.append("Codex MCP config (~/.codex/config.toml)")
     except OSError:
@@ -509,6 +562,9 @@ def uninstall(
     data_dir = Path.home() / ".ouroboros"
     if not keep_data and data_dir.exists():
         targets.append("Data directory (~/.ouroboros/)")
+    startup_cleanup_planned = _remove_windows_codex_mcp_startup(dry_run=True, report=False)
+    if startup_cleanup_planned:
+        targets.append("Codex HTTP MCP Windows login startup entry")
 
     if not targets:
         console.print("[green]Nothing to remove — Ouroboros is not installed.[/green]\n")
@@ -528,6 +584,7 @@ def uninstall(
     console.print()
 
     if dry_run:
+        _remove_windows_codex_mcp_startup(dry_run=True)
         console.print("[yellow]Dry run — no changes made.[/yellow]\n")
         raise typer.Exit()
 
@@ -550,6 +607,9 @@ def uninstall(
     if not _remove_codex_mcp(dry_run=False):
         if any("codex/config.toml" in t for t in targets):
             failed.append("~/.codex/config.toml")
+    if not _remove_windows_codex_mcp_startup(dry_run=False):
+        if any("Windows login startup entry" in t for t in targets):
+            failed.append("Codex HTTP MCP Windows login startup entry")
 
     if not _remove_opencode_mcp(dry_run=False):
         if any("OpenCode MCP" in t for t in targets):

--- a/tests/unit/cli/test_codex_http_mcp.py
+++ b/tests/unit/cli/test_codex_http_mcp.py
@@ -1,0 +1,1029 @@
+"""Tests for the per-user Windows Codex HTTP MCP startup entry."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import ctypes
+import subprocess
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from ouroboros.cli import codex_http_mcp as mcp
+
+LAUNCHER = ("C:\\Program Files\\Ouroboros\\ouroboros.exe", ["mcp", "serve"])
+SETUP_LAUNCHER = (
+    "C:\\Program Files\\Ouroboros\\ouroboros.exe",
+    ["mcp", "serve", "--runtime", "codex", "--llm-backend", "codex"],
+)
+
+
+def _prepare_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_is_windows", lambda: True)
+
+
+_ORIGINAL_STARTUP_MUTEX = mcp._startup_mutex
+_ORIGINAL_ACQUIRE_STARTUP_MUTEX = mcp._acquire_startup_mutex
+_ORIGINAL_PARSE_WINDOWS_COMMAND_LINE = mcp._parse_windows_command_line
+
+
+class _TestLease:
+    def release(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _disable_windows_mutex(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_startup_mutex", lambda: nullcontext(None))
+    monkeypatch.setattr(mcp, "_acquire_startup_mutex", lambda: (_TestLease(), None))
+    monkeypatch.setattr(mcp, "_parse_windows_command_line", lambda _command: None)
+
+
+def test_exact_existing_value_with_healthy_endpoint_is_reused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    command = mcp._startup_command(LAUNCHER)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (command, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_READY)
+    monkeypatch.setattr(mcp, "_launch", lambda _command: pytest.fail("must not launch"))
+
+    provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error is None
+    assert provision == mcp.WindowsHttpProvision(command, False, None)
+
+
+def test_exact_existing_value_relaunches_only_when_endpoint_is_unhealthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    events: list[str] = []
+    command = mcp._startup_command(LAUNCHER)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (command, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_UNREACHABLE)
+    process = SimpleNamespace(pid=101)
+    monkeypatch.setattr(mcp, "_launch", lambda value: events.append(value) or (process, None))
+    monkeypatch.setattr(mcp, "_wait_for_ouroboros_initialize", lambda: None)
+
+    provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error is None
+    assert provision == mcp.WindowsHttpProvision(command, False, process)
+    assert events == [command]
+
+
+def test_mismatched_existing_value_is_refused_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: ("other.exe --other", None))
+    monkeypatch.setattr(mcp, "_launch", lambda _command: pytest.fail("must not launch"))
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error is not None
+    assert "Remove or correct" in error
+
+
+def test_healthy_endpoint_without_startup_value_blocks_write_and_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (None, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_READY)
+    monkeypatch.setattr(mcp, "_write_startup_value", lambda _value: pytest.fail("must not write"))
+    monkeypatch.setattr(mcp, "_launch", lambda _command: pytest.fail("must not launch"))
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error is not None
+    assert "already responds as an Ouroboros MCP endpoint" in error
+
+
+def test_absent_value_is_written_and_launched_detached_without_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    writes: list[str] = []
+    launches: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (None, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_UNREACHABLE)
+    monkeypatch.setattr(
+        mcp, "_write_startup_value", lambda value: (writes.append(value) or True, None)
+    )
+    monkeypatch.setattr(
+        mcp.subprocess,
+        "Popen",
+        lambda *args, **kwargs: launches.append((args, kwargs)) or SimpleNamespace(pid=123),
+    )
+    monkeypatch.setattr(mcp, "_wait_for_ouroboros_initialize", lambda: None)
+
+    provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    command = mcp._startup_command(LAUNCHER)
+    assert error is None
+    assert provision == mcp.WindowsHttpProvision(command, True, provision.process)
+    assert writes == [command]
+    assert launches == [
+        (
+            (command,),
+            {
+                "creationflags": 0x00000008 | 0x08000000,
+                "close_fds": True,
+                "stdin": subprocess.DEVNULL,
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+            },
+        )
+    ]
+
+
+def test_command_line_preserves_setup_runtime_and_backend_without_duplicates() -> None:
+    assert mcp._startup_command(SETUP_LAUNCHER) == subprocess.list2cmdline(
+        [
+            "C:\\Program Files\\Ouroboros\\ouroboros.exe",
+            "mcp",
+            "serve",
+            "--runtime",
+            "codex",
+            "--llm-backend",
+            "codex",
+            "--transport",
+            "streamable-http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8765",
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("launcher", "required_option"),
+    [
+        (
+            (
+                "ouroboros.exe",
+                ["mcp", "serve", "--runtime", "other", "--llm-backend", "codex"],
+            ),
+            "--runtime",
+        ),
+        (
+            (
+                "ouroboros.exe",
+                [
+                    "mcp",
+                    "serve",
+                    "--runtime",
+                    "codex",
+                    "--runtime",
+                    "codex",
+                    "--llm-backend",
+                    "codex",
+                ],
+            ),
+            "--runtime",
+        ),
+    ],
+)
+def test_conflicting_managed_options_fail_without_registry_or_endpoint_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    launcher: tuple[str, list[str]],
+    required_option: str,
+) -> None:
+    _prepare_windows(monkeypatch)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: pytest.fail("must not read"))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: pytest.fail("must not probe"))
+    monkeypatch.setattr(mcp, "_write_startup_value", lambda _value: pytest.fail("must not write"))
+    monkeypatch.setattr(mcp, "_launch", lambda _value: pytest.fail("must not launch"))
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(launcher)
+
+    assert error is not None
+    assert required_option in error
+    assert "run setup again" in error
+
+
+def test_hkcu_run_command_limit_accepts_boundary_and_refuses_overlong_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_command = mcp._startup_command(("x", []))
+    padding = "a" * (mcp._STARTUP_COMMAND_MAX_LENGTH - len(base_command) - 1)
+    boundary_launcher = ("x", [padding])
+    boundary_command = mcp._startup_command(boundary_launcher)
+    assert len(boundary_command) == mcp._STARTUP_COMMAND_MAX_LENGTH
+
+    _prepare_windows(monkeypatch)
+    writes: list[str] = []
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (None, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_UNREACHABLE)
+    monkeypatch.setattr(
+        mcp, "_write_startup_value", lambda value: (writes.append(value) or True, None)
+    )
+    monkeypatch.setattr(mcp, "_launch", lambda _value: (SimpleNamespace(pid=123), None))
+    monkeypatch.setattr(mcp, "_wait_for_ouroboros_initialize", lambda: None)
+
+    provision, error = mcp.provision_windows_codex_mcp_http(boundary_launcher)
+
+    assert error is None
+    assert provision is not None
+    assert writes == [boundary_command]
+
+    overlong_launcher = ("x", [f"{padding}a"])
+    assert len(mcp._startup_command(overlong_launcher)) == mcp._STARTUP_COMMAND_MAX_LENGTH + 1
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: pytest.fail("must not read"))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: pytest.fail("must not probe"))
+    monkeypatch.setattr(mcp, "_write_startup_value", lambda _value: pytest.fail("must not write"))
+    monkeypatch.setattr(mcp, "_launch", lambda _value: pytest.fail("must not launch"))
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(overlong_launcher)
+
+    assert error is not None
+    assert "260-character HKCU Run limit" in error
+
+
+def test_failed_initialize_rolls_back_newly_written_matching_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    command = mcp._startup_command(LAUNCHER)
+    events: list[str] = []
+    process = SimpleNamespace(pid=123)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (None, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_UNREACHABLE)
+    monkeypatch.setattr(mcp, "_write_startup_value", lambda _value: (True, None))
+    monkeypatch.setattr(mcp, "_launch", lambda _value: (process, None))
+    monkeypatch.setattr(mcp, "_wait_for_ouroboros_initialize", lambda: "not ready")
+    monkeypatch.setattr(
+        mcp, "_terminate_process_tree", lambda _process: events.append("terminate") or None
+    )
+    monkeypatch.setattr(
+        mcp,
+        "_delete_startup_value_if_matches",
+        lambda value: (events.append(f"delete:{value}") or True, None),
+    )
+
+    provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert provision is None
+    assert error == "not ready"
+    assert events == ["terminate", f"delete:{command}"]
+
+
+def test_compare_before_delete_rolls_back_only_matching_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = mcp._startup_command(LAUNCHER)
+    calls: list[str] = []
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def query_value(_key: object, _name: str) -> tuple[str, int]:
+        calls.append("query")
+        return expected, 1
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        OpenKey=lambda *_args: Key(),
+        QueryValueEx=query_value,
+        DeleteValue=lambda _key, _name: calls.append("delete"),
+    )
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    assert mcp._delete_startup_value_if_matches(expected) == (True, None)
+    assert calls == ["query", "delete"]
+
+
+def test_concurrently_changed_value_is_preserved_during_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = mcp._startup_command(LAUNCHER)
+    calls: list[str] = []
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def query_value(_key: object, _name: str) -> tuple[str, int]:
+        calls.append("query")
+        return "foreign command", 1
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        OpenKey=lambda *_args: Key(),
+        QueryValueEx=query_value,
+        DeleteValue=lambda _key, _name: calls.append("delete"),
+    )
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    assert mcp._delete_startup_value_if_matches(expected) == (False, None)
+    assert calls == ["query"]
+
+
+def test_startup_mutex_releases_after_write_and_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class Function:
+        def __init__(self, callback: object) -> None:
+            self.callback = callback
+
+        def __call__(self, *args: object) -> object:
+            return self.callback(*args)
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    values: dict[str, str] = {}
+
+    def query_value(_key: object, name: str) -> tuple[str, int]:
+        if name not in values:
+            raise FileNotFoundError
+        return values[name], 1
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        CreateKeyEx=lambda *_args: Key(),
+        OpenKey=lambda *_args: Key(),
+        QueryValueEx=query_value,
+        SetValueEx=lambda _key, name, _reserved, _type, value: values.__setitem__(name, value),
+        DeleteValue=lambda _key, name: values.pop(name),
+    )
+    kernel32 = SimpleNamespace(
+        CreateMutexW=Function(lambda *_args: events.append("create") or 1),
+        WaitForSingleObject=Function(lambda *_args: events.append("wait") or mcp._WAIT_OBJECT_0),
+        ReleaseMutex=Function(lambda *_args: events.append("release") or True),
+        CloseHandle=Function(lambda *_args: events.append("close") or True),
+    )
+    monkeypatch.setattr(mcp, "_startup_mutex", _ORIGINAL_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp, "_acquire_startup_mutex", _ORIGINAL_ACQUIRE_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32, raising=False)
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    assert mcp._write_startup_value("managed") == (True, None)
+    assert mcp._delete_startup_value_if_matches("managed") == (True, None)
+    assert events == ["create", "wait", "release", "close"] * 2
+    assert kernel32.CreateMutexW.argtypes == (ctypes.c_void_p, ctypes.c_bool, ctypes.c_wchar_p)
+    assert kernel32.CreateMutexW.restype == ctypes.c_void_p
+    assert kernel32.WaitForSingleObject.argtypes == (ctypes.c_void_p, ctypes.c_ulong)
+    assert kernel32.WaitForSingleObject.restype == ctypes.c_ulong
+    assert kernel32.ReleaseMutex.argtypes == (ctypes.c_void_p,)
+    assert kernel32.ReleaseMutex.restype == ctypes.c_bool
+    assert kernel32.CloseHandle.argtypes == (ctypes.c_void_p,)
+    assert kernel32.CloseHandle.restype == ctypes.c_bool
+
+
+def test_startup_mutex_reports_timeout_and_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Function:
+        def __init__(self, result: int | bool) -> None:
+            self.result = result
+
+        def __call__(self, *_args: object) -> int | bool:
+            return self.result
+
+    def mutex_result(wait_result: int) -> str | None:
+        kernel32 = SimpleNamespace(
+            CreateMutexW=Function(1),
+            WaitForSingleObject=Function(wait_result),
+            ReleaseMutex=Function(True),
+            CloseHandle=Function(True),
+        )
+        monkeypatch.setattr(mcp.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32, raising=False)
+        monkeypatch.setattr(mcp, "_acquire_startup_mutex", _ORIGINAL_ACQUIRE_STARTUP_MUTEX)
+        monkeypatch.setattr(mcp.ctypes, "get_last_error", lambda: 123, raising=False)
+        with _ORIGINAL_STARTUP_MUTEX() as error:
+            return error
+
+    assert (
+        mutex_result(mcp._WAIT_TIMEOUT)
+        == "Could not acquire Windows startup mutex: timed out after 5000 ms."
+    )
+    assert mutex_result(0xFFFFFFFF) == (
+        "Could not acquire Windows startup mutex: WaitForSingleObject failed (Win32 error 123)."
+    )
+
+
+def test_startup_mutex_balances_nested_acquisition(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class Function:
+        def __init__(self, name: str, result: int | bool) -> None:
+            self.name, self.result = name, result
+
+        def __call__(self, *_args: object) -> int | bool:
+            events.append(self.name)
+            return self.result
+
+    kernel32 = SimpleNamespace(
+        CreateMutexW=Function("create", 1),
+        WaitForSingleObject=Function("wait", mcp._WAIT_OBJECT_0),
+        ReleaseMutex=Function("release", True),
+        CloseHandle=Function("close", True),
+    )
+    monkeypatch.setattr(mcp, "_startup_mutex", _ORIGINAL_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp, "_acquire_startup_mutex", _ORIGINAL_ACQUIRE_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32, raising=False)
+
+    with _ORIGINAL_STARTUP_MUTEX() as first_error:
+        assert first_error is None
+        with _ORIGINAL_STARTUP_MUTEX() as second_error:
+            assert second_error is None
+
+    assert events == ["create", "wait", "create", "wait", "release", "close", "release", "close"]
+
+
+def test_competing_provision_and_remove_wait_for_registry_mutex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = threading.RLock()
+    first_at_probe = threading.Event()
+    allow_first_to_finish = threading.Event()
+    second_started = threading.Event()
+    queries: list[str] = []
+    values: dict[str, str] = {}
+
+    class Function:
+        def __init__(self, callback: object) -> None:
+            self.callback = callback
+
+        def __call__(self, *args: object) -> object:
+            return self.callback(*args)
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def query_value(_key: object, name: str) -> tuple[str, int]:
+        queries.append(threading.current_thread().name)
+        if name not in values:
+            raise FileNotFoundError
+        return values[name], 1
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_READ=1,
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        CreateKeyEx=lambda *_args: Key(),
+        OpenKey=lambda *_args: Key(),
+        QueryValueEx=query_value,
+        SetValueEx=lambda _key, name, _reserved, _type, value: values.__setitem__(name, value),
+        DeleteValue=lambda _key, name: values.pop(name),
+    )
+    kernel32 = SimpleNamespace(
+        CreateMutexW=Function(lambda *_args: 1),
+        WaitForSingleObject=Function(lambda *_args: (lock.acquire(), mcp._WAIT_OBJECT_0)[1]),
+        ReleaseMutex=Function(lambda *_args: lock.release() or True),
+        CloseHandle=Function(lambda *_args: True),
+    )
+
+    def probe() -> str:
+        first_at_probe.set()
+        assert allow_first_to_finish.wait(1)
+        return mcp._ENDPOINT_UNREACHABLE
+
+    monkeypatch.setattr(mcp, "_startup_mutex", _ORIGINAL_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp, "_acquire_startup_mutex", _ORIGINAL_ACQUIRE_STARTUP_MUTEX)
+    monkeypatch.setattr(mcp, "_is_windows", lambda: True)
+    monkeypatch.setattr(mcp.ctypes, "WinDLL", lambda *_args, **_kwargs: kernel32, raising=False)
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+    monkeypatch.setattr(mcp, "_probe_endpoint", probe)
+    monkeypatch.setattr(mcp, "_launch", lambda _command: (None, None))
+    monkeypatch.setattr(mcp, "_wait_for_ouroboros_initialize", lambda: None)
+
+    def provision_and_commit() -> None:
+        provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+        assert error is None and provision is not None
+        mcp.commit_windows_codex_mcp_http(provision)
+
+    first = threading.Thread(target=provision_and_commit, name="provision")
+    second = threading.Thread(
+        target=lambda: (second_started.set(), mcp.remove_windows_codex_mcp_startup(LAUNCHER)),
+        name="remove",
+    )
+    first.start()
+    assert first_at_probe.wait(1)
+    second.start()
+    assert second_started.wait(1)
+    assert queries == ["provision"]
+    allow_first_to_finish.set()
+    first.join(1)
+    second.join(1)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert queries[-1] == "remove"
+
+
+@pytest.mark.parametrize(
+    ("arguments", "managed"),
+    [
+        (
+            [
+                "uvx.exe",
+                "--isolated",
+                "--python",
+                mcp.UVX_PYTHON_FLOOR,
+                "--from",
+                "ouroboros-ai[mcp]",
+                "ouroboros",
+                "mcp",
+                "serve",
+                *mcp._FIXED_OPTIONS,
+            ],
+            True,
+        ),
+        (["ouroboros.exe", "mcp", "serve", *mcp._FIXED_OPTIONS], True),
+        (["python.exe", "-m", "ouroboros", "mcp", "serve", *mcp._FIXED_OPTIONS], True),
+        (
+            [
+                "uvx.exe",
+                "--isolated",
+                "--python",
+                "3.12",
+                "--from",
+                "ouroboros-ai[mcp]",
+                "ouroboros",
+                "mcp",
+                "serve",
+                *mcp._FIXED_OPTIONS,
+            ],
+            False,
+        ),
+        (
+            ["uvx.exe", "--from", "other", "ouroboros", "mcp", "serve", *mcp._FIXED_OPTIONS],
+            False,
+        ),
+        (["not-uvx.exe", "mcp", "serve", *mcp._FIXED_OPTIONS], False),
+        (
+            [
+                "ouroboros.exe",
+                "mcp",
+                "serve",
+                "--runtime",
+                "other",
+                "--llm-backend",
+                "codex",
+                *mcp._FIXED_OPTIONS[4:],
+            ],
+            False,
+        ),
+        (
+            [
+                "python.exe",
+                "-m",
+                "ouroboros",
+                "mcp",
+                "serve",
+                "--runtime",
+                "codex",
+                "--llm-backend",
+                "other",
+                *mcp._FIXED_OPTIONS[4:],
+            ],
+            False,
+        ),
+    ],
+)
+def test_managed_startup_variant_rejects_lookalikes(
+    monkeypatch: pytest.MonkeyPatch, arguments: list[str], managed: bool
+) -> None:
+    monkeypatch.setattr(mcp, "_parse_windows_command_line", lambda _command: arguments)
+    assert mcp._is_managed_startup_variant("ignored") is managed
+
+
+def test_parse_windows_command_line_sets_pointer_signatures_and_frees_argv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    freed: list[object] = []
+    arguments = (ctypes.c_wchar_p * 2)("old.exe", "mcp")
+    argv = ctypes.cast(arguments, ctypes.POINTER(ctypes.c_wchar_p))
+
+    class Function:
+        def __init__(self, callback: object) -> None:
+            self.callback = callback
+
+        def __call__(self, *args: object) -> object:
+            return self.callback(*args)
+
+    def command_line_to_argv(_command: str, count: object) -> object:
+        ctypes.cast(count, ctypes.POINTER(ctypes.c_int)).contents.value = 2
+        return argv
+
+    shell32 = SimpleNamespace(CommandLineToArgvW=Function(command_line_to_argv))
+    kernel32 = SimpleNamespace(LocalFree=Function(lambda value: freed.append(value)))
+    monkeypatch.setattr(
+        mcp.ctypes,
+        "WinDLL",
+        lambda name, **_kwargs: shell32 if name == "shell32" else kernel32,
+        raising=False,
+    )
+    monkeypatch.setattr(mcp, "_parse_windows_command_line", _ORIGINAL_PARSE_WINDOWS_COMMAND_LINE)
+
+    assert _ORIGINAL_PARSE_WINDOWS_COMMAND_LINE("old.exe mcp") == ["old.exe", "mcp"]
+    assert shell32.CommandLineToArgvW.argtypes == (
+        ctypes.c_wchar_p,
+        ctypes.POINTER(ctypes.c_int),
+    )
+    assert shell32.CommandLineToArgvW.restype == ctypes.POINTER(ctypes.c_wchar_p)
+    assert kernel32.LocalFree.argtypes == (ctypes.c_void_p,)
+    assert kernel32.LocalFree.restype == ctypes.c_void_p
+    assert ctypes.cast(freed[0], ctypes.c_void_p).value == ctypes.cast(argv, ctypes.c_void_p).value
+
+
+def test_windows_only_behavior_does_not_touch_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_is_windows", lambda: False)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: pytest.fail("must not read"))
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error == "Codex HTTP MCP startup setup is only supported on Windows."
+
+
+def _initialize_response(payload: bytes) -> object:
+    class Response:
+        def read(self) -> bytes:
+            return payload
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    return Response()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"not json",
+        b'{"jsonrpc":"2.0","id":2,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}',
+        b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}',
+        b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}',
+        b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"other-mcp","version":"1"}}}',
+        b'{"jsonrpc":"1.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}',
+        b'{"jsonrpc":"2.0","id":1,"result":{}}',
+    ],
+)
+def test_initialize_rejects_malformed_or_non_ouroboros_response(
+    monkeypatch: pytest.MonkeyPatch, payload: bytes
+) -> None:
+    monkeypatch.setattr(
+        mcp.urllib.request, "urlopen", lambda *_args, **_kwargs: _initialize_response(payload)
+    )
+
+    assert not mcp._initialize_reports_ouroboros()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}',
+        b'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"ouroboros-mcp","version":"1"}}}\n\n',
+    ],
+)
+def test_initialize_accepts_valid_json_and_sse(
+    monkeypatch: pytest.MonkeyPatch, payload: bytes
+) -> None:
+    monkeypatch.setattr(
+        mcp.urllib.request, "urlopen", lambda *_args, **_kwargs: _initialize_response(payload)
+    )
+
+    assert mcp._initialize_reports_ouroboros()
+
+
+def test_vacant_endpoint_does_not_issue_initialize(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_endpoint_is_reachable", lambda: False)
+    monkeypatch.setattr(
+        mcp, "_initialize_reports_ouroboros", lambda: pytest.fail("must not initialize")
+    )
+
+    assert mcp._probe_endpoint() == mcp._ENDPOINT_UNREACHABLE
+
+
+def test_foreign_tcp_listener_is_occupied_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_endpoint_is_reachable", lambda: True)
+    monkeypatch.setattr(
+        mcp.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _initialize_response(
+            b'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"1","capabilities":{},"serverInfo":{"name":"foreign-mcp","version":"1"}}}'
+        ),
+    )
+
+    assert mcp._probe_endpoint() == mcp._ENDPOINT_OCCUPIED_INVALID
+
+
+def test_readiness_requires_a_ready_ouroboros_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mcp, "_PROBE_ATTEMPTS", 1)
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_OCCUPIED_INVALID)
+
+    assert mcp._wait_for_ouroboros_initialize() is not None
+
+
+@pytest.mark.parametrize("existing", [None, mcp._startup_command(LAUNCHER)])
+def test_occupied_endpoint_refuses_registry_write_and_launch(
+    monkeypatch: pytest.MonkeyPatch, existing: str | None
+) -> None:
+    _prepare_windows(monkeypatch)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (existing, None))
+    monkeypatch.setattr(mcp, "_probe_endpoint", lambda: mcp._ENDPOINT_OCCUPIED_INVALID)
+    monkeypatch.setattr(mcp, "_write_startup_value", lambda _value: pytest.fail("must not write"))
+    monkeypatch.setattr(
+        mcp.subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("must not launch")
+    )
+
+    _provision, error = mcp.provision_windows_codex_mcp_http(LAUNCHER)
+
+    assert error is not None
+    assert "occupied" in error
+
+
+def test_write_startup_value_accepts_exact_concurrent_value_without_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = mcp._startup_command(LAUNCHER)
+    calls: list[str] = []
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        CreateKeyEx=lambda *_args: Key(),
+        QueryValueEx=lambda _key, _name: calls.append("query") or (command, 1),
+        SetValueEx=lambda *_args: calls.append("set"),
+    )
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    assert mcp._write_startup_value(command) == (False, None)
+    assert calls == ["query"]
+
+
+def test_write_startup_value_refuses_foreign_concurrent_value_without_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        CreateKeyEx=lambda *_args: Key(),
+        QueryValueEx=lambda _key, _name: calls.append("query") or ("foreign.exe", 1),
+        SetValueEx=lambda *_args: calls.append("set"),
+    )
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    created, error = mcp._write_startup_value(mcp._startup_command(LAUNCHER))
+
+    assert not created
+    assert error is not None
+    assert calls == ["query"]
+
+
+@pytest.mark.parametrize(
+    "concurrent_value",
+    [mcp._startup_command(LAUNCHER), "foreign.exe --other"],
+)
+def test_write_startup_value_refuses_non_string_concurrent_value_without_overwrite(
+    monkeypatch: pytest.MonkeyPatch, concurrent_value: str
+) -> None:
+    calls: list[str] = []
+
+    class Key:
+        def __enter__(self) -> Key:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    registry = SimpleNamespace(
+        HKEY_CURRENT_USER=object(),
+        KEY_QUERY_VALUE=1,
+        KEY_SET_VALUE=2,
+        REG_SZ=1,
+        CreateKeyEx=lambda *_args: Key(),
+        QueryValueEx=lambda _key, _name: calls.append("query") or (concurrent_value, 4),
+        SetValueEx=lambda *_args: calls.append("set"),
+    )
+    monkeypatch.setattr(mcp, "_winreg", lambda: registry)
+
+    created, error = mcp._write_startup_value(mcp._startup_command(LAUNCHER))
+
+    assert not created
+    assert error is not None
+    assert calls == ["query"]
+
+
+def test_rollback_terminates_only_its_recorded_process_without_deleting_retained_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = SimpleNamespace(pid=123)
+    provision = mcp.WindowsHttpProvision("command", False, process)
+    terminated: list[object] = []
+    monkeypatch.setattr(
+        mcp, "_terminate_process_tree", lambda target: terminated.append(target) or None
+    )
+    monkeypatch.setattr(
+        mcp,
+        "_delete_startup_value_if_matches",
+        lambda _value: pytest.fail("must not delete retained startup value"),
+    )
+
+    assert mcp.rollback_windows_codex_mcp_http(provision) is None
+    assert len(terminated) == 1
+    assert terminated[0] is provision.process
+
+
+def test_terminate_process_tree_uses_system_taskkill_for_recorded_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_directory = "C:\\Windows\\System32"
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Kernel32:
+        def GetSystemDirectoryW(self, buffer: object, _size: int) -> int:
+            buffer.value = system_directory
+            return len(system_directory)
+
+    ctypes = SimpleNamespace(
+        create_unicode_buffer=lambda _size: SimpleNamespace(value=""),
+        windll=SimpleNamespace(kernel32=Kernel32()),
+    )
+    monkeypatch.setitem(sys.modules, "ctypes", ctypes)
+    monkeypatch.setattr(
+        mcp.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)) or SimpleNamespace(),
+    )
+
+    assert mcp._terminate_process_tree(SimpleNamespace(pid=4321)) is None
+    assert calls == [
+        (
+            [
+                mcp.os.path.join(system_directory, "taskkill.exe"),
+                "/PID",
+                "4321",
+                "/T",
+                "/F",
+            ],
+            {
+                "check": True,
+                "close_fds": True,
+                "stdin": subprocess.DEVNULL,
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+            },
+        )
+    ]
+
+
+def test_commit_is_a_noop() -> None:
+    provision = mcp.WindowsHttpProvision("command", True, SimpleNamespace(pid=123))
+
+    assert mcp.commit_windows_codex_mcp_http(provision) is None
+    assert provision == mcp.WindowsHttpProvision("command", True, provision.process)
+
+
+def test_batch_ownership_helpers_preserve_commit_and_reverse_rollback_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provisions = [
+        mcp.WindowsHttpProvision("first", False, None),
+        mcp.WindowsHttpProvision("second", True, None),
+    ]
+    committed: list[str] = []
+    rolled_back: list[str] = []
+    pending: list[mcp.WindowsHttpProvision] = []
+    monkeypatch.setattr(
+        mcp, "commit_windows_codex_mcp_http", lambda provision: committed.append(provision.command)
+    )
+    monkeypatch.setattr(
+        mcp,
+        "rollback_windows_codex_mcp_http",
+        lambda provision: rolled_back.append(provision.command) or f"{provision.command} failed",
+    )
+
+    assert mcp.retain_windows_codex_mcp_http(provisions[0], None) is None
+    assert mcp.retain_windows_codex_mcp_http(provisions[1], pending) is None
+    assert pending == [provisions[1]]
+    assert mcp.rollback_windows_codex_mcp_http_batch(provisions) == [
+        "second failed",
+        "first failed",
+    ]
+    mcp.commit_windows_codex_mcp_http_batch(provisions)
+
+    assert committed == ["first", "first", "second"]
+    assert rolled_back == ["second", "first"]
+
+
+def test_render_windows_codex_http_mcp_section_uses_managed_comment_and_endpoint() -> None:
+    assert mcp.render_windows_codex_http_mcp_section() == (
+        "\n".join(mcp.MANAGED_CODEX_MCP_COMMENT_LINES)
+        + '\n\n[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:8765/mcp"\n'
+    )
+
+
+def test_remove_startup_deletes_only_exact_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    _prepare_windows(monkeypatch)
+    command = mcp._startup_command(LAUNCHER)
+    deleted: list[str] = []
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (command, None))
+    monkeypatch.setattr(
+        mcp, "_delete_startup_value_if_matches", lambda value: (deleted.append(value) or True, None)
+    )
+
+    assert mcp.remove_windows_codex_mcp_startup(LAUNCHER) == (True, None)
+    assert deleted == [command]
+
+
+def test_remove_startup_deletes_observed_managed_launcher_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    observed = "old launcher command"
+    deleted: list[str] = []
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (observed, None))
+    monkeypatch.setattr(mcp, "_is_managed_startup_variant", lambda value: value == observed)
+    monkeypatch.setattr(
+        mcp, "_delete_startup_value_if_matches", lambda value: (deleted.append(value) or True, None)
+    )
+
+    assert mcp.remove_windows_codex_mcp_startup(LAUNCHER) == (True, None)
+    assert deleted == [observed]
+
+
+def test_remove_startup_preserves_mismatched_and_dry_run_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    command = mcp._startup_command(LAUNCHER)
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        mcp, "_delete_startup_value_if_matches", lambda value: (deleted.append(value) or True, None)
+    )
+
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: ("foreign.exe", None))
+    assert mcp.remove_windows_codex_mcp_startup(LAUNCHER) == (False, None)
+
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (command, None))
+    assert mcp.remove_windows_codex_mcp_startup(LAUNCHER, dry_run=True) == (True, None)
+    assert deleted == []
+
+
+def test_remove_startup_does_not_delete_foreign_value_after_exact_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_windows(monkeypatch)
+    command = mcp._startup_command(LAUNCHER)
+    monkeypatch.setattr(mcp, "_read_startup_value", lambda: (command, None))
+    monkeypatch.setattr(mcp, "_delete_startup_value_if_matches", lambda _value: (False, None))
+
+    removed, error = mcp.remove_windows_codex_mcp_startup(LAUNCHER)
+
+    assert not removed
+    assert error is None

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -143,6 +143,11 @@ def test_detect_runtimes_invalid_override_does_not_use_stale_path(
 class TestCodexSetup:
     """Tests for Codex-specific setup behavior."""
 
+    @pytest.fixture(autouse=True)
+    def _use_non_windows_mcp_default(self, monkeypatch) -> None:
+        """Keep existing stdio tests platform-independent."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "linux")
+
     def test_detect_runtimes_uses_bundled_codex_app_cli_when_path_is_missing(
         self, tmp_path: Path
     ) -> None:
@@ -309,6 +314,241 @@ class TestCodexSetup:
             raise failure
 
         assert codex_uses_profile_v2("/configured/codex", run_command=failing_run) is None
+
+    def test_register_codex_mcp_server_uses_windows_http_for_auto(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Windows auto mode provisions before writing the managed HTTP URL."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        launcher = (
+            "C:/tools/uvx.exe",
+            ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.provision_windows_codex_mcp_http",
+                return_value=(setup_cmd.WindowsHttpProvision("managed", False, None), None),
+            ) as provision,
+            patch("ouroboros.cli.commands.setup.retain_windows_codex_mcp_http") as commit,
+        ):
+            assert setup_cmd._register_codex_mcp_server() is True
+
+        provision.assert_called_once_with(launcher)
+        commit.assert_called_once()
+        entry = tomllib.loads((tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8"))[
+            "mcp_servers"
+        ]["ouroboros"]
+        assert entry == {"url": "http://127.0.0.1:8765/mcp"}
+
+    def test_register_codex_mcp_server_http_mode_forwards_launcher(self, tmp_path: Path) -> None:
+        """Explicit HTTP mode uses the same resolved launcher as stdio mode."""
+        launcher = ("C:/Python/python.exe", ["-m", "ouroboros", "mcp", "serve"])
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.provision_windows_codex_mcp_http",
+                return_value=(setup_cmd.WindowsHttpProvision("managed", False, None), None),
+            ) as provision,
+            patch("ouroboros.cli.commands.setup.retain_windows_codex_mcp_http") as commit,
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="http") is True
+
+        provision.assert_called_once_with(launcher)
+        commit.assert_called_once()
+        contents = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
+        assert contents.startswith("# Ouroboros MCP hookup for Codex CLI.\n")
+        assert 'url = "http://127.0.0.1:8765/mcp"' in contents
+        assert "command =" not in contents
+        assert "args =" not in contents
+        assert ".env]" not in contents
+
+    def test_register_codex_mcp_server_non_windows_auto_uses_stdio(self, tmp_path: Path) -> None:
+        """Non-Windows auto mode keeps the managed stdio entry."""
+        launcher = (
+            "/usr/local/bin/uvx",
+            ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"],
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch("ouroboros.cli.commands.setup.provision_windows_codex_mcp_http") as provision,
+        ):
+            assert setup_cmd._register_codex_mcp_server() is True
+
+        provision.assert_not_called()
+        entry = tomllib.loads((tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8"))[
+            "mcp_servers"
+        ]["ouroboros"]
+        assert entry["command"] == launcher[0]
+
+    def test_register_codex_mcp_server_windows_stdio_defers_startup_cleanup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit stdio leaves startup cleanup to the encompassing setup transaction."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        launcher = ("C:/tools/uvx.exe", ["--from", "ouroboros-ai[mcp]", "ouroboros"])
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch("ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup") as remove,
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="stdio") is True
+
+        remove.assert_not_called()
+
+    def test_register_codex_mcp_server_windows_auto_preserves_user_url(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Windows auto mode never provisions for a user-managed URL."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        original = '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+        codex_config.write_text(original, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.provision_windows_codex_mcp_http") as provision,
+        ):
+            assert setup_cmd._register_codex_mcp_server() is True
+
+        provision.assert_not_called()
+        assert codex_config.read_text(encoding="utf-8") == original
+
+    def test_register_codex_mcp_server_windows_auto_preserves_unmarked_fixed_url(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Windows auto mode preserves an unmarked entry at the managed endpoint."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        original = '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:8765/mcp"\n'
+        codex_config.write_text(original, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.commands.setup.provision_windows_codex_mcp_http") as provision,
+        ):
+            assert setup_cmd._register_codex_mcp_server() is True
+
+        provision.assert_not_called()
+        assert codex_config.read_text(encoding="utf-8") == original
+
+    def test_register_codex_mcp_server_http_provision_failure_preserves_config(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed HTTP task setup must not rewrite Codex configuration."""
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        original = '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n'
+        codex_config.write_text(original, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=("C:/tools/uvx.exe", ["--from", "ouroboros-ai[mcp]"]),
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.provision_windows_codex_mcp_http",
+                return_value=(None, "Could not start the Ouroboros MCP task."),
+            ),
+        ):
+            assert setup_cmd._register_codex_mcp_server(mode="http") is False
+
+        assert codex_config.read_text(encoding="utf-8") == original
+
+    def test_register_codex_mcp_server_rolls_back_http_when_config_write_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """HTTP ownership is released when registration cannot write Codex config."""
+        provision = setup_cmd.WindowsHttpProvision("managed", True, None)
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=("C:/tools/uvx.exe", ["--from", "ouroboros-ai[mcp]"]),
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.provision_windows_codex_mcp_http",
+                return_value=(provision, None),
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._atomic_write_text_if_current_matches",
+                side_effect=OSError("disk full"),
+            ),
+            patch("ouroboros.cli.commands.setup.rollback_windows_codex_mcp_http_batch") as rollback,
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                setup_cmd._register_codex_mcp_server(mode="http")
+
+        rollback.assert_called_once_with([provision])
+
+    def test_register_codex_mcp_server_refreshes_managed_windows_http(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Existing managed HTTP config still provisions its fixed task."""
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        original = (
+            "# Ouroboros MCP hookup for Codex CLI.\n"
+            "# Keep Ouroboros runtime settings and per-role model overrides in\n"
+            "# ~/.ouroboros/config.yaml (for example: clarification.default_model,\n"
+            "# llm.qa_model, evaluation.semantic_model, consensus.*).\n"
+            "# This file is only for the Codex MCP/env registration block.\n"
+            "\n"
+            '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:8765/mcp"\n'
+        )
+        codex_config.write_text(original, encoding="utf-8")
+        launcher = ("C:/tools/uvx.exe", ["--from", "ouroboros-ai[mcp]"])
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.provision_windows_codex_mcp_http",
+                return_value=(setup_cmd.WindowsHttpProvision("managed", False, None), None),
+            ) as provision,
+            patch("ouroboros.cli.commands.setup.retain_windows_codex_mcp_http") as commit,
+        ):
+            assert setup_cmd._register_codex_mcp_server() is True
+
+        provision.assert_called_once_with(launcher)
+        commit.assert_called_once()
+        assert codex_config.read_text(encoding="utf-8") == original
+
+    def test_codex_mcp_mode_accepts_http_and_help_lists_it(self) -> None:
+        """CLI validation and help expose all supported Codex MCP modes."""
+        assert setup_cmd._normalize_codex_mcp_mode("HTTP") == "http"
+        with pytest.raises(typer.Exit):
+            setup_cmd._normalize_codex_mcp_mode("socket")
+        help_result = CliRunner().invoke(setup_cmd.app, ["--help"])
+
+        assert help_result.exit_code == 0
+        normalized_help = " ".join(help_result.output.replace("│", " ").split())
+        assert "auto | preserve | stdio | http" in normalized_help
 
     def test_register_codex_mcp_server_writes_guidance_comment(self, tmp_path: Path) -> None:
         """The generated Codex config should explain the config file split."""
@@ -904,7 +1144,13 @@ class TestCodexSetup:
             encoding="utf-8",
         )
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup",
+                return_value=(False, None),
+            ),
+        ):
             assert setup_cmd._register_codex_mcp_server(mode="stdio")
 
         parsed = tomllib.loads(codex_config.read_text(encoding="utf-8"))
@@ -981,6 +1227,10 @@ class TestCodexSetup:
             ),
             patch("ouroboros.cli.commands.setup.importlib_metadata.version", return_value="0.38.2"),
             patch("ouroboros.cli.commands.setup.shutil.which", return_value="/usr/local/bin/uvx"),
+            patch(
+                "ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup",
+                return_value=(False, None),
+            ),
         ):
             setup_cmd._register_codex_mcp_server(mode="stdio")
 
@@ -2133,11 +2383,20 @@ class TestCodexSetup:
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch("ouroboros.cli.commands.setup._install_codex_artifacts") as mock_install,
-            patch("ouroboros.cli.commands.setup._register_codex_mcp_server") as mock_register,
+            patch(
+                "ouroboros.cli.commands.setup._register_codex_mcp_server",
+                side_effect=lambda **kwargs: (
+                    kwargs["http_provisions"].append(
+                        setup_cmd.WindowsHttpProvision("managed", False, None)
+                    )
+                    or True
+                ),
+            ) as mock_register,
             patch("ouroboros.cli.commands.setup._retire_codex_default_profiles") as mock_retire,
             patch(
                 "ouroboros.cli.commands.setup._register_codex_worker_profile"
             ) as mock_worker_profile,
+            patch("ouroboros.cli.commands.setup.commit_windows_codex_mcp_http_batch") as commit,
             patch("ouroboros.cli.commands.setup.print_info") as mock_info,
         ):
             assert setup_cmd._setup_codex("/usr/local/bin/codex") is True
@@ -2159,7 +2418,7 @@ class TestCodexSetup:
         assert config_dict["llm_role_profiles"]["brownfield_explore"] == "frontier"
         assert config_dict["llm_role_profiles"]["clarification"] == "frontier"
         assert config_dict["llm_role_profiles"]["semantic_evaluation"] == "deep"
-        assert config_dict["llm_role_profiles"]["wonder"] == "frontier"
+        commit.assert_called_once()
         assert config_dict["llm_role_profiles"]["consensus_judge"] == "frontier"
         assert config_dict["llm_role_profiles"]["agent_runtime"] == "standard"
         assert config_dict["llm_role_profiles"]["agent_runtime_implementation"] == "standard"
@@ -2285,11 +2544,16 @@ class TestCodexSetup:
         original_toml = '[mcp_servers.ouroboros]\ncommand = "old"\n'
         codex_config.write_text(original_toml, encoding="utf-8")
 
-        def _register(**_kwargs: object) -> bool:
+        provision = setup_cmd.WindowsHttpProvision("managed", False, None)
+
+        def _register(**kwargs: object) -> bool:
             codex_config.write_text('[mcp_servers.ouroboros]\ncommand = "new"\n', encoding="utf-8")
-            expected = _kwargs["expected_snapshots"]
+            expected = kwargs["expected_snapshots"]
             assert isinstance(expected, dict)
             expected[codex_config] = setup_cmd._snapshot_path(codex_config)
+            provisions = kwargs["http_provisions"]
+            assert isinstance(provisions, list)
+            provisions.append(provision)
             return True
 
         with (
@@ -2300,6 +2564,11 @@ class TestCodexSetup:
                 "ouroboros.cli.commands.setup._atomic_write_text",
                 side_effect=OSError("disk full"),
             ),
+            patch(
+                "ouroboros.cli.commands.setup.rollback_windows_codex_mcp_http_batch",
+                return_value=["Could not remove Windows startup entry."],
+            ) as rollback,
+            patch("ouroboros.cli.commands.setup.print_error") as print_error,
             patch("ouroboros.cli.commands.setup._install_codex_artifacts") as mock_install,
             patch("ouroboros.cli.commands.setup._retire_codex_default_profiles") as mock_retire,
             patch(
@@ -2310,6 +2579,15 @@ class TestCodexSetup:
 
         assert config_path.read_text(encoding="utf-8") == original_config
         assert codex_config.read_text(encoding="utf-8") == original_toml
+        rollback.assert_called_once_with([provision])
+        assert any(
+            "Could not save Codex runtime config" in call.args[0]
+            for call in print_error.call_args_list
+        )
+        assert any(
+            "Could not remove Windows startup entry" in call.args[0]
+            for call in print_error.call_args_list
+        )
         mock_install.assert_not_called()
         mock_retire.assert_not_called()
         mock_worker_profile.assert_not_called()
@@ -2592,6 +2870,146 @@ class TestCodexSetup:
         assert codex_config.read_text(encoding="utf-8") == original_toml
         mock_retire.assert_not_called()
         mock_worker_profile.assert_not_called()
+
+    def test_setup_codex_defers_windows_stdio_startup_cleanup_until_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = "orchestrator:\n  runtime_backend: claude\n"
+        config_path.write_text(original_config, encoding="utf-8")
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        codex_config = codex_home / "config.toml"
+        original_toml = '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:8765/mcp"\n'
+        codex_config.write_text(original_toml, encoding="utf-8")
+
+        def _register(**kwargs: object) -> bool:
+            codex_config.write_text(
+                '[mcp_servers.ouroboros]\ncommand = "stdio"\n', encoding="utf-8"
+            )
+            expected = kwargs["expected_snapshots"]
+            assert isinstance(expected, dict)
+            expected[codex_config] = setup_cmd._snapshot_path(codex_config)
+            return True
+
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server", side_effect=_register),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts", return_value=False),
+            patch("ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup") as remove,
+        ):
+            assert setup_cmd._setup_codex("/usr/local/bin/codex", mcp_mode="stdio") is False
+
+        remove.assert_not_called()
+        assert config_path.read_text(encoding="utf-8") == original_config
+        assert codex_config.read_text(encoding="utf-8") == original_toml
+
+    def test_setup_codex_stdio_removes_startup_after_artifacts_and_worker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("orchestrator: {}\n", encoding="utf-8")
+        codex_config = tmp_path / ".codex" / "config.toml"
+        launcher = ("C:/tools/ouroboros.exe", ["mcp", "serve"])
+        events: list[str] = []
+
+        def register(**kwargs: object) -> bool:
+            codex_config.parent.mkdir()
+            codex_config.write_text(
+                '[mcp_servers.ouroboros]\ncommand = "stdio"\n', encoding="utf-8"
+            )
+            kwargs["expected_snapshots"][codex_config] = setup_cmd._snapshot_path(codex_config)
+            return True
+
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server", side_effect=register),
+            patch(
+                "ouroboros.cli.commands.setup._install_codex_artifacts",
+                side_effect=lambda **_kwargs: events.append("artifacts") or True,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._retire_codex_default_profiles",
+                side_effect=lambda **_kwargs: events.append("retire"),
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._register_codex_worker_profile",
+                side_effect=lambda **_kwargs: events.append("worker") or True,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                side_effect=lambda: events.append("resolve") or launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup",
+                side_effect=lambda value: events.append("remove") or (value == launcher, None),
+            ),
+        ):
+            assert setup_cmd._setup_codex("/usr/local/bin/codex", mcp_mode="stdio") is True
+
+        assert events == ["artifacts", "retire", "worker", "resolve", "remove"]
+
+    def test_setup_codex_stdio_cleanup_error_restores_everything(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        original_config = "orchestrator:\n  runtime_backend: claude\n"
+        config_path.write_text(original_config, encoding="utf-8")
+        codex_home = tmp_path / ".codex"
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir(parents=True)
+        artifact = rules_dir / "ouroboros.md"
+        artifact.write_text("old artifact\n", encoding="utf-8")
+        codex_config = codex_home / "config.toml"
+        original_toml = '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:8765/mcp"\n'
+        codex_config.write_text(original_toml, encoding="utf-8")
+        launcher = ("C:/tools/ouroboros.exe", ["mcp", "serve"])
+
+        def register(**kwargs: object) -> bool:
+            codex_config.write_text(
+                '[mcp_servers.ouroboros]\ncommand = "stdio"\n', encoding="utf-8"
+            )
+            kwargs["expected_snapshots"][codex_config] = setup_cmd._snapshot_path(codex_config)
+            return True
+
+        def install(**kwargs: object) -> bool:
+            artifact.write_text("new artifact\n", encoding="utf-8")
+            kwargs["expected_snapshots"][artifact] = setup_cmd._snapshot_path(artifact)
+            return True
+
+        monkeypatch.setattr(setup_cmd.sys, "platform", "win32")
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server", side_effect=register),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts", side_effect=install),
+            patch("ouroboros.cli.commands.setup._retire_codex_default_profiles"),
+            patch("ouroboros.cli.commands.setup._register_codex_worker_profile", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher", return_value=launcher
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.remove_windows_codex_mcp_startup",
+                return_value=(False, "cleanup failed"),
+            ) as remove,
+            patch("ouroboros.cli.commands.setup.print_success") as success,
+        ):
+            assert setup_cmd._setup_codex("/usr/local/bin/codex", mcp_mode="stdio") is False
+
+        remove.assert_called_once_with(launcher)
+        success.assert_not_called()
+        assert config_path.read_text(encoding="utf-8") == original_config
+        assert codex_config.read_text(encoding="utf-8") == original_toml
+        assert artifact.read_text(encoding="utf-8") == "old artifact\n"
 
     def test_setup_codex_removes_partial_artifacts_when_artifact_install_fails(
         self, tmp_path: Path

--- a/tests/unit/cli/test_uninstall.py
+++ b/tests/unit/cli/test_uninstall.py
@@ -16,6 +16,7 @@ from ouroboros.cli.commands.uninstall import (
     _remove_codex_mcp,
     _remove_data_dir,
     _remove_opencode_bridge_plugin,
+    _remove_windows_codex_mcp_startup,
     app,
 )
 
@@ -542,6 +543,118 @@ class TestRemoveDataDir:
         assert data_dir.exists()
 
 
+# ── _remove_windows_codex_mcp_startup ────────────────────────────
+
+
+class TestRemoveWindowsCodexMcpStartup:
+    """Tests for removal of the managed Codex HTTP MCP Run value."""
+
+    _launcher = ("C:/Tools/uvx.exe", ["--from", "ouroboros-ai[mcp]", "ouroboros"])
+
+    def test_removes_exact_managed_startup_value(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=self._launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                return_value=(True, None),
+            ) as remove_startup,
+            patch("ouroboros.cli.commands.uninstall.print_success") as success,
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=False)
+
+        assert result is True
+        remove_startup.assert_called_once_with(self._launcher, dry_run=False)
+        assert "may remain until logoff" in success.call_args.args[0]
+
+    def test_preserves_mismatched_startup_value(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=self._launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                return_value=(False, None),
+            ) as remove_startup,
+            patch("ouroboros.cli.commands.uninstall.print_info") as info,
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=False)
+
+        assert result is False
+        remove_startup.assert_called_once_with(self._launcher, dry_run=False)
+        assert "No matching managed" in info.call_args.args[0]
+
+    def test_preserves_absent_startup_value(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=self._launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                return_value=(False, None),
+            ),
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=False)
+
+        assert result is False
+
+    def test_dry_run_reports_exact_startup_cleanup_without_mutation(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=self._launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                return_value=(True, None),
+            ) as remove_startup,
+            patch("ouroboros.cli.commands.uninstall.print_info") as info,
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=True)
+
+        assert result is True
+        remove_startup.assert_called_once_with(self._launcher, dry_run=True)
+        assert "[dry-run] Would remove" in info.call_args.args[0]
+
+    def test_reports_startup_cleanup_error_without_removing(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=self._launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                return_value=(False, "Could not read Windows startup entry."),
+            ),
+            patch("ouroboros.cli.commands.uninstall.print_warning") as warning,
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=False)
+
+        assert result is False
+        warning.assert_called_once_with("Could not read Windows startup entry.")
+
+    def test_does_not_resolve_or_remove_startup_value_off_windows(self) -> None:
+        with (
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=False),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup"
+            ) as remove_startup,
+        ):
+            result = _remove_windows_codex_mcp_startup(dry_run=False)
+
+        assert result is False
+        remove_startup.assert_not_called()
+
+
 # ── CLI integration ──────────────────────────────────────────────
 
 
@@ -556,6 +669,30 @@ class TestUninstallCLI:
             result = runner.invoke(app, [])
         assert result.exit_code == 0
         assert "Nothing to remove" in result.output
+
+    def test_removes_managed_windows_startup_entry(self, tmp_path: Path) -> None:
+        launcher = ("C:/Tools/uvx.exe", ["--from", "ouroboros-ai[mcp]", "ouroboros"])
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("pathlib.Path.cwd", return_value=tmp_path),
+            patch("ouroboros.cli.commands.uninstall._is_windows", return_value=True),
+            patch(
+                "ouroboros.cli.commands.setup._resolve_codex_mcp_launcher",
+                return_value=launcher,
+            ),
+            patch(
+                "ouroboros.cli.commands.uninstall.remove_windows_codex_mcp_startup",
+                side_effect=[(True, None), (True, None)],
+            ) as remove_startup,
+        ):
+            result = runner.invoke(app, ["-y"])
+
+        assert result.exit_code == 0
+        assert "Codex HTTP MCP Windows login startup entry" in result.output
+        assert remove_startup.call_args_list == [
+            ((launcher,), {"dry_run": True}),
+            ((launcher,), {"dry_run": False}),
+        ]
 
     def test_dry_run_no_changes(self, tmp_path: Path) -> None:
         # Create mcp.json with ouroboros


### PR DESCRIPTION
## Summary

Prevent native-Windows Codex Desktop from owning an Ouroboros stdio MCP child. On Windows, one normal `ouroboros setup --runtime codex` run now:

- registers a setup-marked loopback URL at `http://127.0.0.1:8765/mcp`
- writes one exact per-user `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` startup value
- launches the same command immediately as a detached current-user process
- writes Codex configuration only after a strict MCP initialize response identifies `ouroboros-mcp`

Non-Windows `auto` remains stdio. User-managed entries and `preserve` remain untouched; explicit `stdio` and `http` remain available.

## Deliberate scope

This supersedes the oversized lifecycle design in #2026. It intentionally has:

- no Task Scheduler dependency or elevation
- no generations, supervisor, task replacement/deletion, or service framework
- no zero-downtime upgrade, crash restart, or automatic rollback claim

The startup value launches at login; setup also launches and verifies it immediately. Native Codex Desktop MCP remains experimental, and native Codex CLI worker/runtime execution remains unsupported.

## Verification

- focused startup helper: **53 passed**
- focused Codex setup: **71 passed, 349 deselected**
- focused stdio commit + uninstall cleanup: **25 passed**
- Ruff check/format, mypy, module-size, and diff checks: clean
- native Windows HKCU Run + detached launch + strict MCP initialize: verified
- native rollback and launcher-drift cleanup across uvx/direct/Python variants: verified
- independent final scoped review: **APPROVE / CLEAR**, no HIGH or MEDIUM findings

Closes #2024
Supersedes #2026
