### PR TITLE
docs: add Homebrew tap install instructions to READMEs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -250,6 +250,14 @@ ouroboros setup                         # 런타임 설정
 
 호환성 참고: extras 전환 기간 동안 `ouroboros-ai[dashboard]`도 no-op alias로 계속 허용됩니다.
 
+**Homebrew (macOS/Linux)**:
+```bash
+brew tap q00/tap
+brew install ouroboros-ai
+ouroboros setup                         # 런타임 설정
+```
+homebrew-core에는 아직 등록되지 않은 자가 호스팅 탭입니다. PyPI에 게시된 것과 동일한 패키지를 설치합니다.
+
 런타임별 가이드: [Claude Code](./docs/runtime-guides/claude-code.ko.md) · [Codex CLI](./docs/runtime-guides/codex.ko.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.ko.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.ko.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ Claude is the host. Never install `[mcp,claude]`, `[mcp,claude-sdk]`, or
 
 Legacy compatibility: `ouroboros-ai[dashboard]` is still accepted as a compatibility alias/no-op; it does not install dashboard runtime payload. `ouroboros-ai[all]` includes that no-op alias only for compatibility.
 
+**Homebrew (macOS/Linux)**:
+```bash
+brew tap q00/tap
+brew install ouroboros-ai
+ouroboros setup                         # configure runtime
+```
+Self-hosted tap, not yet in homebrew-core. Installs the same package published to PyPI.
+
 See runtime guides: [Claude Code](./docs/runtime-guides/claude-code.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
 
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,6 +210,14 @@ ouroboros setup                         # 配置运行时
 
 历史兼容：在 extras 迁移期间，`ouroboros-ai[dashboard]` 仍然作为兼容别名保留。
 
+**Homebrew（macOS/Linux）**：
+```bash
+brew tap q00/tap
+brew install ouroboros-ai
+ouroboros setup                         # 配置运行时
+```
+自托管 tap，尚未进入 homebrew-core。安装的是与 PyPI 相同的包。
+
 各运行时指南：[Claude Code](./docs/runtime-guides/claude-code.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json) · [Goose](./docs/runtime-guides/goose.md) · [GJC](./docs/runtime-guides/gjc.md) · [Antigravity CLI](./docs/runtime-guides/antigravity.md) · [Grok Build CLI](./docs/runtime-guides/grok.md)
 
 </details>


### PR DESCRIPTION
Closes #2082.

## Why

q00/tap (github.com/Q00/homebrew-tap) has been live and end-to-end
verified since 2026-08-11 (`brew audit --strict` clean, source build
succeeded, reinstalled from the public tap, `ouroboros --version` and
the `[mcp]` extra import both confirmed) but was never linked from any
README's install section. A working install path that nobody can find
from the docs is effectively undiscoverable.

The official homebrew-core PR (#298071) is a separate, still-blocked
track (closed by Homebrew's bot pending the AI-authorship disclosure
checkbox in their PR template, which requires a human maintainer to
check). This self-hosted tap is unaffected by that and already works
today.

## What

Added a short Homebrew block to the "Other install methods" section
in README.md, README.ko.md, and README.zh-CN.md — same three files,
same relative position (after pip/uv/pipx, before the runtime-guide
links) — labeled as self-hosted / not yet in homebrew-core so it
doesn't overstate its status.

## Verification

- Re-confirmed this round: `brew tap q00/tap` resolves, `brew info
  q00/tap/ouroboros-ai` shows it installed and linked on this machine
  (carried over from the 2026-08-11 full verification pass, not a
  fresh install this round).
- Diff is additive only in all three files; no existing install
  instructions changed.
- All three READMEs now carry the identical addition (translated,
  not just copied) to avoid the single-file-drift pattern seen
  elsewhere in this repo's history.