### PR TITLE
docs(ko): hero claims replayable, not reproducible

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
   <br/>
   <sub>프롬프트를 일일이 짜지 않아도, 에이전트는 실행하고 실패하며 세대마다 똑똑해집니다. 채점 명령과 기대 결과값은 우리가 건네는 성공 계약 안에 들어가지 않습니다.</sub>
   <br/>
-  <sub>재현 가능한 AI 코딩 워크플로우를 위한 <strong>Agent OS</strong></sub>
+  <sub>재생 가능한 AI 코딩 워크플로우를 위한 <strong>Agent OS</strong></sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Closes #2098

One word in README.ko.md:23: 재현 가능한 (reproducible) → 재생 가능한 (replayable).

- Matches the English hero ("replayable AI coding workflows", README.md:23) and the product's own framing that agent work is non-deterministic while its records are replayable (README.md:64).
- Matches the Korean file's own body convention: README.ko.md:81 already renders "replayable event" as "재생 가능한 이벤트".
- The Chinese hero already has the correct counterpart (可重放).
- README.ko.md:348's "재현성" (scoring reproducibility at temperature 0.1) is a different, correct use and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)