### PR TITLE
RFC: native Windows Codex Desktop HTTP task persistence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ replayable execution contract on your choice of runtime backend.
 ### Architecture
 
 - [System Architecture](./architecture.md) - Six-phase architecture, runtime abstraction layer, and core concepts
+- [Native-Windows Codex Desktop HTTP task persistence](./rfc/windows-codex-desktop-http-task.md) - Proposed explicit opt-in loopback HTTP MCP task for native Codex Desktop
 - [Routing B — Route Admission](./rfc/routing-b-route-admission.md) - Deterministic, provider-neutral route contract and Admission Kernel
 - [Routing C — Compatibility Projection](./rfc/routing-c-route-compat.md) - Bridge existing model/effort routing into the Admission Kernel
 - [Routing D — Bounded Escalation](./rfc/routing-d-bounded-escalation.md) - Route observations and finite next-route decisions

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -182,10 +182,13 @@ holding the transaction lock.
 An occupied endpoint is a third compound-state input. Occupancy while `TM` is
 Running is only a candidate prior managed action, never listener ownership
 proof. Explicit reconciliation may stop that exactly proven task and continue
-only if the endpoint is then vacant. Occupancy in every other case, or
-occupancy that remains after the managed stop, is a foreign/residual listener
-conflict and fails closed. No mode adopts a listener from its URL or
-self-reported MCP identity.
+only if the endpoint is then vacant. Except for the receipt-proven inactive
+uninstall path below, occupancy in every other case, or occupancy that remains
+after a managed reconciliation stop, is a foreign/residual listener conflict
+and fails closed. During receipt-proven inactive uninstall, an already-occupied
+endpoint is foreign cleanup context only: it is neither adopted nor touched
+and does not block removal of the exactly owned inactive task. No mode adopts
+a listener from its URL or self-reported MCP identity.
 
 `auto` and `preserve` never repair a compound state. `preserve` validates an
 existing usable command/URL entry and performs no task/configuration lifecycle
@@ -297,12 +300,32 @@ On post-mutation failure, rollback reports primary and rollback errors
 together; no PID handling is allowed. A read-back mismatch is a setup failure
 and MUST NOT start the task or write TOML.
 
-TOML mutation MUST reuse the existing Codex setup snapshot/CAS transaction:
-`_snapshot_path`, `_atomic_write_text_if_current_matches`, and
-`_restore_path_snapshot_if_current_matches`. It constructs complete intended
-bytes without touching the source, preserves unrelated bytes, and uses the
-existing same-directory temp-write, flush, atomic replace, and read-back proof.
-No second TOML transaction or retry path is introduced.
+TOML mutation MUST narrowly extend, not duplicate, the existing Codex setup
+snapshot transaction. It constructs complete intended bytes without touching
+the source and preserves unrelated bytes.
+`_atomic_write_text_if_current_matches` MUST compare the current link-aware
+snapshot immediately before replacement, atomically replace complete bytes
+through a flushed and closed same-directory temporary file, and return an
+immediate post-replace `_snapshot_path(path)` read-back rather than a synthetic
+regular-file snapshot. That read-back MUST show the intended complete bytes and
+the expected regular-file or unchanged-symlink topology; otherwise the write
+fails.
+
+Rollback first compares an immediate link-aware snapshot with the recorded
+forward read-back. For a prior regular file, it restores complete prior bytes
+by same-directory temporary write and atomic replace. For a prior symlink, it
+requires the same link and exact recorded forward target snapshot, atomically
+replaces the target through a temporary file in the target directory, and MUST
+NOT unlink or recreate the symlink. For prior absence, it may unlink only a
+regular file whose immediate snapshot exactly equals the recorded forward
+regular-file snapshot. Every restoration is followed immediately by an exact
+`_snapshot_path(path)` read-back; an observed pre-mutation or read-back mismatch
+is an ownership conflict.
+
+These are compare-immediately-before-mutate checks, not a race-free
+operating-system compare-and-swap. A non-cooperating mutation after the final
+comparison remains the bounded TOCTOU risk stated below. V1 MUST NOT add a
+generalized file transaction, file-locking, retry, or journaling subsystem.
 
 If failure occurs after TOML replacement begins, rollback restores TOML before
 the task through the existing compare-before-restore contract. Exact prior
@@ -345,31 +368,45 @@ invocation is fresh consent to finish removal of the exactly proven task; exact
 `C0` is recorded as prior state and remains a no-op throughout. Every other
 incomplete, foreign, or mismatched state fails closed.
 
-Uninstall re-proves projection/Source before `End`, proves every InstanceGuid
-ceased plus task non-Running and port release, then atomically removes and
-verifies only the exact managed TOML entry for `TM + CM`; for `TM + C0`, it
-instead re-proves that TOML remains exactly absent without writing it. It
-re-proves projection/Source before deleting the task. Delete alone never counts
-as process cessation.
+Immediately before each `End`, TOML cleanup or absence proof, and `Delete`,
+uninstall MUST re-query and re-prove projection, Source, task state, and current
+InstanceGuids. If the receipt recorded a running instance, or if any new
+InstanceGuid is observed before a mutation, uninstall switches to the bounded
+`End`/cessation branch: it re-proves ownership, ends every observed instance,
+and proves each InstanceGuid ceased plus task non-Running before continuing.
+Failure of that proof preserves the task and configuration.
 
-After a post-End failure while the task is still present, rollback restores
-TOML first when `TM + CM` changed it; `TM + C0` retains exact absence. It then
-re-proves the stopped task and vacancy and restarts with a new InstanceGuid
-plus MCP readiness only when the receipt recorded a prior running instance;
-an inactive prior task remains inactive. An ambiguous delete is re-queried:
-proven absence with exact `C0` is the intended `T0 + C0` terminal state, while
-proven presence uses the rollback path above. Ownership conflict preserves
-observed artifacts and reports primary-first.
+A receipt-observed running task additionally requires port release before
+cleanup. A receipt-observed inactive task never requires vacancy during that
+uninstall; any listener remains foreign and untouched even if a newly observed
+managed InstanceGuid must be ended and proven ceased.
+
+Uninstall then atomically removes and verifies only the exact managed TOML
+entry for `TM + CM`; for `TM + C0`, it instead re-proves exact absence without
+writing it. It performs the required immediate ownership/state/InstanceGuid
+re-query before deleting the task. Delete alone never counts as process
+cessation.
+
+After any failure following `End` or TOML cleanup while the task remains
+present, rollback restores TOML first when `TM + CM` changed it; `TM + C0`
+retains exact absence. It re-proves the stopped task and restarts only when the
+receipt recorded a prior running instance, using vacancy, a new InstanceGuid,
+and MCP readiness proof. A receipt-observed inactive task remains inactive and
+requires no vacancy for rollback. An ambiguous delete is re-queried: proven
+absence with exact `C0` is the intended `T0 + C0` terminal state, while proven
+presence uses the rollback path above. Ownership conflict preserves observed
+artifacts and reports primary-first.
 
 Interruption before proven deletion leaves exact `TM + CM` or `TM + C0`;
 interruption after proven deletion leaves `T0 + C0`. A later explicit
 operation reclassifies those states and repeats the same bounded path.
 
-If End, InstanceGuid cessation, or port-release proof fails, preserve task and
-configuration and report the failure. Native evidence proves End changes a
-test task from Running to Ready/`267014` and terminates its action; real MCP
-End/port-release behavior remains required validation before implementation
-merge. If it fails, stop for RFC review rather than adding a PID framework.
+If End, InstanceGuid cessation, or a required port-release proof fails,
+preserve task and configuration and report the failure. Native evidence proves
+End changes a test task from Running to Ready/`267014` and terminates its
+action; real MCP End/port-release behavior remains required validation before
+implementation merge. If it fails, stop for RFC review rather than adding a
+PID framework.
 
 V1 does not migrate or clean up stdio installations. Existing stdio and other
 user-managed TOML entries remain byte-for-byte preserved. No broad scan,
@@ -474,20 +511,29 @@ A later implementation PR is acceptable only if it proves all of these:
     reported as an ownership-conflict rollback failure; replacement rollback
     restores exact prior XML/state and its prior Source only when the current
     Source is the receipt's `forward_write_id`.
-15. The existing Codex snapshot/CAS transaction captures exact prior whole-TOML
-    bytes/absence; same-directory atomic write/read-back and compare-before-
-    restore pass injected concurrent and post-write failures.
+15. The existing Codex snapshot transaction captures exact prior whole-TOML
+    bytes or absence. A forward snapshot-checked write returns an immediate
+    truthful link-aware `_snapshot_path` read-back. Rollback atomically replaces
+    complete regular-file or symlink-target bytes without replacing the symlink
+    itself; prior absence unlinks only a regular file matching the recorded
+    forward snapshot. Tests cover regular files, symlinks, prior absence,
+    mismatch before the final comparison, failure before replacement, and
+    mismatch in the immediate post-replace read-back. The implementation does
+    not claim race-free filesystem compare-and-swap.
 16. Rollback restores exact prior TOML before task rollback; for prior
     `TM + C0`, it instead restores or retains exact absence and never
     synthesizes TOML. TOML ownership conflict preserves the serving task, and
     rollback diagnostics never mask the primary error.
-17. Uninstall from exact `TM + CM` or exact `TM + C0` stops before cleanup,
-    proves Ready/not Running and port release, then re-proves and deletes only
-    the exact managed task. `TM + CM` atomically cleans only exact managed
-    TOML; `TM + C0` treats verified absence as an already-satisfied no-op.
-    Every failure stage follows the specified conditional restart, vacancy,
-    InstanceGuid, readiness, and conflict-preserve rules, including
-    fault-injected ambiguous delete.
+17. Uninstall immediately re-proves ownership, state, and InstanceGuids before
+    every `End`, TOML mutation or absence proof, and `Delete`. A
+    receipt-observed running instance, or any newly observed InstanceGuid,
+    enters the bounded `End`/cessation branch before cleanup. Receipt-observed
+    running state requires port release. Receipt-observed inactive state never
+    requires vacancy during that uninstall; any foreign listener remains
+    untouched and cannot block cleanup. Failure after either `End` or
+    inactive-path TOML cleanup follows the same receipt-conditional rollback
+    rules. The exact managed task alone is deleted, and `TM + C0` never
+    synthesizes TOML.
 18. Fault injection after every durable setup, `TM + C0` recovery, and
     uninstall boundary, followed by abandoned-mutex reclassification, proves
     repeated explicit `http-task` converges to `TM + CM` and repeated uninstall
