### PR TITLE
fix(auto): retry transient Seed QA errors and persist the error detail

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2803,7 +2803,7 @@ class AutoPipeline:
         current_seed = seed
         current_review = review
         max_attempts = max(1, int(state.max_repair_rounds or 1))
-        consumed_error_attempts = max(0, int(state.seed_qa_error_attempts or 0))
+        consumed_calls = max(0, int(state.seed_qa_evaluator_calls or 0))
 
         def _blocked_result() -> tuple[AutoPipelineResult, Seed, SeedReview | None]:
             return (
@@ -2812,20 +2812,20 @@ class AutoPipeline:
                 current_review,
             )
 
-        # The durable error budget bounds evaluator calls across restarts
-        # (#2094): an exhausted session re-blocks without another call.
-        if consumed_error_attempts >= max_attempts:
-            state.mark_blocked(
-                f"Seed QA evaluator error budget exhausted ({max_attempts} attempt(s))",
-                tool_name="seed_qa",
-            )
+        # The durable call budget bounds EVERY evaluator invocation across
+        # restarts (#2094): exhausted sessions re-block with no further call.
+        if consumed_calls >= max_attempts:
+            state.mark_blocked(state.seed_qa_exhausted_blocker(max_attempts), tool_name="seed_qa")
             self._save(state)
             return _blocked_result()
 
-        for attempt in range(1, max_attempts + 1):
+        for attempt in range(consumed_calls + 1, max_attempts + 1):
             timeout = self._deadline_capped_timeout(
                 state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
             )
+            # Count the call fail-closed BEFORE making it (#2094).
+            state.seed_qa_evaluator_calls = consumed_calls = attempt
+            self._save(state)
             try:
                 qa_result = await asyncio.wait_for(
                     self.seed_qa_evaluator(current_seed, ledger), timeout=timeout
@@ -2848,34 +2848,33 @@ class AutoPipeline:
                 return _blocked_result()
 
             if qa_result.error:
-                # Retry within the DURABLE budget instead of blocking on first
-                # occurrence: the consumed count persists before the retry so an
-                # interrupted session resumes mid-budget, not afresh (#2094).
-                state.seed_qa_error_attempts = consumed_error_attempts = consumed_error_attempts + 1
+                # Retry within the remaining durable budget; the final block
+                # records the concrete error detail (#2094).
                 detail = " ".join(str(qa_result.error).split())[:200] or "unspecified"
-                if consumed_error_attempts < max_attempts:
+                if attempt < max_attempts:
                     state.mark_progress(
                         f"Seed QA transient evaluator error "
-                        f"(attempt {consumed_error_attempts}/{max_attempts}); retrying: {detail}",
+                        f"(attempt {attempt}/{max_attempts}); retrying: {detail}",
                         tool_name="seed_qa",
                     )
                     self._save(state)
                     continue
-                state.mark_blocked(
-                    f"Seed QA evaluator error after {max_attempts} attempt(s): {detail}",
-                    tool_name="seed_qa",
+                state.seed_qa_block_detail = (
+                    f"Seed QA evaluator error after {max_attempts} attempt(s): {detail}"
                 )
+                state.mark_blocked(state.seed_qa_block_detail, tool_name="seed_qa")
                 self._save(state)
                 return _blocked_result()
 
-            # A usable evaluator result restores the full error budget.
-            state.seed_qa_error_attempts = 0
             state.last_qa_score = float(qa_result.score)
             state.last_qa_verdict = _safe_seed_qa_verdict(qa_result.verdict)
             state.last_qa_passed = bool(qa_result.passed)
             state.last_qa_differences = _safe_seed_qa_evidence(qa_result.differences)
             state.last_qa_suggestions = _safe_seed_qa_evidence(qa_result.suggestions)
             if qa_result.passed:
+                # A pass concludes the gate: restore the durable budget.
+                state.seed_qa_evaluator_calls = 0
+                state.seed_qa_block_detail = None
                 review_blocker = self._seed_review_gate_blocker(state, current_review)
                 if review_blocker is not None:
                     state.mark_blocked(review_blocker, tool_name="grade_gate")
@@ -2967,7 +2966,8 @@ class AutoPipeline:
                     "reason": "repair_budget_exhausted",
                 },
             )
