### PR TITLE
fix(verification): refuse unbound regex evidence as grounds to overturn an agent FAIL

### DIFF
--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -77,6 +77,32 @@ def _report_identity_error(
     return None
 
 
+def _agent_claimed_pass(
+    report: Any,
+    expected_agent_results: dict[int, bool],
+    ac_index: int,
+) -> bool:
+    """Whether the agent itself claimed this AC passed.
+
+    Two records answer this and only one of them is authoritative. The
+    mechanical summary is the execution's own account of what the agent
+    reported; the report's ``agent_reported_pass`` is a copy the verifier was
+    handed, and a replayed, stale or externally built report carries whatever
+    copy it was constructed with — including a `True` that contradicts the
+    execution, or no field at all, which reads as `True` by default. Trusting
+    the copy alone lets either shape turn a mechanically failed AC into a
+    formal PASS.
+
+    So both are consulted and either one saying "not a pass" settles it.
+    Disagreement is not resolved in favour of the more permissive record: two
+    accounts of the same fact that do not match are not evidence that the
+    agent claimed a pass.
+    """
+    if not bool(getattr(report, "agent_reported_pass", True)):
+        return False
+    return bool(expected_agent_results.get(ac_index, True))
+
+
 def agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
     """Return legacy agent-reported AC outcomes for spec verification.
 
@@ -184,8 +210,8 @@ def evaluation_summary_from_spec_verification(
                 skipped_indices.append(ac_index)
             if not evidence:
                 evidence = "Spec verifier found a discrepancy without evidence details."
-        elif outcomes == {VerificationOutcome.VERIFIED} and not getattr(
-            report, "agent_reported_pass", True
+        elif outcomes == {VerificationOutcome.VERIFIED} and not _agent_claimed_pass(
+            report, expected_agent_results, ac_index
         ):
             # Source-scan evidence may confirm a claimed PASS; it may not
             # reverse a reported FAIL. `SpecVerifier.verify_all` already

--- a/src/ouroboros/mcp/server/spec_verification_adapter.py
+++ b/src/ouroboros/mcp/server/spec_verification_adapter.py
@@ -184,6 +184,26 @@ def evaluation_summary_from_spec_verification(
                 skipped_indices.append(ac_index)
             if not evidence:
                 evidence = "Spec verifier found a discrepancy without evidence details."
+        elif outcomes == {VerificationOutcome.VERIFIED} and not getattr(
+            report, "agent_reported_pass", True
+        ):
+            # Source-scan evidence may confirm a claimed PASS; it may not
+            # reverse a reported FAIL. `SpecVerifier.verify_all` already
+            # refuses to emit this combination, but this adapter is a public
+            # authority boundary that also accepts replayed, legacy and
+            # compatibility summaries built elsewhere. Enforcing the polarity
+            # only in the producer would let a rehydrated report encode the
+            # exact transition the producer forbids, so the boundary that
+            # mints the formal verdict checks it too.
+            unverifiable_indices.append(ac_index)
+            passed = False
+            verdict_state = "not_evaluated"
+            rendered_verdict = "NOT_EVALUATED"
+            evidence = (
+                "Spec verification reported all assertions verified against an "
+                "agent-reported FAIL; source-scan evidence cannot overturn a "
+                "reported FAIL, so the formal AC verdict is not evaluated."
+            )
         elif outcomes == {VerificationOutcome.VERIFIED}:
             passed = True
             verdict_state = "evaluated"

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -701,21 +701,72 @@ def _required_literal_runs(
     return frozenset(runs)
 
 
+def _contains(words: list[str], run: list[str]) -> bool:
+    """Whether `run` appears in `words` as a contiguous stretch."""
+    span = len(run)
+    if not span or span > len(words):
+        return False
+    return any(words[start : start + span] == run for start in range(len(words) - span + 1))
+
+
+# A criterion is prose, and somewhere in the prose is the thing it is about.
+# What separates that thing from the words around it is how the caller spelled
+# it: code names are written as code — `CameraProvider`, `camera_provider`,
+# `WARMUP_FRAMES`, `notes.txt` — or, for a one-word name, capitalised where
+# ordinary words are not. Reading that is what tells `CameraProvider` apart
+# from the `class` beside it.
+#
+# Read from spelling and not from a list of words too ordinary to name
+# anything. Such a list would have to hold every structural noun in English —
+# class, interface, file, module, handler, service — and the next criterion
+# would use the one it had not thought of yet. Spelling is a rule; a list of
+# ordinary words is an argument that never finishes.
+_CRITERION_TOKENS = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.]*")
+
+
+def _named_targets(ac_text: str) -> list[list[str]]:
+    """What the criterion names, read from how the caller spelled it.
+
+    A token spelled as a compound — more than one word inside a single token,
+    which is what CamelCase, snake_case, SCREAMING_CASE and a dotted filename
+    all are — names something. So does a capitalised token standing among
+    ordinary words. The criterion's first token is not read as capitalised,
+    because starting a sentence with a capital is English rather than naming.
+    """
+    targets: list[list[str]] = []
+    for position, token in enumerate(_CRITERION_TOKENS.findall(ac_text)):
+        pieces = _words(token)
+        if not pieces:
+            continue
+        if len(pieces) > 1 or (position > 0 and token[:1].isupper()):
+            targets.append(pieces)
+    return targets
+
+
 def _binds_criterion(pattern: str, ac_text: str) -> bool:
     """Whether a match of this pattern is about what the criterion names.
 
-    True when some text every match must contain spells out, word for word, a
-    run of words the caller wrote in the acceptance criterion — with at least
-    one word of substance among them. Such a pattern cannot match a file that
-    lacks what the criterion asked about; whatever else its match fails to
-    prove, it is evidence *about the criterion*. A pattern with no such text —
-    `[\\s\\S]+`, `CameraProvider|[\\s\\S]+` — matches files the criterion has
-    nothing to say about, so its match says nothing back.
+    Some text every match must contain has to spell out the thing the
+    criterion named. `class\\s+CameraProvider` requires `CameraProvider` and
+    cannot match a file without it; `class\\s+\\w+` requires only `class`, so
+    it matches `class Unrelated` in a project that has no CameraProvider at
+    all, and calling that evidence for the criterion is the defect this guard
+    exists to close. Sharing the criterion's structural vocabulary is not
+    naming its target.
 
-    The comparison is over words, not characters, so `CameraProvider`,
-    `camera_provider` and the criterion's own "CameraProvider interface" all
-    reach each other. Flags are not consulted: what words a literal spells is
-    not something a flag changes.
+    Where the criterion names nothing in code spelling — "maximum 5 retries",
+    all ordinary lowercase words — there is no target to read, and this falls
+    back on the criterion's longest words. That is a weaker reading, and
+    deliberately so: it is the strongest one available from a criterion whose
+    own text does not distinguish its target, and tightening it further would
+    refuse `RETRIES\\s*=\\s*` for that criterion, which is exactly the evidence
+    a T1 assertion is supposed to bring. Its limit is that a criterion written
+    that way can be bound by a long structural word; a criterion that names
+    what it is about — `Cache`, `CameraProvider` — never reaches it.
+
+    The comparison is over words, so `CameraProvider`, `camera_provider` and
+    `CAMERA_PROVIDER` all reach each other. Flags are not consulted: what
+    words a literal spells is not something a flag changes.
     """
     try:
         parsed = regex_parser.parse(pattern)
@@ -724,19 +775,21 @@ def _binds_criterion(pattern: str, ac_text: str) -> bool:
     criterion_words = _words(ac_text)
     if not criterion_words:
         return False
-    for run in _required_literal_runs(parsed):
-        run_words = _words(run)
-        if not run_words:
-            continue
-        if max(len(word) for word in run_words) < _MIN_BINDING_WORD_LENGTH:
-            continue
-        span = len(run_words)
-        if any(
-            criterion_words[start : start + span] == run_words
-            for start in range(len(criterion_words) - span + 1)
-        ):
-            return True
-    return False
+    run_words = [words for words in map(_words, _required_literal_runs(parsed)) if words]
+    if not run_words:
+        return False
+
+    targets = _named_targets(ac_text)
+    if targets:
+        return any(_contains(words, target) for words in run_words for target in targets)
+
+    longest = max(len(word) for word in criterion_words)
+    if longest < _MIN_BINDING_WORD_LENGTH:
+        return False
+    return any(
+        _contains(criterion_words, words) and any(len(word) == longest for word in words)
+        for words in run_words
+    )
 
 
 def _skip_inline_space(text: str, index: int) -> int:

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -621,6 +621,124 @@ def _matches_only_a_blank_subject(pattern: str, flags: int = 0) -> bool:
     return unpinned_at_start is False and unpinned_at_end is False
 
 
+# A binding word has to be a word: something long enough that its appearance in
+# both the criterion and the pattern is a naming rather than a coincidence.
+# `a+` finds an "a" in the criterion "a CameraProvider interface" and in almost
+# every file there is; three characters is where English stops handing those
+# out for free.
+_MIN_BINDING_WORD_LENGTH = 3
+
+_WORD_RUNS = re.compile(r"[A-Za-z0-9]+")
+# One identifier, three spellings: `CameraProvider`, `camera_provider` and
+# `CAMERA_PROVIDER` all name the same thing, and a criterion written in prose
+# names it as "camera provider". Splitting on case transitions and reading
+# every piece lowercase is what lets each spelling find the others.
+_IDENTIFIER_PIECES = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
+
+
+def _words(text: str) -> list[str]:
+    """The word sequence of a text, spelled the way comparisons want it."""
+    pieces: list[str] = []
+    for run in _WORD_RUNS.findall(text):
+        pieces.extend(piece.lower() for piece in _IDENTIFIER_PIECES.findall(run))
+    return pieces
+
+
+def _required_literal_runs(
+    sequence: object,
+    depth: int = 0,
+) -> frozenset[str]:
+    """The literal texts every subject this pattern matches must contain.
+
+    Read off the parse tree, never run. A literal in the main walk is consumed
+    by every match; one inside a repeat that must run at least once, or inside
+    a positive lookaround, is present in every matched subject even when the
+    match does not consume it, which is the fact binding actually needs. An
+    alternation requires only what every branch requires, a repeat that may run
+    zero times requires nothing, and anything this walk cannot read requires
+    nothing either — fewer required runs can only make a pattern harder to
+    admit, so the unknown falls on the side of refusal.
+    """
+    runs: set[str] = set()
+    if depth > _MAX_PARSE_DEPTH:
+        return frozenset()
+    current: list[str] = []
+
+    def flush() -> None:
+        if current:
+            runs.add("".join(current))
+            current.clear()
+
+    for opcode, argument in sequence:  # type: ignore[attr-defined]
+        name = getattr(opcode, "name", str(opcode))
+        if name == "LITERAL" and isinstance(argument, int):
+            current.append(chr(argument))
+            continue
+        flush()
+        if name in _REPEATS:
+            minimum, _maximum, item = argument
+            if minimum >= 1:
+                runs |= _required_literal_runs(item, depth + 1)
+        elif name == "SUBPATTERN":
+            runs |= _required_literal_runs(argument[-1], depth + 1)
+        elif name == "ATOMIC_GROUP":
+            runs |= _required_literal_runs(argument, depth + 1)
+        elif name == "ASSERT":
+            runs |= _required_literal_runs(argument[1], depth + 1)
+        elif name == "BRANCH":
+            branch_runs = [_required_literal_runs(branch, depth + 1) for branch in argument[1]]
+            if branch_runs:
+                runs |= frozenset.intersection(*branch_runs)
+        elif name == "GROUPREF_EXISTS":
+            _reference, yes_arm, no_arm = argument
+            if no_arm is not None:
+                runs |= _required_literal_runs(yes_arm, depth + 1) & _required_literal_runs(
+                    no_arm, depth + 1
+                )
+        # AT, IN, ANY, RANGE, CATEGORY, NOT_LITERAL, ASSERT_NOT, GROUPREF,
+        # FAILURE and anything unrecognised require no particular text.
+    flush()
+    return frozenset(runs)
+
+
+def _binds_criterion(pattern: str, ac_text: str) -> bool:
+    """Whether a match of this pattern is about what the criterion names.
+
+    True when some text every match must contain spells out, word for word, a
+    run of words the caller wrote in the acceptance criterion — with at least
+    one word of substance among them. Such a pattern cannot match a file that
+    lacks what the criterion asked about; whatever else its match fails to
+    prove, it is evidence *about the criterion*. A pattern with no such text —
+    `[\\s\\S]+`, `CameraProvider|[\\s\\S]+` — matches files the criterion has
+    nothing to say about, so its match says nothing back.
+
+    The comparison is over words, not characters, so `CameraProvider`,
+    `camera_provider` and the criterion's own "CameraProvider interface" all
+    reach each other. Flags are not consulted: what words a literal spells is
+    not something a flag changes.
+    """
+    try:
+        parsed = regex_parser.parse(pattern)
+    except Exception:
+        return False
+    criterion_words = _words(ac_text)
+    if not criterion_words:
+        return False
+    for run in _required_literal_runs(parsed):
+        run_words = _words(run)
+        if not run_words:
+            continue
+        if max(len(word) for word in run_words) < _MIN_BINDING_WORD_LENGTH:
+            continue
+        span = len(run_words)
+        if any(
+            criterion_words[start : start + span] == run_words
+            for start in range(len(criterion_words) - span + 1)
+        ):
+            return True
+    return False
+
+
 def _skip_inline_space(text: str, index: int) -> int:
     while index < len(text) and text[index] in " \t\f\v":
         index += 1
@@ -764,7 +882,10 @@ class SpecVerifier:
 
             results: list[SpecVerificationResult] = []
             for assertion in ac_assertions:
-                results.append(self._verify_one(assertion))
+                result = self._verify_one(assertion)
+                if agent_pass is False:
+                    result = self._demoted_unless_bound(result)
+                results.append(result)
 
             reports.append(
                 ACVerificationReport(
@@ -833,6 +954,55 @@ class SpecVerifier:
             )
             return None
         return compiled
+
+    def _demoted_unless_bound(self, result: SpecVerificationResult) -> SpecVerificationResult:
+        """Refuse a VERIFIED that would overturn an agent FAIL on unbound evidence.
+
+        The agent reported this criterion failed, and the caller is asking this
+        scanner to overrule that. Overruling an honest FAIL with a formal PASS
+        is the highest-authority thing a report can do, so it is reserved for
+        evidence that is *about the criterion*: a pattern some part of which —
+        a part every match must contain — names what the criterion names. A
+        non-nullable pattern that matches any file with content in it,
+        `[\\s\\S]+` or `CameraProvider|[\\s\\S]+`, passes the emptiness guard
+        above and still fabricates that PASS; what it lacks is not width but
+        binding, and binding is what is checked here.
+
+        Only the overturn direction is gated. A VERIFIED that agrees with the
+        agent adds no authority the agent's own report did not already claim,
+        and gating it would fail honest confirmations over vocabulary the
+        extractor chose. A pattern that can only match a file with nothing in
+        it is exempt for the same reason it was admitted at all: it names its
+        criterion by matching exactly one possible subject, which no wording
+        check could improve on.
+
+        The demotion is to UNVERIFIABLE, not DISCREPANCY: the pattern is not
+        usable as evidence here, which is different from evidence that the
+        criterion is unmet.
+        """
+        if result.outcome is not VerificationOutcome.VERIFIED:
+            return result
+        pattern = result.assertion.pattern
+        if not pattern:
+            return result
+        if _matches_only_a_blank_subject(pattern):
+            return result
+        if _binds_criterion(pattern, result.assertion.ac_text):
+            return result
+        logger.warning(
+            "Refusing unbound pattern as grounds to overturn an agent FAIL: %r",
+            pattern,
+        )
+        return SpecVerificationResult(
+            assertion=result.assertion,
+            outcome=VerificationOutcome.UNVERIFIABLE,
+            file_path=result.file_path,
+            detail=(
+                "Pattern matched, but nothing every match must contain names what "
+                "the criterion names; unbound evidence cannot overturn an "
+                "agent-reported FAIL"
+            ),
+        )
 
     def _verify_one(self, assertion: SpecAssertion) -> SpecVerificationResult:
         """Verify one assertion, including tiers this scanner deliberately skips."""

--- a/src/ouroboros/verification/verifier.py
+++ b/src/ouroboros/verification/verifier.py
@@ -621,177 +621,6 @@ def _matches_only_a_blank_subject(pattern: str, flags: int = 0) -> bool:
     return unpinned_at_start is False and unpinned_at_end is False
 
 
-# A binding word has to be a word: something long enough that its appearance in
-# both the criterion and the pattern is a naming rather than a coincidence.
-# `a+` finds an "a" in the criterion "a CameraProvider interface" and in almost
-# every file there is; three characters is where English stops handing those
-# out for free.
-_MIN_BINDING_WORD_LENGTH = 3
-
-_WORD_RUNS = re.compile(r"[A-Za-z0-9]+")
-# One identifier, three spellings: `CameraProvider`, `camera_provider` and
-# `CAMERA_PROVIDER` all name the same thing, and a criterion written in prose
-# names it as "camera provider". Splitting on case transitions and reading
-# every piece lowercase is what lets each spelling find the others.
-_IDENTIFIER_PIECES = re.compile(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+")
-
-
-def _words(text: str) -> list[str]:
-    """The word sequence of a text, spelled the way comparisons want it."""
-    pieces: list[str] = []
-    for run in _WORD_RUNS.findall(text):
-        pieces.extend(piece.lower() for piece in _IDENTIFIER_PIECES.findall(run))
-    return pieces
-
-
-def _required_literal_runs(
-    sequence: object,
-    depth: int = 0,
-) -> frozenset[str]:
-    """The literal texts every subject this pattern matches must contain.
-
-    Read off the parse tree, never run. A literal in the main walk is consumed
-    by every match; one inside a repeat that must run at least once, or inside
-    a positive lookaround, is present in every matched subject even when the
-    match does not consume it, which is the fact binding actually needs. An
-    alternation requires only what every branch requires, a repeat that may run
-    zero times requires nothing, and anything this walk cannot read requires
-    nothing either — fewer required runs can only make a pattern harder to
-    admit, so the unknown falls on the side of refusal.
-    """
-    runs: set[str] = set()
-    if depth > _MAX_PARSE_DEPTH:
-        return frozenset()
-    current: list[str] = []
-
-    def flush() -> None:
-        if current:
-            runs.add("".join(current))
-            current.clear()
-
-    for opcode, argument in sequence:  # type: ignore[attr-defined]
-        name = getattr(opcode, "name", str(opcode))
-        if name == "LITERAL" and isinstance(argument, int):
-            current.append(chr(argument))
-            continue
-        flush()
-        if name in _REPEATS:
-            minimum, _maximum, item = argument
-            if minimum >= 1:
-                runs |= _required_literal_runs(item, depth + 1)
-        elif name == "SUBPATTERN":
-            runs |= _required_literal_runs(argument[-1], depth + 1)
-        elif name == "ATOMIC_GROUP":
-            runs |= _required_literal_runs(argument, depth + 1)
-        elif name == "ASSERT":
-            runs |= _required_literal_runs(argument[1], depth + 1)
-        elif name == "BRANCH":
-            branch_runs = [_required_literal_runs(branch, depth + 1) for branch in argument[1]]
-            if branch_runs:
-                runs |= frozenset.intersection(*branch_runs)
-        elif name == "GROUPREF_EXISTS":
-            _reference, yes_arm, no_arm = argument
-            if no_arm is not None:
-                runs |= _required_literal_runs(yes_arm, depth + 1) & _required_literal_runs(
-                    no_arm, depth + 1
-                )
-        # AT, IN, ANY, RANGE, CATEGORY, NOT_LITERAL, ASSERT_NOT, GROUPREF,
-        # FAILURE and anything unrecognised require no particular text.
-    flush()
-    return frozenset(runs)
-
-
-def _contains(words: list[str], run: list[str]) -> bool:
-    """Whether `run` appears in `words` as a contiguous stretch."""
-    span = len(run)
-    if not span or span > len(words):
-        return False
-    return any(words[start : start + span] == run for start in range(len(words) - span + 1))
-
-
-# A criterion is prose, and somewhere in the prose is the thing it is about.
-# What separates that thing from the words around it is how the caller spelled
-# it: code names are written as code — `CameraProvider`, `camera_provider`,
-# `WARMUP_FRAMES`, `notes.txt` — or, for a one-word name, capitalised where
-# ordinary words are not. Reading that is what tells `CameraProvider` apart
-# from the `class` beside it.
-#
-# Read from spelling and not from a list of words too ordinary to name
-# anything. Such a list would have to hold every structural noun in English —
-# class, interface, file, module, handler, service — and the next criterion
-# would use the one it had not thought of yet. Spelling is a rule; a list of
-# ordinary words is an argument that never finishes.
-_CRITERION_TOKENS = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.]*")
-
-
-def _named_targets(ac_text: str) -> list[list[str]]:
-    """What the criterion names, read from how the caller spelled it.
-
-    A token spelled as a compound — more than one word inside a single token,
-    which is what CamelCase, snake_case, SCREAMING_CASE and a dotted filename
-    all are — names something. So does a capitalised token standing among
-    ordinary words. The criterion's first token is not read as capitalised,
-    because starting a sentence with a capital is English rather than naming.
-    """
-    targets: list[list[str]] = []
-    for position, token in enumerate(_CRITERION_TOKENS.findall(ac_text)):
-        pieces = _words(token)
-        if not pieces:
-            continue
-        if len(pieces) > 1 or (position > 0 and token[:1].isupper()):
-            targets.append(pieces)
-    return targets
-
-
-def _binds_criterion(pattern: str, ac_text: str) -> bool:
-    """Whether a match of this pattern is about what the criterion names.
-
-    Some text every match must contain has to spell out the thing the
-    criterion named. `class\\s+CameraProvider` requires `CameraProvider` and
-    cannot match a file without it; `class\\s+\\w+` requires only `class`, so
-    it matches `class Unrelated` in a project that has no CameraProvider at
-    all, and calling that evidence for the criterion is the defect this guard
-    exists to close. Sharing the criterion's structural vocabulary is not
-    naming its target.
-
-    Where the criterion names nothing in code spelling — "maximum 5 retries",
-    all ordinary lowercase words — there is no target to read, and this falls
-    back on the criterion's longest words. That is a weaker reading, and
-    deliberately so: it is the strongest one available from a criterion whose
-    own text does not distinguish its target, and tightening it further would
-    refuse `RETRIES\\s*=\\s*` for that criterion, which is exactly the evidence
-    a T1 assertion is supposed to bring. Its limit is that a criterion written
-    that way can be bound by a long structural word; a criterion that names
-    what it is about — `Cache`, `CameraProvider` — never reaches it.
-
-    The comparison is over words, so `CameraProvider`, `camera_provider` and
-    `CAMERA_PROVIDER` all reach each other. Flags are not consulted: what
-    words a literal spells is not something a flag changes.
-    """
-    try:
-        parsed = regex_parser.parse(pattern)
-    except Exception:
-        return False
-    criterion_words = _words(ac_text)
-    if not criterion_words:
-        return False
-    run_words = [words for words in map(_words, _required_literal_runs(parsed)) if words]
-    if not run_words:
-        return False
-
-    targets = _named_targets(ac_text)
-    if targets:
-        return any(_contains(words, target) for words in run_words for target in targets)
-
-    longest = max(len(word) for word in criterion_words)
-    if longest < _MIN_BINDING_WORD_LENGTH:
-        return False
-    return any(
-        _contains(criterion_words, words) and any(len(word) == longest for word in words)
-        for words in run_words
-    )
-
-
 def _skip_inline_space(text: str, index: int) -> int:
     while index < len(text) and text[index] in " \t\f\v":
         index += 1
@@ -937,7 +766,7 @@ class SpecVerifier:
             for assertion in ac_assertions:
                 result = self._verify_one(assertion)
                 if agent_pass is False:
-                    result = self._demoted_unless_bound(result)
+                    result = self._demoted_from_overturning(result)
                 results.append(result)
 
             reports.append(
@@ -1008,52 +837,47 @@ class SpecVerifier:
             return None
         return compiled
 
-    def _demoted_unless_bound(self, result: SpecVerificationResult) -> SpecVerificationResult:
-        """Refuse a VERIFIED that would overturn an agent FAIL on unbound evidence.
+    def _demoted_from_overturning(self, result: SpecVerificationResult) -> SpecVerificationResult:
+        """Refuse a VERIFIED as grounds to overturn an agent-reported FAIL.
 
-        The agent reported this criterion failed, and the caller is asking this
-        scanner to overrule that. Overruling an honest FAIL with a formal PASS
-        is the highest-authority thing a report can do, so it is reserved for
-        evidence that is *about the criterion*: a pattern some part of which —
-        a part every match must contain — names what the criterion names. A
-        non-nullable pattern that matches any file with content in it,
-        `[\\s\\S]+` or `CameraProvider|[\\s\\S]+`, passes the emptiness guard
-        above and still fabricates that PASS; what it lacks is not width but
-        binding, and binding is what is checked here.
+        This scanner exists to check whether an agent's *claimed PASS* survives
+        contact with the source. Overturning a FAIL is the opposite direction,
+        and it is the direction with no safe stopping point: what a regex match
+        proves about a criterion depends on whether the pattern is really about
+        that criterion, and nothing available here can settle that. A rule that
+        reads the criterion's wording admits `class\\s+\\w+` for "a
+        CameraProvider class" through the shared word `class`; tightening it to
+        read named targets from their spelling admits `MUST` through ordinary
+        requirement prose. Each repair moves the hole rather than closing it,
+        because the question — does this text name this criterion's subject —
+        is not one a finite reading of prose answers.
 
-        Only the overturn direction is gated. A VERIFIED that agrees with the
-        agent adds no authority the agent's own report did not already claim,
-        and gating it would fail honest confirmations over vocabulary the
-        extractor chose. A pattern that can only match a file with nothing in
-        it is exempt for the same reason it was admitted at all: it names its
-        criterion by matching exactly one possible subject, which no wording
-        check could improve on.
+        So the authority is withdrawn rather than qualified. An agent that
+        reported FAIL keeps its FAIL, whatever the pattern matched. No property
+        of the pattern can restore the override, which is what makes this
+        closed rather than merely narrower: there is nothing left to bypass.
 
-        The demotion is to UNVERIFIABLE, not DISCREPANCY: the pattern is not
-        usable as evidence here, which is different from evidence that the
-        criterion is unmet.
+        Only this direction. A VERIFIED that agrees with the agent's own PASS
+        claims no authority the agent had not already claimed, and is passed
+        through untouched — the false-PASS check that is this scanner's actual
+        job.
+
+        The demotion is to UNVERIFIABLE, not DISCREPANCY: the evidence is not
+        usable *here*, which is different from evidence that the criterion is
+        unmet.
         """
         if result.outcome is not VerificationOutcome.VERIFIED:
             return result
-        pattern = result.assertion.pattern
-        if not pattern:
-            return result
-        if _matches_only_a_blank_subject(pattern):
-            return result
-        if _binds_criterion(pattern, result.assertion.ac_text):
-            return result
         logger.warning(
-            "Refusing unbound pattern as grounds to overturn an agent FAIL: %r",
-            pattern,
+            "Refusing regex evidence as grounds to overturn an agent FAIL: %r",
+            result.assertion.pattern,
         )
         return SpecVerificationResult(
             assertion=result.assertion,
             outcome=VerificationOutcome.UNVERIFIABLE,
             file_path=result.file_path,
             detail=(
-                "Pattern matched, but nothing every match must contain names what "
-                "the criterion names; unbound evidence cannot overturn an "
-                "agent-reported FAIL"
+                "Pattern matched, but source-scan evidence cannot overturn an agent-reported FAIL"
             ),
         )
 

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -717,6 +717,127 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.run_verdict == "FAIL"
 
+    @pytest.mark.parametrize(
+        "rehydrate",
+        ["direct", "round_trip", "legacy_booleans"],
+    )
+    def test_a_verified_report_over_an_agent_fail_cannot_mint_a_formal_pass(
+        self, rehydrate: str
+    ) -> None:
+        """Source-scan evidence cannot reverse a reported FAIL at this boundary.
+
+        `SpecVerifier.verify_all` already refuses to emit an all-VERIFIED
+        report against an agent-reported FAIL, but this adapter is a public
+        authority boundary that also accepts summaries built elsewhere:
+        replayed rows, legacy payloads that carry only the old booleans, and
+        compatibility objects from integrations. Enforcing the polarity only
+        in the producer would let any of those encode the exact transition the
+        producer forbids, so all three shapes are driven through here.
+        """
+        ac_text = "MUST define a CameraProvider interface"
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"[\s\S]+",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text=ac_text,
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.VERIFIED,
+                            detail="Pattern found in main.py",
+                        ),
+                    ),
+                    agent_reported_pass=False,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+        if rehydrate != "direct":
+            payload = json.loads(verification.model_dump_json())
+            if rehydrate == "legacy_booleans":
+                for report in payload["reports"]:
+                    for result in report["results"]:
+                        result.pop("outcome", None)
+            verification = SpecVerificationSummary.model_validate(payload)
+
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content=ac_text,
+                    passed=False,
+                    score=0.0,
+                    evidence="Agent reported this criterion failed.",
+                ),
+            ),
+            execution_completion_status="completed",
+        )
+        seed = SimpleNamespace(acceptance_criteria=(ac_text,))
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert "cannot overturn" in summary.ac_results[0].evidence
+
+    def test_a_verified_report_still_confirms_an_agent_pass(self) -> None:
+        """The confirmation direction is unaffected by the polarity gate."""
+        ac_text = "MUST define a CameraProvider interface"
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"class\s+CameraProvider",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text=ac_text,
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.VERIFIED,
+                            detail="Pattern found in camera.py",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content=ac_text,
+                    passed=True,
+                    score=1.0,
+                    evidence="Agent reported this criterion passed.",
+                ),
+            ),
+            execution_completion_status="completed",
+        )
+        seed = SimpleNamespace(acceptance_criteria=(ac_text,))
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is True
+        assert summary.ac_results[0].rendered_verdict == "PASS"
+
     def test_seed_coverage_survives_partial_production_extraction(self, tmp_path: Any) -> None:
         """Parser, extractor, verifier, and formal adapter fail closed together."""
         seed = SimpleNamespace(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -718,6 +718,82 @@ Parallel Execution Verification Report
         assert summary.run_verdict == "FAIL"
 
     @pytest.mark.parametrize(
+        ("report_polarity", "mechanical_pass"),
+        [
+            (True, False),
+            (None, False),
+            (False, True),
+        ],
+        ids=[
+            "report-claims-pass-while-execution-says-fail",
+            "report-omits-polarity-while-execution-says-fail",
+            "report-says-fail-while-execution-says-pass",
+        ],
+    )
+    def test_report_polarity_cannot_outrank_the_execution_record(
+        self, report_polarity: bool | None, mechanical_pass: bool
+    ) -> None:
+        """The report's copy of the agent result is not the authoritative one.
+
+        `agent_reported_pass` on a report is a copy the verifier was handed.
+        A replayed, stale or externally built report carries whatever copy it
+        was constructed with — a `True` contradicting the execution, or no
+        field at all, which reads as `True`. The mechanical summary is the
+        execution's own account, so both are consulted and either one saying
+        "not a pass" settles it. Disagreement is not resolved in favour of the
+        more permissive record.
+        """
+        ac_text = "MUST define a CameraProvider interface"
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"[\s\S]+",
+        )
+        polarity_kwargs = (
+            {} if report_polarity is None else {"agent_reported_pass": report_polarity}
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text=ac_text,
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            outcome=VerificationOutcome.VERIFIED,
+                            detail="Pattern found in main.py",
+                        ),
+                    ),
+                    **polarity_kwargs,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content=ac_text,
+                    passed=mechanical_pass,
+                    score=1.0 if mechanical_pass else 0.0,
+                    evidence="Agent execution record.",
+                ),
+            ),
+            execution_completion_status="completed",
+        )
+        seed = SimpleNamespace(acceptance_criteria=(ac_text,))
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification, seed)
+
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+
+    @pytest.mark.parametrize(
         "rehydrate",
         ["direct", "round_trip", "legacy_booleans"],
     )
