### PR TITLE
feat(install): optional channel attribution via OUROBOROS_INSTALL_REF

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -88,14 +88,21 @@ together, always.
 
 | Event | When | Properties (exact set) |
 |---|---|---|
-| `install_started` | `install.sh` begins | source, os, arch, version, is_local, pre |
-| `install_completed` | `install.sh` finishes | source, os, arch, method (uv/pipx/pip), runtime, detected_runtimes (count), version |
+| `install_started` | `install.sh` begins | source, os, arch, version, is_local, pre, ref |
+| `install_completed` | `install.sh` finishes | source, os, arch, method (uv/pipx/pip), runtime, detected_runtimes (count), version, ref |
 | `command_run` (source=mcp) | An `ouroboros_*` MCP tool is invoked from any host CLI (Claude Code, Codex, OpenCode, …) | command (interview/seed/run/evolve/auto/evaluate/qa/…), tool, source, is_funnel, phase (`submission` or `completion`), accepted (submission only), ok (completion only), duration_ms, error_type, sample_rate (polling tools only), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, frontdoor, app_version, os, python_version, ci |
 | `command_run` (source=cli) | A direct `ooo <subcommand>` invocation in a terminal | command, source, is_funnel, app_version, os, python_version, frontdoor, ci — no tool, phase, duration/outcome fields, or backend context: those are mcp-only |
 | `workflow_outcome` | Two producers (never both for the same evaluation — see Notes): a background MCP job reaches a durable terminal event, **or** a direct (non-job) `ouroboros_evaluate` / `ouroboros_checklist_verify` completion | command, phase (`terminal`), terminal_status, ok, verified, final_approved, `$insert_id` (job-derived variant only — one-way event deduplication digest), runtime_backend, execute_runtime_backend, interview_llm_backend, evaluate_llm_backend, app_version, os, python_version, frontdoor, ci |
 | `mcp_serve_started` | A host CLI attaches the Ouroboros MCP server for a session | transport, tool_count, frontdoor, app_version, os, ci — no python_version, no backend/provider context |
 
 Notes:
+
+- `ref` on the install events is a short opaque channel token (`hellogithub`,
+  `readme`, `guide-zh`, …) that a docs page or listing prepends to the install
+  command as `OUROBOROS_INSTALL_REF=<channel>`. It says which of OUR surfaces
+  the command was copied from; it is chosen by us, never derived from the
+  machine, defaults to `direct`, and is discarded unless it matches
+  `[A-Za-z0-9._-]{1,32}`.
 
 - `source` separates the two entry surfaces cleanly: `cli` means the user typed
   the command in a terminal; `mcp` means it arrived from inside an AI agent

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -835,10 +835,19 @@ if [ "$IS_LOCAL" = false ] && command -v curl &>/dev/null; then
   fi
 fi
 
+# Optional install-channel attribution. A docs page or listing can prepend
+# OUROBOROS_INSTALL_REF=<channel> to the install command so install_started /
+# install_completed carry which surface the install came from. Same privacy
+# contract as every other property here: a short opaque token chosen by us,
+# never derived from the machine. Token-constrained like os/arch above so a
+# hostile value cannot ride into the payload; anything else becomes "direct".
+INSTALL_REF="${OUROBOROS_INSTALL_REF:-direct}"
+[[ "$INSTALL_REF" =~ ^[A-Za-z0-9._-]{1,32}$ ]] || INSTALL_REF="direct"
+
 _banner
 
 _telemetry_notice
-_telemetry_ping install_started "is_local=$IS_LOCAL" "pre=${PRE_FLAG:-no}" "version=${LATEST:-unknown}"
+_telemetry_ping install_started "is_local=$IS_LOCAL" "pre=${PRE_FLAG:-no}" "version=${LATEST:-unknown}" "ref=$INSTALL_REF"
 
 # 1. Detect installer: uv > pipx > pip (determines Python requirement)
 HAS_UV=false
@@ -1349,7 +1358,7 @@ if command -v claude &>/dev/null; then
 fi
 
 _telemetry_ping install_completed "method=${INSTALL_METHOD:-unknown}" "runtime=${RUNTIME:-none}" \
-  "detected_runtimes=${RUNTIME_COUNT:-0}" "version=${LATEST:-unknown}"
+  "detected_runtimes=${RUNTIME_COUNT:-0}" "version=${LATEST:-unknown}" "ref=$INSTALL_REF"
 
 _blank
 _say "${GREEN}${BOLD}Done! Ouroboros is ready.${RESET}"

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -1375,6 +1375,7 @@ def test_installer_ping_uses_exact_declared_property_structure(tmp_path: Path) -
         "is_local",
         "pre",
         "version",