@@ -513,10 +559,13 @@ to the exact prior partial state without automatic repair.
 
 Risks are fixed-port contention, one-minute launch delay, cooperative-trust
 loopback impersonation, non-cooperating external mutation, and unverified
-session boundaries. This RFC does not provide multi-user support, remote
-access, strong local authentication, administrator/malware protection, hung
-recovery, zero-downtime replacement, generalized task management, or
-non-Windows change.
+session boundaries. Non-cooperating TOML mutation between the final snapshot
+comparison and filesystem replacement or unlink is a residual TOCTOU risk.
+Snapshot equality also cannot distinguish an identical ABA recreation; v1
+introduces no generalized filesystem transaction or durable file identity.
+This RFC does not provide multi-user support, remote access, strong local
+authentication, administrator/malware protection, hung recovery, zero-downtime
+replacement, generalized task management, or non-Windows change.
 
 Alternatives rejected: native Codex-owned stdio child; `RestartOnFailure`;
 service/supervisor; dynamic/per-SID port in v1; bearer-token lifecycle; and an

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -137,16 +137,36 @@ The complete v1 projection is:
 | Other triggers | Absent, including boot, idle, time, calendar, event, session-state-change, and custom triggers |
 | Instance policy | `MultipleInstancesPolicy=IgnoreNew` |
 | Battery | `DisallowStartIfOnBatteries=false`, `StopIfGoingOnBatteries=false` |
-| Lifetime | `ExecutionTimeLimit=PT0S`, `DeleteExpiredTaskAfter` absent, `RestartOnFailure` absent |
+| Lifetime | `ExecutionTimeLimit=PT0S`, `DeleteExpiredTaskAfter` absent, `RestartOnFailure` absent (therefore its `Interval` and `Count` children are absent) |
 | Availability | `Enabled=true`, `AllowStartOnDemand=true`, `StartWhenAvailable=false`, `WakeToRun=false`, `Hidden=false` |
-| Other settings | `AllowHardTerminate=true`, `RunOnlyIfNetworkAvailable=false`, `IdleSettings.StopOnIdleEnd=true`, `IdleSettings.RestartOnIdle=false`, `UseUnifiedSchedulingEngine=true`, network/maintenance settings absent, `Volatile=false` |
+| Idle | `RunOnlyIfIdle=false`; exactly one `IdleSettings` with `StopOnIdleEnd=true`, `RestartOnIdle=false`, and `Duration`/`WaitTimeout` absent |
+| Network | `RunOnlyIfNetworkAvailable=false`; `NetworkProfileName` and `NetworkSettings` absent (therefore `NetworkSettings.Name`/`Id` absent) |
+| Scheduler compatibility | `UseUnifiedSchedulingEngine=true`; `DisallowStartOnRemoteAppSession=false`; `Compatibility` absent |
+| Priority | `Priority=7` (the Task Scheduler default priority) |
+| Maintenance | `MaintenanceSettings` absent (therefore `Period`, `Deadline`, and `Exclusive` absent) |
+| Other settings | `AllowHardTerminate=true`, `Volatile=false` |
+
+The rows above are the complete v1 treatment of the Task Scheduler
+`SettingsType` surface, not examples. In schema order, every setting is
+accounted for: `AllowStartOnDemand`, `RestartOnFailure`,
+`MultipleInstancesPolicy`, `DisallowStartIfOnBatteries`,
+`StopIfGoingOnBatteries`, `AllowHardTerminate`, `StartWhenAvailable`,
+`NetworkProfileName`, `RunOnlyIfNetworkAvailable`, `WakeToRun`, `Enabled`,
+`Hidden`, `DeleteExpiredTaskAfter`, `IdleSettings`, `NetworkSettings`,
+`ExecutionTimeLimit`, `Priority`, `RunOnlyIfIdle`, `Compatibility`,
+`UseUnifiedSchedulingEngine`, `DisallowStartOnRemoteAppSession`,
+`MaintenanceSettings`, and `Volatile`. A field introduced by a newer root
+schema version is unconsumed and therefore foreign until a later RFC assigns
+it canonical treatment.
 
 For this table only, absent is equivalent to the documented Task Scheduler
 default for `ProcessTokenSidType=Default`, `RunLevel=LeastPrivilege`, trigger `Enabled=true`,
 `StopAtDurationEnd=false`, settings `Enabled=true`, `AllowStartOnDemand=true`,
 `StartWhenAvailable=false`, `WakeToRun=false`, `Hidden=false`,
 `AllowHardTerminate=true`, `RunOnlyIfNetworkAvailable=false`, and
-`Volatile=false`. Explicit and absent values are not equivalent anywhere else;
+`Volatile=false`, `RunOnlyIfIdle=false`,
+`DisallowStartOnRemoteAppSession=false`, and `Priority=7`. Explicit and absent
+values are not equivalent anywhere else;
 in particular, `ExecutionTimeLimit` MUST semantically be `PT0S`.
 
 The root Task Scheduler namespace and an OS-supported root schema-version
@@ -499,10 +519,15 @@ A later implementation PR is acceptable only if it proves all of these:
     actions even when a launcher with a similar name resolves now.
 12. Canonical-projection tests cover every listed principal, action,
     working-directory, trigger, repetition, instance, battery, lifetime,
-    on-demand, hidden, start-when-available, wake, and other-setting field;
+    on-demand, hidden, start-when-available, wake, and every field in the
+    complete `SettingsType` inventory above. Table-driven mutations exercise
+    each accepted value, each required absence, and each explicitly allowed
+    absent/default pair (including `Priority=7`, `RunOnlyIfIdle=false`, and
+    `DisallowStartOnRemoteAppSession=false`);
     unknown fields, duplicates, and non-equivalent defaults are foreign while
-    only the closed normalization rules are equal; native create/query
-    round-trip and exact `CommandLineToArgvW` token tests pass.
+    only the closed normalization rules are equal. Native create/query
+    round-trip tests assert the entire projected settings record before any
+    lifecycle operation, and exact `CommandLineToArgvW` token tests pass.
     The accepted action projection includes the explicit
     `--runtime codex --llm-backend codex` selectors for every permitted
     executable prefix; omitting either selector is foreign and a fresh

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -52,7 +52,7 @@ The one canonical action is a direct absolute resolved Ouroboros launcher
 `Exec` with this fixed suffix:
 
 ```text
-mcp serve --transport streamable-http --host 127.0.0.1 --port 8765
+mcp serve --runtime codex --llm-backend codex --transport streamable-http --host 127.0.0.1 --port 8765
 ```
 
 There is no generated PowerShell runner, script wrapper, alternative launcher
@@ -503,6 +503,11 @@ A later implementation PR is acceptable only if it proves all of these:
     unknown fields, duplicates, and non-equivalent defaults are foreign while
     only the closed normalization rules are equal; native create/query
     round-trip and exact `CommandLineToArgvW` token tests pass.
