### PR TITLE
docs(readme): link the guide site from the nav row

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -34,7 +34,8 @@
   <a href="#wonder에서-온톨로지로">철학</a> ·
   <a href="#순환-구조">원리</a> ·
   <a href="#명령어">명령어</a> ·
-  <a href="#아홉-개의-사고">에이전트</a>
+  <a href="#아홉-개의-사고">에이전트</a> ·
+  <a href="https://ouroboros.page/learn/">가이드</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@
   <a href="#what-you-get">Results</a> ·
   <a href="#the-loop">How It Works</a> ·
   <a href="#commands">Commands</a> ·
-  <a href="#from-wonder-to-ontology">Philosophy</a>
+  <a href="#from-wonder-to-ontology">Philosophy</a> ·
+  <a href="https://ouroboros.page/learn/en/">Guide</a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,8 @@
   <a href="#你能得到什么">效果</a> ·
   <a href="#循环">运作原理</a> ·
   <a href="#命令">命令</a> ·
-  <a href="#从-wonder-到本体论">理念</a>
+  <a href="#从-wonder-到本体论">理念</a> ·
+  <a href="https://ouroboros.page/learn/zh/">指南</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Closes #2061.

Adds one nav entry to each README pointing at the language-matched guide on `ouroboros.page`.

| file | link | label |
|---|---|---|
| `README.md` | `/learn/en/` | Guide |
| `README.ko.md` | `/learn/` | 가이드 |
| `README.zh-CN.md` | `/learn/zh/` | 指南 |

The guide site is already the repository `homepage` and the PyPI `Homepage`, so this is not a new destination, just the first link to it from the page people actually land on.

Each README points at its own language rather than all three pointing at English. A Chinese reader on `README.zh-CN.md` lands on the Chinese guide.

### Verified

All three URLs return 200. `/learn/xx-nonexistent/` returns 404, so the 200s are not a catch-all route answering everything.

### Not done here

The Korean guide header says `Ouroboros 0.50.4 upstream` while the current release is 0.51.1. That is a different repository, so I left it alone and wrote it into #2061 instead of quietly linking to a stale page without saying so.
