### PR TITLE
feat(plugin): add loop-engineering discovery keywords to manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,9 @@
         "socratic",
         "interview",
         "seed",
-        "evaluation"
+        "evaluation",
+        "agentic-loop",
+        "loop-engineering"
       ],
       "tags": [
         "requirement-engineering",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,7 +17,9 @@
     "seed",
     "evaluation",
     "self-improving",
-    "drift-detection"
+    "drift-detection",
+    "agentic-loop",
+    "loop-engineering"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -15,7 +15,9 @@
     "requirements",
     "socratic",
     "interview",
-    "evaluation"
+    "evaluation",
+    "agentic-loop",
+    "loop-engineering"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.codex.json",


### PR DESCRIPTION
Closes #2075.

## Why

Direct census of `anthropics/claude-plugins-community`'s `marketplace.json`
(2,291 entries) found exactly 0 exact matches for "loop engineering" and only
3 for "agentic loop" -- both effectively unclaimed as discovery terms, versus
17 for "spec-driven" (already crowded). The trend has real but early
validation: Boris Cherny and Peter Steinberger both use the phrase, it went
mildly viral in July 2026, and AugmentCode's own definition of the pattern
("a verifier, feedback path, success exit, iteration cap, budget cap")
structurally matches this repo's RUN/GATE/JUDGE state machine and evolve-loop
stop rules -- not a stretched analogy, an actual mechanism match.

This was already applied to PyPI keywords in #2054 (merged). This repo's own
plugin manifests were deliberately left alone at the time because #2040 was
being actively edited in parallel and touching the same files risked a
conflict. #2040 is merged now, so applying the same two keywords here.

## What

Added `agentic-loop` and `loop-engineering` to the `keywords` array in:
- `.claude-plugin/plugin.json`
- `.codex-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (the file that actually feeds the
  community marketplace census cited above)

Keywords only, no `description` changes -- keywords are a discovery surface,
not a positioning claim, and the term is six weeks old and not yet an
established one (noted so this isn't read as "we invented loop engineering").

## Verification

- All three files validated as syntactically valid JSON.
- `tests/unit/plugin/test_manifest.py`, `test_manifest_schema_0_6.py`,
  `test_manifest_descriptor.py`, `test_userlevel_registry.py`: 92 passed.
- `tests/unit/scripts/test_sync_plugin_version.py`: 75 passed.
