### PR TITLE
fix(config): normalize legacy shipped defaults on Claude backends

### DIFF
--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -2030,34 +2030,23 @@ def _normalize_configured_model_for_backend(
     if not candidate:
         return _default_model_for_backend(default_model, backend=backend)
 
-    resolved = _resolve_llm_backend_for_models(backend)
     # Recognize the current shipped default AND prior-release shipped defaults
     # (#1324): a config persisted before a pin bump still holds the old literal,
-    # and for Claude-incapable backends it must normalize to the sentinel just
-    # like the current default would. Genuinely explicit, never-shipped ids are
-    # absent from this set and fall through to be preserved verbatim.
+    # and it must normalize exactly like the current default would. Genuinely
+    # explicit, never-shipped ids are absent from this set and are preserved
+    # verbatim.
     is_shipped_default = candidate in (
         *recognized_shipped_defaults(default_model),
         *extra_shipped_defaults,
     )
-    if resolved in _CODEX_LLM_BACKENDS and is_shipped_default:
-        return _CODEX_DEFAULT_MODEL
-    if resolved in _KIRO_LLM_BACKENDS and is_shipped_default:
-        return _KIRO_DEFAULT_MODEL
-    if resolved in _COPILOT_LLM_BACKENDS and is_shipped_default:
-        return _COPILOT_DEFAULT_MODEL
-    if resolved in _HERMES_LLM_BACKENDS and is_shipped_default:
-        return _HERMES_DEFAULT_MODEL
-    if resolved in _PI_LLM_BACKENDS and is_shipped_default:
-        return _PI_DEFAULT_MODEL
-    if resolved in _GJC_LLM_BACKENDS and is_shipped_default:
-        return _GJC_DEFAULT_MODEL
-    if resolved in _ANTIGRAVITY_LLM_BACKENDS and is_shipped_default:
-        return _ANTIGRAVITY_DEFAULT_MODEL
-    if resolved in _GROK_LLM_BACKENDS and is_shipped_default:
-        return _GROK_DEFAULT_MODEL
-    if resolved in _ZCODE_LLM_BACKENDS and is_shipped_default:
-        return _ZCODE_DEFAULT_MODEL
+    if is_shipped_default:
+        # A recognized shipped default — current or prior-release — is a pin
+        # the user never chose, so every backend maps it to its own default:
+        # Claude-incapable backends keep their sentinel as before, and
+        # Claude-capable backends now take the current default pin instead of
+        # leaking a retired id to the API (#2069). Never-shipped ids are
+        # deliberate user pins and fall through verbatim.
+        return _default_model_for_backend(default_model, backend=backend)
 
     return candidate
 

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -1945,6 +1945,53 @@ class TestLLMHelperLookups:
             assert get_semantic_model(backend=backend) == "default"
             assert get_assertion_extraction_model(backend=backend) == "default"
 
+    @pytest.mark.parametrize("backend", ["claude", None])
+    def test_legacy_shipped_defaults_normalize_on_claude_backends(
+        self, backend: str | None
+    ) -> None:
+        """Regression for #2069: the #1324 normalization only fired for
+        Claude-incapable backends, so a persisted legacy shipped default
+        (``claude-sonnet-4-20250514``) reached the Claude API verbatim and
+        was rejected as retired. Claude-capable backends must normalize
+        recognized legacy shipped defaults to the current default pin.
+        """
+        legacy_config = OuroborosConfig(
+            llm=LLMConfig(
+                qa_model="claude-sonnet-4-20250514",
+                dependency_analysis_model="claude-opus-4-6",
+                ontology_analysis_model="claude-sonnet-4-20250514",
+            ),
+            evaluation=EvaluationConfig(
+                assertion_extraction_model="claude-sonnet-4-20250514",
+            ),
+        )
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("ouroboros.config.loader.load_config", return_value=legacy_config),
+        ):
+            assert get_qa_model(backend=backend) == DEFAULT_SONNET_MODEL
+            # dependency_analysis recognizes the retired Opus family as
+            # shipped defaults and its current pin is the Sonnet default.
+            assert get_dependency_analysis_model(backend=backend) == DEFAULT_SONNET_MODEL
+            assert get_ontology_analysis_model(backend=backend) == DEFAULT_SONNET_MODEL
+            assert get_assertion_extraction_model(backend=backend) == DEFAULT_SONNET_MODEL
+            # The explicit legacy per-role field takes precedence over stage
+            # models (#2069) and resolves through the same getter, so the
+            # precedence path can no longer leak the retired id either.
+            assert get_llm_model_for_role("qa", backend=backend) == DEFAULT_SONNET_MODEL
+
+    def test_never_shipped_ids_survive_claude_normalization(self) -> None:
+        """A never-shipped id is a deliberate user pin and stays verbatim
+        on Claude-capable backends (#2069)."""
+        custom_config = OuroborosConfig(
+            llm=LLMConfig(qa_model="my-proxy/claude-custom-build"),
+        )
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("ouroboros.config.loader.load_config", return_value=custom_config),
+        ):
+            assert get_qa_model(backend="claude") == "my-proxy/claude-custom-build"
+
     def test_consensus_advocate_legacy_shipped_default_normalizes_to_sentinel(self) -> None:
         """A persisted legacy consensus advocate slug normalizes for Codex (#1324)."""
         legacy_config = OuroborosConfig(


### PR DESCRIPTION
Closes #2069.

## What

A recognized shipped default — current or prior-release — now normalizes on every backend, not only Claude-incapable ones. `_normalize_configured_model_for_backend()` maps it through the existing `_default_model_for_backend()` helper, so Claude-incapable backends keep their `"default"` sentinel exactly as before, and Claude-capable backends take the current default pin instead of returning the retired literal verbatim. Never-shipped ids are absent from the recognized set and still fall through untouched, so genuinely custom/proxy Claude ids are preserved.

This is the branch suggested in the issue, implemented by collapsing the per-backend ladder into the helper that already encodes the same mapping — the nine `resolved in _X_LLM_BACKENDS and is_shipped_default` branches were `_default_model_for_backend` restricted to the shipped-default case, so the gap was exactly the fallthrough this removes.

## Scope note from the issue

The reproduced case was `llm.qa_model`. The regression test also pins `dependency_analysis_model`, `ontology_analysis_model`, and `assertion_extraction_model`, which share the same normalization function — all normalize now. One nuance surfaced while writing the test: `dependency_analysis_model` recognizes the retired Opus family through `extra_shipped_defaults` and its current pin is the Sonnet default, so a persisted `claude-opus-4-6` there resolves to `claude-sonnet-4-6`, consistent with what a fresh config would hold. The `get_llm_model_for_role("qa")` legacy-precedence path is asserted too, since the explicit legacy field resolves through the same getter.

## Tests

- New RED-first regressions: legacy shipped defaults normalize on `backend="claude"` and on the default-resolved backend; a never-shipped id (`my-proxy/claude-custom-build`) stays verbatim.
- `tests/unit/config/`: 546 passed.
- The #1324 sentinel behavior for Claude-incapable backends is covered by the existing parametrized test and is unchanged.
- ruff, ruff format, mypy, and the module-size check pass. A wider sweep over suites referencing the legacy literals shows a failure set byte-identical to origin/main on this machine (known local macOS drift; CI is authoritative).