+        "ref",
     }
     assert set(events["install_completed"]["properties"].keys()) == {
         "source",
@@ -1384,7 +1385,96 @@ def test_installer_ping_uses_exact_declared_property_structure(tmp_path: Path) -
         "runtime",
         "detected_runtimes",
         "version",
+        "ref",
     }
+
+
+def test_installer_ping_ref_defaults_to_direct_when_unset(tmp_path: Path) -> None:
+    """No `OUROBOROS_INSTALL_REF` in the environment -- both telemetry events
+    must carry `ref=direct`, the documented fallback for an install with no
+    channel attribution. `drop_env` (not just omitting it from `env`) is
+    required here: a set-but-empty variable still counts as "set" for shell
+    parameter expansion, so this must genuinely unset the key rather than
+    rely on it being absent from the test's own `env` dict.
+    """
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_TELEMETRY": ""},
+        drop_env=("OUROBOROS_INSTALL_REF",),
+        fake_commands={
+            **_telemetry_fake_commands(tmp_path),
+            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    captures = _wait_for_telemetry(tmp_path)
+    events = {}
+    for line in captures.splitlines():
+        if not line:
+            continue
+        payload = json.loads(line)
+        events[payload["event"]] = payload
+
+    assert events["install_started"]["properties"]["ref"] == "direct"
+    assert events["install_completed"]["properties"]["ref"] == "direct"
+
+
+def test_installer_ping_ref_carries_valid_channel_token(tmp_path: Path) -> None:
+    """A well-formed `OUROBOROS_INSTALL_REF` (matches `^[A-Za-z0-9._-]{1,32}$`)
+    is carried through to both events verbatim -- this is the actual
+    attribution path a docs page or listing is meant to use.
+    """
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "hellogithub"},
+        fake_commands={
+            **_telemetry_fake_commands(tmp_path),
+            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    captures = _wait_for_telemetry(tmp_path)
+    events = {}
+    for line in captures.splitlines():
+        if not line:
+            continue
+        payload = json.loads(line)
+        events[payload["event"]] = payload
+
+    assert events["install_started"]["properties"]["ref"] == "hellogithub"
+    assert events["install_completed"]["properties"]["ref"] == "hellogithub"
+
+
+def test_installer_ping_ref_degrades_hostile_value_to_direct(tmp_path: Path) -> None:
+    """A value outside `^[A-Za-z0-9._-]{1,32}$` (shell metacharacters, spaces,
+    or over-length) must never reach the telemetry payload -- it degrades to
+    `direct` exactly like an unset value. `[[ =~ ]]` never executes its
+    operand, so this is a payload-shape guarantee, not a shell-injection
+    probe; the point is that a hostile value chosen by whoever writes the
+    install command cannot ride into what we record.
+    """
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_TELEMETRY": "", "OUROBOROS_INSTALL_REF": "evil; rm -rf /"},
+        fake_commands={
+            **_telemetry_fake_commands(tmp_path),
+            "curl": _capture_dashd_curl(tmp_path / "telemetry.log"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    captures = _wait_for_telemetry(tmp_path)
+    events = {}
+    for line in captures.splitlines():
+        if not line:
+            continue
+        payload = json.loads(line)
+        events[payload["event"]] = payload
+
+    assert events["install_started"]["properties"]["ref"] == "direct"
+    assert events["install_completed"]["properties"]["ref"] == "direct"
 
 
 def test_installer_ignores_nested_distinct_id_in_valid_json_and_mints_fresh(


### PR DESCRIPTION
## Why

`install_started` / `install_completed` carry `source=install_sh` and nothing about which surface the command was copied from. Marketing currently decides channel investment from GitHub referrer counts, which stop at the page view; installs cannot be attributed to a channel at all.

## What

- `OUROBOROS_INSTALL_REF=<channel>` (env var, same convention as `OUROBOROS_INSTALL_RUNTIME`) adds a `ref` property to both install events.
- Default `direct`; value is token-constrained to `[A-Za-z0-9._-]{1,32}` in the file's existing defensive style, so a hostile value degrades to `direct` instead of riding into the payload. Smoke-tested: unset → `direct`, `hellogithub` → passes, `evil";x=1` → `direct`.
- `TELEMETRY.md` exact property sets updated, plus a note defining the token: chosen by us on our own surfaces, never derived from the machine, same privacy contract and opt-outs as every existing property.

## Usage on our surfaces (follow-up docs PRs, not in this diff)

```
curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme bash
```

with per-surface tokens like `readme`, `guide-zh`, `hellogithub`, `devto`. Once merged, channel-level install conversion becomes a single PostHog breakdown on `ref`.

## Not verified

End-to-end capture with a real PostHog project was not run from this branch; the property passes through the existing `_telemetry_ping` k=v path (JSON-encoded via python3 argv, key whitelist), and `bash -n` plus the constraint smoke tests are the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYVH3FGVNWfE543Taddqov


Closes #2070
