### PR TITLE
docs: reposition llms.txt/llms-full.txt away from spec-first framing

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Ouroboros — Full Model Context Reference
 
-> Specification-first workflow engine for AI coding agents.
+> Pins an acceptance spec and omits any verify command or expected output from the worker.
 > Package: ouroboros-ai | CLI: ouroboros | Claude Code skills: ooo
 > Python >= 3.12 | License: MIT
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Ouroboros — Full Model Context Reference
 
-> Pins an acceptance spec and omits any verify command or expected output from the worker.
+> Pins an acceptance spec and omits any verify command or expected output from the worker's contract.
 > Package: ouroboros-ai | CLI: ouroboros | Claude Code skills: ooo
 > Python >= 3.12 | License: MIT
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ouroboros
 
-> Pins an acceptance spec and omits any verify command or expected output from the worker
+> Pins an acceptance spec and omits any verify command or expected output from the worker's contract
 
 Ouroboros transforms vague ideas into verified, working codebases by replacing ad-hoc prompting with a structured workflow: interview, crystallize, execute, evaluate, evolve. It sits between the user and their AI runtime (Claude Code, Codex CLI, or others).
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Ouroboros
 
-> Specification-first workflow engine for AI coding agents
+> Pins an acceptance spec and omits any verify command or expected output from the worker
 
 Ouroboros transforms vague ideas into verified, working codebases by replacing ad-hoc prompting with a structured workflow: interview, crystallize, execute, evaluate, evolve. It sits between the user and their AI runtime (Claude Code, Codex CLI, or others).
 


### PR DESCRIPTION
Closes #2085.

## Why

Same fix already applied to the README hero (#2084), the GitHub About
field, the PyPI summary, the plugin manifests, the Homebrew formula
description, and the Gitee mirror description: the 2,291-plugin
census of the Claude Code community marketplace found "spec-first"
framing overlaps 19+ other projects, while the actual differentiator
-- omitting the verify command / expected-output assertion from the
executing agent's contract -- has zero overlap.

Both llms.txt and llms-full.txt opened with "Specification-first
workflow engine for AI coding agents" as their first line after the
title. These files are read by LLM-based answer engines rather than
human browsers, so this line is specifically the one-sentence summary
those engines form their understanding from -- arguably higher-stakes
than the human-facing surfaces already fixed.

## What

Replaced the opening line in both files with the wiki-approved
phrasing, reused verbatim from the README hero fix. Nothing else in
either file changed.

## Explicitly out of scope

A repo-wide case-insensitive grep found "specification-first"/
"spec-first" in several other places: README.md's architecture table
and workflow description, AGENTS.md, CLAUDE.md, skills/setup/SKILL.md,
the userlevel-plugins RFC, and various runtime guides. None of those
are touched here -- they're legitimate technical descriptions of the
actual workflow shape or agent-behavior configuration, not
competitive positioning hooks. This PR only touches the two
"first thing an LLM reads" summary lines.

## Verification

- Confirmed no test references either file's content (`grep -rl
  "llms.txt\|llms-full" tests/` -- no matches), so no test breakage.
- Diff is a one-line swap in each file; everything else unchanged.