-            state.mark_blocked("; ".join(details), tool_name="seed_qa")
+            state.seed_qa_block_detail = "; ".join(details)
+            state.mark_blocked(state.seed_qa_block_detail, tool_name="seed_qa")
             self._save(state)
             return _blocked_result()
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2803,6 +2803,14 @@ class AutoPipeline:
         current_seed = seed
         current_review = review
         max_attempts = max(1, int(state.max_repair_rounds or 1))
+
+        def _blocked_result() -> tuple[AutoPipelineResult, Seed, SeedReview | None]:
+            return (
+                self._result(state, ledger, review=current_review, blocker=state.last_error),
+                current_seed,
+                current_review,
+            )
+
         for attempt in range(1, max_attempts + 1):
             timeout = self._deadline_capped_timeout(
                 state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
@@ -2813,46 +2821,41 @@ class AutoPipeline:
                 )
             except TimeoutError:
                 if self._enforce_deadline(state):
-                    return (
-                        self._result(
-                            state, ledger, review=current_review, blocker=state.last_error
-                        ),
-                        current_seed,
-                        current_review,
-                    )
+                    return _blocked_result()
                 state.mark_blocked(
                     f"Seed QA timed out after {timeout:.0f}s",
                     tool_name="seed_qa",
                 )
                 self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
-                )
+                return _blocked_result()
             except Exception as exc:
                 state.mark_blocked(
                     f"Seed QA raised {type(exc).__name__}",
                     tool_name="seed_qa",
                 )
                 self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
-                )
+                return _blocked_result()
 
             if qa_result.error:
+                # A transient evaluator error retries within the attempt
+                # budget instead of blocking on first occurrence, and the
+                # final block persists the concrete error so the state
+                # stops discarding the diagnostic detail (#2094).
+                detail = " ".join(str(qa_result.error).split())[:200] or "unspecified"
+                if attempt < max_attempts:
+                    state.mark_progress(
+                        f"Seed QA transient evaluator error "
+                        f"(attempt {attempt}/{max_attempts}); retrying: {detail}",
+                        tool_name="seed_qa",
+                    )
+                    self._save(state)
+                    continue
                 state.mark_blocked(
-                    "Seed QA reported a transient evaluator error",
+                    f"Seed QA evaluator error after {max_attempts} attempt(s): {detail}",
                     tool_name="seed_qa",
                 )
                 self._save(state)
-                return (
-                    self._result(state, ledger, review=current_review, blocker=state.last_error),
-                    current_seed,
-                    current_review,
-                )
+                return _blocked_result()
 
             state.last_qa_score = float(qa_result.score)
             state.last_qa_verdict = _safe_seed_qa_verdict(qa_result.verdict)
@@ -2905,13 +2908,7 @@ class AutoPipeline:
                         error_code="seed_qa_feedback_unmapped",
                     )
                     self._save(state)