+    The accepted action projection includes the explicit
+    `--runtime codex --llm-backend codex` selectors for every permitted
+    executable prefix; omitting either selector is foreign and a fresh
+    scheduled action must start successfully without relying on global runtime
+    configuration.
 13. A forward write read-back Source/definition mismatch fails before start,
     readiness, or TOML; exact UUID-owned fresh rollback restores absence only
     after End, exact InstanceGuid cessation, and port-closed proof before

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -1,0 +1,342 @@
+# Native-Windows Codex Desktop HTTP task persistence
+
+Status: **Proposed**  
+Related: #2024, #2056, #2026
+
+## Summary
+
+This documentation-only RFC proposes an experimental native-Windows persistence
+path for Codex Desktop MCP. It freezes a deliberately thin design before an
+implementation PR. Approval of this RFC gates that later PR; it does not
+approve implementation or rollout.
+
+Native Codex Desktop uses a loopback streamable-HTTP MCP server maintained by
+one Windows Task Scheduler task, not a Codex-owned stdio child. Codex TOML is
+written only after task and MCP readiness. User-managed entries are preserved,
+and non-Windows behavior is unchanged.
+
+## Scope and constants
+
+This applies only to native Windows (not WSL), Codex Desktop, and explicit
+`--mcp-mode http-task`. The v1 endpoint is exactly:
+
+```text
+http://127.0.0.1:8765/mcp
+```
+
+That exact URL is served by the direct action, used by the readiness probe, and
+written to managed Codex TOML; the streamable-HTTP route MUST be `/mcp`. The
+server MUST bind loopback only, never a remote interface.
+
+The task identities are fixed:
+
+| Field | Exact value |
+| --- | --- |
+| Task folder | `\Ouroboros` |
+| Task name | `Codex Desktop MCP (<canonical SID>)` |
+| Description | `ouroboros-codex-desktop-mcp-v1` |
+| Managed TOML comment | `# Managed by Ouroboros native-Windows Codex Desktop HTTP task v1` |
+
+`<canonical SID>` is the current resolved Windows SID in its canonical string
+form. Each successful forward task-definition write generates a UUIDv4 and sets
+`RegistrationInfo.Source` exactly to
+`ouroboros-codex-desktop-mcp-v1:<UUIDv4>`. This is a non-secret, non-ordered
+write identity only: it is not a generation counter, lifecycle token, service
+registry, or compatibility framework.
+
+The exact Source grammar is
+`^ouroboros-codex-desktop-mcp-v1:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`.
+
+The one canonical action is a direct absolute resolved Ouroboros launcher
+`Exec` with this fixed suffix:
+
+```text
+mcp serve --transport streamable-http --host 127.0.0.1 --port 8765
+```
+
+There is no generated PowerShell runner, script wrapper, alternative launcher
+shape, or action alias.
+
+For stored-task ownership proof, executable basenames are case-insensitively
+limited to `uvx.exe`, `ouroboros.exe`, and `python.exe`. Their corresponding
+managed argument prefixes are, respectively:
+
+```text
+--isolated --python >=3.12 --from ouroboros-ai[mcp] ouroboros
+(empty)
+-m ouroboros
+```
+
+Exactly one of those prefixes, followed immediately by the fixed suffix above,
+is permitted. This freezes the supported launcher families and prevents
+lookalikes; the absolute executable path itself is deliberately not compared
+with the launcher resolved now and may have moved or disappeared.
+
+The exact managed TOML form is the comment immediately followed by this
+URL-only table:
+
+```toml
+# Managed by Ouroboros native-Windows Codex Desktop HTTP task v1
+[mcp_servers.ouroboros]
+url = "http://127.0.0.1:8765/mcp"
+```
+
+## Ownership, proof, and preservation
+
+A **managed task** has the exact identity above, a Source with the exact prefix
+and a valid UUIDv4, and all normalized XML fields required below. A **managed
+HTTP entry** is the exact marked TOML form above. A **foreign** task, listener,
+or entry is anything not so proven. Cleanup proof parses stored normalized XML,
+not the launcher available now, and requires folder/name, description, Source,
+principal SID/logon type/run level, the one absolute direct `Exec` in a frozen
+launcher shape above, trigger types/repetition, multiple-instance policy, both
+battery flags, execution limit, and on-demand setting. Unknown or edited
+shapes are foreign and preserved.
+
+Immediately before every forward mutation, rollback mutation, `End`, `Delete`,
+or restore, the implementation MUST re-query the task and compare its
+normalized definition and Source to the expected value. The Source alone is
+insufficient; structural proof is always required. There are no aliases.
+
+“Preserve” for a user-managed entry means byte-for-byte preservation: no
+rewrite, normalization, reordering, or lifecycle mutation. For an existing
+managed HTTP entry, preserve means validate that the exact entry is usable,
+then make no task or configuration lifecycle mutation.
+
+The task ownership marker alone is insufficient; exact normalized definition
+proof is required. Likewise, URL similarity never authorizes TOML edits.
+
+## Mode and state contract
+
+| Native Windows mode/state | Required behavior |
+| --- | --- |
+| `auto` + absent | Do not create task/configuration; report MCP disabled and point to `--mcp-mode http-task`. |
+| `auto` + user-managed entry | Preserve its bytes; report it preserved. |
+| `auto` + managed HTTP entry | Preserve task and TOML; report already opted in, not disabled. |
+| `auto` + any other state | Do not install, migrate, or mutate persistence/configuration; report the detected state. |
+| `preserve` | Validate an existing usable command/URL entry and perform no task/configuration lifecycle mutation; absence or an unusable entry retains existing error behavior. |
+| explicit `http-task` | The only consent path; create or reconcile only the exact managed task and HTTP entry. |
+| explicit `stdio` | Refuse before mutation; warn that native Codex Desktop stdio is the crash-triggering topology from #2024, and direct users to explicit `http-task` or WSL. |
+
+Existing user-managed entries, including stdio, remain byte-for-byte unchanged.
+A fresh native `auto` setup MUST NOT silently write stdio or install
+persistence. WSL guidance remains for stdio.
+
+## Scheduled-task contract
+
+`http-task` creates at most one deterministic task for the current SID, at the
+fixed folder and name. It MUST be visible and discoverable in Task Scheduler.
+
+| Property | Required value |
+| --- | --- |
+| Principal | Current SID, medium integrity, least privilege |
+| Logon type | `InteractiveToken` |
+| Action | Exact canonical direct absolute `Exec` above |
+| Ownership | Exact description above |
+| Write identity | `RegistrationInfo.Source` format above, newly generated per successful forward definition write |
+| Multiple instances | `IgnoreNew` |
+| Battery start | `DisallowStartIfOnBatteries=false` |
+| Battery transition | `StopIfGoingOnBatteries=false` |
+| Execution limit | No execution time limit |
+| Manual action | Allow on-demand start |
+
+The task has (1) a `RegistrationTrigger` with indefinite one-minute repetition
+for current-session launch attempts and (2) a per-SID `LogonTrigger` for future
+logons. This is periodic 0–60 second relaunch eligibility, not failure-aware
+restart. `IgnoreNew` suppresses a new action while one runs. It does not recover
+hung processes.
+
+The design MUST NOT configure, use, or claim `RestartOnFailure`, a service,
+supervisor, daemon, process monitor, mutex/lease framework, PID registry,
+ordered task generations, parallel replacement tasks, task-prefix cleanup,
+zero-downtime handoff, or launcher-shape compatibility framework. Cooperative
+setup/uninstall commands are serialized only by normal CLI usage: simultaneous
+setup/uninstall is unsupported, and no mutex is added.
+
+## Endpoint and security boundary
+
+V1 retains the fixed endpoint to avoid a port broker, state, discovery, and
+coordination complexity. It supports only one active Windows user per machine.
+Port-vacancy errors MUST say another Windows user or process may own the
+endpoint. Per-SID port derivation is follow-up work, not v1.
+
+This has a local cooperative-trust limitation: another local process/account
+can bind or impersonate loopback. Fresh setup requires port vacancy and MUST
+NOT adopt a listener based only on self-reported identity. No bearer-token
+secret lifecycle is introduced. Strong local-user isolation/authentication is
+follow-up work; administrators and same-user malware are non-goals.
+
+## Setup and rollback transaction
+
+Setup proceeds in this order:
+
+1. Resolve current canonical SID and the fixed task identity.
+2. Preflight exact task ownership and endpoint vacancy; a same-name foreign
+   task or foreign listener fails closed.
+3. Record a receipt containing prior absence, or the prior exact managed XML,
+   prior Source, and whether that prior task was running. Generate the new
+   Source UUID as `forward_write_id`.
+4. Immediately before the forward definition write, re-query and compare the
+   expected prior normalized definition and Source (or absence), then create
+   without `/F` unless exact managed ownership was just proven.
+5. Read back the just-written task and prove its normalized definition and
+   Source equal the intended definition and `forward_write_id` before start,
+   readiness, or TOML.
+6. Immediately before start or reconciliation, re-query and re-prove the
+   written definition and `forward_write_id`.
+7. Start or reconcile the exact managed task.
+8. Require readiness: task Running **and** successful MCP identity probe at the
+   exact endpoint.
+9. Immediately before the TOML write, re-query and re-prove the written
+   definition and `forward_write_id`; only then write the exact marked HTTP
+   entry.
+
+On post-mutation failure, rollback reports primary and rollback errors
+together; no PID handling is allowed. A read-back mismatch is a setup failure
+and MUST NOT start the task or write TOML.
+
+For prior absence, fresh rollback re-queries the task and may `End`/`Delete`
+only when its Source equals `forward_write_id` and its definition is the
+written definition. It then uses `schtasks End`, proves it is not Running and
+the port is no longer listening, re-queries the unchanged written definition
+and `forward_write_id` immediately before delete, then deletes it and restores
+absence. If the task is missing or its Source differs, it MUST preserve it and
+report an ownership-conflict rollback failure.
+
+For prior managed XML, replacement rollback re-queries before every mutation
+and may End or restore the prior XML only while the current Source equals
+`forward_write_id` and the written definition matches. The restored XML
+retains its prior Source; before a receipt-authorized restart, rollback
+re-queries and proves that restored XML and prior Source. A missing or
+different Source is an ownership-conflict rollback failure and is preserved;
+definition equality alone never authorizes rollback. When authorized, rollback
+proves cessation, restarts only when the receipt says it was running, and
+verifies prior readiness. It MUST NOT write a new TOML entry after failed
+readiness.
+
+A foreign task is never overwritten, adopted, ended, or deleted. Replacement is
+allowed only after exact managed proof. `/F` is prohibited for new or unproven
+ownership.
+
+## Uninstall and migration
+
+Uninstall/migration first revalidates exact managed ownership and normalized
+XML, including any valid managed Source UUID and the stored structural action
+shape, independently of whether the current launcher can be resolved. It
+re-queries immediately before `End` and `Delete`, requiring unchanged
+normalized XML and Source. It then uses `schtasks End`, proves task Ready/not
+Running and endpoint unavailable, deletes the task, and only then performs
+exact managed TOML cleanup. `schtasks Delete` alone does not stop a running
+action.
+
+If End or cessation proof fails, preserve task and configuration and report the
+failure. Native evidence proves End changes a test task from Running to
+Ready/`267014` and terminates its action; real MCP End/port-release behavior
+remains required validation before implementation merge. If it fails, stop for
+RFC review rather than adding a PID framework.
+
+Exact managed stdio cleanup/migration is allowed only for exact ownership.
+Foreign TOML entries and tasks are preserved. No broad scan, implicit
+stdio-to-HTTP migration, or task-prefix cleanup is allowed.
+
+## Protocol readiness probe
+
+Following Q00’s non-blocking direction, this is a narrow probe, not an
+expansive SDK-client lifecycle proposal. It sends JSON-RPC `initialize` using
+the implementation-selected request version and retains exact envelope and
+response structural validation. It requires:
+
+- `serverInfo.name == "ouroboros-mcp"`;
+- a non-empty `serverInfo.version`; and
+- a negotiated `protocolVersion` that is a real Gregorian calendar date in
+  `YYYY-MM-DD` form, not merely a lexically well-formed string or exact version
+  equality.
+
+Codex negotiates independently. The implementation PR MUST test acceptance of
+a valid future protocol-version date.
+
+## Diagnostics
+
+For every setup, readiness, rollback, uninstall, or migration failure, report
+in this normative order: (1) primary error; (2) bounded `schtasks` return code,
+stdout, and stderr; (3) best-effort task state and `LastTaskResult`; then (4)
+`~/.ouroboros/logs/ouroboros.log`. Diagnostic collection failure MUST NOT mask
+the primary error. Scheduler Operational history may be disabled and cannot be
+required.
+
+## Native evidence appendix (2026-08-12)
+
+Environment: Windows 11 Pro `10.0.26200`, medium integrity. The following are
+native observations, not guarantees beyond their stated conditions. Private
+probe artifacts are local evidence, not shipped files.
+
+| Probe/settings/action | Observation |
+| --- | --- |
+| Least-privilege XML task create/query/run/end/delete | All operations succeeded without elevation. |
+| `RestartOnFailure` `PT1M`, count `3`; action exits `7` | No relaunch observed. |
+| Same recovery setting; action terminated `0xC0000005` | No relaunch observed. |
+| Registration trigger + indefinite one-minute repetition; `0xC0000005` action | Relaunched at minute ticks and recovered on third start. |
+| `IgnoreNew`; 130-second action | One instance; duplicate suppressed. |
+| `schtasks End` on running test action | State changed to Ready/`267014`; action terminated. |
+
+Logoff/logon, reboot, and real MCP End/port-release boundaries were not
+exercised. They are required native validation before implementation merge.
+The evidence does not establish failure-aware restart or hung-process recovery.
+
+## Normative acceptance criteria
+
+A later implementation PR is acceptable only if it proves all of these:
+
+1. Every mode/state-table case: absent, exact managed, user-managed, and
+   same-name foreign/edited-managed behavior.
+2. Native `auto` creates no persistence/configuration; managed HTTP reports
+   already opted in; user entries remain byte-for-byte unchanged.
+3. `preserve` validates a usable command/URL entry without task/configuration
+   lifecycle mutation; absence or unusable input retains existing error behavior.
+4. Native explicit `stdio` is refused before mutation with the #2024
+   crash-topology warning and `http-task`/WSL direction.
+5. `http-task` creates the exact folder/name/description/action/endpoint,
+   current-SID medium-integrity `InteractiveToken` task with `IgnoreNew`, both
+   specified battery flags, no execution limit, on-demand start, and a fresh
+   valid managed Source UUID on each successful forward definition write.
+6. Trigger behavior is registration repetition plus per-SID logon trigger, with
+   no `RestartOnFailure` configuration or claim.
+7. Fresh setup fails closed for foreign task/listener and identifies another
+   Windows user or process as a potential endpoint owner.
+8. TOML writes occur only after task-Running plus MCP identity readiness;
+   protocol probing accepts a valid future real Gregorian date version.
+9. Cleanup/uninstall recognizes a structurally managed stored task when its
+   launcher path has moved or disappeared, but preserves edited or lookalike
+   actions even when a launcher with a similar name resolves now.
+10. A forward write read-back Source/definition mismatch fails before start,
+    readiness, or TOML; exact UUID-owned fresh rollback restores absence only
+    after End, non-Running, and port-closed proof before delete.
+11. An identical ABA recreation with a different Source is preserved and
+    reported as an ownership-conflict rollback failure; replacement rollback
+    restores exact prior XML/state and its prior Source only when the current
+    Source is the receipt's `forward_write_id`.
+12. Uninstall/migration stops before delete, proves Ready/not Running and port
+    release, then cleans only exact managed TOML; failure preserves both.
+13. Diagnostics retain primary-error-first ordering even when diagnostics fail.
+14. Native logoff/logon, reboot, and real-MCP End/port-release validation pass.
+
+## Size guard, rollout, risks, and non-goals
+
+Implementation plus uninstall helpers SHOULD remain roughly at or below 300
+product lines. Exceeding it MUST stop for RFC review; tests/fixtures do not
+justify hiding a lifecycle framework.
+
+Rollout is explicit opt-in and experimental: no automatic migration or silent
+`auto` enablement. Rollback is only the receipt procedure above or exact
+managed uninstall; it never alters foreign tasks, listeners, or entries.
+
+Risks are fixed-port contention, one-minute launch delay, cooperative-trust
+loopback impersonation, unsupported concurrent commands, and unverified session
+boundaries. This RFC does not provide multi-user support, remote access, strong
+local authentication, administrator/malware protection, hung recovery,
+zero-downtime replacement, generalized task management, or non-Windows change.
+
+Alternatives rejected: native Codex-owned stdio child; `RestartOnFailure`;
+service/supervisor; dynamic/per-SID port in v1; bearer-token lifecycle; and an
+SDK-managed persistent client. Each either contradicts native evidence,
+expands lifecycle scope, or exceeds Q00’s probe direction.

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -1,6 +1,6 @@
 # Native-Windows Codex Desktop HTTP task persistence
 
