### PR TITLE
docs: attach OUROBOROS_INSTALL_REF to install one-liners

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -126,7 +126,7 @@ Ouroboros는 이 철학을 **Double Diamond** 구조로 풀어냅니다:
 **설치** — 한 줄이면 전부 자동:
 
 ```bash
-OUROBOROS_INSTALL_REF=readme-ko curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-ko bash
 ```
 
 **처음 사용** — AI 코딩 에이전트를 열고 입력하세요:

--- a/README.ko.md
+++ b/README.ko.md
@@ -126,7 +126,7 @@ Ouroboros는 이 철학을 **Double Diamond** 구조로 풀어냅니다:
 **설치** — 한 줄이면 전부 자동:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+OUROBOROS_INSTALL_REF=readme-ko curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
 ```
 
 **처음 사용** — AI 코딩 에이전트를 열고 입력하세요:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Most AI coding fails at the **input**, not the output. The bottleneck is not AI 
 **Install** — one command, everything auto-detected:
 
 ```bash
-OUROBOROS_INSTALL_REF=readme curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme bash
 ```
 
 **First use** — open your AI coding agent and type:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Most AI coding fails at the **input**, not the output. The bottleneck is not AI 
 **Install** — one command, everything auto-detected:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+OUROBOROS_INSTALL_REF=readme curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
 ```
 
 **First use** — open your AI coding agent and type:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@ Ouroboros 是面向 AI 编码的 Agent OS：一层本地优先的运行时，把
 **安装** —— 一条命令，环境自动识别：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+OUROBOROS_INSTALL_REF=readme-zh curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
 ```
 
 **开始** —— 打开你的 AI 编码 agent，直接上：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,7 +102,7 @@ Ouroboros 是面向 AI 编码的 Agent OS：一层本地优先的运行时，把
 **安装** —— 一条命令，环境自动识别：
 
 ```bash
-OUROBOROS_INSTALL_REF=readme-zh curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=readme-zh bash
 ```
 
 **开始** —— 打开你的 AI 编码 agent，直接上：

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,7 +180,7 @@ ouroboros --version                   # verify CLI
 
 **One-liner alternative** (auto-detects your runtime and installs matching extras):
 ```bash
-OUROBOROS_INSTALL_REF=docs-getting-started curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | OUROBOROS_INSTALL_REF=docs-getting-started bash
 ```
 
 ### Option 3: From Source (Contributors)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,7 +180,7 @@ ouroboros --version                   # verify CLI
 
 **One-liner alternative** (auto-detects your runtime and installs matching extras):
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
+OUROBOROS_INSTALL_REF=docs-getting-started curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.sh | bash
 ```
 
 ### Option 3: From Source (Contributors)

--- a/tests/unit/test_install_ref_docs_contract.py
+++ b/tests/unit/test_install_ref_docs_contract.py
@@ -1,0 +1,81 @@
+"""Keep the documented OUROBOROS_INSTALL_REF one-liners actually working.
+
+PR #2072's review caught a real bug: `VAR=x curl ... | bash` only scopes VAR
+to the `curl` process, not the `bash` process that actually reads it in
+scripts/install.sh. The fix moves the assignment to the right-hand side of
+the pipe (`curl ... | VAR=x bash`). This file guards both the documented
+command shape and the underlying shell semantics so the mistake can't come
+back silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DOC_SURFACES = {
+    "README.md": "readme",
+    "README.ko.md": "readme-ko",
+    "README.zh-CN.md": "readme-zh",
+    "docs/getting-started.md": "docs-getting-started",
+}
+
+ONE_LINER_RE = re.compile(
+    r"curl -fsSL https://raw\.githubusercontent\.com/Q00/ouroboros/main/scripts/install\.sh \| "
+    r"OUROBOROS_INSTALL_REF=(?P<token>[A-Za-z0-9._-]{1,32}) bash"
+)
+
+
+@pytest.mark.parametrize("doc_path,expected_token", sorted(DOC_SURFACES.items()))
+def test_install_ref_one_liner_puts_assignment_on_bash_side(
+    doc_path: str, expected_token: str
+) -> None:
+    text = (REPO_ROOT / doc_path).read_text(encoding="utf-8")
+    match = ONE_LINER_RE.search(text)
+    assert match, f"{doc_path} is missing the expected OUROBOROS_INSTALL_REF one-liner shape"
+    assert match.group("token") == expected_token
+
+
+@pytest.mark.parametrize("doc_path", sorted(DOC_SURFACES))
+def test_install_ref_one_liner_is_not_the_broken_lhs_shape(doc_path: str) -> None:
+    text = (REPO_ROOT / doc_path).read_text(encoding="utf-8")
+    broken = re.search(r"OUROBOROS_INSTALL_REF=[A-Za-z0-9._-]{1,32} curl -fsSL", text)
+    assert broken is None, (
+        f"{doc_path} has the env assignment on the curl side of the pipe -- it never reaches bash"
+    )
+
+
+def test_env_assignment_on_pipe_rhs_actually_reaches_bash() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'printf "echo \\$OUROBOROS_INSTALL_REF" | OUROBOROS_INSTALL_REF=probe-token bash',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+    )
+    assert result.stdout.strip() == "probe-token"
+
+
+def test_env_assignment_on_pipe_lhs_does_not_reach_bash() -> None:
+    """Negative sanity check: proves the bug this suite guards against is real."""
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'OUROBOROS_INSTALL_REF=probe-token printf "echo \\$OUROBOROS_INSTALL_REF" | bash',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+    )
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Why

#2067 added `OUROBOROS_INSTALL_REF` so `install_started`/`install_completed` can
carry which surface an install command was copied from. None of our own docs
surfaces set it, so every install through our own README/docs still reports
`ref=direct` — indistinguishable from someone typing the command from memory.

Closes #2071.

## What

Prefixed the install one-liner on each surface with its own token:

| Surface | Token |
|---|---|
| README.md | `readme` |
| README.ko.md | `readme-ko` |
| README.zh-CN.md | `readme-zh` |
| docs/getting-started.md | `docs-getting-started` |

Tokens match the `[A-Za-z0-9._-]{1,32}` charset install.sh enforces
(TELEMETRY.md:100-105). No behavior change beyond the env var prefix — same
install.sh, same flags, same runtime auto-detection.

## Out of scope (recorded, not silently dropped)

The ouroboros-site chapter guide (ko/en/zh `install` page) documents the Claude
Code plugin path plus a `pip install` fallback — neither goes through
`install.sh`, so neither can carry this token. Attaching `ref=guide-*` there
would decorate a command that never fires the telemetry event. Left out rather
than added as a no-op; a guide page that actually shows the `install.sh`
one-liner would need to exist first, which is a separate, larger change.