@@ -1581,7 +1657,17 @@ Parallel Execution Verification Report
         assert summary.failure_reason == "1/1 ACs failed (AC 1)"
 
     def test_spec_verification_does_not_approve_failed_execution(self) -> None:
-        """Passing verifier results must not approve a run whose execution failed."""
+        """Passing verifier results must not approve a run whose execution failed.
+
+        The AC itself is now `NOT_EVALUATED` rather than a passing result
+        carried inside a rejected run. The worker reported this task
+        incomplete, so the execution record says the agent did not claim this
+        AC passed, and the report's own `agent_reported_pass=True` is the
+        contradicting copy rather than the authority. Source-scan evidence
+        cannot resolve that disagreement in favour of a pass — this is the
+        shape #1835 describes, a grep result standing in for work a worker
+        reported it never finished.
+        """
         mechanical = EvaluationSummary(
             final_approved=False,
             highest_stage_passed=2,
@@ -1626,12 +1712,15 @@ Parallel Execution Verification Report
         summary = _evaluation_summary_from_spec_verification(mechanical, verification)
 
         assert summary is not None
-        assert summary.ac_results[0].passed is True
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
         assert summary.execution_completion_status == "failed"
         assert summary.approval_status == "rejected"
         assert summary.final_approved is False
         assert summary.run_verdict == "FAIL"
-        assert summary.failure_reason == "execution_completion_status=failed"
+        assert summary.failure_reason == (
+            "unverifiable assertion evidence for AC 1 [execution_completion_status=failed]"
+        )
 
     def test_spec_verification_discrepancy_becomes_formal_ac_failure(self) -> None:
         """False-positive legacy PASS claims remain catchable by spec verification."""

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from pydantic import ValidationError
@@ -2007,49 +2008,127 @@ class TestSpecVerifier:
 
         assert summary.verified_count == 1
 
-    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
     @pytest.mark.parametrize(
-        "pattern",
+        ("ac_text", "pattern", "files", "file_hint", "tier"),
         [
-            r"[\s\S]+",
-            r"CameraProvider|[\s\S]+",
-            r"(?:CameraProvider)?[\s\S]+",
-            r".+",
-            r"a+",
-            r"def\s+\w+",
+            (
+                "MUST define a CameraProvider interface",
+                r"[\s\S]+",
+                {"main.py": "print('hello')\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "MUST define a CameraProvider interface",
+                r"[\s\S]+",
+                {"main.py": "print('hello')\n"},
+                "*.py",
+                VerificationTier.T1_CONSTANT,
+            ),
+            (
+                "MUST define a CameraProvider interface",
+                r"CameraProvider|[\s\S]+",
+                {"main.py": "print('hello')\n"},
+                "*.py",
+                VerificationTier.T1_CONSTANT,
+            ),
+            (
+                "MUST define a CameraProvider interface",
+                r".+",
+                {"main.py": "print('hello')\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "MUST define a CameraProvider class",
+                r"class\s+\w+",
+                {"unrelated.py": "class Unrelated:\n    pass\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "MUST create a CameraProvider file",
+                "file",
+                {"profile.py": "x = 1\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "The implementation MUST define a CameraProvider class",
+                "MUST",
+                {"unrelated.py": "# MUST clean this up later\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "The implementation MUST define a CameraProvider class",
+                "MUST",
+                {"unrelated.py": "# MUST clean this up later\n"},
+                "*.py",
+                VerificationTier.T1_CONSTANT,
+            ),
+            (
+                "MUST define a CameraProvider class",
+                r"class\s+CameraProvider",
+                {"camera.py": "class CameraProvider:\n    pass\n"},
+                "*.py",
+                VerificationTier.T2_STRUCTURAL,
+            ),
+            (
+                "notes.txt MUST be left empty",
+                r"\A\Z",
+                {"notes.txt": ""},
+                "notes.txt",
+                VerificationTier.T2_STRUCTURAL,
+            ),
         ],
         ids=[
-            "consume-everything",
-            "target-or-anything",
-            "optional-target-then-anything",
-            "any-content",
-            "single-letter",
-            "vocabulary-the-criterion-never-used",
+            "consume-everything-t2",
+            "consume-everything-t1",
+            "target-or-anything-t1",
+            "any-content-t2",
+            "structural-keyword-class",
+            "structural-keyword-file-via-filename-path",
+            "requirement-modality-in-a-comment-t2",
+            "requirement-modality-in-a-comment-t1",
+            "genuinely-criterion-bound",
+            "blank-subject-on-a-named-file",
         ],
     )
-    def test_unbound_pattern_cannot_overturn_an_agent_fail(
-        self, tier: VerificationTier, pattern: str
+    def test_no_regex_evidence_overturns_an_agent_fail(
+        self,
+        ac_text: str,
+        pattern: str,
+        files: dict[str, str],
+        file_hint: str,
+        tier: VerificationTier,
     ) -> None:
-        r"""A non-nullable match of nothing in particular must not mint a PASS.
+        r"""An agent that reported FAIL keeps its FAIL, whatever matched.
 
-        The emptiness guard cannot see these: each consumes at least one
-        character, so none is nullable, and each matches the first file with
-        content in it — or, on the T2 filename path, the first filename. What
-        every one of them lacks is any required text the criterion named, and
-        that is the reading that refuses them here. The agent honestly reported
-        this criterion FAILED; the fabricated match is demoted to UNVERIFIABLE
-        rather than being allowed to overturn that report, and it is not a
-        DISCREPANCY either, because a refused pattern is not evidence of
-        absence.
+        The first cases are patterns that match anything with content in it;
+        the next three share the criterion's own words — `class`, `file`, and
+        the `MUST` of ordinary requirement prose — while matching source that
+        has nothing to do with what was asked, the last of those from inside a
+        comment. Every rule that tried to sort these by reading the criterion
+        admitted one of them, because whether a text names a criterion's
+        subject is not a question a finite reading of prose answers.
+
+        So the last two matter most: `class\s+CameraProvider` against a real
+        `class CameraProvider`, and `\A\Z` against a genuinely empty named
+        file, are refused here too. There is no property of a pattern that
+        restores the override, which is what leaves nothing to bypass.
+
+        UNVERIFIABLE and not DISCREPANCY throughout: the evidence is unusable
+        in this direction, which is not evidence that the criterion is unmet.
         """
-        project = self._create_project({"main.py": "print('hello')\ndef anything(): pass\n"})
+        project = self._create_project(files)
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
+            ac_text=ac_text,
             tier=tier,
             pattern=pattern,
             expected_value="",
-            file_hint="*.py",
+            file_hint=file_hint,
         )
 
         report = (
@@ -2062,46 +2141,44 @@ class TestSpecVerifier:
         assert report.results[0].outcome is VerificationOutcome.UNVERIFIABLE
         assert "cannot overturn" in report.results[0].detail
 
-    def test_bound_pattern_still_overturns_an_agent_fail(self) -> None:
-        """Overturning stays available to evidence that is about the criterion.
+    @pytest.mark.parametrize(
+        ("ac_text", "pattern", "files"),
+        [
+            (
+                "MUST define a CameraProvider interface",
+                r"class\s+CameraProvider",
+                {"camera.py": "class CameraProvider:\n    pass\n"},
+            ),
+            (
+                "MUST define a CameraProvider interface",
+                r"def\s+\w+",
+                {"main.py": "def entrypoint(): pass\n"},
+            ),
+            (
+                "notes.txt MUST be left empty",
+                r"\A\Z",
+                {"notes.txt": ""},
+            ),
+        ],
+        ids=["bound", "unbound", "blank-subject"],
+    )
+    def test_agent_pass_confirmation_is_untouched(
+        self, ac_text: str, pattern: str, files: dict[str, str]
+    ) -> None:
+        """Only the overturn direction is withdrawn.
 
-        The agent reported FAIL, the project really does define the class, and
-        the pattern's required text names it. This is the verifier doing its
-        job — catching a wrong self-report in the honest direction too — and
-        the binding gate must not take it away.
+        Checking a claimed PASS against the source is this scanner's actual
+        job — the false-PASS check #1835 says it exists for. A VERIFIED that
+        agrees with the agent claims no authority the agent had not already
+        claimed, so none of these is gated, however loose the pattern.
         """
-        project = self._create_project({"camera.py": "class CameraProvider:\n    pass\n"})
+        project = self._create_project(files)
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
+            ac_text=ac_text,
             tier=VerificationTier.T2_STRUCTURAL,
-            pattern=r"class\s+CameraProvider",
-            file_hint="*.py",
-        )
-
-        report = (
-            SpecVerifier(project_dir=project)
-            .verify_all((assertion,), agent_results={0: False})
-            .reports[0]
-        )
-
-        assert report.verified_pass is True
-        assert report.results[0].outcome is VerificationOutcome.VERIFIED
-
-    def test_unbound_pattern_still_confirms_an_agent_pass(self) -> None:
-        """Only the overturn direction is gated.
-
-        A VERIFIED that agrees with the agent's own PASS claims no authority
-        the agent did not already claim, and refusing it would fail honest
-        confirmations over vocabulary the extractor happened to choose.
-        """
-        project = self._create_project({"main.py": "def entrypoint(): pass\n"})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="MUST define a CameraProvider interface",
-            tier=VerificationTier.T2_STRUCTURAL,
-            pattern=r"def\s+\w+",
-            file_hint="*.py",
+            pattern=pattern,
+            file_hint="notes.txt" if pattern == r"\A\Z" else "*.py",
         )
 
         report = (
@@ -2112,204 +2189,52 @@ class TestSpecVerifier:
 
         assert report.results[0].outcome is VerificationOutcome.VERIFIED
 
-    def test_blank_subject_pattern_may_still_overturn_an_agent_fail(self) -> None:
-        r"""The emptiness rescue is exempt from binding.
+    def test_an_agent_fail_survives_all_the_way_to_the_formal_verdict(self) -> None:
+        """End to end, because the defect was only visible at the far end.
 
-        `\A\Z` can spell no word the criterion uses, and it does not need to:
-        admitted only against the one file the hint names, it matches exactly
-        one possible subject, which binds it to its criterion more tightly
-        than any wording check could.
+        The verifier's demotion is only half the story: #1835 is about what
+        the formal adapter does with an all-VERIFIED report, which is to mint
+        `passed=True` and approve the run. This drives the whole path —
+        criterion, hostile pattern, matching-but-unrelated source, an agent
+        that honestly reported FAIL — and asserts the run is still rejected.
         """
-        project = self._create_project({"notes.txt": ""})
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text="notes.txt MUST be left empty",
-            tier=VerificationTier.T2_STRUCTURAL,
-            pattern=r"\A\Z",
-            file_hint="notes.txt",
+        from ouroboros.mcp.server.spec_verification_adapter import (
+            evaluation_summary_from_spec_verification,
         )
 
-        report = (
-            SpecVerifier(project_dir=project)
-            .verify_all((assertion,), agent_results={0: False})
-            .reports[0]
+        seed = SimpleNamespace(
+            acceptance_criteria=("The implementation MUST define a CameraProvider class",)
         )
-
-        assert report.verified_pass is True
-
-    @pytest.mark.parametrize(
-        ("pattern", "ac_text"),
-        [
-            (r"WARMUP_FRAMES\s*=\s*", "Warmup frames should be set to 10"),
-            (r"camera_provider", "MUST define a CameraProvider interface"),
-            (r"RETRIES\s*=\s*", "maximum 5 retries"),
-        ],
-        ids=["prose-finds-screaming-snake", "snake-finds-camel", "case-folds"],
-    )
-    def test_binding_reads_identifiers_across_spellings(self, pattern: str, ac_text: str) -> None:
-        """One identifier, three spellings, and each finds the others.
-
-        A criterion written in prose names `WARMUP_FRAMES` as "warmup frames";
-        refusing the pattern over an underscore would gate honest overturns on
-        the extractor's casing luck.
-        """
-        source = {"config.py": "WARMUP_FRAMES = 10\nRETRIES = 5\nclass camera_provider: pass\n"}
-        project = self._create_project(source)
+        mechanical = SimpleNamespace(
+            ac_results=(
+                SimpleNamespace(
+                    ac_index=0,
+                    ac_content="The implementation MUST define a CameraProvider class",
+                    authoritative_pass=False,
+                ),
+            ),
+            task_results=(),
+            feedback_metadata=(),
+            execution_completion_status="completed",
+        )
+        project = self._create_project({"unrelated.py": "# MUST clean this up later\n"})
         assertion = SpecAssertion(
             ac_index=0,
-            ac_text=ac_text,
+            ac_text="The implementation MUST define a CameraProvider class",
             tier=VerificationTier.T2_STRUCTURAL,
-            pattern=pattern,
+            pattern="MUST",
             file_hint="*.py",
         )
 
-        report = (
-            SpecVerifier(project_dir=project)
-            .verify_all((assertion,), agent_results={0: False})
-            .reports[0]
+        verification = SpecVerifier(project_dir=project).verify_all(
+            (assertion,), agent_results={0: False}
         )
+        summary = evaluation_summary_from_spec_verification(mechanical, verification, seed)
 
-        assert report.verified_pass is True
-
-    @pytest.mark.parametrize(
-        ("ac_text", "pattern", "files"),
-        [
-            (
-                "MUST define a CameraProvider class",
-                r"class\s+\w+",
-                {"unrelated.py": "class Unrelated:\n    pass\n"},
-            ),
-            (
-                "MUST create a CameraProvider file",
-                "file",
-                {"profile.py": "x = 1\n"},
-            ),
-            (
-                "MUST add a Cache interface",
-                r"interface\s+\w+",
-                {"unrelated.ts": "interface Unrelated {}\n"},
-            ),
-            (
-                "MUST register a CameraProvider handler",
-                r"def\s+\w+",
-                {"unrelated.py": "def unrelated():\n    pass\n"},
-            ),
-        ],
-        ids=[
-            "structural-keyword-class",
-            "structural-keyword-file-via-filename-path",
-            "structural-keyword-interface-is-the-longest-word",
-            "structural-keyword-def",
-        ],
-    )
-    def test_structural_vocabulary_alone_does_not_bind_a_named_target(
-        self, ac_text: str, pattern: str, files: dict[str, str]
-    ) -> None:
-        """Sharing the criterion's structural words is not naming its target.
-
-        Every pattern here spells a word the criterion really does contain —
-        `class`, `file`, `interface`, and a `def` for its "handler" — and every
-        one of them matches source that has nothing to do with what the
-        criterion asked for. Binding has to be to the thing the criterion
-        named, which the caller spelled as code: `CameraProvider`, `Cache`.
-        Word length cannot make that distinction, and `interface` is the
-        longest word in its own criterion.
-        """
-        project = self._create_project(files)
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=VerificationTier.T2_STRUCTURAL,
-            pattern=pattern,
-            file_hint="*.*",
-        )
-
-        report = (
-            SpecVerifier(project_dir=project)
-            .verify_all((assertion,), agent_results={0: False})
-            .reports[0]
-        )
-
-        assert report.verified_pass is False
-        assert report.results[0].outcome is VerificationOutcome.UNVERIFIABLE
-
-    @pytest.mark.parametrize(
-        ("ac_text", "pattern", "files"),
-        [
-            (
-                "MUST define a CameraProvider class",
-                r"class\s+CameraProvider",
-                {"camera.py": "class CameraProvider:\n    pass\n"},
-            ),
-            (
-                "MUST add a Cache interface",
-                r"class\s+Cache\b",
-                {"cache.py": "class Cache:\n    pass\n"},
-            ),
-        ],
-        ids=["compound-name", "single-capitalised-name"],
-    )
-    def test_a_named_target_still_binds_when_spelled_out(
-        self, ac_text: str, pattern: str, files: dict[str, str]
-    ) -> None:
-        """The same structural words bind once the target is spelled with them.
-
-        `class\\s+CameraProvider` differs from `class\\s+\\w+` by exactly the
-        thing that matters: it cannot match a file that lacks the name the
-        criterion gave.
-        """
-        project = self._create_project(files)
-        assertion = SpecAssertion(
-            ac_index=0,
-            ac_text=ac_text,
-            tier=VerificationTier.T2_STRUCTURAL,
-            pattern=pattern,
-            file_hint="*.py",
-        )
-
-        report = (
-            SpecVerifier(project_dir=project)
-            .verify_all((assertion,), agent_results={0: False})
-            .reports[0]
-        )
-
-        assert report.verified_pass is True
-
-    def test_a_criterion_naming_nothing_in_code_spelling_falls_back_to_its_longest_words(
-        self,
-    ) -> None:
-        """The fallback is reached only when the criterion names nothing.
-
-        "maximum 5 retries" spells no compound and capitalises nothing, so
-        there is no target to read and the longest-word reading admits
-        `RETRIES\\s*=\\s*` — the evidence a T1 assertion exists to bring. The
-        same reading still refuses a short structural word, which is what
-        keeps the fallback from becoming a way around the rule above.
-        """
-        project = self._create_project({"config.py": "RETRIES = 5\n", "profile.py": "x = 1\n"})
-        bound = SpecAssertion(
-            ac_index=0,
-            ac_text="maximum 5 retries",
-            tier=VerificationTier.T1_CONSTANT,
-            pattern=r"RETRIES\s*=\s*",
-            expected_value="5",
-            file_hint="*.py",
-        )
-        unbound = SpecAssertion(
-            ac_index=1,
-            ac_text="MUST create a config file",
-            tier=VerificationTier.T2_STRUCTURAL,
-            pattern="file",
-            file_hint="*.py",
-        )
-
-        summary = SpecVerifier(project_dir=project).verify_all(
-            (bound, unbound), agent_results={0: False, 1: False}
-        )
-
-        assert summary.reports[0].verified_pass is True
-        assert summary.reports[1].verified_pass is False
-        assert summary.reports[1].results[0].outcome is VerificationOutcome.UNVERIFIABLE
+        assert summary is not None
+        assert summary.final_approved is False
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
 
 
 # -- Extractor Tests --

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -2171,6 +2171,146 @@ class TestSpecVerifier:
 
         assert report.verified_pass is True
 
+    @pytest.mark.parametrize(
+        ("ac_text", "pattern", "files"),
+        [
+            (
+                "MUST define a CameraProvider class",
+                r"class\s+\w+",
+                {"unrelated.py": "class Unrelated:\n    pass\n"},
+            ),
+            (
+                "MUST create a CameraProvider file",
+                "file",
+                {"profile.py": "x = 1\n"},
+            ),
+            (
+                "MUST add a Cache interface",
+                r"interface\s+\w+",
+                {"unrelated.ts": "interface Unrelated {}\n"},
+            ),
+            (
+                "MUST register a CameraProvider handler",
+                r"def\s+\w+",
+                {"unrelated.py": "def unrelated():\n    pass\n"},
+            ),
+        ],
+        ids=[
+            "structural-keyword-class",
+            "structural-keyword-file-via-filename-path",
+            "structural-keyword-interface-is-the-longest-word",
+            "structural-keyword-def",
+        ],
+    )
+    def test_structural_vocabulary_alone_does_not_bind_a_named_target(
+        self, ac_text: str, pattern: str, files: dict[str, str]
+    ) -> None:
+        """Sharing the criterion's structural words is not naming its target.
+
+        Every pattern here spells a word the criterion really does contain —
+        `class`, `file`, `interface`, and a `def` for its "handler" — and every
+        one of them matches source that has nothing to do with what the
+        criterion asked for. Binding has to be to the thing the criterion
+        named, which the caller spelled as code: `CameraProvider`, `Cache`.
+        Word length cannot make that distinction, and `interface` is the
+        longest word in its own criterion.
+        """
+        project = self._create_project(files)
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=pattern,
+            file_hint="*.*",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is False
+        assert report.results[0].outcome is VerificationOutcome.UNVERIFIABLE
+
+    @pytest.mark.parametrize(
+        ("ac_text", "pattern", "files"),
+        [
+            (
+                "MUST define a CameraProvider class",
+                r"class\s+CameraProvider",
+                {"camera.py": "class CameraProvider:\n    pass\n"},
+            ),
+            (
+                "MUST add a Cache interface",
+                r"class\s+Cache\b",
+                {"cache.py": "class Cache:\n    pass\n"},
+            ),
+        ],
+        ids=["compound-name", "single-capitalised-name"],
+    )
+    def test_a_named_target_still_binds_when_spelled_out(
+        self, ac_text: str, pattern: str, files: dict[str, str]
+    ) -> None:
+        """The same structural words bind once the target is spelled with them.
+
+        `class\\s+CameraProvider` differs from `class\\s+\\w+` by exactly the
+        thing that matters: it cannot match a file that lacks the name the
+        criterion gave.
+        """
+        project = self._create_project(files)
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=pattern,
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is True
+
+    def test_a_criterion_naming_nothing_in_code_spelling_falls_back_to_its_longest_words(
+        self,
+    ) -> None:
+        """The fallback is reached only when the criterion names nothing.
+
+        "maximum 5 retries" spells no compound and capitalises nothing, so
+        there is no target to read and the longest-word reading admits
+        `RETRIES\\s*=\\s*` — the evidence a T1 assertion exists to bring. The
+        same reading still refuses a short structural word, which is what
+        keeps the fallback from becoming a way around the rule above.
+        """
+        project = self._create_project({"config.py": "RETRIES = 5\n", "profile.py": "x = 1\n"})
+        bound = SpecAssertion(
+            ac_index=0,
+            ac_text="maximum 5 retries",
+            tier=VerificationTier.T1_CONSTANT,
+            pattern=r"RETRIES\s*=\s*",
+            expected_value="5",
+            file_hint="*.py",
+        )
+        unbound = SpecAssertion(
+            ac_index=1,
+            ac_text="MUST create a config file",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="file",
+            file_hint="*.py",
+        )
+
+        summary = SpecVerifier(project_dir=project).verify_all(
+            (bound, unbound), agent_results={0: False, 1: False}
+        )
+
+        assert summary.reports[0].verified_pass is True
+        assert summary.reports[1].verified_pass is False
+        assert summary.reports[1].results[0].outcome is VerificationOutcome.UNVERIFIABLE
+
 
 # -- Extractor Tests --
 

--- a/tests/unit/test_verification.py
+++ b/tests/unit/test_verification.py
@@ -2007,6 +2007,170 @@ class TestSpecVerifier:
 
         assert summary.verified_count == 1
 
+    @pytest.mark.parametrize("tier", [VerificationTier.T2_STRUCTURAL, VerificationTier.T1_CONSTANT])
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            r"[\s\S]+",
+            r"CameraProvider|[\s\S]+",
+            r"(?:CameraProvider)?[\s\S]+",
+            r".+",
+            r"a+",
+            r"def\s+\w+",
+        ],
+        ids=[
+            "consume-everything",
+            "target-or-anything",
+            "optional-target-then-anything",
+            "any-content",
+            "single-letter",
+            "vocabulary-the-criterion-never-used",
+        ],
+    )
+    def test_unbound_pattern_cannot_overturn_an_agent_fail(
+        self, tier: VerificationTier, pattern: str
+    ) -> None:
+        r"""A non-nullable match of nothing in particular must not mint a PASS.
+
+        The emptiness guard cannot see these: each consumes at least one
+        character, so none is nullable, and each matches the first file with
+        content in it — or, on the T2 filename path, the first filename. What
+        every one of them lacks is any required text the criterion named, and
+        that is the reading that refuses them here. The agent honestly reported
+        this criterion FAILED; the fabricated match is demoted to UNVERIFIABLE
+        rather than being allowed to overturn that report, and it is not a
+        DISCREPANCY either, because a refused pattern is not evidence of
+        absence.
+        """
+        project = self._create_project({"main.py": "print('hello')\ndef anything(): pass\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=tier,
+            pattern=pattern,
+            expected_value="",
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is False
+        assert report.results[0].outcome is VerificationOutcome.UNVERIFIABLE
+        assert "cannot overturn" in report.results[0].detail
+
+    def test_bound_pattern_still_overturns_an_agent_fail(self) -> None:
+        """Overturning stays available to evidence that is about the criterion.
+
+        The agent reported FAIL, the project really does define the class, and
+        the pattern's required text names it. This is the verifier doing its
+        job — catching a wrong self-report in the honest direction too — and
+        the binding gate must not take it away.
+        """
+        project = self._create_project({"camera.py": "class CameraProvider:\n    pass\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"class\s+CameraProvider",
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is True
+        assert report.results[0].outcome is VerificationOutcome.VERIFIED
+
+    def test_unbound_pattern_still_confirms_an_agent_pass(self) -> None:
+        """Only the overturn direction is gated.
+
+        A VERIFIED that agrees with the agent's own PASS claims no authority
+        the agent did not already claim, and refusing it would fail honest
+        confirmations over vocabulary the extractor happened to choose.
+        """
+        project = self._create_project({"main.py": "def entrypoint(): pass\n"})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="MUST define a CameraProvider interface",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"def\s+\w+",
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: True})
+            .reports[0]
+        )
+
+        assert report.results[0].outcome is VerificationOutcome.VERIFIED
+
+    def test_blank_subject_pattern_may_still_overturn_an_agent_fail(self) -> None:
+        r"""The emptiness rescue is exempt from binding.
+
+        `\A\Z` can spell no word the criterion uses, and it does not need to:
+        admitted only against the one file the hint names, it matches exactly
+        one possible subject, which binds it to its criterion more tightly
+        than any wording check could.
+        """
+        project = self._create_project({"notes.txt": ""})
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="notes.txt MUST be left empty",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=r"\A\Z",
+            file_hint="notes.txt",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is True
+
+    @pytest.mark.parametrize(
+        ("pattern", "ac_text"),
+        [
+            (r"WARMUP_FRAMES\s*=\s*", "Warmup frames should be set to 10"),
+            (r"camera_provider", "MUST define a CameraProvider interface"),
+            (r"RETRIES\s*=\s*", "maximum 5 retries"),
+        ],
+        ids=["prose-finds-screaming-snake", "snake-finds-camel", "case-folds"],
+    )
+    def test_binding_reads_identifiers_across_spellings(self, pattern: str, ac_text: str) -> None:
+        """One identifier, three spellings, and each finds the others.
+
+        A criterion written in prose names `WARMUP_FRAMES` as "warmup frames";
+        refusing the pattern over an underscore would gate honest overturns on
+        the extractor's casing luck.
+        """
+        source = {"config.py": "WARMUP_FRAMES = 10\nRETRIES = 5\nclass camera_provider: pass\n"}
+        project = self._create_project(source)
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text=ac_text,
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern=pattern,
+            file_hint="*.py",
+        )
+
+        report = (
+            SpecVerifier(project_dir=project)
+            .verify_all((assertion,), agent_results={0: False})
+            .reports[0]
+        )
+
+        assert report.verified_pass is True
+
 
 # -- Extractor Tests --
 


### PR DESCRIPTION
Closes #1835. Replaces #1926 (closed by owner decision — see its closing comment).

## The defect

A model-supplied regex that matches any file with content in it — `[\s\S]+`, `CameraProvider|[\s\S]+`, `.+`, or on the T2 filename path anything matching a basename — is not nullable, so #1837's emptiness guard cannot see it. It matches the first candidate, produces an all-`VERIFIED` report, and `evaluation_summary_from_spec_verification` promotes that to a formal PASS **without consulting the agent's own result** — overturning an honest agent FAIL, which is what #1835 reports.

## The invariant

> **Source-scan evidence cannot overturn an agent-reported FAIL.**

Confirmation of an agent-reported PASS is untouched. That is the check #1835 says this scanner exists for — catching a self-report lie — and it claims no authority the agent had not already claimed.

## Why the authority is withdrawn rather than narrowed

The first two attempts qualified the override instead of removing it, admitting evidence that was "about the criterion". Both were bypassed in review:

| rule | bypass |
|---|---|
| shared criterion words above a length floor | `class\s+\w+` for "a CameraProvider **class**" matched `class Unrelated` |
| named targets read from code spelling | `MUST` for "The implementation **MUST** define…" matched `# MUST clean this up later`, reaching `final_approved=True` |

Both are the same failure. Whether a text names a criterion's subject is not a question a finite reading of prose answers, so each repair moved the hole rather than closing it — the non-terminating shape that made #1926 unmergeable, at smaller scale. Excluding `MUST`/`SHALL` would have been the third narrowing, with `SHOULD`, `Given`/`When`/`Then`, `API` and sentence-initial capitals waiting behind it.

So the prose-to-target classifier is **deleted**, not corrected. No property of a pattern restores the override, which is what makes this closed rather than merely narrower: there is nothing left to bypass.

## Enforced at every boundary that can carry it

| boundary | enforcement |
|---|---|
| `SpecVerifier.verify_all` (producer) | never emits `VERIFIED` for an AC the agent reported FAIL; demotes to `UNVERIFIABLE` |
| `evaluation_summary_from_spec_verification` (formal verdict) | refuses to honour that combination, so replayed, legacy and compatibility summaries cannot encode what the producer forbids |
| agent-result source at that boundary | taken from the mechanical execution record, not the report's copy of it; either record saying "not a pass" settles it, and disagreement is never resolved toward the permissive one |

Three places because none of them passes through the others: rehydrated summaries never meet the producer, and a report's `agent_reported_pass` can contradict the execution or be absent entirely (reading as `True`).

`UNVERIFIABLE`, not `DISCREPANCY`: the evidence is unusable in this direction, which is not evidence that the criterion is unmet. The formal verdict renders `NOT_EVALUATED`.

## Deliberately given up

`class\s+CameraProvider` against a real `class CameraProvider`, and `\A\Z` against a genuinely empty named file, no longer overturn a FAIL either. Both were allowed by earlier revisions. An exemption is a bypass surface, and these were the last two; an agent that reported FAIL keeps its FAIL.

No executable-source classification is attempted. `CameraProvider` inside a comment satisfying a pattern remains a known limitation of a grep-level tier — the tier for semantic proof is T3, not a parser fleet. That was #1926's approach and it is not reopened here.

## Coverage

- `test_no_regex_evidence_overturns_an_agent_fail` — every reported bypass plus the two now-refused legitimate shapes, across T1 and T2 including the filename path
- `test_agent_pass_confirmation_is_untouched` — bound, unbound and blank-subject patterns still confirm a PASS
- `test_an_agent_fail_survives_all_the_way_to_the_formal_verdict` — end to end through the formal adapter
- `test_a_verified_report_over_an_agent_fail_cannot_mint_a_formal_pass` — direct, JSON-round-tripped and legacy-boolean summaries
- `test_report_polarity_cannot_outrank_the_execution_record` — report claims PASS / omits the field / contradicts a passing execution

One existing expectation tightened: in `test_spec_verification_does_not_approve_failed_execution` the worker reported its task incomplete while the report claimed PASS, so that AC is now `NOT_EVALUATED` rather than a passing result inside an already-rejected run. Run-level assertions are unchanged. That combination is the shape #1835 describes.

## Size

Production diff is `src/ouroboros/verification/verifier.py` +49 lines, one branch and one helper in `spec_verification_adapter.py`. For comparison, #1926 spent 16,555 lines and 64 review rounds on the same issue without converging.

## Verification

- Local `tests/unit` + `tests/conformance`, CI's 4-worker xdist configuration on Python 3.14: **20,126 passed, 88 skipped, 0 failed**
- `tests/unit/test_verification.py` + `tests/unit/mcp/`: 2,354 passed, 1 skipped
- Ruff check across `src/ouroboros` and `tests/unit`, format, MyPy on both changed source files: clean
- GitHub Actions on `17d1123e`: all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