-Status: **Proposed**  
+Status: **Proposed**
 Related: #2024, #2056, #2026
 
 ## Summary
@@ -173,7 +173,7 @@ holding the transaction lock.
 | `T0 + C0` | Absent. `auto` performs no mutation and points to explicit `http-task`; explicit `http-task` may install. |
 | `T0 + CU` | User-managed configuration. Preserve its bytes in every automatic mode; explicit `http-task` refuses to overwrite it. |
 | `TM + CM` | The only managed installation. `auto` may report already opted in only after proving both artifacts; explicit `http-task` may reconcile it. |
-| `TM + C0` | Incomplete managed task only. Fail closed and preserve; do not synthesize or adopt TOML. |
+| `TM + C0` | Recoverable exact managed task-only state. `auto` and `preserve` fail closed and preserve it. Explicit `http-task` may complete it to exact `TM + CM` through the normal reconciliation transaction; uninstall may remove the exactly proven task to `T0 + C0` without creating or restoring TOML. No other operation may mutate it. |
 | `T0 + CM` | Stale managed TOML only. Fail closed and preserve; do not synthesize or adopt a task. |
 | `TX + CM` | Foreign/edited same-name task plus managed TOML. Fail closed and preserve both. |
 | `TM + CU` or `TM + CX` | Managed task plus foreign, user-managed, or edited TOML. Fail closed and preserve both. |
@@ -190,10 +190,13 @@ self-reported MCP identity.
 `auto` and `preserve` never repair a compound state. `preserve` validates an
 existing usable command/URL entry and performs no task/configuration lifecycle
 mutation; absence or unusable input retains existing error behavior. Explicit
-`http-task` is the only consent path and may mutate only `T0 + C0` or exact
-`TM + CM`. Explicit `stdio` refuses before mutation, warns that native Codex
-Desktop stdio is the crash-triggering topology from #2024, and directs users to
-explicit `http-task` or WSL.
+`http-task` is the only setup consent path and may mutate only `T0 + C0`,
+exact `TM + C0`, or exact `TM + CM`. For `TM + C0`, the explicit operation
+selects the terminal state without inferring whether setup, uninstall, or a
+manual TOML removal produced it: `http-task` completes installation, while
+explicit uninstall removes it. Explicit `stdio` refuses before mutation, warns
+that native Codex Desktop stdio is the crash-triggering topology from #2024,
+and directs users to explicit `http-task` or WSL.
 
 Existing user-managed entries, including stdio, remain byte-for-byte unchanged.
 A fresh native `auto` setup MUST NOT silently write stdio or install
@@ -248,7 +251,7 @@ malware are non-goals.
 
 ## Transaction serialization
 
-Setup, reconciliation, rollback, migration, uninstall, and compound-state
+Setup, reconciliation, rollback, uninstall, and compound-state
 classification use the exact SID-scoped named Windows mutex above, restricted
 to the current SID and `SYSTEM`. Acquire it before the first task, endpoint, or
 TOML read and hold it through success or complete rollback; nested rollback
@@ -256,18 +259,29 @@ reuses it. Creation, ACL verification, or bounded-acquisition failure stops
 before mutation. After an abandoned mutex, reclassify all durable state.
 Immediate re-proof remains mandatory against non-cooperating external edits.
 
+Every receipt in this RFC is an in-memory, process-local transaction record
+discarded when the command exits. V1 MUST NOT add a durable receipt, journal,
+registry, generation store, recovery command, service, supervisor, PID record,
+or migration artifact. `RegistrationInfo.Source` remains only the task-local
+ABA write identity defined above. After an abandoned mutex, a new explicit
+operation may classify exact `TM + C0` and snapshot its current exact
+projection, Source, running InstanceGuids, and `C0` as that operation's prior
+state; automatic modes still preserve it without mutation.
+
 ## Setup and rollback transaction
 
 Setup proceeds in this order:
 
-1. Acquire the lock, classify state, and continue only from `T0 + C0` or exact
-   `TM + CM`. Record prior task XML/projection/Source/running InstanceGuids and
-   the existing Codex `_PathSnapshot` for TOML, including absence or exact
-   whole-file bytes; generate `forward_write_id`.
-2. For `TM + CM`, re-prove and `End` every running prior instance. Prove all
-   ceased, task not Running, and port vacant. `T0 + C0` also requires vacancy.
-   A pre-write failure restarts a receipt-authorized prior run only through
-   projection/Source, vacancy, new InstanceGuid, and readiness proof.
+1. Acquire the lock, classify state, and continue only from `T0 + C0`, exact
+   `TM + C0`, or exact `TM + CM`. Record prior task
+   XML/projection/Source/running InstanceGuids and the existing Codex
+   `_PathSnapshot` for TOML, including absence or exact whole-file bytes;
+   generate `forward_write_id`.
+2. For `TM + C0` or `TM + CM`, re-prove and `End` every running prior instance.
+   Prove all ceased, task not Running, and port vacant. `T0 + C0` also requires
+   vacancy. A pre-write failure restarts a receipt-authorized prior run only
+   through projection/Source, vacancy, new InstanceGuid, and readiness proof;
+   an inactive prior task remains inactive.
 3. Prove no running instance, re-prove prior ownership or absence, write the
    definition, then read back its exact projection and `forward_write_id`.
 4. Start through Task Scheduler COM and capture the unique new
