### PR TITLE
docs(plugin): sync marketplace.json descriptions to plugin.json's text

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "ouroboros",
-  "description": "Requirement crystallization engine — Socratic interviews, seed generation, and an acceptance-criteria evaluation gate",
+  "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
   "owner": {
     "name": "Q00",
     "email": "jqyu.lee@gmail.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "ouroboros",
-      "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly.",
+      "description": "Sits in front of Claude Code and fixes the brief before the code. An interview scores how vague your request is, and a score above the bar blocks spec generation until you pass force explicitly. When an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the worker's contract block, with no flag to put them back, so the worker is asked for the outcome rather than handed the assertion. Redaction of those values elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.",
       "version": "0.51.2",
       "author": {
         "name": "Q00",


### PR DESCRIPTION
Closes #2077.

## Why

`.claude-plugin/marketplace.json` carries two `description` fields, and
both had drifted from `.claude-plugin/plugin.json`'s description, which
#2040 already reviewed and merged. The top-level one still used the
pre-#2040 "crystallization engine" framing; the nested `plugins[0]` one
was a truncated copy that stopped before the two sentences about hiding
each acceptance criterion's verify command and expected output from the
worker -- the exact positioning axis #2040 was about, and the one the
keyword research (0/2,291 exact-term overlap in the community
marketplace census) was built on. This file is literally what feeds
that census, so it mattered that it said the same thing.

## What

Synced both `description` fields in `marketplace.json` to the exact
text already reviewed and live in `plugin.json`. No new wording
introduced, no other fields touched.

## Verification

- Valid JSON.
- `tests/unit/plugin/test_manifest.py`, `test_manifest_schema_0_6.py`,
  `test_manifest_descriptor.py`, `test_userlevel_registry.py`,
  `tests/unit/scripts/test_sync_plugin_version.py`: 167 passed.
