### PR TITLE
fix: scope pyproject.toml description to the worker's contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ouroboros-ai"
 dynamic = ["version"]
-description = "Pins an acceptance spec and omits any verify command or expected output from the worker. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
+description = "Pins an acceptance spec and omits any verify command or expected output from the worker's contract. Works with Claude Code, Codex CLI, OpenCode and 10 more runtimes."
 readme = "README.md"
 authors = [
     { name = "Q00", email = "jqyu.lee@gmail.com" }


### PR DESCRIPTION
Closes #2087.

## Why

Caught while responding to bot review on PR #2084 (README hero
reposition): the wiki's "shortest" approved English phrasing for the
grading-contract-concealment claim -- "...omits any verify command or
expected output from the worker" -- reads as a broader guarantee than
what's implemented.

`docs/hidden-checklist-convergence/requirements.md:17` scopes the
hiding contract to Ouroboros-transported surfaces only (prompt,
context, events, artifacts, retries) and explicitly disclaims
sandboxing an independently accessible raw Seed file. The Korean and
Chinese copies of this claim, and the plugin manifest, already
correctly say "contract block"/契约块; only this compressed English
phrase was missing that scope, and `pyproject.toml`'s `description`
field (which becomes the next PyPI release's summary) had reused it
verbatim.

## What

One-word narrowing: "from the worker" -> "from the worker's
contract". Same fix already applied to the README hero (#2084),
GitHub About field, and llms.txt/llms-full.txt.

## Note on live PyPI

The current live PyPI summary carries the same imprecise wording --
that's pre-existing release lag, not something this PR forces a fix
for. The corrected text goes live on the next normal release.