@@ -276,7 +290,8 @@ Setup proceeds in this order:
    Zero, multiple, pre-existing, or unprovable instances fail.
 5. Before and after MCP identity readiness, re-prove the projection, Source,
    and exact Running `forward_run_id`. Preserve existing `TM + CM` TOML; for
-   fresh setup only, atomically write the marked entry after those proofs.
+   `T0 + C0` or `TM + C0`, atomically write the marked entry only after those
+   proofs.
 
 On post-mutation failure, rollback reports primary and rollback errors
 together; no PID handling is allowed. A read-back mismatch is a setup failure
@@ -310,29 +325,45 @@ and restart only when the receipt says it ran, through new InstanceGuid and MCP
 readiness proof. Any mismatch is preserved; definition equality alone never
 authorizes rollback. Failed readiness never authorizes TOML.
 
+When the prior compound state was `TM + C0`, rollback restores the exact prior
+task XML, Source, and running-or-inactive state while the existing TOML
+snapshot/CAS contract restores or retains exact `C0`; it MUST NOT synthesize a
+managed entry. Interruption of this recovery can leave only `TM + C0`,
+`TM + CM`, or `T0 + C0`, each of which a later explicit operation reclassifies
+under the state table rather than resuming a durable receipt.
+
 A foreign task is never overwritten, adopted, ended, or deleted. Replacement is
 allowed only after exact managed proof. `/F` is prohibited for new or unproven
 ownership.
 
-## Uninstall and migration
+## Uninstall
 
-Uninstall/migration holds the same lock, records the same task/TOML receipt,
-and proves stored ownership without resolving the current launcher. Uninstall
-accepts only exact `TM + CM`; migration accepts only its separately specified
-exact managed-stdio source state. Every incomplete, foreign, or mismatched
-state fails closed, including `TM + C0`.
+Uninstall holds the same lock, records the same process-local task/TOML
+receipt, and proves stored ownership without resolving the current launcher.
+It accepts only exact `TM + CM` or exact `TM + C0`. For `TM + C0`, the explicit
+invocation is fresh consent to finish removal of the exactly proven task; exact
+`C0` is recorded as prior state and remains a no-op throughout. Every other
+incomplete, foreign, or mismatched state fails closed.
 
 Uninstall re-proves projection/Source before `End`, proves every InstanceGuid
 ceased plus task non-Running and port release, then atomically removes and
-verifies only the exact managed TOML entry. It re-proves projection/Source
-before deleting the task. Delete alone never counts as process cessation.
+verifies only the exact managed TOML entry for `TM + CM`; for `TM + C0`, it
+instead re-proves that TOML remains exactly absent without writing it. It
+re-proves projection/Source before deleting the task. Delete alone never counts
+as process cessation.
 
-After a post-End failure, rollback restores TOML first when changed, then
-re-proves the stopped task and vacancy, restarts with a new InstanceGuid, and
-verifies MCP readiness. An ambiguous delete is re-queried: proven presence
-uses that path; proven absence restores task then TOML before the same restart
-gate. Ownership conflict preserves observed artifacts and reports
-primary-first.
+After a post-End failure while the task is still present, rollback restores
+TOML first when `TM + CM` changed it; `TM + C0` retains exact absence. It then
+re-proves the stopped task and vacancy and restarts with a new InstanceGuid
+plus MCP readiness only when the receipt recorded a prior running instance;
+an inactive prior task remains inactive. An ambiguous delete is re-queried:
+proven absence with exact `C0` is the intended `T0 + C0` terminal state, while
+proven presence uses the rollback path above. Ownership conflict preserves
+observed artifacts and reports primary-first.
+
+Interruption before proven deletion leaves exact `TM + CM` or `TM + C0`;
+interruption after proven deletion leaves `T0 + C0`. A later explicit
+operation reclassifies those states and repeats the same bounded path.
 
 If End, InstanceGuid cessation, or port-release proof fails, preserve task and
 configuration and report the failure. Native evidence proves End changes a
@@ -340,9 +371,9 @@ test task from Running to Ready/`267014` and terminates its action; real MCP
 End/port-release behavior remains required validation before implementation
 merge. If it fails, stop for RFC review rather than adding a PID framework.
 
-Exact managed stdio cleanup/migration is allowed only for exact ownership.
-Foreign TOML entries and tasks are preserved. No broad scan, implicit
-stdio-to-HTTP migration, or task-prefix cleanup is allowed.
+V1 does not migrate or clean up stdio installations. Existing stdio and other
+user-managed TOML entries remain byte-for-byte preserved. No broad scan,
+implicit stdio-to-HTTP migration, or task-prefix cleanup is allowed.
 
 ## Protocol readiness probe
 
@@ -362,7 +393,7 @@ a valid future protocol-version date.
 
 ## Diagnostics
 
-For every setup, readiness, rollback, uninstall, or migration failure, report
+For every setup, readiness, rollback, or uninstall failure, report
 in this normative order: (1) primary error; (2) bounded Task Scheduler API or
 `schtasks` error/return code, stdout, and stderr; (3) best-effort lock, task,
 InstanceGuid, endpoint, and TOML rollback state plus `LastTaskResult`; then (4)
@@ -397,6 +428,9 @@ A later implementation PR is acceptable only if it proves all of these:
 1. Every compound-state-table case, including task-only, TOML-only,
    foreign-task/managed-TOML, managed-task/foreign-TOML, edited/mismatched, and
    foreign-listener states, fails closed or proceeds exactly as specified.
+   Exact `TM + C0` alone is operation-selectable: `auto`/`preserve` make no
+   mutation, explicit `http-task` converges to `TM + CM`, and uninstall
+   converges to `T0 + C0`; no other state gains repair authority.
 2. Native `auto` creates no persistence/configuration and reports already
    opted in only for exact `TM + CM`; user entries remain byte-for-byte
    unchanged.
@@ -411,13 +445,14 @@ A later implementation PR is acceptable only if it proves all of these:
 6. Trigger behavior is registration repetition plus per-SID logon trigger, with
    no `RestartOnFailure` configuration or claim.
 7. The SID-scoped named mutex serializes setup, reconciliation, rollback,
-   migration, uninstall, and state classification across independent CLI
+   uninstall, and state classification across independent CLI
    processes, is held through rollback, and fails before mutation on lock
    errors/timeouts.
-8. Active reconciliation proves exact prior ownership, ends all prior
-   instances, proves port release, writes the new definition, and accepts
-   readiness only while the post-write `forward_run_id` is Running; an old
-   action cannot satisfy the gate despite `IgnoreNew`.
+8. Active reconciliation from exact `TM + CM` or recoverable `TM + C0` proves
+   exact prior ownership, ends all prior instances, proves port release, writes
+   the new definition, and accepts readiness only while the post-write
+   `forward_run_id` is Running; an old action cannot satisfy the gate despite
+   `IgnoreNew`.
 9. Fresh setup and inactive reconciliation fail closed for a foreign listener
    and identify another Windows user or process as a potential endpoint owner.
 10. TOML writes occur only after forward execution identity plus MCP readiness;
@@ -442,18 +477,25 @@ A later implementation PR is acceptable only if it proves all of these:
 15. The existing Codex snapshot/CAS transaction captures exact prior whole-TOML
     bytes/absence; same-directory atomic write/read-back and compare-before-
     restore pass injected concurrent and post-write failures.
-16. Rollback restores exact prior TOML before task rollback; TOML ownership
-    conflict preserves the serving task, and rollback diagnostics never mask
-    the primary error.
-17. Uninstall/migration stops before cleanup, proves Ready/not Running and port
-    release, atomically cleans only exact managed TOML, then re-proves and
-    deletes only the exact managed task. Only exact `TM + CM` authorizes
-    uninstall; every failure stage follows the specified restore, vacancy,
+16. Rollback restores exact prior TOML before task rollback; for prior
+    `TM + C0`, it instead restores or retains exact absence and never
+    synthesizes TOML. TOML ownership conflict preserves the serving task, and
+    rollback diagnostics never mask the primary error.
+17. Uninstall from exact `TM + CM` or exact `TM + C0` stops before cleanup,
+    proves Ready/not Running and port release, then re-proves and deletes only
+    the exact managed task. `TM + CM` atomically cleans only exact managed
+    TOML; `TM + C0` treats verified absence as an already-satisfied no-op.
+    Every failure stage follows the specified conditional restart, vacancy,
     InstanceGuid, readiness, and conflict-preserve rules, including
     fault-injected ambiguous delete.
-18. Diagnostics retain primary-error-first ordering even when rollback or
+18. Fault injection after every durable setup, `TM + C0` recovery, and
+    uninstall boundary, followed by abandoned-mutex reclassification, proves
+    repeated explicit `http-task` converges to `TM + CM` and repeated uninstall
+    converges to `T0 + C0`. Interruption produces no durable state outside
+    `T0 + C0`, `TM + C0`, and `TM + CM`, and requires no durable receipt.
+19. Diagnostics retain primary-error-first ordering even when rollback or
     diagnostics fail.
-19. Native projection round-trip, InstanceGuid capture, logoff/logon, reboot,
+20. Native projection round-trip, InstanceGuid capture, logoff/logon, reboot,
     concurrent-CLI serialization, and real-MCP End/port-release validation pass.
 
 ## Size guard, rollout, risks, and non-goals
@@ -462,9 +504,12 @@ Implementation plus uninstall helpers SHOULD remain roughly at or below 300
 product lines. Exceeding it MUST stop for RFC review; tests/fixtures do not
 justify hiding a lifecycle framework.
 