-                    return (
-                        self._result(
-                            state, ledger, review=current_review, blocker=state.last_error
-                        ),
-                        current_seed,
-                        current_review,
-                    )
+                    return _blocked_result()
                 current_review = SeedReviewer(self.grade_gate).review(
                     current_seed,
                     ledger=ledger,
@@ -2928,13 +2925,7 @@ class AutoPipeline:
                     except Exception as exc:
                         state.mark_failed(f"seed save failed: {exc}", tool_name="seed_saver")
                         self._save(state)
-                        return (
-                            self._result(
-                                state, ledger, review=current_review, blocker=state.last_error
-                            ),
-                            current_seed,
-                            current_review,
-                        )
+                        return _blocked_result()
                 state.mark_progress(
                     f"Seed QA repair attempt {attempt}/{max_attempts - 1} applied",
                     tool_name="seed_qa",
@@ -2965,11 +2956,7 @@ class AutoPipeline:
             )
             state.mark_blocked("; ".join(details), tool_name="seed_qa")
             self._save(state)
-            return (
-                self._result(state, ledger, review=current_review, blocker=state.last_error),
-                current_seed,
-                current_review,
-            )
+            return _blocked_result()
 
         return None, current_seed, current_review
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2803,6 +2803,7 @@ class AutoPipeline:
         current_seed = seed
         current_review = review
         max_attempts = max(1, int(state.max_repair_rounds or 1))
+        consumed_error_attempts = max(0, int(state.seed_qa_error_attempts or 0))
 
         def _blocked_result() -> tuple[AutoPipelineResult, Seed, SeedReview | None]:
             return (
@@ -2810,6 +2811,16 @@ class AutoPipeline:
                 current_seed,
                 current_review,
             )
+
+        # The durable error budget bounds evaluator calls across restarts
+        # (#2094): an exhausted session re-blocks without another call.
+        if consumed_error_attempts >= max_attempts:
+            state.mark_blocked(
+                f"Seed QA evaluator error budget exhausted ({max_attempts} attempt(s))",
+                tool_name="seed_qa",
+            )
+            self._save(state)
+            return _blocked_result()
 
         for attempt in range(1, max_attempts + 1):
             timeout = self._deadline_capped_timeout(
@@ -2837,15 +2848,15 @@ class AutoPipeline:
                 return _blocked_result()
 
             if qa_result.error:
-                # A transient evaluator error retries within the attempt
-                # budget instead of blocking on first occurrence, and the
-                # final block persists the concrete error so the state
-                # stops discarding the diagnostic detail (#2094).
+                # Retry within the DURABLE budget instead of blocking on first
+                # occurrence: the consumed count persists before the retry so an
+                # interrupted session resumes mid-budget, not afresh (#2094).
+                state.seed_qa_error_attempts = consumed_error_attempts = consumed_error_attempts + 1
                 detail = " ".join(str(qa_result.error).split())[:200] or "unspecified"
-                if attempt < max_attempts:
+                if consumed_error_attempts < max_attempts:
                     state.mark_progress(
                         f"Seed QA transient evaluator error "
-                        f"(attempt {attempt}/{max_attempts}); retrying: {detail}",
+                        f"(attempt {consumed_error_attempts}/{max_attempts}); retrying: {detail}",
                         tool_name="seed_qa",
                     )
                     self._save(state)
@@ -2857,6 +2868,8 @@ class AutoPipeline:
                 self._save(state)
                 return _blocked_result()
 
+            # A usable evaluator result restores the full error budget.
+            state.seed_qa_error_attempts = 0
             state.last_qa_score = float(qa_result.score)
             state.last_qa_verdict = _safe_seed_qa_verdict(qa_result.verdict)
             state.last_qa_passed = bool(qa_result.passed)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -604,6 +604,10 @@ class AutoPipelineState:
     last_qa_passed: bool | None = None
     last_qa_differences: list[str] = field(default_factory=list)
     last_qa_suggestions: list[str] = field(default_factory=list)
+    # Durable Seed-QA transient-error budget (#2094): consumed error attempts
+    # survive restart and resume so the evaluator is never invoked more than
+    # max_repair_rounds times for one gate; reset when it returns a result.
+    seed_qa_error_attempts: int = 0
     evaluate_artifact_hash: str | None = None
     # The actual artifact text graded during EVALUATE. Persisted verbatim
     # on first entry into ``_run_evaluate`` so a timeout / exception /
@@ -1088,6 +1092,7 @@ class AutoPipelineState:
         payload.setdefault("last_qa_passed", None)
         payload.setdefault("last_qa_differences", [])
         payload.setdefault("last_qa_suggestions", [])
+        payload.setdefault("seed_qa_error_attempts", 0)
         payload.setdefault("evaluate_artifact_hash", None)
         payload.setdefault("evaluate_artifact", None)
         payload.setdefault("last_lateral_persona", None)
@@ -1340,6 +1345,13 @@ class AutoPipelineState:
             raise ValueError(msg)
         if self.last_qa_passed is not None and not isinstance(self.last_qa_passed, bool):
             msg = "last_qa_passed must be a boolean or null"
+            raise ValueError(msg)
+        if (
+            isinstance(self.seed_qa_error_attempts, bool)
+            or not isinstance(self.seed_qa_error_attempts, int)
+            or self.seed_qa_error_attempts < 0
+        ):
+            msg = "seed_qa_error_attempts must be a non-negative integer"
             raise ValueError(msg)
         if not isinstance(self.last_qa_differences, list) or any(
             not isinstance(item, str) for item in self.last_qa_differences

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -604,10 +604,15 @@ class AutoPipelineState:
     last_qa_passed: bool | None = None
     last_qa_differences: list[str] = field(default_factory=list)
     last_qa_suggestions: list[str] = field(default_factory=list)
-    # Durable Seed-QA transient-error budget (#2094): consumed error attempts
-    # survive restart and resume so the evaluator is never invoked more than
-    # max_repair_rounds times for one gate; reset when it returns a result.
-    seed_qa_error_attempts: int = 0
+    # Durable Seed-QA evaluator-call budget (#2094): every evaluator
+    # invocation is counted fail-closed before it is made and survives
+    # restart and resume, so one gate episode never exceeds
+    # max_repair_rounds calls; reset when the gate concludes with a pass.
+    seed_qa_evaluator_calls: int = 0
+    # The final Seed-QA blocker message, persisted separately because resume
+    # transitions clear last_error: an exhausted-budget re-entry replays the
+    # concrete diagnostic instead of a generic label (#2094).
+    seed_qa_block_detail: str | None = None
     evaluate_artifact_hash: str | None = None
     # The actual artifact text graded during EVALUATE. Persisted verbatim
     # on first entry into ``_run_evaluate`` so a timeout / exception /
@@ -737,6 +742,12 @@ class AutoPipelineState:
     def recover(self, next_phase: AutoPhase, message: str) -> None:
         """Move a session back to a valid recoverable phase."""
         self.transition(next_phase, message)
+
+    def seed_qa_exhausted_blocker(self, max_attempts: int) -> str:
+        """The replayed Seed-QA blocker for an exhausted call budget (#2094)."""
+        return self.seed_qa_block_detail or (
+            f"Seed QA evaluator call budget exhausted ({max_attempts} attempt(s))"
+        )
 
     def mark_blocked(
         self,
@@ -1092,7 +1103,8 @@ class AutoPipelineState:
         payload.setdefault("last_qa_passed", None)
         payload.setdefault("last_qa_differences", [])
         payload.setdefault("last_qa_suggestions", [])
-        payload.setdefault("seed_qa_error_attempts", 0)
+        payload.setdefault("seed_qa_evaluator_calls", 0)
+        payload.setdefault("seed_qa_block_detail", None)
         payload.setdefault("evaluate_artifact_hash", None)
         payload.setdefault("evaluate_artifact", None)
         payload.setdefault("last_lateral_persona", None)
@@ -1347,11 +1359,16 @@ class AutoPipelineState:
             msg = "last_qa_passed must be a boolean or null"
             raise ValueError(msg)
         if (
-            isinstance(self.seed_qa_error_attempts, bool)
-            or not isinstance(self.seed_qa_error_attempts, int)
-            or self.seed_qa_error_attempts < 0
+            isinstance(self.seed_qa_evaluator_calls, bool)
+            or not isinstance(self.seed_qa_evaluator_calls, int)
+            or self.seed_qa_evaluator_calls < 0
         ):
-            msg = "seed_qa_error_attempts must be a non-negative integer"
+            msg = "seed_qa_evaluator_calls must be a non-negative integer"
+            raise ValueError(msg)
+        if self.seed_qa_block_detail is not None and (
+            not isinstance(self.seed_qa_block_detail, str) or not self.seed_qa_block_detail.strip()
+        ):
+            msg = "seed_qa_block_detail must be a non-empty string or null"
             raise ValueError(msg)
         if not isinstance(self.last_qa_differences, list) or any(
             not isinstance(item, str) for item in self.last_qa_differences

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1938,6 +1938,131 @@ async def test_seed_qa_persistent_error_blocks_with_detail(tmp_path) -> None:
     assert "2 attempt(s)" in result.blocker
 
 
+def _seed_qa_pipeline(tmp_path, seed_qa, run_seed):
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_budget",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    return AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_qa_error_budget_survives_restart(tmp_path) -> None:
+    """#2094 R1: consumed error attempts persist, so a session interrupted
+    mid-budget resumes with the remainder — never a fresh budget."""
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        return EvaluateResult(passed=False, score=0.0, verdict="unknown", error="boom")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("run must not start while Seed QA errors")
+
+    interrupted = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    interrupted.max_repair_rounds = 2
+    interrupted.seed_qa_error_attempts = 1
+    ledger = SeedDraftLedger.from_goal(interrupted.goal)
+    _fill_ready(ledger)
+    interrupted.ledger = ledger.to_dict()
+    state = AutoPipelineState.from_dict(interrupted.to_dict())
+
+    result = await _seed_qa_pipeline(tmp_path, seed_qa, run_seed).run(state)
+
+    assert result.status == "blocked"
+    assert len(calls) == 1
+    assert state.seed_qa_error_attempts == 2
+    assert result.blocker is not None
+    assert "2 attempt(s)" in result.blocker
+
+
+@pytest.mark.asyncio
+async def test_seed_qa_exhausted_budget_never_calls_evaluator_again(tmp_path) -> None:
+    """#2094 R1: after the budget is spent, a checkpoint/reload resume
+    re-blocks without another evaluator call, so total calls across
+    restarts never exceed max_repair_rounds."""
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        return EvaluateResult(passed=False, score=0.0, verdict="unknown", error="boom")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("run must not start while Seed QA errors")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    first = await _seed_qa_pipeline(tmp_path, seed_qa, run_seed).run(state)
+    assert first.status == "blocked"
+    assert len(calls) == 2
+
+    reloaded = AutoPipelineState.from_dict(state.to_dict())
+    second = await _seed_qa_pipeline(tmp_path, seed_qa, run_seed).run(reloaded)
+
+    assert second.status == "blocked"
+    assert len(calls) == 2
+    assert second.blocker is not None
+    assert "budget exhausted" in second.blocker
+
+
+@pytest.mark.asyncio
+async def test_seed_qa_usable_result_restores_error_budget(tmp_path) -> None:
+    """#2094 R1: a usable evaluator result resets the durable counter."""
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        if len(calls) == 1:
+            return EvaluateResult(passed=False, score=0.0, verdict="unknown", error="boom")
+        return EvaluateResult(passed=True, score=0.9, verdict="pass")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {"job_id": "job_budget_reset"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 3
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    result = await _seed_qa_pipeline(tmp_path, seed_qa, run_seed).run(state)
+
+    assert result.status == "complete"
+    assert len(calls) == 2
+    assert state.seed_qa_error_attempts == 0
+
+
 @pytest.mark.asyncio
 async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1986,7 +1986,7 @@ async def test_seed_qa_error_budget_survives_restart(tmp_path) -> None:
 
     interrupted = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     interrupted.max_repair_rounds = 2
-    interrupted.seed_qa_error_attempts = 1
+    interrupted.seed_qa_evaluator_calls = 1
     ledger = SeedDraftLedger.from_goal(interrupted.goal)
     _fill_ready(ledger)
     interrupted.ledger = ledger.to_dict()
@@ -1996,7 +1996,7 @@ async def test_seed_qa_error_budget_survives_restart(tmp_path) -> None:
 
     assert result.status == "blocked"
     assert len(calls) == 1
-    assert state.seed_qa_error_attempts == 2
+    assert state.seed_qa_evaluator_calls == 2
     assert result.blocker is not None
     assert "2 attempt(s)" in result.blocker
 
@@ -2032,7 +2032,48 @@ async def test_seed_qa_exhausted_budget_never_calls_evaluator_again(tmp_path) ->
     assert second.status == "blocked"
     assert len(calls) == 2
     assert second.blocker is not None
-    assert "budget exhausted" in second.blocker
+    # #2094 R2: the replayed block keeps the concrete evaluator diagnostic
+    # persisted on the final attempt instead of a generic exhaustion label.
+    assert "boom" in second.blocker
+    assert "2 attempt(s)" in second.blocker
+
+
+@pytest.mark.asyncio
+async def test_seed_qa_failed_result_shares_the_durable_call_budget(tmp_path) -> None:
+    """#2094 R2: max_repair_rounds is one evaluator-call budget — a resumed
+    session with one consumed call gets exactly one more evaluator call, and
+    a normal failed QA result on it cannot trigger a repair that would call
+    the evaluator a third time."""
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        return EvaluateResult(
+            passed=False,
+            score=0.4,
+            verdict="revise",
+            differences=("missing nuance",),
+            suggestions=("carry the decision forward",),
+        )
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("run must not start when Seed QA never passes")
+
+    interrupted = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    interrupted.max_repair_rounds = 2
+    interrupted.seed_qa_evaluator_calls = 1
+    ledger = SeedDraftLedger.from_goal(interrupted.goal)
+    _fill_ready(ledger)
+    interrupted.ledger = ledger.to_dict()
+    state = AutoPipelineState.from_dict(interrupted.to_dict())
+
+    result = await _seed_qa_pipeline(tmp_path, seed_qa, run_seed).run(state)
+
+    assert result.status == "blocked"
+    assert len(calls) == 1
+    assert result.blocker is not None
+    assert "did not pass after 2 attempt(s)" in result.blocker
 
 
 @pytest.mark.asyncio
@@ -2060,7 +2101,7 @@ async def test_seed_qa_usable_result_restores_error_budget(tmp_path) -> None:
 
     assert result.status == "complete"
     assert len(calls) == 2
-    assert state.seed_qa_error_attempts == 0
+    assert state.seed_qa_evaluator_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1811,6 +1811,134 @@ async def test_pipeline_runs_after_seed_qa_passes(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_seed_qa_transient_error_retries_then_passes(tmp_path) -> None:
+    """#2094: a transient evaluator error retries inside the attempt budget
+    instead of blocking on first occurrence."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_retry",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {"job_id": "job_seed_qa_retry"}
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        if len(calls) < 3:
+            return EvaluateResult(
+                passed=False,
+                score=0.0,
+                verdict="unknown",
+                error="MCPToolError: LLM call failed (overloaded)",
+            )
+        return EvaluateResult(passed=True, score=0.9, verdict="pass")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 3
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_seed_qa_retry"
+    assert len(calls) == 3
+    assert state.last_qa_score == 0.9
+
+
+@pytest.mark.asyncio
+async def test_seed_qa_persistent_error_blocks_with_detail(tmp_path) -> None:
+    """#2094: after the attempt budget is spent, the block persists the
+    concrete evaluator error instead of a generic transient label."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_error",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("run must not start when Seed QA keeps erroring")
+
+    calls: list[int] = []
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        calls.append(1)
+        return EvaluateResult(
+            passed=False,
+            score=0.0,
+            verdict="unknown",
+            error="MCPToolError: LLM call failed:\n  model overloaded (429)",
+        )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert len(calls) == 2
+    assert state.last_tool_name == "seed_qa"
+    assert result.blocker is not None
+    assert "MCPToolError: LLM call failed: model overloaded (429)" in result.blocker
+    assert "2 attempt(s)" in result.blocker
+
+
+@pytest.mark.asyncio
 async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn(


### PR DESCRIPTION
Closes #2094. Implements the suggested next step for bug 1 and the persistence half of bug 2.

## What

The `qa_result.error` branch in `_run_seed_qa_gate` no longer blocks on first occurrence. A transient evaluator error now retries within the existing attempt budget (`max_repair_rounds`, the same budget the repair path uses): each non-final attempt records a progress entry carrying the concrete error and loops back, and only the final attempt blocks. The block message persists the collapsed evaluator error — single-line, capped at 200 characters — as `Seed QA evaluator error after N attempt(s): <detail>`, so `last_error` in the session state stops discarding exactly the information needed to diagnose the underlying failure. The retry-progress entries give the same detail per attempt, which covers the diagnosis gap from the issue's bug 2 without requiring live structlog access.

On the confidentiality note: the gate's existing `_safe_seed_qa_*` helpers keep withholding QA feedback content (differences/suggestions) from durable state as before — the persisted error string is the evaluator's transport/parse diagnostic (`MCPToolError`, LLM failure, parse error), not seed-grading content.

## Budget

`pipeline.py` sits at its exact grandfathered budget, so the fix pays for itself: the gate's six duplicated blocked-return tuples fold into one `_blocked_result()` closure inside the same function (the closure reads the loop's current seed/review bindings, so behavior is unchanged), leaving the file 13 lines under budget after adding the retry branch.

## Tests

Two RED-first regressions with stub evaluators in the existing gate-test style: an evaluator that errors twice then passes completes the run with exactly `max_attempts` calls, and an evaluator that always errors blocks after exactly the budget with the multi-line error collapsed into the blocker (asserting both the detail and the attempt count). The full interview-pipeline suite (178) and the auto scope (1,978) pass, along with ruff, ruff format, mypy, and the module-size check.
