### PR TITLE
Add MiniMax-M2.7 model metadata

### DIFF
--- a/src/ouroboros/providers/litellm_adapter.py
+++ b/src/ouroboros/providers/litellm_adapter.py
@@ -43,6 +43,27 @@ from ouroboros.providers.frugality_attestation import (
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
 
+_MINIMAX_MODEL_COST_OVERRIDES = {
+    "minimax/MiniMax-M2.7": {
+        "cache_creation_input_token_cost": 3.75e-7,
+        "cache_read_input_token_cost": 6e-8,
+        "input_cost_per_token": 3e-7,
+        "litellm_provider": "minimax",
+        "max_input_tokens": 204800,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-6,
+        "supports_function_calling": True,
+        "supports_prompt_caching": True,
+        "supports_reasoning": True,
+        "supports_system_messages": True,
+        "supports_tool_choice": True,
+    }
+}
+
+# Keep reviewed model metadata available while the optional dependency remains
+# exact-pinned for reproducible installs.
+litellm.register_model(_MINIMAX_MODEL_COST_OVERRIDES)
+
 if TYPE_CHECKING:
     from ouroboros.events.io_recorder import IOJournalRecorder
 

--- a/tests/unit/providers/test_litellm_adapter.py
+++ b/tests/unit/providers/test_litellm_adapter.py
@@ -41,6 +41,18 @@ def create_mock_response(
 class TestLiteLLMAdapterInit:
     """Test LiteLLMAdapter initialization."""
 
+    def test_registers_minimax_m27_model_metadata(self) -> None:
+        """The pinned LiteLLM registry includes the current MiniMax model."""
+        model_info = litellm.model_cost["minimax/MiniMax-M2.7"]
+
+        assert model_info["litellm_provider"] == "minimax"
+        assert model_info["max_input_tokens"] == 204800
+        assert model_info["input_cost_per_token"] == 3e-7
+        assert model_info["output_cost_per_token"] == 1.2e-6
+        assert model_info["cache_read_input_token_cost"] == 6e-8
+        assert model_info["cache_creation_input_token_cost"] == 3.75e-7
+        assert model_info["supports_reasoning"] is True
+
     def test_init_defaults(self) -> None:
         """LiteLLMAdapter initializes with sensible defaults."""
         adapter = LiteLLMAdapter()


### PR DESCRIPTION
Reason: Add current MiniMax model metadata to the pinned LiteLLM registry.

- Register MiniMax-M2.7 pricing, context, caching, and reasoning metadata through LiteLLM's public registry API.
- Add focused coverage for the registered metadata.

Checks:
- `.venv/bin/python -m pytest tests/unit/providers/test_litellm_adapter.py -q`
- `.venv/bin/ruff check src/ouroboros/providers/litellm_adapter.py tests/unit/providers/test_litellm_adapter.py`
- `.venv/bin/ruff format --check src/ouroboros/providers/litellm_adapter.py tests/unit/providers/test_litellm_adapter.py`
- `git diff --check`