-Rollout is explicit opt-in and experimental: no automatic migration or silent
-`auto` enablement. Rollback is only the receipt procedure above or exact
-managed uninstall; it never alters foreign tasks, listeners, or entries.
+Rollout is explicit opt-in and experimental: v1 provides no migration or silent
+`auto` enablement. Rollback is only the process-local receipt procedure above
+or exact managed uninstall; it never alters foreign tasks, listeners, or
+entries. Explicit `http-task` may complete exact `TM + C0`, and explicit
+uninstall may remove it; both may stop a proven running task and may fail back
+to the exact prior partial state without automatic repair.
 
 Risks are fixed-port contention, one-minute launch delay, cooperative-trust
 loopback impersonation, non-cooperating external mutation, and unverified

--- a/docs/rfc/windows-codex-desktop-http-task.md
+++ b/docs/rfc/windows-codex-desktop-http-task.md
@@ -35,6 +35,7 @@ The task identities are fixed:
 | Task folder | `\Ouroboros` |
 | Task name | `Codex Desktop MCP (<canonical SID>)` |
 | Description | `ouroboros-codex-desktop-mcp-v1` |
+| Transaction lock | `Global\Ouroboros.CodexDesktopMcp.v1.<canonical SID>` |
 | Managed TOML comment | `# Managed by Ouroboros native-Windows Codex Desktop HTTP task v1` |
 
 `<canonical SID>` is the current resolved Windows SID in its canonical string
@@ -84,39 +85,115 @@ url = "http://127.0.0.1:8765/mcp"
 ## Ownership, proof, and preservation
 
 A **managed task** has the exact identity above, a Source with the exact prefix
-and a valid UUIDv4, and all normalized XML fields required below. A **managed
-HTTP entry** is the exact marked TOML form above. A **foreign** task, listener,
-or entry is anything not so proven. Cleanup proof parses stored normalized XML,
-not the launcher available now, and requires folder/name, description, Source,
-principal SID/logon type/run level, the one absolute direct `Exec` in a frozen
-launcher shape above, trigger types/repetition, multiple-instance policy, both
-battery flags, execution limit, and on-demand setting. Unknown or edited
-shapes are foreign and preserved.
+and a valid UUIDv4, and the exact canonical projection below. A **managed HTTP
+entry** is the exact marked TOML form above. A **foreign** task, listener, or
+entry is anything not so proven. Cleanup proof parses the stored task XML, not
+the launcher available now. Unknown or edited shapes are foreign and
+preserved.
 
 Immediately before every forward mutation, rollback mutation, `End`, `Delete`,
 or restore, the implementation MUST re-query the task and compare its
-normalized definition and Source to the expected value. The Source alone is
+canonical projection and Source to the expected value. The Source alone is
 insufficient; structural proof is always required. There are no aliases.
 
 “Preserve” for a user-managed entry means byte-for-byte preservation: no
-rewrite, normalization, reordering, or lifecycle mutation. For an existing
-managed HTTP entry, preserve means validate that the exact entry is usable,
-then make no task or configuration lifecycle mutation.
+rewrite, normalization, reordering, or lifecycle mutation. In `auto` or
+`preserve` mode, an existing managed HTTP entry is usable only as part of exact
+`TM + CM`; after validation, those modes make no task or configuration
+lifecycle mutation.
 
-The task ownership marker alone is insufficient; exact normalized definition
+The task ownership marker alone is insufficient; exact canonical-projection
 proof is required. Likewise, URL similarity never authorizes TOML edits.
+
+### Canonical task-definition projection
+
+Ownership comparison is a semantic projection of namespace-aware Task Scheduler
+XML, not serialized-XML equality. Parsing MUST reject duplicate singleton
+elements, duplicate trigger/action kinds, malformed values, and entity
+expansion. XML declaration, namespace prefixes, attribute order, sibling order,
+indentation, and inter-element whitespace do not affect the projection. The
+two unique trigger records project into the fixed tuple order
+`(RegistrationTrigger, LogonTrigger)`. Element text is trimmed only for schema
+values whose grammar excludes surrounding whitespace; command and argument
+text is not otherwise normalized.
+
+The complete v1 projection is:
+
+| Area | Canonical value |
+| --- | --- |
+| Task path | Exact fixed folder and SID-derived name above |
+| Registration | Exact Description and task-path URI; Source separately equals the expected valid managed UUID value; Date, Author, Version, Documentation, and SecurityDescriptor absent |
+| Principal cardinality | Exactly one principal |
+| Principal binding | Principal `id=OuroborosCurrentUser`; `Actions@Context=OuroborosCurrentUser` |
+| Principal identity | `UserId` is the current canonical SID; `GroupId`, `DisplayName`, and `RequiredPrivileges` are absent |
+| Principal mode | `LogonType=InteractiveToken`, `RunLevel` absent or `LeastPrivilege`, `ProcessTokenSidType=Default` |
+| Actions | Exactly one `Exec`; no `ComHandler`, `SendEmail`, `ShowMessage`, or other action |
+| Action identifier | `Exec@id` absent |
+| Exec command | Absolute path; basename case-insensitively one of the three frozen launcher basenames |
+| Exec arguments | `CommandLineToArgvW` token sequence equals the corresponding frozen prefix plus fixed suffix |
+| Exec working directory | Absent or empty |
+| Registration trigger | Exactly one; `id` absent; enabled; no delay/start/end boundary; repetition interval `PT1M`, duration absent, `StopAtDurationEnd=false` |
+| Logon trigger | Exactly one; `id` absent; enabled; `UserId` is the current canonical SID; no delay/start/end boundary or repetition |
+| Other triggers | Absent, including boot, idle, time, calendar, event, session-state-change, and custom triggers |
+| Instance policy | `MultipleInstancesPolicy=IgnoreNew` |
+| Battery | `DisallowStartIfOnBatteries=false`, `StopIfGoingOnBatteries=false` |
+| Lifetime | `ExecutionTimeLimit=PT0S`, `DeleteExpiredTaskAfter` absent, `RestartOnFailure` absent |
+| Availability | `Enabled=true`, `AllowStartOnDemand=true`, `StartWhenAvailable=false`, `WakeToRun=false`, `Hidden=false` |
+| Other settings | `AllowHardTerminate=true`, `RunOnlyIfNetworkAvailable=false`, `IdleSettings.StopOnIdleEnd=true`, `IdleSettings.RestartOnIdle=false`, `UseUnifiedSchedulingEngine=true`, network/maintenance settings absent, `Volatile=false` |
+
+For this table only, absent is equivalent to the documented Task Scheduler
+default for `ProcessTokenSidType=Default`, `RunLevel=LeastPrivilege`, trigger `Enabled=true`,
+`StopAtDurationEnd=false`, settings `Enabled=true`, `AllowStartOnDemand=true`,
+`StartWhenAvailable=false`, `WakeToRun=false`, `Hidden=false`,
+`AllowHardTerminate=true`, `RunOnlyIfNetworkAvailable=false`, and
+`Volatile=false`. Explicit and absent values are not equivalent anywhere else;
+in particular, `ExecutionTimeLimit` MUST semantically be `PT0S`.
+
+The root Task Scheduler namespace and an OS-supported root schema-version
+attribute are schema bookkeeping and are not projected. Every other XML
+element or attribute not consumed by the table, including a second action,
+principal, or trigger, makes the task foreign. This rule, the explicit
+absent/default and absent/empty equivalences, case-insensitive executable
+basename comparison, `CommandLineToArgvW` tokenization, and the
+ordering/whitespace rules are the only normalization. Implementations MUST NOT
+add their own ignored fields or defaults.
 
 ## Mode and state contract
 
-| Native Windows mode/state | Required behavior |
+Task and Codex configuration are one compound installation. The deterministic
+task name is classified as `T0` (absent), `TM` (exact managed proof), or `TX`
+(present but foreign/edited). The `mcp_servers.ouroboros` configuration is
+classified as `C0` (absent), `CM` (the exact marked HTTP form), `CU`
+(user-managed with no managed marker), or `CX` (managed marker present but
+edited, malformed, duplicated, or mismatched). Classification occurs while
+holding the transaction lock.
+
+| Compound state | Classification and required behavior |
 | --- | --- |
-| `auto` + absent | Do not create task/configuration; report MCP disabled and point to `--mcp-mode http-task`. |
-| `auto` + user-managed entry | Preserve its bytes; report it preserved. |
-| `auto` + managed HTTP entry | Preserve task and TOML; report already opted in, not disabled. |
-| `auto` + any other state | Do not install, migrate, or mutate persistence/configuration; report the detected state. |
-| `preserve` | Validate an existing usable command/URL entry and perform no task/configuration lifecycle mutation; absence or an unusable entry retains existing error behavior. |
-| explicit `http-task` | The only consent path; create or reconcile only the exact managed task and HTTP entry. |
-| explicit `stdio` | Refuse before mutation; warn that native Codex Desktop stdio is the crash-triggering topology from #2024, and direct users to explicit `http-task` or WSL. |
+| `T0 + C0` | Absent. `auto` performs no mutation and points to explicit `http-task`; explicit `http-task` may install. |
+| `T0 + CU` | User-managed configuration. Preserve its bytes in every automatic mode; explicit `http-task` refuses to overwrite it. |
+| `TM + CM` | The only managed installation. `auto` may report already opted in only after proving both artifacts; explicit `http-task` may reconcile it. |
+| `TM + C0` | Incomplete managed task only. Fail closed and preserve; do not synthesize or adopt TOML. |
+| `T0 + CM` | Stale managed TOML only. Fail closed and preserve; do not synthesize or adopt a task. |
+| `TX + CM` | Foreign/edited same-name task plus managed TOML. Fail closed and preserve both. |
+| `TM + CU` or `TM + CX` | Managed task plus foreign, user-managed, or edited TOML. Fail closed and preserve both. |
+| `T0 + CX`, `TX + C0`, `TX + CU`, or `TX + CX` | Foreign or mismatched installation. Fail closed and preserve every artifact. |
+
+An occupied endpoint is a third compound-state input. Occupancy while `TM` is
+Running is only a candidate prior managed action, never listener ownership
+proof. Explicit reconciliation may stop that exactly proven task and continue
+only if the endpoint is then vacant. Occupancy in every other case, or
+occupancy that remains after the managed stop, is a foreign/residual listener
+conflict and fails closed. No mode adopts a listener from its URL or
+self-reported MCP identity.
+
+`auto` and `preserve` never repair a compound state. `preserve` validates an
+existing usable command/URL entry and performs no task/configuration lifecycle
+mutation; absence or unusable input retains existing error behavior. Explicit
+`http-task` is the only consent path and may mutate only `T0 + C0` or exact
+`TM + CM`. Explicit `stdio` refuses before mutation, warns that native Codex
+Desktop stdio is the crash-triggering topology from #2024, and directs users to
+explicit `http-task` or WSL.
 
 Existing user-managed entries, including stdio, remain byte-for-byte unchanged.
 A fresh native `auto` setup MUST NOT silently write stdio or install
