### PR TITLE
llms.txt: match the README's current Agent OS positioning

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ouroboros
 
-> Specification-first workflow engine for AI coding agents
+> The Agent OS for replayable, specification-first AI coding workflows
 
 Ouroboros transforms vague ideas into verified, working codebases by replacing ad-hoc prompting with a structured workflow: interview, crystallize, execute, evaluate, evolve. It sits between the user and their AI runtime (Claude Code, Codex CLI, or others).
 


### PR DESCRIPTION
## What

`llms.txt`'s tagline still read "Specification-first workflow engine for AI coding agents," predating the Agent OS framing the rest of the repo already uses (README.md hero tagline, line 21; README.md body, lines 61-63). Replaced it with the exact hero tagline from README.md so an LLM (or anyone) reading `llms.txt` gets the same positioning as a human reading the README.

## Why this file, why now

`ouroboros.page/llms.txt` (a separate file on the guide site) already uses the Agent OS framing, and referrer data shows `chatgpt.com` sending traffic (35 views / 14 days) -- something is already reading and citing these files. This repo's own `llms.txt` was the one surface still out of sync with its own README.

## Verification

- Diff is the one line; nothing else touched.
- Checked `llms.txt` and `llms-full.txt` against the 26 known-bad claim patterns tracked in the marketing repo's wiki (0 hits).
- Spot-checked the core loop description, the SQLite EventStore claim, and the `docs/guides/seed-authoring.md` reference against source -- all accurate, no other changes needed.
