### PR TITLE
docs: add naming-collision note to llms-full.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17,6 +17,12 @@ The core insight: most AI coding fails at the INPUT, not the output.
 Ouroboros forces clarity before code through Socratic questioning and
 ontological analysis.
 
+Note: this is github.com/Q00/ouroboros. A separate, unaffiliated open-source
+project also named "Ouroboros" (github.com/razzant/ouroboros, by Anton
+Razzhigaev) is a self-modifying, autonomous-memory agent that rewrites its
+own architecture -- a different project with a different design, no shared
+code.
+
 ---
 
 ## Command Surfaces


### PR DESCRIPTION
Closes #2079.

## Why

#2074's bot review flagged, as a non-blocking follow-up, that
`llms-full.txt` was missing the same naming-collision note added to
`llms.txt` and all three READMEs. LLM-based answer engines that read
the fuller context file instead of the compact one would still
conflate this project with the unaffiliated same-named
`razzant/ouroboros`.

## What

Added the identical note (adapted to this file's plain-text style) to
`llms-full.txt`, placed right after the "What Ouroboros Does" section --
the same relative position `llms.txt` uses.

## Verification

- Diff is additive only; no existing content changed.
- Confirmed the note wasn't already present (`grep -c razzant` was 0
  before this change).