@@ -147,11 +224,12 @@ restart. `IgnoreNew` suppresses a new action while one runs. It does not recover
 hung processes.
 
 The design MUST NOT configure, use, or claim `RestartOnFailure`, a service,
-supervisor, daemon, process monitor, mutex/lease framework, PID registry,
-ordered task generations, parallel replacement tasks, task-prefix cleanup,
-zero-downtime handoff, or launcher-shape compatibility framework. Cooperative
-setup/uninstall commands are serialized only by normal CLI usage: simultaneous
-setup/uninstall is unsupported, and no mutex is added.
+supervisor, daemon, process monitor, server-lifetime mutex/lease framework, PID
+registry, ordered task generations, parallel replacement tasks, task-prefix
+cleanup, zero-downtime handoff, or launcher-shape compatibility framework. The
+single bounded CLI transaction lock below is required only to serialize
+ownership proof and lifecycle mutation; it is not held by the MCP server and is
+not a liveness or restart mechanism.
 
 ## Endpoint and security boundary
 
@@ -161,58 +239,76 @@ Port-vacancy errors MUST say another Windows user or process may own the
 endpoint. Per-SID port derivation is follow-up work, not v1.
 
 This has a local cooperative-trust limitation: another local process/account
-can bind or impersonate loopback. Fresh setup requires port vacancy and MUST
-NOT adopt a listener based only on self-reported identity. No bearer-token
-secret lifecycle is introduced. Strong local-user isolation/authentication is
-follow-up work; administrators and same-user malware are non-goals.
+can bind or impersonate loopback. Setup requires vacancy immediately before a
+forward start. Reconciliation obtains vacancy only through the exact managed
+stop procedure below and MUST NOT adopt a listener based only on self-reported
+identity. No bearer-token secret lifecycle is introduced. Strong local-user
+isolation/authentication is follow-up work; administrators and same-user
+malware are non-goals.
+
+## Transaction serialization
+
+Setup, reconciliation, rollback, migration, uninstall, and compound-state
+classification use the exact SID-scoped named Windows mutex above, restricted
+to the current SID and `SYSTEM`. Acquire it before the first task, endpoint, or
+TOML read and hold it through success or complete rollback; nested rollback
+reuses it. Creation, ACL verification, or bounded-acquisition failure stops
+before mutation. After an abandoned mutex, reclassify all durable state.
+Immediate re-proof remains mandatory against non-cooperating external edits.
 
 ## Setup and rollback transaction
 
 Setup proceeds in this order:
 
-1. Resolve current canonical SID and the fixed task identity.
-2. Preflight exact task ownership and endpoint vacancy; a same-name foreign
-   task or foreign listener fails closed.
-3. Record a receipt containing prior absence, or the prior exact managed XML,
-   prior Source, and whether that prior task was running. Generate the new
-   Source UUID as `forward_write_id`.
-4. Immediately before the forward definition write, re-query and compare the
-   expected prior normalized definition and Source (or absence), then create
-   without `/F` unless exact managed ownership was just proven.
-5. Read back the just-written task and prove its normalized definition and
-   Source equal the intended definition and `forward_write_id` before start,
-   readiness, or TOML.
-6. Immediately before start or reconciliation, re-query and re-prove the
-   written definition and `forward_write_id`.
-7. Start or reconcile the exact managed task.
-8. Require readiness: task Running **and** successful MCP identity probe at the
-   exact endpoint.
-9. Immediately before the TOML write, re-query and re-prove the written
-   definition and `forward_write_id`; only then write the exact marked HTTP
-   entry.
+1. Acquire the lock, classify state, and continue only from `T0 + C0` or exact
+   `TM + CM`. Record prior task XML/projection/Source/running InstanceGuids and
+   the existing Codex `_PathSnapshot` for TOML, including absence or exact
+   whole-file bytes; generate `forward_write_id`.
+2. For `TM + CM`, re-prove and `End` every running prior instance. Prove all
+   ceased, task not Running, and port vacant. `T0 + C0` also requires vacancy.
+   A pre-write failure restarts a receipt-authorized prior run only through
+   projection/Source, vacancy, new InstanceGuid, and readiness proof.
+3. Prove no running instance, re-prove prior ownership or absence, write the
+   definition, then read back its exact projection and `forward_write_id`.
+4. Start through Task Scheduler COM and capture the unique new
+   `IRunningTask.InstanceGuid` as `forward_run_id`; if RegistrationTrigger wins,
+   accept only the one post-write GUID absent from the pre-write snapshot.
+   Zero, multiple, pre-existing, or unprovable instances fail.
+5. Before and after MCP identity readiness, re-prove the projection, Source,
+   and exact Running `forward_run_id`. Preserve existing `TM + CM` TOML; for
+   fresh setup only, atomically write the marked entry after those proofs.
 
 On post-mutation failure, rollback reports primary and rollback errors
 together; no PID handling is allowed. A read-back mismatch is a setup failure
 and MUST NOT start the task or write TOML.
 
+TOML mutation MUST reuse the existing Codex setup snapshot/CAS transaction:
+`_snapshot_path`, `_atomic_write_text_if_current_matches`, and
+`_restore_path_snapshot_if_current_matches`. It constructs complete intended
+bytes without touching the source, preserves unrelated bytes, and uses the
+existing same-directory temp-write, flush, atomic replace, and read-back proof.
+No second TOML transaction or retry path is introduced.
+
+If failure occurs after TOML replacement begins, rollback restores TOML before
+the task through the existing compare-before-restore contract. Exact prior
+snapshot or already-restored state is success; any current-snapshot mismatch
+preserves file and serving task as an ownership conflict. Task rollback
+requires proven prior TOML state, so it cannot leave a managed entry pointing
+to a deleted task.
+
 For prior absence, fresh rollback re-queries the task and may `End`/`Delete`
 only when its Source equals `forward_write_id` and its definition is the
-written definition. It then uses `schtasks End`, proves it is not Running and
-the port is no longer listening, re-queries the unchanged written definition
-and `forward_write_id` immediately before delete, then deletes it and restores
-absence. If the task is missing or its Source differs, it MUST preserve it and
-report an ownership-conflict rollback failure.
+written projection. If started, `forward_run_id` must be the only running
+instance before `End`; otherwise prove no instance runs. Prove cessation and
+port release, re-prove projection/Source, then delete. Missing or changed
+ownership is preserved as rollback conflict.
 
 For prior managed XML, replacement rollback re-queries before every mutation
-and may End or restore the prior XML only while the current Source equals
-`forward_write_id` and the written definition matches. The restored XML
-retains its prior Source; before a receipt-authorized restart, rollback
-re-queries and proves that restored XML and prior Source. A missing or
-different Source is an ownership-conflict rollback failure and is preserved;
-definition equality alone never authorizes rollback. When authorized, rollback
-proves cessation, restarts only when the receipt says it was running, and
-verifies prior readiness. It MUST NOT write a new TOML entry after failed
-readiness.
+and requires matching written projection/`forward_write_id`, plus the same
+started-or-not cessation proof. Restore exact prior XML/Source, re-prove it,
+and restart only when the receipt says it ran, through new InstanceGuid and MCP
+readiness proof. Any mismatch is preserved; definition equality alone never
+authorizes rollback. Failed readiness never authorizes TOML.
 
 A foreign task is never overwritten, adopted, ended, or deleted. Replacement is
 allowed only after exact managed proof. `/F` is prohibited for new or unproven
@@ -220,20 +316,29 @@ ownership.
 
 ## Uninstall and migration
 
-Uninstall/migration first revalidates exact managed ownership and normalized
-XML, including any valid managed Source UUID and the stored structural action
-shape, independently of whether the current launcher can be resolved. It
-re-queries immediately before `End` and `Delete`, requiring unchanged
-normalized XML and Source. It then uses `schtasks End`, proves task Ready/not
-Running and endpoint unavailable, deletes the task, and only then performs
-exact managed TOML cleanup. `schtasks Delete` alone does not stop a running
-action.
+Uninstall/migration holds the same lock, records the same task/TOML receipt,
+and proves stored ownership without resolving the current launcher. Uninstall
+accepts only exact `TM + CM`; migration accepts only its separately specified
+exact managed-stdio source state. Every incomplete, foreign, or mismatched
+state fails closed, including `TM + C0`.
 
-If End or cessation proof fails, preserve task and configuration and report the
-failure. Native evidence proves End changes a test task from Running to
-Ready/`267014` and terminates its action; real MCP End/port-release behavior
-remains required validation before implementation merge. If it fails, stop for
-RFC review rather than adding a PID framework.
+Uninstall re-proves projection/Source before `End`, proves every InstanceGuid
+ceased plus task non-Running and port release, then atomically removes and
+verifies only the exact managed TOML entry. It re-proves projection/Source
+before deleting the task. Delete alone never counts as process cessation.
+
+After a post-End failure, rollback restores TOML first when changed, then
+re-proves the stopped task and vacancy, restarts with a new InstanceGuid, and
+verifies MCP readiness. An ambiguous delete is re-queried: proven presence
+uses that path; proven absence restores task then TOML before the same restart
+gate. Ownership conflict preserves observed artifacts and reports
+primary-first.
+
+If End, InstanceGuid cessation, or port-release proof fails, preserve task and
+configuration and report the failure. Native evidence proves End changes a
+test task from Running to Ready/`267014` and terminates its action; real MCP
+End/port-release behavior remains required validation before implementation
+merge. If it fails, stop for RFC review rather than adding a PID framework.
 
 Exact managed stdio cleanup/migration is allowed only for exact ownership.
 Foreign TOML entries and tasks are preserved. No broad scan, implicit
@@ -258,11 +363,12 @@ a valid future protocol-version date.
 ## Diagnostics
 
 For every setup, readiness, rollback, uninstall, or migration failure, report
-in this normative order: (1) primary error; (2) bounded `schtasks` return code,
-stdout, and stderr; (3) best-effort task state and `LastTaskResult`; then (4)
-`~/.ouroboros/logs/ouroboros.log`. Diagnostic collection failure MUST NOT mask
-the primary error. Scheduler Operational history may be disabled and cannot be
-required.
+in this normative order: (1) primary error; (2) bounded Task Scheduler API or
+`schtasks` error/return code, stdout, and stderr; (3) best-effort lock, task,
+InstanceGuid, endpoint, and TOML rollback state plus `LastTaskResult`; then (4)
+`~/.ouroboros/logs/ouroboros.log`. Rollback errors follow the primary error in
+the same order. Diagnostic collection failure MUST NOT mask the primary error.
+Scheduler Operational history may be disabled and cannot be required.
 
 ## Native evidence appendix (2026-08-12)
 
@@ -278,6 +384,7 @@ probe artifacts are local evidence, not shipped files.
 | Registration trigger + indefinite one-minute repetition; `0xC0000005` action | Relaunched at minute ticks and recovered on third start. |
 | `IgnoreNew`; 130-second action | One instance; duplicate suppressed. |
 | `schtasks End` on running test action | State changed to Ready/`267014`; action terminated. |
+| Canonical XML create/query round-trip | Scheduler persisted task URI and `Actions@Context`, omitted explicit `LeastPrivilege`, and materialized the listed idle/unified-engine defaults. |
 
 Logoff/logon, reboot, and real MCP End/port-release boundaries were not
 exercised. They are required native validation before implementation merge.
@@ -287,10 +394,12 @@ The evidence does not establish failure-aware restart or hung-process recovery.
 
 A later implementation PR is acceptable only if it proves all of these:
 
-1. Every mode/state-table case: absent, exact managed, user-managed, and
-   same-name foreign/edited-managed behavior.
-2. Native `auto` creates no persistence/configuration; managed HTTP reports
-   already opted in; user entries remain byte-for-byte unchanged.
+1. Every compound-state-table case, including task-only, TOML-only,
+   foreign-task/managed-TOML, managed-task/foreign-TOML, edited/mismatched, and
+   foreign-listener states, fails closed or proceeds exactly as specified.
+2. Native `auto` creates no persistence/configuration and reports already
+   opted in only for exact `TM + CM`; user entries remain byte-for-byte
+   unchanged.
 3. `preserve` validates a usable command/URL entry without task/configuration
    lifecycle mutation; absence or unusable input retains existing error behavior.
 4. Native explicit `stdio` is refused before mutation with the #2024
@@ -301,24 +410,51 @@ A later implementation PR is acceptable only if it proves all of these:
    valid managed Source UUID on each successful forward definition write.
 6. Trigger behavior is registration repetition plus per-SID logon trigger, with
    no `RestartOnFailure` configuration or claim.
-7. Fresh setup fails closed for foreign task/listener and identifies another
-   Windows user or process as a potential endpoint owner.
-8. TOML writes occur only after task-Running plus MCP identity readiness;
-   protocol probing accepts a valid future real Gregorian date version.
-9. Cleanup/uninstall recognizes a structurally managed stored task when its
-   launcher path has moved or disappeared, but preserves edited or lookalike
-   actions even when a launcher with a similar name resolves now.
-10. A forward write read-back Source/definition mismatch fails before start,
+7. The SID-scoped named mutex serializes setup, reconciliation, rollback,
+   migration, uninstall, and state classification across independent CLI
+   processes, is held through rollback, and fails before mutation on lock
+   errors/timeouts.
+8. Active reconciliation proves exact prior ownership, ends all prior
+   instances, proves port release, writes the new definition, and accepts
+   readiness only while the post-write `forward_run_id` is Running; an old
+   action cannot satisfy the gate despite `IgnoreNew`.
+9. Fresh setup and inactive reconciliation fail closed for a foreign listener
+   and identify another Windows user or process as a potential endpoint owner.
+10. TOML writes occur only after forward execution identity plus MCP readiness;
+    protocol probing accepts a valid future real Gregorian date version.
+11. Cleanup/uninstall recognizes a structurally managed stored task when its
+    launcher path has moved or disappeared, but preserves edited or lookalike
+    actions even when a launcher with a similar name resolves now.
+12. Canonical-projection tests cover every listed principal, action,
+    working-directory, trigger, repetition, instance, battery, lifetime,
+    on-demand, hidden, start-when-available, wake, and other-setting field;
+    unknown fields, duplicates, and non-equivalent defaults are foreign while
+    only the closed normalization rules are equal; native create/query
+    round-trip and exact `CommandLineToArgvW` token tests pass.
+13. A forward write read-back Source/definition mismatch fails before start,
     readiness, or TOML; exact UUID-owned fresh rollback restores absence only
-    after End, non-Running, and port-closed proof before delete.
-11. An identical ABA recreation with a different Source is preserved and
+    after End, exact InstanceGuid cessation, and port-closed proof before
+    delete.
+14. An identical ABA recreation with a different Source is preserved and
     reported as an ownership-conflict rollback failure; replacement rollback
     restores exact prior XML/state and its prior Source only when the current
     Source is the receipt's `forward_write_id`.
-12. Uninstall/migration stops before delete, proves Ready/not Running and port
-    release, then cleans only exact managed TOML; failure preserves both.
-13. Diagnostics retain primary-error-first ordering even when diagnostics fail.
-14. Native logoff/logon, reboot, and real-MCP End/port-release validation pass.
+15. The existing Codex snapshot/CAS transaction captures exact prior whole-TOML
+    bytes/absence; same-directory atomic write/read-back and compare-before-
+    restore pass injected concurrent and post-write failures.
+16. Rollback restores exact prior TOML before task rollback; TOML ownership
+    conflict preserves the serving task, and rollback diagnostics never mask
+    the primary error.
+17. Uninstall/migration stops before cleanup, proves Ready/not Running and port
+    release, atomically cleans only exact managed TOML, then re-proves and
+    deletes only the exact managed task. Only exact `TM + CM` authorizes
+    uninstall; every failure stage follows the specified restore, vacancy,
+    InstanceGuid, readiness, and conflict-preserve rules, including
+    fault-injected ambiguous delete.
+18. Diagnostics retain primary-error-first ordering even when rollback or
+    diagnostics fail.
+19. Native projection round-trip, InstanceGuid capture, logoff/logon, reboot,
+    concurrent-CLI serialization, and real-MCP End/port-release validation pass.
 
 ## Size guard, rollout, risks, and non-goals
 
@@ -331,10 +467,11 @@ Rollout is explicit opt-in and experimental: no automatic migration or silent
 managed uninstall; it never alters foreign tasks, listeners, or entries.
 
 Risks are fixed-port contention, one-minute launch delay, cooperative-trust
-loopback impersonation, unsupported concurrent commands, and unverified session
-boundaries. This RFC does not provide multi-user support, remote access, strong
-local authentication, administrator/malware protection, hung recovery,
-zero-downtime replacement, generalized task management, or non-Windows change.
+loopback impersonation, non-cooperating external mutation, and unverified
+session boundaries. This RFC does not provide multi-user support, remote
+access, strong local authentication, administrator/malware protection, hung
+recovery, zero-downtime replacement, generalized task management, or
+non-Windows change.
 
 Alternatives rejected: native Codex-owned stdio child; `RestartOnFailure`;
 service/supervisor; dynamic/per-SID port in v1; bearer-token lifecycle; and an


### PR DESCRIPTION
## Summary

Documentation-only RFC for the native-Windows Codex Desktop HTTP MCP direction requested in #2056.

It keeps the accepted HTTP topology, strict MCP identity gate, user-managed config preservation, and non-Windows behavior, while replacing HKCU Run with one explicit opt-in, least-privilege Scheduled Task contract. The RFC deliberately excludes the generations/supervisor/service/zero-downtime machinery from #2026.

## Preflight evidence

Native Windows 11 Pro 10.0.26200, medium integrity:

- least-privilege current-user XML task create/query/run/end/delete succeeded without elevation
- `RestartOnFailure` did **not** relaunch either exit code 7 or a process terminated with `0xC0000005`
- `RegistrationTrigger` with indefinite one-minute repetition relaunched abnormal exits at minute ticks and recovered on the third launch
- `IgnoreNew` suppressed duplicate instances for a 130-second action
- `schtasks End` changed a running test action to Ready/`267014` and terminated it

The RFC therefore uses evidence-backed periodic launch attempts rather than claiming failure-aware restart. Logoff/logon, reboot, battery-start, and real MCP End/port-release remain explicit implementation-merge validation gates.

## Frozen boundaries

- native Windows persistence only through explicit `--mcp-mode http-task`
- fresh native `auto` creates no MCP persistence or stdio entry
- native explicit `stdio` is refused with #2024 warning and HTTP/WSL guidance
- exact `http://127.0.0.1:8765/mcp`, with one-active-Windows-user limitation documented
- one SID-scoped direct-Exec task; no runner, mutex, PID registry, generations, or supervisor
- stop/prove/delete rollback and uninstall ordering
- negotiated MCP protocol date accepted without exact-version equality
- implementation helper size guard of roughly 300 product lines

## Verification

- `git diff --check`
- independent scoped architecture review: **APPROVE / CLEAR**, no HIGH or MEDIUM findings

Related: #2024, #2056, #2026